### PR TITLE
Handle unauthorized server errors

### DIFF
--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -87,6 +87,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.createCommandEvent.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createCommandEvent.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.createCommandEvent.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -235,6 +248,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.downloadCacheArtifact.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.downloadCacheArtifact.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 402:
                     let headers: Operations.downloadCacheArtifact.Output.PaymentRequired.Headers =
                         .init()
@@ -341,6 +368,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.cacheArtifactExists.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.cacheArtifactExists.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 402:
                     let headers: Operations.cacheArtifactExists.Output.PaymentRequired.Headers =
                         .init()
@@ -467,6 +508,22 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers:
+                        Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized.Headers =
+                            .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 402:
                     let headers:
                         Operations.completeCacheArtifactMultipartUpload.Output.PaymentRequired
@@ -592,6 +649,22 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers:
+                        Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized
+                            .Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 402:
                     let headers:
                         Operations.generateCacheArtifactMultipartUploadURL.Output.PaymentRequired
@@ -707,6 +780,22 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers:
+                        Operations.startCacheArtifactMultipartUpload.Output.Unauthorized.Headers =
+                            .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.startCacheArtifactMultipartUpload.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 402:
                     let headers:
                         Operations.startCacheArtifactMultipartUpload.Output.PaymentRequired.Headers =
@@ -799,6 +888,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.listOrganizations.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.listOrganizations.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.listOrganizations.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -930,6 +1032,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.showOrganization.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showOrganization.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.showOrganization.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1029,6 +1144,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.updateOrganization__2_.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganization__2_.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.updateOrganization__2_.Output.Forbidden.Headers =
                         .init()
@@ -1128,6 +1257,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.updateOrganization.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganization.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.updateOrganization.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1200,6 +1342,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .noContent(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.deleteOrganization.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteOrganization.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.deleteOrganization.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1298,6 +1453,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.createInvitation.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createInvitation.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.createInvitation.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1383,6 +1551,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .noContent(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.cancelInvitation.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.cancelInvitation.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.cancelInvitation.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1482,6 +1663,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganizationMember.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.updateOrganizationMember.Output.Forbidden.Headers =
                         .init()
@@ -1571,6 +1766,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.removeOrganizationMember.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.removeOrganizationMember.Output.Forbidden.Headers =
                         .init()
@@ -1645,6 +1854,20 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.showOrganizationUsage.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showOrganizationUsage.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.showOrganizationUsage.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1715,6 +1938,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.listProjects.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.listProjects.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 default: return .undocumented(statusCode: response.statusCode, .init())
                 }
             }
@@ -1785,6 +2021,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.createProject.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createProject.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.createProject.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1842,6 +2091,19 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.showProject.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showProject.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.showProject.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1902,6 +2164,19 @@ public struct Client: APIProtocol {
                 case 204:
                     let headers: Operations.cleanCache.Output.NoContent.Headers = .init()
                     return .noContent(.init(headers: headers, body: nil))
+                case 401:
+                    let headers: Operations.cleanCache.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.cleanCache.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.cleanCache.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -1962,6 +2237,19 @@ public struct Client: APIProtocol {
                 case 204:
                     let headers: Operations.deleteProject.Output.NoContent.Headers = .init()
                     return .noContent(.init(headers: headers, body: nil))
+                case 401:
+                    let headers: Operations.deleteProject.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteProject.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers: Operations.deleteProject.Output.Forbidden.Headers = .init()
                     try converter.validateContentTypeIfPresent(
@@ -2039,6 +2327,22 @@ public struct Client: APIProtocol {
                         Operations.completeAnalyticsArtifactMultipartUpload.Output.NoContent.Headers =
                             .init()
                     return .noContent(.init(headers: headers, body: nil))
+                case 401:
+                    let headers:
+                        Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized
+                            .Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers:
                         Operations.completeAnalyticsArtifactMultipartUpload.Output.Forbidden.Headers =
@@ -2122,6 +2426,22 @@ public struct Client: APIProtocol {
                         Operations.completeAnalyticsArtifactsUploads.Output.NoContent.Headers =
                             .init()
                     return .noContent(.init(headers: headers, body: nil))
+                case 401:
+                    let headers:
+                        Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized.Headers =
+                            .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers:
                         Operations.completeAnalyticsArtifactsUploads.Output.Forbidden.Headers =
@@ -2214,6 +2534,22 @@ public struct Client: APIProtocol {
                                 transforming: { value in .json(value) }
                             )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers:
+                        Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized
+                            .Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized
+                            .Body = try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers:
                         Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Forbidden
@@ -2306,6 +2642,22 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers:
+                        Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized.Headers =
+                            .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body:
+                        Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized.Body =
+                            try converter.getResponseBodyAsJSON(
+                                Components.Schemas._Error.self,
+                                from: response.body,
+                                transforming: { value in .json(value) }
+                            )
+                    return .unauthorized(.init(headers: headers, body: body))
                 case 403:
                     let headers:
                         Operations.startAnalyticsArtifactMultipartUpload.Output.Forbidden.Headers =

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -1462,6 +1462,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.createCommandEvent.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createCommandEvent.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createCommandEvent.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createCommandEvent.Output.Unauthorized.Headers = .init(),
+                    body: Operations.createCommandEvent.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/analytics/post(createCommandEvent)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.createCommandEvent.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -1776,6 +1807,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.downloadCacheArtifact.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.downloadCacheArtifact.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.downloadCacheArtifact.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.downloadCacheArtifact.Output.Unauthorized.Headers = .init(),
+                    body: Operations.downloadCacheArtifact.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/get(downloadCacheArtifact)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.downloadCacheArtifact.Output.Unauthorized)
             public struct PaymentRequired: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -2030,6 +2092,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.cacheArtifactExists.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cacheArtifactExists.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.cacheArtifactExists.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cacheArtifactExists.Output.Unauthorized.Headers = .init(),
+                    body: Operations.cacheArtifactExists.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/exists/get(cacheArtifactExists)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.cacheArtifactExists.Output.Unauthorized)
             public struct PaymentRequired: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -2379,6 +2472,40 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.completeCacheArtifactMultipartUpload.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/multipart/complete/post(completeCacheArtifactMultipartUpload)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.completeCacheArtifactMultipartUpload.Output.Unauthorized)
             public struct PaymentRequired: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -2605,6 +2732,43 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.generateCacheArtifactMultipartUploadURL.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized
+                        .Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/multipart/generate-url/post(generateCacheArtifactMultipartUploadURL)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(
+                Operations.generateCacheArtifactMultipartUploadURL.Output.Unauthorized
+            )
             public struct PaymentRequired: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -2823,6 +2987,40 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.startCacheArtifactMultipartUpload.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.startCacheArtifactMultipartUpload.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.startCacheArtifactMultipartUpload.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.startCacheArtifactMultipartUpload.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.startCacheArtifactMultipartUpload.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/cache/multipart/start/post(startCacheArtifactMultipartUpload)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.startCacheArtifactMultipartUpload.Output.Unauthorized)
             public struct PaymentRequired: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -3031,6 +3229,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.listOrganizations.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listOrganizations.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.listOrganizations.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listOrganizations.Output.Unauthorized.Headers = .init(),
+                    body: Operations.listOrganizations.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/get(listOrganizations)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.listOrganizations.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -3298,6 +3527,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.showOrganization.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showOrganization.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showOrganization.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showOrganization.Output.Unauthorized.Headers = .init(),
+                    body: Operations.showOrganization.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/get(showOrganization)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.showOrganization.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -3549,6 +3809,38 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.updateOrganization__2_.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganization__2_.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganization__2_.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganization__2_.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.updateOrganization__2_.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/patch(updateOrganization (2))/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.updateOrganization__2_.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -3799,6 +4091,37 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.updateOrganization.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganization.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganization.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganization.Output.Unauthorized.Headers = .init(),
+                    body: Operations.updateOrganization.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/put(updateOrganization)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.updateOrganization.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -3958,6 +4281,37 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.deleteOrganization.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteOrganization.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteOrganization.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteOrganization.Output.Unauthorized.Headers = .init(),
+                    body: Operations.deleteOrganization.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.deleteOrganization.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -4165,6 +4519,37 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.createInvitation.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createInvitation.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createInvitation.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createInvitation.Output.Unauthorized.Headers = .init(),
+                    body: Operations.createInvitation.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createInvitation)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.createInvitation.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -4341,6 +4726,37 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.cancelInvitation.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cancelInvitation.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.cancelInvitation.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cancelInvitation.Output.Unauthorized.Headers = .init(),
+                    body: Operations.cancelInvitation.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelInvitation)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.cancelInvitation.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -4582,6 +4998,38 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.updateOrganizationMember.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganizationMember.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.updateOrganizationMember.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{user_name}/put(updateOrganizationMember)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.updateOrganizationMember.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -4776,6 +5224,38 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.removeOrganizationMember.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.removeOrganizationMember.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.removeOrganizationMember.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{user_name}/delete(removeOrganizationMember)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.removeOrganizationMember.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -4935,6 +5415,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.showOrganizationUsage.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showOrganizationUsage.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showOrganizationUsage.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showOrganizationUsage.Output.Unauthorized.Headers = .init(),
+                    body: Operations.showOrganizationUsage.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.showOrganizationUsage.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -5099,6 +5610,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.listProjects.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.listProjects.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.listProjects.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.listProjects.Output.Unauthorized.Headers = .init(),
+                    body: Operations.listProjects.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/get(listProjects)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.listProjects.Output.Unauthorized)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.
@@ -5247,6 +5789,37 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.createProject.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createProject.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createProject.Output.Unauthorized.Headers = .init(),
+                    body: Operations.createProject.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/post(createProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.createProject.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -5376,6 +5949,37 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.showProject.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showProject.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showProject.Output.Unauthorized.Headers = .init(),
+                    body: Operations.showProject.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(showProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.showProject.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -5534,6 +6138,37 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.cleanCache.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cleanCache.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.cleanCache.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cleanCache.Output.Unauthorized.Headers = .init(),
+                    body: Operations.cleanCache.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/cache/clean/put(cleanCache)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.cleanCache.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -5687,6 +6322,37 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.deleteProject.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteProject.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteProject.Output.Unauthorized.Headers = .init(),
+                    body: Operations.deleteProject.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.deleteProject.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -5878,6 +6544,43 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.completeAnalyticsArtifactMultipartUpload.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized
+                        .Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUpload)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(
+                Operations.completeAnalyticsArtifactMultipartUpload.Output.Unauthorized
+            )
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -6058,6 +6761,40 @@ public enum Operations {
             ///
             /// HTTP response code: `204 noContent`.
             case noContent(Operations.completeAnalyticsArtifactsUploads.Output.NoContent)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.completeAnalyticsArtifactsUploads.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -6253,6 +6990,44 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized
+                        .Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.generateAnalyticsArtifactMultipartUploadURL.Output
+                        .Unauthorized.Headers = .init(),
+                    body: Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized
+                        .Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURL)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(
+                Operations.generateAnalyticsArtifactMultipartUploadURL.Output.Unauthorized
+            )
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.
@@ -6422,6 +7197,40 @@ public enum Operations {
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.startAnalyticsArtifactMultipartUpload.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers:
+                    Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body:
+                    Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized
+                        .Headers = .init(),
+                    body: Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUpload)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.startAnalyticsArtifactMultipartUpload.Output.Unauthorized)
             public struct Forbidden: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.

--- a/Sources/TuistServer/OpenAPI/cloud.yml
+++ b/Sources/TuistServer/OpenAPI/cloud.yml
@@ -504,6 +504,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/CommandEvent'
           description: The command event was created
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -588,6 +594,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/CacheArtifactDownloadURL'
           description: The artifact exists and is downloadable
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
@@ -657,6 +669,12 @@ paths:
                 title: CacheArtifactExistence
                 type: object
           description: The artifact exists
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
@@ -762,6 +780,12 @@ paths:
                 title: CacheArtifactMultipartUploadCompletion
                 type: object
           description: The upload has been completed
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
@@ -831,6 +855,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArtifactMultipartUploadURL'
           description: The URL has been generated
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
@@ -888,6 +918,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArtifactUploadID'
           description: The upload has been started
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
@@ -930,6 +966,12 @@ paths:
                 title: OrganizationList
                 type: object
           description: The list of organizations
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -988,6 +1030,12 @@ paths:
           content:
             application/json: {}
           description: The organization was deleted
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1020,6 +1068,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
           description: The organization
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1076,6 +1130,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The organization could not be updated due to a validation error
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1132,6 +1192,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The organization could not be updated due to a validation error
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1176,6 +1242,12 @@ paths:
           content:
             application/json: {}
           description: The invitation was cancelled
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1227,6 +1299,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The user could not be invited due to a validation error
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1270,6 +1348,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The member could not be removed due to a validation error
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1330,6 +1414,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The member could not be updated due to a validation error
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1363,6 +1453,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrganizationUsage'
           description: The organization usage
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1396,6 +1492,12 @@ paths:
                   - projects
                 type: object
           description: List of projects
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
       summary: List projects the authenticated user has access to.
       tags: []
     post:
@@ -1431,6 +1533,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: The account was not found
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1463,6 +1571,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Project'
           description: The project to show
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1497,6 +1611,12 @@ paths:
       responses:
         204:
           description: The cache has been successfully cleaned
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1525,6 +1645,12 @@ paths:
       responses:
         204:
           description: The project was successfully deleted.
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1569,6 +1695,12 @@ paths:
       responses:
         204:
           description: The upload has been completed
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1613,6 +1745,12 @@ paths:
       responses:
         204:
           description: The command event artifact uploads were successfully finished
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1661,6 +1799,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArtifactMultipartUploadURL'
           description: The URL has been generated
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
@@ -1701,6 +1845,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArtifactUploadID'
           description: The upload has been started
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
         403:
           content:
             application/json:

--- a/Sources/TuistServer/Services/CacheExistsService.swift
+++ b/Sources/TuistServer/Services/CacheExistsService.swift
@@ -19,12 +19,13 @@ public enum CacheExistsServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -33,7 +34,7 @@ public enum CacheExistsServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The remote cache could not be used due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -75,6 +76,11 @@ public final class CacheExistsService: CacheExistsServicing {
             switch forbiddenResponse.body {
             case let .json(error):
                 throw CacheExistsServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/CancelOrganizationInviteService.swift
+++ b/Sources/TuistServer/Services/CancelOrganizationInviteService.swift
@@ -14,12 +14,13 @@ enum CancelOrganizationInviteServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden:
+        case .notFound, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -28,7 +29,7 @@ enum CancelOrganizationInviteServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The invitation could not be cancelled due to an unknown cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -63,6 +64,11 @@ public final class CancelOrganizationInviteService: CancelOrganizationInviteServ
             switch forbidden.body {
             case let .json(error):
                 throw CancelOrganizationInviteServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw CancelOrganizationInviteServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/CleanCacheService.swift
+++ b/Sources/TuistServer/Services/CleanCacheService.swift
@@ -14,12 +14,13 @@ enum CleanCacheServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden:
+        case .notFound, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -28,7 +29,7 @@ enum CleanCacheServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The project clean failed due to an unknown cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -61,6 +62,11 @@ public final class CleanCacheService: CleanCacheServicing {
             switch forbiddenResponse.body {
             case let .json(error):
                 throw CleanCacheServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw CleanCacheServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/CompleteAnalyticsArtifactsUploads.swift
+++ b/Sources/TuistServer/Services/CompleteAnalyticsArtifactsUploads.swift
@@ -16,12 +16,13 @@ public enum CompleteAnalyticsArtifactsUploadsServiceError: FatalError, Equatable
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden:
+        case .notFound, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ public enum CompleteAnalyticsArtifactsUploadsServiceError: FatalError, Equatable
         switch self {
         case let .unknownError(statusCode):
             return "The analytics artifacts uploads could not get completed due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -67,6 +68,11 @@ public final class CompleteAnalyticsArtifactsUploadsService: CompleteAnalyticsAr
             switch notFoundResponse.body {
             case let .json(error):
                 throw CompleteAnalyticsArtifactsUploadsServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -16,12 +16,13 @@ public protocol CreateCommandEventServicing {
 enum CreateCommandEventServiceError: FatalError {
     case unknownError(Int)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden:
+        case .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ enum CreateCommandEventServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The organization could not be created due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message):
+        case let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -98,6 +99,11 @@ public final class CreateCommandEventService: CreateCommandEventServicing {
             switch forbiddenResponse.body {
             case let .json(error):
                 throw CreateCommandEventServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/CreateOrganizationInviteService.swift
+++ b/Sources/TuistServer/Services/CreateOrganizationInviteService.swift
@@ -17,12 +17,13 @@ enum CreateOrganizationInviteServiceError: FatalError {
     case notFound(String)
     case forbidden(String)
     case badRequest(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden, .badRequest:
+        case .notFound, .forbidden, .badRequest, .unauthorized:
             return .abort
         }
     }
@@ -31,7 +32,7 @@ enum CreateOrganizationInviteServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The user could not be invited due to an unknown cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message), let .badRequest(message):
+        case let .notFound(message), let .forbidden(message), let .badRequest(message), let .unauthorized(message):
             return message
         }
     }
@@ -76,6 +77,11 @@ public final class CreateOrganizationInviteService: CreateOrganizationInviteServ
             }
         case let .undocumented(statusCode: statusCode, _):
             throw CreateOrganizationInviteServiceError.unknownError(statusCode)
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
+            }
         }
     }
 }

--- a/Sources/TuistServer/Services/CreateProjectService.swift
+++ b/Sources/TuistServer/Services/CreateProjectService.swift
@@ -16,12 +16,13 @@ enum CreateProjectServiceError: FatalError {
     case unknownError(Int)
     case forbidden(String)
     case badRequest(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .badRequest:
+        case .forbidden, .badRequest, .unauthorized:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ enum CreateProjectServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The project could not be created due to an unknown Cloud response of \(statusCode)."
-        case let .forbidden(message), let .badRequest(message):
+        case let .forbidden(message), let .badRequest(message), let .unauthorized(message):
             return message
         }
     }
@@ -73,6 +74,11 @@ public final class CreateProjectService: CreateProjectServicing {
             switch badRequestResponse.body {
             case let .json(error):
                 throw CreateProjectServiceError.badRequest(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/DeleteOrganizationService.swift
+++ b/Sources/TuistServer/Services/DeleteOrganizationService.swift
@@ -13,12 +13,13 @@ enum DeleteOrganizationServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound:
+        case .forbidden, .unauthorized, .notFound:
             return .abort
         }
     }
@@ -27,7 +28,7 @@ enum DeleteOrganizationServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The organization could not be deleted due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message):
+        case let .forbidden(message), let .unauthorized(message), let .notFound(message):
             return message
         }
     }
@@ -62,6 +63,11 @@ public final class DeleteOrganizationService: DeleteOrganizationServicing {
             switch forbidden.body {
             case let .json(error):
                 throw DeleteOrganizationServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw DeleteOrganizationServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/DeleteProjectService.swift
+++ b/Sources/TuistServer/Services/DeleteProjectService.swift
@@ -15,12 +15,13 @@ enum DeleteProjectServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound:
+        case .forbidden, .notFound, .unauthorized:
             return .abort
         }
     }
@@ -29,7 +30,7 @@ enum DeleteProjectServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The project could not be deleted due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message):
+        case let .forbidden(message), let .unauthorized(message), let .notFound(message):
             return message
         }
     }
@@ -62,6 +63,11 @@ public final class DeleteProjectService: DeleteProjectServicing {
             switch forbidden.body {
             case let .json(error):
                 throw DeleteProjectServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw DeleteProjectServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/GetCacheService.swift
+++ b/Sources/TuistServer/Services/GetCacheService.swift
@@ -19,12 +19,13 @@ public enum GetCacheServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -33,7 +34,7 @@ public enum GetCacheServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The remote cache could not be used due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -77,6 +78,11 @@ public final class GetCacheService: GetCacheServicing {
             switch notFound.body {
             case let .json(error):
                 throw GetCacheServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/GetOrganizationService.swift
+++ b/Sources/TuistServer/Services/GetOrganizationService.swift
@@ -15,12 +15,13 @@ enum GetOrganizationServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound:
+        case .forbidden, .notFound, .unauthorized:
             return .abort
         }
     }
@@ -29,7 +30,7 @@ enum GetOrganizationServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "We could not get the organization due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message):
+        case let .forbidden(message), let .notFound(message), let .unauthorized(message):
             return message
         }
     }
@@ -66,6 +67,11 @@ public final class GetOrganizationService: GetOrganizationServicing {
             switch forbidden.body {
             case let .json(error):
                 throw GetOrganizationServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw GetOrganizationServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/GetOrganizationUsage.swift
+++ b/Sources/TuistServer/Services/GetOrganizationUsage.swift
@@ -15,12 +15,13 @@ enum GetOrganizationUsageServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound:
+        case .forbidden, .notFound, .unauthorized:
             return .abort
         }
     }
@@ -29,7 +30,7 @@ enum GetOrganizationUsageServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "We could not get the OrganizationUsage due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message):
+        case let .forbidden(message), let .notFound(message), let .unauthorized(message):
             return message
         }
     }
@@ -66,6 +67,11 @@ public final class GetOrganizationUsageService: GetOrganizationUsageServicing {
             switch forbidden.body {
             case let .json(error):
                 throw GetOrganizationUsageServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw GetOrganizationUsageServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/GetProjectService.swift
+++ b/Sources/TuistServer/Services/GetProjectService.swift
@@ -16,12 +16,13 @@ enum GetProjectServiceError: FatalError {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound:
+        case .forbidden, .notFound, .unauthorized:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ enum GetProjectServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "We could not get the project due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message):
+        case let .forbidden(message), let .notFound(message), let .unauthorized(message):
             return message
         }
     }
@@ -69,6 +70,11 @@ public final class GetProjectService: GetProjectServicing {
             switch forbidden.body {
             case let .json(error):
                 throw GetProjectServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw GetProjectServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/ListProjectsService.swift
+++ b/Sources/TuistServer/Services/ListProjectsService.swift
@@ -18,11 +18,14 @@ public protocol ListProjectsServicing {
 
 enum ListProjectsServiceError: FatalError {
     case unknownError(Int)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
+        case .unauthorized:
+            return .abort
         }
     }
 
@@ -30,6 +33,8 @@ enum ListProjectsServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The project could not be listed due to an unknown cloud response of \(statusCode)."
+        case let .unauthorized(message):
+            return message
         }
     }
 }
@@ -65,6 +70,11 @@ public final class ListProjectsService: ListProjectsServicing {
             }
         case let .undocumented(statusCode: statusCode, _):
             throw ListProjectsServiceError.unknownError(statusCode)
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
+            }
         }
     }
 }

--- a/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
@@ -18,12 +18,13 @@ public enum MultipartUploadCompleteAnalyticsServiceError: FatalError, Equatable 
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden:
+        case .notFound, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -32,7 +33,7 @@ public enum MultipartUploadCompleteAnalyticsServiceError: FatalError, Equatable 
         switch self {
         case let .unknownError(statusCode):
             return "The multi-part upload could not get completed due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -78,6 +79,11 @@ public final class MultipartUploadCompleteAnalyticsService: MultipartUploadCompl
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadCompleteAnalyticsServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadCompleteCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadCompleteCacheService.swift
@@ -22,12 +22,13 @@ public enum MultipartUploadCompleteCacheServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -36,7 +37,7 @@ public enum MultipartUploadCompleteCacheServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The multi-part upload could not get completed due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -84,6 +85,11 @@ public final class MultipartUploadCompleteCacheService: MultipartUploadCompleteC
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadCompleteCacheServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
@@ -17,12 +17,13 @@ public enum MultipartUploadGenerateURLAnalyticsServiceError: FatalError, Equatab
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden:
+        case .notFound, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -31,7 +32,7 @@ public enum MultipartUploadGenerateURLAnalyticsServiceError: FatalError, Equatab
         switch self {
         case let .unknownError(statusCode):
             return "The generation of a multi-part upload URL failed due to an unknown Tuist response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -79,6 +80,11 @@ public final class MultipartUploadGenerateURLAnalyticsService: MultipartUploadGe
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadGenerateURLAnalyticsServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadGenerateURLCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadGenerateURLCacheService.swift
@@ -21,12 +21,13 @@ public enum MultipartUploadGenerateURLCacheServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -35,7 +36,7 @@ public enum MultipartUploadGenerateURLCacheServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The generation of a multi-part upload URL failed due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -84,6 +85,11 @@ public final class MultipartUploadGenerateURLCacheService: MultipartUploadGenera
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadGenerateURLCacheServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
@@ -16,12 +16,13 @@ public enum MultipartUploadStartAnalyticsServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ public enum MultipartUploadStartAnalyticsServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The remote cache artifact could not be uploaded due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -68,6 +69,11 @@ public final class MultipartUploadStartAnalyticsService: MultipartUploadStartAna
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadStartAnalyticsServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadStartCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartCacheService.swift
@@ -19,12 +19,13 @@ public enum MultipartUploadStartCacheServiceError: FatalError, Equatable {
     case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
+    case unauthorized(String)
 
     public var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden:
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -33,7 +34,7 @@ public enum MultipartUploadStartCacheServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The remote cache artifact could not be uploaded due to an unknown Tuist Cloud response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message):
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -78,6 +79,11 @@ public final class MultipartUploadStartCacheService: MultipartUploadStartCacheSe
             switch notFoundResponse.body {
             case let .json(error):
                 throw MultipartUploadStartCacheServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/RemoveOrganizationMemberService.swift
+++ b/Sources/TuistServer/Services/RemoveOrganizationMemberService.swift
@@ -15,12 +15,13 @@ enum RemoveOrganizationMemberServiceError: FatalError {
     case notFound(String)
     case forbidden(String)
     case badRequest(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden, .badRequest:
+        case .notFound, .forbidden, .badRequest, .unauthorized:
             return .abort
         }
     }
@@ -29,7 +30,7 @@ enum RemoveOrganizationMemberServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The member could not be removed due to an unknown cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message), let .badRequest(message):
+        case let .notFound(message), let .forbidden(message), let .badRequest(message), let .unauthorized(message):
             return message
         }
     }
@@ -73,6 +74,11 @@ public final class RemoveOrganizationMemberService: RemoveOrganizationMemberServ
             switch badRequestResponse.body {
             case let .json(error):
                 throw RemoveOrganizationMemberServiceError.badRequest(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/UpdateOrganizationMemberService.swift
+++ b/Sources/TuistServer/Services/UpdateOrganizationMemberService.swift
@@ -16,12 +16,13 @@ enum UpdateOrganizationMemberServiceError: FatalError {
     case notFound(String)
     case forbidden(String)
     case badRequest(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .forbidden, .badRequest:
+        case .notFound, .forbidden, .unauthorized, .badRequest:
             return .abort
         }
     }
@@ -30,7 +31,7 @@ enum UpdateOrganizationMemberServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "The member could not be updated due to an unknown cloud response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message), let .badRequest(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message), let .badRequest(message):
             return message
         }
     }
@@ -71,6 +72,11 @@ public final class UpdateOrganizationMemberService: UpdateOrganizationMemberServ
             switch forbiddenResponse.body {
             case let .json(error):
                 throw UpdateOrganizationMemberServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .undocumented(statusCode: statusCode, _):
             throw UpdateOrganizationMemberServiceError.unknownError(statusCode)

--- a/Sources/TuistServer/Services/UpdateOrganizationService.swift
+++ b/Sources/TuistServer/Services/UpdateOrganizationService.swift
@@ -17,12 +17,13 @@ enum UpdateOrganizationServiceError: FatalError {
     case notFound(String)
     case forbidden(String)
     case badRequest(String)
+    case unauthorized(String)
 
     var type: ErrorType {
         switch self {
         case .unknownError:
             return .bug
-        case .forbidden, .notFound, .badRequest:
+        case .forbidden, .notFound, .badRequest, .unauthorized:
             return .abort
         }
     }
@@ -31,7 +32,7 @@ enum UpdateOrganizationServiceError: FatalError {
         switch self {
         case let .unknownError(statusCode):
             return "We could not get the organization due to an unknown cloud response of \(statusCode)."
-        case let .forbidden(message), let .notFound(message), let .badRequest(message):
+        case let .forbidden(message), let .notFound(message), let .badRequest(message), let .unauthorized(message):
             return message
         }
     }
@@ -89,6 +90,11 @@ public final class UpdateOrganizationService: UpdateOrganizationServicing {
             switch forbidden.body {
             case let .json(error):
                 throw UpdateOrganizationServiceError.forbidden(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
             }
         case let .badRequest(badRequest):
             switch badRequest.body {

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1297,7 +1297,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .willProduce { path in
                 (path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])))
             }
-        var testedSchemes: [String] = []
         given(xcodebuildController)
             .test(
                 .any,


### PR DESCRIPTION
### Short description 📝

Handle unauthorized server errors.

### How to test the changes locally 🧐

Run:
```
CI=true TUIST_CONFIG_CLOUD_TOKEN="invalid-token" tuist cloud project list
```

You should receive a "You need to be authenticated to access this resource" error instead of:
```
The project could not be created due to an unknown Cloud response of 401.
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
