### PR TITLE
Run only TuistDependenciesAcceptanceTests in the tuist_dependencies_acceptance_tests workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -201,7 +201,7 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test
+        script: mise x -- tuist test TuistDependenciesAcceptanceTests
     triggering:
       << : *branch_triggering
 


### PR DESCRIPTION
### Short description 📝

We were running _all_ tests in the `tuist_dependencies_acceptance_tests` effectively running them twice. This also lead to some intermittent failures tied to this workflow such as: https://github.com/tuist/tuist/pull/6381/checks?check_run_id=26781128677

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
