### PR TITLE
Support run on xcode cloud

### DIFF
--- a/Sources/TuistAutomation/Utilities/TargetRunner.swift
+++ b/Sources/TuistAutomation/Utilities/TargetRunner.swift
@@ -15,6 +15,7 @@ public protocol TargetRunning {
     ///   - version: Specific version, ignored if nil
     ///   - minVersion: Minimum version of the OS
     ///   - deviceName: The name of the simulator device to run the target on, if none provided uses a default device.
+    ///   - derivedDataPath: An optional path for derived data.
     ///   - arguments: Arguments to forward to the runnable target when running.
     func runTarget(
         _ target: GraphTarget,
@@ -25,6 +26,7 @@ public protocol TargetRunning {
         minVersion: Version?,
         version: Version?,
         deviceName: String?,
+        derivedDataPath: AbsolutePath?,
         arguments: [String]
     ) async throws
 
@@ -83,6 +85,7 @@ public final class TargetRunner: TargetRunning {
         minVersion: Version?,
         version: Version?,
         deviceName: String?,
+        derivedDataPath: AbsolutePath?,
         arguments: [String]
     ) async throws {
         try assertCanRunTarget(target.target)
@@ -92,7 +95,7 @@ public final class TargetRunner: TargetRunning {
         let xcodeBuildDirectory = try xcodeProjectBuildDirectoryLocator.locate(
             platform: platform,
             projectPath: workspacePath,
-            derivedDataPath: nil,
+            derivedDataPath: derivedDataPath,
             configuration: configuration
         )
         let runnablePath = xcodeBuildDirectory.appending(component: target.target.productNameWithExtension)

--- a/Sources/TuistAutomationTesting/Utilities/MockTargetRunner.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockTargetRunner.swift
@@ -7,7 +7,7 @@ public final class MockTargetRunner: TargetRunning {
     public init() {}
 
     public var runTargetStub: (
-        (GraphTarget, AbsolutePath, String, String?, Version?, Version?, String?, [String]) throws
+        (GraphTarget, AbsolutePath, String, String?, Version?, Version?, String?, AbsolutePath?, [String]) throws
             -> Void
     )?
     public func runTarget(
@@ -19,9 +19,10 @@ public final class MockTargetRunner: TargetRunning {
         minVersion: Version?,
         version: Version?,
         deviceName: String?,
+        derivedDataPath: AbsolutePath?,
         arguments: [String]
     ) throws {
-        try runTargetStub?(target, workspacePath, schemeName, configuration, minVersion, version, deviceName, arguments)
+        try runTargetStub?(target, workspacePath, schemeName, configuration, minVersion, version, deviceName, derivedDataPath, arguments)
     }
 
     public var assertCanRunTargetStub: ((Target) throws -> Void)?

--- a/Sources/TuistAutomationTesting/Utilities/MockTargetRunner.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockTargetRunner.swift
@@ -22,7 +22,17 @@ public final class MockTargetRunner: TargetRunning {
         derivedDataPath: AbsolutePath?,
         arguments: [String]
     ) throws {
-        try runTargetStub?(target, workspacePath, schemeName, configuration, minVersion, version, deviceName, derivedDataPath, arguments)
+        try runTargetStub?(
+            target,
+            workspacePath,
+            schemeName,
+            configuration,
+            minVersion,
+            version,
+            deviceName,
+            derivedDataPath,
+            arguments
+        )
     }
 
     public var assertCanRunTargetStub: ((Target) throws -> Void)?

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -107,6 +107,13 @@ final class RunService {
 
         try targetRunner.assertCanRunTarget(graphTarget.target)
 
+        let derivedDataPath = try? System.shared.env["CI_DERIVED_DATA_PATH"].map {
+            try AbsolutePath(
+                validating: $0,
+                relativeTo: FileHandler.shared.currentPath
+            )
+        }
+
         try await targetBuilder.buildTarget(
             graphTarget,
             platform: try graphTarget.target.servicePlatform,
@@ -115,7 +122,7 @@ final class RunService {
             clean: clean,
             configuration: configuration,
             buildOutputPath: nil,
-            derivedDataPath: nil,
+            derivedDataPath: derivedDataPath,
             device: device,
             osVersion: version?.version().map { .init(stringLiteral: $0.description) },
             rosetta: rosetta,
@@ -154,6 +161,7 @@ final class RunService {
             minVersion: minVersion,
             version: version,
             deviceName: device,
+            derivedDataPath: derivedDataPath,
             arguments: arguments
         )
     }

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -161,7 +161,8 @@ final class RunServiceTests: TuistUnitTestCase {
         let deviceName = "iPhone 11"
         let arguments = ["-arg1", "--arg2", "SomeArgument"]
         targetRunner
-            .runTargetStub = { _, _workspacePath, _schemeName, _configuration, _minVersion, _version, _deviceName, _, _arguments in
+            .runTargetStub =
+            { _, _workspacePath, _schemeName, _configuration, _minVersion, _version, _deviceName, _, _arguments in
                 // Then
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_schemeName, schemeName)

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -161,7 +161,7 @@ final class RunServiceTests: TuistUnitTestCase {
         let deviceName = "iPhone 11"
         let arguments = ["-arg1", "--arg2", "SomeArgument"]
         targetRunner
-            .runTargetStub = { _, _workspacePath, _schemeName, _configuration, _minVersion, _version, _deviceName, _arguments in
+            .runTargetStub = { _, _workspacePath, _schemeName, _configuration, _minVersion, _version, _deviceName, _, _arguments in
                 // Then
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_schemeName, schemeName)


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6452>

### Short description 📝

When executing `tuist run MyCommandLineTool` on Xcode Cloud, the command line tool is built to the directory specified by `$CI_DERIVED_DATA_PATH`, but tuist looks for (and fails to find) the build product in `/Users/local/Library/Developer/Xcode/DerivedData/`. This change has `tuist run` check for `$CI_DERIVED_DATA_PATH` and if present uses that as the derived data dir for both the build and run phases.

### How to test the changes locally 🧐

1. `tuist generate`
2. Select the `tuist` scheme
3. Set the run arguments to `install`
4. Set the working dir to `<dir with your clone of the branch>/fixtures/command_line_tool_basic`
5. Build and run
6. Set the run arguments to `run CommandLineTool`
7. Build and run

Expected: "CommandLineTool was run" in the output

8. Add a `CI_DERIVED_DATA_PATH` env var with value `<dir with your clone of the branch>/test_derived_data`
9. Build and run

Expected: "CommandLineTool was run" in the output

10. Run `<dir with your clone of the branch>/test_derived_data/Build/Products/Debug/CommandLineTool` from the command line

Expected: "CommandLineTool was run" in the output

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
