### PR TITLE
Align client plan with server

### DIFF
--- a/Sources/TuistServer/Models/CloudOrganization.swift
+++ b/Sources/TuistServer/Models/CloudOrganization.swift
@@ -2,24 +2,22 @@ import Foundation
 
 /// Cloud organization
 public struct CloudOrganization: Codable {
-    public enum Plan: Codable, RawRepresentable {
-        case team, none
+    public enum Plan: String, Codable {
+        case air
+        case pro
+        case enterprise
+        case none
 
-        public init(rawValue: String) {
-            switch rawValue {
-            case "team":
-                self = .team
-            default:
+        public init(_ organization: Components.Schemas.Organization.planPayload) {
+            switch organization {
+            case .air:
+                self = .air
+            case .pro:
+                self = .pro
+            case .enterprise:
+                self = .enterprise
+            case .none, .undocumented:
                 self = .none
-            }
-        }
-
-        public var rawValue: String {
-            switch self {
-            case .team:
-                return "team"
-            case .none:
-                return "none"
             }
         }
     }
@@ -95,7 +93,7 @@ extension CloudOrganization {
     init(_ organization: Components.Schemas.Organization) {
         id = Int(organization.id)
         name = organization.name
-        plan = Plan(rawValue: organization.plan.rawValue)
+        plan = Plan(organization.plan)
         members = organization.members.map(Member.init)
         invitations = organization.invitations.map(CloudInvitation.init)
         if let ssoProvider = organization.sso_provider,
@@ -132,7 +130,7 @@ extension CloudOrganization.Member {
         public static func test(
             id: Int = 0,
             name: String = "test",
-            plan: Plan = .team,
+            plan: Plan = .air,
             members: [Member] = [],
             invitations: [CloudInvitation] = [],
             ssoOrganization: SSOOrganization? = nil

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -902,22 +902,31 @@ public enum Components {
             public enum planPayload: RawRepresentable, Codable, Equatable, Hashable, Sendable,
                 _AutoLosslessStringConvertible, CaseIterable
             {
-                case team
+                case air
+                case pro
+                case enterprise
+                case none
                 /// Parsed a raw value that was not defined in the OpenAPI document.
                 case undocumented(String)
                 public init?(rawValue: String) {
                     switch rawValue {
-                    case "team": self = .team
+                    case "air": self = .air
+                    case "pro": self = .pro
+                    case "enterprise": self = .enterprise
+                    case "none": self = .none
                     default: self = .undocumented(rawValue)
                     }
                 }
                 public var rawValue: String {
                     switch self {
                     case let .undocumented(string): return string
-                    case .team: return "team"
+                    case .air: return "air"
+                    case .pro: return "pro"
+                    case .enterprise: return "enterprise"
+                    case .none: return "none"
                     }
                 }
-                public static var allCases: [planPayload] { [.team] }
+                public static var allCases: [planPayload] { [.air, .pro, .enterprise, .none] }
             }
             /// The plan associated with the organization
             ///

--- a/Sources/TuistServer/OpenAPI/cloud.yml
+++ b/Sources/TuistServer/OpenAPI/cloud.yml
@@ -285,7 +285,10 @@ components:
         plan:
           description: The plan associated with the organization
           enum:
-            - team
+            - air
+            - pro
+            - enterprise
+            - none
           type: string
         sso_organization_id:
           description: The organization ID associated with the SSO provider

--- a/Tests/TuistKitTests/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Cloud/CloudOrganizationShowServiceTests.swift
@@ -46,7 +46,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
             .willReturn(
                 .test(
                     name: "test-one",
-                    plan: .team,
+                    plan: .air,
                     members: [
                         .test(
                             name: "name-one",
@@ -83,7 +83,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         XCTAssertPrinterOutputContains("""
         \(TerminalStyle.bold.open)Organization\(TerminalStyle.reset.open)
         Name: test-one
-        Plan: Team
+        Plan: Air
 
         \(TerminalStyle.bold.open)Usage\(TerminalStyle.reset.open) (current calendar month)
         Remote cache hits: 210
@@ -106,7 +106,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
             .willReturn(
                 .test(
                     name: "test-one",
-                    plan: .team,
+                    plan: .pro,
                     ssoOrganization: .google("tuist.io")
                 )
             )
@@ -126,7 +126,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
             """
             \(TerminalStyle.bold.open)Organization\(TerminalStyle.reset.open)
             Name: test-one
-            Plan: Team
+            Plan: Pro
             SSO: Google (tuist.io)
             """
         )


### PR DESCRIPTION
### Short description 📝

We are updating the Tuist plans. This PR aligns the plans with the server definition.

### How to test the changes locally 🧐

Run `tuist cloud organization show my-org` and you should see your current plan.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x]  Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
