### PR TITLE
Flatten the tuist-cloud cache directory into the tuist cache directory

### DIFF
--- a/Sources/TuistCore/Cache/CacheCategory.swift
+++ b/Sources/TuistCore/Cache/CacheCategory.swift
@@ -18,6 +18,12 @@ public enum CacheCategory: String, CaseIterable, RawRepresentable {
     /// The Tuist Runs cache
     case runs
 
+    /// The Tuist Binaries cache
+    case binaries
+
+    /// The Tuist Selective Tests cache
+    case selectiveTests
+
     public var directoryName: String {
         switch self {
         case .plugins:
@@ -32,20 +38,15 @@ public enum CacheCategory: String, CaseIterable, RawRepresentable {
             return "EditProjects"
         case .runs:
             return "Runs"
+        case .binaries:
+            return "Binaries"
+        case .selectiveTests:
+            return "SelectiveTests"
         }
     }
+}
 
-    public enum App: String, CaseIterable {
-        case binaries
-        case selectiveTests
-
-        public var directoryName: String {
-            switch self {
-            case .binaries:
-                return "BinaryCache"
-            case .selectiveTests:
-                return "SelectiveTests"
-            }
-        }
-    }
+public enum RemoteCacheCategory {
+    case binaries
+    case selectiveTests
 }

--- a/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
+++ b/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
@@ -7,13 +7,7 @@ import XcodeGraph
 @Mockable
 public protocol CacheDirectoriesProviding {
     /// Returns the cache directory for a Tuist cache category
-    func tuistCacheDirectory(for category: CacheCategory) throws -> AbsolutePath
-
-    func tuistCloudCacheDirectory(for category: CacheCategory.App) throws -> AbsolutePath
-    func tuistCloudSelectiveTestsDirectory() throws -> AbsolutePath
-    func tuistCloudBinaryCacheDirectory() throws -> AbsolutePath
-    func tuistCloudCacheDirectory() throws -> AbsolutePath
-
+    func cacheDirectory(for category: CacheCategory) throws -> AbsolutePath
     func cacheDirectory() throws -> AbsolutePath
 }
 
@@ -28,12 +22,8 @@ public final class CacheDirectoriesProvider: CacheDirectoriesProviding {
         self.init(fileHandler: FileHandler.shared)
     }
 
-    public func tuistCacheDirectory(for category: CacheCategory) throws -> AbsolutePath {
-        return CacheDirectoriesProvider.tuistCacheDirectory(for: category, cacheDirectory: try cacheDirectory())
-    }
-
-    public static func tuistCacheDirectory(for category: CacheCategory, cacheDirectory: AbsolutePath) -> AbsolutePath {
-        return cacheDirectory.appending(components: ["tuist", category.directoryName])
+    public func cacheDirectory(for category: CacheCategory) throws -> AbsolutePath {
+        try cacheDirectory().appending(components: ["tuist", category.directoryName])
     }
 
     public func cacheDirectory() throws -> Path.AbsolutePath {
@@ -42,28 +32,5 @@ public final class CacheDirectoriesProvider: CacheDirectoriesProviding {
         } else {
             return FileHandler.shared.homeDirectory.appending(components: ".cache")
         }
-    }
-
-    public static func tuistCloudCacheDirectory(for category: CacheCategory.App, cacheDirectory: AbsolutePath) -> AbsolutePath {
-        cacheDirectory.appending(components: ["tuist-cloud", category.directoryName])
-    }
-
-    public func tuistCloudCacheDirectory(for category: CacheCategory.App) throws -> AbsolutePath {
-        switch category {
-        case .binaries: return try tuistCloudBinaryCacheDirectory()
-        case .selectiveTests: return try tuistCloudSelectiveTestsDirectory()
-        }
-    }
-
-    public func tuistCloudSelectiveTestsDirectory() throws -> AbsolutePath {
-        try tuistCloudCacheDirectory().appending(component: CacheCategory.App.selectiveTests.directoryName)
-    }
-
-    public func tuistCloudBinaryCacheDirectory() throws -> AbsolutePath {
-        try tuistCloudCacheDirectory().appending(component: CacheCategory.App.binaries.directoryName)
-    }
-
-    public func tuistCloudCacheDirectory() throws -> AbsolutePath {
-        try cacheDirectory().appending(components: ["tuist-cloud"])
     }
 }

--- a/Sources/TuistCore/Cache/CacheDirectoriesProviderFactory.swift
+++ b/Sources/TuistCore/Cache/CacheDirectoriesProviderFactory.swift
@@ -13,7 +13,7 @@ public final class CacheDirectoriesProviderFactory: CacheDirectoriesProviderFact
     public func cacheDirectories() throws -> CacheDirectoriesProviding {
         let provider = CacheDirectoriesProvider()
         for category in CacheCategory.allCases {
-            let directory = try provider.tuistCacheDirectory(for: category)
+            let directory = try provider.cacheDirectory(for: category)
             if !FileHandler.shared.exists(directory) {
                 try FileHandler.shared.createFolder(directory)
             }

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -135,7 +135,7 @@ final class ProjectEditor: ProjectEditing {
         let configPath = manifestFilesLocator.locateConfig(at: editingPath)
         let cacheDirectory = try cacheDirectoryProviderFactory.cacheDirectories()
         let projectDescriptionHelpersBuilder = projectDescriptionHelpersBuilderFactory.projectDescriptionHelpersBuilder(
-            cacheDirectory: try cacheDirectory.tuistCacheDirectory(for: .projectDescriptionHelpers)
+            cacheDirectory: try cacheDirectory.cacheDirectory(for: .projectDescriptionHelpers)
         )
         let packageManifestPath = manifestFilesLocator.locatePackageManifest(at: editingPath)
 

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -56,7 +56,7 @@ final class EditService {
 
         if !permanent {
             let cacheDirectoryProvider = try cacheDirectoryProviderFactory.cacheDirectories()
-            let cacheDirectory = try cacheDirectoryProvider.tuistCacheDirectory(for: .editProjects)
+            let cacheDirectory = try cacheDirectoryProvider.cacheDirectory(for: .editProjects)
             let cachedManifestDirectory = cacheDirectory.appending(component: path.pathString.md5)
 
             guard let selectedXcode = try XcodeController.shared.selected() else {

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -352,7 +352,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         config: Config
     ) throws -> AbsolutePath? {
         let runResultBundlePath = try cacheDirectoryProviderFactory.cacheDirectories()
-            .tuistCacheDirectory(for: .runs)
+            .cacheDirectory(for: .runs)
             .appending(components: runId, Constants.resultBundleName)
 
         if config.cloud == nil {

--- a/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
+++ b/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
@@ -50,7 +50,7 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
         )
 
         let runDirectory = try cacheDirectoriesProviderFactory.cacheDirectories()
-            .tuistCacheDirectory(for: .runs)
+            .cacheDirectory(for: .runs)
             .appending(component: commandEvent.runId)
 
         let resultBundle = runDirectory

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -54,7 +54,7 @@ public class CachedManifestLoader: ManifestLoading {
         self.cacheDirectoryProviderFactory = cacheDirectoryProviderFactory
         self.tuistVersion = tuistVersion
         cacheDirectory = ThrowableCaching {
-            try cacheDirectoryProviderFactory.cacheDirectories().tuistCacheDirectory(for: .manifests)
+            try cacheDirectoryProviderFactory.cacheDirectories().cacheDirectory(for: .manifests)
         }
     }
 

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -360,7 +360,7 @@ public class ManifestLoader: ManifestLoading {
         ]
         let projectDescriptionHelpersCacheDirectory = try cacheDirectoryProviderFactory
             .cacheDirectories()
-            .tuistCacheDirectory(for: .projectDescriptionHelpers)
+            .cacheDirectory(for: .projectDescriptionHelpers)
 
         let projectDescriptionHelperArguments: [String] = try {
             switch manifest {

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -239,7 +239,7 @@ public final class PluginService: PluginServicing {
         config _: Config
     ) throws -> AbsolutePath {
         let cacheDirectories = try cacheDirectoryProviderFactory.cacheDirectories()
-        let cacheDirectory = try cacheDirectories.tuistCacheDirectory(for: .plugins)
+        let cacheDirectory = try cacheDirectories.cacheDirectory(for: .plugins)
         let fingerprint = "\(url)-\(gitId)".md5
         return cacheDirectory
             .appending(component: fingerprint)

--- a/Sources/TuistServer/Cache/CacheStoring.swift
+++ b/Sources/TuistServer/Cache/CacheStoring.swift
@@ -39,18 +39,18 @@ public struct CacheStorableItem: Hashable, Equatable {
 public protocol CacheStoring {
     func fetch(
         _ items: Set<CacheStorableItem>,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> [CacheStorableItem: AbsolutePath]
     func store(
         _ items: [CacheStorableItem: [AbsolutePath]],
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws
 }
 
 extension CacheStoring {
     public func fetch(
         _ targets: Set<CacheStorableTarget>,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> [CacheStorableTarget: AbsolutePath] {
         Dictionary(
             uniqueKeysWithValues: try await fetch(
@@ -66,7 +66,7 @@ extension CacheStoring {
 
     public func store(
         _ targets: [CacheStorableTarget: [AbsolutePath]],
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws {
         let items = Dictionary(uniqueKeysWithValues: targets.map { target, paths -> (CacheStorableItem, [AbsolutePath]) in
             (CacheStorableItem(name: target.name, hash: target.hash), paths)

--- a/Sources/TuistServer/Cache/EmptyCacheStorage.swift
+++ b/Sources/TuistServer/Cache/EmptyCacheStorage.swift
@@ -8,10 +8,10 @@ public final class EmptyCacheStorage: CacheStoring {
 
     public func fetch(
         _: Set<CacheStorableItem>,
-        cacheCategory _: CacheCategory.App
+        cacheCategory _: RemoteCacheCategory
     ) async throws -> [CacheStorableItem: AbsolutePath] {
         [:]
     }
 
-    public func store(_: [CacheStorableItem: [AbsolutePath]], cacheCategory _: CacheCategory.App) async throws {}
+    public func store(_: [CacheStorableItem: [AbsolutePath]], cacheCategory _: RemoteCacheCategory) async throws {}
 }

--- a/Sources/TuistServer/OpenAPI/CacheCategoryParameter+Extras.swift
+++ b/Sources/TuistServer/OpenAPI/CacheCategoryParameter+Extras.swift
@@ -1,7 +1,7 @@
 import TuistCore
 
 extension Components.Schemas.CacheCategory {
-    init(_ cacheCategory: CacheCategory.App) {
+    init(_ cacheCategory: RemoteCacheCategory) {
         switch cacheCategory {
         case .binaries:
             self = .builds

--- a/Sources/TuistServer/Services/CacheExistsService.swift
+++ b/Sources/TuistServer/Services/CacheExistsService.swift
@@ -10,7 +10,7 @@ public protocol CacheExistsServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws
 }
 
@@ -48,7 +48,7 @@ public final class CacheExistsService: CacheExistsServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws {
         let client = Client.authenticated(serverURL: serverURL)
 

--- a/Sources/TuistServer/Services/GetCacheService.swift
+++ b/Sources/TuistServer/Services/GetCacheService.swift
@@ -10,7 +10,7 @@ public protocol GetCacheServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> ServerCacheArtifact
 }
 
@@ -48,7 +48,7 @@ public final class GetCacheService: GetCacheServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> ServerCacheArtifact {
         let client = Client.authenticated(serverURL: serverURL)
 

--- a/Sources/TuistServer/Services/MultipartUploadCompleteCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadCompleteCacheService.swift
@@ -11,7 +11,7 @@ public protocol MultipartUploadCompleteCacheServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App,
+        cacheCategory: RemoteCacheCategory,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)]
     ) async throws
@@ -51,7 +51,7 @@ public final class MultipartUploadCompleteCacheService: MultipartUploadCompleteC
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App,
+        cacheCategory: RemoteCacheCategory,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)]
     ) async throws {

--- a/Sources/TuistServer/Services/MultipartUploadGenerateURLCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadGenerateURLCacheService.swift
@@ -10,7 +10,7 @@ public protocol MultipartUploadGenerateURLCacheServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App,
+        cacheCategory: RemoteCacheCategory,
         uploadId: String,
         partNumber: Int
     ) async throws -> String
@@ -50,7 +50,7 @@ public final class MultipartUploadGenerateURLCacheService: MultipartUploadGenera
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App,
+        cacheCategory: RemoteCacheCategory,
         uploadId: String,
         partNumber: Int
     ) async throws -> String {

--- a/Sources/TuistServer/Services/MultipartUploadStartCacheService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartCacheService.swift
@@ -10,7 +10,7 @@ public protocol MultipartUploadStartCacheServicing {
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> String
 }
 
@@ -48,7 +48,7 @@ public final class MultipartUploadStartCacheService: MultipartUploadStartCacheSe
         projectId: String,
         hash: String,
         name: String,
-        cacheCategory: CacheCategory.App
+        cacheCategory: RemoteCacheCategory
     ) async throws -> String {
         let client = Client.authenticated(serverURL: serverURL)
         let response = try await client.startCacheArtifactMultipartUpload(.init(query: .init(

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -58,8 +58,11 @@ final class CleanServiceTests: TuistUnitTestCase {
 
         let cachePath = cachePaths[0].parentDirectory.parentDirectory
         given(cacheDirectoriesProvider)
-            .cacheDirectory()
-            .willReturn(cachePath)
+            .cacheDirectory(for: .value(.manifests))
+            .willReturn(cachePaths[0])
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.projectDescriptionHelpers))
+            .willReturn(cachePaths[1])
         given(rootDirectoryLocator)
             .locate(from: .any)
             .willReturn(cachePath)
@@ -144,11 +147,10 @@ final class CleanServiceTests: TuistUnitTestCase {
     func test_run_without_category_cleans_all() async throws {
         // Given
         let cachePaths = try createFolders(["tuist/Manifests"])
-        let cachePath = cachePaths[0].parentDirectory.parentDirectory
 
         given(cacheDirectoriesProvider)
-            .cacheDirectory()
-            .willReturn(cachePath)
+            .cacheDirectory(for: .any)
+            .willReturn(cachePaths[0])
 
         let projectPath = try temporaryPath()
         given(rootDirectoryLocator)
@@ -204,7 +206,7 @@ final class CleanServiceTests: TuistUnitTestCase {
             .willReturn(())
 
         given(cacheDirectoriesProvider)
-            .cacheDirectory()
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
 
         let projectPath = try temporaryPath()

--- a/Tests/TuistKitTests/Services/EditServiceTests.swift
+++ b/Tests/TuistKitTests/Services/EditServiceTests.swift
@@ -34,7 +34,7 @@ final class EditServiceTests: XCTestCase {
         cacheDirectoriesProvider = mockCacheDirectoriesProvider
 
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.editProjects))
+            .cacheDirectory(for: .value(.editProjects))
             .willReturn("/Users/tuist/cache/EditProjects")
 
         let cacheDirectoryProviderFactory = MockCacheDirectoriesProviderFactoring()
@@ -55,7 +55,7 @@ final class EditServiceTests: XCTestCase {
 
     func test_edit_uses_caches_directory() async throws {
         let path: AbsolutePath = "/private/tmp"
-        let cacheDirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .editProjects)
+        let cacheDirectory = try cacheDirectoriesProvider.cacheDirectory(for: .editProjects)
         let projectDirectory = cacheDirectory.appending(component: path.pathString.md5)
 
         given(projectEditor!)
@@ -79,7 +79,7 @@ final class EditServiceTests: XCTestCase {
 
     func test_edit_permanent_does_not_open_workspace() async throws {
         let path: AbsolutePath = "/private/tmp"
-        let cacheDirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .editProjects)
+        let cacheDirectory = try cacheDirectoriesProvider.cacheDirectory(for: .editProjects)
         let projectDirectory = cacheDirectory.appending(component: path.pathString.md5)
 
         given(projectEditor!)

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -44,7 +44,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         let runsCacheDirectory = try temporaryPath()
         given(mockCacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(runsCacheDirectory)
 
         configLoader = .init()
@@ -924,7 +924,7 @@ final class TestServiceTests: TuistUnitTestCase {
         givenGenerator()
         var resultBundlePath: AbsolutePath?
         let expectedResultBundlePath = try cacheDirectoriesProvider
-            .tuistCacheDirectory(for: .runs)
+            .cacheDirectory(for: .runs)
             .appending(components: "run-id", Constants.resultBundleName)
 
         given(xcodebuildController)
@@ -974,7 +974,7 @@ final class TestServiceTests: TuistUnitTestCase {
 
         let runsCacheDirectory = try temporaryPath()
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(runsCacheDirectory)
 
         try fileHandler.createFolder(runsCacheDirectory)

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -78,7 +78,7 @@ final class TuistAnalyticsDispatcherTests: TuistUnitTestCase {
             .willReturn(cacheDirectoriesProvider)
 
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(try temporaryPath())
 
         // When

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
@@ -55,7 +55,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
     func test_send_when_is_not_ci() async throws {
         // Given
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(try temporaryPath())
         ciChecker.isCIStub = false
         let event = CommandEvent.test()
@@ -82,7 +82,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
     func test_send_when_is_ci() async throws {
         // Given
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(try temporaryPath())
         ciChecker.isCIStub = true
         let event = CommandEvent.test()
@@ -124,11 +124,11 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
             )
 
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .value(.runs))
+            .cacheDirectory(for: .value(.runs))
             .willReturn(try temporaryPath())
 
         let resultBundle = try cacheDirectoriesProvider
-            .tuistCacheDirectory(for: .runs)
+            .cacheDirectory(for: .runs)
             .appending(components: event.runId, "\(Constants.resultBundleName).xcresult")
         try fileHandler.createFolder(resultBundle)
 

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -41,7 +41,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
                 .cacheDirectories()
                 .willReturn(cacheDirectoriesProvider)
             given(cacheDirectoriesProvider)
-                .tuistCacheDirectory(for: .value(.manifests))
+                .cacheDirectory(for: .value(.manifests))
                 .willReturn(cacheDirectory)
         } catch {
             XCTFail("Failed to create temporary directory")

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -86,13 +86,13 @@ final class PluginServiceTests: TuistUnitTestCase {
             ]
         )
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
-        let pluginADirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let pluginADirectory = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(component: pluginAFingerprint)
-        let pluginBDirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let pluginBDirectory = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(component: pluginBFingerprint)
-        let pluginCDirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let pluginCDirectory = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(component: pluginCFingerprint)
         try fileHandler.touch(
             pluginBDirectory.appending(components: PluginServiceConstants.release)
@@ -145,7 +145,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             invokedCheckoutPath = path
         }
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
 
         // When
@@ -155,13 +155,13 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(invokedCloneURL, pluginGitURL)
         XCTAssertEqual(
             invokedClonePath,
-            try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+            try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
                 .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         )
         XCTAssertEqual(invokedCheckoutID, pluginGitSha)
         XCTAssertEqual(
             invokedCheckoutPath,
-            try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+            try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
                 .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         )
     }
@@ -189,7 +189,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             invokedCheckoutPath = path
         }
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
 
         // When
@@ -199,13 +199,13 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(invokedCloneURL, pluginGitURL)
         XCTAssertEqual(
             invokedClonePath,
-            try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+            try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
                 .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         )
         XCTAssertEqual(invokedCheckoutID, pluginGitTag)
         XCTAssertEqual(
             invokedCheckoutPath,
-            try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+            try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
                 .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         )
     }
@@ -223,10 +223,10 @@ final class PluginServiceTests: TuistUnitTestCase {
 
         let temporaryDirectory = try temporaryPath()
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(temporaryDirectory)
 
-        let pluginDirectory = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let pluginDirectory = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(component: pluginFingerprint)
         try fileHandler.touch(
             pluginDirectory
@@ -279,10 +279,10 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitUrl)-\(pluginGitReference)".md5
 
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
 
-        let cachedPluginPath = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let cachedPluginPath = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         let pluginName = "TestPlugin"
 
@@ -309,7 +309,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             ),
         ])
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
 
         // When
@@ -360,9 +360,9 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginGitReference = "1.0.0"
         let pluginFingerprint = "\(pluginGitUrl)-\(pluginGitReference)".md5
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
-        let cachedPluginPath = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let cachedPluginPath = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         let pluginName = "TestPlugin"
         let resourceTemplatesPath = cachedPluginPath.appending(components: "ResourceSynthesizers")
@@ -439,9 +439,9 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginGitReference = "1.0.0"
         let pluginFingerprint = "\(pluginGitUrl)-\(pluginGitReference)".md5
         given(cacheDirectoriesProvider)
-            .tuistCacheDirectory(for: .any)
+            .cacheDirectory(for: .any)
             .willReturn(try temporaryPath())
-        let cachedPluginPath = try cacheDirectoriesProvider.tuistCacheDirectory(for: .plugins)
+        let cachedPluginPath = try cacheDirectoriesProvider.cacheDirectory(for: .plugins)
             .appending(components: pluginFingerprint, PluginServiceConstants.repository)
         let pluginName = "TestPlugin"
         let templatePath = cachedPluginPath.appending(components: "Templates", "custom")


### PR DESCRIPTION
### Short description 📝

As part of rebranding Tuist Cloud to simply Tuist, we're merging the individual global cache directories, `tuist-cloud` and `tuist`, to just `tuist`.

### How to test the changes locally 🧐

Cleaning and storing artifacts in cache should still work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
