### PR TITLE
Deprecate the usage TUIST_CONFIG_CLOUD_TOKEN in favor of TUIST_CONFIG_TOKEN

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -45,7 +45,7 @@ func schemes() -> [Scheme] {
                         "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
                         "TUIST_FRAMEWORK_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
                         "CI": "true",
-                        "TUIST_CONFIG_CLOUD_TOKEN": "i1932DHAyBwEtHCsRYyE2Ub6ReHNwQ",
+                        "TUIST_CONFIG_TOKEN": "i1932DHAyBwEtHCsRYyE2Ub6ReHNwQ",
                     ]
                 )
             )
@@ -97,7 +97,7 @@ func schemes() -> [Scheme] {
                         "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
                         "TUIST_FRAMEWORK_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
                         "CI": "true",
-                        "TUIST_CONFIG_CLOUD_TOKEN": "i1932DHAyBwEtHCsRYyE2Ub6ReHNwQ",
+                        "TUIST_CONFIG_TOKEN": "i1932DHAyBwEtHCsRYyE2Ub6ReHNwQ",
                     ]
                 )
             )

--- a/Sources/TuistKit/Commands/Project/ProjectTokenCommand.swift
+++ b/Sources/TuistKit/Commands/Project/ProjectTokenCommand.swift
@@ -8,7 +8,7 @@ struct ProjectTokenCommand: AsyncParsableCommand {
         CommandConfiguration(
             commandName: "token",
             _superCommandName: "project",
-            abstract: "Get a project token. You can save this token in the `TUIST_CONFIG_CLOUD_TOKEN` environment variable to use the remote cache on the CI."
+            abstract: "Get a project token. You can save this token in the `TUIST_CONFIG_TOKEN` environment variable to use the remote cache on the CI."
         )
     }
 

--- a/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
+++ b/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
@@ -55,7 +55,15 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
     public func authenticationToken(serverURL: URL) throws -> ServerAuthenticationToken? {
         if ciChecker.isCI() {
             let environment = environmentVariables()
-            return environment[Constants.EnvironmentVariables.token].map { .project($0) }
+            if let deprecatedToken = environment[Constants.EnvironmentVariables.deprecatedToken] {
+                logger
+                    .warning(
+                        "Use `TUIST_CONFIG_TOKEN` environment variable instead of `TUIST_CONFIG_CLOUD_TOKEN` to authenticate on the CI"
+                    )
+                return .project(deprecatedToken)
+            } else {
+                return environment[Constants.EnvironmentVariables.token].map { .project($0) }
+            }
         } else {
             return (try credentialsStore.read(serverURL: serverURL)?.token).map { .user($0) }
         }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -70,7 +70,9 @@ public enum Constants {
         public static let osLog = "TUIST_CONFIG_OS_LOG"
         /// `tuistBinaryPath` is used for specifying the exact tuist binary in tuist tasks.
         public static let tuistBinaryPath = "TUIST_CONFIG_BINARY_PATH"
-        public static let token = "TUIST_CONFIG_CLOUD_TOKEN"
+        public static let token = "TUIST_CONFIG_TOKEN"
+        @available(*, deprecated, message: "Use `token` instead")
+        public static let deprecatedToken = "TUIST_CONFIG_CLOUD_TOKEN"
     }
 
     public enum URLs {

--- a/docs/docs/cloud/get-started.md
+++ b/docs/docs/cloud/get-started.md
@@ -99,7 +99,7 @@ For CI environments, authentication is managed differently; it's done using **pr
 tuist project token my-organization/my-project
 ```
 
-You will then need to set the token as an environment variable named `TUIST_CONFIG_CLOUD_TOKEN` to make it accessible.
+You will then need to set the token as an environment variable named `TUIST_CONFIG_TOKEN` to make it accessible.
 
 > [!NOTE] EXPOSING SECRET ENVIRONMENT VARIABLES IN CI ENVIRONMENTS
 > How environment secret environment variables are exposed in CI environments varies depending on the CI provider. Ensure you follow the guidelines provided by your CI provider to securely manage these tokens. 


### PR DESCRIPTION
### Short description 📝

We're deprecating the usage of `TUIST_CONFIG_CLOUD_TOKEN` in favor of `TUIST_CONFIG_TOKEN` as part of our rebrand.

### How to test the changes locally 🧐

You should be able to both tokens but get a warning when using TUIST_CONFIG_CLOUD_TOKEN.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
