### PR TITLE
Rename shared tuist URLSession for disambiguation

### DIFF
--- a/Sources/TuistServer/Client/Client+Server.swift
+++ b/Sources/TuistServer/Client/Client+Server.swift
@@ -13,7 +13,7 @@ extension Client {
     static func authenticated(serverURL: URL) -> Client {
         .init(
             serverURL: serverURL,
-            transport: URLSessionTransport(configuration: .init(session: .shared)),
+            transport: URLSessionTransport(configuration: .init(session: .tuistShared)),
             middlewares: commonMiddlewares + [
                 ServerClientRequestIdMiddleware(),
                 ServerClientCLIMetadataHeadersMiddleware(),
@@ -28,7 +28,7 @@ extension Client {
     static func unauthenticated(serverURL: URL) -> Client {
         .init(
             serverURL: serverURL,
-            transport: URLSessionTransport(configuration: .init(session: .shared)),
+            transport: URLSessionTransport(configuration: .init(session: .tuistShared)),
             middlewares: commonMiddlewares
         )
     }

--- a/Sources/TuistServer/Network/URLSession+Server.swift
+++ b/Sources/TuistServer/Network/URLSession+Server.swift
@@ -21,7 +21,7 @@ private func tuistURLSessionConfiguration() -> URLSessionConfiguration {
 private var _tuistURLSession: URLSession = .init(configuration: tuistURLSessionConfiguration())
 
 extension URLSession {
-    public static var shared: URLSession {
+    public static var tuistShared: URLSession {
         _tuistURLSession
     }
 }

--- a/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -48,7 +48,7 @@ public protocol MultipartUploadArtifactServicing {
 public final class MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     private let urlSession: URLSession
 
-    public init(urlSession: URLSession = .shared) {
+    public init(urlSession: URLSession = .tuistShared) {
         self.urlSession = urlSession
     }
 


### PR DESCRIPTION
### Short description 📝

Rename shared tuist URLSession for disambiguation

### How to test the changes locally 🧐

CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x]  Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
