### PR TITLE
Fix Okta callback url

### DIFF
--- a/docs/docs/cloud/on-premise.md
+++ b/docs/docs/cloud/on-premise.md
@@ -108,7 +108,7 @@ You can enable authentication with Okta through the [OAuth 2.0](https://oauth.ne
         
 - **App integration name:** `Tuist Cloud`
 - **Grant type:** Enable *Authorization Code* for *Client acting on behalf of a user*
-- **Sign-in redirect URL:** `{url}/users/auth/github/callback` where `url` is the public URL your service is accessed through.
+- **Sign-in redirect URL:** `{url}/users/auth/okta/callback` where `url` is the public URL your service is accessed through.
 - **Assignments:** This configuration will depend on your security team requirements.
 
 If you'd like Tuist Cloud to detect when a user is removed from the application, you'll have to configure an [event hook](https://help.okta.com/en-us/content/topics/automation-hooks/event-hooks-main.htm). In your Okta organization, go to **Workflow > Event Hooks** and create a new event hook with the following data:


### PR DESCRIPTION
### Short description 📝

Fixing the callback URL for okta that was incorrectly pointing readers to github instead.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
