### PR TITLE
Fix missing test targets when generating an SPM package

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -468,16 +468,11 @@ public final class PackageInfoMapper: PackageInfoMapping {
             destinations = Set([.mac])
         case .test:
             var testDestinations = Set(XcodeGraph.Destination.allCases)
-            let dependencyNames = target.dependencies.map(\.name)
-            for dependencyName in dependencyNames {
-                let dependencyProducts = targetToProducts[dependencyName] ?? Set()
-                let isExternalDependency = dependencyProducts.isEmpty
-                let dependencyDestinations: XcodeGraph.Destinations = if isExternalDependency {
-                    Set(Destination.allCases)
-                } else {
-                    unionDestinationsOfProducts(dependencyProducts, in: productDestinations)
+            for dependencyTarget in target.dependencies {
+                if let dependencyProducts = targetToProducts[dependencyTarget.name] {
+                    let dependencyDestinations = unionDestinationsOfProducts(dependencyProducts, in: productDestinations)
+                    testDestinations.formIntersection(dependencyDestinations)
                 }
-                testDestinations.formIntersection(dependencyDestinations)
             }
             destinations = ProjectDescription.Destinations.from(destinations: testDestinations)
         default:

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -471,8 +471,13 @@ public final class PackageInfoMapper: PackageInfoMapping {
             let dependencyNames = target.dependencies.map(\.name)
             for dependencyName in dependencyNames {
                 let dependencyProducts = targetToProducts[dependencyName] ?? Set()
-                let destinations = unionDestinationsOfProducts(dependencyProducts, in: productDestinations)
-                testDestinations.formIntersection(destinations)
+                let isExternalDependency = dependencyProducts.isEmpty
+                let dependencyDestinations: XcodeGraph.Destinations = if isExternalDependency {
+                    Set(Destination.allCases)
+                } else {
+                    unionDestinationsOfProducts(dependencyProducts, in: productDestinations)
+                }
+                testDestinations.formIntersection(dependencyDestinations)
             }
             destinations = ProjectDescription.Destinations.from(destinations: testDestinations)
         default:

--- a/fixtures/spm_package/Package.resolved
+++ b/fixtures/spm_package/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "b2fa556e4e48cbf06cf8c63def138c98f4b811fa",
         "version" : "5.8.0"
       }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
     }
   ],
   "version" : 2

--- a/fixtures/spm_package/Package.swift
+++ b/fixtures/spm_package/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.8.0"),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", exact: "9.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -69,6 +70,8 @@ let package = Package(
             dependencies: [
                 "MyPackage",
                 "MyCommonPackage",
+                .product(name: "OHHTTPStubs", package: "OHHTTPStubs"),
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6143>

### Short description 📝

When determining destinations for the test targets in the project generated from `Package.project`, it was not considered **external** dependencies for testing such as `OHHTTPStubs`, `RxTest`, `Mockable` and so on.

I have resolved it from identifying external dependencies and using the point that an external dependency is supposed to have all destinations.

### How to test the changes locally 🧐

Run `tuist install` and `tuist generate` on `spm_package` fixture and there are test targets `MyPackageTests` and `MyUIKitPackageTests`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
