### PR TITLE
Support Info.plist for configurations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "72762ee5d0c1c6693d240f855baa564f33c1989e012f95666662934d0ad27a2d",
+  "originHash" : "31674f34fe3cf58c8de54e095e97294b4203ceab709901dd704669fe3418ad30",
   "pins" : [
     {
       "identity" : "aexml",
@@ -274,10 +274,10 @@
     {
       "identity" : "xcodegraph",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeGraph.git",
+      "location" : "https://github.com/lieuvu/XcodeGraph",
       "state" : {
-        "revision" : "0e44220403553ce7f20a79e49873b492302b4650",
-        "version" : "0.5.0"
+        "branch" : "feat/support-info-plist-for-configurations",
+        "revision" : "a4641c603a25373c827f125d63b78f9dd3b8ade0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -466,8 +466,8 @@ let package = Package(
         .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
-        .package(url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.5.0")),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/lieuvu/XcodeGraph", branch: "feat/support-info-plist-for-configurations"),
     ],
     targets: targets
 )

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -42,6 +42,7 @@ public struct Configuration: Equatable, Codable, Sendable {
     public var variant: Variant
     public var settings: SettingsDictionary
     public var xcconfig: Path?
+    public var infoPlist: InfoPlist?
 
     /// Returns a debug configuration.
     ///
@@ -49,17 +50,20 @@ public struct Configuration: Equatable, Codable, Sendable {
     ///   - name: The name of the configuration to use
     ///   - settings: The base build settings to apply
     ///   - xcconfig: The xcconfig file to associate with this configuration
+    ///   - infoPlist: The Info.plist representation for this configuration
     /// - Returns: A debug `CustomConfiguration`
     public static func debug(
         name: ConfigurationName,
         settings: SettingsDictionary = [:],
-        xcconfig: Path? = nil
+        xcconfig: Path? = nil,
+        infoPlist: InfoPlist? = nil
     ) -> Configuration {
         Configuration(
             name: name,
             variant: .debug,
             settings: settings,
-            xcconfig: xcconfig
+            xcconfig: xcconfig,
+            infoPlist: infoPlist
         )
     }
 
@@ -69,17 +73,20 @@ public struct Configuration: Equatable, Codable, Sendable {
     ///   - name: The name of the configuration to use
     ///   - settings: The base build settings to apply
     ///   - xcconfig: The xcconfig file to associate with this configuration
+    ///   - infoPlist: The Info.plist representation for this configuration
     /// - Returns: A release `CustomConfiguration`
     public static func release(
         name: ConfigurationName,
         settings: SettingsDictionary = [:],
-        xcconfig: Path? = nil
+        xcconfig: Path? = nil,
+        infoPlist: InfoPlist? = nil
     ) -> Configuration {
         Configuration(
             name: name,
             variant: .release,
             settings: settings,
-            xcconfig: xcconfig
+            xcconfig: xcconfig,
+            infoPlist: infoPlist
         )
     }
 }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -154,6 +154,10 @@ class ProjectFileElements {
             files.insert(path)
         }
 
+        target.settings?.configurations.values
+            .compactMap { configuration in configuration?.infoPlist?.path }
+            .forEach { infoPlistPath in files.insert(infoPlistPath) }
+
         if let entitlements = target.entitlements, let path = entitlements.path {
             files.insert(path)
         }

--- a/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
@@ -17,6 +17,7 @@ extension XcodeGraph.Configuration {
         guard let manifest else { return nil }
         let settings = manifest.settings.mapValues(XcodeGraph.SettingValue.from)
         let xcconfig = try manifest.xcconfig.flatMap { try generatorPaths.resolve(path: $0) }
-        return Configuration(settings: settings, xcconfig: xcconfig)
+        let infoPlist = try XcodeGraph.InfoPlist.from(manifest: manifest.infoPlist, generatorPaths: generatorPaths)
+        return Configuration(settings: settings, xcconfig: xcconfig, infoPlist: infoPlist)
     }
 }

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
@@ -28,7 +28,7 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_map() throws {
+    func test_map_whenOnlyInfoPlistInTarget() throws {
         // Given
         let targetA = Target.test(name: "A", infoPlist: .dictionary(["A": "A_VALUE"]))
         let targetB = Target.test(name: "B", infoPlist: .dictionary(["B": "B_VALUE"]))
@@ -59,6 +59,95 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
         )
         XCTAssertTargetExistsWithDerivedInfoPlist(
             named: "B-Info.plist",
+            project: mappedProject
+        )
+    }
+
+    func test_map_whenOnlyInfoPlistInConfigurations() throws {
+        // Given
+        let targetA = Target.test(
+            name: "A",
+            settings: Settings(
+                configurations: [
+                    .debug("CustomDebug"): Configuration(infoPlist: .dictionary(["A": "A1_VALUE"])),
+                    .debug: Configuration(infoPlist: .dictionary(["A": "A2_VALUE"])),
+                    .release: Configuration(infoPlist: .dictionary(["A": "A3_VALUE"])),
+                ]
+            )
+        )
+        let project = Project.test(targets: [targetA])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(sideEffects.count, 3)
+        XCTAssertEqual(mappedProject.targets.count, 1)
+
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-CustomDebug-Info.plist",
+            content: ["A": "A1_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-Debug-Info.plist",
+            content: ["A": "A2_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-Release-Info.plist",
+            content: ["A": "A3_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        XCTAssertTargetExistsWithoutDerivedInfoPlist(project: mappedProject)
+    }
+
+    func test_map_whenInfoPlistInBothTargetAndConfigurations() throws {
+        // Given
+        let targetA = Target.test(
+            name: "A",
+            infoPlist: .dictionary(["A": "A_VALUE"]),
+            settings: Settings(
+                configurations: [
+                    .debug("CustomDebug"): Configuration(),
+                    .debug("AnotherDebug"): nil,
+                    .debug: Configuration(infoPlist: .dictionary(["A": "A2_VALUE"])),
+                    .release: Configuration(infoPlist: .dictionary(["A": "A3_VALUE"])),
+                ]
+            )
+        )
+        let project = Project.test(targets: [targetA])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(sideEffects.count, 3)
+        XCTAssertEqual(mappedProject.targets.count, 1)
+
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-Info.plist",
+            content: ["A": "A_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-Debug-Info.plist",
+            content: ["A": "A2_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        try XCTAssertSideEffectsCreateDerivedInfoPlist(
+            named: "A-Release-Info.plist",
+            content: ["A": "A3_VALUE"],
+            projectPath: project.path,
+            sideEffects: sideEffects
+        )
+        XCTAssertTargetExistsWithDerivedInfoPlist(
+            named: "A-Info.plist",
             project: mappedProject
         )
     }
@@ -100,5 +189,15 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
                 .appending(component: Constants.DerivedDirectory.infoPlists)
                 .appending(component: named)
         }), file: file, line: line)
+    }
+
+    private func XCTAssertTargetExistsWithoutDerivedInfoPlist(
+        project: Project,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        for target in project.targets.values {
+            XCTAssertNil(target.infoPlist, file: file, line: line)
+        }
     }
 }

--- a/fixtures/ios_app_with_multi_configs/App/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/App/Project.swift
@@ -35,6 +35,7 @@ let project = Project(
             dependencies: [
                 .project(target: "Framework1", path: "../Framework1"),
                 .project(target: "Framework2", path: "../Framework2"),
+                .project(target: "Framework3", path: "../Framework3"),
             ]
         ),
         .target(

--- a/fixtures/ios_app_with_multi_configs/Framework3/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework3/Project.swift
@@ -1,0 +1,87 @@
+import ProjectDescription
+
+func getInfoPlist(displayName: String, appQueriesSchemes: [String] = []) -> InfoPlist {
+    var plistContent: [String: Plist.Value] = [
+        "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+        "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+        "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": "$(PRODUCT_NAME)",
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "1",
+        "LSRequiresIPhoneOS": true,
+        "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+    ]
+
+    plistContent["CFBundleDisplayName"] = .string(displayName)
+
+    if !appQueriesSchemes.isEmpty {
+        plistContent["LSApplicationQueriesSchemes"] = .array(appQueriesSchemes.map { .string($0) })
+    }
+
+    return .dictionary(plistContent)
+}
+
+let settings: Settings = .settings(
+    configurations: [
+        .debug(name: "Debug", xcconfig: "../ConfigurationFiles/Debug.xcconfig"),
+        .release(name: "Beta", xcconfig: "../ConfigurationFiles/Beta.xcconfig"),
+        .release(name: "Release", xcconfig: "../ConfigurationFiles/Release.xcconfig"),
+    ]
+)
+
+// Targets can override select configurations if needed
+let targetSettings: Settings = .settings(
+    base: [
+        "TARGET_BASE": "TARGET_BASE",
+    ],
+    configurations: [
+        .debug(
+            name: "Debug",
+            infoPlist: getInfoPlist(displayName: "Framework3 Debug")
+        ),
+        .release(
+            name: "Beta",
+            infoPlist: getInfoPlist(
+                displayName: "Framework3 Beta",
+                appQueriesSchemes: ["googlemail", "message", "ymail"]
+            )
+        ),
+        .release(
+            name: "Release",
+            xcconfig: "../ConfigurationFiles/Target.Release.xcconfig",
+            infoPlist: getInfoPlist(
+                displayName: "Framework3",
+                appQueriesSchemes: ["googlemail", "message", "ms-outlook", "ymail"]
+            )
+        ),
+    ]
+)
+
+let project = Project(
+    name: "Framework3",
+    settings: settings,
+    targets: [
+        .target(
+            name: "Framework3",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.Framework3",
+            infoPlist: nil,
+            sources: "Sources/**",
+            dependencies: [],
+            settings: targetSettings
+        ),
+        .target(
+            name: "Framework3Tests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.Framework3Tests",
+            sources: "Tests/**",
+            dependencies: [
+                .target(name: "Framework3"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_multi_configs/Framework3/Sources/Framework3File.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework3/Sources/Framework3File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework3File {
+    public init() {}
+
+    public func hello() -> String {
+        "Framework3File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_multi_configs/Framework3/Tests/Framework3FileTests.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework3/Tests/Framework3FileTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework3
+
+class Framework3Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework3File()
+
+        XCTAssertEqual("Framework3File.hello()", sut.hello())
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1157

### Short description 📝

#### Motivation

Currently, Tuist generates one `Info.plist` file for all configurations. It seems not solving more complex scenarios as follows:
  
- A project requires different values for different configurations for a key in the plist file and the value type is **an array** or **a dictionary**.  For example for a key `LSApplicationQueriesSchemes` expects an array and `NSPinnedDomains` expects a dictionary. This can not be achieved by setting a value for an environment variable in settings since it only accepts string or an array of strings.
- A project requires **dynamic keys** for different configurations in the plist file. For instance under `NSPinnedDomains`, it is expected to have different domains for different configurations such as `debug.foo.com` for Debug, `beta.foo.com` for Beta and `foo.com` for Release.
- A project requires an entry to show in the plist file for certain configurations and not for other configurations.

This PR attempts to support `Info.plist` for configurations by adding one more param `infoPlist` when creating configuration.

#### Discussion

The `Info.plist` file linked to configuration is created with the format `<Target>-<Configuration Name>-Info.plist`.

The `Info.plist` file defined in the project settings is ignored. Only the `Info.plist` file defined in target settings is taken into account.

With the changes, a target can define info plist with both `infoPlist` param in **target** and `infoPlist` param in **configuration**. Here are how the PR resolves.

| infoPlist param (target) | infoPlist param (configuration) | Result |
| ------------------------| ------------------------------| ------ |
| nil                                     | nil                                               | No Info.plist is created/linked |
| nil                                     | defined                                      | Info.plist file is created/linked with the configuration |
| defined                            | nil                                               | Info.plist file of target is created/linked with all configurations |
| defined                            | defined.                                     | Info.plist file of the configuration is created/linked with the configurations. The Info.plist file of the target is created if it is dictionary but not linked to the target |

### How to test the changes locally 🧐

Run `tuist generate` of the project `fixtures/ios_app_with_multi_configs/Framework3` to see the results.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
