### PR TITLE
Fix missing TUIST_CONFIG_TOKEN in ServerAcceptanceTests

### DIFF
--- a/Tests/TuistKitAcceptanceTests/ServerAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ServerAcceptanceTests.swift
@@ -18,6 +18,7 @@ final class ServerAcceptanceTestProjects: ServerAcceptanceTestCase {
 final class ServerAcceptanceTestProjectTokens: ServerAcceptanceTestCase {
     func test_create_list_and_revoke_project_token() async throws {
         try await run(ProjectTokensCreateCommand.self, fullHandle)
+        TestingLogHandler.reset()
         try await run(ProjectTokensListCommand.self, fullHandle)
         let id = try XCTUnwrap(
             TestingLogHandler.collected[.info, <=].components(separatedBy: .newlines).dropLast().last?

--- a/Tests/TuistKitAcceptanceTests/ServerAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ServerAcceptanceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TuistAcceptanceTesting
+import TuistSupport
 import TuistSupportTesting
 import XCTest
 
@@ -40,6 +41,8 @@ class ServerAcceptanceTestCase: TuistAcceptanceTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        environment.tuistVariables[Constants.EnvironmentVariables.token] = ProcessInfo.processInfo
+            .environment[Constants.EnvironmentVariables.token]
         try setUpFixture(.iosAppWithFrameworks)
         organizationHandle = String(UUID().uuidString.prefix(12).lowercased())
         projectHandle = String(UUID().uuidString.prefix(12).lowercased())


### PR DESCRIPTION
### Short description 📝

Fixes a failing acceptance test such as: https://cloud.tuist.io/tuist/tuist/runs/346367

The test was failing because the acceptance tests use the `MockEnvironment`, so the `TUIST_CONFIG_TOKEN` defined as the run argument would not be used.

### How to test the changes locally 🧐

CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
