### PR TITLE
Respect --verbose for machine readable commands

### DIFF
--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -89,6 +89,6 @@ extension OSLogHandler: VerboseLogHandler {
 
 extension JSONLogHandler: VerboseLogHandler {
     public static func verbose(label: String) -> LogHandler {
-        JSONLogHandler(label: label, logLevel: .debug)
+        StandardLogHandler(label: label, logLevel: .debug)
     }
 }

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -18,7 +18,12 @@ private enum TuistServer {
         let isCommandMachineReadable = CommandLine.arguments.count > 1 && machineReadableCommands.map { $0._commandName }.contains(CommandLine.arguments[1])
         // swiftformat:enable all
         if isCommandMachineReadable || CommandLine.arguments.contains("--json") {
-            TuistSupport.LogOutput.bootstrap(config: LoggingConfig(loggerType: .json, verbose: false))
+            TuistSupport.LogOutput.bootstrap(
+                config: LoggingConfig(
+                    loggerType: .json,
+                    verbose: ProcessEnv.vars[Constants.EnvironmentVariables.verbose] != nil
+                )
+            )
         } else {
             TuistSupport.LogOutput.bootstrap()
         }


### PR DESCRIPTION
### Short description 📝

When running `tuist dump`, the output contains _only_ logs with the `.json` metadata. This was implemented in [this PR](https://github.com/tuist/tuist/pull/6440) to prevent unexpected logs breaking processing the JSON output.

However, when run with `--verbose`, we should fallback to a regular logger to provide extra output for debugging if necessary.

### How to test the changes locally 🧐

Run `tuist dump --verbose` -> you should see full logs, not just the object's JSON representation.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
