### PR TITLE
Fix linking static xcframeworks linked via dynamic xcframeworks

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -27,6 +27,7 @@ public enum TuistAcceptanceFixtures {
     case iosWppWithCustomResourceParserOptions
     case iosAppWithCustomScheme
     case iosAppWithExtensions
+    case iosAppWithDynamicFrameworksLinkingStaticFrameworks
     case iosAppWithFrameworkAndResources
     case iosAppWithFrameworkAndDisabledResources
     case iosAppWithFrameworkLinkingStaticFramework
@@ -119,6 +120,8 @@ public enum TuistAcceptanceFixtures {
             return "ios_app_with_custom_configuration"
         case .iosAppWithCustomDevelopmentRegion:
             return "ios_app_with_custom_development_region"
+        case .iosAppWithDynamicFrameworksLinkingStaticFrameworks:
+            return "ios_app_with_dynamic_frameworks_linking_static_frameworks"
         case .iosWppWithCustomResourceParserOptions:
             return "ios_app_with_custom_resource_parser_options"
         case .iosAppWithCustomScheme:

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -366,14 +366,22 @@ public class GraphTraverser: GraphTraversing {
             .filter(\.isPrecompiled)
 
         let precompiledDependencies = precompiled
-            .flatMap { filterDependencies(from: $0)
-            }
+            .flatMap { filterDependencies(from: $0) }
 
-        let precompiledLibrariesAndFrameworks = Set(precompiled + precompiledDependencies)
+        let precompiledDynamicLibrariesAndFrameworks = Set(precompiled + precompiledDependencies)
             .filter(\.isPrecompiledDynamicAndLinkable)
-            .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
 
-        references.formUnion(precompiledLibrariesAndFrameworks)
+        let staticXCFrameworksLinkedByDynamicXCFrameworkDependencies = filterDependencies(
+            from: Set(precompiledDynamicLibrariesAndFrameworks).filter { $0.xcframeworkDependency != nil },
+            test: { $0.xcframeworkDependency?.linking == .static },
+            skip: { $0.xcframeworkDependency == nil }
+        )
+
+        let precompiledLibrariesAndFrameworks =
+            (precompiledDynamicLibrariesAndFrameworks + staticXCFrameworksLinkedByDynamicXCFrameworkDependencies)
+                .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
+
+        references.formUnion(Set(precompiledLibrariesAndFrameworks))
 
         // Static libraries and frameworks / Static libraries' dynamic libraries
         if target.target.canLinkStaticProducts() {
@@ -1240,3 +1248,14 @@ public class GraphTraverser: GraphTraversing {
 }
 
 // swiftlint:enable type_body_length
+
+extension GraphDependency {
+    fileprivate var xcframeworkDependency: GraphDependency.XCFramework? {
+        switch self {
+        case let .xcframework(xcframework):
+            return xcframework
+        default:
+            return nil
+        }
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/.gitignore
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Sources/App.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Sources/App.swift
@@ -1,0 +1,13 @@
+import DynamicFrameworkA
+import SwiftUI
+
+@main
+struct MyApp: App {
+    private var dynamicFramework = DynamicFrameworkA()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Sources/ContentView.swift
@@ -1,0 +1,21 @@
+import DynamicFrameworkA
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        let choice = Thing().choice
+        if choice.is(\.bluePill) {
+            Text("Blue")
+        } else {
+            Text("Red")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/App/Tests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class AppTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkA/DynamicFrameworkA.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkA/DynamicFrameworkA.swift
@@ -1,0 +1,17 @@
+import GoogleMobileAds
+import UIKit
+
+public class DynamicFrameworkA: NSObject {
+    let googleAds = GADExtras()
+    override public init() {
+        super.init()
+    }
+}
+
+extension DynamicFrameworkA: GADAdSizeDelegate {
+    public func adView(_ bannerView: GADBannerView, willChangeAdSizeTo size: GADAdSize) {
+        var frame = bannerView.frame
+        frame.size.height = CGSizeFromGADAdSize(size).height
+        print("new frame \(frame)")
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkA/Thing.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkA/Thing.swift
@@ -1,0 +1,9 @@
+import DynamicFrameworkB
+
+public struct Thing {
+    public var choice: Choice
+
+    public init() {
+        choice = .redPill
+    }
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkB/Choice.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/DynamicFrameworkB/Choice.swift
@@ -1,0 +1,7 @@
+import CasePaths
+
+@CasePathable
+public enum Choice {
+    case bluePill
+    case redPill
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Project.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Project.swift
@@ -1,0 +1,57 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            resources: [],
+            dependencies: [
+                .target(name: "DynamicFrameworkA"),
+            ]
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.AppTests",
+            infoPlist: .default,
+            sources: ["App/Tests/**"],
+            resources: [],
+            dependencies: [.target(name: "App")]
+        ),
+        .target(
+            name: "DynamicFrameworkA",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.DynamicFrameworkA",
+            sources: ["DynamicFrameworkA/**"],
+            dependencies: [
+                .external(name: "GoogleMobileAds"),
+                .target(name: "DynamicFrameworkB"),
+            ]
+        ),
+        .target(
+            name: "DynamicFrameworkB",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.DynamicFrameworkB",
+            sources: ["DynamicFrameworkB/**"],
+            dependencies: [
+                .external(name: "CasePaths"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "b9ad2661b6e8fb411fef6a441c9955c3413afac0",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "5ff977255c2ba5844e7e9da779f1f2a5a00e0028",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "459949af1286c12487a6efd76f00f3e9d951c9ba",
+        "version" : "2.5.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
+        "version" : "600.0.0-prerelease-2024-06-12"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+#if TUIST
+    import ProjectDescription
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", exact: "11.2.0"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.4.2"),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6485
Resolves https://github.com/tuist/tuist/issues/6514

### Short description 📝

We start with the following graph:
`App -> SomeDynamicFramework -> SomeStaticFramework`

Where `SomeStaticFramework` could also be a pre-built XCFramework (as is the case with `GoogleMobileAds`) and it can be both ObjC or Swift (i.e., the issue occurs regardless of the language it is written in).

When using Tuist Cache Binaries, the `SomeDynamicFramework` is turned into a dynamic XCFramework:
`App -> SomeDynamicFramework -> SomeStaticFramework`

The issue happens when `App` needs to reference symbols from `SomeStaticFramework`. As suggested in [this Swift forum post](https://forums.swift.org/t/issue-with-third-party-dependencies-inside-a-xcframework-through-swiftpm/41977/3), we could import `SomeStaticFramework` with `@_implementationOnly` but not in cases we actually need to use the symbols in the `App` target.

If we can't use `@_implementationOnly`, how do we make `SomeStaticFramework` symbols visible in the `App`?

#### Manually setting `HEADER_SEARCH_PATHS` and modulemaps

Let's take the `GoogleMobileAds` XCFramework as an example. The `GoogleMobileAds` target is located in `Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds.xcframework`. Its `.modulemap` is then located in that directory in `GoogleMobileAds.xcframework/ios-arm64/GoogleMobileAds.framework/Modules/module.modulemap`. Similarly, headers are then in that same framework but in the `Headers` directory. Note that `ios-arm64` is only referencing to one architecture but the headers should be the same across architecture.

What we can do is reference the headers and modulemaps by setting the following settings:
```
HEADER_SEARCH_PATHS=$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds.xcframework/ios-arm64/GoogleMobileAds.framework/Headers
OTHER_SWIFT_FLAGS=-Xcc -fmodule-map-file=$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds.xcframework/ios-arm64/GoogleMobileAds.framework/Modules/module.modulemap
OTHER_CFLAGS=-fmodule-map-file=$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds.xcframework/ios-arm64/GoogleMobileAds.framework/Modules/module.modulemap
```

This does change the build error from `Missing required module 'GoogleMobileAds'` to `Could not build Objective-C module 'GoogleMobileAds'` where the error occurs when using the `GoogleMobileAds.h` on the following line:
`#import <GoogleMobileAds/GADAdChoicesPosition.h>`

The header complains about the `<GoogleMobileAds/GADAdChoicePosition.h>` not being found. Note that changing the import to `#import "GADAdChoicePosition.h` does work but we obviously can't change the header like that as it's outside of our control.

My assumption is that the header can't be found because to resolve it, we need to resolve the `modulemap` which is defined using `GoogleMobileAds.h`, leading to a sort of cyclic reference. Note I wasn't able to confirm this is true.

For a Swift dependency, we should be able to follow similar steps, but I had issues there, too (I haven't spent that much time looking into that, however).

What does work is adding the `FRAMEWORK_SEARCH_PATHS=$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds.xcframework/ios-arm64`. However, this only works for one architecture and we can't add one framework twice with different architectures.


#### Relinking static xcframeworks in downstream targets

Since the above doesn't work, we can instead re-link the static xcframeworks in the downstream targets. In the example above, it would mean that `GoogleMobileAds.xcframework` would be added to the `Link Binary with Libraries` build phase.

That does mean we'd unnecessarily increase the binary size since now `GoogleMobileAds` symbols would be included in both `App` and `DynamicFramework`.

However, as implemented in this PR, we would only do that when a **dynamic xcframework** depends on a static xcframework. This scenario can only happen when using Tuist Cache as otherwise, the links between xcframeworks are not declared.
 
Since for releases, we don't recommend using Tuist Cache, the issue of bloated binary size is not a huge issue. However, it would be definitely more correct to change the build settings with modulemaps and header search paths only, but I wasn't able to resolve that.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
