### PR TITLE
Generate a `Tuist/Config.swift` by default when creating a new project

### DIFF
--- a/Templates/default/Config.stencil
+++ b/Templates/default/Config.stencil
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let config = Config(
+//    Create an account with "tuist auth" and a projet with "tuist project create"
+//    then uncomment the section below and set the project full-handle.
+//
+//    cloud: .cloud(projectId: "{account_handle}/{project_handle}")
+)

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -22,6 +22,10 @@ let template = Template(
             templatePath: "Package.stencil"
         ),
         .file(
+            path: projectPath + "/Tuist/Config.swift",
+            templatePath: "Config.stencil"
+        ),
+        .file(
             path: appPath + "/Sources/\(classNameAttribute)App.swift",
             templatePath: "app.stencil"
         ),


### PR DESCRIPTION
### Short description 📝
While revamping our docs, I realized that we don't create a `Tuist/Config.swift` by default, resulting in friction in the first-time experience. I think we should include it, with a comment explaining how to plug their projects to a server to benefit from features like caching and smart test runs.

### How to test the changes locally 🧐
You should be able to run `tuist run tuist init --path ~/Downloads/MyApp`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
