### PR TITLE
Document the need for `PGDATA` when configuring the timescaledb service with the Tuist server

### DIFF
--- a/docs/docs/guides/dashboard/on-premise/install.md
+++ b/docs/docs/guides/dashboard/on-premise/install.md
@@ -227,6 +227,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - PGDATA=/var/lib/postgresql/data/pgdata
     ports:
       - '5432:5432'
     volumes: 


### PR DESCRIPTION
### Short description 📝
We got a report that Timescale needs the `PGDATA` to configure where the database data lives.

I've updated the documentation accordingly.