### PR TITLE
Add note about tuist auth during set up for contributors

### DIFF
--- a/docs/docs/contributors/get-started.md
+++ b/docs/docs/contributors/get-started.md
@@ -28,6 +28,7 @@ To start working on the project, we can follow the steps below:
 - [Install](https://mise.jdx.dev/getting-started.html) Mise to provision the development environment.
 - Run `mise install` to install the system dependencies needed by Tuist
 - Run `tuist install` to install the external dependencies needed by Tuist
+- (Optional) Run `tuist auth` to get access to the [Tuist Cache](/guides/develop/build/cache)
 - Run `tuist generate` to generate the Tuist Xcode project using Tuist itself
 
 **The generated project opens automatically**. If you need to open again without generating it, run open `Tuist.xcworkspace` (or use Finder).


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/6511

### Short description 📝

Any user authenticated with Tuist can now use the Tuist Cache in the `tuist/tuist` repo (or any public project for that matter).

I'm adding a note in the contributor's guide to highlight this.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
