### PR TITLE
Fix token not found when using TUIST_CONFIG_TOKEN environment variable

### DIFF
--- a/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
@@ -4,7 +4,7 @@ import TuistSupport
 public final class ManifestLoaderFactory {
     private let useCache: Bool
     public convenience init(environment: Environmenting = Environment.shared) {
-        let cacheSetting = environment.tuistConfigVariables[Constants.EnvironmentVariables.cacheManifests, default: "1"]
+        let cacheSetting = environment.tuistVariables[Constants.EnvironmentVariables.cacheManifests, default: "1"]
         self.init(useCache: cacheSetting == "1")
     }
 

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -21,9 +21,6 @@ public protocol Environmenting: AnyObject, Sendable {
     /// Returns all the environment variables that are specific to Tuist (prefixed with TUIST_)
     var tuistVariables: [String: String] { get }
 
-    /// Returns all the environment variables that are specific to Tuist configuration (prefixed with TUIST_CONFIG_)
-    var tuistConfigVariables: [String: String] { get }
-
     /// Returns all the environment variables that can be included during the manifest loading process
     var manifestLoadingVariables: [String: String] { get }
 
@@ -167,12 +164,7 @@ public final class Environment: Environmenting {
 
     /// Returns all the environment variables that are specific to Tuist (prefixed with TUIST_)
     public var tuistVariables: [String: String] {
-        ProcessInfo.processInfo.environment.filter { $0.key.hasPrefix("TUIST_") }.filter { !$0.key.hasPrefix("TUIST_CONFIG_") }
-    }
-
-    /// Returns all the environment variables that are specific to Tuist config (prefixed with TUIST_CONFIG_)
-    public var tuistConfigVariables: [String: String] {
-        ProcessInfo.processInfo.environment.filter { $0.key.hasPrefix("TUIST_CONFIG_") }
+        ProcessInfo.processInfo.environment.filter { $0.key.hasPrefix("TUIST_") }
     }
 
     public var manifestLoadingVariables: [String: String] {

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -22,7 +22,6 @@ public class MockEnvironment: Environmenting {
     public var shouldOutputBeColoured: Bool = false
     public var isStandardOutputInteractive: Bool = false
     public var tuistVariables: [String: String] = [:]
-    public var tuistConfigVariables: [String: String] = [:]
     public var manifestLoadingVariables: [String: String] = [:]
     public var isStatsEnabled: Bool = true
     public var isGitHubActions: Bool = false

--- a/Tests/TuistLoaderTests/Loaders/ManifestLoaderFactoryTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestLoaderFactoryTests.swift
@@ -25,7 +25,7 @@ final class ManifestLoaderFactoryTests: TuistUnitTestCase {
 
     func test_create_non_cached_manifest_loader_when_explicitely_configured_via_enviromentvariable() {
         // Given
-        environment.tuistConfigVariables[Constants.EnvironmentVariables.cacheManifests] = "0"
+        environment.tuistVariables[Constants.EnvironmentVariables.cacheManifests] = "0"
         let sut = ManifestLoaderFactory()
         // When
         let result = sut.createManifestLoader()


### PR DESCRIPTION
### Short description 📝

When [accessing the token](https://github.com/tuist/tuist/blob/main/Sources/TuistServer/Utilities/ServerAuthenticationController.swift#L86) in the `ServerAuthenticationController`, we go through `tuistVariables`. However, `tuistVariables` [filters out](https://github.com/tuist/tuist/blob/main/Sources/TuistSupport/Utils/Environment.swift#L170) any environment variables with the `TUIST_CONFIG` prefix as we were supposed to access those through `tuistConfigVariables`.

I find the distinction confusing and unnecessary, so I'm removing the `tuistConfigVariables` in favor of using `tuistVariables` only.

### How to test the changes locally 🧐

You should be able to use `TUIST_CONFIG_TOKEN` for authenticating as a project when `CI="true`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
