### PR TITLE
Migrate Tuist/Config.swift to the new API

### DIFF
--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -24,6 +24,7 @@ public struct Cloud: Codable, Equatable, Sendable {
     ///   - url: Base URL to the Cloud server.
     ///   - options: Cloud options.
     /// - Returns: A Cloud instance.
+    @available(*, deprecated, message: "Use the `fullHandle` and `url` properties directly in the `Config`")
     public static func cloud(projectId: String, url: String = "https://cloud.tuist.io", options: [Option] = []) -> Cloud {
         Cloud(url: url, projectId: projectId, options: options)
     }

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -38,7 +38,6 @@ public struct Config: Codable, Equatable, Sendable {
     public let plugins: [PluginLocation]
 
     /// Cloud configuration.
-    @available(*, deprecated, message: "Use the `fullHandle` and `url` properties directly in the `Config`")
     public let cloud: Cloud?
 
     /// The full project handle such as tuist-org/tuist.

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,10 +1,10 @@
 import ProjectDescription
 
 let config = Config(
-    cloud: .cloud(
-        projectId: "tuist/tuist",
-        url: "https://cloud.tuist.io",
-        options: [.optional]
-    ),
-    swiftVersion: .init("5.10")
+    fullHandle: "tuist/tuist",
+    url: "https://cloud.tuist.io",
+    swiftVersion: .init("5.10"),
+    generationOptions: .options(
+        optionalAuthentication: true
+    )
 )


### PR DESCRIPTION
### Short description 📝

I've noticed that using the deprecated Tuist server setup:
```swift
let config = Cloud(
   cloud: .cloud(...)
)
```

does not trigger a deprecation warning. The issue is that the deprecation is set on the `cloud` property of `ProjectDescription.Cloud` which only triggers a warning when _accessing_ the property, not when defining in the init.

We should instead deprecate the `static func cloud` initializer.

I am also taking the opportunity to migrate to the new api in `tuist/tuist` itself.

### How to test the changes locally 🧐

- Run `tuist edit` for a project with the deprecated `.cloud` init.
- The generated edit project should give you a warning that disappears once you move to the new API.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
