### PR TITLE
Fix optionalAuthentication generation option in Config.swift

### DIFF
--- a/Sources/TuistCore/Models/Config.swift
+++ b/Sources/TuistCore/Models/Config.swift
@@ -112,7 +112,8 @@ public struct Config: Equatable, Hashable {
             clonedSourcePackagesDirPath: AbsolutePath? = nil,
             staticSideEffectsWarningTargets: TuistCore.Config.GenerationOptions.StaticSideEffectsWarningTargets = .all,
             enforceExplicitDependencies: Bool = false,
-            defaultConfiguration: String? = nil
+            defaultConfiguration: String? = nil,
+            optionalAuthentication: Bool = false
         ) -> Self {
             .init(
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
@@ -120,7 +121,8 @@ public struct Config: Equatable, Hashable {
                 clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
                 staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
                 enforceExplicitDependencies: enforceExplicitDependencies,
-                defaultConfiguration: defaultConfiguration
+                defaultConfiguration: defaultConfiguration,
+                optionalAuthentication: optionalAuthentication
             )
         }
     }

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -96,7 +96,8 @@ extension TuistCore.Config.GenerationOptions {
             staticSideEffectsWarningTargets: TuistCore.Config.GenerationOptions.StaticSideEffectsWarningTargets
                 .from(manifest: manifest.staticSideEffectsWarningTargets),
             enforceExplicitDependencies: manifest.enforceExplicitDependencies,
-            defaultConfiguration: manifest.defaultConfiguration
+            defaultConfiguration: manifest.defaultConfiguration,
+            optionalAuthentication: manifest.optionalAuthentication
         )
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -138,7 +138,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         stub(
             config: .test(
                 fullHandle: "tuist/tuist",
-                url: "https://test.cloud.tuist.io"
+                url: "https://test.tuist.io"
             ),
             at: "/project/Tuist"
         )
@@ -150,7 +150,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         XCTAssertBetterEqual(result, TuistCore.Config(
             compatibleXcodeVersions: .all,
             fullHandle: "tuist/tuist",
-            url: try XCTUnwrap(URL(string: "https://test.cloud.tuist.io")),
+            url: try XCTUnwrap(URL(string: "https://test.tuist.io")),
             swiftVersion: nil,
             plugins: [],
             generationOptions: .test(),
@@ -158,15 +158,16 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         ))
     }
 
-    func test_loadConfig_with_deprecated_cloud() throws {
+    func test_loadConfig_with_full_handle_and_url_and_optional_authentication() throws {
         // Given
         stub(rootDirectory: "/project")
         stub(path: "/project/Tuist/Config.swift", exists: true)
         stub(
-            config: ProjectDescription.Config(
-                cloud: .cloud(
-                    projectId: "tuist/tuist",
-                    url: "https://test.cloud.tuist.io"
+            config: .test(
+                fullHandle: "tuist/tuist",
+                url: "https://test.tuist.io",
+                generationOptions: .options(
+                    optionalAuthentication: true
                 )
             ),
             at: "/project/Tuist"
@@ -179,7 +180,38 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         XCTAssertBetterEqual(result, TuistCore.Config(
             compatibleXcodeVersions: .all,
             fullHandle: "tuist/tuist",
-            url: try XCTUnwrap(URL(string: "https://test.cloud.tuist.io")),
+            url: try XCTUnwrap(URL(string: "https://test.tuist.io")),
+            swiftVersion: nil,
+            plugins: [],
+            generationOptions: .test(
+                optionalAuthentication: true
+            ),
+            path: "/project/Tuist/Config.swift"
+        ))
+    }
+
+    func test_loadConfig_with_deprecated_cloud() throws {
+        // Given
+        stub(rootDirectory: "/project")
+        stub(path: "/project/Tuist/Config.swift", exists: true)
+        stub(
+            config: ProjectDescription.Config(
+                cloud: .cloud(
+                    projectId: "tuist/tuist",
+                    url: "https://test.tuist.io"
+                )
+            ),
+            at: "/project/Tuist"
+        )
+
+        // When
+        let result = try subject.loadConfig(path: "/project")
+
+        // Then
+        XCTAssertBetterEqual(result, TuistCore.Config(
+            compatibleXcodeVersions: .all,
+            fullHandle: "tuist/tuist",
+            url: try XCTUnwrap(URL(string: "https://test.tuist.io")),
             swiftVersion: nil,
             plugins: [],
             generationOptions: .test(),


### PR DESCRIPTION
### Short description 📝

This [PR](https://github.com/tuist/tuist/pull/6529) fails because:
- The latest release doesn't properly use the `TUIST_CONFIG_TOKEN` (as fixed in https://github.com/tuist/tuist/pull/6528)
- If the token is missing, the generation should still succeed with a warning since authentication is [set as optional](https://github.com/tuist/tuist/pull/6529/files#diff-ca1097423dd3f1e7020942c8ddd832ccb5f95fbf1cca6fd583cbd6ae73dc4666R8)

However, `optionalAuthentication` generation option is not applied as it's not properly passed through when being mapped from the `ProjectDescription` to the `TuistCore` definition. The default value of `false` is used instead, leading to the behavior described above.

### How to test the changes locally 🧐

- Run `tuist generate` with Tuist `url` specified without being logged in when `optionalAuthentication` is set to `true`
- `tuist generate` should succeed with a warning

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
