### PR TITLE
Mark the Cloud static initializer as deprecated

### DIFF
--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -24,6 +24,7 @@ public struct Cloud: Codable, Equatable, Sendable {
     ///   - url: Base URL to the Cloud server.
     ///   - options: Cloud options.
     /// - Returns: A Cloud instance.
+    @available(*, deprecated, message: "Use the `fullHandle` and `url` properties directly in the `Config`")
     public static func cloud(projectId: String, url: String = "https://cloud.tuist.io", options: [Option] = []) -> Cloud {
         Cloud(url: url, projectId: projectId, options: options)
     }


### PR DESCRIPTION
### Short description 📝

Moving the deprecation from this [PR](https://github.com/tuist/tuist/pull/6529) as migrating to the new API is not possible due to: https://github.com/tuist/tuist/pull/6530

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
