### PR TITLE
Migrate `FileHandler.shared.delete` to `await FileSystem().remove`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dc4a35b9ed535c9d2a720826820ddba97515ea7aae953fc69429768c6acc657a",
+  "originHash" : "72762ee5d0c1c6693d240f855baa564f33c1989e012f95666662934d0ad27a2d",
   "pins" : [
     {
       "identity" : "aexml",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "f627d00718033c3d7888acd5f4e3524a843db1cf",
         "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "filesystem",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/FileSystem.git",
+      "state" : {
+        "revision" : "0cbe28158a51ca6234dd00da59be88de2b7b22be",
+        "version" : "0.2.0"
       }
     },
     {
@@ -164,12 +173,39 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio",
+      "state" : {
+        "revision" : "fc79798d5a150d61361a27ce0c51169b889e23de",
+        "version" : "2.68.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -70,6 +70,7 @@ var targets: [Target] = [
             "XcodeGraph",
             "Mockable",
             "TuistServer",
+            "FileSystem",
             .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
         ],
         swiftSettings: [
@@ -102,6 +103,7 @@ var targets: [Target] = [
             "ZIPFoundation",
             "ProjectDescription",
             "Mockable",
+            "FileSystem"
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -141,6 +143,7 @@ var targets: [Target] = [
             swiftGenKitDependency,
             "StencilSwiftKit",
             "Mockable",
+            "FileSystem"
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -164,6 +167,7 @@ var targets: [Target] = [
             "StencilSwiftKit",
             "Stencil",
             "Mockable",
+            "FileSystem"
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -179,6 +183,7 @@ var targets: [Target] = [
             "XcodeGraph",
             "TuistSupport",
             "Mockable",
+            "FileSystem"
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -223,6 +228,7 @@ var targets: [Target] = [
             "Mockable",
             pathDependency,
             "Queuer",
+            "FileSystem"
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -277,6 +283,7 @@ var targets: [Target] = [
             "TuistSupport",
             "TuistScaffold",
             "Mockable",
+            "FileSystem",
             pathDependency,
         ],
         swiftSettings: [
@@ -288,6 +295,7 @@ var targets: [Target] = [
         dependencies: [
             "TuistCore",
             "TuistSupport",
+            "FileSystem",
             pathDependency,
             .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
             .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),

--- a/Package.swift
+++ b/Package.swift
@@ -304,6 +304,7 @@ var targets: [Target] = [
 
     let packageSettings = PackageSettings(
         productTypes: [
+            "FileSystem", .staticFramework,
             "TSCBasic": .staticFramework,
             "TSCUtility": .staticFramework,
             "TSCclibc": .staticFramework,

--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ var targets: [Target] = [
             "ZIPFoundation",
             "ProjectDescription",
             "Mockable",
-            "FileSystem"
+            "FileSystem",
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -143,7 +143,7 @@ var targets: [Target] = [
             swiftGenKitDependency,
             "StencilSwiftKit",
             "Mockable",
-            "FileSystem"
+            "FileSystem",
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -167,7 +167,7 @@ var targets: [Target] = [
             "StencilSwiftKit",
             "Stencil",
             "Mockable",
-            "FileSystem"
+            "FileSystem",
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -183,7 +183,7 @@ var targets: [Target] = [
             "XcodeGraph",
             "TuistSupport",
             "Mockable",
-            "FileSystem"
+            "FileSystem",
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
@@ -228,7 +228,7 @@ var targets: [Target] = [
             "Mockable",
             pathDependency,
             "Queuer",
-            "FileSystem"
+            "FileSystem",
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),

--- a/Package.swift
+++ b/Package.swift
@@ -422,6 +422,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.5.0")),
+        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0"))
     ],
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -422,7 +422,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0"))
+        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -304,7 +304,6 @@ var targets: [Target] = [
 
     let packageSettings = PackageSettings(
         productTypes: [
-            "SystemPackage": .staticFramework,
             "TSCBasic": .staticFramework,
             "TSCUtility": .staticFramework,
             "TSCclibc": .staticFramework,
@@ -312,7 +311,8 @@ var targets: [Target] = [
             "ArgumentParser": .staticFramework,
             "Mockable": .staticFramework,
             "MockableTest": .staticFramework,
-        ]
+        ],
+        baseSettings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES"])
     )
 
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -304,7 +304,7 @@ var targets: [Target] = [
 
     let packageSettings = PackageSettings(
         productTypes: [
-            "FileSystem", .staticFramework,
+            "FileSystem": .staticFramework,
             "TSCBasic": .staticFramework,
             "TSCUtility": .staticFramework,
             "TSCclibc": .staticFramework,

--- a/Sources/TuistAcceptanceTesting/ServerAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/ServerAcceptanceTestCase.swift
@@ -37,7 +37,7 @@ open class ServerAcceptanceTestCase: TuistAcceptanceTestCase {
     override open func tearDown() async throws {
         try await run(ProjectDeleteCommand.self, fullHandle)
         try await run(OrganizationDeleteCommand.self, organizationHandle)
-        try run(LogoutCommand.self)
+        try await run(LogoutCommand.self)
         try await super.tearDown()
     }
 }

--- a/Sources/TuistAnalytics/TuistAnalytics.swift
+++ b/Sources/TuistAnalytics/TuistAnalytics.swift
@@ -7,7 +7,7 @@ import XcodeGraph
 public enum TuistAnalytics {
     public static func bootstrap(dispatcher: TuistAnalyticsDispatcher) throws {
         AsyncQueue.sharedInstance.register(dispatcher: dispatcher)
-        Task.detached(priority: .background) {
+        Task {
             await AsyncQueue.sharedInstance.start() // Re-try to send all events that got persisted and haven't been sent yet
         }
     }

--- a/Sources/TuistAnalytics/TuistAnalytics.swift
+++ b/Sources/TuistAnalytics/TuistAnalytics.swift
@@ -8,7 +8,7 @@ public enum TuistAnalytics {
     public static func bootstrap(dispatcher: TuistAnalyticsDispatcher) throws {
         AsyncQueue.sharedInstance.register(dispatcher: dispatcher)
         Task.detached(priority: .background) {
-            AsyncQueue.sharedInstance.start() // Re-try to send all events that got persisted and haven't been sent yet
+            await AsyncQueue.sharedInstance.start() // Re-try to send all events that got persisted and haven't been sent yet
         }
     }
 }

--- a/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
+++ b/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
@@ -18,16 +18,16 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
 
     public var identifier = TuistAnalyticsDispatcher.dispatcherId
 
-    public func dispatch(event: AsyncQueueEvent, completion: @escaping () throws -> Void) throws {
+    public func dispatch(event: AsyncQueueEvent, completion: @escaping () async throws -> Void) throws {
         guard let commandEvent = event as? CommandEvent else { return }
 
         Task.detached {
             _ = try? await backend?.send(commandEvent: commandEvent)
-            try completion()
+            try await completion()
         }
     }
 
-    public func dispatchPersisted(data: Data, completion: @escaping () throws -> Void) throws {
+    public func dispatchPersisted(data: Data, completion: @escaping () async throws -> Void) throws {
         let decoder = JSONDecoder()
         let commandEvent = try decoder.decode(CommandEvent.self, from: data)
         return try dispatch(event: commandEvent, completion: completion)

--- a/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
+++ b/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
@@ -21,7 +21,7 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
     public func dispatch(event: AsyncQueueEvent, completion: @escaping () async throws -> Void) throws {
         guard let commandEvent = event as? CommandEvent else { return }
 
-        Task.detached {
+        Task {
             _ = try? await backend?.send(commandEvent: commandEvent)
             try await completion()
         }

--- a/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
+++ b/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
@@ -1,8 +1,8 @@
+import FileSystem
 import Foundation
 import Path
 import TuistCore
 import TuistSupport
-import FileSystem
 
 // swiftlint:disable:next large_tuple
 public typealias AsyncQueueEventTuple = (dispatcherId: String, id: UUID, date: Date, data: Data, filename: String)

--- a/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
+++ b/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
@@ -52,7 +52,7 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
     func delete(filename: String) async throws {
         let path = directory.appending(component: filename)
         guard FileHandler.shared.exists(path) else { return }
-        try await fileSystem.remove(.init(validating: path.pathString))
+        try await fileSystem.remove(path)
     }
 
     func readAll() async throws -> [AsyncQueueEventTuple] {
@@ -67,7 +67,7 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
             else {
                 /// Changing the naming convention is a breaking change. When detected
                 /// we delete the event.
-                try? await fileSystem.remove(.init(validating: eventPath.pathString))
+                try? await fileSystem.remove(eventPath)
                 continue
             }
             do {
@@ -81,7 +81,7 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
                 )
                 events.append(event)
             } catch {
-                try? await fileSystem.remove(.init(validating: eventPath.pathString))
+                try? await fileSystem.remove(eventPath)
             }
         }
         return events

--- a/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
+++ b/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
@@ -2,13 +2,14 @@ import Foundation
 import Path
 import TuistCore
 import TuistSupport
+import FileSystem
 
 // swiftlint:disable:next large_tuple
 public typealias AsyncQueueEventTuple = (dispatcherId: String, id: UUID, date: Date, data: Data, filename: String)
 
 public protocol AsyncQueuePersisting {
     /// Reads all the persisted events and returns them.
-    func readAll() throws -> [AsyncQueueEventTuple]
+    func readAll() async throws -> [AsyncQueueEventTuple]
 
     /// Persiss a given event.
     /// - Parameter event: Event to be persisted.
@@ -16,11 +17,11 @@ public protocol AsyncQueuePersisting {
 
     /// Deletes the given event from disk.
     /// - Parameter event: Event to be deleted.
-    func delete<T: AsyncQueueEvent>(event: T) throws
+    func delete<T: AsyncQueueEvent>(event: T) async throws
 
     /// Deletes the given file name from disk.
     /// - Parameter filename: Name of the file to be deleted.
-    func delete(filename: String) throws
+    func delete(filename: String) async throws
 }
 
 final class AsyncQueuePersistor: AsyncQueuePersisting {
@@ -28,11 +29,13 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
 
     let directory: AbsolutePath
     let jsonEncoder = JSONEncoder()
+    let fileSystem: FileSystem
 
     // MARK: - Init
 
-    init(directory: AbsolutePath = Environment.shared.queueDirectory) {
+    init(directory: AbsolutePath = Environment.shared.queueDirectory, fileSystem: FileSystem = FileSystem()) {
         self.directory = directory
+        self.fileSystem = fileSystem
     }
 
     func write(event: some AsyncQueueEvent) throws {
@@ -42,17 +45,17 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
         try data.write(to: path.url)
     }
 
-    func delete(event: some AsyncQueueEvent) throws {
-        try delete(filename: filename(event: event))
+    func delete(event: some AsyncQueueEvent) async throws {
+        try await delete(filename: filename(event: event))
     }
 
-    func delete(filename: String) throws {
+    func delete(filename: String) async throws {
         let path = directory.appending(component: filename)
         guard FileHandler.shared.exists(path) else { return }
-        try FileHandler.shared.delete(path)
+        try await fileSystem.remove(.init(validating: path.pathString))
     }
 
-    func readAll() throws -> [AsyncQueueEventTuple] {
+    func readAll() async throws -> [AsyncQueueEventTuple] {
         let paths = FileHandler.shared.glob(directory, glob: "*.json")
         var events: [AsyncQueueEventTuple] = []
         for eventPath in paths {
@@ -64,7 +67,7 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
             else {
                 /// Changing the naming convention is a breaking change. When detected
                 /// we delete the event.
-                try? FileHandler.shared.delete(eventPath)
+                try? await fileSystem.remove(.init(validating: eventPath.pathString))
                 continue
             }
             do {
@@ -78,7 +81,7 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
                 )
                 events.append(event)
             } catch {
-                try? FileHandler.shared.delete(eventPath)
+                try? await fileSystem.remove(.init(validating: eventPath.pathString))
             }
         }
         return events

--- a/Sources/TuistAsyncQueueTesting/MockAsyncQueueDispatcher.swift
+++ b/Sources/TuistAsyncQueueTesting/MockAsyncQueueDispatcher.swift
@@ -26,7 +26,7 @@ public class MockAsyncQueueDispatcher: AsyncQueueDispatching {
     public var invokedDispatchParametersEventsList = [AsyncQueueEvent]()
     public var stubbedDispatchError: Error?
 
-    public func dispatch(event: AsyncQueueEvent, completion: @escaping () throws -> Void) throws {
+    public func dispatch(event: AsyncQueueEvent, completion: @escaping () async throws -> Void) throws {
         invokedDispatch = true
         invokedDispatchCount += 1
         invokedDispatchParameterEvent = event
@@ -36,7 +36,12 @@ public class MockAsyncQueueDispatcher: AsyncQueueDispatching {
             throw error
         }
         invokedDispatchCallBack()
-        try completion()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            try await completion()
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
 
     public var invokedDispatchPersisted = false
@@ -46,7 +51,7 @@ public class MockAsyncQueueDispatcher: AsyncQueueDispatching {
     public var invokedDispatchPersistedParametersDataList = [Data]()
     public var stubbedDispatchPersistedError: Error?
 
-    public func dispatchPersisted(data: Data, completion: @escaping () throws -> Void) throws {
+    public func dispatchPersisted(data: Data, completion: @escaping () async throws -> Void) throws {
         invokedDispatchPersisted = true
         invokedDispatchPersistedCount += 1
         invokedDispatchPersistedDataParameter = data
@@ -56,6 +61,11 @@ public class MockAsyncQueueDispatcher: AsyncQueueDispatching {
             throw error
         }
         invokedDispatchPersistedCallBack()
-        try completion()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            try await completion()
+            semaphore.signal()
+        }
+        semaphore.wait()
     }
 }

--- a/Sources/TuistAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/TuistAutomation/Utilities/TargetBuilder.swift
@@ -165,7 +165,7 @@ public final class TargetBuilder: TargetBuilding {
         for product in try FileHandler.shared.contentsOfDirectory(xcodeSchemeBuildPath) {
             let productOutputPath = buildOutputPath.appending(component: product.basename)
             if FileHandler.shared.exists(productOutputPath) {
-                try await fileSystem.remove(.init(validating: productOutputPath.pathString))
+                try await fileSystem.remove(productOutputPath)
             }
 
             try FileHandler.shared.copy(from: product, to: productOutputPath)

--- a/Sources/TuistAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/TuistAutomation/Utilities/TargetBuilder.swift
@@ -1,9 +1,9 @@
+import FileSystem
 import Path
 import TSCUtility
 import TuistCore
 import TuistSupport
 import XcodeGraph
-import FileSystem
 
 public protocol TargetBuilding {
     /// Builds a provided target.

--- a/Sources/TuistCore/AsyncQueue/AsyncQueueDispatching.swift
+++ b/Sources/TuistCore/AsyncQueue/AsyncQueueDispatching.swift
@@ -7,9 +7,9 @@ public protocol AsyncQueueDispatching {
 
     /// Dispatches a given event.
     /// - Parameter event: Event to be dispatched.
-    func dispatch(event: AsyncQueueEvent, completion: @escaping () throws -> Void) throws
+    func dispatch(event: AsyncQueueEvent, completion: @escaping () async throws -> Void) throws
 
     /// Dispatch a persisted event.
     /// - Parameter data: Serialized data of the event.
-    func dispatchPersisted(data: Data, completion: @escaping () throws -> Void) throws
+    func dispatchPersisted(data: Data, completion: @escaping () async throws -> Void) throws
 }

--- a/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
+++ b/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
@@ -45,7 +45,7 @@ public final class SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
                 try FileHandler.shared.touch(file.path)
             }
         case .absent:
-            try await fileSystem.remove(.init(validating: file.path.pathString))
+            try await fileSystem.remove(file.path)
         }
     }
 
@@ -57,7 +57,7 @@ public final class SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
             }
         case .absent:
             if FileHandler.shared.exists(directory.path) {
-                try await fileSystem.remove(.init(validating: directory.path.pathString))
+                try await fileSystem.remove(directory.path)
             }
         }
     }

--- a/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
+++ b/Sources/TuistGenerator/Descriptors/SideEffectDescriptorExecutor.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import TuistCore
 import TuistSupport
@@ -6,31 +7,35 @@ import TuistSupport
 public protocol SideEffectDescriptorExecuting: AnyObject {
     /// Executes the given side effects sequentially.
     /// - Parameter sideEffects: Side effects to be executed.
-    func execute(sideEffects: [SideEffectDescriptor]) throws
+    func execute(sideEffects: [SideEffectDescriptor]) async throws
 }
 
 public final class SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
-    public init() {}
+    private let fileSystem: FileSystem
+
+    public init(fileSystem: FileSystem = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
 
     // MARK: - SideEffectDescriptorExecuting
 
-    public func execute(sideEffects: [SideEffectDescriptor]) throws {
+    public func execute(sideEffects: [SideEffectDescriptor]) async throws {
         for sideEffect in sideEffects {
             logger.debug("Side effect: \(sideEffect)")
             switch sideEffect {
             case let .command(commandDescriptor):
                 try perform(command: commandDescriptor)
             case let .file(fileDescriptor):
-                try process(file: fileDescriptor)
+                try await process(file: fileDescriptor)
             case let .directory(directoryDescriptor):
-                try process(directory: directoryDescriptor)
+                try await process(directory: directoryDescriptor)
             }
         }
     }
 
     // MARK: - Fileprivate
 
-    private func process(file: FileDescriptor) throws {
+    private func process(file: FileDescriptor) async throws {
         switch file.state {
         case .present:
             try FileHandler.shared.createFolder(file.path.parentDirectory)
@@ -40,11 +45,11 @@ public final class SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
                 try FileHandler.shared.touch(file.path)
             }
         case .absent:
-            try FileHandler.shared.delete(file.path)
+            try await fileSystem.remove(.init(validating: file.path.pathString))
         }
     }
 
-    private func process(directory: DirectoryDescriptor) throws {
+    private func process(directory: DirectoryDescriptor) async throws {
         switch directory.state {
         case .present:
             if !FileHandler.shared.exists(directory.path) {
@@ -52,7 +57,7 @@ public final class SideEffectDescriptorExecutor: SideEffectDescriptorExecuting {
             }
         case .absent:
             if FileHandler.shared.exists(directory.path) {
-                try FileHandler.shared.delete(directory.path)
+                try await fileSystem.remove(.init(validating: directory.path.pathString))
             }
         }
     }

--- a/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
+++ b/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import TuistCore
@@ -5,8 +6,8 @@ import TuistSupport
 import XcodeProj
 
 public protocol XcodeProjWriting {
-    func write(project: ProjectDescriptor) throws
-    func write(workspace: WorkspaceDescriptor) throws
+    func write(project: ProjectDescriptor) async throws
+    func write(workspace: WorkspaceDescriptor) async throws
 }
 
 // MARK: -
@@ -27,34 +28,37 @@ public final class XcodeProjWriter: XcodeProjWriting {
 
     private let config: Config
     private let sideEffectDescriptorExecutor: SideEffectDescriptorExecuting
+    private let fileSystem: FileSystem
 
     public init(
         sideEffectDescriptorExecutor: SideEffectDescriptorExecuting = SideEffectDescriptorExecutor(),
-        config: Config = .default
+        config: Config = .default,
+        fileSystem: FileSystem = FileSystem()
     ) {
         self.sideEffectDescriptorExecutor = sideEffectDescriptorExecutor
         self.config = config
+        self.fileSystem = fileSystem
     }
 
-    public func write(project: ProjectDescriptor) throws {
-        try write(project: project, schemesOrderHint: nil)
+    public func write(project: ProjectDescriptor) async throws {
+        try await write(project: project, schemesOrderHint: nil)
     }
 
-    public func write(workspace: WorkspaceDescriptor) throws {
+    public func write(workspace: WorkspaceDescriptor) async throws {
         let allSchemes = workspace.schemeDescriptors + workspace.projectDescriptors.flatMap(\.schemeDescriptors)
         let schemesOrderHint = schemesOrderHint(schemes: allSchemes)
-        try workspace.projectDescriptors.forEach(context: config.projectDescriptorWritingContext) { projectDescriptor in
-            try self.write(project: projectDescriptor, schemesOrderHint: schemesOrderHint)
+        try await workspace.projectDescriptors.forEach(context: config.projectDescriptorWritingContext) { projectDescriptor in
+            try await self.write(project: projectDescriptor, schemesOrderHint: schemesOrderHint)
         }
         try workspace.xcworkspace.write(path: workspace.xcworkspacePath.path, override: true)
 
         // Write all schemes (XCWorkspace doesn't manage any schemes like XcodeProj.sharedData)
-        try writeSchemes(
+        try await writeSchemes(
             schemeDescriptors: workspace.schemeDescriptors,
             xccontainerPath: workspace.xcworkspacePath,
             wipeSharedSchemesBeforeWriting: true
         )
-        try writeXCSchemeManagement(
+        try await writeXCSchemeManagement(
             schemes: workspace.schemeDescriptors,
             xccontainerPath: workspace.xcworkspacePath,
             schemesOrderHint: schemesOrderHint
@@ -66,14 +70,14 @@ public final class XcodeProjWriter: XcodeProjWriting {
                 xccontainerPath: workspace.xcworkspacePath
             )
         } else {
-            try deleteWorkspaceSettingsIfNeeded(xccontainerPath: workspace.xcworkspacePath)
+            try await deleteWorkspaceSettingsIfNeeded(xccontainerPath: workspace.xcworkspacePath)
         }
-        try sideEffectDescriptorExecutor.execute(sideEffects: workspace.sideEffectDescriptors)
+        try await sideEffectDescriptorExecutor.execute(sideEffects: workspace.sideEffectDescriptors)
     }
 
     // MARK: - Private
 
-    private func write(project: ProjectDescriptor, schemesOrderHint: [String: Int]?) throws {
+    private func write(project: ProjectDescriptor, schemesOrderHint: [String: Int]?) async throws {
         let schemesOrderHint = schemesOrderHint ?? self.schemesOrderHint(schemes: project.schemeDescriptors)
 
         // XcodeProj can manage writing of shared schemes, we have to manually manage the user schemes
@@ -81,28 +85,28 @@ public final class XcodeProjWriter: XcodeProjWriting {
         try project.xcodeProj.write(path: project.xcodeprojPath.path)
 
         // Write user schemes only
-        try writeSchemes(
+        try await writeSchemes(
             schemeDescriptors: project.userSchemeDescriptors,
             xccontainerPath: project.xcodeprojPath,
             wipeSharedSchemesBeforeWriting: false // Since we are only writing user schemes
         )
-        try writeXCSchemeManagement(
+        try await writeXCSchemeManagement(
             schemes: project.schemeDescriptors,
             xccontainerPath: project.xcodeprojPath,
             schemesOrderHint: schemesOrderHint
         )
 
-        try sideEffectDescriptorExecutor.execute(sideEffects: project.sideEffectDescriptors)
+        try await sideEffectDescriptorExecutor.execute(sideEffects: project.sideEffectDescriptors)
     }
 
     private func writeSchemes(
         schemeDescriptors: [SchemeDescriptor],
         xccontainerPath: AbsolutePath,
         wipeSharedSchemesBeforeWriting: Bool
-    ) throws {
+    ) async throws {
         let sharedSchemesPath = try schemeDirectory(path: xccontainerPath, shared: true)
         if wipeSharedSchemesBeforeWriting, FileHandler.shared.exists(sharedSchemesPath) {
-            try FileHandler.shared.delete(sharedSchemesPath)
+            try await fileSystem.remove(.init(validating: sharedSchemesPath.pathString))
         }
         try schemeDescriptors.forEach { try write(scheme: $0, xccontainerPath: xccontainerPath) }
     }
@@ -143,18 +147,17 @@ public final class XcodeProjWriter: XcodeProjWriting {
             .write(path: settingsPath.path, override: true)
     }
 
-    private func deleteWorkspaceSettingsIfNeeded(xccontainerPath: AbsolutePath) throws {
+    private func deleteWorkspaceSettingsIfNeeded(xccontainerPath: AbsolutePath) async throws {
         let settingsPath = WorkspaceSettingsDescriptor.xcsettingsFilePath(relativeToWorkspace: xccontainerPath)
         guard FileHandler.shared.exists(settingsPath) else { return }
-
-        try FileHandler.shared.delete(settingsPath)
+        try await fileSystem.remove(.init(validating: settingsPath.pathString))
     }
 
     private func writeXCSchemeManagement(
         schemes: [SchemeDescriptor],
         xccontainerPath: AbsolutePath,
         schemesOrderHint: [String: Int] = [:]
-    ) throws {
+    ) async throws {
         let xcschememanagementPath = try schemeDirectory(
             path: xccontainerPath,
             shared: false
@@ -168,7 +171,7 @@ public final class XcodeProjWriter: XcodeProjWriting {
             )
         }
         if FileHandler.shared.exists(xcschememanagementPath) {
-            try FileHandler.shared.delete(xcschememanagementPath)
+            try await fileSystem.remove(.init(validating: xcschememanagementPath.pathString))
         }
         try FileHandler.shared.createFolder(xcschememanagementPath.parentDirectory)
         try XCSchemeManagement(schemeUserState: userStateSchemes, suppressBuildableAutocreation: nil)

--- a/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
+++ b/Sources/TuistGenerator/Writers/XcodeProjWriter.swift
@@ -106,7 +106,7 @@ public final class XcodeProjWriter: XcodeProjWriting {
     ) async throws {
         let sharedSchemesPath = try schemeDirectory(path: xccontainerPath, shared: true)
         if wipeSharedSchemesBeforeWriting, FileHandler.shared.exists(sharedSchemesPath) {
-            try await fileSystem.remove(.init(validating: sharedSchemesPath.pathString))
+            try await fileSystem.remove(sharedSchemesPath)
         }
         try schemeDescriptors.forEach { try write(scheme: $0, xccontainerPath: xccontainerPath) }
     }
@@ -150,7 +150,7 @@ public final class XcodeProjWriter: XcodeProjWriting {
     private func deleteWorkspaceSettingsIfNeeded(xccontainerPath: AbsolutePath) async throws {
         let settingsPath = WorkspaceSettingsDescriptor.xcsettingsFilePath(relativeToWorkspace: xccontainerPath)
         guard FileHandler.shared.exists(settingsPath) else { return }
-        try await fileSystem.remove(.init(validating: settingsPath.pathString))
+        try await fileSystem.remove(settingsPath)
     }
 
     private func writeXCSchemeManagement(
@@ -171,7 +171,7 @@ public final class XcodeProjWriter: XcodeProjWriting {
             )
         }
         if FileHandler.shared.exists(xcschememanagementPath) {
-            try await fileSystem.remove(.init(validating: xcschememanagementPath.pathString))
+            try await fileSystem.remove(xcschememanagementPath)
         }
         try FileHandler.shared.createFolder(xcschememanagementPath.parentDirectory)
         try XCSchemeManagement(schemeUserState: userStateSchemes, suppressBuildableAutocreation: nil)

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -12,7 +12,7 @@ import XcodeGraph
 private typealias Platform = XcodeGraph.Platform
 private typealias Product = XcodeGraph.Product
 
-public struct InitCommand: ParsableCommand, HasTrackableParameters {
+public struct InitCommand: AsyncParsableCommand, HasTrackableParameters {
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
@@ -78,13 +78,13 @@ public struct InitCommand: ParsableCommand, HasTrackableParameters {
         }
     }
 
-    public func run() throws {
+    public func run() async throws {
         InitCommand.analyticsDelegate?.addParameters(
             [
                 "platform": AnyCodable(platform ?? "unknown"),
             ]
         )
-        try InitService().run(
+        try await InitService().run(
             name: name,
             platform: platform,
             path: path,
@@ -102,7 +102,7 @@ extension InitCommand {
     static var optionalTemplateOptions: [(name: String, option: Option<String?>)] = []
 
     /// We do not know template's option in advance -> we need to dynamically add them
-    static func preprocess(_ arguments: [String]? = nil) throws {
+    static func preprocess(_ arguments: [String]? = nil) async throws {
         guard let arguments,
               arguments.contains("--template") ||
               arguments.contains("-t")
@@ -125,7 +125,7 @@ extension InitCommand {
               templateName != "default"
         else { return }
 
-        let (required, optional) = try InitService().loadTemplateOptions(
+        let (required, optional) = try await InitService().loadTemplateOptions(
             templateName: templateName,
             path: command.path
         )

--- a/Sources/TuistKit/Commands/LogoutCommand.swift
+++ b/Sources/TuistKit/Commands/LogoutCommand.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import Path
 
-struct LogoutCommand: ParsableCommand {
+struct LogoutCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "logout",
@@ -18,8 +18,8 @@ struct LogoutCommand: ParsableCommand {
     )
     var path: String?
 
-    func run() throws {
-        try LogoutService().logout(
+    func run() async throws {
+        try await LogoutService().logout(
             directory: path
         )
     }

--- a/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import Path
 
-struct PluginArchiveCommand: ParsableCommand {
+struct PluginArchiveCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "archive",
@@ -18,8 +18,8 @@ struct PluginArchiveCommand: ParsableCommand {
     )
     var path: String?
 
-    func run() throws {
-        try PluginArchiveService().run(
+    func run() async throws {
+        try await PluginArchiveService().run(
             path: path
         )
     }

--- a/Sources/TuistKit/Commands/SessionCommand.swift
+++ b/Sources/TuistKit/Commands/SessionCommand.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 import Path
 
-struct SessionCommand: ParsableCommand {
+struct SessionCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "session",
@@ -18,8 +18,8 @@ struct SessionCommand: ParsableCommand {
     )
     var path: String?
 
-    func run() throws {
-        try SessionService().printSession(
+    func run() async throws {
+        try await SessionService().printSession(
             directory: path
         )
     }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -51,7 +51,7 @@ public struct TuistCommand: AsyncParsableCommand {
         }
 
         let backend: TuistAnalyticsBackend?
-        let config = try ConfigLoader().loadConfig(path: path)
+        let config = try await ConfigLoader().loadConfig(path: path)
         if let fullHandle = config.fullHandle {
             backend = TuistAnalyticsServerBackend(
                 fullHandle: fullHandle,
@@ -85,7 +85,7 @@ public struct TuistCommand: AsyncParsableCommand {
         } catch {
             parsedError = error
             executeCommand = {
-                try executeTask(with: processedArguments)
+                try await executeTask(with: processedArguments)
             }
         }
 
@@ -116,8 +116,8 @@ public struct TuistCommand: AsyncParsableCommand {
         }
     }
 
-    private static func executeTask(with processedArguments: [String]) throws {
-        try TuistService().run(
+    private static func executeTask(with processedArguments: [String]) async throws {
+        try await TuistService().run(
             arguments: processedArguments,
             tuistBinaryPath: processArguments()!.first!
         )

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -72,7 +72,7 @@ public struct TuistCommand: AsyncParsableCommand {
                 try await ScaffoldCommand.preprocess(processedArguments)
             }
             if processedArguments.first == InitCommand.configuration.commandName {
-                try InitCommand.preprocess(processedArguments)
+                try await InitCommand.preprocess(processedArguments)
             }
             let command = try parseAsRoot(processedArguments)
             executeCommand = {

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -55,7 +55,7 @@ public class Generator: Generating {
         let graphTraverser = GraphTraverser(graph: graph)
 
         // Lint
-        try lint(graphTraverser: graphTraverser)
+        try await lint(graphTraverser: graphTraverser)
 
         // Generate
         let workspaceDescriptor = try generator.generateWorkspace(graphTraverser: graphTraverser)
@@ -91,8 +91,8 @@ public class Generator: Generating {
         return (graph, sideEffectDescriptors)
     }
 
-    private func lint(graphTraverser: GraphTraversing) throws {
-        let config = try configLoader.loadConfig(path: graphTraverser.path)
+    private func lint(graphTraverser: GraphTraversing) async throws {
+        let config = try await configLoader.loadConfig(path: graphTraverser.path)
 
         let environmentIssues = try environmentLinter.lint(config: config)
         try environmentIssues.printAndThrowErrorsIfNeeded()
@@ -104,7 +104,7 @@ public class Generator: Generating {
     }
 
     private func postGenerationActions(graphTraverser: GraphTraversing, workspaceName: String) async throws {
-        let config = try configLoader.loadConfig(path: graphTraverser.path)
+        let config = try await configLoader.loadConfig(path: graphTraverser.path)
 
         try await swiftPackageManagerInteractor.install(
             graphTraverser: graphTraverser,

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -61,10 +61,10 @@ public class Generator: Generating {
         let workspaceDescriptor = try generator.generateWorkspace(graphTraverser: graphTraverser)
 
         // Write
-        try writer.write(workspace: workspaceDescriptor)
+        try await writer.write(workspace: workspaceDescriptor)
 
         // Mapper side effects
-        try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
+        try await sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
 
         // Post Generate Actions
         try await postGenerationActions(

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -168,7 +168,7 @@ final class ProjectEditor: ProjectEditing {
             plugins: plugins,
             onlyCurrentDirectory: onlyCurrentDirectory
         )
-        let builtPluginHelperModules = try buildRemotePluginModules(
+        let builtPluginHelperModules = try await buildRemotePluginModules(
             in: editingPath,
             projectDescriptionPath: projectDescriptionPath,
             plugins: plugins,
@@ -237,9 +237,9 @@ final class ProjectEditor: ProjectEditing {
         projectDescriptionPath: AbsolutePath,
         plugins: Plugins,
         projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding
-    ) throws -> [ProjectDescriptionHelpersModule] {
+    ) async throws -> [ProjectDescriptionHelpersModule] {
         let loadedPluginHelpers = plugins.projectDescriptionHelpers.filter { $0.location == .remote }
-        return try projectDescriptionHelpersBuilder.buildPlugins(
+        return try await projectDescriptionHelpersBuilder.buildPlugins(
             at: path,
             projectDescriptionSearchPaths: ProjectDescriptionSearchPaths.paths(for: projectDescriptionPath),
             projectDescriptionHelperPlugins: loadedPluginHelpers

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -40,7 +40,7 @@ protocol ProjectEditing: AnyObject {
         in destinationDirectory: AbsolutePath,
         onlyCurrentDirectory: Bool,
         plugins: Plugins
-    ) throws -> AbsolutePath
+    ) async throws -> AbsolutePath
 }
 
 final class ProjectEditor: ProjectEditing {
@@ -107,7 +107,7 @@ final class ProjectEditor: ProjectEditing {
         in destinationDirectory: AbsolutePath,
         onlyCurrentDirectory: Bool,
         plugins: Plugins
-    ) throws -> AbsolutePath {
+    ) async throws -> AbsolutePath {
         let tuistIgnoreContent = (try? FileHandler.shared.readTextFile(editingPath.appending(component: ".tuistignore"))) ?? ""
         let tuistIgnoreEntries = try tuistIgnoreContent
             .split(separator: "\n")
@@ -206,7 +206,7 @@ final class ProjectEditor: ProjectEditing {
 
         let graphTraverser = GraphTraverser(graph: graph)
         let descriptor = try generator.generateWorkspace(graphTraverser: graphTraverser)
-        try writer.write(workspace: descriptor)
+        try await writer.write(workspace: descriptor)
         return descriptor.xcworkspacePath
     }
 

--- a/Sources/TuistKit/Services/AnalyticsService.swift
+++ b/Sources/TuistKit/Services/AnalyticsService.swift
@@ -45,7 +45,7 @@ final class AnalyticsService: AnalyticsServicing {
         path: String?
     ) async throws {
         let path: AbsolutePath = try self.path(path)
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
 
         guard let fullHandle = config.fullHandle else { throw AnalyticsServiceError.fullHandleNotFound }
         try opener.open(

--- a/Sources/TuistKit/Services/AuthService.swift
+++ b/Sources/TuistKit/Services/AuthService.swift
@@ -52,7 +52,7 @@ final class AuthService: AuthServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         if email != nil || password != nil {

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -74,7 +74,7 @@ public final class BuildService {
         passthroughXcodeBuildArguments: [String]
     ) async throws {
         let graph: Graph
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         let cacheStorage = try cacheStorageFactory.cacheStorage(config: config)
         let generator = generatorFactory.building(
             config: config,

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import TuistCore
@@ -61,6 +62,8 @@ final class CleanService {
     private let configLoader: ConfigLoading
     private let serverURLService: ServerURLServicing
     private let cleanCacheService: CleanCacheServicing
+    private let fileSystem: FileSystem
+
     init(
         fileHandler: FileHandling,
         rootDirectoryLocator: RootDirectoryLocating,
@@ -68,7 +71,8 @@ final class CleanService {
         manifestFilesLocator: ManifestFilesLocating,
         configLoader: ConfigLoading,
         serverURLService: ServerURLServicing,
-        cleanCacheService: CleanCacheServicing
+        cleanCacheService: CleanCacheServicing,
+        fileSystem: FileSystem
     ) {
         self.fileHandler = fileHandler
         self.rootDirectoryLocator = rootDirectoryLocator
@@ -77,6 +81,7 @@ final class CleanService {
         self.configLoader = configLoader
         self.serverURLService = serverURLService
         self.cleanCacheService = cleanCacheService
+        self.fileSystem = fileSystem
     }
 
     public convenience init() {
@@ -87,7 +92,8 @@ final class CleanService {
             manifestFilesLocator: ManifestFilesLocator(),
             configLoader: ConfigLoader(),
             serverURLService: ServerURLService(),
-            cleanCacheService: CleanCacheService()
+            cleanCacheService: CleanCacheService(),
+            fileSystem: FileSystem()
         )
     }
 
@@ -117,7 +123,7 @@ final class CleanService {
             if let directory,
                fileHandler.exists(directory)
             {
-                try FileHandler.shared.delete(directory)
+                try await fileSystem.remove(directory)
                 logger.notice("Successfully cleaned artifacts at path \(directory.pathString)", metadata: .success)
             } else {
                 logger.notice("There's nothing to clean for \(category.defaultValueDescription)")

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -125,7 +125,7 @@ final class CleanService {
         }
 
         if remote {
-            let config = try configLoader.loadConfig(path: resolvedPath)
+            let config = try await configLoader.loadConfig(path: resolvedPath)
             guard let fullHandle = config.fullHandle else { return }
             let serverURL = try serverURLService.url(configServerURL: config.url)
             try await cleanCacheService.cleanCache(

--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -31,17 +31,17 @@ final class DumpService {
         let encoded: Encodable
         switch manifest {
         case .project:
-            encoded = try manifestLoader.loadProject(at: projectPath)
+            encoded = try await manifestLoader.loadProject(at: projectPath)
         case .workspace:
-            encoded = try manifestLoader.loadWorkspace(at: projectPath)
+            encoded = try await manifestLoader.loadWorkspace(at: projectPath)
         case .config:
-            encoded = try manifestLoader.loadConfig(at: projectPath.appending(component: Constants.tuistDirectoryName))
+            encoded = try await manifestLoader.loadConfig(at: projectPath.appending(component: Constants.tuistDirectoryName))
         case .template:
-            encoded = try manifestLoader.loadTemplate(at: projectPath)
+            encoded = try await manifestLoader.loadTemplate(at: projectPath)
         case .plugin:
-            encoded = try manifestLoader.loadPlugin(at: projectPath)
+            encoded = try await manifestLoader.loadPlugin(at: projectPath)
         case .package:
-            encoded = try manifestLoader.loadPackageSettings(at: projectPath)
+            encoded = try await manifestLoader.loadPackageSettings(at: projectPath)
         }
 
         let json: JSON = try encoded.toJSON()

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -94,7 +94,7 @@ final class EditService {
     }
 
     private func loadPlugins(at path: AbsolutePath) async -> Plugins {
-        guard let config = try? configLoader.loadConfig(path: path) else {
+        guard let config = try? await configLoader.loadConfig(path: path) else {
             logger.warning("Unable to load Config.swift, fix any compiler errors and re-run for plugins to be loaded.")
             return .none
         }

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -63,7 +63,7 @@ final class EditService {
                 throw EditServiceError.xcodeNotSelected
             }
 
-            let workspacePath = try projectEditor.edit(
+            let workspacePath = try await projectEditor.edit(
                 at: path,
                 in: cachedManifestDirectory,
                 onlyCurrentDirectory: onlyCurrentDirectory,
@@ -73,7 +73,7 @@ final class EditService {
             try opener.open(path: workspacePath, application: selectedXcode.path, wait: false)
 
         } else {
-            let workspacePath = try projectEditor.edit(
+            let workspacePath = try await projectEditor.edit(
                 at: path,
                 in: path,
                 onlyCurrentDirectory: onlyCurrentDirectory,

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -47,7 +47,7 @@ final class GenerateService {
     ) async throws {
         let timer = clock.startTimer()
         let path = try self.path(path)
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         let cacheStorage = try cacheStorageFactory.cacheStorage(config: config)
         let generator = generatorFactory.generation(
             config: config,

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -1,4 +1,5 @@
 import DOT
+import FileSystem
 import Foundation
 import GraphViz
 import Path
@@ -14,6 +15,7 @@ import XcodeGraph
 final class GraphService {
     private let graphVizMapper: GraphToGraphVizMapping
     private let manifestGraphLoader: ManifestGraphLoading
+    private let fileSystem: FileSystem
 
     convenience init() {
         let manifestLoader = ManifestLoaderFactory()
@@ -32,10 +34,12 @@ final class GraphService {
 
     init(
         graphVizGenerator: GraphToGraphVizMapping,
-        manifestGraphLoader: ManifestGraphLoading
+        manifestGraphLoader: ManifestGraphLoading,
+        fileSystem: FileSystem = FileSystem()
     ) {
         graphVizMapper = graphVizGenerator
         self.manifestGraphLoader = manifestGraphLoader
+        self.fileSystem = fileSystem
     }
 
     func run(
@@ -54,7 +58,7 @@ final class GraphService {
         let filePath = outputPath.appending(component: "graph.\(format.rawValue)")
         if FileHandler.shared.exists(filePath) {
             logger.notice("Deleting existing graph at \(filePath.pathString)")
-            try FileHandler.shared.delete(filePath)
+            try await fileSystem.remove(filePath)
         }
 
         let filteredTargetsAndDependencies = graph.filter(

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -63,7 +63,7 @@ class InitService {
     func loadTemplateOptions(
         templateName: String,
         path: String?
-    ) throws -> (
+    ) async throws -> (
         required: [String],
         optional: [String]
     ) {
@@ -72,7 +72,7 @@ class InitService {
         var attributes: [Template.Attribute] = []
 
         if templateName.isGitURL {
-            try templateGitLoader.loadTemplate(from: templateName) { template in
+            try await templateGitLoader.loadTemplate(from: templateName) { template in
                 attributes = template.attributes
             }
         } else {
@@ -108,7 +108,7 @@ class InitService {
         templateName: String?,
         requiredTemplateOptions: [String: String],
         optionalTemplateOptions: [String: String?]
-    ) throws {
+    ) async throws {
         let platform = try self.platform(platform)
         let path = try self.path(path)
         let name = try self.name(name, path: path)
@@ -117,8 +117,8 @@ class InitService {
         try verifyDirectoryIsEmpty(path: path)
 
         if templateName.isGitURL {
-            try templateGitLoader.loadTemplate(from: templateName, closure: { template in
-                let parsedAttributes = try parseAttributes(
+            try await templateGitLoader.loadTemplate(from: templateName, closure: { template in
+                let parsedAttributes = try self.parseAttributes(
                     name: name,
                     platform: platform,
                     tuistVersion: tuistVersion,
@@ -127,7 +127,7 @@ class InitService {
                     template: template
                 )
 
-                try templateGenerator.generate(
+                try await self.templateGenerator.generate(
                     template: template,
                     to: path,
                     attributes: parsedAttributes
@@ -148,7 +148,7 @@ class InitService {
                 template: template
             )
 
-            try templateGenerator.generate(
+            try await templateGenerator.generate(
                 template: template,
                 to: path,
                 attributes: parsedAttributes

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -81,7 +81,7 @@ class InitService {
                 template: templateName
             )
 
-            let template = try templateLoader.loadTemplate(at: templateDirectory, plugins: .none)
+            let template = try await templateLoader.loadTemplate(at: templateDirectory, plugins: .none)
             attributes = template.attributes
         }
 
@@ -138,7 +138,7 @@ class InitService {
             guard let templateDirectory = directories.first(where: { $0.basename == templateName })
             else { throw InitServiceError.templateNotFound(templateName) }
 
-            let template = try templateLoader.loadTemplate(at: templateDirectory, plugins: .none)
+            let template = try await templateLoader.loadTemplate(at: templateDirectory, plugins: .none)
             let parsedAttributes = try parseAttributes(
                 name: name,
                 platform: platform,

--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -54,7 +54,7 @@ final class InstallService {
     private func fetchPlugins(path: AbsolutePath) async throws {
         logger.notice("Resolving and fetching plugins.", metadata: .section)
 
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         _ = try await pluginService.loadPlugins(using: config)
 
         logger.notice("Plugins resolved and fetched successfully.", metadata: .success)

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -37,8 +37,8 @@ class ListService {
 
         let plugins = try await loadPlugins(at: path)
         let templateDirectories = try locateTemplateDirectories(at: path, plugins: plugins)
-        let templates: [PrintableTemplate] = try templateDirectories.map { path in
-            let template = try templateLoader.loadTemplate(at: path, plugins: plugins)
+        let templates: [PrintableTemplate] = try await templateDirectories.concurrentMap { path in
+            let template = try await self.templateLoader.loadTemplate(at: path, plugins: plugins)
             return PrintableTemplate(name: path.basename, description: template.description)
         }
 
@@ -74,7 +74,7 @@ class ListService {
     }
 
     private func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         return try await pluginService.loadPlugins(using: config)
     }
 

--- a/Sources/TuistKit/Services/LogoutService.swift
+++ b/Sources/TuistKit/Services/LogoutService.swift
@@ -37,7 +37,7 @@ final class LogoutService: LogoutServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
         try await serverSessionController.logout(serverURL: serverURL)
     }

--- a/Sources/TuistKit/Services/LogoutService.swift
+++ b/Sources/TuistKit/Services/LogoutService.swift
@@ -10,7 +10,7 @@ protocol LogoutServicing: AnyObject {
     /// the keychain
     func logout(
         directory: String?
-    ) throws
+    ) async throws
 }
 
 final class LogoutService: LogoutServicing {
@@ -30,7 +30,7 @@ final class LogoutService: LogoutServicing {
 
     func logout(
         directory: String?
-    ) throws {
+    ) async throws {
         let directoryPath: AbsolutePath
         if let directory {
             directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
@@ -39,6 +39,6 @@ final class LogoutService: LogoutServicing {
         }
         let config = try configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
-        try serverSessionController.logout(serverURL: serverURL)
+        try await serverSessionController.logout(serverURL: serverURL)
     }
 }

--- a/Sources/TuistKit/Services/Organization/OrganizationBillingService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationBillingService.swift
@@ -36,7 +36,7 @@ final class OrganizationBillingService: OrganizationBillingServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
         try opener.open(
             url: serverURL

--- a/Sources/TuistKit/Services/Organization/OrganizationCreateService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationCreateService.swift
@@ -36,7 +36,7 @@ final class OrganizationCreateService: OrganizationCreateServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let organization = try await createOrganizationService.createOrganization(

--- a/Sources/TuistKit/Services/Organization/OrganizationDeleteService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationDeleteService.swift
@@ -36,7 +36,7 @@ final class OrganizationDeleteService: OrganizationDeleteServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         try await deleteOrganizationService.deleteOrganization(

--- a/Sources/TuistKit/Services/Organization/OrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationInviteService.swift
@@ -38,7 +38,7 @@ final class OrganizationInviteService: OrganizationInviteServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let invitation = try await createOrganizationInviteService.createOrganizationInvite(

--- a/Sources/TuistKit/Services/Organization/OrganizationListService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationListService.swift
@@ -36,7 +36,7 @@ final class OrganizationListService: OrganizationListServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let organizations = try await listOrganizationsService.listOrganizations(

--- a/Sources/TuistKit/Services/Organization/OrganizationRemoveInviteService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationRemoveInviteService.swift
@@ -38,7 +38,7 @@ final class OrganizationRemoveInviteService: OrganizationRemoveInviteServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         try await cancelOrganizationRemoveInviteService.cancelOrganizationInvite(

--- a/Sources/TuistKit/Services/Organization/OrganizationRemoveMemberService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationRemoveMemberService.swift
@@ -38,7 +38,7 @@ final class OrganizationRemoveMemberService: OrganizationRemoveMemberServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         try await removeOrganizationMemberService.removeOrganizationMember(

--- a/Sources/TuistKit/Services/Organization/OrganizationRemoveSSOService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationRemoveSSOService.swift
@@ -36,7 +36,7 @@ final class OrganizationRemoveSSOService: OrganizationRemoveSSOServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
 
         let serverURL = try serverURLService.url(configServerURL: config.url)
         _ = try await updateOrganizationService.updateOrganization(

--- a/Sources/TuistKit/Services/Organization/OrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationShowService.swift
@@ -41,7 +41,7 @@ final class OrganizationShowService: OrganizationShowServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let organization = try await getOrganizationService.getOrganization(

--- a/Sources/TuistKit/Services/Organization/OrganizationUpdateMemberService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationUpdateMemberService.swift
@@ -40,7 +40,7 @@ final class OrganizationUpdateMemberService: OrganizationUpdateMemberServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
 
         let serverURL = try serverURLService.url(configServerURL: config.url)
         let member = try await updateOrganizationMemberService.updateOrganizationMember(

--- a/Sources/TuistKit/Services/Organization/OrganizationUpdateService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationUpdateService.swift
@@ -40,7 +40,7 @@ final class OrganizationUpdateSSOService: OrganizationUpdateSSOServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
 
         let ssoOrganization: SSOOrganization
         switch provider {

--- a/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import ProjectDescription
@@ -9,6 +10,7 @@ final class PluginArchiveService {
     private let swiftPackageManagerController: SwiftPackageManagerControlling
     private let manifestLoader: ManifestLoading
     private let fileArchiverFactory: FileArchivingFactorying
+    private let fileSystem: FileSystem
 
     init(
         swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(
@@ -16,11 +18,13 @@ final class PluginArchiveService {
             fileHandler: FileHandler.shared
         ),
         manifestLoader: ManifestLoading = ManifestLoader(),
-        fileArchiverFactory: FileArchivingFactorying = FileArchivingFactory()
+        fileArchiverFactory: FileArchivingFactorying = FileArchivingFactory(),
+        fileSystem: FileSystem = FileSystem()
     ) {
         self.swiftPackageManagerController = swiftPackageManagerController
         self.manifestLoader = manifestLoader
         self.fileArchiverFactory = fileArchiverFactory
+        self.fileSystem = fileSystem
     }
 
     func run(path: String?) async throws {
@@ -91,7 +95,7 @@ final class PluginArchiveService {
         let temporaryZipPath = try archiver.zip(name: zipName)
         let zipPath = path.appending(component: zipName)
         if FileHandler.shared.exists(zipPath) {
-            try FileHandler.shared.delete(zipPath)
+            try await fileSystem.remove(zipPath)
         }
         try FileHandler.shared.copy(
             from: temporaryZipPath,

--- a/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
@@ -23,7 +23,7 @@ final class PluginArchiveService {
         self.fileArchiverFactory = fileArchiverFactory
     }
 
-    func run(path: String?) throws {
+    func run(path: String?) async throws {
         let path = try self.path(path)
 
         let packageInfo = try swiftPackageManagerController.loadPackageInfo(at: path)
@@ -47,8 +47,8 @@ final class PluginArchiveService {
 
         let plugin = try manifestLoader.loadPlugin(at: path)
 
-        try FileHandler.shared.inTemporaryDirectory { temporaryDirectory in
-            try archiveProducts(
+        try await FileHandler.shared.inTemporaryDirectory { temporaryDirectory in
+            try await self.archiveProducts(
                 taskProducts: taskProducts,
                 path: path,
                 plugin: plugin,
@@ -72,7 +72,7 @@ final class PluginArchiveService {
         path: AbsolutePath,
         plugin: Plugin,
         in temporaryDirectory: AbsolutePath
-    ) throws {
+    ) async throws {
         let artifactsPath = temporaryDirectory.appending(component: "artifacts")
         for product in taskProducts {
             logger.notice("Building \(product)...")
@@ -97,7 +97,7 @@ final class PluginArchiveService {
             from: temporaryZipPath,
             to: zipPath
         )
-        try archiver.delete()
+        try await archiver.delete()
 
         logger.notice(
             "Plugin was successfully archived. Create a new Github release and attach the file \(zipPath.pathString) as an artifact.",

--- a/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
@@ -45,7 +45,7 @@ final class PluginArchiveService {
             return
         }
 
-        let plugin = try manifestLoader.loadPlugin(at: path)
+        let plugin = try await manifestLoader.loadPlugin(at: path)
 
         try await FileHandler.shared.inTemporaryDirectory { temporaryDirectory in
             try await self.archiveProducts(

--- a/Sources/TuistKit/Services/Project/ProjectCreateService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectCreateService.swift
@@ -36,7 +36,7 @@ final class ProjectCreateService: ProjectCreateServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
 
         let serverURL = try serverURLService.url(configServerURL: config.url)
 

--- a/Sources/TuistKit/Services/Project/ProjectDeleteService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectDeleteService.swift
@@ -42,7 +42,7 @@ final class ProjectDeleteService: ProjectDeleteServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let project = try await getProjectService.getProject(

--- a/Sources/TuistKit/Services/Project/ProjectListService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectListService.swift
@@ -36,7 +36,7 @@ final class ProjectListService: ProjectListServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let projects = try await listProjectsService.listProjects(

--- a/Sources/TuistKit/Services/Project/ProjectTokensCreateService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectTokensCreateService.swift
@@ -44,7 +44,7 @@ final class ProjectTokensCreateService: ProjectTokensCreateServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let token = try await createProjectTokenService.createProjectToken(

--- a/Sources/TuistKit/Services/Project/ProjectTokensListService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectTokensListService.swift
@@ -36,7 +36,7 @@ final class ProjectTokensListService: ProjectTokensListServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         let tokens = try await listProjectTokensService.listProjectTokens(

--- a/Sources/TuistKit/Services/Project/ProjectTokensRevokeService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectTokensRevokeService.swift
@@ -38,7 +38,7 @@ final class ProjectTokensRevokeService: ProjectTokensRevokeServicing {
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
         try await revokeProjectTokenService.revokeProjectToken(

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -79,7 +79,7 @@ final class RunService {
         }
 
         let graph: Graph
-        let config = try configLoader.loadConfig(path: runPath)
+        let config = try await configLoader.loadConfig(path: runPath)
         let generator = generatorFactory.defaultGenerator(config: config)
         if try (generate || buildGraphInspector.workspacePath(directory: runPath) == nil) {
             logger.notice("Generating project for running", metadata: .section)

--- a/Sources/TuistKit/Services/ScaffoldService.swift
+++ b/Sources/TuistKit/Services/ScaffoldService.swift
@@ -100,7 +100,7 @@ final class ScaffoldService {
             template: template
         )
 
-        try templateGenerator.generate(
+        try await templateGenerator.generate(
             template: template,
             to: path,
             attributes: parsedAttributes

--- a/Sources/TuistKit/Services/ScaffoldService.swift
+++ b/Sources/TuistKit/Services/ScaffoldService.swift
@@ -66,7 +66,7 @@ final class ScaffoldService {
             template: templateName
         )
 
-        let template = try templateLoader.loadTemplate(at: templateDirectory, plugins: plugins)
+        let template = try await templateLoader.loadTemplate(at: templateDirectory, plugins: plugins)
 
         return template.attributes.reduce(into: (required: [], optional: [])) { currentValue, attribute in
             switch attribute {
@@ -92,7 +92,7 @@ final class ScaffoldService {
             templateDirectories: templateDirectories,
             template: templateName
         )
-        let template = try templateLoader.loadTemplate(at: templateDirectory, plugins: plugins)
+        let template = try await templateLoader.loadTemplate(at: templateDirectory, plugins: plugins)
 
         let parsedAttributes = try parseAttributes(
             requiredTemplateOptions: requiredTemplateOptions,
@@ -120,7 +120,7 @@ final class ScaffoldService {
     }
 
     private func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         return try await pluginService.loadPlugins(using: config)
     }
 

--- a/Sources/TuistKit/Services/SessionService.swift
+++ b/Sources/TuistKit/Services/SessionService.swift
@@ -10,7 +10,7 @@ protocol SessionServicing: AnyObject {
     /// on a server identified by that URL.
     func printSession(
         directory: String?
-    ) throws
+    ) async throws
 }
 
 final class SessionService: SessionServicing {
@@ -34,14 +34,14 @@ final class SessionService: SessionServicing {
 
     func printSession(
         directory: String?
-    ) throws {
+    ) async throws {
         let directoryPath: AbsolutePath
         if let directory {
             directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
         } else {
             directoryPath = FileHandler.shared.currentPath
         }
-        let config = try configLoader.loadConfig(path: directoryPath)
+        let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
         try serverSessionController.printSession(serverURL: serverURL)
     }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -188,7 +188,7 @@ final class TestService { // swiftlint:disable:this type_body_length
             )
         }
         // Load config
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         let cacheStorage = try cacheStorageFactory.cacheStorage(config: config)
 
         let testsCacheTemporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)

--- a/Sources/TuistKit/Services/TuistService.swift
+++ b/Sources/TuistKit/Services/TuistService.swift
@@ -24,7 +24,7 @@ final class TuistService: NSObject {
     func run(
         arguments: [String],
         tuistBinaryPath: String
-    ) throws {
+    ) async throws {
         var arguments = arguments
 
         let commandName = "tuist-\(arguments[0])"
@@ -39,7 +39,7 @@ final class TuistService: NSObject {
             path = FileHandler.shared.currentPath
         }
 
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
 
         var pluginPaths = try pluginService.remotePluginPaths(using: config)
             .compactMap(\.releasePath)

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -100,7 +100,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         let plugins = try await loadPlugins(at: path)
 
         // Load Workspace
-        var allManifests = try recursiveManifestLoader.loadWorkspace(at: path)
+        var allManifests = try await recursiveManifestLoader.loadWorkspace(at: path)
         let isSPMProjectOnly = allManifests.projects.isEmpty
         let hasExternalDependencies = allManifests.projects.values.contains { $0.containsExternalDependencies }
 
@@ -113,12 +113,12 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         if let packagePath = manifestFilesLocator.locatePackageManifest(at: path),
            isSPMProjectOnly || hasExternalDependencies
         {
-            let loadedPackageSettings = try packageSettingsLoader.loadPackageSettings(
+            let loadedPackageSettings = try await packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins
             )
 
-            let manifest = try swiftPackageManagerGraphLoader.load(
+            let manifest = try await swiftPackageManagerGraphLoader.load(
                 packagePath: packagePath,
                 packageSettings: loadedPackageSettings
             )
@@ -131,7 +131,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Merge SPM graph
         if let packageSettings {
-            allManifests = try recursiveManifestLoader.loadAndMergePackageProjects(
+            allManifests = try await recursiveManifestLoader.loadAndMergePackageProjects(
                 in: allManifests,
                 packageSettings: packageSettings
             )
@@ -199,7 +199,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
     @discardableResult
     func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
-        let config = try configLoader.loadConfig(path: path)
+        let config = try await configLoader.loadConfig(path: path)
         let plugins = try await pluginsService.loadPlugins(using: config)
         try manifestLoader.register(plugins: plugins)
         return plugins

--- a/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
+++ b/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import TuistAnalytics
@@ -15,6 +16,7 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
     private let ciChecker: CIChecking
     private let cacheDirectoriesProviderFactory: CacheDirectoriesProviderFactoring
     private let analyticsArtifactUploadService: AnalyticsArtifactUploadServicing
+    private let fileSystem: FileSystem
 
     public convenience init(
         fullHandle: String,
@@ -27,7 +29,8 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
             fileHandler: FileHandler.shared,
             ciChecker: CIChecker(),
             cacheDirectoriesProviderFactory: CacheDirectoriesProviderFactory(),
-            analyticsArtifactUploadService: AnalyticsArtifactUploadService()
+            analyticsArtifactUploadService: AnalyticsArtifactUploadService(),
+            fileSystem: FileSystem()
         )
     }
 
@@ -38,7 +41,8 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
         fileHandler: FileHandling,
         ciChecker: CIChecking,
         cacheDirectoriesProviderFactory: CacheDirectoriesProviderFactoring,
-        analyticsArtifactUploadService: AnalyticsArtifactUploadServicing
+        analyticsArtifactUploadService: AnalyticsArtifactUploadServicing,
+        fileSystem: FileSystem
     ) {
         self.fullHandle = fullHandle
         self.url = url
@@ -47,6 +51,7 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
         self.ciChecker = ciChecker
         self.cacheDirectoriesProviderFactory = cacheDirectoriesProviderFactory
         self.analyticsArtifactUploadService = analyticsArtifactUploadService
+        self.fileSystem = fileSystem
     }
 
     public func send(commandEvent: CommandEvent) async throws {
@@ -77,7 +82,7 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
         }
 
         if fileHandler.exists(runDirectory) {
-            try fileHandler.delete(runDirectory)
+            try await fileSystem.remove(runDirectory)
         }
 
         if #available(macOS 13.0, *), ciChecker.isCI() {

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -58,46 +58,46 @@ public class CachedManifestLoader: ManifestLoading {
         }
     }
 
-    public func loadConfig(at path: AbsolutePath) throws -> ProjectDescription.Config {
-        try load(manifest: .config, at: path) {
-            let projectDescriptionConfig = try manifestLoader.loadConfig(at: path)
+    public func loadConfig(at path: AbsolutePath) async throws -> ProjectDescription.Config {
+        try await load(manifest: .config, at: path) {
+            let projectDescriptionConfig = try await manifestLoader.loadConfig(at: path)
             return projectDescriptionConfig
         }
     }
 
-    public func loadProject(at path: AbsolutePath) throws -> Project {
-        try load(manifest: .project, at: path) {
-            try manifestLoader.loadProject(at: path)
+    public func loadProject(at path: AbsolutePath) async throws -> Project {
+        try await load(manifest: .project, at: path) {
+            try await manifestLoader.loadProject(at: path)
         }
     }
 
-    public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
-        try load(manifest: .workspace, at: path) {
-            try manifestLoader.loadWorkspace(at: path)
+    public func loadWorkspace(at path: AbsolutePath) async throws -> Workspace {
+        try await load(manifest: .workspace, at: path) {
+            try await manifestLoader.loadWorkspace(at: path)
         }
     }
 
-    public func loadTemplate(at path: AbsolutePath) throws -> ProjectDescription.Template {
-        try load(manifest: .template, at: path) {
-            try manifestLoader.loadTemplate(at: path)
+    public func loadTemplate(at path: AbsolutePath) async throws -> ProjectDescription.Template {
+        try await load(manifest: .template, at: path) {
+            try await manifestLoader.loadTemplate(at: path)
         }
     }
 
-    public func loadPlugin(at path: AbsolutePath) throws -> ProjectDescription.Plugin {
-        try load(manifest: .plugin, at: path) {
-            try manifestLoader.loadPlugin(at: path)
+    public func loadPlugin(at path: AbsolutePath) async throws -> ProjectDescription.Plugin {
+        try await load(manifest: .plugin, at: path) {
+            try await manifestLoader.loadPlugin(at: path)
         }
     }
 
-    public func loadPackageSettings(at path: AbsolutePath) throws -> ProjectDescription.PackageSettings {
-        try load(manifest: .packageSettings, at: path) {
-            try manifestLoader.loadPackageSettings(at: path)
+    public func loadPackageSettings(at path: AbsolutePath) async throws -> ProjectDescription.PackageSettings {
+        try await load(manifest: .packageSettings, at: path) {
+            try await manifestLoader.loadPackageSettings(at: path)
         }
     }
 
-    public func loadPackage(at path: AbsolutePath) throws -> PackageInfo {
-        try load(manifest: .package, at: path) {
-            try manifestLoader.loadPackage(at: path)
+    public func loadPackage(at path: AbsolutePath) async throws -> PackageInfo {
+        try await load(manifest: .package, at: path) {
+            try await manifestLoader.loadPackage(at: path)
         }
     }
 
@@ -116,7 +116,7 @@ public class CachedManifestLoader: ManifestLoading {
 
     // MARK: - Private
 
-    private func load<T: Codable>(manifest: Manifest, at path: AbsolutePath, loader: () throws -> T) throws -> T {
+    private func load<T: Codable>(manifest: Manifest, at path: AbsolutePath, loader: () async throws -> T) async throws -> T {
         let manifestPath = path.appending(component: manifest.fileName(path))
         guard fileHandler.exists(manifestPath) else {
             throw ManifestLoaderError.manifestNotFound(manifest, path)
@@ -130,7 +130,7 @@ public class CachedManifestLoader: ManifestLoading {
 
         guard let hashes = calculatedHashes else {
             logger.warning("Unable to calculate manifest hash at path: \(path)")
-            return try loader()
+            return try await loader()
         }
 
         let cachedManifestPath = try cachedPath(for: manifestPath)
@@ -141,7 +141,7 @@ public class CachedManifestLoader: ManifestLoading {
             return cached
         }
 
-        let loadedManifest = try loader()
+        let loadedManifest = try await loader()
 
         try cacheManifest(
             manifest: manifest,

--- a/Sources/TuistLoader/Loaders/ConfigLoader.swift
+++ b/Sources/TuistLoader/Loaders/ConfigLoader.swift
@@ -14,7 +14,7 @@ public protocol ConfigLoading {
     /// - Parameter path: Directory from which look up and load the Config.
     /// - Returns: Loaded Config object.
     /// - Throws: An error if the Config.swift can't be parsed.
-    func loadConfig(path: AbsolutePath) throws -> TuistCore.Config
+    func loadConfig(path: AbsolutePath) async throws -> TuistCore.Config
 
     /// Locates the Config.swift manifest from the given directory.
     func locateConfig(at: AbsolutePath) -> AbsolutePath?
@@ -36,7 +36,7 @@ public final class ConfigLoader: ConfigLoading {
         self.fileHandler = fileHandler
     }
 
-    public func loadConfig(path: AbsolutePath) throws -> TuistCore.Config {
+    public func loadConfig(path: AbsolutePath) async throws -> TuistCore.Config {
         if let cached = cachedConfigs[path] {
             return cached
         }
@@ -47,7 +47,7 @@ public final class ConfigLoader: ConfigLoading {
             return config
         }
 
-        let manifest = try manifestLoader.loadConfig(at: configPath.parentDirectory)
+        let manifest = try await manifestLoader.loadConfig(at: configPath.parentDirectory)
         let config = try TuistCore.Config.from(manifest: manifest, at: configPath)
         cachedConfigs[path] = config
         return config

--- a/Sources/TuistLoader/Loaders/PackageSettingsLoader.swift
+++ b/Sources/TuistLoader/Loaders/PackageSettingsLoader.swift
@@ -12,7 +12,7 @@ public protocol PackageSettingsLoading {
     /// - Parameter path: The absolute path for the `PackageSettings` to load.
     /// - Parameter plugins: The plugins for the `PackageSettings` to load.
     /// - Returns: The `PackageSettings` loaded from the specified path.
-    func loadPackageSettings(at path: AbsolutePath, with plugins: Plugins) throws -> TuistCore.PackageSettings
+    func loadPackageSettings(at path: AbsolutePath, with plugins: Plugins) async throws -> TuistCore.PackageSettings
 }
 
 public final class PackageSettingsLoader: PackageSettingsLoading {
@@ -36,10 +36,10 @@ public final class PackageSettingsLoader: PackageSettingsLoading {
         self.manifestFilesLocator = manifestFilesLocator
     }
 
-    public func loadPackageSettings(at path: AbsolutePath, with plugins: Plugins) throws -> TuistCore.PackageSettings {
+    public func loadPackageSettings(at path: AbsolutePath, with plugins: Plugins) async throws -> TuistCore.PackageSettings {
         let path = manifestFilesLocator.locatePackageManifest(at: path)?.parentDirectory ?? path
         try manifestLoader.register(plugins: plugins)
-        let manifest = try manifestLoader.loadPackageSettings(at: path)
+        let manifest = try await manifestLoader.loadPackageSettings(at: path)
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         let swiftToolsVersion = try swiftPackageManagerController.getToolsVersion(
             at: path

--- a/Sources/TuistLoader/Loaders/TemplateGitLoader.swift
+++ b/Sources/TuistLoader/Loaders/TemplateGitLoader.swift
@@ -38,7 +38,10 @@ public final class TemplateGitLoader: TemplateGitLoading {
         self.templateLocationParser = templateLocationParser
     }
 
-    public func loadTemplate(from templateURL: String, closure: @escaping (TuistCore.Template) async throws -> Void) async throws {
+    public func loadTemplate(
+        from templateURL: String,
+        closure: @escaping (TuistCore.Template) async throws -> Void
+    ) async throws {
         let repoURL = templateLocationParser.parseRepositoryURL(from: templateURL)
         let repoBranch = templateLocationParser.parseRepositoryBranch(from: templateURL)
 

--- a/Sources/TuistLoader/Loaders/TemplateGitLoader.swift
+++ b/Sources/TuistLoader/Loaders/TemplateGitLoader.swift
@@ -49,7 +49,7 @@ public final class TemplateGitLoader: TemplateGitLoading {
             if let repoBranch {
                 try self.gitHandler.checkout(id: repoBranch, in: templatePath)
             }
-            let template = try self.templateLoader.loadTemplate(at: templatePath, plugins: .none)
+            let template = try await self.templateLoader.loadTemplate(at: templatePath, plugins: .none)
             try await closure(template)
         }
     }

--- a/Sources/TuistLoader/Loaders/TemplateLoader.swift
+++ b/Sources/TuistLoader/Loaders/TemplateLoader.swift
@@ -11,7 +11,7 @@ public protocol TemplateLoading {
     ///     - path: Path of template manifest file `name_of_template.swift`
     ///     - plugins: List of available plugins.
     /// - Returns: Loaded `TuistCore.Template`
-    func loadTemplate(at path: AbsolutePath, plugins: Plugins) throws -> TuistCore.Template
+    func loadTemplate(at path: AbsolutePath, plugins: Plugins) async throws -> TuistCore.Template
 }
 
 public class TemplateLoader: TemplateLoading {
@@ -26,9 +26,9 @@ public class TemplateLoader: TemplateLoading {
         self.manifestLoader = manifestLoader
     }
 
-    public func loadTemplate(at path: AbsolutePath, plugins: Plugins) throws -> TuistCore.Template {
+    public func loadTemplate(at path: AbsolutePath, plugins: Plugins) async throws -> TuistCore.Template {
         try manifestLoader.register(plugins: plugins)
-        let template = try manifestLoader.loadTemplate(at: path)
+        let template = try await manifestLoader.loadTemplate(at: path)
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         return try TuistCore.Template.from(
             manifest: template,

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -2,6 +2,7 @@ import Foundation
 import Path
 import TuistCore
 import TuistSupport
+import FileSystem
 
 /// This protocol defines the interface to compile a temporary module with the
 /// helper files under /Tuist/ProjectDescriptionHelpers that can be imported
@@ -20,7 +21,7 @@ public protocol ProjectDescriptionHelpersBuilding: AnyObject {
         at path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [TuistCore.ProjectDescriptionHelpersPlugin]
-    ) throws -> [ProjectDescriptionHelpersModule]
+    ) async throws -> [ProjectDescriptionHelpersModule]
 
     /// Builds all the plugin helpers module and returns the location to the built modules.
     ///
@@ -34,13 +35,13 @@ public protocol ProjectDescriptionHelpersBuilding: AnyObject {
         at path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
-    ) throws -> [ProjectDescriptionHelpersModule]
+    ) async throws -> [ProjectDescriptionHelpersModule]
 }
 
 public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding {
     /// A dictionary that keeps in memory the helpers (value of the dictionary) that have been built
     /// in the current process for helpers directories (key of the dictionary)
-    private var builtHelpers: [AbsolutePath: ProjectDescriptionHelpersModule] = [:]
+    private var builtHelpers: ThreadSafe<[AbsolutePath: ProjectDescriptionHelpersModule]> = ThreadSafe([:])
 
     /// Path to the cache directory.
     private let cacheDirectory: AbsolutePath
@@ -53,9 +54,11 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
 
     /// Clock for measuring build duration.
     private let clock: Clock
+    private let fileSystem: FileSystem
 
     /// The name of the default project description helpers module
     static let defaultHelpersName = "ProjectDescriptionHelpers"
+    
 
     /// Initializes the builder with its attributes.
     /// - Parameters:
@@ -67,26 +70,28 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         projectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing = ProjectDescriptionHelpersHasher(),
         cacheDirectory: AbsolutePath,
         helpersDirectoryLocator: HelpersDirectoryLocating = HelpersDirectoryLocator(),
-        clock: Clock = WallClock()
+        clock: Clock = WallClock(),
+        fileSystem: FileSystem = FileSystem()
     ) {
         self.projectDescriptionHelpersHasher = projectDescriptionHelpersHasher
         self.cacheDirectory = cacheDirectory
         self.helpersDirectoryLocator = helpersDirectoryLocator
         self.clock = clock
+        self.fileSystem = fileSystem
     }
 
     public func build(
         at path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
-    ) throws -> [ProjectDescriptionHelpersModule] {
-        let pluginHelpers = try buildPlugins(
+    ) async throws -> [ProjectDescriptionHelpersModule] {
+        let pluginHelpers = try await buildPlugins(
             at: path,
             projectDescriptionSearchPaths: projectDescriptionSearchPaths,
             projectDescriptionHelperPlugins: projectDescriptionHelperPlugins
         )
 
-        let defaultHelpers = try buildDefaultHelpers(
+        let defaultHelpers = try await buildDefaultHelpers(
             in: path,
             projectDescriptionSearchPaths: projectDescriptionSearchPaths,
             customProjectDescriptionHelperModules: pluginHelpers
@@ -101,19 +106,17 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         at _: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
-    ) throws -> [ProjectDescriptionHelpersModule] {
-        let pluginHelpers = try projectDescriptionHelperPlugins.map {
-            try buildHelpers(name: $0.name, in: $0.path, projectDescriptionSearchPaths: projectDescriptionSearchPaths)
+    ) async throws -> [ProjectDescriptionHelpersModule] {
+        return try await projectDescriptionHelperPlugins.concurrentMap { plugin in
+            try await self.buildHelpers(name: plugin.name, in: plugin.path, projectDescriptionSearchPaths: projectDescriptionSearchPaths)
         }
-
-        return pluginHelpers
     }
 
     private func buildDefaultHelpers(
         in path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         customProjectDescriptionHelperModules: [ProjectDescriptionHelpersModule]
-    ) throws -> ProjectDescriptionHelpersModule? {
+    ) async throws -> ProjectDescriptionHelpersModule? {
         guard let tuistHelpersDirectory = helpersDirectoryLocator.locate(at: path) else { return nil }
         #if DEBUG
             if let sourceRoot = ProcessInfo.processInfo.environment["TUIST_CONFIG_SRCROOT"],
@@ -125,7 +128,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
                 return nil
             }
         #endif
-        return try buildHelpers(
+        return try await buildHelpers(
             name: Self.defaultHelpersName,
             in: tuistHelpersDirectory,
             projectDescriptionSearchPaths: projectDescriptionSearchPaths,
@@ -152,8 +155,8 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         in path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         customProjectDescriptionHelperModules: [ProjectDescriptionHelpersModule] = []
-    ) throws -> ProjectDescriptionHelpersModule {
-        if let cachedModule = builtHelpers[path] { return cachedModule }
+    ) async throws -> ProjectDescriptionHelpersModule {
+        if let cachedModule = builtHelpers.withValue({ $0[path] }) { return cachedModule }
 
         let hash = try projectDescriptionHelpersHasher.hash(helpersDirectory: path)
         let prefixHash = projectDescriptionHelpersHasher.prefixHash(helpersDirectory: path)
@@ -164,8 +167,8 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         let modulePath = helpersModuleCachePath.appending(component: dylibName)
         let projectDescriptionHelpersModule = ProjectDescriptionHelpersModule(name: name, path: modulePath)
 
-        builtHelpers[path] = projectDescriptionHelpersModule
-
+        builtHelpers.mutate({ $0[path] = projectDescriptionHelpersModule })
+        
         if FileHandler.shared.exists(helpersModuleCachePath) {
             return projectDescriptionHelpersModule
         }
@@ -173,7 +176,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         // If the same helpers directory has been previously compiled
         // we delete it before compiling the new changes.
         if FileHandler.shared.exists(helpersCachePath) {
-            try FileHandler.shared.delete(helpersCachePath)
+            try await fileSystem.remove(helpersCachePath)
         }
 
         try FileHandler.shared.createFolder(helpersModuleCachePath)

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -1,8 +1,8 @@
+import FileSystem
 import Foundation
 import Path
 import TuistCore
 import TuistSupport
-import FileSystem
 
 /// This protocol defines the interface to compile a temporary module with the
 /// helper files under /Tuist/ProjectDescriptionHelpers that can be imported
@@ -58,7 +58,6 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
 
     /// The name of the default project description helpers module
     static let defaultHelpersName = "ProjectDescriptionHelpers"
-    
 
     /// Initializes the builder with its attributes.
     /// - Parameters:
@@ -108,7 +107,11 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
     ) async throws -> [ProjectDescriptionHelpersModule] {
         return try await projectDescriptionHelperPlugins.concurrentMap { plugin in
-            try await self.buildHelpers(name: plugin.name, in: plugin.path, projectDescriptionSearchPaths: projectDescriptionSearchPaths)
+            try await self.buildHelpers(
+                name: plugin.name,
+                in: plugin.path,
+                projectDescriptionSearchPaths: projectDescriptionSearchPaths
+            )
         }
     }
 
@@ -167,8 +170,8 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         let modulePath = helpersModuleCachePath.appending(component: dylibName)
         let projectDescriptionHelpersModule = ProjectDescriptionHelpersModule(name: name, path: modulePath)
 
-        builtHelpers.mutate({ $0[path] = projectDescriptionHelpersModule })
-        
+        builtHelpers.mutate { $0[path] = projectDescriptionHelpersModule }
+
         if FileHandler.shared.exists(helpersModuleCachePath) {
             return projectDescriptionHelpersModule
         }

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockTemplateGitLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockTemplateGitLoader.swift
@@ -5,8 +5,8 @@ import TuistLoader
 
 public final class MockTemplateGitLoader: TemplateGitLoading {
     public var loadTemplateStub: ((String) throws -> Template)?
-    public func loadTemplate(from templateURL: String, closure: (Template) throws -> Void) throws {
+    public func loadTemplate(from templateURL: String, closure: @escaping (Template) async throws -> Void) async throws {
         let template = try loadTemplateStub?(templateURL) ?? Template(description: "", attributes: [], items: [])
-        try closure(template)
+        try await closure(template)
     }
 }

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -295,7 +295,7 @@ public final class PluginService: PluginServicing {
             let downloadZipPath = downloadPath.removingLastComponent().appending(component: "release.zip")
             let fileUnarchiver = try self.fileArchivingFactory.makeFileUnarchiver(for: downloadZipPath)
 
-            var _error: Error?
+            var thrownError: Error?
 
             do {
                 if FileHandler.shared.exists(downloadZipPath) {
@@ -323,14 +323,14 @@ public final class PluginService: PluginServicing {
                         try System.shared.chmod(.executable, path: $0, options: [.onlyFiles])
                     }
             } catch {
-                _error = error
+                thrownError = error
             }
 
             try? await fileUnarchiver.delete()
             try? await self.fileSystem.remove(downloadPath)
             try? await self.fileSystem.remove(downloadZipPath)
 
-            if let error = _error { throw error }
+            if let thrownError { throw thrownError }
         }
     }
 

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -299,7 +299,7 @@ public final class PluginService: PluginServicing {
 
             do {
                 if FileHandler.shared.exists(downloadZipPath) {
-                    try await self.fileSystem.remove(.init(validating: downloadZipPath.pathString))
+                    try await self.fileSystem.remove(downloadZipPath)
                 }
                 try FileHandler.shared.move(from: downloadPath, to: downloadZipPath)
 
@@ -327,8 +327,8 @@ public final class PluginService: PluginServicing {
             }
 
             try? await fileUnarchiver.delete()
-            try? await self.fileSystem.remove(.init(validating: downloadPath.pathString))
-            try? await self.fileSystem.remove(.init(validating: downloadZipPath.pathString))
+            try? await self.fileSystem.remove(downloadPath)
+            try? await self.fileSystem.remove(downloadZipPath)
 
             if let error = _error { throw error }
         }

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import TuistCore
@@ -68,6 +69,7 @@ public final class PluginService: PluginServicing {
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
     private let fileArchivingFactory: FileArchivingFactorying
     private let fileClient: FileClienting
+    private let fileSystem: FileSystem
 
     /// Creates a `PluginService`.
     /// - Parameters:
@@ -85,7 +87,8 @@ public final class PluginService: PluginServicing {
         gitHandler: GitHandling = GitHandler(),
         cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring = CacheDirectoriesProviderFactory(),
         fileArchivingFactory: FileArchivingFactorying = FileArchivingFactory(),
-        fileClient: FileClienting = FileClient()
+        fileClient: FileClienting = FileClient(),
+        fileSystem: FileSystem = FileSystem()
     ) {
         self.manifestLoader = manifestLoader
         self.templatesDirectoryLocator = templatesDirectoryLocator
@@ -94,6 +97,7 @@ public final class PluginService: PluginServicing {
         self.cacheDirectoryProviderFactory = cacheDirectoryProviderFactory
         self.fileArchivingFactory = fileArchivingFactory
         self.fileClient = fileClient
+        self.fileSystem = fileSystem
     }
 
     public func remotePluginPaths(using config: Config) throws -> [RemotePluginPaths] {
@@ -289,37 +293,45 @@ public final class PluginService: PluginServicing {
             // Currently, we assume the release path exists.
             let downloadPath = try await self.fileClient.download(url: releaseURL)
             let downloadZipPath = downloadPath.removingLastComponent().appending(component: "release.zip")
-            defer {
-                try? FileHandler.shared.delete(downloadPath)
-                try? FileHandler.shared.delete(downloadZipPath)
-            }
-            if FileHandler.shared.exists(downloadZipPath) {
-                try FileHandler.shared.delete(downloadZipPath)
-            }
-            try FileHandler.shared.move(from: downloadPath, to: downloadZipPath)
 
-            // Unzip
-            let fileUnarchiver = try self.fileArchivingFactory.makeFileUnarchiver(for: downloadZipPath)
-            let unarchivedContents = try FileHandler.shared.contentsOfDirectory(
-                try fileUnarchiver.unzip()
-            )
-            defer {
-                try? fileUnarchiver.delete()
-            }
-            try FileHandler.shared.createFolder(pluginReleaseDirectory)
-            for unarchivedContent in unarchivedContents {
-                try FileHandler.shared.move(
-                    from: unarchivedContent,
-                    to: pluginReleaseDirectory.appending(component: unarchivedContent.basename)
-                )
-            }
+            var _error: Error?
 
-            // Mark files as executables (this information is lost during (un)archiving)
-            try FileHandler.shared.contentsOfDirectory(pluginReleaseDirectory)
-                .filter { $0.basename.hasPrefix("tuist-") }
-                .forEach {
-                    try System.shared.chmod(.executable, path: $0, options: [.onlyFiles])
+            do {
+                if FileHandler.shared.exists(downloadZipPath) {
+                    try await self.fileSystem.remove(.init(validating: downloadZipPath.pathString))
                 }
+                try FileHandler.shared.move(from: downloadPath, to: downloadZipPath)
+
+                // Unzip
+                let fileUnarchiver = try self.fileArchivingFactory.makeFileUnarchiver(for: downloadZipPath)
+                let unarchivedContents = try FileHandler.shared.contentsOfDirectory(
+                    try fileUnarchiver.unzip()
+                )
+                defer {
+                    try? fileUnarchiver.delete()
+                }
+                try FileHandler.shared.createFolder(pluginReleaseDirectory)
+                for unarchivedContent in unarchivedContents {
+                    try FileHandler.shared.move(
+                        from: unarchivedContent,
+                        to: pluginReleaseDirectory.appending(component: unarchivedContent.basename)
+                    )
+                }
+
+                // Mark files as executables (this information is lost during (un)archiving)
+                try FileHandler.shared.contentsOfDirectory(pluginReleaseDirectory)
+                    .filter { $0.basename.hasPrefix("tuist-") }
+                    .forEach {
+                        try System.shared.chmod(.executable, path: $0, options: [.onlyFiles])
+                    }
+            } catch {
+                _error = error
+            }
+
+            try? await self.fileSystem.remove(.init(validating: downloadPath.pathString))
+            try? await self.fileSystem.remove(.init(validating: downloadZipPath.pathString))
+
+            if let error = _error { throw error }
         }
     }
 

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -153,12 +153,12 @@ public final class PluginService: PluginServicing {
                     return nil
                 }
             }
-        let localPluginManifests = try localPluginPaths.map(manifestLoader.loadPlugin)
+        let localPluginManifests = try await localPluginPaths.concurrentMap(manifestLoader.loadPlugin)
 
         let remotePluginPaths = try remotePluginPaths(using: config)
         let remotePluginRepositoryPaths = remotePluginPaths.map(\.repositoryPath)
-        let remotePluginManifests = try remotePluginRepositoryPaths
-            .map(manifestLoader.loadPlugin)
+        let remotePluginManifests = try await remotePluginRepositoryPaths
+            .concurrentMap(manifestLoader.loadPlugin)
         let pluginPaths = localPluginPaths + remotePluginRepositoryPaths
         let missingRemotePlugins = zip(remotePluginManifests, remotePluginRepositoryPaths)
             .filter { !FileHandler.shared.exists($0.1) }
@@ -283,7 +283,7 @@ public final class PluginService: PluginServicing {
             return
         }
 
-        let plugin = try manifestLoader.loadPlugin(at: pluginRepositoryDirectory)
+        let plugin = try await manifestLoader.loadPlugin(at: pluginRepositoryDirectory)
         guard let releaseURL = getPluginDownloadUrl(gitUrl: url, gitTag: gitTag, pluginName: plugin.name, releaseUrl: releaseUrl)
         else { throw PluginServiceError.invalidURL(url) }
 

--- a/Sources/TuistScaffold/TemplateGenerator.swift
+++ b/Sources/TuistScaffold/TemplateGenerator.swift
@@ -1,10 +1,10 @@
+import FileSystem
 import Foundation
 import Path
 import PathKit
 import StencilSwiftKit
 import TuistCore
 import TuistSupport
-import FileSystem
 
 /// Interface for generating content defined in template manifest
 public protocol TemplateGenerating {
@@ -21,9 +21,8 @@ public protocol TemplateGenerating {
 }
 
 public final class TemplateGenerator: TemplateGenerating {
-    
     private let fileSystem: FileSystem
-    
+
     // Public initializer
     public init(fileSystem: FileSystem = FileSystem()) {
         self.fileSystem = fileSystem
@@ -141,7 +140,7 @@ public final class TemplateGenerator: TemplateGenerating {
                     try FileHandler.shared.createFolder(destinationDirectoryPath.parentDirectory)
                 }
                 if FileHandler.shared.exists(destinationDirectoryPath) {
-                    try await fileSystem.remove(.init(validating: destinationDirectoryPath.pathString))
+                    try await fileSystem.remove(destinationDirectoryPath)
                 }
                 try FileHandler.shared.copy(from: path, to: destinationDirectoryPath)
                 renderedContents = nil

--- a/Sources/TuistServer/Session/ServerSessionController.swift
+++ b/Sources/TuistServer/Session/ServerSessionController.swift
@@ -14,7 +14,7 @@ public protocol ServerSessionControlling: AnyObject {
 
     /// Removes the session for the server with the given URL.
     /// - Parameter serverURL: Server URL.
-    func logout(serverURL: URL) throws
+    func logout(serverURL: URL) async throws
 }
 
 public final class ServerSessionController: ServerSessionControlling {
@@ -105,9 +105,9 @@ public final class ServerSessionController: ServerSessionControlling {
         }
     }
 
-    public func logout(serverURL: URL) throws {
+    public func logout(serverURL: URL) async throws {
         logger.notice("Removing session for server with URL \(serverURL.absoluteString)")
-        try credentialsStore.delete(serverURL: serverURL)
+        try await credentialsStore.delete(serverURL: serverURL)
         logger.notice("Session deleted successfully", metadata: .success)
     }
 

--- a/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
+++ b/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
@@ -1,8 +1,8 @@
+import FileSystem
 import Foundation
 import Mockable
 import Path
 import TuistSupport
-import FileSystem
 
 public struct ServerCredentials: Codable, Equatable {
     /// Deprecated authentication token.

--- a/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
+++ b/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
@@ -131,7 +131,7 @@ public final class ServerCredentialsStore: ServerCredentialsStoring {
     public func delete(serverURL: URL) async throws {
         let path = try credentialsFilePath(serverURL: serverURL)
         if fileHandler.exists(path) {
-            try await fileSystem.remove(.init(validating: path.pathString))
+            try await fileSystem.remove(path)
         }
     }
 

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -44,6 +44,6 @@ public class FileArchiver: FileArchiving {
     }
 
     public func delete() async throws {
-        try await fileSystem.remove(.init(validating: temporaryDirectory.pathString))
+        try await fileSystem.remove(temporaryDirectory)
     }
 }

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Mockable
 import Path
@@ -10,20 +11,23 @@ public protocol FileArchiving {
     func zip(name: String) throws -> AbsolutePath
 
     /// Call this method to delete the temporary directory where the .zip file has been generated.
-    func delete() throws
+    func delete() async throws
 }
 
 public class FileArchiver: FileArchiving {
     /// Paths to be archived.
     private let paths: [AbsolutePath]
 
+    private let fileSystem: FileSystem
+
     /// Temporary directory in which the .zip file will be generated.
     private var temporaryDirectory: AbsolutePath
 
     /// Initializes the archiver with a list of files to archive.
     /// - Parameter paths: Paths to archive
-    public init(paths: [AbsolutePath]) throws {
+    public init(paths: [AbsolutePath], fileSystem: FileSystem = FileSystem()) throws {
         self.paths = paths
+        self.fileSystem = fileSystem
         temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: false).path
     }
 
@@ -39,7 +43,7 @@ public class FileArchiver: FileArchiving {
         return destinationZipPath
     }
 
-    public func delete() throws {
-        try FileHandler.shared.delete(temporaryDirectory)
+    public func delete() async throws {
+        try await fileSystem.remove(.init(validating: temporaryDirectory.pathString))
     }
 }

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -71,8 +71,6 @@ public protocol FileHandling: AnyObject {
     func throwingGlob(_ path: Path.AbsolutePath, glob: String) throws -> [Path.AbsolutePath]
     func linkFile(atPath: Path.AbsolutePath, toPath: Path.AbsolutePath) throws
     func createFolder(_ path: Path.AbsolutePath) throws
-    @available(*, deprecated, message: "Use remove() from FileSystem.FileSystem")
-    func delete(_ path: Path.AbsolutePath) throws
     func isFolder(_ path: Path.AbsolutePath) -> Bool
     func touch(_ path: Path.AbsolutePath) throws
     func contentsOfDirectory(_ path: Path.AbsolutePath) throws -> [Path.AbsolutePath]
@@ -292,12 +290,6 @@ public class FileHandler: FileHandling {
             withIntermediateDirectories: true,
             attributes: nil
         )
-    }
-
-    public func delete(_ path: Path.AbsolutePath) throws {
-        if exists(path) {
-            try fileManager.removeItem(atPath: path.pathString)
-        }
     }
 
     public func touch(_ path: Path.AbsolutePath) throws {

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -71,6 +71,7 @@ public protocol FileHandling: AnyObject {
     func throwingGlob(_ path: Path.AbsolutePath, glob: String) throws -> [Path.AbsolutePath]
     func linkFile(atPath: Path.AbsolutePath, toPath: Path.AbsolutePath) throws
     func createFolder(_ path: Path.AbsolutePath) throws
+    @available(*, deprecated, message: "Use remove() from FileSystem.FileSystem")
     func delete(_ path: Path.AbsolutePath) throws
     func isFolder(_ path: Path.AbsolutePath) -> Bool
     func touch(_ path: Path.AbsolutePath) throws

--- a/Sources/TuistSupport/Utils/FileUnarchiver.swift
+++ b/Sources/TuistSupport/Utils/FileUnarchiver.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Mockable
 import Path
@@ -8,7 +9,7 @@ public protocol FileUnarchiving {
     func unzip() throws -> AbsolutePath
 
     /// Call this method to delete the temporary directory where the .zip file has been generated.
-    func delete() throws
+    func delete() async throws
 }
 
 public class FileUnarchiver: FileUnarchiving {
@@ -18,10 +19,13 @@ public class FileUnarchiver: FileUnarchiving {
     /// Temporary directory in which the .zip file will be generated.
     private var temporaryDirectory: AbsolutePath
 
+    private let fileSystem: FileSystem
+
     /// Initializes the unarchiver with the path to the file to unarchive.
     /// - Parameter path: Path to the .zip file to unarchive.
-    public init(path: AbsolutePath) throws {
+    public init(path: AbsolutePath, fileSystem: FileSystem = FileSystem()) throws {
         self.path = path
+        self.fileSystem = fileSystem
         temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: false).path
     }
 
@@ -30,7 +34,7 @@ public class FileUnarchiver: FileUnarchiving {
         return temporaryDirectory
     }
 
-    public func delete() throws {
-        try FileHandler.shared.delete(temporaryDirectory)
+    public func delete() async throws {
+        try await fileSystem.remove(.init(validating: temporaryDirectory.pathString))
     }
 }

--- a/Sources/TuistSupport/Utils/FileUnarchiver.swift
+++ b/Sources/TuistSupport/Utils/FileUnarchiver.swift
@@ -35,6 +35,6 @@ public class FileUnarchiver: FileUnarchiving {
     }
 
     public func delete() async throws {
-        try await fileSystem.remove(.init(validating: temporaryDirectory.pathString))
+        try await fileSystem.remove(temporaryDirectory)
     }
 }

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -121,6 +121,24 @@ extension XCTestCase {
         }
         XCTFail("No error was thrown", file: file, line: line)
     }
+    
+    public func XCTAssertThrowsSpecific<Error: Swift.Error & Equatable>(
+        _ closure: () async throws -> some Any,
+        _ error: Error,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await closure()
+        } catch let closureError as Error {
+            XCTAssertEqual(closureError, error, file: file, line: line)
+            return
+        } catch let closureError {
+            XCTFail("\(error) is not equal to: \(closureError)", file: file, line: line)
+            return
+        }
+        XCTFail("No error was thrown", file: file, line: line)
+    }
 
     public func XCTAssertThrowsSpecific<Error: Swift.Error & Equatable>(
         _ closure: @autoclosure () async throws -> some Any,

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -121,7 +121,7 @@ extension XCTestCase {
         }
         XCTFail("No error was thrown", file: file, line: line)
     }
-    
+
     public func XCTAssertThrowsSpecific<Error: Swift.Error & Equatable>(
         _ closure: () async throws -> some Any,
         _ error: Error,

--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -21,7 +21,7 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_write() throws {
+    func test_write() async throws {
         // Given
         let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
 
@@ -29,7 +29,7 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         try subject.write(event: event)
 
         // Then
-        let got = try subject.readAll()
+        let got = try await subject.readAll()
         let gotEvent = try XCTUnwrap(got.first)
         XCTAssertEqual(gotEvent.dispatcherId, "dispatcher")
         XCTAssertEqual(gotEvent.id, event.id)
@@ -37,7 +37,7 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         XCTAssertEqual(gotEvent.date, normalizedDate)
     }
 
-    func test_write_whenDirectoryDoesntExist_itCreatesDirectory() throws {
+    func test_write_whenDirectoryDoesntExist_itCreatesDirectory() async throws {
         let temporaryDirectory = try! temporaryPath()
         subject = AsyncQueuePersistor(directory: temporaryDirectory.appending(try RelativePath(validating: "test/")))
 
@@ -48,7 +48,7 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         try subject.write(event: event)
 
         // Then
-        let got = try subject.readAll()
+        let got = try await subject.readAll()
         let gotEvent = try XCTUnwrap(got.first)
         XCTAssertEqual(gotEvent.dispatcherId, "dispatcher")
         XCTAssertEqual(gotEvent.id, event.id)
@@ -56,18 +56,18 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         XCTAssertEqual(gotEvent.date, normalizedDate)
     }
 
-    func test_delete() throws {
+    func test_delete() async throws {
         // Given
         let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
         try subject.write(event: event)
-        var persistedEvents = try subject.readAll()
+        var persistedEvents = try await subject.readAll()
         XCTAssertEqual(persistedEvents.count, 1)
 
         // When
-        try subject.delete(event: event)
+        try await subject.delete(event: event)
 
         // Then
-        persistedEvents = try subject.readAll()
+        persistedEvents = try await subject.readAll()
         XCTAssertEqual(persistedEvents.count, 0)
     }
 }

--- a/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
@@ -197,7 +197,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
         XCTAssertEqual(mockPersistor.invokedDeleteEventCount, 0)
     }
 
-    func test_waits_for_queue_to_finish_when_CI() throws {
+    func test_waits_for_queue_to_finish_when_CI() async throws {
         // Given
         let eventTuple1: AsyncQueueEventTuple = makeEventTuple(id: 1)
         mockPersistor.stubbedReadAllResult = [eventTuple1]
@@ -207,7 +207,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
 
         // When
         subject = makeSubject(queue: Queuer.shared)
-        subject.start()
+        await subject.start()
 
         // Then
         XCTAssertEqual(Queuer.shared.operationCount, 0)
@@ -228,7 +228,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
     //     XCTAssertEqual(Queuer.shared.operationCount, 1)
     // }
 
-    func test_start_readsPersistedEventsInitialization() throws {
+    func test_start_readsPersistedEventsInitialization() async throws {
         // Given
         given(ciChecker)
             .isCI()
@@ -240,7 +240,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
 
         // When
         subject = makeSubject()
-        subject.start()
+        await subject.start()
 
         // Then
         let numberOfOperationsQueued = mockQueuer.invokedAddOperationCount
@@ -265,7 +265,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
         XCTAssertEqual(queuedOperation3.name, eventTuple3.id.uuidString)
     }
 
-    func test_start_persistedEventIsDispatchedByTheRightDispatcher() throws {
+    func test_start_persistedEventIsDispatchedByTheRightDispatcher() async throws {
         // Given
         given(ciChecker)
             .isCI()
@@ -280,7 +280,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
 
         // When
         subject = makeSubject(queue: Queuer.shared)
-        subject.start()
+        await subject.start()
 
         // Then
         wait(for: [expectation], timeout: timeout)
@@ -293,7 +293,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
         XCTAssertEqual(mockAsyncQueueDispatcher2.invokedDispatchPersistedCount, 0)
     }
 
-    func test_start_sentPersistedEventIsThenDeleted() throws {
+    func test_start_sentPersistedEventIsThenDeleted() async throws {
         // Given
         given(ciChecker)
             .isCI()
@@ -309,7 +309,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
 
         // When
         subject = makeSubject(queue: Queuer.shared)
-        subject.start()
+        await subject.start()
 
         // Then
         wait(for: [expectation], timeout: timeout)

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -8,7 +8,7 @@ import XCTest
 /// Build projects using Tuist build
 final class BuildAcceptanceTestWithTemplates: TuistAcceptanceTestCase {
     func test_with_templates() async throws {
-        try run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
+        try await run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -20,7 +20,7 @@ final class BuildAcceptanceTestWithTemplates: TuistAcceptanceTestCase {
 
 final class BuildAcceptanceTestInvalidArguments: TuistAcceptanceTestCase {
     func test_with_invalid_arguments() async throws {
-        try run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
+        try await run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         await XCTAssertThrowsSpecific(

--- a/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -25,18 +25,22 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         }
     }
 
-    func testGenerateThrowsLintingErrorWhenConfigurationsAreEmpty() throws {
+    func testGenerateThrowsLintingErrorWhenConfigurationsAreEmpty() async throws {
         // Given
         let projectSettings = Settings(configurations: [:])
         let targetSettings: Settings? = nil
 
         // When / Then
-        XCTAssertThrowsError(
-            try generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
-        )
+        var _error: Error?
+        do {
+            try await generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
+        } catch {
+            _error = error
+        }
+        XCTAssertNotNil(_error)
     }
 
-    func testGenerateWhenSingleDebugConfigurationInProject() throws {
+    func testGenerateWhenSingleDebugConfigurationInProject() async throws {
         // Given
         let projectSettings = Settings(
             base: ["A": "A"],
@@ -44,7 +48,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         )
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
         assertProject(expectedConfigurations: ["Debug"])
@@ -54,7 +58,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertTrue(debug.contains("A", "A")) // from base
     }
 
-    func testGenerateWhenConfigurationSettingsOverrideXCConfig() throws {
+    func testGenerateWhenConfigurationSettingsOverrideXCConfig() async throws {
         // Given
         let debugFilePath = try createFile(path: "Configs/debug.xcconfig", content: """
         A=A_XCCONFIG
@@ -67,7 +71,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let projectSettings = Settings(configurations: [.debug: debugConfiguration])
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
         assertProject(expectedConfigurations: ["Debug"])
@@ -79,7 +83,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertTrue(debug.contains("C", "C")) // from settings
     }
 
-    func testGenerateWhenConfigurationSettingsOverrideBase() throws {
+    func testGenerateWhenConfigurationSettingsOverrideBase() async throws {
         // Given
         let debugConfiguration = Configuration(settings: ["A": "A", "C": "C"])
         let projectSettings = Settings(
@@ -88,7 +92,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         )
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
         assertProject(expectedConfigurations: ["Debug"])
@@ -100,7 +104,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertTrue(debug.contains("C", "C")) // from settings
     }
 
-    func testGenerateWhenBuildConfigurationWithCustomName() throws {
+    func testGenerateWhenBuildConfigurationWithCustomName() async throws {
         // Given
         let customConfiguration = Configuration(settings: ["A": "A", "C": "C"])
         let projectSettings = Settings(
@@ -112,7 +116,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         )
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
         assertProject(expectedConfigurations: ["Custom", "Release"])
@@ -129,7 +133,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertFalse(release.contains("C", "C")) // non-existing, only defined in Custom
     }
 
-    func testGenerateWhenTargetSettingsOverrideTargetXCConfig() throws {
+    func testGenerateWhenTargetSettingsOverrideTargetXCConfig() async throws {
         // Given
         let debugFilePath = try createFile(path: "Configs/debug.xcconfig", content: """
         A=A_XCCONFIG
@@ -143,7 +147,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let targetSettings = Settings(configurations: [.debug: debugConfiguration])
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
 
         // Then
         assertProject(expectedConfigurations: ["Debug"])
@@ -155,7 +159,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertTrue(debug.contains("C", "C")) // from target settings
     }
 
-    func testGenerateWhenMultipleConfigurations() throws {
+    func testGenerateWhenMultipleConfigurations() async throws {
         // Given
         let projectDebugConfiguration = Configuration(settings: [
             "A": "A_PROJECT_DEBUG",
@@ -179,7 +183,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         ])
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
 
         // Then
         assertProject(expectedConfigurations: ["Debug", "ProjectRelease"])
@@ -209,7 +213,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
      - target base
      - target configuraiton settings
      */
-    func testGenerateWhenTargetSettingsOverrideProjectBaseSettingsAndXCConfig() throws {
+    func testGenerateWhenTargetSettingsOverrideProjectBaseSettingsAndXCConfig() async throws {
         // Given
         let projectDebugFilePath = try createFile(path: "Configs/project_debug.xcconfig", content: """
         A=A_PROJECT_XCCONFIG
@@ -267,7 +271,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         )
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: targetSettings)
 
         // Then
         assertProject(expectedConfigurations: ["Debug"])
@@ -288,7 +292,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         XCTAssertTrue(debug.contains("TARGET", "YES")) // from target settings
     }
 
-    func testGenerateWhenCustomConfigurations() throws {
+    func testGenerateWhenCustomConfigurations() async throws {
         // Given
         let projectDebugConfiguration = Configuration(settings: [
             "A": "A_PROJECT_DEBUG",
@@ -308,7 +312,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         ])
 
         // When
-        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+        try await generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
         assertProject(expectedConfigurations: ["CustomDebug", "CustomRelease", "Debug", "Release"])
@@ -336,7 +340,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
 
     // MARK: - Helpers
 
-    private func generateWorkspace(projectSettings: Settings, targetSettings: Settings?) throws {
+    private func generateWorkspace(projectSettings: Settings, targetSettings: Settings?) async throws {
         let models = try createModels(projectSettings: projectSettings, targetSettings: targetSettings)
         let subject = DescriptorGenerator()
         let writer = XcodeProjWriter()
@@ -348,7 +352,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let graphTraverser = GraphTraverser(graph: graph)
         try linter.lint(graphTraverser: graphTraverser, config: config).printAndThrowErrorsIfNeeded()
         let descriptor = try subject.generateWorkspace(graphTraverser: graphTraverser)
-        try writer.write(workspace: descriptor)
+        try await writer.write(workspace: descriptor)
     }
 
     private func setupTestProject() throws {

--- a/Tests/TuistGeneratorIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class StableXcodeProjIntegrationTests: TuistTestCase {
-    func testXcodeProjStructureDoesNotChangeAfterRegeneration() throws {
+    func testXcodeProjStructureDoesNotChangeAfterRegeneration() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         var capturedProjects = [[XcodeProj]]()
@@ -43,7 +43,7 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
 
             // Note: While we already have access to the `XcodeProj` models in `workspaceDescriptor`
             // unfortunately they are not equatable, however once serialized & deserialized back they are
-            try writer.write(workspace: workspaceDescriptor)
+            try await writer.write(workspace: workspaceDescriptor)
             let xcworkspace = try XCWorkspace(path: workspaceDescriptor.xcworkspacePath.path)
             let xcodeProjs = try findXcodeProjs(in: xcworkspace)
             let sharedSchemes = try findSharedSchemes(in: xcworkspace)

--- a/Tests/TuistGeneratorIntegrationTests/Generator/XcodeProjWriterTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/XcodeProjWriterTests.swift
@@ -22,20 +22,20 @@ final class XcodeProjWriterTests: TuistTestCase {
         super.tearDown()
     }
 
-    func test_writeProject() throws {
+    func test_writeProject() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
         let descriptor = ProjectDescriptor.test(path: path, xcodeprojPath: xcodeProjPath)
 
         // When
-        try subject.write(project: descriptor)
+        try await subject.write(project: descriptor)
 
         // Then
         XCTAssertTrue(FileHandler.shared.exists(xcodeProjPath))
     }
 
-    func test_writeProject_fileSideEffects() throws {
+    func test_writeProject_fileSideEffects() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
@@ -52,7 +52,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         )
 
         // When
-        try subject.write(project: descriptor)
+        try await subject.write(project: descriptor)
 
         // Then
         let fileHandler = FileHandler.shared
@@ -60,7 +60,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         XCTAssertEqual(try fileHandler.readFile(filePath), contents)
     }
 
-    func test_writeProject_deleteFileSideEffects() throws {
+    func test_writeProject_deleteFileSideEffects() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
@@ -76,13 +76,13 @@ final class XcodeProjWriterTests: TuistTestCase {
         )
 
         // When
-        try subject.write(project: descriptor)
+        try await subject.write(project: descriptor)
 
         // Then
         XCTAssertFalse(fileHandler.exists(filePath))
     }
 
-    func test_generate_doesNotWipeUserData() throws {
+    func test_generate_doesNotWipeUserData() async throws {
         // Given
         let path = try temporaryPath()
         let paths = try createFiles([
@@ -98,14 +98,14 @@ final class XcodeProjWriterTests: TuistTestCase {
 
         // When
         for _ in 0 ..< 2 {
-            try subject.write(project: descriptor)
+            try await subject.write(project: descriptor)
         }
 
         // Then
         XCTAssertTrue(paths.allSatisfy { FileHandler.shared.exists($0) })
     }
 
-    func test_generate_replacesProjectSharedSchemes() throws {
+    func test_generate_replacesProjectSharedSchemes() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
@@ -125,7 +125,7 @@ final class XcodeProjWriterTests: TuistTestCase {
                 xcodeprojPath: xcodeProjPath,
                 schemes: schemes
             )
-            try subject.write(project: descriptor)
+            try await subject.write(project: descriptor)
         }
 
         // Then
@@ -137,7 +137,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         ])
     }
 
-    func test_generate_preservesProjectUserSchemes() throws {
+    func test_generate_preservesProjectUserSchemes() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
@@ -156,7 +156,7 @@ final class XcodeProjWriterTests: TuistTestCase {
                 xcodeprojPath: xcodeProjPath,
                 schemes: schemes
             )
-            try subject.write(project: descriptor)
+            try await subject.write(project: descriptor)
         }
 
         // Then
@@ -168,7 +168,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         ])
     }
 
-    func test_generate_replacesWorkspaceSharedSchemes() throws {
+    func test_generate_replacesWorkspaceSharedSchemes() async throws {
         // Given
         let path = try temporaryPath()
         let xcworkspacePath = path.appending(component: "Workspace.xcworkspace")
@@ -188,7 +188,7 @@ final class XcodeProjWriterTests: TuistTestCase {
                 xcworkspacePath: xcworkspacePath,
                 schemes: schemes
             )
-            try subject.write(workspace: descriptor)
+            try await subject.write(workspace: descriptor)
         }
 
         // Then
@@ -200,7 +200,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         ])
     }
 
-    func test_generate_preservesWorkspaceUserSchemes() throws {
+    func test_generate_preservesWorkspaceUserSchemes() async throws {
         // Given
         let path = try temporaryPath()
         let xcworkspacePath = path.appending(component: "Workspace.xcworkspace")
@@ -219,7 +219,7 @@ final class XcodeProjWriterTests: TuistTestCase {
                 xcworkspacePath: xcworkspacePath,
                 schemes: schemes
             )
-            try subject.write(workspace: descriptor)
+            try await subject.write(workspace: descriptor)
         }
 
         // Then
@@ -231,7 +231,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         ])
     }
 
-    func test_generate_local_scheme() throws {
+    func test_generate_local_scheme() async throws {
         // Given
         let path = try temporaryPath()
         let xcodeProjPath = path.appending(component: "Project.xcodeproj")
@@ -239,7 +239,7 @@ final class XcodeProjWriterTests: TuistTestCase {
         let descriptor = ProjectDescriptor.test(path: path, xcodeprojPath: xcodeProjPath, schemes: [userScheme])
 
         // When
-        try subject.write(project: descriptor)
+        try await subject.write(project: descriptor)
 
         // Then
         let fileHandler = FileHandler.shared

--- a/Tests/TuistKitAcceptanceTests/InitAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/InitAcceptanceTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class InitAcceptanceTestmacOSApp: TuistAcceptanceTestCase {
     func test_init_macos_app() async throws {
-        try run(InitCommand.self, "--platform", "macos", "--name", "Test")
+        try await run(InitCommand.self, "--platform", "macos", "--name", "Test")
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -16,7 +16,7 @@ final class InitAcceptanceTestmacOSApp: TuistAcceptanceTestCase {
 
 final class InitAcceptanceTestiOSApp: TuistAcceptanceTestCase {
     func test_init_ios_app() async throws {
-        try run(InitCommand.self, "--platform", "ios", "--name", "My-App")
+        try await run(InitCommand.self, "--platform", "ios", "--name", "My-App")
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -33,7 +33,13 @@ final class InitAcceptanceTestiOSApp: TuistAcceptanceTestCase {
 
 final class InitAcceptanceTestCLIProjectWithTemplateInADifferentRepository: TuistAcceptanceTestCase {
     func test_cli_project_with_template_in_a_different_repository() async throws {
-        try run(InitCommand.self, "--template", "https://github.com/tuist/ExampleTuistTemplate-Tuist4.git", "--name", "MyApp")
+        try await run(
+            InitCommand.self,
+            "--template",
+            "https://github.com/tuist/ExampleTuistTemplate-Tuist4.git",
+            "--name",
+            "MyApp"
+        )
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
     }

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -78,7 +78,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_edit() throws {
+    func test_edit() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -131,7 +131,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -144,7 +144,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.packageManifestPath, packageManifestPath)
     }
 
-    func test_edit_when_there_are_no_editable_files() throws {
+    func test_edit_when_there_are_no_editable_files() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -172,14 +172,14 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // Then
-        XCTAssertThrowsSpecific(
+        await XCTAssertThrowsSpecific(
             // When
-            try subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test()),
+            try await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test()),
             ProjectEditorError.noEditableFiles(directory)
         )
     }
 
-    func test_edit_with_plugin() throws {
+    func test_edit_with_plugin() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -208,7 +208,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -220,7 +220,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.pluginProjectDescriptionHelpersModule, [])
     }
 
-    func test_edit_with_many_plugins() throws {
+    func test_edit_with_many_plugins() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -254,7 +254,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -266,7 +266,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.pluginProjectDescriptionHelpersModule, [])
     }
 
-    func test_edit_project_with_local_plugins() throws {
+    func test_edit_project_with_local_plugins() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -312,7 +312,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -325,7 +325,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.pluginProjectDescriptionHelpersModule, [])
     }
 
-    func test_edit_project_with_local_plugin_outside_editing_path() throws {
+    func test_edit_project_with_local_plugin_outside_editing_path() async throws {
         // Given
         let rootPath = try temporaryPath()
         let editingPath = rootPath.appending(component: "Editing")
@@ -368,7 +368,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
 
-        try _ = subject.edit(at: editingPath, in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = await subject.edit(at: editingPath, in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -381,7 +381,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.pluginProjectDescriptionHelpersModule, [])
     }
 
-    func test_edit_project_with_remote_plugin() throws {
+    func test_edit_project_with_remote_plugin() async throws {
         // Given
         let directory = try temporaryPath()
         let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
@@ -422,7 +422,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "RemotePlugin", path: try AbsolutePath(validating: "/Some/Path/To/Plugin"), location: .remote),
         ])
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import MockableTest
 import Path
@@ -37,7 +38,8 @@ final class CleanServiceTests: TuistUnitTestCase {
             manifestFilesLocator: manifestFilesLocator,
             configLoader: configLoader,
             serverURLService: serverURLService,
-            cleanCacheService: cleanCacheService
+            cleanCacheService: cleanCacheService,
+            fileSystem: FileSystem()
         )
     }
 

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -43,21 +43,21 @@ final class InitServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_fails_when_directory_not_empty() throws {
+    func test_fails_when_directory_not_empty() async throws {
         // Given
         let path = FileHandler.shared.currentPath
         try FileHandler.shared.touch(path.appending(component: "dummy"))
 
         // Then
-        XCTAssertThrowsSpecific(try subject.testRun(), InitServiceError.nonEmptyDirectory(path))
+        await XCTAssertThrowsSpecific({ try await self.subject.testRun() }, InitServiceError.nonEmptyDirectory(path))
     }
 
-    func test_init_fails_when_template_not_found() throws {
+    func test_init_fails_when_template_not_found() async throws {
         let templateName = "template"
-        XCTAssertThrowsSpecific(try subject.testRun(templateName: templateName), InitServiceError.templateNotFound(templateName))
+        await XCTAssertThrowsSpecific({ try await self.subject.testRun(templateName: templateName) }, InitServiceError.templateNotFound(templateName))
     }
 
-    func test_init_default_when_no_template() throws {
+    func test_init_default_when_no_template() async throws {
         // Given
         let defaultTemplatePath = try temporaryPath().appending(component: "default")
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
@@ -80,13 +80,13 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(name: "Name", platform: "macos")
+        try await subject.testRun(name: "Name", platform: "macos")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
     }
 
-    func test_init_default_platform() throws {
+    func test_init_default_platform() async throws {
         // Given
         let defaultTemplatePath = try temporaryPath().appending(component: "default")
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
@@ -109,13 +109,13 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(name: "Name")
+        try await subject.testRun(name: "Name")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
     }
 
-    func test_init_default_with_unusual_name() throws {
+    func test_init_default_with_unusual_name() async throws {
         // Given
         let defaultTemplatePath = try temporaryPath().appending(component: "default")
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
@@ -137,7 +137,7 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(name: "unusual name")
+        try await subject.testRun(name: "unusual name")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
@@ -174,7 +174,7 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(
+        try await subject.testRun(
             name: "Name",
             platform: "macos",
             templateName: "https://url/to/repo.git",
@@ -223,7 +223,7 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(name: "Name")
+        try await subject.testRun(name: "Name")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
@@ -262,7 +262,7 @@ final class InitServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(name: "Name")
+        try await subject.testRun(name: "Name")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
@@ -277,8 +277,8 @@ extension InitService {
         templateName: String? = nil,
         requiredTemplateOptions: [String: String] = [:],
         optionalTemplateOptions: [String: String?] = [:]
-    ) throws {
-        try run(
+    ) async throws {
+        try await run(
             name: name,
             platform: platform,
             path: path,

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -54,7 +54,10 @@ final class InitServiceTests: TuistUnitTestCase {
 
     func test_init_fails_when_template_not_found() async throws {
         let templateName = "template"
-        await XCTAssertThrowsSpecific({ try await self.subject.testRun(templateName: templateName) }, InitServiceError.templateNotFound(templateName))
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.testRun(templateName: templateName) },
+            InitServiceError.templateNotFound(templateName)
+        )
     }
 
     func test_init_default_when_no_template() async throws {

--- a/Tests/TuistKitTests/Services/LogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/LogoutServiceTests.swift
@@ -39,13 +39,13 @@ final class LogoutServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_logout() throws {
+    func test_logout() async throws {
         // Given
         given(serverSessionController)
             .logout(serverURL: .value(serverURL))
             .willReturn(())
 
         // When / Then
-        try subject.logout(directory: nil)
+        try await subject.logout(directory: nil)
     }
 }

--- a/Tests/TuistKitTests/Services/Plugin/PluginArchiveServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Plugin/PluginArchiveServiceTests.swift
@@ -32,7 +32,7 @@ final class PluginArchiveServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_run_when_no_task_products_defined() throws {
+    func test_run_when_no_task_products_defined() async throws {
         // Given
         swiftPackageManagerController.loadPackageInfoStub = { _ in
             PackageInfo.test(
@@ -47,7 +47,7 @@ final class PluginArchiveServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.run(path: nil)
+        try await subject.run(path: nil)
 
         // Then
         XCTAssertPrinterContains(
@@ -57,7 +57,7 @@ final class PluginArchiveServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_run() throws {
+    func test_run() async throws {
         // Given
         let path = try temporaryPath()
         var invokedPackagePath: AbsolutePath?
@@ -106,7 +106,7 @@ final class PluginArchiveServiceTests: TuistUnitTestCase {
         try fileHandler.createFolder(zipPath)
 
         // When
-        try subject.run(path: path.pathString)
+        try await subject.run(path: path.pathString)
 
         // Then
         XCTAssertEqual(invokedPackagePath, path)

--- a/Tests/TuistKitTests/Services/SessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/SessionServiceTests.swift
@@ -39,13 +39,13 @@ final class SessionServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_printSession() throws {
+    func test_printSession() async throws {
         // Given
         given(serverSessionController)
             .printSession(serverURL: .value(serverURL))
             .willReturn(())
 
         // When / Then
-        try subject.printSession(directory: nil)
+        try await subject.printSession(directory: nil)
     }
 }

--- a/Tests/TuistKitTests/Services/TuistServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TuistServiceTests.swift
@@ -31,20 +31,20 @@ final class TuistServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_run_when_command_not_found() throws {
+    func test_run_when_command_not_found() async throws {
         // Given
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.default)
 
         // When / Then
-        XCTAssertThrowsSpecific(
-            try subject.run(arguments: ["my-command"], tuistBinaryPath: ""),
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.run(arguments: ["my-command"], tuistBinaryPath: "") },
             TuistServiceError.taskUnavailable
         )
     }
 
-    func test_run_when_plugin_executable() throws {
+    func test_run_when_plugin_executable() async throws {
         // Given
         let path = try temporaryPath()
         let projectPath = path.appending(component: "Project")
@@ -71,11 +71,11 @@ final class TuistServiceTests: TuistUnitTestCase {
 
         // When/Then
         XCTAssertNoThrow(
-            try subject.run(arguments: ["command-b", "--path", projectPath.pathString], tuistBinaryPath: "")
+            { try await self.subject.run(arguments: ["command-b", "--path", projectPath.pathString], tuistBinaryPath: "") }
         )
     }
 
-    func test_run_when_command_is_global() throws {
+    func test_run_when_command_is_global() async throws {
         // Given
         var whichCommand: String?
         system.whichStub = { invokedWhichCommand in
@@ -88,9 +88,13 @@ final class TuistServiceTests: TuistUnitTestCase {
             .willReturn(.default)
 
         // When/Then
-        XCTAssertNoThrow(
-            try subject.run(arguments: ["my-command", "argument-one"], tuistBinaryPath: "")
-        )
+        var _error: Error?
+        do  {
+            try await self.subject.run(arguments: ["my-command", "argument-one"], tuistBinaryPath: "")
+        } catch {
+            _error = error
+        }
+        XCTAssertNil(_error)
         XCTAssertEqual(whichCommand, "tuist-my-command")
     }
 }

--- a/Tests/TuistKitTests/Services/TuistServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TuistServiceTests.swift
@@ -89,8 +89,8 @@ final class TuistServiceTests: TuistUnitTestCase {
 
         // When/Then
         var _error: Error?
-        do  {
-            try await self.subject.run(arguments: ["my-command", "argument-one"], tuistBinaryPath: "")
+        do {
+            try await subject.run(arguments: ["my-command", "argument-one"], tuistBinaryPath: "")
         } catch {
             _error = error
         }

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Mockable
 import MockableTest
 import TuistCore
@@ -45,7 +46,8 @@ final class TuistAnalyticsDispatcherTests: TuistUnitTestCase {
             fileHandler: fileHandler,
             ciChecker: ciChecker,
             cacheDirectoriesProviderFactory: cacheDirectoriesProviderFactory,
-            analyticsArtifactUploadService: analyticsArtifactUploadService
+            analyticsArtifactUploadService: analyticsArtifactUploadService,
+            fileSystem: FileSystem()
         )
         subject = TuistAnalyticsDispatcher(
             backend: backend

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import MockableTest
 import TuistAnalytics
 import TuistCore
@@ -35,7 +36,8 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
             fileHandler: fileHandler,
             ciChecker: ciChecker,
             cacheDirectoriesProviderFactory: cacheDirectoriesProviderFactory,
-            analyticsArtifactUploadService: analyticsArtifactUploadService
+            analyticsArtifactUploadService: analyticsArtifactUploadService,
+            fileSystem: FileSystem()
         )
     }
 

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -300,7 +300,7 @@ final class ManifestLoaderTests: TuistTestCase {
         // When / Then
         var _error: Error?
         do {
-            _ = try await self.subject.loadProject(at: temporaryPath)
+            _ = try await subject.loadProject(at: temporaryPath)
         } catch {
             _error = error
         }
@@ -309,7 +309,10 @@ final class ManifestLoaderTests: TuistTestCase {
 
     func test_load_missingManifest() async throws {
         let temporaryPath = try temporaryPath()
-        await  XCTAssertThrowsSpecific({ try await self.subject.loadProject(at: temporaryPath) }, ManifestLoaderError.manifestNotFound(.project, temporaryPath))
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadProject(at: temporaryPath) },
+            ManifestLoaderError.manifestNotFound(.project, temporaryPath)
+        )
     }
 
     func test_manifestsAt() throws {
@@ -338,13 +341,16 @@ final class ManifestLoaderTests: TuistTestCase {
         let data = try fileHandler.readFile(configPath)
 
         // When
-        await XCTAssertThrowsSpecific({ try await self.subject.loadConfig(at: temporaryPath) }, ManifestLoaderError.manifestLoadingFailed(
-            path: temporaryPath.appending(component: "Config.swift"),
-            data: data,
-            context: """
-            The encoded data for the manifest is corrupted.
-            The given data was not valid JSON.
-            """
-        ))
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadConfig(at: temporaryPath) },
+            ManifestLoaderError.manifestLoadingFailed(
+                path: temporaryPath.appending(component: "Config.swift"),
+                data: data,
+                context: """
+                The encoded data for the manifest is corrupted.
+                The given data was not valid JSON.
+                """
+            )
+        )
     }
 }

--- a/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
@@ -46,7 +46,11 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
 
         // When
         let paths = try await Array(0 ..< 3).concurrentMap { _ in
-            try await self.subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: [])
+            try await self.subject.build(
+                at: path,
+                projectDescriptionSearchPaths: searchPaths,
+                projectDescriptionHelperPlugins: []
+            )
         }
 
         // Then
@@ -77,7 +81,11 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
 
         // When
         let paths = try await Array(0 ..< 3).concurrentMap { _ in
-            try await self.subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: plugins)
+            try await self.subject.build(
+                at: path,
+                projectDescriptionSearchPaths: searchPaths,
+                projectDescriptionHelperPlugins: plugins
+            )
         }
 
         // Then

--- a/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
@@ -25,7 +25,7 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         super.tearDown()
     }
 
-    func test_build_when_the_helpers_is_a_dylib() throws {
+    func test_build_when_the_helpers_is_a_dylib() async throws {
         // Given
         let path = try temporaryPath()
         subject = ProjectDescriptionHelpersBuilder(
@@ -45,8 +45,8 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         let searchPaths = ProjectDescriptionSearchPaths.paths(for: projectDescriptionPath)
 
         // When
-        let paths = try (0 ..< 3).map { _ in
-            try subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: [])
+        let paths = try await Array(0 ..< 3).concurrentMap { _ in
+            try await self.subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: [])
         }
 
         // Then
@@ -58,7 +58,7 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         XCTAssertTrue(FileHandler.shared.exists(helpersModule.path))
     }
 
-    func test_build_when_the_helpers_is_a_plugin() throws {
+    func test_build_when_the_helpers_is_a_plugin() async throws {
         // Given
         let path = try temporaryPath()
         subject = ProjectDescriptionHelpersBuilder(cacheDirectory: path, helpersDirectoryLocator: helpersDirectoryLocator)
@@ -76,8 +76,8 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         let plugins = [ProjectDescriptionHelpersPlugin(name: "Plugin", path: helpersPluginPath, location: .local)]
 
         // When
-        let paths = try (0 ..< 3).map { _ in
-            try subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: plugins)
+        let paths = try await Array(0 ..< 3).concurrentMap { _ in
+            try await self.subject.build(at: path, projectDescriptionSearchPaths: searchPaths, projectDescriptionHelperPlugins: plugins)
         }
 
         // Then

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -98,73 +98,73 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_load_manifestNotCached() throws {
+    func test_load_manifestNotCached() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
 
         // When
-        let result = try subject.loadProject(at: path)
+        let result = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(result, project)
         XCTAssertEqual(result.name, "App")
     }
 
-    func test_load_manifestCached() throws {
+    func test_load_manifestCached() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
 
         // When
-        _ = try subject.loadProject(at: path)
-        _ = try subject.loadProject(at: path)
-        _ = try subject.loadProject(at: path)
-        let result = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        let result = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(result, project)
         XCTAssertEqual(recordedLoadProjectCalls, 1)
     }
 
-    func test_load_manifestHashChanged() throws {
+    func test_load_manifestHashChanged() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let originalProject = Project.test(name: "Original")
         try stubProject(originalProject, at: path)
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         let modifiedProject = Project.test(name: "Modified")
         try stubProject(modifiedProject, at: path)
-        let result = try subject.loadProject(at: path)
+        let result = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(result, modifiedProject)
         XCTAssertEqual(result.name, "Modified")
     }
 
-    func test_load_helpersHashChanged() throws {
+    func test_load_helpersHashChanged() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
         try stubHelpers(withHash: "hash")
 
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         try stubHelpers(withHash: "updatedHash")
         subject = createSubject() // we need to re-create the subject as it internally caches hashes
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(recordedLoadProjectCalls, 2)
     }
 
-    func test_load_pluginsHashChanged() throws {
+    func test_load_pluginsHashChanged() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
@@ -174,18 +174,18 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
             .willReturn()
         try stubPlugins(withHash: "hash")
 
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         try stubPlugins(withHash: "updatedHash")
         subject = createSubject() // we need to re-create the subject as it internally caches hashes
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(recordedLoadProjectCalls, 2)
     }
 
-    func test_load_environmentVariablesRemainTheSame() throws {
+    func test_load_environmentVariablesRemainTheSame() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
@@ -193,87 +193,87 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         environment.manifestLoadingVariables = ["NAME": "A"]
 
         // When
-        _ = try subject.loadProject(at: path)
-        _ = try subject.loadProject(at: path)
-        _ = try subject.loadProject(at: path)
-        let result = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
+        let result = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(result, project)
         XCTAssertEqual(recordedLoadProjectCalls, 1)
     }
 
-    func test_load_environmentVariablesChange() throws {
+    func test_load_environmentVariablesChange() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
         environment.manifestLoadingVariables = ["NAME": "A"]
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         environment.manifestLoadingVariables = ["NAME": "B"]
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(recordedLoadProjectCalls, 2)
     }
 
-    func test_load_tuistVersionRemainsTheSame() throws {
+    func test_load_tuistVersionRemainsTheSame() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
         subject = createSubject(tuistVersion: "1.0")
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         subject = createSubject(tuistVersion: "1.0")
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(recordedLoadProjectCalls, 1)
     }
 
-    func test_load_tuistVersionChanged() throws {
+    func test_load_tuistVersionChanged() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
         subject = createSubject(tuistVersion: "1.0")
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         subject = createSubject(tuistVersion: "2.0")
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(recordedLoadProjectCalls, 2)
     }
 
-    func test_load_corruptedCache() throws {
+    func test_load_corruptedCache() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stubProject(project, at: path)
-        _ = try subject.loadProject(at: path)
+        _ = try await subject.loadProject(at: path)
 
         // When
         try corruptFiles(at: cacheDirectory)
-        let result = try subject.loadProject(at: path)
+        let result = try await subject.loadProject(at: path)
 
         // Then
         XCTAssertEqual(result, project)
         XCTAssertEqual(recordedLoadProjectCalls, 2)
     }
 
-    func test_load_missingManifest() throws {
+    func test_load_missingManifest() async throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
 
         // When / Then
-        XCTAssertThrowsSpecific(
-            try subject.loadProject(at: path),
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadProject(at: path) },
             ManifestLoaderError.manifestNotFound(.project, path)
         )
     }

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -51,20 +51,20 @@ final class ConfigLoaderTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_loadConfig_defaultReturnedWhenPathDoesNotExist() throws {
+    func test_loadConfig_defaultReturnedWhenPathDoesNotExist() async throws {
         // Given
         let path: AbsolutePath = "/some/random/path"
         stub(path: path, exists: false)
         stub(rootDirectory: "/project")
 
         // When
-        let result = try subject.loadConfig(path: path)
+        let result = try await subject.loadConfig(path: path)
 
         // Then
         XCTAssertEqual(result, .default)
     }
 
-    func test_loadConfig_loadConfig() throws {
+    func test_loadConfig_loadConfig() async throws {
         // Given
         let path: AbsolutePath = "/project/Tuist/Config.swift"
         stub(path: path, exists: true)
@@ -75,7 +75,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         stub(rootDirectory: "/project")
 
         // When
-        let result = try subject.loadConfig(path: path)
+        let result = try await subject.loadConfig(path: path)
 
         // Then
         XCTAssertEqual(result, TuistCore.Config(
@@ -89,7 +89,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         ))
     }
 
-    func test_loadConfig_loadConfigError() throws {
+    func test_loadConfig_loadConfigError() async throws {
         // Given
         let path: AbsolutePath = "/project/Tuist/Config.swift"
         stub(path: path, exists: true)
@@ -97,10 +97,10 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         stub(rootDirectory: "/project")
 
         // When / Then
-        XCTAssertThrowsSpecific(try subject.loadConfig(path: path), TestError.testError)
+        await XCTAssertThrowsSpecific({ try await self.subject.loadConfig(path: path) }, TestError.testError)
     }
 
-    func test_loadConfig_loadConfigInRootDirectory() throws {
+    func test_loadConfig_loadConfigInRootDirectory() async throws {
         // Given
         stub(rootDirectory: "/project")
         let paths: [AbsolutePath] = [
@@ -117,7 +117,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        let result = try subject.loadConfig(path: "/project/Module/A/")
+        let result = try await subject.loadConfig(path: "/project/Module/A/")
 
         // Then
         XCTAssertEqual(result, TuistCore.Config(
@@ -131,7 +131,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         ))
     }
 
-    func test_loadConfig_with_full_handle_and_url() throws {
+    func test_loadConfig_with_full_handle_and_url() async throws {
         // Given
         stub(rootDirectory: "/project")
         stub(path: "/project/Tuist/Config.swift", exists: true)
@@ -144,7 +144,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        let result = try subject.loadConfig(path: "/project")
+        let result = try await subject.loadConfig(path: "/project")
 
         // Then
         XCTAssertBetterEqual(result, TuistCore.Config(
@@ -158,7 +158,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         ))
     }
 
-    func test_loadConfig_with_full_handle_and_url_and_optional_authentication() throws {
+    func test_loadConfig_with_deprecated_cloud() async throws {
         // Given
         stub(rootDirectory: "/project")
         stub(path: "/project/Tuist/Config.swift", exists: true)
@@ -174,7 +174,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        let result = try subject.loadConfig(path: "/project")
+        let result = try await subject.loadConfig(path: "/project")
 
         // Then
         XCTAssertBetterEqual(result, TuistCore.Config(

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -163,38 +163,6 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         stub(rootDirectory: "/project")
         stub(path: "/project/Tuist/Config.swift", exists: true)
         stub(
-            config: .test(
-                fullHandle: "tuist/tuist",
-                url: "https://test.tuist.io",
-                generationOptions: .options(
-                    optionalAuthentication: true
-                )
-            ),
-            at: "/project/Tuist"
-        )
-
-        // When
-        let result = try await subject.loadConfig(path: "/project")
-
-        // Then
-        XCTAssertBetterEqual(result, TuistCore.Config(
-            compatibleXcodeVersions: .all,
-            fullHandle: "tuist/tuist",
-            url: try XCTUnwrap(URL(string: "https://test.tuist.io")),
-            swiftVersion: nil,
-            plugins: [],
-            generationOptions: .test(
-                optionalAuthentication: true
-            ),
-            path: "/project/Tuist/Config.swift"
-        ))
-    }
-
-    func test_loadConfig_with_deprecated_cloud() throws {
-        // Given
-        stub(rootDirectory: "/project")
-        stub(path: "/project/Tuist/Config.swift", exists: true)
-        stub(
             config: ProjectDescription.Config(
                 cloud: .cloud(
                     projectId: "tuist/tuist",
@@ -205,7 +173,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        let result = try subject.loadConfig(path: "/project")
+        let result = try await subject.loadConfig(path: "/project")
 
         // Then
         XCTAssertBetterEqual(result, TuistCore.Config(

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -41,7 +41,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_loadPackageSettings() throws {
+    func test_loadPackageSettings() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         let plugins = Plugins.test()
@@ -62,7 +62,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try subject.loadPackageSettings(at: temporaryPath, with: plugins)
+        let got = try await subject.loadPackageSettings(at: temporaryPath, with: plugins)
 
         // Then
         let expected: TuistCore.PackageSettings = .init(

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -45,13 +45,13 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_loadProject_loadingSingleProject() throws {
+    func test_loadProject_loadingSingleProject() async throws {
         // Given
         let projectA = createProject(name: "ProjectA")
         try stub(manifest: projectA, at: try RelativePath(validating: "Some/Path/A"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -59,7 +59,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadProject_projectWithDependencies() throws {
+    func test_loadProject_projectWithDependencies() async throws {
         // Given
         let projectA = createProject(
             name: "ProjectA",
@@ -87,7 +87,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectC, at: try RelativePath(validating: "Some/Path/C"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -97,7 +97,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadProject_projectWithTransitiveDependencies() throws {
+    func test_loadProject_projectWithTransitiveDependencies() async throws {
         // Given
         let projectA = createProject(
             name: "ProjectA",
@@ -139,7 +139,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectE, at: try RelativePath(validating: "Some/Path/E"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -151,7 +151,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadProject_missingManifest() throws {
+    func test_loadProject_missingManifest() async throws {
         // Given
         let projectA = createProject(
             name: "ProjectA",
@@ -164,13 +164,13 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectA, at: try RelativePath(validating: "Some/Path/A"))
 
         // When / Then
-        XCTAssertThrowsSpecific(
-            try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A"))),
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadWorkspace(at: self.path.appending(try RelativePath(validating: "Some/Path/A"))) },
             ManifestLoaderError.manifestNotFound(.project, path.appending(try RelativePath(validating: "Some/Path/B")))
         )
     }
 
-    func test_loadWorkspace() throws {
+    func test_loadWorkspace() async throws {
         // Given
         let workspace = Workspace.test(
             name: "Workspace",
@@ -205,7 +205,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -217,7 +217,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadWorkspace_withGlobPattern() throws {
+    func test_loadWorkspace_withGlobPattern() async throws {
         // Given
         let workspace = Workspace.test(
             name: "Workspace",
@@ -251,7 +251,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -263,7 +263,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadWorkspace_withSameProjectName() throws {
+    func test_loadWorkspace_withSameProjectName() async throws {
         // Given
         let workspace = Workspace.test(
             name: "MyWorkspace",
@@ -286,7 +286,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
+        let manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -296,7 +296,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
-    func test_loadSPM_Package() throws {
+    func test_loadSPM_Package() async throws {
         // Given
         let packageA = createPackage(name: "PackageA")
         try stub(manifest: packageA, at: try RelativePath(validating: "Some/Path/A"))
@@ -312,8 +312,8 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        var manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
-        manifests = try subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test())
+        var manifests = try await subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
+        manifests = try await subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test())
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [

--- a/Tests/TuistLoaderTests/Loaders/TemplateGitLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/TemplateGitLoaderTests.swift
@@ -32,7 +32,7 @@ final class TemplateGitLoaderTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_loadTemplatePath_isSameWithClonedRepository() throws {
+    func test_loadTemplatePath_isSameWithClonedRepository() async throws {
         // Given
         var clonedRepositoryPath: AbsolutePath?
         gitHandler.cloneToStub = { _, path in
@@ -48,7 +48,7 @@ final class TemplateGitLoaderTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.loadTemplate(from: "https://url/to/repo.git", closure: { _ in })
+        try await subject.loadTemplate(from: "https://url/to/repo.git", closure: { _ in })
 
         // Then
         XCTAssertNotNil(pathToLoadTemplateFrom)

--- a/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
@@ -24,7 +24,7 @@ final class TemplateLoaderTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_loadTemplate_when_not_found() throws {
+    func test_loadTemplate_when_not_found() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         given(manifestLoader)
@@ -37,13 +37,13 @@ final class TemplateLoaderTests: TuistUnitTestCase {
             .willReturn(())
 
         // Then
-        XCTAssertThrowsSpecific(
-            try subject.loadTemplate(at: temporaryPath, plugins: .none),
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadTemplate(at: temporaryPath, plugins: .none) },
             ManifestLoaderError.manifestNotFound(temporaryPath)
         )
     }
 
-    func test_loadTemplate_files() throws {
+    func test_loadTemplate_files() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         given(manifestLoader)
@@ -63,7 +63,7 @@ final class TemplateLoaderTests: TuistUnitTestCase {
             .willReturn(())
 
         // When
-        let got = try subject.loadTemplate(at: temporaryPath, plugins: .none)
+        let got = try await subject.loadTemplate(at: temporaryPath, plugins: .none)
 
         // Then
         XCTAssertEqual(got, TuistCore.Template(

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import MockableTest
 import Path
 import ProjectDescription
@@ -13,10 +14,11 @@ import XCTest
 
 final class PackageInfoMapperTests: TuistUnitTestCase {
     private var subject: PackageInfoMapper!
+    private var fileSystem: FileSystem!
 
     override func setUp() {
         super.setUp()
-
+        fileSystem = FileSystem()
         given(swiftVersionProvider)
             .swiftVersion()
             .willReturn("5.9")
@@ -25,7 +27,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
 
     override func tearDown() {
         subject = nil
-
+        fileSystem = nil
         super.tearDown()
     }
 
@@ -520,7 +522,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
-    func testMap_whenAlternativeDefaultSources() throws {
+    func testMap_whenAlternativeDefaultSources() async throws {
         for alternativeDefaultSource in ["Source", "src", "srcs"] {
             let basePath = try temporaryPath()
             let sourcesPath = basePath.appending(try RelativePath(validating: "Package/\(alternativeDefaultSource)/Target1"))
@@ -566,7 +568,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 )
             )
 
-            try fileHandler.delete(sourcesPath)
+            try await fileSystem.remove(sourcesPath)
         }
     }
 

--- a/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
+++ b/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
@@ -22,7 +22,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         super.tearDown()
     }
 
-    func test_directories_are_generated() throws {
+    func test_directories_are_generated() async throws {
         // Given
         let directories = [
             try RelativePath(validating: "a"),
@@ -38,7 +38,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         let template = Template.test(items: items)
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: [:]
@@ -48,7 +48,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         XCTAssertTrue(expectedDirectories.allSatisfy(FileHandler.shared.exists))
     }
 
-    func test_directories_with_attributes() throws {
+    func test_directories_with_attributes() async throws {
         // Given
         let directories = [
             try RelativePath(validating: "{{ name|lowercase }}"),
@@ -67,7 +67,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ].map(destinationPath.appending)
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: [
@@ -81,7 +81,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         XCTAssertTrue(expectedDirectories.allSatisfy(FileHandler.shared.exists))
     }
 
-    func test_files_are_generated() throws {
+    func test_files_are_generated() async throws {
         // Given
         let items: [Template.Item] = [
             Template.Item(path: try RelativePath(validating: "a"), contents: .string("aContent")),
@@ -104,7 +104,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         }
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: [:]
@@ -116,7 +116,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         }
     }
 
-    func test_files_are_generated_with_attributes() throws {
+    func test_files_are_generated_with_attributes() async throws {
         // Given
         let sourcePath = try temporaryPath()
         let items = [
@@ -146,7 +146,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ]
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: [
@@ -164,7 +164,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         }
     }
 
-    func test_rendered_files() throws {
+    func test_rendered_files() async throws {
         // Given
         let sourcePath = try temporaryPath()
         let destinationPath = try temporaryPath()
@@ -190,7 +190,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ]
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: ["name": .string(name)]
@@ -202,7 +202,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         }
     }
 
-    func test_file_rendered_with_attributes() throws {
+    func test_file_rendered_with_attributes() async throws {
         // Given
         let sourcePath = try temporaryPath()
         let destinationPath = try temporaryPath()
@@ -218,7 +218,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         )])
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: ["name": .string("attribute name")]
@@ -231,7 +231,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         )
     }
 
-    func test_only_stencil_files_rendered() throws {
+    func test_only_stencil_files_rendered() async throws {
         // Given
         let sourcePath = try temporaryPath()
         let destinationPath = try temporaryPath()
@@ -259,7 +259,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ])
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: ["name": .string("attribute name")]
@@ -276,7 +276,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         )
     }
 
-    func test_empty_stencil_files_are_skipped() throws {
+    func test_empty_stencil_files_are_skipped() async throws {
         // Given
         let sourcePath = try temporaryPath()
         let destinationPath = try temporaryPath()
@@ -293,7 +293,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ])
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: ["name": .string("attribute name")]
@@ -303,7 +303,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         XCTAssertFalse(FileHandler.shared.exists(destinationPath.appending(component: "ignore")))
     }
 
-    func test_copy_directory() throws {
+    func test_copy_directory() async throws {
         // Given
         let sourcePath = try temporaryPath().appending(components: "folder")
         try FileHandler.shared.createFolder(sourcePath)
@@ -325,7 +325,7 @@ final class TemplateGeneratorTests: TuistTestCase {
         ])
 
         // When
-        try subject.generate(
+        try await subject.generate(
             template: template,
             to: destinationPath,
             attributes: [:]

--- a/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -135,7 +135,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
         """)
     }
 
-    func test_logout_deletesLegacyCredentials() throws {
+    func test_logout_deletesLegacyCredentials() async throws {
         // Given
         let credentials = ServerCredentials(
             token: "token",
@@ -152,7 +152,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             .willReturn()
 
         // When
-        try subject.logout(serverURL: serverURL)
+        try await subject.logout(serverURL: serverURL)
 
         // Then
         XCTAssertPrinterOutputContains("""
@@ -161,7 +161,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
         """)
     }
 
-    func test_logout_deletesCredentials() throws {
+    func test_logout_deletesCredentials() async throws {
         // Given
         let credentials = ServerCredentials(
             token: nil,
@@ -178,7 +178,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             .willReturn()
 
         // When
-        try subject.logout(serverURL: serverURL)
+        try await subject.logout(serverURL: serverURL)
 
         // Then
         XCTAssertPrinterOutputContains("""

--- a/Tests/TuistServerTests/Utilities/ServerCredentialsStoreTests.swift
+++ b/Tests/TuistServerTests/Utilities/ServerCredentialsStoreTests.swift
@@ -17,7 +17,7 @@ final class ServerCredentialsStoreTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_crud_with_legacy_token() throws {
+    func test_crud_with_legacy_token() async throws {
         // Given
         let temporaryDirectory = try temporaryPath()
         let subject = ServerCredentialsStore(
@@ -30,11 +30,11 @@ final class ServerCredentialsStoreTests: TuistUnitTestCase {
         // When/Then
         try subject.store(credentials: credentials, serverURL: serverURL)
         XCTAssertEqual(try subject.read(serverURL: serverURL), credentials)
-        try subject.delete(serverURL: serverURL)
+        try await subject.delete(serverURL: serverURL)
         XCTAssertEqual(try subject.read(serverURL: serverURL), nil)
     }
 
-    func test_crud() throws {
+    func test_crud() async throws {
         // Given
         let temporaryDirectory = try temporaryPath()
         let subject = ServerCredentialsStore(
@@ -47,7 +47,7 @@ final class ServerCredentialsStoreTests: TuistUnitTestCase {
         // When/Then
         try subject.store(credentials: credentials, serverURL: serverURL)
         XCTAssertEqual(try subject.read(serverURL: serverURL), credentials)
-        try subject.delete(serverURL: serverURL)
+        try await subject.delete(serverURL: serverURL)
         XCTAssertEqual(try subject.read(serverURL: serverURL), nil)
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -228,6 +228,7 @@ public enum Module: String, CaseIterable {
         case .support:
             [
                 .target(name: Module.projectDescription.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "AnyCodable"),
                 .external(name: "XcodeProj"),
@@ -251,6 +252,7 @@ public enum Module: String, CaseIterable {
                 .target(name: Module.asyncQueue.targetName),
                 .target(name: Module.analytics.targetName),
                 .target(name: Module.plugin.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "XcodeGraph"),
                 .external(name: "ArgumentParser"),
@@ -270,6 +272,7 @@ public enum Module: String, CaseIterable {
             [
                 .target(name: Module.core.targetName),
                 .target(name: Module.support.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "XcodeGraph"),
                 .external(name: "SwiftGenKit"),
                 .external(name: "PathKit"),
@@ -282,6 +285,7 @@ public enum Module: String, CaseIterable {
             [
                 .target(name: Module.core.targetName),
                 .target(name: Module.support.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "XcodeGraph"),
                 .external(name: "PathKit"),
                 .external(name: "StencilSwiftKit"),
@@ -299,6 +303,7 @@ public enum Module: String, CaseIterable {
             [
                 .target(name: Module.core.targetName),
                 .target(name: Module.support.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "XcodeGraph"),
                 .external(name: "Queuer"),
                 .external(name: "XcodeProj"),
@@ -309,6 +314,7 @@ public enum Module: String, CaseIterable {
                 .target(name: Module.loader.targetName),
                 .target(name: Module.support.targetName),
                 .target(name: Module.scaffold.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "SwiftToolsSupport"),
             ]
         case .analytics:
@@ -340,6 +346,7 @@ public enum Module: String, CaseIterable {
             [
                 .target(name: Module.core.targetName),
                 .target(name: Module.support.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "XcodeProj"),
                 .external(name: "XcbeautifyLib"),
                 .external(name: "XcodeGraph"),
@@ -348,6 +355,7 @@ public enum Module: String, CaseIterable {
             [
                 .target(name: Module.core.targetName),
                 .target(name: Module.support.targetName),
+                .external(name: "FileSystem"),
                 .external(name: "OpenAPIRuntime"),
                 .external(name: "OpenAPIURLSession"),
             ]


### PR DESCRIPTION
### Short description 📝
As part of the effort to simplify the setup to merge the cache logic into Tuist, I'm breaking the dependencies of the `TuistGenerator` business logic with `TuistSupport` utilities. One is the dependency with `FileHandler`, which I'm replacing with [FileSystem](https://github.com/tuist/FileSystem/). FileSystem is an implementation that's more aligned with Swift's structured concurrency, allowing the parallelization of IO tasks with good ergonomics and minimizing the risks of race conditions. 

Because dropping `FileHandler` in one shot is a large effort, I'll create a PR per function being removed.

> [!NOTE]
> Most of the changes in this PR are changes to accommodate `async` functions upstream.

### How to test the changes locally 🧐
Tests should pass and you should be able to run Tuist workflows against an existing project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
