### PR TITLE
Validate target references in custom workspace schemes

### DIFF
--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -143,6 +143,8 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         )
 
         // Lint Manifests
+        let workspaceLintingIssues = manifestLinter.lint(workspace: allManifests.workspace)
+        try workspaceLintingIssues.printAndThrowErrorsIfNeeded()
         let lintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
         try lintingIssues.printAndThrowErrorsIfNeeded()
 

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -145,8 +145,8 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         // Lint Manifests
         let workspaceLintingIssues = manifestLinter.lint(workspace: allManifests.workspace)
         let projectLintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
-        try projectLintingIssues.printAndThrowErrorsIfNeeded()
         let lintingIssues = workspaceLintingIssues + projectLintingIssues
+        try lintingIssues.printAndThrowErrorsIfNeeded()
 
         // Convert to models
         let projectsModels = try convert(

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -144,7 +144,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Lint Manifests
         let workspaceLintingIssues = manifestLinter.lint(workspace: allManifests.workspace)
-        try workspaceLintingIssues.printAndThrowErrorsIfNeeded()
+        workspaceLintingIssues.printWarningsIfNeeded()
         let lintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
         try lintingIssues.printAndThrowErrorsIfNeeded()
 

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -144,9 +144,9 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Lint Manifests
         let workspaceLintingIssues = manifestLinter.lint(workspace: allManifests.workspace)
-        workspaceLintingIssues.printWarningsIfNeeded()
-        let lintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
-        try lintingIssues.printAndThrowErrorsIfNeeded()
+        let projectLintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
+        try projectLintingIssues.printAndThrowErrorsIfNeeded()
+        let lintingIssues = workspaceLintingIssues + projectLintingIssues
 
         // Convert to models
         let projectsModels = try convert(

--- a/Sources/TuistLoader/Linter/ManifestLinter.swift
+++ b/Sources/TuistLoader/Linter/ManifestLinter.swift
@@ -5,18 +5,32 @@ import TuistSupport
 
 public protocol ManifestLinting {
     func lint(project: ProjectDescription.Project) -> [LintingIssue]
+    func lint(workspace: ProjectDescription.Workspace) -> [LintingIssue]
 }
 
 public class AnyManifestLinter: ManifestLinting {
-    let lint: ((ProjectDescription.Project) -> [LintingIssue])?
+    let lintProject: ((ProjectDescription.Project) -> [LintingIssue])?
+    let lintWorkspace: ((ProjectDescription.Workspace) -> [LintingIssue])?
 
-    public init(lint: ((ProjectDescription.Project) -> [LintingIssue])? = nil) {
-        self.lint = lint
+    public init(
+        lintProject: ((ProjectDescription.Project) -> [LintingIssue])? = nil,
+        lintWorkspace: ((ProjectDescription.Workspace) -> [LintingIssue])? = nil
+    ) {
+        self.lintProject = lintProject
+        self.lintWorkspace = lintWorkspace
     }
 
     public func lint(project: ProjectDescription.Project) -> [LintingIssue] {
-        if let lint {
-            return lint(project)
+        if let lintProject {
+            return lintProject(project)
+        } else {
+            return []
+        }
+    }
+
+    public func lint(workspace: ProjectDescription.Workspace) -> [LintingIssue] {
+        if let lintWorkspace {
+            return lintWorkspace(workspace)
         } else {
             return []
         }
@@ -35,6 +49,118 @@ public class ManifestLinter: ManifestLinting {
 
         issues.append(contentsOf: lintDuplicates(project: project))
         issues.append(contentsOf: project.targets.flatMap(lint))
+
+        return issues
+    }
+
+    public func lint(workspace: ProjectDescription.Workspace) -> [LintingIssue] {
+        var issues = [LintingIssue]()
+
+        for scheme in workspace.schemes {
+            if let buildAction = scheme.buildAction {
+                issues.append(contentsOf: lintWorkspaceSchemeBuildActions(
+                    buildAction.targets,
+                    scheme: scheme,
+                    workspace: workspace
+                ))
+            }
+
+            if let runAction = scheme.runAction {
+                issues.append(contentsOf: lintWorkspaceSchemeRunActions(
+                    runAction.expandVariableFromTarget,
+                    scheme: scheme,
+                    workspace: workspace
+                ))
+            }
+
+            if let profileAction = scheme.profileAction {
+                issues.append(contentsOf: lintWorkspaceSchemeProfileActions(
+                    profileAction.executable,
+                    scheme: scheme,
+                    workspace: workspace
+                ))
+            }
+        }
+
+        return issues
+    }
+
+    private func lintWorkspaceSchemeBuildActions(
+        _ targets: [TargetReference],
+        scheme: Scheme, workspace _: ProjectDescription.Workspace
+    ) -> [LintingIssue] {
+        var issues = [LintingIssue]()
+
+        targets.forEach { targetReference in
+            guard targetReference.projectPath == nil else { return }
+            issues.append(
+                LintingIssue(
+                    reason: """
+                    Workspace.swift: The target '\(targetReference.targetName)' in the scheme '\(
+                        scheme
+                            .name
+                    )' is missing the project path.
+                    Please specify the project path using .project(path:, target:).
+
+                    """,
+                    severity: .error
+                )
+            )
+        }
+
+        return issues
+    }
+
+    private func lintWorkspaceSchemeRunActions(
+        _ targetReference: TargetReference?,
+        scheme: Scheme, workspace _: ProjectDescription.Workspace
+    ) -> [LintingIssue] {
+        var issues = [LintingIssue]()
+
+        guard let targetReference else { return issues }
+
+        guard targetReference.projectPath == nil else { return issues }
+
+        issues.append(
+            LintingIssue(
+                reason: """
+                Workspace.swift: The target '\(targetReference.targetName)' in the run action of the scheme '\(
+                    scheme
+                        .name
+                )' is missing the project path.
+                Please specify the project path using .project(path:, target:).
+
+                """,
+                severity: .error
+            )
+        )
+
+        return issues
+    }
+
+    private func lintWorkspaceSchemeProfileActions(
+        _ targetReference: TargetReference?,
+        scheme: Scheme, workspace _: ProjectDescription.Workspace
+    ) -> [LintingIssue] {
+        var issues = [LintingIssue]()
+
+        guard let targetReference else { return issues }
+
+        guard targetReference.projectPath == nil else { return issues }
+
+        issues.append(
+            LintingIssue(
+                reason: """
+                Workspace.swift: The target '\(targetReference.targetName)' in the profile action of the scheme '\(
+                    scheme
+                        .name
+                )' is missing the project path.
+                Please specify the project path using .project(path:, target:).
+
+                """,
+                severity: .error
+            )
+        )
 
         return issues
     }

--- a/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -105,7 +105,7 @@ class ManifestLinterTests: XCTestCase {
             Workspace.swift: The target 'TargetA' in the buildAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
             """,
-            severity: .warning
+            severity: .error
         )))
     }
 
@@ -124,7 +124,7 @@ class ManifestLinterTests: XCTestCase {
             Workspace.swift: The target 'TargetA' in the runAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
             """,
-            severity: .warning
+            severity: .error
         )))
     }
 
@@ -143,7 +143,166 @@ class ManifestLinterTests: XCTestCase {
             Workspace.swift: The target 'TargetA' in the profileAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
             """,
-            severity: .warning
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInTestAction() {
+        // Given
+        let testAction = TestAction.test(targets: [.testableTarget(target: .target("TargetA"))])
+        let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the testAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInBuildActionPreActions() {
+        // Given
+        let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let buildAction = BuildAction.buildAction(targets: [], preActions: preActions)
+        let scheme = Scheme.scheme(name: "MyScheme", buildAction: buildAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the buildAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInRunActionPreActions() {
+        // Given
+        let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let runAction = RunAction.runAction(preActions: preActions)
+        let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the runAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInProfileActionPreActions() {
+        // Given
+        let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let profileAction = ProfileAction.profileAction(preActions: preActions)
+        let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the profileAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInTestActionPreActions() {
+        // Given
+        let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let testAction = TestAction.targets([], preActions: preActions)
+        let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the testAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInRunActionPostActions() {
+        // Given
+        let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let runAction = RunAction.runAction(postActions: postActions)
+        let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the runAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInProfileActionPostActions() {
+        // Given
+        let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let profileAction = ProfileAction.profileAction(postActions: postActions)
+        let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the profileAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInTestActionPostActions() {
+        // Given
+        let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
+        let testAction = TestAction.targets([], preActions: postActions)
+        let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the testAction of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+            """,
+            severity: .error
         )))
     }
 }

--- a/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -106,7 +106,7 @@ class ManifestLinterTests: XCTestCase {
             Please specify the project path using .project(path:, target:).
 
             """,
-            severity: .error
+            severity: .warning
         )))
     }
 
@@ -126,7 +126,7 @@ class ManifestLinterTests: XCTestCase {
             Please specify the project path using .project(path:, target:).
 
             """,
-            severity: .error
+            severity: .warning
         )))
     }
 
@@ -146,7 +146,7 @@ class ManifestLinterTests: XCTestCase {
             Please specify the project path using .project(path:, target:).
 
             """,
-            severity: .error
+            severity: .warning
         )))
     }
 }

--- a/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -88,4 +88,65 @@ class ManifestLinterTests: XCTestCase {
             severity: .error
         )))
     }
+
+    func test_lint_workspace_scheme_missingProjectPathInBuildAction() {
+        // Given
+
+        let buildAction = BuildAction.buildAction(targets: [.target("TargetA")])
+        let scheme = Scheme.scheme(name: "MyScheme", buildAction: buildAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInRunAction() {
+        // Given
+        let runAction = RunAction.runAction(expandVariableFromTarget: .target("TargetA"))
+        let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the run action of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+
+            """,
+            severity: .error
+        )))
+    }
+
+    func test_lint_workspace_scheme_missingProjectPathInProfileAction() {
+        // Given
+        let profileAction = ProfileAction.profileAction(executable: .target("TargetA"))
+        let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
+        let workspace = Workspace.test(schemes: [scheme])
+
+        // When
+        let results = subject.lint(workspace: workspace)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: """
+            Workspace.swift: The target 'TargetA' in the profile action of the scheme 'MyScheme' is missing the project path.
+            Please specify the project path using .project(path:, target:).
+
+            """,
+            severity: .error
+        )))
+    }
 }

--- a/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -102,9 +102,8 @@ class ManifestLinterTests: XCTestCase {
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
             reason: """
-            Workspace.swift: The target 'TargetA' in the scheme 'MyScheme' is missing the project path.
+            Workspace.swift: The target 'TargetA' in the buildAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
-
             """,
             severity: .warning
         )))
@@ -122,9 +121,8 @@ class ManifestLinterTests: XCTestCase {
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
             reason: """
-            Workspace.swift: The target 'TargetA' in the run action of the scheme 'MyScheme' is missing the project path.
+            Workspace.swift: The target 'TargetA' in the runAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
-
             """,
             severity: .warning
         )))
@@ -142,9 +140,8 @@ class ManifestLinterTests: XCTestCase {
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
             reason: """
-            Workspace.swift: The target 'TargetA' in the profile action of the scheme 'MyScheme' is missing the project path.
+            Workspace.swift: The target 'TargetA' in the profileAction of the scheme 'MyScheme' is missing the project path.
             Please specify the project path using .project(path:, target:).
-
             """,
             severity: .warning
         )))

--- a/Tests/TuistLoaderTests/Linters/Mocks/MockManifestLinter.swift
+++ b/Tests/TuistLoaderTests/Linters/Mocks/MockManifestLinter.swift
@@ -6,7 +6,13 @@ import TuistSupport
 
 class MockManifestLinter: ManifestLinting {
     var stubLintProject: [LintingIssue] = []
+    var stubLintWorkspace: [LintingIssue] = []
+
     func lint(project _: ProjectDescription.Project) -> [LintingIssue] {
         stubLintProject
+    }
+
+    func lint(workspace _: ProjectDescription.Workspace) -> [TuistCore.LintingIssue] {
+        stubLintWorkspace
     }
 }


### PR DESCRIPTION
Resolves #6510

### Short description 📝

This PR enhances the `ManifestLinter` to validate target references in workspace schemes, ensuring that targets are correctly specified with their project paths. This improvement prevents the generation of invalid build actions in custom, non-Tuist defined schemes.

### Key features:

- **Target Reference Validation**: Ensures that targets in workspace schemes specify their project paths using `.project(path:, target:)`.
- **Comprehensive Linting**: Adds linting for `buildAction`, `runAction`, and `profileAction` in workspace schemes to check for unspecified `projectPaths`.
- **User-Friendly Warnings**: Provides clear and friendly error messages, indicating the need to specify project paths and highlighting the source of the issue in `Workspace.swift`.
- **Improved Scheme Integrity**: Prevents the generation of empty build actions by ensuring all targets are validated for existence and correctness.

### How to test the changes locally 🧐

1. **Prepare Workspace.swift**:
    - Define schemes in `Workspace.swift` with targets that lack project paths.
    - Example:
      ```swift
      import ProjectDescription

      let workspace = Workspace(
          name: "MyWorkspace",
          projects: [
              "MyProject",
          ],
          schemes: [
              .scheme(
                  name: "MyScheme",
                  buildAction: .buildAction(
                      targets: [.target("TargetA")]
                  ),
                  runAction: .runAction(
                      expandVariableFromTarget: .target("TargetA")
                  ),
                  profileAction: .profileAction(
                      executable: .target("TargetA")
                  )
              ),
          ]
      )
      ```

2. **Run Linter**:
    - Execute the linter and observe the warnings:
      ```sh
      swift run tuist generate --path path/to/project --no-open 
      ```

3. **Verify Warnings**:
    - Confirm that warnings are displayed for each instance where a target is missing its project path:
      ```
      Workspace.swift: The target 'InvalidTarget' in the scheme 'MyScheme' is missing the project path.
      Please specify the project path using .project(path:, target:).
      ```

### Contributor checklist ✅

- [x] The code has been linted using `run mise run lint:fix`.
- [x] The change is tested via unit testing or acceptance testing, or both.
- [x] The title of the PR is formulated in a way that is usable as a changelog entry.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry.