### PR TITLE
Update generated code templates to add `Sendable` Conformance

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -74,7 +74,7 @@ extension SynthesizedResourceInterfaceTemplates {
       {% elif asset.type == "symbol" %}
       {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{imageType}}(name: "{{asset.value}}")
       {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
-      {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+      {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: Sendable {
         {% filter indent:2 %}{% call casesBlock asset.items %}{% endfilter %}
       }
       {% elif asset.items %}
@@ -95,7 +95,7 @@ extension SynthesizedResourceInterfaceTemplates {
       {% endfor %}
     {% endmacro %}
     // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-    {{accessModifier}} enum {{enumName}} {
+    {{accessModifier}} enum {{enumName}}: Sendable {
       {% if catalogs.count > 1 or param.forceFileNameEnum %}
       {% for catalog in catalogs %}
       {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
@@ -111,8 +111,8 @@ extension SynthesizedResourceInterfaceTemplates {
     // MARK: - Implementation Details
 
     {% if resourceCount.arresourcegroup > 0 %}
-    {{accessModifier}} struct {{arResourceGroupType}} {
-      {{accessModifier}} fileprivate(set) var name: String
+    {{accessModifier}} struct {{arResourceGroupType}}: Sendable {
+      {{accessModifier}} let name: String
 
       #if os(iOS)
       @available(iOS 11.3, *)
@@ -147,8 +147,8 @@ extension SynthesizedResourceInterfaceTemplates {
 
     {% endif %}
     {% if resourceCount.color > 0 %}
-    {{accessModifier}} final class {{colorType}} {
-      {{accessModifier}} fileprivate(set) var name: String
+    {{accessModifier}} final class {{colorType}}: Sendable {
+      {{accessModifier}} let name: String
 
       #if os(macOS)
       {{accessModifier}} typealias Color = NSColor
@@ -157,27 +157,17 @@ extension SynthesizedResourceInterfaceTemplates {
       #endif
 
       @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, visionOS 1.0, *)
-      {{accessModifier}} private(set) lazy var color: Color = {
+      {{accessModifier}} var color: Color {
         guard let color = Color(asset: self) else {
           fatalError("Unable to load color asset named \\(name).")
         }
         return color
-      }()
+      }
 
       #if canImport(SwiftUI)
-      private var _swiftUIColor: Any? = nil
       @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
-      {{accessModifier}} private(set) var swiftUIColor: SwiftUI.Color {
-        get {
-          if self._swiftUIColor == nil {
-            self._swiftUIColor = SwiftUI.Color(asset: self)
-          }
-
-          return self._swiftUIColor as! SwiftUI.Color
-        }
-        set {
-          self._swiftUIColor = newValue
-        }
+      {{accessModifier}} var swiftUIColor: SwiftUI.Color {
+          return SwiftUI.Color(asset: self)
       }
       #endif
 
@@ -212,8 +202,8 @@ extension SynthesizedResourceInterfaceTemplates {
 
     {% endif %}
     {% if resourceCount.data > 0 %}
-    {{accessModifier}} struct {{dataType}} {
-      {{accessModifier}} fileprivate(set) var name: String
+    {{accessModifier}} struct {{dataType}}: Sendable {
+      {{accessModifier}} let name: String
 
       #if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
       @available(iOS 9.0, macOS 10.11, visionOS 1.0, *)
@@ -242,8 +232,8 @@ extension SynthesizedResourceInterfaceTemplates {
 
     {% endif %}
     {% if resourceCount.image > 0 or resourceCount.symbol > 0 %}
-    {{accessModifier}} struct {{imageType}} {
-      {{accessModifier}} fileprivate(set) var name: String
+    {{accessModifier}} struct {{imageType}}: Sendable {
+      {{accessModifier}} let name: String
 
       #if os(macOS)
       {{accessModifier}} typealias Image = NSImage

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -30,9 +30,9 @@ extension SynthesizedResourceInterfaceTemplates {
         {{path|basename}}
       {% endif %}
     {% endfilter %}{% endmacro %}
-    {{accessModifier}} enum {{param.name}}FontFamily {
+    {{accessModifier}} enum {{param.name}}FontFamily: Sendable {
       {% for family in families %}
-      {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+      {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: Sendable {
         {% for font in family.fonts %}
         {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{fontType}}(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
         {% endfor %}
@@ -48,7 +48,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
     // MARK: - Implementation Details
 
-    {{accessModifier}} struct {{fontType}} {
+    {{accessModifier}} struct {{fontType}}: Sendable {
       {{accessModifier}} let name: String
       {{accessModifier}} let family: String
       {{accessModifier}} let path: String

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -70,7 +70,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
     // swiftlint:disable identifier_name line_length number_separator type_body_length
     {% for file in files %}
-    {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: Sendable {
       {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
     }
     {% endfor %}

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -54,7 +54,7 @@ extension SynthesizedResourceInterfaceTemplates {
       {% endfor %}
       {% for child in item.children %}
 
-      {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+      {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: Sendable {
         {% filter indent:2 %}{% call recursiveBlock table child %}{% endfilter %}
       }
       {% endfor %}
@@ -62,7 +62,7 @@ extension SynthesizedResourceInterfaceTemplates {
     // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
     // swiftlint:disable nesting type_body_length type_name
     {% set enumName %}{{param.name}}Strings{% endset %}
-    {{accessModifier}} enum {{enumName}} {
+    {{accessModifier}} enum {{enumName}}: Sendable {
       {% if tables.count > 1 or param.forceFileNameEnum %}
       {% for table in tables %}
       {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Project.swift
@@ -11,7 +11,8 @@ let project = Project(
             infoPlist: .default,
             resources: "Resources/**",
             dependencies: [
-            ]
+            ],
+            settings: .settings(base: ["SWIFT_STRICT_CONCURRENCY": .string("complete")], defaultSettings: .recommended())
         ),
     ]
 )

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/Property List.plist
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/Property List.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Key</key>
+	<string>Value</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Color.colorset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "textures" : [
+    {
+      "cube-face" : "x-",
+      "filename" : "Universal -X.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "y-",
+      "filename" : "Universal -Y.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "z-",
+      "filename" : "Universal -Z.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "x+",
+      "filename" : "Universal +X.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "y+",
+      "filename" : "Universal +Y.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "z+",
+      "filename" : "Universal +Z.mipmapset",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +X.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +X.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +Y.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +Y.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +Z.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal +Z.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -X.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -X.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -Y.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -Y.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -Z.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Cube Texture.cubetextureset/Universal -Z.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Data.dataset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Data.dataset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "data" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Sprites.spriteatlas/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Sprites.spriteatlas/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Sprites.spriteatlas/Sprite.imageset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Sprites.spriteatlas/Sprite.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Symbol.symbolset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Symbol.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Texture.textureset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Texture.textureset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "textures" : [
+    {
+      "filename" : "Universal.mipmapset",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Texture.textureset/Universal.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/assets.xcassets/Texture.textureset/Universal.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/en.lproj/Localizable.strings
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* 
+  Localizable.strings
+  StaticFramework5
+
+  Created by Michael Simons on 7/22/24.
+  
+*/
+"Test String" = "Test String";

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/en.lproj/Localizable.strings
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Resources/en.lproj/Localizable.strings
@@ -1,8 +1,1 @@
-/* 
-  Localizable.strings
-  StaticFramework5
-
-  Created by Michael Simons on 7/22/24.
-  
-*/
 "Test String" = "Test String";


### PR DESCRIPTION
Resolves #6535 

### Short description 📝

Add `Sendable` Conformance to the templates used for Resource Synthesizers.

### How to test the changes locally 🧐

The `ios_app_with_framework_and_resources` StaticFramework5 should not have any concurrency warnings for the resource accessors that are generated.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
