### PR TITLE
Fix init acceptance tests

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -80,6 +80,23 @@ open class TuistAcceptanceTestCase: XCTestCase {
         try await parsedCommand.run()
     }
 
+    public func run(_ command: InitCommand.Type, _ arguments: String...) async throws {
+        try await run(command, arguments)
+    }
+
+    public func run(_ command: InitCommand.Type, _ arguments: [String] = []) async throws {
+        fixturePath = fixtureTemporaryDirectory.path.appending(
+            component: arguments[arguments.firstIndex(where: { $0 == "--name" })! + 1]
+        )
+
+        let arguments = [
+            "--path", fixturePath.pathString,
+        ] + arguments
+
+        let parsedCommand = try command.parse(arguments)
+        try await parsedCommand.run()
+    }
+
     public func run(_ command: RunCommand.Type, _ arguments: String...) async throws {
         try await run(command, arguments)
     }
@@ -169,11 +186,6 @@ open class TuistAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: (some ParsableCommand).Type, _ arguments: [String] = []) throws {
-        if String(describing: command) == "InitCommand" {
-            fixturePath = fixtureTemporaryDirectory.path.appending(
-                component: arguments[arguments.firstIndex(where: { $0 == "--name" })! + 1]
-            )
-        }
         var parsedCommand = try command.parseAsRoot(
             arguments +
                 ["--path", fixturePath.pathString]


### PR DESCRIPTION
### Short description 📝

The current `init` acceptance tests are broken, such as here: https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/669fcb1676cec081a6bfdd62#step:8

This is because the `InitCommand` is now an `AsyncParsableCommand` instead of `ParsableCommand` (implemented [here](https://github.com/tuist/tuist/pull/6533)). We should investigate why the selective tests considered the test case to be successful even though it never seems to pass (at least I couldn't find such a case in the PR).

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x]  Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
