### PR TITLE
Update fullHandle of ios_app_with_frameworks fixture

### DIFF
--- a/fixtures/ios_app_with_frameworks/Tuist/Config.swift
+++ b/fixtures/ios_app_with_frameworks/Tuist/Config.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let config = Config(
-    fullHandle: "tuist/tuist-cloud-acceptance-tests",
+    fullHandle: "tuist/ios_app_with_frameworks",
     url: "https://canary.tuist.io",
     generationOptions: .options(
         optionalAuthentication: true


### PR DESCRIPTION
### Short description 📝

As we're adding more fixtures with the server configuration, instead of having one `tuist-cloud-acceptance-tests`, we're moving to having multiple Tuist projects.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
