### PR TITLE
Use clean urls in docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
       lange: "en",
     },
   },
+  cleanUrls: true,
   head: [
     [
       "script",


### PR DESCRIPTION
### Short description 📝

Currently, all links in docs have a `.html` suffix. Not only the links don't look clean, but it also adds complexity to redirects as we'd need to always redirect to both the clean and non-clean version. I believe we should instead use [clean urls](https://vitepress.dev/reference/site-config#cleanurls) from VitePress.

Before:
![image](https://github.com/user-attachments/assets/2f9137cd-fa19-4f67-acbe-9de2d434ddae)

After:
![image](https://github.com/user-attachments/assets/4a40b6b8-edac-4a73-bb1d-8098bfabf619)


### How to test the changes locally 🧐

Preview the docs.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
