### PR TITLE
Opensource DefaultConfigurationFetcher

### DIFF
--- a/Sources/TuistCore/Utils/DefaultConfigurationFetcher.swift
+++ b/Sources/TuistCore/Utils/DefaultConfigurationFetcher.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Mockable
+import TuistSupport
+import XcodeGraph
+
+@Mockable
+public protocol DefaultConfigurationFetching {
+    func fetch(
+        configuration: String?,
+        config: TuistCore.Config,
+        graph: XcodeGraph.Graph
+    ) throws -> String
+}
+
+enum DefaultConfigurationFetcherError: FatalError, Equatable {
+    case debugBuildConfigurationNotFound
+    case configurationNotFound(String, available: [String])
+    case defaultConfigurationNotFound(String, available: [String])
+
+    var type: ErrorType {
+        switch self {
+        case .debugBuildConfigurationNotFound, .configurationNotFound, .defaultConfigurationNotFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .debugBuildConfigurationNotFound:
+            return "We couldn't find a build configuration of variant 'debug' for caching. Make sure one exists in the project."
+        case let .configurationNotFound(configuration, available):
+            return "We couldn't find the configuration \(configuration) in the project. The configurations available are: \(available.joined(separator: ", "))"
+        case let .defaultConfigurationNotFound(configuration, available):
+            return "We couldn't find the default configuration \(configuration) specified in your Config.swift in the project. The configurations available are: \(available.joined(separator: ", "))"
+        }
+    }
+}
+
+public struct DefaultConfigurationFetcher: DefaultConfigurationFetching {
+    public init() {}
+
+    public func fetch(
+        configuration: String?,
+        config: TuistCore.Config,
+        graph: XcodeGraph.Graph
+    ) throws -> String {
+        let allProjectConfigurations = Set(graph.projects.values.map(\.settings).flatMap(\.configurations.keys)).sorted()
+
+        if let configuration {
+            if allProjectConfigurations.first(where: { $0.name == configuration }) != nil {
+                return configuration
+            } else {
+                throw DefaultConfigurationFetcherError.configurationNotFound(
+                    configuration,
+                    available: allProjectConfigurations.map(\.name)
+                )
+            }
+        }
+
+        if let defaultConfiguration = config.generationOptions.defaultConfiguration {
+            if allProjectConfigurations.first(where: { $0.name == defaultConfiguration }) != nil {
+                return defaultConfiguration
+            } else {
+                throw DefaultConfigurationFetcherError.defaultConfigurationNotFound(
+                    defaultConfiguration,
+                    available: allProjectConfigurations.map(\.name)
+                )
+            }
+        }
+
+        guard let debugConfigurationName = graph.projects.values.map(\.settings).flatMap(\.configurations.keys).sorted()
+            .first(where: {
+                $0.variant == .debug
+            })?.name
+        else {
+            throw DefaultConfigurationFetcherError.debugBuildConfigurationNotFound
+        }
+
+        return debugConfigurationName
+    }
+}

--- a/Tests/TuistCoreTests/Utils/DefaultConfigurationFetcherTests.swift
+++ b/Tests/TuistCoreTests/Utils/DefaultConfigurationFetcherTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Path
+import TuistSupportTesting
+import XcodeGraph
+import XCTest
+
+@testable import TuistCore
+
+final class DefaultConfigurationFetcherTests: TuistUnitTestCase {
+    private var subject: DefaultConfigurationFetcher!
+
+    override func setUp() {
+        super.setUp()
+        subject = DefaultConfigurationFetcher()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_fetch_throws_an_error_when_debug_configuration_not_found() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project.test(settings: Settings(configurations: [:])),
+        ])
+
+        // When/Then
+        XCTAssertThrowsSpecific(
+            try subject.fetch(configuration: nil, config: .test(), graph: graph),
+            DefaultConfigurationFetcherError.debugBuildConfigurationNotFound
+        )
+    }
+
+    func test_fetch_returns_the_first_debug_configuration_found() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(settings: Settings(configurations: [BuildConfiguration(name: "Development", variant: .debug): .test()])),
+        ])
+
+        // When
+        let got = try subject.fetch(configuration: nil, config: .test(), graph: graph)
+
+        // Then
+        XCTAssertEqual(got, "Development")
+    }
+
+    func test_fetch_returns_the_configuration_if_the_configuration_exists_in_the_project() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(settings: Settings(configurations: [BuildConfiguration(name: "Dev", variant: .debug): .test()])),
+        ])
+
+        // When
+        let got = try subject.fetch(configuration: "Dev", config: .test(), graph: graph)
+
+        // Then
+        XCTAssertEqual(got, "Dev")
+    }
+
+    func test_fetch_throws_an_error_when_the_configuration_passed_points_to_a_non_existing_configuration() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(settings: Settings(configurations: [BuildConfiguration(name: "Dev", variant: .debug): .test()])),
+        ])
+
+        // When
+        XCTAssertThrowsSpecific(
+            try subject.fetch(configuration: "Debug", config: .test(), graph: graph),
+            DefaultConfigurationFetcherError.configurationNotFound("Debug", available: ["Dev"])
+        )
+    }
+
+    func test_fetch_returns_the_default_configuration_if_the_configuration_exists_in_the_project() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(
+                    settings: Settings(
+                        configurations: [
+                            BuildConfiguration(name: "Dev", variant: .debug): .test(),
+                            BuildConfiguration(name: "Release", variant: .release): .test(),
+                        ]
+                    )
+                ),
+        ])
+
+        // When
+        let got = try subject.fetch(
+            configuration: nil,
+            config: .test(
+                generationOptions: .test(
+                    defaultConfiguration: "Release"
+                )
+            ),
+            graph: graph
+        )
+
+        // Then
+        XCTAssertEqual(got, "Release")
+    }
+
+    func test_fetch_returns_the_configuration_if_the_configuration_and_default_configuration_exist_in_the_project() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(
+                    settings: Settings(
+                        configurations: [
+                            BuildConfiguration(name: "Dev", variant: .debug): .test(),
+                            BuildConfiguration(name: "Release", variant: .release): .test(),
+                        ]
+                    )
+                ),
+        ])
+
+        // When
+        let got = try subject.fetch(
+            configuration: "Dev",
+            config: .test(
+                generationOptions: .test(
+                    defaultConfiguration: "Release"
+                )
+            ),
+            graph: graph
+        )
+
+        // Then
+        XCTAssertEqual(got, "Dev")
+    }
+
+    func test_fetch_throws_an_error_when_the_default_configuration_passed_points_to_a_non_existing_configuration() throws {
+        // Given
+        let graph = Graph.test(projects: [
+            try AbsolutePath(validating: "/project-a"): Project
+                .test(settings: Settings(configurations: [BuildConfiguration(name: "Dev", variant: .debug): .test()])),
+        ])
+
+        // When
+        XCTAssertThrowsSpecific(
+            try subject.fetch(
+                configuration: nil,
+                config: .test(
+                    generationOptions: .test(
+                        defaultConfiguration: "Debug"
+                    )
+                ),
+                graph: graph
+            ),
+            DefaultConfigurationFetcherError.defaultConfigurationNotFound("Debug", available: ["Dev"])
+        )
+    }
+}


### PR DESCRIPTION
### Short description 📝

Opensourcing `DefaultConfigurationFetcher`. This will be used by `tuist share` command and the `tuist cache --print-hashes` that we'll opensource soon as well.

### How to test the changes locally 🧐

CI should pass – the class is not directly used in this repo right now.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
