### PR TITLE
add automatic mapping to 'static' framework for alamofire (#6557)

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -269,6 +269,10 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "RxSwift", // https://github.com/ReactiveX/RxSwift
                 ].map {
                     ($0, .framework)
+                } + [
+                    "Alamofire" // https://github.com/Alamofire/Alamofire
+                ].map {
+                    ($0, .staticFramework)
                 }
             ),
             uniquingKeysWith: { userDefined, _ in userDefined }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3057,7 +3057,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             "ViewInspector",
             "XCTVapor",
         ]
-        let allTargets = ["RxSwift"] + testTargets
+        let allTargets = ["RxSwift", "Alamofire"] + testTargets
         try allTargets
             .map { basePath.appending(try RelativePath(validating: "Package/Sources/\($0)")) }
             .forEach { try fileHandler.createFolder($0) }
@@ -3093,6 +3093,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 name: "Package",
                 targets: [
                     .test("RxSwift", basePath: basePath, product: .framework),
+                    .test("Alamofire", basePath: basePath, product: .staticFramework),
                 ] + testTargets.map {
                     let customSettings: ProjectDescription.SettingsDictionary
                     var customProductName: String?


### PR DESCRIPTION
Resolves #6557 
/claim #6557 

### Short description 📝
add automatic mapping of product type to 'static' framework for alamofire

### How to test the changes locally 🧐
Added a test case

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
