### PR TITLE
Update sentry to 8.32.0 in app with spm dependencies fixture to fix Xcode 16 issue

### DIFF
--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78f7dd0ebfab47739cc0e35c49d4996c86d420124374e3f4789e90b5a00daa6a",
+  "originHash" : "a18b44e37498cdc083fe1514666ea3bbc090f84d03b3b5888bf4d09314e4a1db",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "b847a202a517a90763e8fd0656d8028aeee7b78d",
-        "version" : "8.20.0"
+        "revision" : "5421f94cc859eb65f5ae3866165a053aa634431e",
+        "version" : "8.32.0"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/ZipArchive/ZipArchive", .upToNextMajor(from: "2.5.5")),
         .package(url: "https://github.com/jpsim/Yams", .upToNextMajor(from: "5.0.6")),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", .upToNextMajor(from: "7.0.0")),
-        .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "8.20.0")),
+        .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "8.32.0")),
         .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.46.0")),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", .upToNextMajor(from: "3.8.4")),
         .package(url: "https://github.com/facebook/zstd", exact: "1.5.5"),


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

Older Sentry versions don't compile with Xcode 16. This was fixed by Sentry. I struggled to identify CI issues in another PR as the tests failed on main and my PR. This was because I used Xcode 16 and it contained the old broken Sentry version.

https://github.com/tuist/tuist/pull/6538#issuecomment-2251762966
https://github.com/getsentry/sentry-cocoa/issues/4050

### How to test the changes locally 🧐

Run unit tests that use the app with spm dependencies fixture in Xcode 16.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
