### PR TITLE
Pin XcodeGraph to 0.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "72762ee5d0c1c6693d240f855baa564f33c1989e012f95666662934d0ad27a2d",
+  "originHash" : "860409f905f22a0d0832780098d0b02ddb05b588e08be4963e3a52e66bcd28c8",
   "pins" : [
     {
       "identity" : "aexml",

--- a/Package.swift
+++ b/Package.swift
@@ -466,7 +466,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
-        .package(url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.5.0")),
+        .package(url: "https://github.com/tuist/XcodeGraph.git", .exact("0.5.0")),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: targets


### PR DESCRIPTION
### Short description 📝

The resolved version of `XcodeGraph` on the CI seems to sometimes be `0.7.0` instead of `0.5.0`. We can't use `0.7.0` because the version contains a breaking change in `XcodeGraph` and the PR resolving the breaking change is still opened in tuist.

We should probably allow passing a flag to `tuist install`, so that `swift package resolve` is called with `--disable-automatic-resolution` on the CI:
```
  --force-resolved-versions, --disable-automatic-resolution, --only-use-versions-from-resolved-file
                          Only use versions from the Package.resolved file and fail resolution if it is out-of-date
```

We could even add that flag by default on the CI.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x]  Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
