### PR TITLE
Fix the Homebrew installation instructions in the docs

### DIFF
--- a/docs/docs/guides/quick-start/install-tuist.md
+++ b/docs/docs/guides/quick-start/install-tuist.md
@@ -105,8 +105,8 @@ you can install Tuist using [Homebrew](https://brew.sh) and [our formulas](https
 
 ```bash
 brew tap tuist/tuist
-brew install tuist
-brew install tuist@x.y.z
+brew install --formula tuist
+brew install --formula tuist@x.y.z
 ```
 
 ### Shell completions


### PR DESCRIPTION
### Short description 📝
The `homebrew/homebrew-cask` repository contains an outdated cask for Tuist, which might cause the installation to fail if that one takes precedence over the formula included in [our tap](https://github.com/tuist/homebrew-tuist). As suggested by @buresdv, I'm adjusting the installation steps to make the installation default to the formula distributed by the tap. 

### How to test the changes locally 🧐
If you run `brew install --formula tuist` it should succeed and install the latest version.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
