### PR TITLE
Generate module bundle for SPM dynamic frameworks

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -43,7 +43,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         let bundleName = "\(project.name)_\(sanitizedTargetName)"
         var modifiedTarget = target
 
-        if !target.supportsResources {
+        if !target.supportsResources || project.isExternal {
             let resourcesTarget = Target(
                 name: bundleName,
                 destinations: target.destinations,
@@ -172,7 +172,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         // swiftformat:disable all
         import Foundation
         """
-        if !target.supportsResources {
+        if !target.supportsResources || project.isExternal {
             content += swiftSPMBundleAccessorString(for: target, and: bundleName)
         } else {
             content += swiftFrameworkBundleAccessorString(for: target)


### PR DESCRIPTION
### Short description 📝

Possible solution for: https://github.com/tuist/tuist/issues/6539

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
