### PR TITLE
Generate SPM Objective-C resource accessor only when a bundle is generated

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -84,7 +84,8 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         if project.isExternal,
            target.supportsSources,
            target.sources.containsObjcFiles,
-           target.resources.containsBundleAccessedResources
+           target.resources.containsBundleAccessedResources,
+           !target.supportsResources
         {
             let (headerFilePath, headerData) = synthesizedObjcHeaderFile(bundleName: bundleName, target: target, project: project)
 

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -86,6 +86,20 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         ])
     }
 
+    func test_map_when_an_external_objc_target_that_has_resources_and_supports_them() throws {
+        // Given
+        let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let target = Target.test(product: .framework, sources: ["/Absolute/File.m"], resources: .init(resources))
+        project = Project.test(targets: [target], isExternal: true)
+
+        // Got
+        let (gotProject, gotSideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertEqual(project, gotProject)
+    }
+
     func testMap_whenDisableBundleAccessorsIsTrue_doesNotGenerateAccessors() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6539

### Short description 📝

The `2.7.2` version of `PocketSVG` assumes that a bundle will be included when the compiler directive `SWIFT_PACKAGE` is set: https://github.com/pocketsvg/PocketSVG/blob/10c6885e427e88d35fbb64010fbd6385cb58fef7/Sources/SVGEngine.mm#L899-L903

That assumption is not right as SPM doesn't generate the objc resource accessor regardless of the final product type: https://github.com/swiftlang/swift-package-manager/blob/a681cd0282ae83a186423022e8a991c113b0918b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift#L181

The latest version (`2.7.3`) correctly checks for whether `SWIFTPM_MODULE_BUNDLE` is defined: https://github.com/pocketsvg/PocketSVG/blob/d992b55c140df70c2d9e1ff0704e201c880011a3/Sources/SVGEngine.mm#L899

Even with that version, the app crashes in runtime on the current tuist version as we generate the objc resource accessor regardless of whether we generate the bundle when the product does not support resources.

This PR remedies that and the objc `SWIFTPM_MODULE_BUNDLE` resource accessor is generated only when needed to align the behavior with SPM.

### How to test the changes locally 🧐

Get the [repro sample](https://github.com/user-attachments/files/16338521/repro.zip)

Run `tuist install && tuist generate` and run the app. The app should not crash in runtime.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
