### PR TITLE
Fix generate performance when using Tuist Cache xcframeworks

### DIFF
--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -72,6 +72,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         if let cachedResult = cache.results(for: dependency) {
             return cachedResult
         }
+        cache.cache(results: StaticProducts(), for: dependency)
 
         // Collect dependency results traversing the graph (dfs)
         var results = dependencies(for: dependency, graphTraverser: graphTraverser).reduce(StaticProducts()) { results, dep in

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -72,7 +72,6 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         if let cachedResult = cache.results(for: dependency) {
             return cachedResult
         }
-        cache.cache(results: StaticProducts(), for: dependency)
 
         // Collect dependency results traversing the graph (dfs)
         var results = dependencies(for: dependency, graphTraverser: graphTraverser).reduce(StaticProducts()) { results, dep in
@@ -92,6 +91,10 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
               let dependencyTarget = graphTraverser.target(path: targetPath, name: targetName),
               dependencyTarget.target.canLinkStaticProducts()
         else {
+            cache.cache(
+                results: results,
+                for: dependency
+            )
             return results
         }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6587

### Short description 📝

This was a fun one. So, as reported in the attached issue, the performance of `tuist generate` is abysmal for _some_ graphs when xcframeworks replaced some of the nodes.

Thanks to @ffittschen exploration, the perf bottleneck turned out to be `StaticProductsGraphLinter`.

As described [here](https://github.com/tuist/tuist/issues/6587#issuecomment-2263871206), the linter runs a DFS on the graph to check for possibly duplicated symbols. When run with the repro case, I found out that we visit a lot of nodes multiple times – which should never happen in a DFS.

I first thought the issue was we should mark a node as `visited` immediately as we step into it. However, that should generally not be necessary in a DAG. The issue instead was that:
- When replacing nodes with xcframeworks, we keep the dependency links between xcframeworks (which is not possible to define with `ProjectDescription` only)
- The `StaticProductsGraphLinter` assumes that it doesn't need to cache the products for a non-target node: https://github.com/tuist/tuist/blob/main/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift#L94

Keeping the links between xcframeworks has actually turned out to be useful in this PR: https://github.com/tuist/tuist/pull/6520

So, I decided to instead cache the products for non-target types as well, thus ensuring that an xcframework won't be visited multiple times. I tested this change with the repro case and could confirm that the performance regression is no longer present.

### How to test the changes locally 🧐

Run the repro based on the repro steps from the attached issue. Note this can be done only from the closed source repo.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
