### PR TITLE
Fix unstable hashing of target dependencies

### DIFF
--- a/Sources/TuistHasher/DependenciesContentHasher.swift
+++ b/Sources/TuistHasher/DependenciesContentHasher.swift
@@ -62,7 +62,7 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
     ) throws -> String {
         let hashes = try graphTarget.target.dependencies
             .map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths) }
-        return hashes.compactMap { $0 }.joined()
+        return hashes.sorted().compactMap { $0 }.joined()
     }
 
     // MARK: - Private

--- a/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
@@ -286,4 +286,29 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .hash(Parameter<String>.any)
             .called(1)
     }
+
+    func test_hash_sorts_dependency_hashes() throws {
+        // Given
+        let dependencyFoo = TargetDependency.target(name: "foo")
+        let dependencyBar = TargetDependency.target(name: "bar")
+
+        // When
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependencyFoo, dependencyBar]))
+        hashedTargets[
+            GraphHashedTarget(
+                projectPath: graphTarget.path,
+                targetName: "foo"
+            )
+        ] = "target-foo-hash"
+        hashedTargets[
+            GraphHashedTarget(
+                projectPath: graphTarget.path,
+                targetName: "bar"
+            )
+        ] = "target-bar-hash"
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+
+        // Then
+        XCTAssertEqual(hash, "target-bar-hashtarget-foo-hash")
+    }
 }


### PR DESCRIPTION
### Short description 📝

I'd expect the `Target`'s dependencies array to be stable as it should follow the order defined in the Project manifests: https://github.com/tuist/tuist/blob/main/Sources/TuistLoader/Models%2BManifestMappers/Target%2BManifestMapper.swift#L42-L47

However, it seems that somewhere during the subsequent mapping, the order can be changed. If the order of the dependencies is different in `DependenciesContentHasher`, so will the hash. I'm making the `DependenciesContentHasher` more stable by making sure the dependencies hashes are always sorted. That way, we don't need to rely on the assumption that the `Target.dependencies` array is ordered always the same (as the order doesn't matter for whether a target should be a hit or miss)

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
