### PR TITLE
Prevent Tuist authentication kickouts by retrying token refresh

### DIFF
--- a/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -74,10 +74,13 @@ struct ServerClientAuthenticationMiddleware: ClientMiddleware {
 
                 if isExpired {
                     do {
-                        let newTokens = try await refreshAuthTokenService.refreshTokens(
-                            serverURL: baseURL,
-                            refreshToken: refreshToken.token
-                        )
+                        let newTokens = try await RetryProvider()
+                            .runWithRetries {
+                                return try await refreshAuthTokenService.refreshTokens(
+                                    serverURL: baseURL,
+                                    refreshToken: refreshToken.token
+                                )
+                            }
                         try serverCredentialsStore
                             .store(
                                 credentials: ServerCredentials(


### PR DESCRIPTION
### Short description 📝

This was reported by @natanrolnik. Even when a user was logged in, we sometimes kick the user out of the session and they need to run `tuist auth` again.

I wasn't able to reproduce the issue. This PR is an attempt to prevent unnecessary kickouts by retrying the refresh token request. If this doesn't fix it, we'll need to dig deeper.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
