### PR TITLE
Fix installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's open source and written in Swift.
 
 The recommended installation method is to [install mise](https://mise.jdx.dev/getting-started.html#quickstart) and then run `mise install tuist` to install Tuist.
 
-You can check out [the documentation](https://docs.tuist.io/documentation/tuist/installation) to learn more about the rationale behind our installation approach and alternative approaches.
+You can check out [the documentation](https://docs.tuist.io/guides/quick-start/install-tuist) to learn more about the rationale behind our installation approach and alternative approaches.
 
 ## 🌀 Bootstrap your first project
 


### PR DESCRIPTION
### Short description 📝

Fixes link to installation documentation. Current link points to https://docs.tuist.io/documentation/tuist/installation which, at least for me, gives 404: 
![Screenshot 2024-08-02 at 14 37 16](https://github.com/user-attachments/assets/b3a04a13-9efe-4581-9db0-1cf58279ec1d)

### How to test the changes locally 🧐

-

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
