### PR TITLE
Fix missing external resource bundle in app extension

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1145,6 +1145,7 @@ public class GraphTraverser: GraphTraversing {
             .appClip,
             .unitTests,
             .uiTests,
+            .appExtension,
             .watch2Extension,
             .systemExtension,
             .xpc,

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -383,6 +383,52 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(dynamicFrameworkBundleDependencies, [])
     }
 
+    func test_resourceBundleDependencies_when_app_extension_depends_on_external_static_framework_with_resources() {
+        // Given
+        // AppExtension -> StaticLibrary (External) -> Bundle
+        let appExtension = Target.test(name: "AppExtension", product: .appExtension)
+        let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
+        let bundle = Target.test(name: "Bundle", product: .bundle)
+        let project = Project.test(targets: [appExtension])
+        let externalProject = Project.test(
+            path: try! AbsolutePath(validating: "/ExternalProject"),
+            targets: [staticLibrary, bundle],
+            isExternal: true
+        )
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: appExtension.name, path: project.path): Set([.target(
+                name: staticLibrary.name,
+                path: externalProject.path
+            )]),
+            .target(name: staticLibrary.name, path: externalProject.path): Set([.target(
+                name: bundle.name,
+                path: externalProject.path
+            )]),
+            .target(name: bundle.name, path: externalProject.path): Set([]),
+        ]
+
+        // Given: Value Graph
+        let graph = Graph.test(
+            path: project.path,
+            projects: [
+                project.path: project,
+                externalProject.path: externalProject,
+            ],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let appExtensionBundleDependencies = subject.resourceBundleDependencies(path: project.path, name: appExtension.name)
+            .sorted()
+
+        // Then
+        XCTAssertEqual(appExtensionBundleDependencies, [
+            .product(target: bundle.name, productName: bundle.productNameWithExtension),
+        ])
+    }
+
     func test_resourceBundleDependencies_when_the_target_doesnt_support_resources() {
         // Given
         // StaticLibrary -> Bundle


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6586

### Short description 📝

As reported in the issue, we introduced in: https://github.com/tuist/tuist/pull/6565

What changed in that PR is that we no longer copy external resource bundles of static frameworks into any target that can host resources, but only to targets that can embed products (such as App).

The repro sample from the issue has the following graph:
![graph](https://github.com/user-attachments/assets/28b86c65-a1dd-4609-898b-581892e73771)

Where `LiveActivity` is an app extension and `Localization` is a resource bundle. Before the PR was merged, both `LiveActivity` and `LiveActivityApp` would copy the resource bundle. Now, since `.appExtension` is not marked as it can embed products, only the `LiveActivityApp` would copy it. But `.appExtension` _can_ embed products – so the fix is to add it to the list of target types in `canEmbedProducts`.

Before:
![image](https://github.com/user-attachments/assets/1dd8cc6f-7c1e-4b39-a347-852fed9e5e57)

After:
![image](https://github.com/user-attachments/assets/881c5291-ceb1-4ec1-9ea8-616d5b883b3b)



### How to test the changes locally 🧐

Follow the repro steps from the attached issue. The localized app activity should show the string properly when the localization bundle is properly copied.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
