### PR TITLE
Add "--replace-scm-with-registry" flag to "tuist install" command

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -38,6 +38,7 @@ public enum EnvKey: String, CaseIterable {
     // INSTALL
     case installPath = "TUIST_INSTALL_PATH"
     case installUpdate = "TUIST_INSTALL_UPDATE"
+    case installReplaceScmWithRegistry = "TUIST_INSTALL_REPLACE_SCM_WITH_REGISTRY"
 
     // GENERATE
     case generatePath = "TUIST_GENERATE_PATH"

--- a/Sources/TuistKit/Commands/InstallCommand.swift
+++ b/Sources/TuistKit/Commands/InstallCommand.swift
@@ -29,7 +29,7 @@ public struct InstallCommand: AsyncParsableCommand {
 
     @Flag(
         name: .shortAndLong,
-        help: "Look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.",
+        help: "Look up dependencies in the Swift Package Registry and use the registry to retrieve them instead of source control when possible.",
         envKey: .installReplaceScmWithRegistry
     )
     var replaceScmWithRegistry: Bool = false

--- a/Sources/TuistKit/Commands/InstallCommand.swift
+++ b/Sources/TuistKit/Commands/InstallCommand.swift
@@ -27,10 +27,18 @@ public struct InstallCommand: AsyncParsableCommand {
     )
     var update: Bool = false
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.",
+        envKey: .installReplaceScmWithRegistry
+    )
+    var replaceScmWithRegistry: Bool = false
+
     public func run() async throws {
         try await InstallService().run(
             path: path,
-            update: update
+            update: update,
+            replaceScmWithRegistry: replaceScmWithRegistry
         )
     }
 }

--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -33,12 +33,13 @@ final class InstallService {
 
     func run(
         path: String?,
-        update: Bool
+        update: Bool,
+        replaceScmWithRegistry: Bool
     ) async throws {
         let path = try self.path(path)
 
         try await fetchPlugins(path: path)
-        try fetchDependencies(path: path, update: update)
+        try fetchDependencies(path: path, update: update, replaceScmWithRegistry: replaceScmWithRegistry)
     }
 
     // MARK: - Helpers
@@ -60,7 +61,7 @@ final class InstallService {
         logger.notice("Plugins resolved and fetched successfully.", metadata: .success)
     }
 
-    private func fetchDependencies(path: AbsolutePath, update: Bool) throws {
+    private func fetchDependencies(path: AbsolutePath, update: Bool, replaceScmWithRegistry: Bool) throws {
         guard let packageManifestPath = manifestFilesLocator.locatePackageManifest(at: path)
         else {
             return
@@ -69,11 +70,11 @@ final class InstallService {
         if update {
             logger.notice("Updating dependencies.", metadata: .section)
 
-            try swiftPackageManagerController.update(at: packageManifestPath.parentDirectory, printOutput: true)
+            try swiftPackageManagerController.update(at: packageManifestPath.parentDirectory, replaceScmWithRegistry: replaceScmWithRegistry, printOutput: true)
         } else {
             logger.notice("Resolving and fetching dependencies.", metadata: .section)
 
-            try swiftPackageManagerController.resolve(at: packageManifestPath.parentDirectory, printOutput: true)
+            try swiftPackageManagerController.resolve(at: packageManifestPath.parentDirectory, replaceScmWithRegistry: replaceScmWithRegistry, printOutput: true)
         }
     }
 }

--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -70,11 +70,19 @@ final class InstallService {
         if update {
             logger.notice("Updating dependencies.", metadata: .section)
 
-            try swiftPackageManagerController.update(at: packageManifestPath.parentDirectory, replaceScmWithRegistry: replaceScmWithRegistry, printOutput: true)
+            try swiftPackageManagerController.update(
+                at: packageManifestPath.parentDirectory,
+                replaceScmWithRegistry: replaceScmWithRegistry,
+                printOutput: true
+            )
         } else {
             logger.notice("Resolving and fetching dependencies.", metadata: .section)
 
-            try swiftPackageManagerController.resolve(at: packageManifestPath.parentDirectory, replaceScmWithRegistry: replaceScmWithRegistry, printOutput: true)
+            try swiftPackageManagerController.resolve(
+                at: packageManifestPath.parentDirectory,
+                replaceScmWithRegistry: replaceScmWithRegistry,
+                printOutput: true
+            )
         }
     }
 }

--- a/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -7,14 +7,16 @@ public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
-    func resolve(at path: AbsolutePath, printOutput: Bool) throws
+    func resolve(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws
 
     /// Updates package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
-    func update(at path: AbsolutePath, printOutput: Bool) throws
+    func update(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws
 
     /// Gets the tools version of the package at the given path
     /// - Parameter path: Directory where the `Package.swift` is defined.
@@ -53,16 +55,26 @@ public final class SwiftPackageManagerController: SwiftPackageManagerControlling
         self.fileHandler = fileHandler
     }
 
-    public func resolve(at path: AbsolutePath, printOutput: Bool) throws {
-        let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["resolve"])
+    public func resolve(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws {
+        var arguments: [String] = []
+        if replaceScmWithRegistry {
+            arguments.append("--replace-scm-with-registry")
+        }
+        arguments.append("resolve")
+        let command = buildSwiftPackageCommand(packagePath: path, extraArguments: arguments)
 
         printOutput ?
             try system.runAndPrint(command) :
             try system.run(command)
     }
 
-    public func update(at path: AbsolutePath, printOutput: Bool) throws {
-        let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["update"])
+    public func update(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws {
+        var arguments: [String] = []
+        if replaceScmWithRegistry {
+            arguments.append("--replace-scm-with-registry")
+        }
+        arguments.append("update")
+        let command = buildSwiftPackageCommand(packagePath: path, extraArguments: arguments)
 
         printOutput ?
             try system.runAndPrint(command) :

--- a/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -7,7 +7,7 @@ public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the Swift Package Registry and use the registry to
     /// retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
     func resolve(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws
@@ -15,7 +15,7 @@ public protocol SwiftPackageManagerControlling {
     /// Updates package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the Swift Package Registry and use the registry to
     /// retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
     func update(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws

--- a/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -7,14 +7,16 @@ public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to
+    /// retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
     func resolve(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws
 
     /// Updates package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.
+    ///   - replaceScmWithRegistry: When true it will look up dependencies in the swift package registry and use the registry to
+    /// retrieve them instead of source control when possible.
     ///   - printOutput: When true it prints the Swift Package Manager's output.
     func update(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws
 

--- a/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
@@ -6,17 +6,17 @@ public final class MockSwiftPackageManagerController: SwiftPackageManagerControl
     public init() {}
 
     public var invokedResolve = false
-    public var resolveStub: ((AbsolutePath, Bool) throws -> Void)?
-    public func resolve(at path: AbsolutePath, printOutput: Bool) throws {
+    public var resolveStub: ((AbsolutePath, Bool, Bool) throws -> Void)?
+    public func resolve(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws {
         invokedResolve = true
-        try resolveStub?(path, printOutput)
+        try resolveStub?(path, replaceScmWithRegistry, printOutput)
     }
 
     public var invokedUpdate = false
-    public var updateStub: ((AbsolutePath, Bool) throws -> Void)?
-    public func update(at path: AbsolutePath, printOutput: Bool) throws {
+    public var updateStub: ((AbsolutePath, Bool, Bool) throws -> Void)?
+    public func update(at path: AbsolutePath, replaceScmWithRegistry: Bool, printOutput: Bool) throws {
         invokedUpdate = true
-        try updateStub?(path, printOutput)
+        try updateStub?(path, replaceScmWithRegistry, printOutput)
     }
 
     public var invokedSetToolsVersion = false

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -240,17 +240,21 @@ final class CommandEnvironmentVariableTests: XCTestCase {
     func testInstallCommandUsesEnvVars() throws {
         setVariable(.installPath, value: "/path/to/install")
         setVariable(.installUpdate, value: "true")
+        setVariable(.installReplaceScmWithRegistry, value: "true")
 
         let installCommandWithEnvVars = try InstallCommand.parse([])
         XCTAssertEqual(installCommandWithEnvVars.path, "/path/to/install")
         XCTAssertTrue(installCommandWithEnvVars.update)
+        XCTAssertTrue(installCommandWithEnvVars.replaceScmWithRegistry)
 
         let installCommandWithArgs = try InstallCommand.parse([
             "--path", "/new/install/path",
             "--no-update",
+            "--no-replace-scm-with-registry"
         ])
         XCTAssertEqual(installCommandWithArgs.path, "/new/install/path")
         XCTAssertFalse(installCommandWithArgs.update)
+        XCTAssertFalse(installCommandWithArgs.replaceScmWithRegistry)
     }
 
     func testListCommandUsesEnvVars() throws {

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -250,7 +250,7 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         let installCommandWithArgs = try InstallCommand.parse([
             "--path", "/new/install/path",
             "--no-update",
-            "--no-replace-scm-with-registry"
+            "--no-replace-scm-with-registry",
         ])
         XCTAssertEqual(installCommandWithArgs.path, "/new/install/path")
         XCTAssertFalse(installCommandWithArgs.update)

--- a/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -76,7 +76,7 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: stubbedPath.pathString,
-            update: true, 
+            update: true,
             replaceScmWithRegistry: false
         )
 
@@ -107,7 +107,7 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: nil,
-            update: false, 
+            update: false,
             replaceScmWithRegistry: false
         )
 
@@ -141,7 +141,7 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: stubbedPath.pathString,
-            update: false, 
+            update: false,
             replaceScmWithRegistry: false
         )
 
@@ -169,7 +169,7 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When - This will cause the `loadDependenciesStub` closure to be called and assert if needed
         try await subject.run(
             path: temporaryDirectory.pathString,
-            update: false, 
+            update: false,
             replaceScmWithRegistry: false
         )
     }

--- a/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -76,7 +76,8 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: stubbedPath.pathString,
-            update: true
+            update: true, 
+            replaceScmWithRegistry: false
         )
 
         // Then
@@ -106,7 +107,8 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: nil,
-            update: false
+            update: false, 
+            replaceScmWithRegistry: false
         )
 
         // Then
@@ -139,7 +141,8 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(
             path: stubbedPath.pathString,
-            update: false
+            update: false, 
+            replaceScmWithRegistry: false
         )
 
         // Then
@@ -166,7 +169,8 @@ final class InstallServiceTests: TuistUnitTestCase {
         // When - This will cause the `loadDependenciesStub` closure to be called and assert if needed
         try await subject.run(
             path: temporaryDirectory.pathString,
-            update: false
+            update: false, 
+            replaceScmWithRegistry: false
         )
     }
 }

--- a/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -33,7 +33,23 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.resolve(at: path, printOutput: false))
+        XCTAssertNoThrow(try subject.resolve(at: path, replaceScmWithRegistry: false, printOutput: false))
+    }
+
+    func test_resolve_replace_scm_with_registry() throws {
+        // Given
+        let path = try temporaryPath()
+        system.succeedCommand([
+            "swift",
+            "package",
+            "--package-path",
+            path.pathString,
+            "--replace-scm-with-registry",
+            "resolve",
+        ])
+
+        // When / Then
+        XCTAssertNoThrow(try subject.resolve(at: path, replaceScmWithRegistry: true, printOutput: false))
     }
 
     func test_update() throws {
@@ -48,7 +64,23 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path, printOutput: false))
+        XCTAssertNoThrow(try subject.update(at: path, replaceScmWithRegistry: false, printOutput: false))
+    }
+
+    func test_update_replace_scm_with_registry() throws {
+        // Given
+        let path = try temporaryPath()
+        system.succeedCommand([
+            "swift",
+            "package",
+            "--package-path",
+            path.pathString,
+            "--replace-scm-with-registry",
+            "update",
+        ])
+
+        // When / Then
+        XCTAssertNoThrow(try subject.update(at: path, replaceScmWithRegistry: true, printOutput: false))
     }
 
     func test_setToolsVersion_specificVersion() throws {


### PR DESCRIPTION
### Short description 📝

This PR adds `--replace-scm-with-registry` flag to `tuist install` command.

> --replace-scm-with-registry (env. TUIST_INSTALL_REPLACE_SCM_WITH_REGISTRY)
> Look up dependencies in the swift package registry and use the registry to retrieve them instead of source control when possible.

The flag, when set to `true`, will pass `--replace-scm-with-registry` to `swift` executable when calling `resolve` and `update` subcommands.

This change makes it possible to use Tuist with Swift Package Manager's [Package-Registry](https://github.com/swiftlang/swift-package-manager/blob/fbf87bf26efcad1c71c1111cb700d2874a1bf339/Documentation/PackageRegistry/PackageRegistryUsage.md) feature.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
