### PR TITLE
Favor TUIST_CONFIG_TOKEN over TUIST_CONFIG_CLOUD_TOKEN

### DIFF
--- a/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
+++ b/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
@@ -76,14 +76,16 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
 
     public func authenticationToken(serverURL: URL) throws -> AuthenticationToken? {
         if ciChecker.isCI() {
-            if let deprecatedToken = environment.tuistVariables[Constants.EnvironmentVariables.deprecatedToken] {
+            if let configToken = environment.tuistVariables[Constants.EnvironmentVariables.token] {
+                return .project(configToken)
+            } else if let deprecatedToken = environment.tuistVariables[Constants.EnvironmentVariables.deprecatedToken] {
                 logger
                     .warning(
                         "Use `TUIST_CONFIG_TOKEN` environment variable instead of `TUIST_CONFIG_CLOUD_TOKEN` to authenticate on the CI"
                     )
                 return .project(deprecatedToken)
             } else {
-                return environment.tuistVariables[Constants.EnvironmentVariables.token].map { .project($0) }
+                return nil
             }
         } else {
             let credentials = try credentialsStore.read(serverURL: serverURL)

--- a/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -85,6 +85,34 @@ final class ServerAuthenticationControllerTests: TuistUnitTestCase {
             got,
             .project("project-token")
         )
+        XCTAssertStandardOutput(
+            pattern: "Use `TUIST_CONFIG_TOKEN` environment variable instead of `TUIST_CONFIG_CLOUD_TOKEN` to authenticate on the CI"
+        )
+    }
+
+    func test_when_deprecated_and_current_config_tokens_are_present_and_is_ci() throws {
+        // Given
+        environment.tuistVariables[
+            Constants.EnvironmentVariables.deprecatedToken
+        ] = "deprecated-project-token"
+        environment.tuistVariables[
+            Constants.EnvironmentVariables.token
+        ] = "project-token"
+        given(ciChecker)
+            .isCI()
+            .willReturn(true)
+
+        // When
+        let got = try subject.authenticationToken(serverURL: .test())
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .project("project-token")
+        )
+        XCTAssertPrinterOutputNotContains(
+            "Use `TUIST_CONFIG_TOKEN` environment variable instead of `TUIST_CONFIG_CLOUD_TOKEN` to authenticate on the CI"
+        )
     }
 
     func test_when_credentials_store_returns_legacy_token() throws {


### PR DESCRIPTION
### Short description 📝

When moving to the new `TUIST_CONFIG_TOKEN`, developers often initially leave `TUIST_CONFIG_CLOUD_TOKEN`, so they don't accidentally break their pipelines. But when both `TUIST_CONFIG_TOKEN` and `TUIST_CONFIG_CLOUD_TOKEN` are defined, Tuist would `TUIST_CONFIG_CLOUD_TOKEN` and output the warning that a deprecated token is used, even though `TUIST_CONFIG_TOKEN` is present in the env variables.

### How to test the changes locally 🧐

`TUIST_CONFIG_CLOUD_TOKEN="xxx" TUIST_CONFIG_TOKEN="yyy" CI="true" tuist generate` -> no token-related warning should be printed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
