### PR TITLE
Fix app not found when running tuist share with different target and product names

### DIFF
--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -179,7 +179,7 @@ struct ShareService {
                 for: platforms,
                 workspacePath: graph.workspace.xcWorkspacePath,
                 configuration: configuration,
-                app: appTarget.target.name,
+                app: appTarget.target.productName,
                 derivedDataPath: derivedDataPath,
                 fullHandle: fullHandle,
                 serverURL: serverURL

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -109,8 +109,9 @@ final class ShareServiceTests: TuistUnitTestCase {
 
         let projectPath = try temporaryPath()
         let appTarget: Target = .test(
-            name: "App",
-            destinations: [.appleVision, .iPhone]
+            name: "AppTarget",
+            destinations: [.appleVision, .iPhone],
+            productName: "App"
         )
         let appTargetTwo: Target = .test(name: "AppTwo")
         let project: Project = .test(


### PR DESCRIPTION
### Short description 📝

If the product and target names differ, `tuist share` fails because it looks up the `xxx.app` based on the `target.name`. However, the basename of `xxx.app` is equal to `target.productName`.

### How to test the changes locally 🧐

Run `tuist share SomeAppTarget` where the app target name and product names differ.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
