### PR TITLE
Fix missing linked system libraries in Tuist Cache

### DIFF
--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1937,6 +1937,63 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_linkableAndEmbeddableDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticXCFrameworkDependencyWithALinkedSystemLibrary(
+    ) throws {
+        // App ---(depends on)---> Dynamic XCFramework ----> Static XCFramework (A) ----> libc++.tbd
+
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+
+        // Given: Value Graph
+        let dependencyDynamicXCFramework = GraphDependency.testXCFramework(
+            path: "/test/DynamicFramework.xcframework",
+            linking: .dynamic
+        )
+        let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
+            path: "/test/StaticFrameworkA.xcframework",
+            linking: .static
+        )
+        let dependencyLibCpp = GraphDependency.testSDK(
+            name: "libc++.tbd",
+            path: try AbsolutePath(validating: "/libc++.tbd")
+        )
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: target.name, path: project.path): Set(arrayLiteral: dependencyDynamicXCFramework),
+            dependencyDynamicXCFramework: Set(arrayLiteral: dependencyStaticXCFrameworkA),
+            dependencyStaticXCFrameworkA: Set(arrayLiteral: dependencyLibCpp),
+        ]
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.linkableDependencies(path: project.path, name: target.name).sorted()
+
+        // Then
+        XCTAssertBetterEqual(got, [
+            .sdk(
+                path: try AbsolutePath(validating: "/libc++.tbd"),
+                status: .required,
+                source: .system,
+                condition: nil
+            ),
+            GraphDependencyReference(dependencyDynamicXCFramework),
+            GraphDependencyReference(dependencyStaticXCFrameworkA),
+        ])
+
+        // When
+        let embeddable = subject.embeddableFrameworks(path: project.path, name: target.name)
+
+        // Then
+        XCTAssertBetterEqual(embeddable, [
+            GraphDependencyReference(dependencyDynamicXCFramework),
+        ])
+    }
+
     func test_linkableAndEmbeddableDependencies_when_appDependensOnPrecompiledStaticBinaryWithPrecompiledDynamicBinaryDependency(
     ) throws {
         // App ---(depends on)---> Precompiled static binary (A) ----> Precompiled dynamic binary (B)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6609

### Short description 📝

The issue follows a similar scenario to: https://github.com/tuist/tuist/pull/6520

The initial scenario we fixed was the following:
`App -> Dynamic XCFramework -> Static XCFramework`

However, if you try to build the `App` from the repro, you will see errors such as:
```
Undefined symbols for architecture arm64:
  "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::at(unsigned long) const", referenced from:
      GMSx_proto2::io::Tokenizer::GMSx_IsIdentifier(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in GoogleMapsCore.a
```

The missing symbols are the standard lib of C++.

The graph is as follows:
`App -> Dynamic XCFramework -> Static XCFramework -> libc++.tbd`

What we need to do when linking a static xcframework through a dynamic xcframework is also link the system libraries.

### How to test the changes locally 🧐

This needs to be tested through the closed source repo. We added an acceptance test that checks this scenario.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
