### PR TITLE
Skip user token deprecation warning when new user tokens are available

### DIFF
--- a/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
+++ b/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
@@ -90,15 +90,20 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
         } else {
             let credentials = try credentialsStore.read(serverURL: serverURL)
             return try credentials.map {
-                if $0.token != nil {
+                if let refreshToken = $0.refreshToken {
+                    return .user(
+                        legacyToken: nil,
+                        accessToken: try $0.accessToken.map(parseJWT),
+                        refreshToken: try parseJWT(refreshToken)
+                    )
+                } else {
                     logger.warning("You are using a deprecated user token. Please, reauthenticate by running `tuist auth`.")
+                    return .user(
+                        legacyToken: $0.token,
+                        accessToken: nil,
+                        refreshToken: nil
+                    )
                 }
-
-                return .user(
-                    legacyToken: $0.token,
-                    accessToken: try $0.accessToken.map(parseJWT),
-                    refreshToken: try $0.refreshToken.map(parseJWT)
-                )
             }
         }
     }


### PR DESCRIPTION
### Short description 📝

Follow up to: https://github.com/tuist/tuist/pull/6610

We should favor the new user tokens over the legacy ones the same way we fixed it for project tokens.

### How to test the changes locally 🧐

- Run `tuist auth` with an old Tuist version (< 4.21.0)
- Run `tuist auth` on a new Tuist version
- Run `tuist project show your-project` -> you shouldn't see a warning anymore

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
