### PR TITLE
chore: Add a page to document best practices working with Xcode and Tuist projects

### DIFF
--- a/docs/.vitepress/sidebars.mjs
+++ b/docs/.vitepress/sidebars.mjs
@@ -261,6 +261,10 @@ export const guidesSidebar = [
             text: "Modular architecture",
             link: "guides/develop/projects/tma-architecture",
           },
+          {
+            text: "Best practices",
+            link: "guides/develop/projects/best-practices",
+          },
         ],
       },
       {

--- a/docs/docs/guides/develop/projects/best-practices.md
+++ b/docs/docs/guides/develop/projects/best-practices.md
@@ -1,0 +1,32 @@
+---
+title: Best practices
+titleTemplate: ":title | Projects | Tuist"
+description: Learn about the Modular Architecture (TMA) and how to structure your projects using it.
+---
+
+# Best practices
+
+Over the years working with different teams and projects, we've identified a set of best practices that we recommend following when working with Tuist and Xcode projects. These practices are not mandatory, but they can help you structure your projects in a way that makes them easier to maintain and scale.
+
+## Xcode
+
+### Discouraged patterns
+
+#### Configurations to model remote environments
+
+Many organizations use build configurations to model different remote environments (e.g., `Debug-Production` or `Release-Canary`), but this approach has some downsides:
+
+- **Inconsistencies:** If there are configuration inconsistencies throughout the graph, the build system might end up using the wrong configuration for some targets.
+- **Complexity:** Projects can end up with a long list of local configurations and remote environments that are hard to reason about and maintain.
+
+Build configurations were designed to embody different build settings, and projects rarely need more than just `Debug` and `Release`. The need to model different environments can be achieved by using schemes:
+
+- Set a scheme environment variable: `REMOTE_ENV=production`.
+- Add a new key to the `Info.plist` of the bundle that will use the environment information (e.g., app bundle): `REMOTE_ENV=${REMOTE_ENV}`.
+- You can then read the value at runtime:
+
+    ```swift
+    let remoteEnvString = Bundle.main.object(forInfoDictionaryKey: "REMOTE_ENV") as? String
+    ```
+
+Thanks to the above, you can keep the list of configurations simple, preventing the aforementioned downsides, and give developers the flexibility to customize things like the remote environment via schemes.

--- a/docs/docs/guides/develop/projects/best-practices.md
+++ b/docs/docs/guides/develop/projects/best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Best practices
 titleTemplate: ":title | Projects | Tuist"
-description: Learn about the Modular Architecture (TMA) and how to structure your projects using it.
+description: Learn about the best practices for working with Tuist and Xcode projects.
 ---
 
 # Best practices

--- a/docs/docs/guides/develop/projects/code-sharing.md
+++ b/docs/docs/guides/develop/projects/code-sharing.md
@@ -1,5 +1,6 @@
 ---
 title: Code sharing
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how to share code across manifest files to reduce duplications and ensure consistency
 ---
 

--- a/docs/docs/guides/develop/projects/cost-of-convenience.md
+++ b/docs/docs/guides/develop/projects/cost-of-convenience.md
@@ -1,5 +1,6 @@
 ---
 title: The cost of convenience
+titleTemplate: ":title | Projects | Tuist"
 description: Learn about the cost of convenience in Xcode and how Tuist helps you prevent the issues that come with it.
 ---
 

--- a/docs/docs/guides/develop/projects/dependencies.md
+++ b/docs/docs/guides/develop/projects/dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: Dependencies
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how to declare dependencies in your Tuist project.
 ---
 

--- a/docs/docs/guides/develop/projects/directory-structure.md
+++ b/docs/docs/guides/develop/projects/directory-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Directory structure
+titleTemplate: ":title | Projects | Tuist"
 description: Learn about the structure of Tuist projects and how to organize them.
 ---
 

--- a/docs/docs/guides/develop/projects/dynamic-configuration.md
+++ b/docs/docs/guides/develop/projects/dynamic-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Dynamic configuration
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how how to use environment variables to dynamically configure your project.
 ---
 

--- a/docs/docs/guides/develop/projects/editing.md
+++ b/docs/docs/guides/develop/projects/editing.md
@@ -1,5 +1,6 @@
 ---
 title: Editing
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how to use Tuist's edit workflow to declare your project leveraging Xcode's build system and editor capabilities.
 ---
 

--- a/docs/docs/guides/develop/projects/hashing.md
+++ b/docs/docs/guides/develop/projects/hashing.md
@@ -1,5 +1,6 @@
 ---
 title: Hashing
+titleTemplate: ":title | Projects | Tuist"
 description: Learn about Tuist's hashing logic upon which features like binary caching and selective testing are built.
 ---
 

--- a/docs/docs/guides/develop/projects/manifests.md
+++ b/docs/docs/guides/develop/projects/manifests.md
@@ -1,5 +1,6 @@
 ---
 title: Manifests
+titleTemplate: ":title | Projects | Tuist"
 description: Learn about the manifest files that Tuist uses to define projects and workspaces and configure the generation process.
 ---
 

--- a/docs/docs/guides/develop/projects/plugins.md
+++ b/docs/docs/guides/develop/projects/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how to create and use plugins in Tuist to extend its functionality.
 ---
 

--- a/docs/docs/guides/develop/projects/synthesized-files.md
+++ b/docs/docs/guides/develop/projects/synthesized-files.md
@@ -1,5 +1,6 @@
 ---
 title: Synthesized files
+titleTemplate: ":title | Projects | Tuist"
 description: Learn about synthesized files in Tuist projects.
 ---
 

--- a/docs/docs/guides/develop/projects/templates.md
+++ b/docs/docs/guides/develop/projects/templates.md
@@ -1,5 +1,6 @@
 ---
 title: Templates
+titleTemplate: ":title | Projects | Tuist"
 description: Learn how to create and use templates in Tuist to generate code in your projects.
 ---
 

--- a/docs/docs/guides/develop/projects/tma-architecture.md
+++ b/docs/docs/guides/develop/projects/tma-architecture.md
@@ -1,7 +1,7 @@
 ---
 title: The Modular Architecture (TMA)
 titleTemplate: ":title | Projects | Tuist"
-description: Learn about the Modular Architecture (TMA) and how to structure your projects using it.
+description: Learn about The Modular Architecture (TMA) and how to structure your projects using it.
 ---
 
 # The Modular Architecture (TMA)

--- a/docs/docs/guides/develop/projects/tma-architecture.md
+++ b/docs/docs/guides/develop/projects/tma-architecture.md
@@ -1,5 +1,10 @@
-# The Modular Architecture (TMA)
+---
+title: The Modular Architecture (TMA)
+titleTemplate: ":title | Projects | Tuist"
+description: Learn about the Modular Architecture (TMA) and how to structure your projects using it.
+---
 
+# The Modular Architecture (TMA)
 
 TMA is an architectural approach to structure Apple OS applications to enable scalability, optimize build and test cycles, and ensure good practices in your team. Its core idea is to build your apps by building independent features that are interconnected using clear and concise APIs.
 


### PR DESCRIPTION
Do's and don'ts are a recurring theme in our Slack. It's time to capture this on our documentation website and make it SEO-indexable for anyone coming across similar wonders.