### PR TITLE
Support generating a focused set of targets in open source Tuist

### DIFF
--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesService.swift
@@ -52,7 +52,7 @@ final class CachePrintHashesService {
         let absolutePath = try absolutePath(path)
         let timer = clock.startTimer()
         let config = try await configLoader.loadConfig(path: absolutePath)
-        let generator = generatorFactory.defaultGenerator(config: config)
+        let generator = generatorFactory.defaultGenerator(config: config, sources: [])
         let graph = try await generator.load(path: absolutePath)
         let hashes = try cacheGraphContentHasher.contentHashes(
             for: graph,

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -60,9 +60,11 @@ public protocol GeneratorFactorying {
 
     /// Returns the default generator.
     /// - Parameter config: The project configuration.
+    /// - Parameter sources: The list of targets whose sources should be included.
     /// - Returns: A Generator instance.
     func defaultGenerator(
-        config: Config
+        config: Config,
+        sources: Set<String>
     ) -> Generating
 }
 
@@ -110,12 +112,12 @@ public class GeneratorFactory: GeneratorFactorying {
 
     public func generation(
         config: Config,
-        sources _: Set<String>,
+        sources: Set<String>,
         configuration _: String?,
         ignoreBinaryCache _: Bool,
         cacheStorage _: CacheStoring
     ) -> Generating {
-        defaultGenerator(config: config)
+        defaultGenerator(config: config, sources: sources)
     }
 
     public func building(
@@ -124,16 +126,24 @@ public class GeneratorFactory: GeneratorFactorying {
         ignoreBinaryCache _: Bool,
         cacheStorage _: CacheStoring
     ) -> Generating {
-        defaultGenerator(config: config)
+        defaultGenerator(config: config, sources: [])
     }
 
-    public func defaultGenerator(config: Config) -> Generating {
+    public func defaultGenerator(
+        config: Config,
+        sources: Set<String>
+    ) -> Generating {
         let contentHasher = ContentHasher()
         let projectMapperFactory = ProjectMapperFactory(contentHasher: contentHasher)
         let projectMappers = projectMapperFactory.default()
         let workspaceMapperFactory = WorkspaceMapperFactory(projectMapper: SequentialProjectMapper(mappers: projectMappers))
         let graphMapperFactory = GraphMapperFactory()
-        let graphMappers = graphMapperFactory.default(config: config)
+        let graphMappers = graphMapperFactory.automation(
+            config: config,
+            testPlan: nil,
+            includedTargets: sources,
+            excludedTargets: []
+        )
         let workspaceMappers = workspaceMapperFactory.default()
         let manifestLoader = ManifestLoaderFactory().createManifestLoader()
         return Generator(

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -214,7 +214,7 @@ final class RunService {
     ) async throws {
         let graph: Graph
         let config = try await configLoader.loadConfig(path: path)
-        let generator = generatorFactory.defaultGenerator(config: config)
+        let generator = generatorFactory.defaultGenerator(config: config, sources: [])
         if try (generate || buildGraphInspector.workspacePath(directory: path) == nil) {
             logger.notice("Generating project for running", metadata: .section)
             graph = try await generator.generateWithGraph(path: path).1

--- a/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
@@ -6,12 +6,12 @@ final class CacheAcceptanceTestiOSAppWithFrameworks: TuistAcceptanceTestCase {
         try await setUpFixture(.iosAppWithFrameworks)
         try await run(CacheCommand.self, "--print-hashes")
         XCTAssertStandardOutput(pattern: """
-        Framework1 - 31b5dd46503cc78a7d84514b3a59e462
-        Framework2-iOS - 75676dc68658f4996630a6eb070f3072
-        Framework2-macOS - 965232ae7d0ef41aa39a5556dae4dc50
-        Framework3 - 8e0d6b1a1fc70c0b9f27c41e1b0669d5
-        Framework4 - 3657f4ec388cc692d6f18ed906838d71
-        Framework5 - daf3deb97fcd2aef89d7f417bdccac0b
+        Framework1 - e845d28f46587f3fe6b4b558dd4a1b05
+        Framework2-iOS - 5f1ab129436c39c03f2eed8bf6296fae
+        Framework2-macOS - 643fa7eae68924aa6fbfb46daff362c8
+        Framework3 - 2e484e2f796c7b3c108f00d51d24d261
+        Framework4 - fcdfa208380722d426314089c4fd407f
+        Framework5 - 362f186534c225e0068aa20c0b95b603
         """)
     }
 }

--- a/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
@@ -27,7 +27,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         generatorFactory = MockGeneratorFactorying()
         generator = .init()
         given(generatorFactory)
-            .defaultGenerator(config: .any)
+            .defaultGenerator(config: .any, sources: .any)
             .willReturn(generator)
 
         cacheGraphContentHasher = MockCacheGraphContentHashing()

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -61,7 +61,7 @@ final class RunServiceTests: TuistUnitTestCase {
         generator = .init()
         generatorFactory = MockGeneratorFactorying()
         given(generatorFactory)
-            .defaultGenerator(config: .any)
+            .defaultGenerator(config: .any, sources: .any)
             .willReturn(generator)
         buildGraphInspector = .init()
         targetBuilder = MockTargetBuilder()


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6624>

### Short description 📝

This adds plumbing to connect the `sources` arguments of the `tuist generate` command to the `GraphMapperFactory`. I believe this is handled correctly in the closed source, but I haven't been able to get it to work when building from this repo, preventing me from helping with related issues.

### How to test the changes locally 🧐

1. Check out this branch
2. `tuist install && tuist generate`
3. Add argument `generate AppCore --path "$(SRCROOT)/fixtures/ios_app_with_tests"` to the run action of the `tuist` scheme in Xcode
4. Run the `tuist` scheme in Xcode

Expected: it should generate a project with only 1 target

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
