### PR TITLE
Automatically include unit tests that depend on focus targets

### DIFF
--- a/Sources/TuistCore/GraphTraverser/GraphTraverser+Extra.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraverser+Extra.swift
@@ -24,6 +24,19 @@ extension GraphTraversing {
                     return false
                 }
                 if !includedTargets.isEmpty {
+                    if target.target.product == .unitTests {
+                        let dependencyTargetNames = Set(target.target.dependencies.compactMap { dependency in
+                            switch dependency {
+                            case let .target(targetName, _), let .project(targetName, _, _):
+                                return targetName
+                            case .framework, .xcframework, .library, .package, .sdk, .xctest:
+                                return nil
+                            }
+                        })
+                        if !dependencyTargetNames.intersection(includedTargets).isEmpty {
+                            return true
+                        }
+                    }
                     return includedTargets.contains(target.target.name)
                 }
                 if excludedTargets.contains(target.target.name) {

--- a/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -153,7 +153,11 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         // Given
         let targetNames = ["foo", "bar", "baz"].shuffled()
         let aTarget = Target.test(name: targetNames[0])
-        let aTestTarget = Target.test(name: targetNames[0] + "Tests", product: .unitTests, dependencies: [.target(name: targetNames[0])])
+        let aTestTarget = Target.test(
+            name: targetNames[0] + "Tests",
+            product: .unitTests,
+            dependencies: [.target(name: targetNames[0])]
+        )
         let bTarget = Target.test(name: targetNames[1])
         let cTarget = Target.test(name: targetNames[2])
         let subject = FocusTargetsGraphMappers(includedTargets: [aTarget.name])

--- a/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -149,11 +149,11 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         )
     }
 
-    func test_map_when_included_targets_is_target_with_no_dependency_but_with_test_target_also_test_target_is_pruned() throws {
+    func test_map_when_included_targets_is_target_with_no_dependency_but_with_test_target_also_test_target_is_not_pruned() throws {
         // Given
         let targetNames = ["foo", "bar", "baz"].shuffled()
         let aTarget = Target.test(name: targetNames[0])
-        let aTestTarget = Target.test(name: targetNames[0] + "Tests", product: .unitTests)
+        let aTestTarget = Target.test(name: targetNames[0] + "Tests", product: .unitTests, dependencies: [.target(name: targetNames[0])])
         let bTarget = Target.test(name: targetNames[1])
         let cTarget = Target.test(name: targetNames[2])
         let subject = FocusTargetsGraphMappers(includedTargets: [aTarget.name])
@@ -177,7 +177,7 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         // When
         let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: MapperEnvironment())
 
-        let expectingTargets = [bTarget, cTarget, aTestTarget]
+        let expectingTargets = [bTarget, cTarget]
         let pruningTargets = gotGraph.projects.values.flatMap(\.targets.values).sorted().filter(\.prune)
 
         // Then


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6512>

### Short description 📝

This automatically includes unit test targets that depend on focus targets in `FocusTargetsGraphMappers`, based on discussion in https://github.com/tuist/tuist/issues/6512.

### How to test the changes locally 🧐

1. Check out branch
2. Rebase off https://github.com/tuist/tuist/pull/6625 to get target focusing capability with open source tuist
3. `tuist install && tuist generate`
4. Add argument `generate AppCore --path "$(SRCROOT)/fixtures/ios_app_with_tests"` to the run action of the `tuist` scheme in Xcode
5. Run the `tuist` scheme in Xcode

Expected: it should generate a project with 2 targets: `AppCore` and `AppCoreTests`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
