### PR TITLE
Prune schemes when expandVariableFromTarget is pruned

### DIFF
--- a/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -94,6 +94,18 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
                 return nil
             }
 
+            if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget,
+               !sourceTargets.contains(expandVariableFromTarget)
+            {
+                return nil
+            }
+
+            if let expandVariableFromTarget = scheme.testAction?.expandVariableFromTarget,
+               !sourceTargets.contains(expandVariableFromTarget)
+            {
+                return nil
+            }
+
             return scheme
         }
     }

--- a/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -94,6 +94,62 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
     }
 
+    func test_map_removes_project_schemes_with_whose_run_action_expand_variable_from_target_has_been_removed() throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let prunedTarget = Target.test(name: "first", prune: true)
+        let keptTarget = Target.test(name: "second", prune: false)
+        let schemes: [Scheme] = [
+            .test(
+                buildAction: .test(targets: [.init(projectPath: path, name: keptTarget.name)]),
+                runAction: .test(expandVariableFromTarget: .init(projectPath: path, name: prunedTarget.name))
+            ),
+        ]
+        let project = Project.test(path: path, targets: [prunedTarget, keptTarget], schemes: schemes)
+
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertNotEmpty(gotGraph.projects)
+        XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
+    }
+
+    func test_map_removes_project_schemes_with_whose_test_action_expand_variable_from_target_has_been_removed() throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let prunedTarget = Target.test(name: "first", prune: true)
+        let keptTarget = Target.test(name: "second", prune: false)
+        let schemes: [Scheme] = [
+            .test(
+                buildAction: .test(targets: [.init(projectPath: path, name: keptTarget.name)]),
+                testAction: .test(expandVariableFromTarget: .init(projectPath: path, name: prunedTarget.name))
+            ),
+        ]
+        let project = Project.test(path: path, targets: [prunedTarget, keptTarget], schemes: schemes)
+
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertNotEmpty(gotGraph.projects)
+        XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
+    }
+
     func test_map_keeps_project_schemes_with_whose_all_targets_have_been_removed_but_have_test_plans() throws {
         let path = try AbsolutePath(validating: "/project")
         let prunedTarget = Target.test(name: "first", prune: true)


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6615>

### Short description 📝

This prunes schemes that have an `expandVariableFromTarget` specified in the run or test action when that target has also been pruned.

### How to test the changes locally 🧐

1. Check out branch
2. Rebase off https://github.com/tuist/tuist/pull/6625 to get target focusing capability with open source tuist
3. `tuist install && tuist generate`
4. Follow validation steps from https://github.com/tuist/tuist/issues/6615

Expected: project should generate without any lint errors

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
