### PR TITLE
Support #import with spaces prefix in umbrella headers.

### DIFF
--- a/Sources/TuistLoader/Loaders/UmbrellaHeaderHeadersExtractor.swift
+++ b/Sources/TuistLoader/Loaders/UmbrellaHeaderHeadersExtractor.swift
@@ -16,7 +16,7 @@ public enum UmbrellaHeaderHeadersExtractor {
 
         return lines.compactMap { line in
             let stripped = line.trimmingCharacters(in: .whitespaces)
-            guard let matchingPrefix = expectedPrefixes.first(where: { line.hasPrefix($0) }) else {
+            guard let matchingPrefix = expectedPrefixes.first(where: { stripped.hasPrefix($0) }) else {
                 return nil
             }
             // also we need drop comments and spaces before comments

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Headers+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Headers+ManifestMapperTests.swift
@@ -413,7 +413,7 @@ final class HeadersManifestMapperTests: TuistUnitTestCase {
         // In this header, you should import all the public headers of your framework using statements like #import <TuistTestModule/PublicHeader.h>
 
         #import <TuistTestModule/A1.h>
-        #import <TuistTestModule/A2.h>
+          #import <TuistTestModule/A2.h> // to test spaces prefix
         #import "A3.h" // to test modules with legacy format
         #import <TuistTestModule/A2+Protected.h> // to test modules, where some protected files became public
         #import <UIKit/A4+Private.h> // to test incorrect module
@@ -476,7 +476,7 @@ final class HeadersManifestMapperTests: TuistUnitTestCase {
         // In this header, you should import all the public headers of your framework using statements like #import <TuistTestModule/PublicHeader.h>
 
         #import <TuistTestModule/A1.h>
-        #import <TuistTestModule/A2.h>
+          #import <TuistTestModule/A2.h> // to test spaces prefix
         #import "A3.h" // to test modules with legacy format
         """
         let umbrellaPath = temporaryPath.appending(try RelativePath(validating: "Sources/Umbrella.h"))
@@ -543,7 +543,7 @@ final class HeadersManifestMapperTests: TuistUnitTestCase {
         // In this header, you should import all the public headers of your framework using statements like #import <TuistTestModule/PublicHeader.h>
 
         #import <TuistTestModule/A1.h>
-        #import <TuistTestModule/A2.h>
+          #import <TuistTestModule/A2.h> // to test spaces prefix
         #import "A3.h" // to test modules with legacy format
         """
         let umbrellaPath = temporaryPath.appending(try RelativePath(validating: "Sources/Umbrella.h"))


### PR DESCRIPTION
### Short description 📝
In a few umbrella headers, there are cases where there are spaces before the `#import` directive, like

```
#if TARGET_OS_IOS
  #import <Framework/SomeHeader.h>
#endif
```

Before this change, the headers with spaces are not detected and the headers are not considered public, this PR fixes this issue.

### How to test the changes locally 🧐

1. Create a framework target, configure a framework with an umbrella header and a headers parameter, for example
```
headers: .allHeaders(from: "Framework/**", umbrella: "Framework/Framework.h")
```
2. Make sure the umbrella header contains `#import` directives with spaces before them.
3. Run `tuist generate` and make sure the headers with the spaces appear as public in the copy headers phase in Xcode.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
