### PR TITLE
Create public absolutePath method for CopyFilesAction

### DIFF
--- a/Sources/ProjectDescription/CopyFilesAction.swift
+++ b/Sources/ProjectDescription/CopyFilesAction.swift
@@ -47,6 +47,25 @@ public struct CopyFilesAction: Codable, Equatable, Sendable {
 
     // MARK: - Static initializers
 
+    /// A copy files action for an absolute path.
+    /// - Parameters:
+    ///   - name: Name of the build phase when the project gets generated.
+    ///   - subpath: Path to a folder inside the destination.
+    ///   - files: Relative paths to the files to be copied.
+    /// - Returns: Copy files action.
+    public static func absolutePath(
+        name: String,
+        subpath: String? = nil,
+        files: [CopyFileElement]
+    ) -> CopyFilesAction {
+        CopyFilesAction(
+            name: name,
+            destination: .absolutePath,
+            subpath: subpath,
+            files: files
+        )
+    }
+
     /// A copy files action for the products directory.
     /// - Parameters:
     ///   - name: Name of the build phase when the project gets generated.


### PR DESCRIPTION
### Short description 📝

Support the creation of `CopyFilesAction` with an `.absolutePath` destination with a public static method, similar to other methods for other destinations.

### How to test the changes locally 🧐

A target with `copyFiles: [.absolutePath(name: "My Action", subpath: "$(TARGET_BUILD_DIR)", files: [])]` should generate a project with the respective `My Action` build phase.

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
