### PR TITLE
Allow adding macOS bundles to iOS targets

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -140,6 +140,7 @@ public class GraphLinter: GraphLinting {
             guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency,
                   let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
 
+            guard fromTarget.target.product != .bundle else { return [] }
             let fromPlatforms = fromTarget.target.supportedPlatforms
 
             let dependencies: [LintingIssue] = graphTraverser.directTargetDependencies(path: fromTargetPath, name: fromTargetName)
@@ -465,6 +466,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .bundle),
             LintableTarget(platform: .iOS, product: .appClip),
+            LintableTarget(platform: .macOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .macro),
         ],
         LintableTarget(platform: .iOS, product: .appExtension): [
@@ -515,6 +517,13 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .xpc),
             LintableTarget(platform: .macOS, product: .systemExtension),
             LintableTarget(platform: .macOS, product: .macro),
+        ],
+        LintableTarget(platform: .macOS, product: .bundle): [
+            LintableTarget(platform: .iOS, product: .app),
+            LintableTarget(platform: .iOS, product: .staticLibrary),
+            LintableTarget(platform: .iOS, product: .dynamicLibrary),
+            LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .iOS, product: .framework),
         ],
         LintableTarget(platform: .macOS, product: .staticLibrary): [
             LintableTarget(platform: .macOS, product: .staticLibrary),

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1635,6 +1635,64 @@ final class GraphLinterTests: TuistUnitTestCase {
         XCTAssertEmpty(got)
     }
 
+    func test_lint_ios_uitests_allows_macos_bundle_dependency() {
+        let path: AbsolutePath = "/project"
+
+        let uitests = Target.test(name: "UITests", platform: .iOS, product: .uiTests)
+        let bundle = Target.test(name: "Bundle", platform: .macOS, product: .bundle)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: uitests.name, path: path): Set([
+                .target(name: bundle.name, path: path),
+            ]),
+        ]
+
+        let project = Project.test(path: path, targets: [uitests, bundle])
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            dependencies: dependencies
+        )
+
+        // When
+        let got = subject.lint(graphTraverser: GraphTraverser(graph: graph), config: Config.test())
+
+        // Then
+        XCTAssertEmpty(got)
+    }
+
+    func test_lint_macos_bundle_allows_ios_dependencies() {
+        let path: AbsolutePath = "/project"
+
+        let bundle = Target.test(name: "Bundle", platform: .macOS, product: .bundle)
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let framework = Target.test(name: "Framework", platform: .iOS, product: .framework)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: bundle.name, path: path): Set([
+                .target(name: app.name, path: path),
+                .target(name: framework.name, path: path),
+            ]),
+        ]
+
+        let project = Project.test(path: path, targets: [bundle, app, framework])
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            dependencies: dependencies
+        )
+
+        // When
+        let got = subject.lint(graphTraverser: GraphTraverser(graph: graph), config: Config.test())
+
+        // Then
+        XCTAssertEmpty(got)
+    }
+
     func test_lintDifferentBundleIdentifiers() {
         // Given
         let path: AbsolutePath = "/project"


### PR DESCRIPTION
### Short description 📝

For open-box tests it is sometimes necessary to add a macOS bundle to a target. This PR removes the restriction from the graph linter and removes restrictions on platform requirements for bundles.

### How to test the changes locally 🧐

Create a target with platform `.macOS` platforms and product type `.bundle`. This target needs to be embedded, not linked (which is not supported by Tuist right now, but a copy files build phase can replicate this (not necessary to test).
Add an `.app` and/or a `.framework` target to the bundle target. Then run `tuist generate`.

Inspecting the Xcode workspace will show a bundle target generated with its respective dependencies.

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
