### PR TITLE
Draft: Add -F flag to remove state restoration on open

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -42,6 +42,7 @@ public enum EnvKey: String, CaseIterable {
     // GENERATE
     case generatePath = "TUIST_GENERATE_PATH"
     case generateOpen = "TUIST_GENERATE_OPEN"
+    case generateFresh = "TUIST_GENERATE_FRESH"
     case generateBinaryCache = "TUIST_GENERATE_BINARY_CACHE"
 
     // GRAPH

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -44,6 +44,13 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     var open: Bool = true
 
     @Flag(
+        name: .shortAndLong,
+        help: "Opens the application \"fresh,\" that is, without restoring windows. Saved persistent state is lost, except for Untitled documents. **THIS WILL HAVE NO EFFECT UNLESS YOU QUIT XCODE FIRST.**",
+        envKey: .generateFresh
+    )
+    var fresh: Bool = false
+
+    @Flag(
         help: "Ignore binary cache and use sources only.",
         envKey: .generateBinaryCache
     )
@@ -56,10 +63,12 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     var configuration: String?
 
     public func run() async throws {
+        print("NK: opening fresh \(fresh)")
         defer {
             GenerateCommand.analyticsDelegate?.addParameters(
                 [
                     "no_open": AnyCodable(!open),
+                    "fresh": AnyCodable(!fresh),
                     "no_binary_cache": AnyCodable(!binaryCache),
                     "n_targets": AnyCodable(sources.count),
                     "cacheable_targets": AnyCodable(CacheAnalyticsStore.shared.cacheableTargets),
@@ -78,6 +87,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             path: path,
             sources: Set(sources),
             noOpen: !open,
+            fresh: fresh,
             configuration: configuration,
             ignoreBinaryCache: !binaryCache
         )

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -70,7 +70,7 @@ final class EditService {
                 plugins: plugins
             )
             logger.notice("Opening Xcode to edit the project.", metadata: .pretty)
-            try opener.open(path: workspacePath, application: selectedXcode.path, wait: false)
+            try opener.open(path: workspacePath, application: selectedXcode.path, wait: false, fresh: false)
 
         } else {
             let workspacePath = try await projectEditor.edit(

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -42,6 +42,7 @@ final class GenerateService {
         path: String?,
         sources: Set<String>,
         noOpen: Bool,
+        fresh: Bool,
         configuration: String?,
         ignoreBinaryCache: Bool
     ) async throws {
@@ -58,7 +59,7 @@ final class GenerateService {
         )
         let workspacePath = try await generator.generate(path: path)
         if !noOpen {
-            try opener.open(path: workspacePath)
+            try opener.open(path: workspacePath, fresh: fresh)
         }
         logger.notice("Project generated.", metadata: .success)
         logger.notice(timeTakenLoggerFormatter.timeTakenMessage(for: timer))

--- a/Sources/TuistKit/Services/Organization/OrganizationBillingService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationBillingService.swift
@@ -41,7 +41,8 @@ final class OrganizationBillingService: OrganizationBillingServicing {
         try opener.open(
             url: serverURL
                 .appendingPathComponent(organizationName)
-                .appendingPathComponent("billing")
+                .appendingPathComponent("billing"),
+            fresh: false
         )
     }
 }

--- a/Sources/TuistKit/Services/Project/ProjectShowService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectShowService.swift
@@ -55,7 +55,7 @@ struct ProjectShowService {
         if web {
             var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
             components.path = "/\(fullHandle)"
-            try opener.open(url: components.url!)
+            try opener.open(url: components.url!, fresh: false)
         } else {
             let project = try await getProjectService.getProject(
                 fullHandle: fullHandle,

--- a/Sources/TuistServer/Session/ServerSessionController.swift
+++ b/Sources/TuistServer/Session/ServerSessionController.swift
@@ -65,7 +65,7 @@ public final class ServerSessionController: ServerSessionControlling {
         let authURL = components.url!
 
         logger.notice("Opening \(authURL.absoluteString) to start the authentication flow")
-        try opener.open(url: authURL)
+        try opener.open(url: authURL, fresh: false)
 
         if Environment.shared.shouldOutputBeColoured {
             logger.notice("Press \("CTRL + C".cyan()) once to cancel the process.", metadata: .pretty)

--- a/Sources/TuistSupport/Utils/Opener.swift
+++ b/Sources/TuistSupport/Utils/Opener.swift
@@ -22,12 +22,12 @@ enum OpeningError: FatalError, Equatable {
 
 @Mockable
 public protocol Opening: AnyObject {
-    func open(path: AbsolutePath, wait: Bool) throws
-    func open(path: AbsolutePath) throws
-    func open(path: AbsolutePath, application: AbsolutePath) throws
-    func open(path: AbsolutePath, application: AbsolutePath, wait: Bool) throws
-    func open(url: URL) throws
-    func open(target: String, wait: Bool) throws
+    func open(path: AbsolutePath, wait: Bool, fresh: Bool) throws
+    func open(path: AbsolutePath, fresh: Bool) throws
+    func open(path: AbsolutePath, application: AbsolutePath, fresh: Bool) throws
+    func open(path: AbsolutePath, application: AbsolutePath, wait: Bool, fresh: Bool) throws
+    func open(url: URL, fresh: Bool) throws
+    func open(target: String, wait: Bool, fresh: Bool) throws
 }
 
 public class Opener: Opening {
@@ -35,40 +35,42 @@ public class Opener: Opening {
 
     // MARK: - Opening
 
-    public func open(path: AbsolutePath, wait: Bool) throws {
+    public func open(path: AbsolutePath, wait: Bool, fresh: Bool = false) throws {
         if !FileHandler.shared.exists(path) {
             throw OpeningError.notFound(path)
         }
-        try open(target: path.pathString, wait: wait)
+        try open(target: path.pathString, wait: wait, fresh: fresh)
     }
 
-    public func open(path: AbsolutePath) throws {
-        try open(path: path, wait: false)
+    public func open(path: AbsolutePath, fresh: Bool = false) throws {
+        try open(path: path, wait: false, fresh: fresh)
     }
 
-    public func open(url: URL) throws {
-        try open(target: url.absoluteString, wait: false)
+    public func open(url: URL, fresh: Bool = false) throws {
+        try open(target: url.absoluteString, wait: false, fresh: fresh)
     }
 
-    public func open(target: String, wait: Bool) throws {
+    public func open(target: String, wait: Bool, fresh: Bool = false) throws {
         var arguments: [String] = []
         arguments.append(contentsOf: ["/usr/bin/open"])
         if wait { arguments.append("-W") }
+        if fresh { arguments.append("-F") }
         arguments.append(target)
 
         try System.shared.run(arguments)
     }
 
-    public func open(path: AbsolutePath, application: AbsolutePath) throws {
-        try open(path: path, application: application, wait: true)
+    public func open(path: AbsolutePath, application: AbsolutePath, fresh: Bool = false) throws {
+        try open(path: path, application: application, wait: true, fresh: fresh)
     }
 
-    public func open(path: AbsolutePath, application: AbsolutePath, wait: Bool) throws {
+    public func open(path: AbsolutePath, application: AbsolutePath, wait: Bool, fresh: Bool = false) throws {
         var arguments: [String] = []
         arguments.append(contentsOf: ["/usr/bin/open"])
         arguments.append(path.pathString)
         arguments.append(contentsOf: ["-a", application.pathString])
         if wait { arguments.append("-W") }
+        if fresh { arguments.append("-F") }
         try System.shared.run(arguments)
     }
 }

--- a/Tests/TuistKitTests/Services/EditServiceTests.swift
+++ b/Tests/TuistKitTests/Services/EditServiceTests.swift
@@ -65,7 +65,7 @@ final class EditServiceTests: XCTestCase {
             .willReturn(projectDirectory)
 
         given(opener)
-            .open(path: .any, application: .any, wait: .any)
+            .open(path: .any, application: .any, wait: .any, fresh: .any)
             .willReturn()
 
         // When
@@ -80,7 +80,8 @@ final class EditServiceTests: XCTestCase {
             .open(
                 path: .value(projectDirectory),
                 application: .any,
-                wait: .value(false)
+                wait: .value(false),
+                fresh: .any
             )
             .called(1)
 
@@ -111,7 +112,8 @@ final class EditServiceTests: XCTestCase {
             .open(
                 path: .any,
                 application: .any,
-                wait: .any
+                wait: .any,
+                fresh: .any
             )
             .called(0)
 

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -70,6 +70,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
                     path: nil,
                     sources: [],
                     noOpen: true,
+                    fresh: false,
                     configuration: nil,
                     ignoreBinaryCache: false
                 )
@@ -88,7 +89,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
             .willReturn(workspacePath)
 
         given(opener)
-            .open(path: .any)
+            .open(path: .any, fresh: .any)
             .willReturn()
 
         // When
@@ -96,13 +97,14 @@ final class GenerateServiceTests: TuistUnitTestCase {
             path: nil,
             sources: [],
             noOpen: false,
+            fresh: false,
             configuration: nil,
             ignoreBinaryCache: false
         )
 
         // Then
         verify(opener)
-            .open(path: .value(workspacePath))
+            .open(path: .value(workspacePath), fresh: .any)
             .called(1)
     }
 
@@ -111,7 +113,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/test.xcworkspace")
 
         given(opener)
-            .open(path: .any)
+            .open(path: .any, fresh: .any)
             .willReturn()
 
         given(generator)
@@ -127,6 +129,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
             path: nil,
             sources: [],
             noOpen: false,
+            fresh: false,
             configuration: nil,
             ignoreBinaryCache: false
         )

--- a/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
@@ -47,7 +47,7 @@ final class ProjectShowServiceTests: TuistUnitTestCase {
         // Given
         var expectedURLComponents = URLComponents(url: Constants.URLs.production, resolvingAgainstBaseURL: false)!
         expectedURLComponents.path = "/tuist/tuist"
-        given(opener).open(url: .value(expectedURLComponents.url!)).willReturn()
+        given(opener).open(url: .value(expectedURLComponents.url!), fresh: .any).willReturn()
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test())
@@ -56,7 +56,7 @@ final class ProjectShowServiceTests: TuistUnitTestCase {
         try await subject.run(fullHandle: "tuist/tuist", web: true, path: nil)
 
         // Then
-        verify(opener).open(url: .value(expectedURLComponents.url!)).called(1)
+        verify(opener).open(url: .value(expectedURLComponents.url!), fresh: .any).called(1)
     }
 
     func test_run_with_web_when_theFullHandleIsNotProvided_and_aConfigWithFullHandleCanBeLoaded() async throws {
@@ -66,13 +66,13 @@ final class ProjectShowServiceTests: TuistUnitTestCase {
         expectedURLComponents.path = "/tuist/tuist"
         let config = Config.test(fullHandle: "tuist/tuist")
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
-        given(opener).open(url: .any).willReturn()
+        given(opener).open(url: .any, fresh: .any).willReturn()
 
         // When
         try await subject.run(fullHandle: nil, web: true, path: path.pathString)
 
         // Then
-        verify(opener).open(url: .value(expectedURLComponents.url!)).called(1)
+        verify(opener).open(url: .value(expectedURLComponents.url!), fresh: .any).called(1)
     }
 
     func test_run_with_web_when_theFullHandleIsNotProvided_and_aConfigWithoutFullHandleCanBeLoaded() async throws {
@@ -80,7 +80,7 @@ final class ProjectShowServiceTests: TuistUnitTestCase {
         let path = try temporaryPath()
         var expectedURLComponents = URLComponents(url: Constants.URLs.production, resolvingAgainstBaseURL: false)!
         expectedURLComponents.path = "/tuist/tuist"
-        given(opener).open(url: .value(expectedURLComponents.url!)).willReturn()
+        given(opener).open(url: .value(expectedURLComponents.url!), fresh: .any).willReturn()
         let config = Config.test(fullHandle: nil)
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
 

--- a/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -37,7 +37,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
         )
 
         given(opener)
-            .open(url: .any)
+            .open(url: .any, fresh: .any)
             .willReturn()
     }
 

--- a/Tests/TuistSupportTests/Utils/OpenerTests.swift
+++ b/Tests/TuistSupportTests/Utils/OpenerTests.swift
@@ -44,4 +44,12 @@ final class OpenerTests: TuistUnitTestCase {
         system.succeedCommand(["/usr/bin/open", path.pathString])
         try subject.open(path: path)
     }
+
+    func test_open_when_fresh_is_true() throws {
+        let temporaryPath = try temporaryPath()
+        let path = temporaryPath.appending(component: "tool")
+        try FileHandler.shared.touch(path)
+        system.succeedCommand(["/usr/bin/open", "-F", path.pathString])
+        try subject.open(path: path, fresh: true)
+    }
 }


### PR DESCRIPTION
[open-without-state-restoration]

Resolves <https://github.com/tuist/tuist/issues/6635>

### Short description 📝

Adds the ability to pass `-F` to `/usr/bin/open` so that you can instruct your editor to not open every project that was previously open.

**Important note:** This will really only do what you expect if you have first closed your editor and then use `tuist generate -f`.

### How to test the changes locally 🧐

1. Have a project that is generated by tuist
2. Have multiple projects/packages open in Xcode
3. Quit Xcode without closing each project/package
4. Run `tuist generate -f` for a project
5. You should observe that Xcode only opens that project and nothing else

You can verify the current behavior still working by doing the same steps (1-3) and then running `tuist generate` on a project.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
