### PR TITLE
Update SwiftLint repository and corresponding manifest configuration in documentation

### DIFF
--- a/docs/docs/guides/develop/projects/dependencies.md
+++ b/docs/docs/guides/develop/projects/dependencies.md
@@ -182,7 +182,7 @@ let package = Package(
         .library(name: "Framework", targets: ["Framework"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", from: "0.55.0"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", .upToNextMajor(from: "0.56.1")),
     ],
     targets: [
         .target(
@@ -203,13 +203,13 @@ import ProjectDescription
 let project = Project(
     name: "Framework",
     packages: [
-        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", from: "0.55.0"),
+        .remote(url: "https://github.com/SimplyDanny/SwiftLintPlugins", requirement: .upToNextMajor(from: "0.56.1")),
     ],
     targets: [
         .target(
             name: "Framework",
             dependencies: [
-                .package(product: "SwiftLint", type: .plugin),
+                .package(product: "SwiftLintBuildToolPlugin", type: .plugin),
             ]
         ),
     ]
@@ -246,7 +246,7 @@ pod install
 
 ## Static or dynamic
 
-Frameworks and libraries can be linked either statically or dynamically, **a choice that has significant implications for aspects like app size and boot time**. Despite its importance, this decision is often made without much consideration. 
+Frameworks and libraries can be linked either statically or dynamically, **a choice that has significant implications for aspects like app size and boot time**. Despite its importance, this decision is often made without much consideration.
 
 The **general rule of thumb** is that you want as many things as possible to be statically linked in release builds to achieve fast boot times, and as many things as possible to be dynamically linked in debug builds to achieve fast iteration times.
 


### PR DESCRIPTION
### Short description 📝

The documentation for [SPM Build Tool Plugins](https://docs.tuist.io/guides/develop/projects/dependencies#external-dependencies) includes an outdated repository for SwiftLint. As per the [SwiftLint README](https://github.com/realm/SwiftLint#installation), the repository `SimplyDanny/SwiftLintPlugins` should be used instead. This PR fixes the URL.

Moreover, due to changes in SwiftLint, a new Build Tool Plugin called `SwiftLintBuildToolPlugin` was introduced to handle the linting. This PR also describes how to make it work.

### How to test the changes locally 🧐

1. Build the documentation. Changes should be present

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
