### PR TITLE
Default to --no-open in CI environments for tuist generate

### DIFF
--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -41,7 +41,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "Don't open the project after generating it.",
         envKey: .generateOpen
     )
-    var open: Bool = true
+    var open: Bool = !CIChecker().isCI()
 
     @Flag(
         help: "Ignore binary cache and use sources only.",


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

This PR checks if the execution environment is the CI and then defaults to `--no-open`. 

Without this change, anyone executing `tuist generate` on the CI would also spin up an Xcode process thereby hogging resources on their CI and slowing down their build.

[Incident](https://tuist-community.slack.com/archives/C018QG7U7SN/p1722598276116619?thread_ts=1722250397.614839&cid=C018QG7U7SN)

### How to test the changes locally 🧐
- Export an env var locally `IS_CI=1` 
- run `tuist generate`
- The Tuist project should be generated but not opened automatically
- Remember to set `IS_CI` back to `0` to avoid any other side effects.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
