### PR TITLE
fix: not embed dynamic frameworks in app extensions

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -194,9 +194,9 @@ public class GraphTraverser: GraphTraversing {
             from: .target(name: name, path: path),
             test: { dependency in
                 isDependencyResourceBundle(dependency: dependency) && isDependencyExternal(dependency) &&
-                    canEmbedProducts(target: target)
+                    canEmbedBundles(target: target)
             },
-            skip: canDependencyEmbedProducts
+            skip: canDependencyEmbedBinaries
         )
 
         return Set(
@@ -276,7 +276,7 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func embeddableFrameworks(path: Path.AbsolutePath, name: String) -> Set<GraphDependencyReference> {
-        guard let target = target(path: path, name: name), canEmbedProducts(target: target.target) else { return Set() }
+        guard let target = target(path: path, name: name), canEmbedBinaries(target: target.target) else { return Set() }
 
         var references: Set<GraphDependencyReference> = Set([])
 
@@ -284,7 +284,7 @@ public class GraphTraverser: GraphTraversing {
         var precompiledFrameworks = filterDependencies(
             from: .target(name: name, path: path),
             test: { $0.isPrecompiledDynamicAndLinkable },
-            skip: or(canDependencyEmbedProducts, isDependencyPrecompiledMacro)
+            skip: or(canDependencyEmbedBinaries, isDependencyPrecompiledMacro)
         )
         // Skip merged precompiled libraries from merging into the runnable binary
         if case let .manual(dependenciesToMerge) = target.target.mergedBinaryType {
@@ -300,7 +300,7 @@ public class GraphTraverser: GraphTraversing {
         var otherTargetFrameworks = filterDependencies(
             from: .target(name: name, path: path),
             test: isDependencyDynamicTarget,
-            skip: canDependencyEmbedProducts
+            skip: canDependencyEmbedBinaries
         )
 
         if target.target.mergedBinaryType != .disabled {
@@ -566,7 +566,7 @@ public class GraphTraverser: GraphTraversing {
 
     public func runPathSearchPaths(path: Path.AbsolutePath, name: String) -> Set<Path.AbsolutePath> {
         guard let target = target(path: path, name: name),
-              canEmbedProducts(target: target.target),
+              canEmbedBinaries(target: target.target),
               target.target.product == .unitTests,
               unitTestHost(path: path, name: name) == nil
         else {
@@ -579,7 +579,7 @@ public class GraphTraverser: GraphTraversing {
         let precompiledFrameworksPaths = filterDependencies(
             from: from,
             test: { $0.isPrecompiledDynamicAndLinkable },
-            skip: canDependencyEmbedProducts
+            skip: canDependencyEmbedBinaries
         )
         .lazy
         .compactMap { (dependency: GraphDependency) -> Path.AbsolutePath? in
@@ -1130,10 +1130,10 @@ public class GraphTraverser: GraphTraversing {
         }
     }
 
-    func canDependencyEmbedProducts(dependency: GraphDependency) -> Bool {
+    func canDependencyEmbedBinaries(dependency: GraphDependency) -> Bool {
         guard case let GraphDependency.target(name, path) = dependency,
               let target = target(path: path, name: name) else { return false }
-        return canEmbedProducts(target: target.target)
+        return canEmbedBinaries(target: target.target)
     }
 
     func canDependencyLinkStaticProducts(dependency: GraphDependency) -> Bool {
@@ -1154,14 +1154,28 @@ public class GraphTraverser: GraphTraversing {
             .first(where: { $0.target.product.canHostTests() })?.graphTarget
     }
 
-    func canEmbedProducts(target: Target) -> Bool {
+    func canEmbedBinaries(target: Target) -> Bool {
         let validProducts: [Product] = [
             .app,
             .watch2App,
             .appClip,
             .unitTests,
             .uiTests,
+            .watch2Extension,
+            .systemExtension,
+            .xpc,
+        ]
+        return validProducts.contains(target.product)
+    }
+
+    func canEmbedBundles(target: Target) -> Bool {
+        let validProducts: [Product] = [
+            .app,
             .appExtension,
+            .watch2App,
+            .appClip,
+            .unitTests,
+            .uiTests,
             .watch2Extension,
             .systemExtension,
             .xpc,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -196,7 +196,7 @@ public class GraphTraverser: GraphTraversing {
                 isDependencyResourceBundle(dependency: dependency) && isDependencyExternal(dependency) &&
                     canEmbedBundles(target: target)
             },
-            skip: canDependencyEmbedBinaries
+            skip: canDependencyEmbedBundles
         )
 
         return Set(
@@ -276,7 +276,7 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func embeddableFrameworks(path: Path.AbsolutePath, name: String) -> Set<GraphDependencyReference> {
-        guard let target = target(path: path, name: name), canEmbedBinaries(target: target.target) else { return Set() }
+        guard let target = target(path: path, name: name), canEmbedFrameworks(target: target.target) else { return Set() }
 
         var references: Set<GraphDependencyReference> = Set([])
 
@@ -566,7 +566,7 @@ public class GraphTraverser: GraphTraversing {
 
     public func runPathSearchPaths(path: Path.AbsolutePath, name: String) -> Set<Path.AbsolutePath> {
         guard let target = target(path: path, name: name),
-              canEmbedBinaries(target: target.target),
+              canEmbedFrameworks(target: target.target),
               target.target.product == .unitTests,
               unitTestHost(path: path, name: name) == nil
         else {
@@ -1133,8 +1133,15 @@ public class GraphTraverser: GraphTraversing {
     func canDependencyEmbedBinaries(dependency: GraphDependency) -> Bool {
         guard case let GraphDependency.target(name, path) = dependency,
               let target = target(path: path, name: name) else { return false }
-        return canEmbedBinaries(target: target.target)
+        return canEmbedFrameworks(target: target.target)
     }
+    
+    func canDependencyEmbedBundles(dependency: GraphDependency) -> Bool {
+        guard case let GraphDependency.target(name, path) = dependency,
+              let target = target(path: path, name: name) else { return false }
+        return canEmbedBundles(target: target.target)
+    }
+
 
     func canDependencyLinkStaticProducts(dependency: GraphDependency) -> Bool {
         switch dependency {
@@ -1154,7 +1161,7 @@ public class GraphTraverser: GraphTraversing {
             .first(where: { $0.target.product.canHostTests() })?.graphTarget
     }
 
-    func canEmbedBinaries(target: Target) -> Bool {
+    func canEmbedFrameworks(target: Target) -> Bool {
         let validProducts: [Product] = [
             .app,
             .watch2App,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1135,13 +1135,12 @@ public class GraphTraverser: GraphTraversing {
               let target = target(path: path, name: name) else { return false }
         return canEmbedFrameworks(target: target.target)
     }
-    
+
     func canDependencyEmbedBundles(dependency: GraphDependency) -> Bool {
         guard case let GraphDependency.target(name, path) = dependency,
               let target = target(path: path, name: name) else { return false }
         return canEmbedBundles(target: target.target)
     }
-
 
     func canDependencyLinkStaticProducts(dependency: GraphDependency) -> Bool {
         switch dependency {

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1614,7 +1614,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
-    func test_embeddableDependencies_whenHostedTestTarget_transitiveDependencies() throws {
+    func test_embeddableFrameworks_whenHostedTestTarget_transitiveDependencies() throws {
         // Given
         let framework = Target.test(
             name: "Framework",
@@ -1659,7 +1659,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
-    func test_embeddableDependencies_whenUITest_andAppPrecompiledDependencies() throws {
+    func test_embeddableFrameworks_whenUITest_andAppPrecompiledDependencies() throws {
         // Given
         let app = Target.test(name: "App", product: .app)
         let uiTests = Target.test(name: "AppUITests", product: .uiTests)
@@ -1687,6 +1687,26 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // When
         let got = subject.embeddableFrameworks(path: project.path, name: uiTests.name).sorted()
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+
+    func test_embeddableFrameworks_when_appExtensionWithFrameworkDependency() throws {
+        // Given
+        let appExtension = Target.test(name: "AppExtension", product: .appExtension)
+        let framework = Target.test(name: "Framework", product: .framework)
+        let project = Project.test(targets: [appExtension, framework])
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: appExtension.name, path: project.path): Set([.target(name: framework.name, path: project.path)]),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: project.path, name: appExtension.name).sorted()
 
         // Then
         XCTAssertTrue(got.isEmpty)

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -5,6 +5,14 @@ import TuistSupportTesting
 import XcodeProj
 import XCTest
 
+final class GenerateAcceptanceTestAppWithFrameworkAndTests: TuistAcceptanceTestCase {
+    func test_app_with_framework_and_tests() async throws {
+        try await setUpFixture(.appWithFrameworkAndTests)
+        try await run(GenerateCommand.self)
+        try XCTAssertFrameworkNotEmbedded("Framework", by: "AppExtension")
+    }
+}
+
 final class GenerateAcceptanceTestiOSAppWithTests: TuistAcceptanceTestCase {
     func test_ios_app_with_tests() async throws {
         try await setUpFixture(.iosAppWithTests)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -297,7 +297,7 @@ workflows:
         script: mise x -- tuist install
       - name: Run tests
         working_directory: $CM_BUILD_DIR/app
-        script: mise x -- tuist test
+        script: mise x -- tuist test -- CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
     triggering:
       << : *branch_triggering
   warm_app_cache:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -297,7 +297,7 @@ workflows:
         script: mise x -- tuist install
       - name: Run tests
         working_directory: $CM_BUILD_DIR/app
-        script: mise x -- tuist test -- CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+        script: mise x -- tuist test -- CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
     triggering:
       << : *branch_triggering
   warm_app_cache:

--- a/fixtures/app_with_framework_and_tests/AppExtension/Extension.swift
+++ b/fixtures/app_with_framework_and_tests/AppExtension/Extension.swift
@@ -1,24 +1,17 @@
-//
-//  Extension.swift
-//  Extension
-//
-//  Created by msimons on 8/21/24.
-//
-
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 struct Provider: TimelineProvider {
-    func placeholder(in context: Context) -> SimpleEntry {
+    func placeholder(in _: Context) -> SimpleEntry {
         SimpleEntry(date: Date(), emoji: "😀")
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+    func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
         let entry = SimpleEntry(date: Date(), emoji: "😀")
         completion(entry)
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+    func getTimeline(in _: Context, completion: @escaping (Timeline<Entry>) -> Void) {
         var entries: [SimpleEntry] = []
 
         // Generate a timeline consisting of five entries an hour apart, starting from the current date.
@@ -39,7 +32,7 @@ struct SimpleEntry: TimelineEntry {
     let emoji: String
 }
 
-struct ExtensionEntryView : View {
+struct ExtensionEntryView: View {
     var entry: Provider.Entry
 
     var body: some View {

--- a/fixtures/app_with_framework_and_tests/AppExtension/Extension.swift
+++ b/fixtures/app_with_framework_and_tests/AppExtension/Extension.swift
@@ -1,0 +1,80 @@
+//
+//  Extension.swift
+//  Extension
+//
+//  Created by msimons on 8/21/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), emoji: "😀")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let entry = SimpleEntry(date: Date(), emoji: "😀")
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, emoji: "😀")
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let emoji: String
+}
+
+struct ExtensionEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Emoji:")
+            Text(entry.emoji)
+        }
+    }
+}
+
+struct Extension: Widget {
+    let kind: String = "Extension"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            if #available(iOS 17.0, *) {
+                ExtensionEntryView(entry: entry)
+                    .containerBackground(.fill.tertiary, for: .widget)
+            } else {
+                ExtensionEntryView(entry: entry)
+                    .padding()
+                    .background()
+            }
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+    }
+}
+
+#Preview(as: .systemSmall) {
+    Extension()
+} timeline: {
+    SimpleEntry(date: .now, emoji: "😀")
+    SimpleEntry(date: .now, emoji: "🤩")
+}

--- a/fixtures/app_with_framework_and_tests/AppExtension/ExtensionBundle.swift
+++ b/fixtures/app_with_framework_and_tests/AppExtension/ExtensionBundle.swift
@@ -1,12 +1,5 @@
-//
-//  ExtensionBundle.swift
-//  Extension
-//
-//  Created by msimons on 8/21/24.
-//
-
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 @main
 struct ExtensionBundle: WidgetBundle {

--- a/fixtures/app_with_framework_and_tests/AppExtension/ExtensionBundle.swift
+++ b/fixtures/app_with_framework_and_tests/AppExtension/ExtensionBundle.swift
@@ -1,0 +1,16 @@
+//
+//  ExtensionBundle.swift
+//  Extension
+//
+//  Created by msimons on 8/21/24.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct ExtensionBundle: WidgetBundle {
+    var body: some Widget {
+        Extension()
+    }
+}

--- a/fixtures/app_with_framework_and_tests/AppExtension/Info.plist
+++ b/fixtures/app_with_framework_and_tests/AppExtension/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/fixtures/app_with_framework_and_tests/AppExtension/Info.plist
+++ b/fixtures/app_with_framework_and_tests/AppExtension/Info.plist
@@ -7,5 +7,19 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
 </dict>
 </plist>

--- a/fixtures/app_with_framework_and_tests/Project.swift
+++ b/fixtures/app_with_framework_and_tests/Project.swift
@@ -30,7 +30,7 @@ let project = Project(
             name: "AppExtension",
             destinations: .iOS,
             product: .appExtension,
-            bundleId: "io.tuist.extension",
+            bundleId: "io.tuist.app.extension",
             infoPlist: "AppExtension/Info.plist",
             sources: "AppExtension/**",
             dependencies: [

--- a/fixtures/app_with_framework_and_tests/Project.swift
+++ b/fixtures/app_with_framework_and_tests/Project.swift
@@ -12,6 +12,7 @@ let project = Project(
             sources: "App/**",
             dependencies: [
                 .target(name: "Framework"),
+                .target(name: "AppExtension"),
             ]
         ),
         .target(
@@ -23,6 +24,17 @@ let project = Project(
             sources: "AppTests/**",
             dependencies: [
                 .target(name: "App"),
+            ]
+        ),
+        .target(
+            name: "AppExtension",
+            destinations: .iOS,
+            product: .appExtension,
+            bundleId: "io.tuist.extension",
+            infoPlist: "AppExtension/Info.plist",
+            sources: "AppExtension/**",
+            dependencies: [
+                .target(name: "Framework"),
             ]
         ),
         .target(


### PR DESCRIPTION
### Short description 📝
[This PR](https://github.com/tuist/tuist/pull/6604) introduced a regression that caused dynamic frameworks to get embedded in an app extension. 

I'm not entirely sure about this, but dynamic frameworks app extensions depend on should get copied into the app containing the extension. This PR fixes it by differentiating between a target that "can embed binaries" and a target that "can embed bundles", and using the right one based the graph traverse function.

### How to test the changes locally 🧐
1. Run `tuist run tuist generate --path fixtures/app_with_framework_and_tests`
2. The target `AppExtension` in the generated project should link `Framework` without copying it. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
