### PR TITLE
Clarify usage of Tuist Previews

### DIFF
--- a/Sources/TuistKit/Services/Organization/OrganizationListService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationListService.swift
@@ -50,7 +50,7 @@ final class OrganizationListService: OrganizationListServicing {
         }
 
         if organizations.isEmpty {
-            logger.info("You currently have no Cloud organizations. Create one by running `tuist organization create`.")
+            logger.info("You currently have no Tuist organizations. Create one by running `tuist organization create`.")
             return
         }
 

--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -22,13 +22,13 @@ enum ShareServiceError: Equatable, FatalError {
         case let .noAppsFound(app: app, configuration: configuration):
             return "\(app) for the \(configuration) configuration was not found. You can build it by running `tuist build \(app)`"
         case .appNotSpecified:
-            return "If you're not using Tuist projects, you must specify the app name when sharing an app, such as `tuist share App --platforms ios`."
+            return "If you're not using Tuist projects, you must specify the app name when sharing an app, such as `tuist share App --platforms iOS`."
         case .platformsNotSpecified:
-            return "If you're not using Tuist projects, you must specify the platforms when sharing an app, such as `tuist share App --platforms ios`."
+            return "If you're not using Tuist projects, you must specify the platforms when sharing an app, such as `tuist share App --platforms iOS`."
         case let .multipleAppsSpecified(apps):
             return "You specified multiple apps to share: \(apps.joined(separator: " ")). You cannot specify multiple apps when using `tuist share`."
         case .fullHandleNotFound:
-            return "You are missing full handle in your Config.swift."
+            return "You are missing full handle for your Tuist Project in the Config.swift file. If you don't have a Tuist Project, yet, follow the steps in our documentation: https://docs.tuist.io/guides/quick-start/gather-insights"
         }
     }
 

--- a/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
@@ -66,7 +66,7 @@ final class OrganizationListServiceTests: TuistUnitTestCase {
 
         // Then
         XCTAssertPrinterOutputContains(
-            "You currently have no Cloud organizations. Create one by running `tuist organization create`."
+            "You currently have no Tuist organizations. Create one by running `tuist organization create`."
         )
     }
 }

--- a/docs/docs/guides/develop/build/cache.md
+++ b/docs/docs/guides/develop/build/cache.md
@@ -6,7 +6,7 @@ description: Optimize your build times by caching compiled binaries and sharing 
 # Cache
 
 > [!IMPORTANT] REQUIRES AN ACCOUNT
-> You need to be authenticated and have and [a project set up](/guides/quick-start/gather-insights) to persist and share the cache across environments.
+> You need to be authenticated and have [a project set up](/guides/quick-start/gather-insights) to persist and share the cache across environments.
 
 Xcode's build system provides [incremental builds](https://en.wikipedia.org/wiki/Incremental_build_model), enhancing efficiency under normal circumstances. However, this feature falls short in [Continuous Integration (CI) environments](https://en.wikipedia.org/wiki/Continuous_integration), where data essential for incremental builds is not shared across different builds. Additionally, **developers often reset this data locally to troubleshoot complex compilation problems**, leading to more frequent clean builds. This results in teams spending excessive time waiting for local builds to finish or for Continuous Integration pipelines to provide feedback on pull requests. Furthermore, the frequent context switching in such an environment compounds this unproductiveness.
 

--- a/docs/docs/guides/quick-start/gather-insights.md
+++ b/docs/docs/guides/quick-start/gather-insights.md
@@ -13,17 +13,39 @@ First of all, you'll need to authenticate by running:
 tuist auth
 ```
 
+## Create an organization (optional)
+
+Unless you work on a personal project, you will need to create a Tuist organization, so that all your teammates get access to the new Tuist project. Run the following to create one:
+```bash
+tuist organization create MyOrganization
+```
+
+You will then need to invite your teammates:
+```bash
+tuist organization invite MyOrganization teammate1@org.com
+tuist organization invite MyOrganization teammate2@org.com
+```
+
+Alternatively, you can use Google single sign-on (SSO):
+```bash
+tuist organization update --provider google --organization-id org.com
+```
+
+That way, anyone in your Google organization automatically gets access to projects created in your Tuist organization.
+
 ## Create a project
 
 You can then create a project by running:
 
 ```bash
-tuist project create my-handle/MyApp
+tuist project create MyOrganization/MyApp
 
-# Tuist project my-handle/MyApp was successfully created 🎉
+# Tuist project MyOrganization/MyApp was successfully created 🎉
 ```
 
-Copy `my-handle/MyApp`, which represents the full handle of the project.
+If you are creating a personal project, replace `MyOrganization` with your personal handle.
+
+Copy `MyOrganization/MyApp`, which represents the full handle of the project.
 
 ## Connect projects
 

--- a/docs/docs/guides/quick-start/gather-insights.md
+++ b/docs/docs/guides/quick-start/gather-insights.md
@@ -26,13 +26,6 @@ tuist organization invite MyOrganization teammate1@org.com
 tuist organization invite MyOrganization teammate2@org.com
 ```
 
-Alternatively, you can use Google single sign-on (SSO):
-```bash
-tuist organization update --provider google --organization-id org.com
-```
-
-That way, anyone in your Google organization automatically gets access to projects created in your Tuist organization.
-
 ## Create a project
 
 You can then create a project by running:
@@ -54,7 +47,7 @@ After creating the project on the server, you'll have to connect it to your loca
 ```swift
 import ProjectDescription
 
-let config = Config(fullHandle: "my-handle/MyApp")
+let config = Config(fullHandle: "MyOrganization/MyApp")
 ```
 
 Voilà! You're now ready to gather insights about your project and builds. Run `tuist test` to run the tests reporting the results to the server.

--- a/docs/docs/guides/share/previews.md
+++ b/docs/docs/guides/share/previews.md
@@ -5,6 +5,8 @@ description: Learn how to generate and share previews of your apps with anyone.
 
 # Previews
 
+> [!IMPORTANT] REQUIRES AN ACCOUNT
+> You need to be authenticated and have [a project set up](/guides/quick-start/gather-insights) to share Tuist Previews. Additionally, when sharing with others, the project must be within an organization, and the recipient must be a member of that organization.
 
 When building an app, you may want to share it with others to get feedback.
 Traditionally, this is something that teams do by building, signing, and pushing their apps to platforms like Apple's [TestFlight](https://developer.apple.com/testflight/).
@@ -22,15 +24,15 @@ tuist share App
 ```
 ```bash [Xcode Project]
 xcodebuild -scheme App -project App.xcodeproj -configuration Debug
-tuist share App --configuration Debug --platform iOS
+tuist share App --configuration Debug --platforms iOS
 ```
 :::
 
-The command will generate a link that you can share with anyone to run the app. All they'll need to do is to run the command below:
+The command will generate a link that you can share with any member of your Tuist organization to run the app. All they'll need to do is to run the command below:
 
 ```bash
 tuist run {url}
 ```
 
 > [!IMPORTANT] PREVIEWS' VISIBILITY
-> Only people with access to the organization the project belongs to can access the previews. We plan to add support for expiring links.
+> Only people with access to the project belongs to can access the previews. We plan to add support for expiring links.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6657

### Short description 📝

Addresses feedback from the attached issue to make usage of Tuist Previews clearer:
- Fixes typo in `--platforms` option in docs
- Improves error message when running `tuist share` when the `fullHandle` in the `Config.swift` is missing
- Adds documentation for how to create a Tuist organization

### How to test the changes locally 🧐

Check out docs, CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
