### PR TITLE
ci: fix Tuist App should-release logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           echo "${changelog_content}"
   
           # Compare the outputs and set the result
-          if [ "${bumped_output}" = "${changelog_content}" ]; then
+          if [ "${bumped_output}" != "${changelog_content}" ]; then
             echo "should-release=true" >> $GITHUB_ENV
           else
             echo "should-release=false" >> $GITHUB_ENV


### PR DESCRIPTION
### Short description 📝

The Tuist App was not released in the latest commit as the workflow logic is incorrect.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
