### PR TITLE
Detect and warn about outdated dependencies

### DIFF
--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -75,5 +75,18 @@ final class InstallService {
 
             try swiftPackageManagerController.resolve(at: packageManifestPath.parentDirectory, printOutput: true)
         }
+
+        try savePackageResolved(at: packageManifestPath.parentDirectory)
+    }
+
+    private func savePackageResolved(at path: AbsolutePath) throws {
+        let sourcePath = path.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        let destinationPath = path.appending(components: [
+            Constants.SwiftPackageManager.packageBuildDirectoryName,
+            Constants.DerivedDirectory.name,
+            Constants.SwiftPackageManager.packageResolvedName,
+        ])
+        try fileHandler.createFolder(destinationPath.parentDirectory)
+        try fileHandler.replace(destinationPath, with: sourcePath)
     }
 }

--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -81,6 +81,8 @@ final class InstallService {
 
     private func savePackageResolved(at path: AbsolutePath) throws {
         let sourcePath = path.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        guard fileHandler.exists(sourcePath) else { return }
+
         let destinationPath = path.appending(components: [
             Constants.SwiftPackageManager.packageBuildDirectoryName,
             Constants.DerivedDirectory.name,

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -180,7 +180,7 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         let currentData = try? fileHandler.readFile(currentPackageResolvedPath)
 
         if currentData != savedData {
-            logger.warning("We found outdated dependencies. Run `tuist install` to resolve.")
+            logger.warning("We detected outdated dependencies. Please run \"tuist install\" to update them.")
         }
     }
 }

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -91,7 +91,7 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         let workspaceState = try JSONDecoder()
             .decode(SwiftPackageManagerWorkspaceState.self, from: try fileHandler.readFile(workspacePath))
 
-        validatePackageResolved(at: packagePath.parentDirectory)
+        try validatePackageResolved(at: packagePath.parentDirectory)
 
         let packageInfos: [
             // swiftlint:disable:next large_tuple
@@ -168,16 +168,26 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         )
     }
 
-    private func validatePackageResolved(at path: AbsolutePath) {
+    private func validatePackageResolved(at path: AbsolutePath) throws {
         let savedPackageResolvedPath = path.appending(components: [
             Constants.SwiftPackageManager.packageBuildDirectoryName,
             Constants.DerivedDirectory.name,
             Constants.SwiftPackageManager.packageResolvedName,
         ])
-        let savedData = try? fileHandler.readFile(savedPackageResolvedPath)
+        let savedData: Data?
+        if fileHandler.exists(savedPackageResolvedPath) {
+            savedData = try fileHandler.readFile(savedPackageResolvedPath)
+        } else {
+            savedData = nil
+        }
 
         let currentPackageResolvedPath = path.appending(component: Constants.SwiftPackageManager.packageResolvedName)
-        let currentData = try? fileHandler.readFile(currentPackageResolvedPath)
+        let currentData: Data?
+        if fileHandler.exists(currentPackageResolvedPath) {
+            currentData = try fileHandler.readFile(currentPackageResolvedPath)
+        } else {
+            currentData = nil
+        }
 
         if currentData != savedData {
             logger.warning("We detected outdated dependencies. Please run \"tuist install\" to update them.")

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -91,6 +91,8 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         let workspaceState = try JSONDecoder()
             .decode(SwiftPackageManagerWorkspaceState.self, from: try fileHandler.readFile(workspacePath))
 
+        validatePackageResolved(at: packagePath.parentDirectory)
+
         let packageInfos: [
             // swiftlint:disable:next large_tuple
             (
@@ -164,6 +166,22 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
             externalDependencies: externalDependencies,
             externalProjects: externalProjects
         )
+    }
+
+    private func validatePackageResolved(at path: AbsolutePath) {
+        let savedPackageResolvedPath = path.appending(components: [
+            Constants.SwiftPackageManager.packageBuildDirectoryName,
+            Constants.DerivedDirectory.name,
+            Constants.SwiftPackageManager.packageResolvedName,
+        ])
+        let savedData = try? fileHandler.readFile(savedPackageResolvedPath)
+
+        let currentPackageResolvedPath = path.appending(component: Constants.SwiftPackageManager.packageResolvedName)
+        let currentData = try? fileHandler.readFile(currentPackageResolvedPath)
+
+        if currentData != savedData {
+            logger.warning("We found outdated dependencies. Run `tuist install` to resolve.")
+        }
     }
 }
 

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -78,6 +78,22 @@ extension XCTestCase {
         XCTAssertTrue(standardOutput.contains(pattern), message, file: file, line: line)
     }
 
+    public func XCTAssertStandardOutputNotContains(_ pattern: String, file: StaticString = #file, line: UInt = #line) {
+        let standardOutput = TestingLogHandler.collected[.info, <=]
+
+        let message = """
+        The standard output:
+        ===========
+        \(standardOutput)
+
+        Contains the not expected:
+        ===========
+        \(pattern)
+        """
+
+        XCTAssertFalse(standardOutput.contains(pattern), message, file: file, line: line)
+    }
+
     public func XCTAssertStandardError(pattern: String, file: StaticString = #file, line: UInt = #line) {
         let standardError = TestingLogHandler.collected[.error, ==]
 

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -50,10 +50,10 @@ final class DependenciesAcceptanceTestIosAppWithSPMDependenciesWithOutdatedDepen
         let packageResolvedContents = try FileHandler.shared.readTextFile(packageResolvedPath)
         try FileHandler.shared.write(packageResolvedContents + " ", path: packageResolvedPath, atomically: true)
         try await run(GenerateCommand.self)
-        XCTAssertStandardOutput(pattern: "We found outdated dependencies. Run `tuist install` to resolve.")
+        XCTAssertStandardOutput(pattern: "We detected outdated dependencies. Please run \"tuist install\" to update them.")
         TestingLogHandler.reset()
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
-        XCTAssertStandardOutputNotContains("We found outdated dependencies. Run `tuist install` to resolve.")
+        XCTAssertStandardOutputNotContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
     }
 }

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -41,3 +41,19 @@ final class DependenciesAcceptanceTestIosAppWithSPMDependencies: TuistAcceptance
         try await run(TestCommand.self, "App")
     }
 }
+
+final class DependenciesAcceptanceTestIosAppWithSPMDependenciesWithOutdatedDependencies: TuistAcceptanceTestCase {
+    func test() async throws {
+        try await setUpFixture(.iosAppWithSpmDependencies)
+        try await run(InstallCommand.self)
+        let packageResolvedPath = fixturePath.appending(components: ["Tuist", "Package.resolved"])
+        let packageResolvedContents = try FileHandler.shared.readTextFile(packageResolvedPath)
+        try FileHandler.shared.write(packageResolvedContents + " ", path: packageResolvedPath, atomically: true)
+        try await run(GenerateCommand.self)
+        XCTAssertStandardOutput(pattern: "We found outdated dependencies. Run `tuist install` to resolve.")
+        TestingLogHandler.reset()
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        XCTAssertStandardOutputNotContains("We found outdated dependencies. Run `tuist install` to resolve.")
+    }
+}

--- a/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -193,7 +193,12 @@ final class InstallServiceTests: TuistUnitTestCase {
             update: false
         )
 
-        let savedPackageResolvedPath = temporaryDirectory.appending(components: ["Tuist", ".build", "Derived", "Package.resolved"])
+        let savedPackageResolvedPath = temporaryDirectory.appending(components: [
+            "Tuist",
+            ".build",
+            "Derived",
+            "Package.resolved",
+        ])
         let savedPackageResolvedContents = try fileHandler.readTextFile(savedPackageResolvedPath)
 
         // Then

--- a/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -51,6 +51,7 @@ final class InstallServiceTests: TuistUnitTestCase {
     func test_run_when_updating_dependencies() async throws {
         // Given
         let stubbedPath = try temporaryPath()
+        let expectedPackageResolvedPath = stubbedPath.appending(components: ["Tuist", "Package.resolved"])
 
         given(manifestFilesLocator)
             .locatePackageManifest(at: .any)
@@ -73,15 +74,23 @@ final class InstallServiceTests: TuistUnitTestCase {
             )
         )
 
+        // Package.resolved
+        try fileHandler.touch(expectedPackageResolvedPath)
+        try fileHandler.write("resolved", path: expectedPackageResolvedPath, atomically: true)
+
         // When
         try await subject.run(
             path: stubbedPath.pathString,
             update: true
         )
 
+        let savedPackageResolvedPath = stubbedPath.appending(components: ["Tuist", ".build", "Derived", "Package.resolved"])
+        let savedPackageResolvedContents = try fileHandler.readTextFile(savedPackageResolvedPath)
+
         // Then
         XCTAssertTrue(swiftPackageManagerController.invokedUpdate)
         XCTAssertFalse(swiftPackageManagerController.invokedResolve)
+        XCTAssertEqual(savedPackageResolvedContents, "resolved")
     }
 
     func test_run_when_installing_plugins() async throws {
@@ -116,6 +125,7 @@ final class InstallServiceTests: TuistUnitTestCase {
     func test_run_when_installing_dependencies() async throws {
         // Given
         let stubbedPath = try temporaryPath()
+        let expectedPackageResolvedPath = stubbedPath.appending(components: ["Tuist", "Package.resolved"])
 
         given(manifestFilesLocator)
             .locatePackageManifest(at: .any)
@@ -136,15 +146,23 @@ final class InstallServiceTests: TuistUnitTestCase {
             )
         )
 
+        // Package.resolved
+        try fileHandler.touch(expectedPackageResolvedPath)
+        try fileHandler.write("resolved", path: expectedPackageResolvedPath, atomically: true)
+
         // When
         try await subject.run(
             path: stubbedPath.pathString,
             update: false
         )
 
+        let savedPackageResolvedPath = stubbedPath.appending(components: ["Tuist", ".build", "Derived", "Package.resolved"])
+        let savedPackageResolvedContents = try fileHandler.readTextFile(savedPackageResolvedPath)
+
         // Then
         XCTAssertTrue(swiftPackageManagerController.invokedResolve)
         XCTAssertFalse(swiftPackageManagerController.invokedUpdate)
+        XCTAssertEqual(savedPackageResolvedContents, "resolved")
     }
 
     func test_install_when_from_a_tuist_project_directory() async throws {
@@ -153,6 +171,8 @@ final class InstallServiceTests: TuistUnitTestCase {
         let expectedFoundPackageLocation = temporaryDirectory.appending(
             components: Constants.tuistDirectoryName, Manifest.package.fileName(temporaryDirectory)
         )
+        let expectedPackageResolvedPath = temporaryDirectory.appending(components: ["Tuist", "Package.resolved"])
+
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.default)
@@ -163,10 +183,20 @@ final class InstallServiceTests: TuistUnitTestCase {
         // Dependencies.swift in root
         try fileHandler.touch(expectedFoundPackageLocation)
 
+        // Package.resolved
+        try fileHandler.touch(expectedPackageResolvedPath)
+        try fileHandler.write("resolved", path: expectedPackageResolvedPath, atomically: true)
+
         // When - This will cause the `loadDependenciesStub` closure to be called and assert if needed
         try await subject.run(
             path: temporaryDirectory.pathString,
             update: false
         )
+
+        let savedPackageResolvedPath = temporaryDirectory.appending(components: ["Tuist", ".build", "Derived", "Package.resolved"])
+        let savedPackageResolvedContents = try fileHandler.readTextFile(savedPackageResolvedPath)
+
+        // Then
+        XCTAssertEqual(savedPackageResolvedContents, "resolved")
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -1,16 +1,16 @@
 import MockableTest
 import TuistCore
 import TuistSupport
+import TuistSupportTesting
 import XCTest
 
 @testable import TuistLoader
-@testable import TuistSupportTesting
 
 final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
-    var swiftPackageManagerController: MockSwiftPackageManagerController!
-    var packageInfoMapper: MockPackageInfoMapping!
-    var manifestLoader: MockManifestLoading!
-    var subject: SwiftPackageManagerGraphLoader!
+    private var swiftPackageManagerController: MockSwiftPackageManagerController!
+    private var packageInfoMapper: MockPackageInfoMapping!
+    private var manifestLoader: MockManifestLoading!
+    private var subject: SwiftPackageManagerGraphLoader!
 
     override func setUp() {
         super.setUp()
@@ -90,7 +90,11 @@ final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
             atomically: true
         )
 
-        try fileHandler.touch(temporaryPath.appending(components: [".build", "Derived", "Package.resolved"]))
+        let savedPackageResolvedPath = temporaryPath.appending(components: [".build", "Derived", "Package.resolved"])
+        let currentPackageResolvedPath = temporaryPath.appending(component: "Package.resolved")
+        try fileHandler.touch(savedPackageResolvedPath)
+        try fileHandler.write("outdated", path: savedPackageResolvedPath, atomically: true)
+        try fileHandler.touch(currentPackageResolvedPath)
 
         given(packageInfoMapper)
             .resolveExternalDependencies(packageInfos: .any, packageToFolder: .any, packageToTargetsToArtifactPaths: .any)

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -1,0 +1,108 @@
+import MockableTest
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistSupportTesting
+
+final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
+    var swiftPackageManagerController: MockSwiftPackageManagerController!
+    var packageInfoMapper: MockPackageInfoMapping!
+    var manifestLoader: MockManifestLoading!
+    var subject: SwiftPackageManagerGraphLoader!
+
+    override func setUp() {
+        super.setUp()
+        swiftPackageManagerController = MockSwiftPackageManagerController()
+        packageInfoMapper = MockPackageInfoMapping()
+        manifestLoader = MockManifestLoading()
+        subject = SwiftPackageManagerGraphLoader(
+            swiftPackageManagerController: swiftPackageManagerController,
+            packageInfoMapper: packageInfoMapper,
+            manifestLoader: manifestLoader,
+            fileHandler: FileHandler.shared
+        )
+    }
+
+    override func tearDown() {
+        subject = nil
+        manifestLoader = nil
+        packageInfoMapper = nil
+        swiftPackageManagerController = nil
+        super.tearDown()
+    }
+
+    func test_load() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let packageSettings = PackageSettings.test()
+
+        let workspacePath = temporaryPath.appending(components: [".build", "workspace-state.json"])
+        try fileHandler.createFolder(workspacePath.parentDirectory)
+        try fileHandler.write(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : []
+              }
+            }
+            """,
+            path: workspacePath,
+            atomically: true
+        )
+
+        try fileHandler.touch(temporaryPath.appending(components: [".build", "Derived", "Package.resolved"]))
+        try fileHandler.touch(temporaryPath.appending(component: "Package.resolved"))
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(packageInfos: .any, packageToFolder: .any, packageToTargetsToArtifactPaths: .any)
+            .willReturn([:])
+
+        // When
+        let _ = try await subject.load(
+            packagePath: temporaryPath.appending(component: "Package.swift"),
+            packageSettings: packageSettings
+        )
+
+        // Then
+        XCTAssertPrinterOutputNotContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
+    }
+
+    func test_load_warnOutdatedDependencies() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let packageSettings = PackageSettings.test()
+
+        let workspacePath = temporaryPath.appending(components: [".build", "workspace-state.json"])
+        try fileHandler.createFolder(workspacePath.parentDirectory)
+        try fileHandler.write(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : []
+              }
+            }
+            """,
+            path: workspacePath,
+            atomically: true
+        )
+
+        try fileHandler.touch(temporaryPath.appending(components: [".build", "Derived", "Package.resolved"]))
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(packageInfos: .any, packageToFolder: .any, packageToTargetsToArtifactPaths: .any)
+            .willReturn([:])
+
+        // When
+        let _ = try await subject.load(
+            packagePath: temporaryPath.appending(component: "Package.swift"),
+            packageSettings: packageSettings
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
+    }
+}


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6588>

### Short description 📝

This detects when SPM dependencies are outdated and should be installed with `tuist install`.

### How to test the changes locally 🧐

1. Add launch arg `generate --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"` to `tuist` scheme and run from Xcode

Expected:

```
Loading and constructing the graph
It might take a while if the cache is empty
We could not find external dependencies. Run `tuist install` before you continue.
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

2. Add launch arg `install --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"` to `tuist` scheme and run from Xcode
3. Re-run `generate --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"`

Expected:

```
Loading and constructing the graph
It might take a while if the cache is empty
Generating workspace App.xcworkspace
Generating project App
Generating project Mobile Buy SDK
Generating project swift-certificates
Generating project KSCrash
Generating project swift-asn1
Generating project BigInt
Generating project jwt-kit
Generating project swift-crypto
Project generated.
Total time taken: 2.631s
```

4. Modify `fixtures/ios_app_with_spm_dependencies/Tuist/.build/Derived/Package.resolved` (can just add a space at the end)
5. Re-run `generate --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"`

Expected:

```
Loading and constructing the graph
It might take a while if the cache is empty
Generating workspace App.xcworkspace
Generating project BigInt
Generating project KSCrash
Generating project App
Generating project swift-certificates
Generating project Mobile Buy SDK
Generating project swift-asn1
Generating project swift-crypto
Generating project jwt-kit
Project generated.
Total time taken: 0.848s

The following warnings need attention:
 · We found outdated dependencies. Run `tuist install` to resolve.
```

6. Re-run `install --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"`
7. Re-run `generate --path "$(SRCROOT)/fixtures/ios_app_with_spm_dependencies"`

Expected:

```
Loading and constructing the graph
It might take a while if the cache is empty
Generating workspace App.xcworkspace
Generating project App
Generating project Mobile Buy SDK
Generating project swift-certificates
Generating project KSCrash
Generating project swift-asn1
Generating project BigInt
Generating project jwt-kit
Generating project swift-crypto
Project generated.
Total time taken: 2.631s
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
