### PR TITLE
Fix lint not being triggered on PRs

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -22,13 +22,6 @@ workflows:
         - pattern: '*'
           include: true
       cancel_previous_builds: true
-    triggering: &main_triggering
-      events:
-        - push
-      branch_patterns:
-        - pattern: 'main'
-          include: true
-      cancel_previous_builds: true
   spm_build:
     name: SPM Build
     max_build_duration: 60
@@ -117,8 +110,13 @@ workflows:
         script: mise x -- tuist cache --print-hashes
       - name: Cache
         script: mise x -- tuist cache
-    triggering:
-      << : *main_triggering
+    triggering: &main_triggering
+      events:
+        - push
+      branch_patterns:
+        - pattern: 'main'
+          include: true
+      cancel_previous_builds: true
 
   deploy_docs:
     name: Deploy Documentation


### PR DESCRIPTION
### Short description 📝

The `Lint` job is not run on PRs as it was mistakenly overwritten with `main_triggering` configuration.

### How to test the changes locally 🧐

CI should run the `Lint` job.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x]  In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
