### PR TITLE
Adjust ResourcesContentHasher to return a MerkleTree

### DIFF
--- a/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -22,6 +22,10 @@ public final class ContentHasher: ContentHashing {
             .compactMap { String(format: "%02x", $0) }.joined()
     }
 
+    public func hash(_ boolean: Bool) throws -> String {
+        return try hash(boolean ? "1" : "0")
+    }
+
     public func hash(_ string: String) throws -> String {
         guard let data = string.data(using: .utf8) else {
             throw ContentHashingError.stringHashingFailed(string)

--- a/Sources/TuistCore/ContentHashing/ContentHashing.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHashing.swift
@@ -6,6 +6,7 @@ import Path
 public protocol ContentHashing: FileContentHashing {
     func hash(_ data: Data) throws -> String
     func hash(_ string: String) throws -> String
+    func hash(_ boolean: Bool) throws -> String
     func hash(_ strings: [String]) throws -> String
     func hash(_ dictionary: [String: String]) throws -> String
     func hash(path filePath: AbsolutePath) throws -> String

--- a/Sources/TuistHasher/CachedContentHasher.swift
+++ b/Sources/TuistHasher/CachedContentHasher.swift
@@ -22,6 +22,10 @@ public final class CachedContentHasher: ContentHashing {
         try contentHasher.hash(string)
     }
 
+    public func hash(_ boolean: Bool) throws -> String {
+        try contentHasher.hash(boolean)
+    }
+
     public func hash(_ strings: [String]) throws -> String {
         try contentHasher.hash(strings)
     }

--- a/Sources/TuistHasher/MerkleNode.swift
+++ b/Sources/TuistHasher/MerkleNode.swift
@@ -18,4 +18,10 @@ public struct MerkleNode: Codable, Equatable, Hashable {
 
     /// Node children.
     public var children: [MerkleNode]
+
+    public init(hash: String, identifier: String, children: [MerkleNode] = []) {
+        self.hash = hash
+        self.identifier = identifier
+        self.children = children
+    }
 }

--- a/Sources/TuistHasher/ResourcesContentHasher.swift
+++ b/Sources/TuistHasher/ResourcesContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import XcodeGraph
 
 public protocol ResourcesContentHashing {
-    func hash(resources: ResourceFileElements) throws -> String
+    func hash(identifier: String, resources: ResourceFileElements) throws -> MerkleNode
 }
 
 /// `ResourcesContentHasher`
@@ -11,35 +11,71 @@ public protocol ResourcesContentHashing {
 public final class ResourcesContentHasher: ResourcesContentHashing {
     private let contentHasher: ContentHashing
     private let privacyManifestContentHasher: PrivacyManifestContentHasher
+    private let platformConditionContentHasher: PlatformConditionContentHashing
 
     // MARK: - Init
 
     public convenience init(contentHasher: ContentHashing) {
         self.init(
             contentHasher: contentHasher,
-            privacyManifestContentHasher: PrivacyManifestContentHasher(contentHasher: contentHasher)
+            privacyManifestContentHasher: PrivacyManifestContentHasher(contentHasher: contentHasher),
+            platformConditionContentHasher: PlatformConditionContentHasher(contentHasher: contentHasher)
         )
     }
 
     public init(
         contentHasher: ContentHashing,
-        privacyManifestContentHasher: PrivacyManifestContentHasher
+        privacyManifestContentHasher: PrivacyManifestContentHasher,
+        platformConditionContentHasher: PlatformConditionContentHashing
     ) {
         self.contentHasher = contentHasher
         self.privacyManifestContentHasher = privacyManifestContentHasher
+        self.platformConditionContentHasher = platformConditionContentHasher
     }
 
     // MARK: - ResourcesContentHashing
 
-    public func hash(resources: ResourceFileElements) throws -> String {
-        var hashes = try resources.resources
-            .sorted(by: { $0.path < $1.path })
-            .map { try contentHasher.hash(path: $0.path) }
+    public func hash(identifier: String, resources: ResourceFileElements) throws -> MerkleNode {
+        var children: [MerkleNode] = []
+
+        children
+            .append(
+                contentsOf: try resources.resources.sorted(by: { $0.path < $1.path })
+                    .map { try hashResourceFileElement(element: $0) }
+            )
 
         if let privacyManifest = resources.privacyManifest {
-            hashes.append(try privacyManifestContentHasher.hash(privacyManifest))
+            children.append(MerkleNode(
+                hash: try privacyManifestContentHasher.hash(privacyManifest),
+                identifier: "privacyManifest",
+                children: []
+            ))
         }
 
-        return try contentHasher.hash(hashes)
+        return MerkleNode(
+            hash: try contentHasher.hash(children.map(\.hash)),
+            identifier: identifier,
+            children: children
+        )
+    }
+
+    private func hashResourceFileElement(element: ResourceFileElement) throws -> MerkleNode {
+        var children: [MerkleNode] = []
+
+        children.append(MerkleNode(hash: try contentHasher.hash(path: element.path), identifier: "content"))
+        children.append(MerkleNode(hash: try contentHasher.hash(element.isReference), identifier: "isReference"))
+        children.append(MerkleNode(hash: try contentHasher.hash(element.tags), identifier: "tags"))
+        if let inclusionCondition = element.inclusionCondition {
+            children.append(try platformConditionContentHasher.hash(
+                identifier: "inclusionCondition",
+                platformCondition: inclusionCondition
+            ))
+        }
+
+        return MerkleNode(
+            hash: try contentHasher.hash(path: element.path),
+            identifier: element.path.pathString,
+            children: []
+        )
     }
 }

--- a/Sources/TuistHasher/ResourcesContentHasher.swift
+++ b/Sources/TuistHasher/ResourcesContentHasher.swift
@@ -45,10 +45,9 @@ public final class ResourcesContentHasher: ResourcesContentHashing {
             )
 
         if let privacyManifest = resources.privacyManifest {
-            children.append(MerkleNode(
-                hash: try privacyManifestContentHasher.hash(privacyManifest),
+            children.append(try privacyManifestContentHasher.hash(
                 identifier: "privacyManifest",
-                children: []
+                privacyManifest: privacyManifest
             ))
         }
 

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -84,7 +84,7 @@ public final class TargetContentHasher: TargetContentHashing {
         additionalStrings: [String] = []
     ) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash
-        let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)
+        let resourcesHash = try resourcesContentHasher.hash(identifier: "resources", resources: graphTarget.target.resources).hash
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
         let targetScriptsHash = try targetScriptsContentHasher.hash(

--- a/Tests/TuistHasherTests/PrivacyManifestContentHasherTests.swift
+++ b/Tests/TuistHasherTests/PrivacyManifestContentHasherTests.swift
@@ -32,10 +32,51 @@ final class PrivacyManifestContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 0 ... 100 {
-            results.insert(try subject.hash(privacyManifest))
+            results.insert(try subject.hash(identifier: "privacyManifest", privacyManifest: privacyManifest).hash)
         }
 
         // Then
         XCTAssertEqual(results.count, 1)
+    }
+
+    func test_hash_returnsACorrectMerkleNode() throws {
+        // Given
+        let privacyManifest = PrivacyManifest(
+            tracking: true,
+            trackingDomains: ["io.tuist"],
+            collectedDataTypes: [["test": .string("tuist")]],
+            accessedApiTypes: [["test": .string("tuist")]]
+        )
+
+        // When
+        let got = try subject.hash(identifier: "privacyManifest", privacyManifest: privacyManifest)
+
+        // Then
+        XCTAssertEqual(got, MerkleNode(
+            hash: "bdb8825693f6a3fef832665ef7b93d14",
+            identifier: "privacyManifest",
+            children: [
+                MerkleNode(
+                    hash: "c4ca4238a0b923820dcc509a6f75849b",
+                    identifier: "tracking",
+                    children: []
+                ),
+                MerkleNode(
+                    hash: "fb24174794a54483a3c3bdb2ce3dde75",
+                    identifier: "trackingDomains",
+                    children: []
+                ),
+                MerkleNode(
+                    hash: "18f8dcf557f61dc3c1cd766f1245c130",
+                    identifier: "collectedDataTypes",
+                    children: []
+                ),
+                MerkleNode(
+                    hash: "18f8dcf557f61dc3c1cd766f1245c130",
+                    identifier: "accessedApiTypes",
+                    children: []
+                ),
+            ]
+        ))
     }
 }

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -81,18 +81,72 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got, MerkleNode(
-            hash: "93fdd9b5838add3a2b695d6d07389ca6",
+            hash: "a1e41502d881675442e20a7a0ce58245",
             identifier: "resources",
             children: [
                 MerkleNode(
-                    hash: "c4ca4238a0b923820dcc509a6f75849b",
+                    hash: "069310d0d484da1c8bcc98386a1f36e7",
                     identifier: resource1.pathString,
-                    children: []
+                    children: [
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "content",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "cfcd208495d565ef66e7dff9f98764da",
+                            identifier: "isReference",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "e9bae3ce1d7ac00b0b1aa2fbddc50cfb",
+                            identifier: "tags",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "4ed91b7e02b960dc31256de17f3f131f",
+                            identifier: "inclusionCondition",
+                            children: [
+                                MerkleNode(
+                                    hash: "43b9d8ea18c48c3a64c4e37338fc668f",
+                                    identifier: "macos",
+                                    children: []
+                                ),
+                            ]
+                        ),
+                    ]
                 ),
                 MerkleNode(
-                    hash: "c81e728d9d4c2f636f067f89cc14862c",
+                    hash: "09eb77e7eb4c9f21384c143fc399c5ca",
                     identifier: resource2.parentDirectory.pathString,
-                    children: []
+                    children: [
+                        MerkleNode(
+                            hash: "c81e728d9d4c2f636f067f89cc14862c",
+                            identifier: "content",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "isReference",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "f32af7d8e6b19f67a63af85e5e7b8a82",
+                            identifier: "tags",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "12ee3b51be5e4bd87bf7a4c8895cc088",
+                            identifier: "inclusionCondition",
+                            children: [
+                                MerkleNode(
+                                    hash: "9e304d4e8df1b74cfa009913198428ab",
+                                    identifier: "ios",
+                                    children: []
+                                ),
+                            ]
+                        ),
+                    ]
                 ),
                 MerkleNode(
                     hash: "bdb8825693f6a3fef832665ef7b93d14",

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -11,18 +11,14 @@ import XCTest
 
 final class ResourcesContentHasherTests: TuistUnitTestCase {
     private var subject: ResourcesContentHasher!
-    private var contentHasher: MockContentHashing!
+    private var contentHasher: ContentHasher!
     private let filePath1 = try! AbsolutePath(validating: "/file1")
     private let filePath2 = try! AbsolutePath(validating: "/file2")
 
     override func setUp() {
         super.setUp()
-        contentHasher = .init()
+        contentHasher = ContentHasher()
         subject = ResourcesContentHasher(contentHasher: contentHasher)
-
-        given(contentHasher)
-            .hash(Parameter<[String]>.any)
-            .willProduce { $0.joined(separator: ";") }
     }
 
     override func tearDown() {
@@ -31,86 +27,5 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    // MARK: - Tests
-
-    func test_hash_callsContentHasherWithTheExpectedParameter() throws {
-        // Given
-        let file1 = ResourceFileElement.file(path: filePath1)
-        let file2 = ResourceFileElement.file(path: filePath2)
-        given(contentHasher)
-            .hash(path: .value(filePath1))
-            .willReturn("1")
-        given(contentHasher)
-            .hash(path: .value(filePath2))
-            .willReturn("2")
-
-        // When
-        let hash = try subject.hash(resources: .init([file1, file2]))
-
-        // Then
-        verify(contentHasher)
-            .hash(path: .any)
-            .called(2)
-        XCTAssertEqual(hash, "1;2")
-    }
-
-    func test_hash_includesFolderReference() throws {
-        // Given
-        let file1 = ResourceFileElement.file(path: filePath1)
-        let file2 = ResourceFileElement.folderReference(path: filePath2)
-        given(contentHasher)
-            .hash(path: .value(filePath1))
-            .willReturn("1")
-        given(contentHasher)
-            .hash(path: .value(filePath2))
-            .willReturn("2")
-
-        // When
-        let hash = try subject.hash(resources: .init([file1, file2]))
-
-        // Then
-        verify(contentHasher)
-            .hash(path: .any)
-            .called(2)
-        XCTAssertEqual(hash, "1;2")
-    }
-
-    func test_hash_sortsTheResourcesBeforeCalculatingTheHash() throws {
-        // Given
-        let file1 = ResourceFileElement.file(path: filePath1)
-        let file2 = ResourceFileElement.folderReference(path: filePath2)
-        given(contentHasher)
-            .hash(path: .value(filePath1))
-            .willReturn("1")
-        given(contentHasher)
-            .hash(path: .value(filePath2))
-            .willReturn("2")
-
-        // When/Then
-        XCTAssertEqual(try subject.hash(resources: .init([file1, file2])), try subject.hash(resources: .init([file2, file1])))
-    }
-
-    func test_hash_hashesThePrivacyManifestToo() throws {
-        // Given
-        let file1 = ResourceFileElement.file(path: filePath1)
-        given(contentHasher)
-            .hash(path: .value(filePath1))
-            .willReturn("1")
-        given(contentHasher)
-            .hash(path: .value(filePath2))
-            .willReturn("2")
-        given(contentHasher)
-            .hash(Parameter<String>.any)
-            .willProduce { $0 }
-
-        let resources = ResourceFileElements([file1, file1], privacyManifest: PrivacyManifest(
-            tracking: true,
-            trackingDomains: ["io.tuist"],
-            collectedDataTypes: [["test": .string("tuist")]],
-            accessedApiTypes: [["test": .string("tuist")]]
-        ))
-
-        // When/Then
-        XCTAssertEqual(try subject.hash(resources: resources), try subject.hash(resources: resources))
-    }
+    func test_hash_returnsAValidTree() throws {}
 }

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import MockableTest
 import Path
@@ -12,8 +13,6 @@ import XCTest
 final class ResourcesContentHasherTests: TuistUnitTestCase {
     private var subject: ResourcesContentHasher!
     private var contentHasher: ContentHasher!
-    private let filePath1 = try! AbsolutePath(validating: "/file1")
-    private let filePath2 = try! AbsolutePath(validating: "/file2")
 
     override func setUp() {
         super.setUp()
@@ -27,5 +26,101 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_hash_returnsAValidTree() throws {}
+    func test_hash_is_deterministic() async throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        let fileSystem = FileSystem()
+        let resource1 = temporaryDirectory.appending(component: "1.png")
+        let resource2 = temporaryDirectory.appending(component: "referenced-folder").appending(component: "2.png")
+        try await fileSystem.makeDirectory(at: resource2.parentDirectory)
+        try await fileSystem.writeText("1", at: resource1)
+        try await fileSystem.writeText("2", at: resource2)
+        let privacyManifest = PrivacyManifest(
+            tracking: true,
+            trackingDomains: ["io.tuist"],
+            collectedDataTypes: [["test": .string("tuist")]],
+            accessedApiTypes: [["test": .string("tuist")]]
+        )
+        let resourceFileElements = ResourceFileElements([
+            .file(path: resource1, tags: ["tag1"], inclusionCondition: .when(Set([.macos]))),
+            .folderReference(path: resource2.parentDirectory, tags: ["tag2"], inclusionCondition: .when(Set([.ios]))),
+        ], privacyManifest: privacyManifest)
+        var hashes: Set<String> = Set()
+
+        // When
+        for i in 0 ..< 100 {
+            hashes.insert(try subject.hash(identifier: "resources", resources: resourceFileElements).hash)
+        }
+
+        // Then
+        XCTAssertEqual(hashes.count, 1)
+    }
+
+    func test_hash_returnsTheRightMerkleNode() async throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        let fileSystem = FileSystem()
+        let resource1 = temporaryDirectory.appending(component: "1.png")
+        let resource2 = temporaryDirectory.appending(component: "referenced-folder").appending(component: "2.png")
+        try await fileSystem.makeDirectory(at: resource2.parentDirectory)
+        try await fileSystem.writeText("1", at: resource1)
+        try await fileSystem.writeText("2", at: resource2)
+        let privacyManifest = PrivacyManifest(
+            tracking: true,
+            trackingDomains: ["io.tuist"],
+            collectedDataTypes: [["test": .string("tuist")]],
+            accessedApiTypes: [["test": .string("tuist")]]
+        )
+        let resourceFileElements = ResourceFileElements([
+            .file(path: resource1, tags: ["tag1"], inclusionCondition: .when(Set([.macos]))),
+            .folderReference(path: resource2.parentDirectory, tags: ["tag2"], inclusionCondition: .when(Set([.ios]))),
+        ], privacyManifest: privacyManifest)
+
+        // When
+        let got = try subject.hash(identifier: "resources", resources: resourceFileElements)
+
+        // Then
+        XCTAssertEqual(got, MerkleNode(
+            hash: "93fdd9b5838add3a2b695d6d07389ca6",
+            identifier: "resources",
+            children: [
+                MerkleNode(
+                    hash: "c4ca4238a0b923820dcc509a6f75849b",
+                    identifier: resource1.pathString,
+                    children: []
+                ),
+                MerkleNode(
+                    hash: "c81e728d9d4c2f636f067f89cc14862c",
+                    identifier: resource2.parentDirectory.pathString,
+                    children: []
+                ),
+                MerkleNode(
+                    hash: "bdb8825693f6a3fef832665ef7b93d14",
+                    identifier: "privacyManifest",
+                    children: [
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "tracking",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "fb24174794a54483a3c3bdb2ce3dde75",
+                            identifier: "trackingDomains",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "18f8dcf557f61dc3c1cd766f1245c130",
+                            identifier: "collectedDataTypes",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "18f8dcf557f61dc3c1cd766f1245c130",
+                            identifier: "accessedApiTypes",
+                            children: []
+                        ),
+                    ]
+                ),
+            ]
+        ))
+    }
 }


### PR DESCRIPTION
### Short description 📝
I'm adjusting `ResourcesContentHasher` to return a merkle tree instead of a hash. The final goal of this effort is to have a tree for every target in the graph and provide the tools for easy debugging of hash changes.

### How to test the changes locally 🧐
Tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
