### PR TITLE
Fix false positive when linting duplicate symbols of a macro

### DIFF
--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -120,6 +120,13 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             return []
         }
 
+        // Statically linking a macro does not present a problem so it should not be flagged
+        if case let .target(name, path) = staticProduct,
+           !graphTraverser.directSwiftMacroExecutables(path: path, name: name).isEmpty
+        {
+            return []
+        }
+
         // Common dependencies between test bundles and their hosts are automatically omitted
         // during generation - as such those shouldn't be flagged
         //


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6209>

### Short description 📝

Skips statically linked macros in the graph linter as they do not present an actual problem. I didn't do any original work in this PR, only synthesized what was discovered in https://github.com/tuist/tuist/pull/6210.

### How to test the changes locally 🧐

1. Extract [frameworks_with_macro.zip](https://github.com/user-attachments/files/16787159/frameworks_with_macro.zip)
2. Run `tuist install`
3. Add launch arg `generate --path frameworks_with_macro` to `tuist` scheme in Xcode
4. Run `tuist` scheme

Expected: no warnings

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
