### PR TITLE
Fix mapping of SPM binary zip paths when using non-default SPM integration

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -144,14 +144,14 @@ public final class PackageInfoMapper: PackageInfoMapping {
         let targetDependencyToFramework: [String: Path] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             try packageInfo.value.targets.forEach { target in
                 guard target.type == .binary else { return }
-                if let path = target.path {
-                    // local binary
+                if let path = target.path, !path.hasSuffix(".zip") {
+                    // local non .zip binary
                     result[target.name] = .path(
                         packageToFolder[packageInfo.key]!.appending(try RelativePath(validating: path))
                             .pathString
                     )
                 }
-                // remote binaries are checked out by SPM in artifacts/<Package.name>/<Target>.xcframework
+                // remote or .zip binaries are checked out by SPM in artifacts/<Package.name>/<Target>.xcframework
                 // or in artifacts/<Package.identity>/<Target>.xcframework when using SPM 5.6 and later
                 else if let artifactPath = packageToTargetsToArtifactPaths[packageInfo.key]?[target.name] {
                     result[target.name] = .path(artifactPath.pathString)

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -69,7 +69,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func testResolveDependencies_whenProductContainsBinaryTargetWithPathToXcframework_mapsToXcframework() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_1")))
@@ -105,7 +105,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func testResolveDependencies_whenProductContainsBinaryTargetWithPathToZip_mapsToXcframework() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_1")))


### PR DESCRIPTION
Resolves #6665

### Short description 📝

> This pull request fixes an issue when using the Xcodeproj-based SPM integration to load an SPM package with binary targets pointed to a .zip file via a local path. Prior to this change, Tuist's graph generation would fail in this case because the Swift package target was treated as pointing directly to an .xcframework, rather than being mapped to the unzipped framework in `.build/artifacts/...` as would be the case for a URL-based binary target.

### How to test the changes locally 🧐

I've modified one test case and added two new test cases for the `resolveExternalDependencies` function, to validate the detailed use cases being supported here. Additionally, even though the `.map` function was not modified, I similarly added a second test case for that function to cover the distinct cases of paths ending in both .xcframework and .zip. Throughout these added/edited test cases, I adjust the path values being passed in and/or expected, so that they resemble the actual inputs and outputs that would be produced by SPM as closely as possible. 

These changes can also be built and tested against the example repo linked in #6665 to show that it works correctly in a real use case. Please let me know if any other type of automated testing is needed!

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
