### PR TITLE
Fix warning about using static frameworks inside XPC

### DIFF
--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -231,7 +231,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             // ExtensionKit extensions can safely link the same static products as apps
             // as they are an independent product
             return false
-        case (.app, .app), (.app, .commandLineTool):
+        case (.app, .app), (.app, .commandLineTool), (.app, .xpc):
             // macOS application target can embed other helper applications, those helper applications
             // can safely link the same static products as they are independent products
             return false

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1081,6 +1081,37 @@ class StaticProductsGraphLinterTests: XCTestCase {
         ])
     }
 
+    func test_lint_whenNoStaticProductLinkedTwice_xpc() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.test(name: "App")
+        let xpc = Target.test(name: "XPC", product: .xpc)
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let project = Project.test(targets: [app, xpc, staticFramework])
+
+        let appDependency = GraphDependency.target(name: app.name, path: path)
+        let xpcDependency = GraphDependency.target(name: xpc.name, path: path)
+        let staticFrameworkDependency = GraphDependency.target(name: staticFramework.name, path: path)
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            appDependency: Set([xpcDependency, staticFrameworkDependency]),
+            xpcDependency: Set([staticFrameworkDependency]),
+            staticFrameworkDependency: Set([]),
+        ]
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: dependencies
+        )
+        let config = Config.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
     func test_lint_whenStaticProductLinkedTwice_and_productExcluded() throws {
         // Given
         let path: AbsolutePath = "/project"


### PR DESCRIPTION
### Short description 📝

The PR allows using static frameworks inside separate binaries because a macOS app can have an XPC with their own dependencies.

Here's an example of a bundle structure: 

- App
  - XPC
    - StaticFramework
  - StaticFramework

XPC is a separate binary in the app bundle, so it can have static frameworks or libraries

### How to test the changes locally 🧐

Tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
