### PR TITLE
Add support for SPM moduleAliases

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -8,6 +8,7 @@ public enum TuistAcceptanceFixtures {
     case appWithPlugins
     case appWithPreviews
     case appWithSpmDependencies
+    case appWithSpmModuleAliases
     case appWithTestPlan
     case appWithTests
     case commandLineToolBasic
@@ -92,6 +93,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_previews"
         case .appWithSpmDependencies:
             return "app_with_spm_dependencies"
+        case .appWithSpmModuleAliases:
+            return "app_with_spm_module_aliases"
         case .appWithTestPlan:
             return "app_with_test_plan"
         case .appWithTests:

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -135,7 +135,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
                     path: $0,
                     packageType: .local,
                     packageSettings: packageSettings,
-                    packageToProject: [:]
+                    packageModuleAliases: [:]
                 )
             }
             var newDependenciesPaths = Set<AbsolutePath>()

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -930,6 +930,15 @@ final class GenerateAcceptanceTestFrameworkWithMacroAndPluginPackages: TuistAcce
     }
 }
 
+final class GenerateAcceptanceTestAppWithSPMModuleAliases: TuistAcceptanceTestCase {
+    func test_app_with_spm_module_aliases() async throws {
+        try await setUpFixture(.appWithSpmModuleAliases)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self)
+    }
+}
+
 // frameworkWithMacroAndPluginPackages
 
 extension TuistAcceptanceTestCase {

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -305,7 +305,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
             path: .any,
             packageType: .any,
             packageSettings: .any,
-            packageToProject: .any
+            packageModuleAliases: .any
         )
         .willReturn(
             .test(name: "PackageA")

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -57,7 +57,12 @@ final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
         try fileHandler.touch(temporaryPath.appending(component: "Package.resolved"))
 
         given(packageInfoMapper)
-            .resolveExternalDependencies(packageInfos: .any, packageToFolder: .any, packageToTargetsToArtifactPaths: .any)
+            .resolveExternalDependencies(
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any
+            )
             .willReturn([:])
 
         // When
@@ -97,7 +102,12 @@ final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
         try fileHandler.touch(currentPackageResolvedPath)
 
         given(packageInfoMapper)
-            .resolveExternalDependencies(packageInfos: .any, packageToFolder: .any, packageToTargetsToArtifactPaths: .any)
+            .resolveExternalDependencies(
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any
+            )
             .willReturn([:])
 
         // When

--- a/fixtures/app_with_spm_module_aliases/.gitignore
+++ b/fixtures/app_with_spm_module_aliases/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/app_with_spm_module_aliases/App/Sources/App.swift
+++ b/fixtures/app_with_spm_module_aliases/App/Sources/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/App/Sources/ContentView.swift
+++ b/fixtures/app_with_spm_module_aliases/App/Sources/ContentView.swift
@@ -1,0 +1,21 @@
+import LibraryA
+import LibraryB
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {
+        LibraryA.libraryA()
+        LibraryB.libraryB()
+    }
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/LibraryA/.gitignore
+++ b/fixtures/app_with_spm_module_aliases/LibraryA/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/fixtures/app_with_spm_module_aliases/LibraryA/Package.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryA/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LibraryA",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "LibraryA",
+            targets: ["LibraryA"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "LibraryA",
+            dependencies: [
+                .target(name: "Utilities"),
+            ]
+        ),
+        .target(
+            name: "Utilities"
+        ),
+    ]
+)

--- a/fixtures/app_with_spm_module_aliases/LibraryA/Sources/LibraryA/LibraryA.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryA/Sources/LibraryA/LibraryA.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Utilities
+
+public enum LibraryA {
+    public static func libraryA() {
+        LibraryAUtilities.doSomething()
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/LibraryA/Sources/Utilities/Utilities.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryA/Sources/Utilities/Utilities.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum LibraryAUtilities {
+    public static func doSomething() {
+        print("LibraryAUtilities did something")
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/LibraryB/.gitignore
+++ b/fixtures/app_with_spm_module_aliases/LibraryB/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/fixtures/app_with_spm_module_aliases/LibraryB/Package.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryB/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LibraryB",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "LibraryB",
+            targets: ["LibraryB"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../LibraryA"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "LibraryB",
+            dependencies: [
+                .product(name: "LibraryA", package: "LibraryA", moduleAliases: ["Utilities": "LibraryAUtilities"]),
+                .target(name: "Utilities"),
+            ]
+        ),
+        .target(
+            name: "Utilities"
+        ),
+    ]
+)

--- a/fixtures/app_with_spm_module_aliases/LibraryB/Sources/LibraryB/LibraryB.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryB/Sources/LibraryB/LibraryB.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Utilities
+
+public enum LibraryB {
+    public static func libraryB() {
+        LibraryBUtilities.doSomething()
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/LibraryB/Sources/Utilities/Utilities.swift
+++ b/fixtures/app_with_spm_module_aliases/LibraryB/Sources/Utilities/Utilities.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum LibraryBUtilities {
+    public static func doSomething() {
+        print("LibraryBUtilities did something")
+    }
+}

--- a/fixtures/app_with_spm_module_aliases/Project.swift
+++ b/fixtures/app_with_spm_module_aliases/Project.swift
@@ -1,0 +1,27 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            resources: [],
+            dependencies: [
+                .external(name: "LibraryA"),
+                .external(name: "LibraryB"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_spm_module_aliases/Tuist/Package.swift
+++ b/fixtures/app_with_spm_module_aliases/Tuist/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(path: "../LibraryA"),
+        .package(path: "../LibraryB"),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6660

### Short description 📝

This PR adds support for SPM [moduleAliases](https://developer.apple.com/documentation/packagedescription/package/dependency/modulealiases).

The changes have been inspired by the Swift Frontend changes from the original SPM proposal: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0339-module-aliasing-for-disambiguation.md#changes-to-swift-frontend

The support for `moduleAliases` works roughly as follows:
- We create an initial map of package to product module aliases by going through the `.product` dependencies (the module aliases cannot be defined elsewhere)
- Using the map, we change the target name to the aliased name. We can't make this decision during build time as SPM does, so if there are multiple conflicting `moduleAliases` for a single product, we use only one.
- When mapping target dependencies, we also add the `-module-alias InitialTargetName=AliasedTargetName` to the `OTHER_SWIFT_FLAGS`. This ensures that even though we renamed the generated target name any `import InitialTargetName` are still valid

### How to test the changes locally 🧐

- Generate the new `app_with_spm_module_aliases` and the [repro project](https://github.com/tuist/tuist/issues/6660#issuecomment-2324746393). Both should successfully build with the changes from this PR whereas they don't build with the latest Tuist version.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
