### PR TITLE
Adjust `CopyFilesContentHasher` to return a merkle tree node

### DIFF
--- a/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import XcodeGraph
 
 public protocol CopyFilesContentHashing {
-    func hash(copyFiles: [CopyFilesAction]) throws -> String
+    func hash(identifier: String, copyFiles: [CopyFilesAction]) throws -> MerkleNode
 }
 
 /// `CopyFilesContentHasher`
@@ -19,12 +19,15 @@ public final class CopyFilesContentHasher: CopyFilesContentHashing {
 
     // MARK: - CopyFilesContentHashing
 
-    public func hash(copyFiles: [CopyFilesAction]) throws -> String {
-        var stringsToHash: [String] = []
-        for action in copyFiles {
-            let fileHashes = try action.files.map { try contentHasher.hash(path: $0.path) }
-            stringsToHash.append(contentsOf: fileHashes + [action.name, action.destination.rawValue, action.subpath ?? ""])
+    public func hash(identifier: String, copyFiles: [CopyFilesAction]) throws -> MerkleNode {
+        let children = copyFiles.map { _ in
+            return MerkleNode(hash: "xxx", identifier: "uuu", children: [])
         }
-        return try contentHasher.hash(stringsToHash)
+        return MerkleNode(
+            hash: try contentHasher.hash(children),
+
+            identifier: identifier,
+            children: children
+        )
     }
 }

--- a/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -10,18 +10,55 @@ public protocol CopyFilesContentHashing {
 /// is responsible for computing a unique hash that identifies a list of CopyFilesAction models
 public final class CopyFilesContentHasher: CopyFilesContentHashing {
     private let contentHasher: ContentHashing
+    private let platformConditionContentHasher: PlatformConditionContentHashing
 
     // MARK: - Init
 
-    public init(contentHasher: ContentHashing) {
+    public init(contentHasher: ContentHashing, platformConditionContentHasher: PlatformConditionContentHashing) {
         self.contentHasher = contentHasher
+        self.platformConditionContentHasher = platformConditionContentHasher
     }
 
     // MARK: - CopyFilesContentHashing
 
     public func hash(identifier: String, copyFiles: [CopyFilesAction]) throws -> MerkleNode {
-        let children = copyFiles.map { _ in
-            return MerkleNode(hash: "xxx", identifier: "uuu", children: [])
+        let children = try copyFiles.map { action in
+            var actionChildren: [MerkleNode] = [
+                MerkleNode(hash: try contentHasher.hash(action.name), identifier: "name"),
+                MerkleNode(hash: try contentHasher.hash(action.destination.rawValue), identifier: "destination"),
+            ]
+            let actionFiles = try action.files.sorted(by: { $0.path < $1.path }).map { file in
+                var fileChildren: [MerkleNode] = [
+                    MerkleNode(hash: try contentHasher.hash(path: file.path), identifier: "content"),
+                    MerkleNode(hash: try contentHasher.hash(file.isReference), identifier: "isReference"),
+                    MerkleNode(hash: try contentHasher.hash(file.codeSignOnCopy), identifier: "codeSignOnCopy"),
+                ]
+                if let condition = file.condition {
+                    fileChildren.append(try platformConditionContentHasher.hash(
+                        identifier: "condition",
+                        platformCondition: condition
+                    ))
+                }
+                return MerkleNode(
+                    hash: try contentHasher.hash(fileChildren),
+                    identifier: file.path.pathString,
+                    children: fileChildren
+                )
+            }
+            actionChildren.append(MerkleNode(
+                hash: try contentHasher.hash(actionFiles),
+                identifier: "files",
+                children: actionFiles
+            ))
+
+            if let subpath = action.subpath {
+                actionChildren.append(MerkleNode(hash: try contentHasher.hash(subpath), identifier: "subpath"))
+            }
+            return MerkleNode(
+                hash: try contentHasher.hash(actionChildren),
+                identifier: action.name,
+                children: actionChildren
+            )
         }
         return MerkleNode(
             hash: try contentHasher.hash(children),

--- a/Sources/TuistHasher/Extensions/ContentHashing+Extras.swift
+++ b/Sources/TuistHasher/Extensions/ContentHashing+Extras.swift
@@ -1,0 +1,7 @@
+import TuistCore
+
+extension ContentHashing {
+    func hash(_ merkleNodes: [MerkleNode]) throws -> String {
+        return try hash(merkleNodes.map(\.hash))
+    }
+}

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -31,16 +31,20 @@ public final class TargetContentHasher: TargetContentHashing {
     // MARK: - Init
 
     public convenience init(contentHasher: ContentHashing) {
+        let platformConditionContentHasher = PlatformConditionContentHasher(contentHasher: contentHasher)
         self.init(
             contentHasher: contentHasher,
             sourceFilesContentHasher: SourceFilesContentHasher(
                 contentHasher: contentHasher,
-                platformConditionContentHasher: PlatformConditionContentHasher(contentHasher: contentHasher)
+                platformConditionContentHasher: platformConditionContentHasher
             ),
             targetScriptsContentHasher: TargetScriptsContentHasher(contentHasher: contentHasher),
             coreDataModelsContentHasher: CoreDataModelsContentHasher(contentHasher: contentHasher),
             resourcesContentHasher: ResourcesContentHasher(contentHasher: contentHasher),
-            copyFilesContentHasher: CopyFilesContentHasher(contentHasher: contentHasher),
+            copyFilesContentHasher: CopyFilesContentHasher(
+                contentHasher: contentHasher,
+                platformConditionContentHasher: platformConditionContentHasher
+            ),
             headersContentHasher: HeadersContentHasher(contentHasher: contentHasher),
             deploymentTargetContentHasher: DeploymentTargetsContentHasher(contentHasher: contentHasher),
             plistContentHasher: PlistContentHasher(contentHasher: contentHasher),

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -85,7 +85,7 @@ public final class TargetContentHasher: TargetContentHashing {
     ) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash
         let resourcesHash = try resourcesContentHasher.hash(identifier: "resources", resources: graphTarget.target.resources).hash
-        let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
+        let copyFilesHash = try copyFilesContentHasher.hash(identifier: "copyFiles", copyFiles: graphTarget.target.copyFiles).hash
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
         let targetScriptsHash = try targetScriptsContentHasher.hash(
             targetScripts: graphTarget.target.scripts,

--- a/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import MockableTest
 import Path
@@ -11,102 +12,141 @@ import XCTest
 
 final class CopyFilesContentHasherTests: TuistUnitTestCase {
     private var subject: CopyFilesContentHasher!
-    private var contentHasher: MockContentHashing!
-    private var temporaryDirectory: TemporaryDirectory!
 
     override func setUp() {
         super.setUp()
-        contentHasher = .init()
-        subject = CopyFilesContentHasher(contentHasher: contentHasher)
-
-        given(contentHasher)
-            .hash(Parameter<[String]>.any)
-            .willProduce { $0.joined(separator: ";") }
-
-        do {
-            temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
-        } catch {
-            XCTFail("Error while creating temporary directory")
-        }
+        let contentHasher = ContentHasher()
+        subject = CopyFilesContentHasher(
+            contentHasher: contentHasher,
+            platformConditionContentHasher: PlatformConditionContentHasher(contentHasher: contentHasher)
+        )
     }
 
     override func tearDown() {
         subject = nil
-        temporaryDirectory = nil
-        contentHasher = nil
-
         super.tearDown()
-    }
-
-    private func makeCopyFilesAction(
-        name: String = "Copy Fonts",
-        destination: CopyFilesAction.Destination = .resources,
-        subpath: String? = "Fonts",
-        files: [CopyFileElement] = [.file(path: "/file1.ttf"), .file(path: "/file2.ttf")]
-    ) -> CopyFilesAction {
-        CopyFilesAction(
-            name: name,
-            destination: destination,
-            subpath: subpath,
-            files: files
-        )
     }
 
     // MARK: - Tests
 
-    func test_hash_copyFilesAction_callsMockHasherWithExpectedStrings() throws {
+    func test_hash_isDeterministicAcrossRuns() async throws {
         // Given
-        let file1Hash = "file1-content-hash"
-        let file2Hash = "file2-content-hash"
-        let copyFilesAction = makeCopyFilesAction()
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/file1.ttf")))
-            .willReturn(file1Hash)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/file2.ttf")))
-            .willReturn(file2Hash)
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let filePath = temporaryDirectory.appending(component: "file")
+        try await fileSystem.touch(filePath)
+        let copyFilesAction = CopyFilesAction(
+            name: "action",
+            destination: .resources,
+            subpath: "sub-directory",
+            files: [
+                CopyFileElement.file(
+                    path: filePath,
+                    condition: .when(Set([.macos])),
+                    codeSignOnCopy: true
+                ),
+            ]
+        )
+        var results: Set<String> = Set()
 
         // When
-        _ = try subject.hash(copyFiles: [copyFilesAction])
+        for _ in 0 ... 100 {
+            results.insert(try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction]).hash)
+        }
 
         // Then
-        verify(contentHasher)
-            .hash(.value(["file1-content-hash", "file2-content-hash", "Copy Fonts", "resources", "Fonts"]))
-            .called(1)
-        verify(contentHasher)
-            .hash(Parameter<[String]>.any)
-            .called(1)
-        verify(contentHasher)
-            .hash(path: .any)
-            .called(2)
+        XCTAssertEqual(results.count, 1)
     }
 
-    func test_hash__copyFilesAction_valuesAreNotHarcoded() throws {
+    func test_hash_returnsTheRightContent() async throws {
         // Given
-        let file1Hash = "file1-content-hash"
-        let copyFilesAction = makeCopyFilesAction(
-            name: "Copy Templates",
-            destination: .sharedSupport,
-            subpath: "Templates",
-            files: [.file(path: "/file1.template")]
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let filePath = temporaryDirectory.appending(component: "file")
+        try await fileSystem.touch(filePath)
+        let copyFilesAction = CopyFilesAction(
+            name: "action",
+            destination: .resources,
+            subpath: "sub-directory",
+            files: [
+                CopyFileElement.file(
+                    path: filePath,
+                    condition: .when(Set([.macos])),
+                    codeSignOnCopy: true
+                ),
+            ]
         )
 
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/file1.template")))
-            .willReturn(file1Hash)
-
         // When
-        _ = try subject.hash(copyFiles: [copyFilesAction])
+        let got = try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction])
 
         // Then
-        verify(contentHasher)
-            .hash(.value(["file1-content-hash", "Copy Templates", "sharedSupport", "Templates"]))
-            .called(1)
-        verify(contentHasher)
-            .hash(Parameter<[String]>.any)
-            .called(1)
-        verify(contentHasher)
-            .hash(path: .any)
-            .called(1)
+        XCTAssertEqual(got, MerkleNode(
+            hash: "bee08a6b2a62c3722cd4f95b4e6366e2",
+
+            identifier: "copyFilesActions",
+            children: [
+                MerkleNode(
+                    hash: "b2bae3352cca3429a35d6321df8faa83",
+                    identifier: "action",
+                    children: [
+                        MerkleNode(
+                            hash: "418c5509e2171d55b0aee5c2ea4442b5",
+                            identifier: "name",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "55b558c7ef820e6e00e5993b9e55d93b",
+                            identifier: "destination",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "a513dff02e1d54f35f36556fb1dd6e88",
+                            identifier: "files",
+                            children: [
+                                MerkleNode(
+                                    hash: "7178d66b2f9f58b50207c4ac3eef73d4",
+                                    identifier: filePath.pathString,
+                                    children: [
+                                        MerkleNode(
+                                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                                            identifier: "content",
+
+                                            children: []
+                                        ),
+                                        MerkleNode(
+                                            hash: "cfcd208495d565ef66e7dff9f98764da",
+                                            identifier: "isReference",
+                                            children: []
+                                        ),
+                                        MerkleNode(
+                                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                                            identifier: "codeSignOnCopy",
+                                            children: []
+                                        ),
+                                        MerkleNode(
+                                            hash: "4ed91b7e02b960dc31256de17f3f131f",
+                                            identifier: "condition",
+                                            children: [
+                                                MerkleNode(
+                                                    hash: "43b9d8ea18c48c3a64c4e37338fc668f",
+                                                    identifier: "macos",
+                                                    children: []
+                                                ),
+                                            ]
+                                        ),
+                                    ]
+                                ),
+                            ]
+                        ),
+                        MerkleNode(
+                            hash: "d18d3d91d86b6429bf6cc4cf4ec5b99a",
+                            identifier: "subpath",
+                            children: []
+                        ),
+                    ]
+                ),
+            ]
+        ))
     }
 }


### PR DESCRIPTION
Continuing with our effort to enhance the experience of debugging Tuist's hashing logic, I'm updating `CopyFilesContentHasher` to return a merkle tree node instead of a flattened hash.