### PR TITLE
Fix cache sidebare label

### DIFF
--- a/docs/.vitepress/sidebars.mjs
+++ b/docs/.vitepress/sidebars.mjs
@@ -306,7 +306,7 @@ export const guidesSidebar = [
         collapsed: true,
         items: [
           {
-            text: `<span style="display: flex; flex-direction: row; align-items: center; gap: 7px;">Cache}</span>`,
+            text: `<span style="display: flex; flex-direction: row; align-items: center; gap: 7px;">Cache</span>`,
             link: "/guides/develop/build/cache",
           },
         ],


### PR DESCRIPTION

<img width="244" alt="Screenshot 2024-09-03 at 18 25 57" src="https://github.com/user-attachments/assets/7572dfcf-d599-4115-b409-aceb170327af">
Small fix of label in website

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
