### PR TITLE
Added Strict mode and Xcode warnings

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -88,6 +88,8 @@ public enum EnvKey: String, CaseIterable {
 
     // LINT
     case lintImplicitDependenciesPath = "TUIST_LINT_IMPLICIT_DEPENDENCIES_PATH"
+    case lintImplicitDependenciesXcode = "TUIST_LINT_IMPLICIT_DEPENDENCIES_XCODE"
+    case lintImplicitDependenciesStrict = "TUIST_LINT_IMPLICIT_DEPENDENCIES_STRICT"
 
     // RUN
     case runBuildTests = "TUIST_RUN_BUILD_TESTS"

--- a/Sources/TuistKit/Commands/Inspect/InspectImplicitImportsCommand.swift
+++ b/Sources/TuistKit/Commands/Inspect/InspectImplicitImportsCommand.swift
@@ -17,8 +17,26 @@ struct InspectImplicitImportsCommand: AsyncParsableCommand {
     )
     var path: String?
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Format of output. Use it if you launch command from XCode Run Script phase.",
+        envKey: .lintImplicitDependenciesXcode
+    )
+    var xcode: Bool = false
+
+    @Flag(
+        name: .shortAndLong,
+        help: "Exit with non-zero status if any unused code is found",
+        envKey: .lintImplicitDependenciesStrict
+    )
+    var strict: Bool = false
+
     func run() async throws {
         try await InspectImplicitImportsService()
-            .run(path: path)
+            .run(
+                path: path,
+                xcode: xcode,
+                strict: strict
+            )
     }
 }

--- a/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
@@ -5,23 +5,15 @@ import TuistLoader
 import TuistSupport
 import XcodeGraph
 
-struct InspectImplicitImportsServiceErrorIssue: Equatable {
-    let target: String
-    let implicitDependencies: Set<String>
-}
-
 enum InspectImplicitImportsServiceError: FatalError, Equatable {
-    case implicitImportsFound([InspectImplicitImportsServiceErrorIssue])
+    case implicitImportsFound([String])
 
     public var description: String {
         switch self {
         case let .implicitImportsFound(issues):
             """
             The following implicit dependencies were found:
-            \(
-                issues.map { " - \($0.target) implicitly depends on: \($0.implicitDependencies.joined(separator: ", "))" }
-                    .joined(separator: "\n")
-            )
+            \(issues)
             """
         }
     }
@@ -46,42 +38,69 @@ final class InspectImplicitImportsService {
         self.targetScanner = targetScanner
     }
 
-    func run(path: String?) async throws {
+    func run(
+        path: String?,
+        xcode: Bool,
+        strict: Bool
+    ) async throws {
         let path = try self.path(path)
         let config = try await configLoader.loadConfig(path: path)
         let generator = generatorFactory.defaultGenerator(config: config, sources: [])
         let graph = try await generator.load(path: path)
-        let issues = try await lint(graphTraverser: GraphTraverser(graph: graph))
+        let implicitImports = try await lint(graphTraverser: GraphTraverser(graph: graph))
+        let issues = implicitImports.map { target, implicitDependencies in
+            if xcode {
+                return implicitDependencies.map { implicitImport in
+                    "\(implicitImport.file.pathString):\(implicitImport.line): warning: Target \(implicitImport.module) was implicitly imported"
+                }
+            } else {
+                let targetNames = implicitDependencies.map(\.module)
+                return [
+                    "Target \(target.name) implicitly imports \(targetNames.joined(separator: ", ")).",
+                ]
+            }
+        }
+        .flatMap { $0 }
+
         guard issues.isEmpty else {
-            throw InspectImplicitImportsServiceError.implicitImportsFound(issues)
+            if strict {
+                throw InspectImplicitImportsServiceError.implicitImportsFound(issues)
+            } else {
+                logger.warning("The following implicit dependencies were found:")
+                for issue in issues {
+                    logger.warning("\(issue)")
+                }
+                return
+            }
         }
         logger.log(level: .info, "We did not find any implicit dependencies in your project.")
     }
 
-    private func lint(graphTraverser: GraphTraverser) async throws -> [InspectImplicitImportsServiceErrorIssue] {
+    private func lint(graphTraverser: GraphTraverser) async throws -> [Target: [ModuleImport]] {
         let allTargets = graphTraverser
             .allInternalTargets()
 
         let allTargetNames = Set(allTargets.map(\.target.productName))
 
-        var implicitTargetImports: [Target: Set<String>] = [:]
+        var implicitTargetImports: [Target: [ModuleImport]] = [:]
         for project in graphTraverser.projects.values {
             let allTargets = project.targets.values
 
             for target in allTargets {
-                let sourceDependencies = Set(try await targetScanner.imports(for: target))
+                let sourceDependencies = try await targetScanner.imports(for: target)
                 let explicitTargetDependencies = graphTraverser
                     .directTargetDependencies(path: project.path, name: target.name)
                     .map(\.graphTarget.target.productName)
-                let implicitImports = sourceDependencies.intersection(allTargetNames).subtracting(explicitTargetDependencies)
+                let implicitImports = sourceDependencies
+                    .filter {
+                        allTargetNames.contains($0.module) && !explicitTargetDependencies.contains($0.module)
+                    }
                 if !implicitImports.isEmpty {
                     implicitTargetImports[target] = implicitImports
                 }
             }
         }
-        return implicitTargetImports.map { target, implicitDependencies in
-            return InspectImplicitImportsServiceErrorIssue(target: target.name, implicitDependencies: implicitDependencies)
-        }
+        return implicitTargetImports
     }
 
     private func path(_ path: String?) throws -> AbsolutePath {

--- a/Sources/TuistKit/Utils/ImportSourceCodeScanner.swift
+++ b/Sources/TuistKit/Utils/ImportSourceCodeScanner.swift
@@ -5,8 +5,13 @@ enum ProgrammingLanguage {
     case objc
 }
 
+struct FoundImport: Equatable {
+    let module: String
+    let line: Int
+}
+
 final class ImportSourceCodeScanner {
-    func extractImports(from sourceCode: String, language: ProgrammingLanguage) throws -> [String] {
+    func extractImports(from sourceCode: String, language: ProgrammingLanguage) throws -> [FoundImport] {
         switch language {
         case .swift:
             try extractAllImportsSwift(from: sourceCode)
@@ -15,55 +20,66 @@ final class ImportSourceCodeScanner {
         }
     }
 
-    private func extractAllImportsSwift(from code: String) throws -> [String] {
+    private func extractAllImportsSwift(from code: String) throws -> [FoundImport] {
         let pattern = #"import\s+(?:struct\s+|enum\s+|class\s+)?([\w]+)"#
 
-        var modules: [String] = []
+        var result: [FoundImport] = []
 
         let regex = try NSRegularExpression(pattern: pattern, options: [])
 
-        let matches = regex.matches(
-            in: code,
-            options: [],
-            range: NSRange(
-                location: 0,
-                length: code.utf16.count
-            )
-        )
+        let lines = code.components(separatedBy: .newlines)
 
-        for match in matches {
-            if let moduleRange = Range(match.range(at: 1), in: code) {
-                let module = String(code[moduleRange])
-                let topLevelModule = module.split(separator: ".").first.map(String.init)
-                if let topLevelModule, !modules.contains(topLevelModule) {
-                    modules.append(topLevelModule)
+        for (lineNumber, line) in lines.enumerated() {
+            let range = NSRange(location: 0, length: line.utf16.count)
+            let matches = regex.matches(in: line, options: [], range: range)
+
+            for match in matches {
+                if let moduleRange = Range(match.range(at: 1), in: line) {
+                    let module = String(line[moduleRange])
+                    let topLevelModule = module.split(separator: ".").first.map(String.init)
+                    if let topLevelModule, !result.contains(where: { $0.module == topLevelModule }) {
+                        result.append(FoundImport(
+                            module: topLevelModule,
+                            line: lineNumber + 1
+                        ))
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    func extractAllImportsObjc(from text: String) throws -> [FoundImport] {
+        let pattern = #"@import\s+([A-Za-z_0-9]+)|#(?:import|include)\s+<([A-Za-z_0-9-]+)"#
+
+        var result: [FoundImport] = []
+
+        let regex = try NSRegularExpression(pattern: pattern, options: [])
+
+        // Split the text into lines
+        let lines = text.components(separatedBy: .newlines)
+
+        // Iterate over each line to find matches
+        for (lineNumber, line) in lines.enumerated() {
+            let range = NSRange(location: 0, length: line.utf16.count)
+            let matches = regex.matches(in: line, options: [], range: range)
+
+            for match in matches {
+                var module: String?
+                if let range = Range(match.range(at: 1), in: line) {
+                    module = String(line[range])
+                } else if let range = Range(match.range(at: 2), in: line) {
+                    module = String(line[range])
+                }
+
+                if let module, !result.contains(where: { $0.module == module }) {
+                    result.append(FoundImport(
+                        module: module, line: lineNumber + 1
+                    ))
                 }
             }
         }
 
-        return modules
-    }
-
-    func extractAllImportsObjc(from text: String) throws -> [String] {
-        let pattern = "@import\\s+([A-Za-z_0-9]+)|#(?:import|include)\\s+<([A-Za-z_0-9-]+)/"
-
-        let regex = try NSRegularExpression(pattern: pattern, options: [])
-        let matches = regex.matches(
-            in: text,
-            options: [],
-            range: NSRange(
-                location: 0,
-                length: text.utf16.count
-            )
-        )
-
-        return matches.compactMap { match in
-            if let range = Range(match.range(at: 1), in: text) {
-                return String(text[range])
-            } else if let range = Range(match.range(at: 2), in: text) {
-                return String(text[range])
-            }
-            return nil
-        }
+        return result
     }
 }

--- a/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
@@ -3,7 +3,7 @@ import TuistAcceptanceTesting
 import XCTest
 @testable import TuistKit
 
-final class LintAcceptanceTests: TuistAcceptanceTestCase {
+final class InspectAcceptanceTests: TuistAcceptanceTestCase {
     func test_ios_app_with_headers() async throws {
         try await setUpFixture(.iosAppWithHeaders)
         try await run(InspectImplicitImportsCommand.self)
@@ -12,6 +12,18 @@ final class LintAcceptanceTests: TuistAcceptanceTestCase {
 
     func test_ios_app_with_implicit_dependencies() async throws {
         try await setUpFixture(.iosAppWithImplicitDependencies)
+        try await run(InspectImplicitImportsCommand.self)
+        XCTAssertStandardOutput(
+            pattern:
+            """
+            The following implicit dependencies were found:
+            Target FrameworkA implicitly imports FrameworkB.
+            """
+        )
+    }
+
+    func test_ios_app_with_implicit_dependencies_strict() async throws {
+        try await setUpFixture(.iosAppWithImplicitDependencies)
         do {
             try await run(InspectImplicitImportsCommand.self)
         } catch let error as InspectImplicitImportsServiceError {
@@ -19,9 +31,21 @@ final class LintAcceptanceTests: TuistAcceptanceTestCase {
                 error.description,
                 """
                 The following implicit dependencies were found:
-                 - FrameworkA implicitly depends on: FrameworkB
+                Target FrameworkA implicitly imports FrameworkB.
                 """
             )
         }
+    }
+
+    func test_ios_app_with_implicit_dependencies_xcode() async throws {
+        try await setUpFixture(.iosAppWithImplicitDependencies)
+        try await run(InspectImplicitImportsCommand.self, ["--xcode"])
+
+        XCTAssertStandardOutput(
+            pattern: "The following implicit dependencies were found:"
+        )
+        XCTAssertStandardOutput(
+            pattern: "ios_app_with_implicit_dependencies/Targets/FrameworkA/Sources/FrameworkA.swift:2: warning: Target FrameworkB was implicitly imported"
+        )
     }
 }

--- a/Tests/TuistKitTests/ImportFinder/ImportSourceCodeScannerTests.swift
+++ b/Tests/TuistKitTests/ImportFinder/ImportSourceCodeScannerTests.swift
@@ -27,7 +27,10 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
         @end
         """
         let imports = try subject.extractImports(from: code, language: .objc)
-        XCTAssertEqual(imports, ["UIKit", "A"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "UIKit", line: 1),
+            FoundImport(module: "A", line: 2),
+        ])
     }
 
     func test_whenObjcCodeWithOneLineImports() throws {
@@ -41,7 +44,10 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
         @end
         """
         let imports = try subject.extractImports(from: code, language: .objc)
-        XCTAssertEqual(imports, ["ModuleA", "ModuleB"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ModuleA", line: 1),
+            FoundImport(module: "ModuleB", line: 1),
+        ])
     }
 
     func test_whenObjcCodeWithSubmoduleImport() throws {
@@ -55,7 +61,9 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
         @end
         """
         let imports = try subject.extractImports(from: code, language: .objc)
-        XCTAssertEqual(imports, ["ModuleA"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ModuleA", line: 1),
+        ])
     }
 
     func test_whenObjcWithSemanticImports() throws {
@@ -71,7 +79,10 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
         #define AXTEXTMRKRNG_TAG "hs.axuielement.axtextmarkerrange"
         """
         let imports = try subject.extractImports(from: code, language: .objc)
-        XCTAssertEqual(imports, ["Cocoa", "LuaSkin"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "Cocoa", line: 1),
+            FoundImport(module: "LuaSkin", line: 2),
+        ])
     }
 
     func test_whenObjcWithInclude() throws {
@@ -87,7 +98,11 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .objc
         )
-        XCTAssertEqual(imports, ["Foundation", "mach-o", "objc"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "Foundation", line: 1),
+            FoundImport(module: "mach-o", line: 2),
+            FoundImport(module: "objc", line: 3),
+        ])
     }
 
     func test_whenSwiftWithDefaultImport() throws {
@@ -100,7 +115,9 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["PackageDescription"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "PackageDescription", line: 1),
+        ])
     }
 
     func test_whenSwiftWithOneLineImports() throws {
@@ -113,7 +130,10 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["ModuleA", "ModuleB"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ModuleA", line: 1),
+            FoundImport(module: "ModuleB", line: 1),
+        ])
     }
 
     func test_whenSwiftWithSubmoduleImport() throws {
@@ -126,7 +146,9 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["ModuleC"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ModuleC", line: 1),
+        ])
     }
 
     func test_whenSwiftWithTypeImports() throws {
@@ -141,7 +163,11 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["ModuleA", "ModuleB", "ModuleC"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ModuleA", line: 1),
+            FoundImport(module: "ModuleB", line: 2),
+            FoundImport(module: "ModuleC", line: 3),
+        ])
     }
 
     func test_whenSwiftWithIfImport() throws {
@@ -161,7 +187,10 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["ProjectDescription", "ProjectDescriptionHelpers"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ProjectDescription", line: 2),
+            FoundImport(module: "ProjectDescriptionHelpers", line: 3),
+        ])
     }
 
     func test_whenSwiftWithTestableImport() throws {
@@ -179,6 +208,9 @@ final class ImportSourceCodeScannerTests: TuistUnitTestCase {
             from: code,
             language: .swift
         )
-        XCTAssertEqual(imports, ["ProjectDescription", "ProjectDescriptionHelpers"])
+        XCTAssertEqual(imports, [
+            FoundImport(module: "ProjectDescription", line: 1),
+            FoundImport(module: "ProjectDescriptionHelpers", line: 2),
+        ])
     }
 }

--- a/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
+++ b/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
@@ -50,6 +50,22 @@ final class TargetImportsScannerTests: TuistUnitTestCase {
             .imports(for: target)
 
         // Then
-        XCTAssertEqual(result, ["SecondTarget", "ThirdTarget", "A"])
+        XCTAssertEqual(result, [
+            ModuleImport(
+                module: "SecondTarget",
+                line: 1,
+                file: targetFirstFile
+            ),
+            ModuleImport(
+                module: "A",
+                line: 2,
+                file: targetFirstFile
+            ),
+            ModuleImport(
+                module: "ThirdTarget",
+                line: 1,
+                file: targetSecondFile
+            ),
+        ])
     }
 }

--- a/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import TuistKit
 
-final class LintImplicitImportsServiceTests: TuistUnitTestCase {
+final class InspectImplicitImportsServiceTests: TuistUnitTestCase {
     private var configLoader: MockConfigLoading!
     private var generatorFactory: MockGeneratorFactorying!
     private var targetScanner: MockTargetImportsScanning!
@@ -53,15 +53,19 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
         given(generatorFactory).defaultGenerator(config: .value(config), sources: .any).willReturn(generator)
         given(generator).load(path: .value(path)).willReturn(graph)
-        given(targetScanner).imports(for: .value(app)).willReturn(Set(["Framework"]))
-        given(targetScanner).imports(for: .value(framework)).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(app)).willReturn([ModuleImport(module: "Framework", line: 1, file: path)])
+        given(targetScanner).imports(for: .value(framework)).willReturn([])
 
-        let expectedError = InspectImplicitImportsServiceError.implicitImportsFound([
-            InspectImplicitImportsServiceErrorIssue(target: "App", implicitDependencies: Set(["Framework"])),
-        ])
+        let expectedError = InspectImplicitImportsServiceError.implicitImportsFound(
+            ["Target App implicitly imports Framework."]
+        )
 
         // When
-        await XCTAssertThrowsSpecific({ try await subject.run(path: path.pathString) }, expectedError)
+        await XCTAssertThrowsSpecific({ try await subject.run(
+            path: path.pathString,
+            xcode: false,
+            strict: true
+        ) }, expectedError)
     }
 
     func test_run_doesntThrowAnyErrors_when_thereAreNoIssues() async throws {
@@ -84,10 +88,14 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
         given(generatorFactory).defaultGenerator(config: .value(config), sources: .any).willReturn(generator)
         given(generator).load(path: .value(path)).willReturn(graph)
-        given(targetScanner).imports(for: .value(app)).willReturn(Set(["Framework"]))
-        given(targetScanner).imports(for: .value(framework)).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(app)).willReturn([])
+        given(targetScanner).imports(for: .value(framework)).willReturn([])
 
         // When
-        try await subject.run(path: path.pathString)
+        try await subject.run(
+            path: path.pathString,
+            xcode: false,
+            strict: true
+        )
     }
 }


### PR DESCRIPTION
### Short description 📝

Added strict mode for inspect command which is classic for lint utils. [Here](https://github.com/realm/SwiftLint/blob/dfd19bddc20538e4b151927556ea542c8fb021db/Source/SwiftLintCore/Models/Configuration.swift#L39) and [here](https://github.com/peripheryapp/periphery/blob/41e5034d81472e911983dc9191391f120192bbc0/Sources/Shared/Configuration.swift#L99). We need this mode, because when user try to launch tuist inspect from xcode, the build will stop after executing our script, but in some cases user wants to execute few scripts in a row or just use our script as a helper, but not as stopper for build

Also added xcode flag which is adding new format of output, that xcode can read. 

### How to test the changes locally 🧐

To test strict just pass --strict as a parametr

To test xcode launch Xcode Project -> Add run script Phase ->swift run --package-path <path-to-your-tuist> tuist lint implicit-imports --path <path-to-test-project> --xcode

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [✅ ] The code has been linted using run `mise run lint-fix`
- [✅ ] The change is tested via unit testing or acceptance testing, or both
- [ ✅] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
