### PR TITLE
Fix inspect implicit imports command name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 #### Added
 
-- Add `tuist inspect implicit-dependencies` to detect implicit dependencies [#6516](https://github.com/tuist/tuist/pull/6516) by [@rofle100lvl](https://github.com/rofle100lvl)
+- Add `tuist inspect implicit-imports` to detect implicit dependencies [#6516](https://github.com/tuist/tuist/pull/6516) by [@rofle100lvl](https://github.com/rofle100lvl)
 - Detect and warn about outdated dependencies [#6663](https://github.com/tuist/tuist/pull/6663) by [@hiltonc](https://github.com/hiltonc)
 - Add support for SPM moduleAliases [#6685](https://github.com/tuist/tuist/pull/6685) by [@fortmarek](https://github.com/fortmarek)
 
@@ -1342,7 +1342,7 @@
   - `SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD`
   - `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD`
   - `SUPPORTS_MACCATALYST`
-  
+
 
 ## 3.22.0 - 2023-07-31
 

--- a/docs/docs/guides/develop/inspect/implicit-dependencies.md
+++ b/docs/docs/guides/develop/inspect/implicit-dependencies.md
@@ -1,6 +1,6 @@
 ---
 title: Implicit dependencies
-description: Learn how to use Tuist to find Implicit dependencies.
+description: Learn how to use Tuist to find implicit dependencies.
 ---
 
 # Implicit dependencies
@@ -10,10 +10,10 @@ To alleviate the complexity of maintaining an Xcode project graph with raw Xcode
 The problem is that you can't prevent implicit dependencies from happening. Any developer can add an `import` statement to their Swift code, and the implicit dependency will be created. This is where Tuist comes in. Tuist provides a command to inspect the implicit dependencies by statically analyzing the code in your project. The following command will output the implicit dependencies of your project:
 
 ```bash
-tuist inspect implicit-dependencies
+tuist inspect implicit-imports
 ```
 
-If the command detects any implicit dependencies, it exits with an exit code other than zero.
+If the command detects any implicit imports, it exits with an exit code other than zero.
 
 > [!TIP] VALIDATE IN CI
 > We strongly recommend to run this command as part of your [continuous integration](/guides/develop/automate/continuous-integration) command every time new code is pushed upstream.


### PR DESCRIPTION
### Short description 📝

As pointed out by @sphanley [here](https://github.com/tuist/tuist/pull/6516#issuecomment-2326905325), we had a wrong name for the new `implicit-imports` command both in changelog and in our docs.

### How to test the changes locally 🧐

`mise run docs:dev`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
