### PR TITLE
Fix stored run event being too large

### DIFF
--- a/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
+++ b/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
@@ -8,9 +8,9 @@ import XcodeGraph
 public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
     public static let dispatcherId = "TuistAnalytics"
 
-    private let backend: TuistAnalyticsBackend?
+    private let backend: TuistAnalyticsBackend
 
-    public init(backend: TuistAnalyticsBackend?) {
+    public init(backend: TuistAnalyticsBackend) {
         self.backend = backend
     }
 
@@ -22,7 +22,7 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
         guard let commandEvent = event as? CommandEvent else { return }
 
         Task {
-            _ = try? await backend?.send(commandEvent: commandEvent)
+            _ = try? await backend.send(commandEvent: commandEvent)
             try await completion()
         }
     }

--- a/Sources/TuistAsyncQueue/AsyncQueue.swift
+++ b/Sources/TuistAsyncQueue/AsyncQueue.swift
@@ -64,7 +64,7 @@ public class AsyncQueue: AsyncQueuing {
 
     public func dispatch(event: some AsyncQueueEvent) throws {
         guard let dispatcher = dispatchers[event.dispatcherId] else {
-            logger.error("Couldn't find dispatcher with id: \(event.dispatcherId)")
+            logger.debug("Couldn't find dispatcher with id: \(event.dispatcherId), skipping dispatching \(event.id)")
             return
         }
 

--- a/Sources/TuistCore/Analytics/CommandEvent.swift
+++ b/Sources/TuistCore/Analytics/CommandEvent.swift
@@ -20,6 +20,8 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
     public let gitCommitSHA: String?
     public let gitRef: String?
     public let gitRemoteURLOrigin: String?
+    public let targetHashes: [CommandEventGraphTarget: String]?
+    public let graphPath: AbsolutePath?
 
     public enum Status: Codable, Equatable {
         case success, failure(String)
@@ -46,6 +48,8 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         case gitCommitSHA
         case gitRef
         case gitRemoteURLOrigin
+        case targetHashes
+        case graphPath
     }
 
     public init(
@@ -64,7 +68,9 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         status: Status,
         gitCommitSHA: String?,
         gitRef: String?,
-        gitRemoteURLOrigin: String?
+        gitRemoteURLOrigin: String?,
+        targetHashes: [CommandEventGraphTarget: String]?,
+        graphPath: AbsolutePath?
     ) {
         self.runId = runId
         self.name = name
@@ -82,6 +88,8 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         self.gitCommitSHA = gitCommitSHA
         self.gitRef = gitRef
         self.gitRemoteURLOrigin = gitRemoteURLOrigin
+        self.targetHashes = targetHashes
+        self.graphPath = graphPath
     }
 }
 
@@ -102,7 +110,9 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
             status: Status = .success,
             gitCommitSHA: String? = "0f783ea776192241154f5c192cd143efde7443aa",
             gitRef: String? = "refs/heads/main",
-            gitRemoteURLOrigin: String? = "https://github.com/tuist/tuist"
+            gitRemoteURLOrigin: String? = "https://github.com/tuist/tuist",
+            targetHashes: [CommandEventGraphTarget: String]? = nil,
+            graphPath: AbsolutePath? = nil
         ) -> CommandEvent {
             CommandEvent(
                 runId: runId,
@@ -120,7 +130,9 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
                 status: status,
                 gitCommitSHA: gitCommitSHA,
                 gitRef: gitRef,
-                gitRemoteURLOrigin: gitRemoteURLOrigin
+                gitRemoteURLOrigin: gitRemoteURLOrigin,
+                targetHashes: targetHashes,
+                graphPath: graphPath
             )
         }
     }

--- a/Sources/TuistCore/Analytics/CommandEventGraphTarget.swift
+++ b/Sources/TuistCore/Analytics/CommandEventGraphTarget.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XcodeGraph
+
+/// A simplified `GraphTarget` to store in `CommandEvent`. As this model gets stored on disk, we want to minimize the information
+/// we end up storing.
+public struct CommandEventGraphTarget: Codable, Hashable {
+    public init(
+        target: CommandEventTarget,
+        project: CommandEventProject
+    ) {
+        self.target = target
+        self.project = project
+    }
+
+    public init(
+        _ graphTarget: GraphTarget
+    ) {
+        target = CommandEventTarget(graphTarget.target)
+        project = CommandEventProject(graphTarget.project)
+    }
+
+    public let target: CommandEventTarget
+    public let project: CommandEventProject
+}
+
+#if DEBUG
+    extension CommandEventGraphTarget {
+        public static func test(
+            target: CommandEventTarget = .test(),
+            project: CommandEventProject = .test()
+        ) -> Self {
+            Self(
+                target: target,
+                project: project
+            )
+        }
+    }
+#endif

--- a/Sources/TuistCore/Analytics/CommandEventProject.swift
+++ b/Sources/TuistCore/Analytics/CommandEventProject.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Path
+import XcodeGraph
+
+/// A simplified `GraphTarget` to store in `CommandEvent`.
+public struct CommandEventProject: Codable, Hashable {
+    public init(
+        xcodeProjPath: AbsolutePath
+    ) {
+        self.xcodeProjPath = xcodeProjPath
+    }
+
+    public init(
+        _ project: Project
+    ) {
+        xcodeProjPath = project.xcodeProjPath
+    }
+
+    public let xcodeProjPath: AbsolutePath
+}
+
+#if DEBUG
+    extension CommandEventProject {
+        public static func test(
+            xcodeProjPath: AbsolutePath =
+                try! AbsolutePath(validating: "/test/text.xcodeproj") // swiftlint:disable:this force_try
+        ) -> Self {
+            Self(
+                xcodeProjPath: xcodeProjPath
+            )
+        }
+    }
+#endif

--- a/Sources/TuistCore/Analytics/CommandEventTarget.swift
+++ b/Sources/TuistCore/Analytics/CommandEventTarget.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XcodeGraph
+
+/// A simplified version of `Target` to store in `CommandEvent`.
+public struct CommandEventTarget: Codable, Hashable {
+    public init(
+        name: String
+    ) {
+        self.name = name
+    }
+
+    public init(
+        _ target: Target
+    ) {
+        name = target.name
+    }
+
+    public let name: String
+}
+
+#if DEBUG
+    extension CommandEventTarget {
+        public static func test(
+            name: String = "Target"
+        ) -> Self {
+            Self(
+                name: name
+            )
+        }
+    }
+#endif

--- a/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
+++ b/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
@@ -31,14 +31,10 @@ public final class CacheDirectoriesProvider: CacheDirectoriesProviding {
     }
 
     public func cacheDirectory(for category: CacheCategory) throws -> AbsolutePath {
-        cacheDirectory().appending(components: ["tuist", category.directoryName])
+        cacheDirectory().appending(component: category.directoryName)
     }
 
     public func cacheDirectory() -> Path.AbsolutePath {
-        if let cacheDirectory = environment.cacheDirectory {
-            return cacheDirectory
-        } else {
-            return FileHandler.shared.homeDirectory.appending(components: ".cache")
-        }
+        environment.cacheDirectory
     }
 }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -642,6 +642,7 @@ public class GraphTraverser: GraphTraversing {
     public func needsEnableTestingSearchPaths(path: Path.AbsolutePath, name: String) -> Bool {
         var cache: [GraphTarget: Bool] = [:]
 
+        // swiftlint:disable:next identifier_name
         func _needsEnableTestingSearchPaths(
             path: Path.AbsolutePath,
             name: String

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -229,9 +229,9 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             parameters["test_targets"] = AnyCodable(CacheAnalyticsStore.shared.testTargets)
             parameters["local_test_target_hits"] = AnyCodable(CacheAnalyticsStore.shared.localTestTargetHits)
             parameters["remote_test_target_hits"] = AnyCodable(CacheAnalyticsStore.shared.remoteTestTargetHits)
-            parameters["target_hashes"] = AnyCodable(CacheAnalyticsStore.shared.targetHashes)
-            parameters["graph_path"] = AnyCodable(CacheAnalyticsStore.shared.graphPath)
 
+            TestCommand.analyticsDelegate?.targetHashes = CacheAnalyticsStore.shared.targetHashes
+            TestCommand.analyticsDelegate?.graphPath = CacheAnalyticsStore.shared.graphPath
             TestCommand.analyticsDelegate?.addParameters(
                 parameters
             )

--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -51,7 +51,9 @@ public final class CommandEventFactory {
             status: info.status,
             gitCommitSHA: gitCommitSHA,
             gitRef: gitController.ref(environment: environment),
-            gitRemoteURLOrigin: gitRemoteURLOrigin
+            gitRemoteURLOrigin: gitRemoteURLOrigin,
+            targetHashes: info.targetHashes,
+            graphPath: info.graphPath
         )
         return commandEvent
     }

--- a/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -16,10 +16,15 @@ public struct TrackableCommandInfo {
     let commandArguments: [String]
     let durationInMs: Int
     let status: CommandEvent.Status
+    let targetHashes: [CommandEventGraphTarget: String]?
+    let graphPath: AbsolutePath?
 }
 
 /// A `TrackableCommand` wraps a `ParsableCommand` and reports its execution to an analytics provider
 public class TrackableCommand: TrackableParametersDelegate {
+    public var targetHashes: [CommandEventGraphTarget: String]?
+    public var graphPath: AbsolutePath?
+
     private var command: ParsableCommand
     private let clock: Clock
     private var trackedParameters: [String: AnyCodable] = [:]
@@ -91,7 +96,9 @@ public class TrackableCommand: TrackableParametersDelegate {
             parameters: trackedParameters,
             commandArguments: commandArguments,
             durationInMs: durationInMs,
-            status: status
+            status: status,
+            targetHashes: targetHashes,
+            graphPath: graphPath
         )
         let commandEvent = try commandEventFactory.make(
             from: info,

--- a/Sources/TuistKit/Commands/TrackableCommand/TrackableParametersDelegate.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/TrackableParametersDelegate.swift
@@ -1,5 +1,7 @@
 import AnyCodable
 import Foundation
+import Path
+import TuistCore
 
 /// Commands that conform to `HasTrackableParameters` can report extra parameters that are only known at runtime
 public protocol HasTrackableParameters {
@@ -11,5 +13,7 @@ public protocol HasTrackableParameters {
 /// `TrackableParametersDelegate` contains the callback that should be called
 /// before running a command, with extra parameters that are only known at runtime
 public protocol TrackableParametersDelegate: AnyObject {
+    var targetHashes: [CommandEventGraphTarget: String]? { get set }
+    var graphPath: AbsolutePath? { get set }
     func addParameters(_ parameters: [String: AnyCodable])
 }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -72,19 +72,16 @@ public struct TuistCommand: AsyncParsableCommand {
             path = .current
         }
 
-        let backend: TuistAnalyticsBackend?
         let config = try await ConfigLoader().loadConfig(path: path)
         let url = try ServerURLService().url(configServerURL: config.url)
         if let fullHandle = config.fullHandle {
-            backend = TuistAnalyticsServerBackend(
+            let backend = TuistAnalyticsServerBackend(
                 fullHandle: fullHandle,
                 url: url
             )
-        } else {
-            backend = nil
+            let dispatcher = TuistAnalyticsDispatcher(backend: backend)
+            try TuistAnalytics.bootstrap(dispatcher: dispatcher)
         }
-        let dispatcher = TuistAnalyticsDispatcher(backend: backend)
-        try TuistAnalytics.bootstrap(dispatcher: dispatcher)
 
         let errorHandler = ErrorHandler()
         let executeCommand: () async throws -> Void

--- a/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
+++ b/Sources/TuistKit/Utils/TuistAnalyticsServerBackend.swift
@@ -69,8 +69,8 @@ public class TuistAnalyticsServerBackend: TuistAnalyticsBackend {
             .appending(component: "\(Constants.resultBundleName).xcresult")
 
         if fileHandler.exists(resultBundle),
-           let targetHashes = commandEvent.params["target_hashes"]?.value as? [GraphTarget: String],
-           let graphPath = commandEvent.params["graph_path"]?.value as? AbsolutePath
+           let targetHashes = commandEvent.targetHashes,
+           let graphPath = commandEvent.graphPath
         {
             try await analyticsArtifactUploadService.uploadResultBundle(
                 resultBundle,

--- a/Sources/TuistServer/Cache/CacheAnalytics.swift
+++ b/Sources/TuistServer/Cache/CacheAnalytics.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mockable
 import Path
+import TuistCore
 import TuistSupport
 import XcodeGraph
 
@@ -12,8 +13,7 @@ public protocol CacheAnalyticsStoring: AnyObject {
     var testTargets: [String] { get set }
     var localTestTargetHits: [String] { get set }
     var remoteTestTargetHits: [String] { get set }
-    /// Map of a relative path of a project that has a map of a target name to its hash
-    var targetHashes: [GraphTarget: String] { get set }
+    var targetHashes: [CommandEventGraphTarget: String] { get set }
     var graphPath: AbsolutePath? { get set }
 }
 
@@ -24,7 +24,7 @@ public final class CacheAnalyticsStore: CacheAnalyticsStoring {
     public var testTargets: [String] = []
     public var localTestTargetHits: [String] = []
     public var remoteTestTargetHits: [String] = []
-    public var targetHashes: [GraphTarget: String] = [:]
+    public var targetHashes: [CommandEventGraphTarget: String] = [:]
     public var graphPath: AbsolutePath?
 
     public static let shared = CacheAnalyticsStore()

--- a/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mockable
 import Path
+import TuistCore
 import TuistSupport
 import XcodeGraph
 
@@ -8,7 +9,7 @@ import XcodeGraph
 public protocol AnalyticsArtifactUploadServicing {
     func uploadResultBundle(
         _ resultBundle: AbsolutePath,
-        targetHashes: [GraphTarget: String],
+        targetHashes: [CommandEventGraphTarget: String],
         graphPath: AbsolutePath,
         commandEventId: Int,
         serverURL: URL
@@ -66,7 +67,7 @@ public final class AnalyticsArtifactUploadService: AnalyticsArtifactUploadServic
 
     public func uploadResultBundle(
         _ resultBundle: AbsolutePath,
-        targetHashes: [GraphTarget: String],
+        targetHashes: [CommandEventGraphTarget: String],
         graphPath: AbsolutePath,
         commandEventId: Int,
         serverURL: URL

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -3,18 +3,13 @@ import Path
 import TuistSupport
 import XCTest
 
-public class MockEnvironment: Environmenting {
+public final class MockEnvironment: Environmenting {
     fileprivate let directory: TemporaryDirectory
     fileprivate var setupCallCount: UInt = 0
     fileprivate var setupErrorStub: Error?
 
     init() throws {
         directory = try TemporaryDirectory(removeTreeOnDeinit: true)
-        try FileManager.default.createDirectory(
-            at: versionsDirectory.url,
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
     }
 
     public var isVerbose: Bool = false
@@ -26,29 +21,15 @@ public class MockEnvironment: Environmenting {
     public var isStatsEnabled: Bool = true
     public var isGitHubActions: Bool = false
 
-    public var versionsDirectory: AbsolutePath {
-        directory.path.appending(component: "Versions")
-    }
-
-    public var settingsPath: AbsolutePath {
-        directory.path.appending(component: "settings.json")
-    }
-
     public var automationPath: AbsolutePath? {
         nil
     }
 
-    public var cacheDirectory: AbsolutePath? {
+    public var cacheDirectory: AbsolutePath {
         directory.path.appending(components: ".cache")
     }
 
     public var queueDirectory: AbsolutePath {
         queueDirectoryStub ?? directory.path.appending(component: Constants.AsyncQueue.directoryName)
     }
-
-    func path(version: String) -> AbsolutePath {
-        versionsDirectory.appending(component: version)
-    }
-
-    public func bootstrap() throws {}
 }

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -28,8 +28,6 @@ private enum TuistServer {
             TuistSupport.LogOutput.bootstrap()
         }
 
-        try TuistSupport.Environment.shared.bootstrap()
-
         try await TuistCommand.main()
     }
 }

--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MockableTest
 import Path
 import TuistCore
 import TuistSupport
@@ -8,22 +9,36 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class AsyncQueuePersistorTests: TuistUnitTestCase {
-    var subject: AsyncQueuePersistor!
+    private var subject: AsyncQueuePersistor!
+    private var dateService: MockDateServicing!
+    private var date = Date(timeIntervalSince1970: 1_725_440_035)
 
     override func setUp() {
         super.setUp()
         let temporaryDirectory = try! temporaryPath()
-        subject = AsyncQueuePersistor(directory: temporaryDirectory)
+        dateService = MockDateServicing()
+        subject = AsyncQueuePersistor(
+            directory: temporaryDirectory,
+            dateService: dateService
+        )
+
+        given(dateService)
+            .now()
+            .willProduce { self.date }
     }
 
     override func tearDown() {
+        dateService = nil
         subject = nil
         super.tearDown()
     }
 
     func test_write() async throws {
         // Given
-        let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
+        let event = AnyAsyncQueueEvent(
+            dispatcherId: "dispatcher",
+            date: date
+        )
 
         // When
         try subject.write(event: event)
@@ -42,7 +57,10 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         subject = AsyncQueuePersistor(directory: temporaryDirectory.appending(try RelativePath(validating: "test/")))
 
         // Given
-        let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
+        let event = AnyAsyncQueueEvent(
+            dispatcherId: "dispatcher",
+            date: date
+        )
 
         // When
         try subject.write(event: event)
@@ -58,7 +76,10 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
 
     func test_delete() async throws {
         // Given
-        let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
+        let event = AnyAsyncQueueEvent(
+            dispatcherId: "dispatcher",
+            date: date
+        )
         try subject.write(event: event)
         var persistedEvents = try await subject.readAll()
         XCTAssertEqual(persistedEvents.count, 1)
@@ -68,6 +89,24 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
 
         // Then
         persistedEvents = try await subject.readAll()
+        XCTAssertEqual(persistedEvents.count, 0)
+    }
+
+    func test_delete_old_events() async throws {
+        // Given
+        let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
+        try subject.write(event: event)
+        var persistedEvents = try await subject.readAll()
+        XCTAssertEqual(persistedEvents.count, 1)
+
+        // Moving the clock by over 24 hours
+        // Events older than that should get automatically deleted
+        date = Date(timeIntervalSince1970: date.timeIntervalSince1970 + 100_000)
+
+        // When
+        persistedEvents = try await subject.readAll()
+
+        // Then
         XCTAssertEqual(persistedEvents.count, 0)
     }
 }

--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -94,14 +94,17 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
 
     func test_delete_old_events() async throws {
         // Given
-        let event = AnyAsyncQueueEvent(dispatcherId: "dispatcher")
+        let event = AnyAsyncQueueEvent(
+            dispatcherId: "dispatcher",
+            date: date
+        )
         try subject.write(event: event)
         var persistedEvents = try await subject.readAll()
         XCTAssertEqual(persistedEvents.count, 1)
 
         // Moving the clock by over 24 hours
         // Events older than that should get automatically deleted
-        date = Date(timeIntervalSince1970: date.timeIntervalSince1970 + 100_000)
+        date = Date(timeIntervalSince1970: date.timeIntervalSince1970 + 100_005)
 
         // When
         persistedEvents = try await subject.readAll()

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -48,7 +48,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         var hashes: Set<String> = Set()
 
         // When
-        for i in 0 ..< 100 {
+        for _ in 0 ..< 100 {
             hashes.insert(try subject.hash(identifier: "resources", resources: resourceFileElements).hash)
         }
 

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -43,7 +43,9 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             parameters: ["foo": "bar"],
             commandArguments: ["cache", "warm"],
             durationInMs: 5000,
-            status: .failure("Failed!")
+            status: .failure("Failed!"),
+            targetHashes: nil,
+            graphPath: path
         )
         let expectedEvent = CommandEvent(
             runId: "run-id",
@@ -61,7 +63,9 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             status: .failure("Failed!"),
             gitCommitSHA: "commit-sha",
             gitRef: "github-ref",
-            gitRemoteURLOrigin: "https://github.com/tuist/tuist"
+            gitRemoteURLOrigin: "https://github.com/tuist/tuist",
+            targetHashes: nil,
+            graphPath: path
         )
         given(gitController)
             .currentCommitSHA(workingDirectory: .value(path))
@@ -99,6 +103,8 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
         XCTAssertEqual(event.gitCommitSHA, expectedEvent.gitCommitSHA)
         XCTAssertEqual(event.gitRemoteURLOrigin, expectedEvent.gitRemoteURLOrigin)
         XCTAssertEqual(event.gitRef, expectedEvent.gitRef)
+        XCTAssertEqual(event.targetHashes, expectedEvent.targetHashes)
+        XCTAssertEqual(event.graphPath, expectedEvent.graphPath)
     }
 
     func test_make_when_is_not_in_git_repository() throws {
@@ -111,7 +117,9 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             parameters: ["foo": "bar"],
             commandArguments: ["cache", "warm"],
             durationInMs: 5000,
-            status: .failure("Failed!")
+            status: .failure("Failed!"),
+            targetHashes: nil,
+            graphPath: nil
         )
 
         given(gitController)

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -35,7 +35,7 @@ final class TuistAnalyticsDispatcherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func testDispatch_whenAnalyticsIsEnabled_sendsToServer() throws {
+    func testDispatch_sendsToServer() throws {
         // Given
         let fullHandle = "project"
         let url = URL.test()
@@ -111,7 +111,9 @@ final class TuistAnalyticsDispatcherTests: TuistUnitTestCase {
             status: .success,
             gitCommitSHA: "26f4fda1548502c474642ce63db7630307242312",
             gitRef: nil,
-            gitRemoteURLOrigin: "https://github.com/tuist/tuist"
+            gitRemoteURLOrigin: "https://github.com/tuist/tuist",
+            targetHashes: nil,
+            graphPath: nil
         )
     }
 

--- a/Tests/TuistServerTests/Client/ServerClientOutputWarningsMiddlewareTests.swift
+++ b/Tests/TuistServerTests/Client/ServerClientOutputWarningsMiddlewareTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import TuistServer
 @testable import TuistSupportTesting
 
-private class MockWarningController: WarningControlling {
+private final class MockWarningController: WarningControlling {
     var warnings: [String] = []
     func append(warning: String) {
         warnings.append(warning)

--- a/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MockableTest
+import TuistCore
 import TuistSupport
 import TuistSupportTesting
 import XcodeGraph
@@ -151,8 +152,7 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         try await subject.uploadResultBundle(
             resultBundle,
             targetHashes: [
-                GraphTarget(
-                    path: try temporaryPath(),
+                CommandEventGraphTarget(
                     target: .test(),
                     project: .test()
                 ): "target-hash",


### PR DESCRIPTION
### Short description 📝

This was initially reported by @ffittschen. Turns out the `target_hashes` property of `CommandEvent` can get _very_ large in larger projects. In @ffittschen case, the `CommandEvent` JSON size reached over 5 GB. The issue is that we're saving each `GraphTarget` as a whole, unnecessarily duplicating information and including data we don't need.

To fix this, I created a new `CommandEventGraphTarget` that includes only the pieces of information needed for reporting hashes to the Tuist server.

I also made the following minor adjustments:
- Events are not dispatched when the `fullHandle` is missing as sending such events would always fail anyway
- Events older than 24 hours are automatically deleted. This ensures the `Queue` directory doesn't grow indefinitely.
- The `Queue` directory was moved from `~/.tuist/Queue` to `~/.cache/tuist/Queue`. The current location is still in the legacy directory. I also removed references to the legacy `~/.tuist/Versions` directory.
- The `targetHashes` and `graphPath` are now saved directly in the `CommandEvent` instead of `params`. With `params`, we're losing the type safety as we're using `AnyCodable`. We don't have a strong reason to do that.

### How to test the changes locally 🧐

Run `tuist test` in `ios_app_with_frameworks`. The command event and the result bundle should be uploaded.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
