### PR TITLE
Optimize storing and fetching selective tests

### DIFF
--- a/Sources/TuistServer/Models/ServerCacheActionItem.swift
+++ b/Sources/TuistServer/Models/ServerCacheActionItem.swift
@@ -1,0 +1,32 @@
+import Foundation
+import TuistCore
+import TuistSupport
+
+/// Server cache action item
+public struct ServerCacheActionItem: Equatable {
+    public init(
+        hash: String
+    ) {
+        self.hash = hash
+    }
+
+    public let hash: String
+}
+
+extension ServerCacheActionItem {
+    init(_ cacheActionItem: Components.Schemas.CacheActionItem) {
+        hash = cacheActionItem.hash
+    }
+}
+
+#if DEBUG
+    extension ServerCacheActionItem {
+        public static func test(
+            hash: String = "hash"
+        ) -> Self {
+            .init(
+                hash: hash
+            )
+        }
+    }
+#endif

--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -2377,6 +2377,234 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// It uploads a given cache action item.
+    ///
+    /// The endpoint caches a given action item without uploading a file. To upload files, use the multipart upload instead.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/cache/ac`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)`.
+    public func uploadCacheActionItem(_ input: Operations.uploadCacheActionItem.Input) async throws
+        -> Operations.uploadCacheActionItem.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.uploadCacheActionItem.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/projects/{}/{}/cache/ac",
+                    parameters: [input.path.account_handle, input.path.project_handle]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                request.body = try converter.setOptionalRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 201:
+                    let headers: Operations.uploadCacheActionItem.Output.Created.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.Created.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.CacheActionItem.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .created(.init(headers: headers, body: body))
+                case 400:
+                    let headers: Operations.uploadCacheActionItem.Output.BadRequest.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.BadRequest.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .badRequest(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.uploadCacheActionItem.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                case 402:
+                    let headers: Operations.uploadCacheActionItem.Output.PaymentRequired.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.PaymentRequired.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .paymentRequired(.init(headers: headers, body: body))
+                case 403:
+                    let headers: Operations.uploadCacheActionItem.Output.Forbidden.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.Forbidden.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .forbidden(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.uploadCacheActionItem.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
+    /// Get a cache action item.
+    ///
+    /// This endpoint gets an item from the action cache.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache/ac/{hash}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)`.
+    public func getCacheActionItem(_ input: Operations.getCacheActionItem.Input) async throws
+        -> Operations.getCacheActionItem.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getCacheActionItem.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/projects/{}/{}/cache/ac/{}",
+                    parameters: [
+                        input.path.account_handle, input.path.project_handle, input.path.hash,
+                    ]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .get)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.getCacheActionItem.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getCacheActionItem.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.CacheActionItem.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.getCacheActionItem.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getCacheActionItem.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                case 402:
+                    let headers: Operations.getCacheActionItem.Output.PaymentRequired.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getCacheActionItem.Output.PaymentRequired.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .paymentRequired(.init(headers: headers, body: body))
+                case 403:
+                    let headers: Operations.getCacheActionItem.Output.Forbidden.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getCacheActionItem.Output.Forbidden.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .forbidden(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.getCacheActionItem.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getCacheActionItem.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
     /// Cleans cache for a given project
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/cache/clean`.

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -195,6 +195,22 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/put(updateProject)`.
     func updateProject(_ input: Operations.updateProject.Input) async throws
         -> Operations.updateProject.Output
+    /// It uploads a given cache action item.
+    ///
+    /// The endpoint caches a given action item without uploading a file. To upload files, use the multipart upload instead.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/cache/ac`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)`.
+    func uploadCacheActionItem(_ input: Operations.uploadCacheActionItem.Input) async throws
+        -> Operations.uploadCacheActionItem.Output
+    /// Get a cache action item.
+    ///
+    /// This endpoint gets an item from the action cache.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache/ac/{hash}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)`.
+    func getCacheActionItem(_ input: Operations.getCacheActionItem.Input) async throws
+        -> Operations.getCacheActionItem.Output
     /// Cleans cache for a given project
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/cache/clean`.
@@ -600,6 +616,34 @@ public enum Components {
                 case access_token
                 case refresh_token
             }
+        }
+        /// Represents an action item stored in the cache.
+        ///
+        /// - Remark: Generated from `#/components/schemas/CacheActionItem`.
+        public struct CacheActionItem: Codable, Equatable, Hashable, Sendable {
+            /// The hash that uniquely identifies the artifact in the cache.
+            ///
+            /// - Remark: Generated from `#/components/schemas/CacheActionItem/hash`.
+            public var hash: Swift.String
+            /// Creates a new `CacheActionItem`.
+            ///
+            /// - Parameters:
+            ///   - hash: The hash that uniquely identifies the artifact in the cache.
+            public init(hash: Swift.String) { self.hash = hash }
+            public enum CodingKeys: String, CodingKey { case hash }
+        }
+        /// - Remark: Generated from `#/components/schemas/CacheActionItemUploadParams`.
+        public struct CacheActionItemUploadParams: Codable, Equatable, Hashable, Sendable {
+            /// The hash of the cache action item.
+            ///
+            /// - Remark: Generated from `#/components/schemas/CacheActionItemUploadParams/hash`.
+            public var hash: Swift.String?
+            /// Creates a new `CacheActionItemUploadParams`.
+            ///
+            /// - Parameters:
+            ///   - hash: The hash of the cache action item.
+            public init(hash: Swift.String? = nil) { self.hash = hash }
+            public enum CodingKeys: String, CodingKey { case hash }
         }
         /// The URL to download the artifact from the cache.
         ///
@@ -1362,7 +1406,7 @@ public enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/Project/id`.
             public var id: Swift.Double
-            /// The URL of the connected git repository.
+            /// The URL of the connected git repository, such as https://github.com/tuist/tuist or https://github.com/tuist/tuist.git
             ///
             /// - Remark: Generated from `#/components/schemas/Project/repository_url`.
             public var repository_url: Swift.String?
@@ -1376,7 +1420,7 @@ public enum Components {
             ///   - default_branch: The default branch of the project.
             ///   - full_name: The full name of the project (e.g. tuist/tuist)
             ///   - id: ID of the project
-            ///   - repository_url: The URL of the connected git repository.
+            ///   - repository_url: The URL of the connected git repository, such as https://github.com/tuist/tuist or https://github.com/tuist/tuist.git
             ///   - token: The token that should be used to authenticate the project. For CI only.
             public init(
                 default_branch: Swift.String,
@@ -6876,7 +6920,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The request is invalid, for example when updating to a non-supported git repository
+            /// The request is invalid, for example when attempting to link the project to a repository the authenticated user doesn't have access to.
             ///
             /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/put(updateProject)/responses/400`.
             ///
@@ -6975,6 +7019,510 @@ public enum Operations {
             ///
             /// HTTP response code: `404 notFound`.
             case notFound(Operations.updateProject.Output.NotFound)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// It uploads a given cache action item.
+    ///
+    /// The endpoint caches a given action item without uploading a file. To upload files, use the multipart upload instead.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/cache/ac`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)`.
+    public enum uploadCacheActionItem {
+        public static let id: String = "uploadCacheActionItem"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var account_handle: Swift.String
+                public var project_handle: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle:
+                ///   - project_handle:
+                public init(account_handle: Swift.String, project_handle: Swift.String) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                }
+            }
+            public var path: Operations.uploadCacheActionItem.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.uploadCacheActionItem.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.uploadCacheActionItem.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.uploadCacheActionItem.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// Cache action item upload params
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache/ac/POST/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// The hash of the cache action item.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/cache/ac/POST/json/hash`.
+                    public var hash: Swift.String?
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - hash: The hash of the cache action item.
+                    public init(hash: Swift.String? = nil) { self.hash = hash }
+                    public enum CodingKeys: String, CodingKey { case hash }
+                }
+                case json(Operations.uploadCacheActionItem.Input.Body.jsonPayload)
+            }
+            public var body: Operations.uploadCacheActionItem.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.uploadCacheActionItem.Input.Path,
+                query: Operations.uploadCacheActionItem.Input.Query = .init(),
+                headers: Operations.uploadCacheActionItem.Input.Headers = .init(),
+                cookies: Operations.uploadCacheActionItem.Input.Cookies = .init(),
+                body: Operations.uploadCacheActionItem.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Created: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.Created.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.CacheActionItem)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.Created.Body
+                /// Creates a new `Created`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.Created.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.Created.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The action item was cached
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/201`.
+            ///
+            /// HTTP response code: `201 created`.
+            case created(Operations.uploadCacheActionItem.Output.Created)
+            public struct BadRequest: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.BadRequest.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.BadRequest.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.BadRequest.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The request has missing or invalid parameters
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.uploadCacheActionItem.Output.BadRequest)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.Unauthorized.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.uploadCacheActionItem.Output.Unauthorized)
+            public struct PaymentRequired: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.PaymentRequired.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.PaymentRequired.Body
+                /// Creates a new `PaymentRequired`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.PaymentRequired.Headers =
+                        .init(),
+                    body: Operations.uploadCacheActionItem.Output.PaymentRequired.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The account has an invalid plan
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/402`.
+            ///
+            /// HTTP response code: `402 paymentRequired`.
+            case paymentRequired(Operations.uploadCacheActionItem.Output.PaymentRequired)
+            public struct Forbidden: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.Forbidden.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.Forbidden.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.Forbidden.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.uploadCacheActionItem.Output.Forbidden)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.NotFound.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The project doesn't exist
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.uploadCacheActionItem.Output.NotFound)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// Get a cache action item.
+    ///
+    /// This endpoint gets an item from the action cache.
+    ///
+    /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache/ac/{hash}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)`.
+    public enum getCacheActionItem {
+        public static let id: String = "getCacheActionItem"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var account_handle: Swift.String
+                public var project_handle: Swift.String
+                public var hash: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle:
+                ///   - project_handle:
+                ///   - hash:
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    hash: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.hash = hash
+                }
+            }
+            public var path: Operations.getCacheActionItem.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.getCacheActionItem.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.getCacheActionItem.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.getCacheActionItem.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.getCacheActionItem.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.getCacheActionItem.Input.Path,
+                query: Operations.getCacheActionItem.Input.Query = .init(),
+                headers: Operations.getCacheActionItem.Input.Headers = .init(),
+                cookies: Operations.getCacheActionItem.Input.Cookies = .init(),
+                body: Operations.getCacheActionItem.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getCacheActionItem.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.CacheActionItem)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getCacheActionItem.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getCacheActionItem.Output.Ok.Headers = .init(),
+                    body: Operations.getCacheActionItem.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The item exists in the action cache
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getCacheActionItem.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getCacheActionItem.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getCacheActionItem.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getCacheActionItem.Output.Unauthorized.Headers = .init(),
+                    body: Operations.getCacheActionItem.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.getCacheActionItem.Output.Unauthorized)
+            public struct PaymentRequired: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getCacheActionItem.Output.PaymentRequired.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getCacheActionItem.Output.PaymentRequired.Body
+                /// Creates a new `PaymentRequired`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getCacheActionItem.Output.PaymentRequired.Headers = .init(),
+                    body: Operations.getCacheActionItem.Output.PaymentRequired.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The account has an invalid plan
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)/responses/402`.
+            ///
+            /// HTTP response code: `402 paymentRequired`.
+            case paymentRequired(Operations.getCacheActionItem.Output.PaymentRequired)
+            public struct Forbidden: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getCacheActionItem.Output.Forbidden.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getCacheActionItem.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getCacheActionItem.Output.Forbidden.Headers = .init(),
+                    body: Operations.getCacheActionItem.Output.Forbidden.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.getCacheActionItem.Output.Forbidden)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getCacheActionItem.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getCacheActionItem.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getCacheActionItem.Output.NotFound.Headers = .init(),
+                    body: Operations.getCacheActionItem.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The item doesn't exist in the actino cache
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getCacheActionItem.Output.NotFound)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -131,6 +131,24 @@ components:
       title: AuthenticationTokens
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.AuthenticationTokens
+    CacheActionItem:
+      description: Represents an action item stored in the cache.
+      properties:
+        hash:
+          description: The hash that uniquely identifies the artifact in the cache.
+          type: string
+      required:
+        - hash
+      title: CacheActionItem
+      type: object
+      x-struct: Elixir.TuistWeb.API.Schemas.CacheActionItem
+    CacheActionItemUploadParams:
+      properties:
+        hash:
+          description: The hash of the cache action item.
+          type: string
+      title: CacheActionItemUploadParams
+      type: object
     CacheArtifactDownloadURL:
       description: The URL to download the artifact from the cache.
       properties:
@@ -441,7 +459,7 @@ components:
           description: ID of the project
           type: number
         repository_url:
-          description: The URL of the connected git repository.
+          description: The URL of the connected git repository, such as https://github.com/tuist/tuist or https://github.com/tuist/tuist.git
           type: string
         token:
           deprecated: true
@@ -1879,7 +1897,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: The request is invalid, for example when updating to a non-supported git repository
+          description: The request is invalid, for example when attempting to link the project to a repository the authenticated user doesn't have access to.
         401:
           content:
             application/json:
@@ -1901,6 +1919,134 @@ paths:
       summary: Updates a project
       tags:
         - Projects
+  /api/projects/{account_handle}/{project_handle}/cache/ac:
+    post:
+      callbacks: {}
+      description: The endpoint caches a given action item without uploading a file. To upload files, use the multipart upload instead.
+      operationId: uploadCacheActionItem
+      parameters:
+        - description: The name of the account that the project belongs to.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+        - description: The name of the project to clean cache for
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hash:
+                  description: The hash of the cache action item.
+                  type: string
+              title: CacheActionItemUploadParams
+              type: object
+        description: Cache action item upload params
+        required: false
+      responses:
+        201:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheActionItem'
+          description: The action item was cached
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request has missing or invalid parameters
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        402:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The account has an invalid plan
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The project doesn't exist
+      summary: It uploads a given cache action item.
+      tags:
+        - Cache
+  /api/projects/{account_handle}/{project_handle}/cache/ac/{hash}:
+    get:
+      callbacks: {}
+      description: This endpoint gets an item from the action cache.
+      operationId: getCacheActionItem
+      parameters:
+        - description: The name of the account that the project belongs to.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+        - description: The name of the project the cache action item belongs to.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+        - description: The hash that uniquely identifies an item in the action cache.
+          in: path
+          name: hash
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheActionItem'
+          description: The item exists in the action cache
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        402:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The account has an invalid plan
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The item doesn't exist in the actino cache
+      summary: Get a cache action item.
+      tags:
+        - Cache
   /api/projects/{account_handle}/{project_handle}/cache/clean:
     put:
       callbacks: {}

--- a/Sources/TuistServer/Services/CacheExistsService.swift
+++ b/Sources/TuistServer/Services/CacheExistsService.swift
@@ -11,12 +11,11 @@ public protocol CacheExistsServicing {
         hash: String,
         name: String,
         cacheCategory: RemoteCacheCategory
-    ) async throws
+    ) async throws -> Bool
 }
 
 public enum CacheExistsServiceError: FatalError, Equatable {
     case unknownError(Int)
-    case notFound(String)
     case paymentRequired(String)
     case forbidden(String)
     case unauthorized(String)
@@ -25,7 +24,7 @@ public enum CacheExistsServiceError: FatalError, Equatable {
         switch self {
         case .unknownError:
             return .bug
-        case .notFound, .paymentRequired, .forbidden, .unauthorized:
+        case .paymentRequired, .forbidden, .unauthorized:
             return .abort
         }
     }
@@ -34,7 +33,7 @@ public enum CacheExistsServiceError: FatalError, Equatable {
         switch self {
         case let .unknownError(statusCode):
             return "The remote cache could not be used due to an unknown Tuist response of \(statusCode)."
-        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
+        case let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
             return message
         }
     }
@@ -49,7 +48,7 @@ public final class CacheExistsService: CacheExistsServicing {
         hash: String,
         name: String,
         cacheCategory: RemoteCacheCategory
-    ) async throws {
+    ) async throws -> Bool {
         let client = Client.authenticated(serverURL: serverURL)
 
         let response = try await client.cacheArtifactExists(
@@ -58,13 +57,9 @@ public final class CacheExistsService: CacheExistsServicing {
 
         switch response {
         case .ok:
-            // noop
-            break
+            return true
         case let .notFound(notFoundResponse):
-            switch notFoundResponse.body {
-            case let .json(body):
-                throw CacheExistsServiceError.notFound(body.error?.first?.message ?? "The remote cache artifact does not exist")
-            }
+            return false
         case let .paymentRequired(paymentRequiredResponse):
             switch paymentRequiredResponse.body {
             case let .json(error):

--- a/Sources/TuistServer/Services/GetCacheActionItemService.swift
+++ b/Sources/TuistServer/Services/GetCacheActionItemService.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Mockable
+import TuistCore
+import TuistSupport
+
+@Mockable
+public protocol GetCacheActionItemServicing {
+    func getCacheActionItem(
+        serverURL: URL,
+        fullHandle: String,
+        hash: String
+    ) async throws -> ServerCacheActionItem
+}
+
+public enum GetCacheActionItemServiceError: FatalError, Equatable {
+    case unknownError(Int)
+    case notFound(String)
+    case paymentRequired(String)
+    case forbidden(String)
+    case unauthorized(String)
+
+    public var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .paymentRequired, .forbidden, .unauthorized:
+            return .abort
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The cache item could not be fetched due to an unknown Tuist response of \(statusCode)."
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message):
+            return message
+        }
+    }
+}
+
+public final class GetCacheActionItemService: GetCacheActionItemServicing {
+    private let fullHandleService: FullHandleServicing
+
+    public convenience init() {
+        self.init(fullHandleService: FullHandleService())
+    }
+
+    init(
+        fullHandleService: FullHandleServicing
+    ) {
+        self.fullHandleService = fullHandleService
+    }
+
+    public func getCacheActionItem(
+        serverURL: URL,
+        fullHandle: String,
+        hash: String
+    ) async throws -> ServerCacheActionItem {
+        let client = Client.authenticated(serverURL: serverURL)
+
+        let handles = try fullHandleService.parse(fullHandle)
+
+        let response = try await client.getCacheActionItem(
+            .init(
+                path: .init(
+                    account_handle: handles.accountHandle,
+                    project_handle:
+                    handles.projectHandle,
+                    hash: hash
+                )
+            )
+        )
+
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(cacheActionItem):
+                return ServerCacheActionItem(cacheActionItem)
+            }
+        case let .paymentRequired(paymentRequiredResponse):
+            switch paymentRequiredResponse.body {
+            case let .json(error):
+                throw GetCacheActionItemServiceError.paymentRequired(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw GetCacheActionItemServiceError.unknownError(statusCode)
+        case let .forbidden(forbiddenResponse):
+            switch forbiddenResponse.body {
+            case let .json(error):
+                throw GetCacheActionItemServiceError.forbidden(error.message)
+            }
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw GetCacheActionItemServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.unauthorized(error.message)
+            }
+        }
+    }
+}

--- a/Sources/TuistServer/Services/UploadCacheActionItemService.swift
+++ b/Sources/TuistServer/Services/UploadCacheActionItemService.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Mockable
+import TuistCore
+import TuistSupport
+
+@Mockable
+public protocol UploadCacheActionItemServicing {
+    func uploadCacheActionItem(
+        serverURL: URL,
+        fullHandle: String,
+        hash: String
+    ) async throws -> ServerCacheActionItem
+}
+
+public enum UploadCacheActionItemServiceError: FatalError, Equatable {
+    case unknownError(Int)
+    case notFound(String)
+    case paymentRequired(String)
+    case forbidden(String)
+    case unauthorized(String)
+    case badRequest(String)
+
+    public var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .paymentRequired, .forbidden, .unauthorized, .badRequest:
+            return .abort
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The cache item could not be uploaded due to an unknown Tuist response of \(statusCode)."
+        case let .notFound(message), let .paymentRequired(message), let .forbidden(message), let .unauthorized(message),
+             let .badRequest(message):
+            return message
+        }
+    }
+}
+
+public final class UploadCacheActionItemService: UploadCacheActionItemServicing {
+    private let fullHandleService: FullHandleServicing
+
+    public convenience init() {
+        self.init(fullHandleService: FullHandleService())
+    }
+
+    init(
+        fullHandleService: FullHandleServicing
+    ) {
+        self.fullHandleService = fullHandleService
+    }
+
+    public func uploadCacheActionItem(
+        serverURL: URL,
+        fullHandle: String,
+        hash: String
+    ) async throws -> ServerCacheActionItem {
+        let client = Client.authenticated(serverURL: serverURL)
+
+        let handles = try fullHandleService.parse(fullHandle)
+
+        let response = try await client.uploadCacheActionItem(
+            .init(
+                path: .init(
+                    account_handle: handles.accountHandle,
+                    project_handle:
+                    handles.projectHandle
+                ),
+                body: .json(
+                    .init(
+                        hash: hash
+                    )
+                )
+            )
+        )
+
+        switch response {
+        case let .created(createdResponse):
+            switch createdResponse.body {
+            case let .json(cacheActionItem):
+                return ServerCacheActionItem(cacheActionItem)
+            }
+        case let .paymentRequired(paymentRequiredResponse):
+            switch paymentRequiredResponse.body {
+            case let .json(error):
+                throw UploadCacheActionItemServiceError.paymentRequired(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw UploadCacheActionItemServiceError.unknownError(statusCode)
+        case let .forbidden(forbiddenResponse):
+            switch forbiddenResponse.body {
+            case let .json(error):
+                throw UploadCacheActionItemServiceError.forbidden(error.message)
+            }
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw UploadCacheActionItemServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw UploadCacheActionItemServiceError.unauthorized(error.message)
+            }
+        case let .badRequest(badRequestResponse):
+            switch badRequestResponse.body {
+            case let .json(error):
+                throw UploadCacheActionItemServiceError.badRequest(error.message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝

We're optimizing storing and fetching selective tests. There are two new endpoints that enable us to skip uploading/downloading actual files for selective testing since selective tests don't product any artifacts – only hashes of successful test runs.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
