### PR TITLE
fix test which requires date to be within an hour of current

### DIFF
--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -59,7 +59,7 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
         // Given
         let event = AnyAsyncQueueEvent(
             dispatcherId: "dispatcher",
-            date: date
+            date: Date()
         )
 
         // When


### PR DESCRIPTION

### Short description 📝
`test_write_whenDirectoryDoesntExist_itCreatesDirectory` was failing because the event was checked to be within one day. The date used for the test constant and worked within a day of when the time filter was added. This change makes sure the test always passes for the time check.

### How to test the changes locally 🧐

`tuist test --test-targets TuistAsyncQueueTests/AsyncQueuePersistorTests/test_write_whenDirectoryDoesntExist_itCreatesDirectory`

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
