### PR TITLE
Fix AsyncQueuePersistorTests due to unmocked date

### DIFF
--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -54,7 +54,10 @@ final class AsyncQueuePersistorTests: TuistUnitTestCase {
 
     func test_write_whenDirectoryDoesntExist_itCreatesDirectory() async throws {
         let temporaryDirectory = try! temporaryPath()
-        subject = AsyncQueuePersistor(directory: temporaryDirectory.appending(try RelativePath(validating: "test/")))
+        subject = AsyncQueuePersistor(
+            directory: temporaryDirectory.appending(try RelativePath(validating: "test/")),
+            dateService: dateService
+        )
 
         // Given
         let event = AnyAsyncQueueEvent(

--- a/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
@@ -283,7 +283,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
         await subject.start()
 
         // Then
-        wait(for: [expectation], timeout: timeout)
+        await fulfillment(of: [expectation], timeout: timeout)
         guard let dispatchedEventData = mockAsyncQueueDispatcher1.invokedDispatchPersistedDataParameter else {
             XCTFail("Data from persisted event was not dispatched")
             return
@@ -312,7 +312,7 @@ final class AsyncQueueTests: TuistUnitTestCase {
         await subject.start()
 
         // Then
-        wait(for: [expectation], timeout: timeout)
+        await fulfillment(of: [expectation], timeout: timeout)
         guard let filename = mockPersistor.invokedDeleteFilenameParameter else {
             XCTFail("Sent persisted event was then not deleted")
             return


### PR DESCRIPTION
### Short description 📝

Supersedes: https://github.com/tuist/tuist/pull/6718

Fixing a failing test. The reason why it got in was that it was successful for the first 24 hours before starting to fail. The issue was that we were not mocking the `DateService`.

### How to test the changes locally 🧐

The test should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
