### PR TITLE
Fix selective testing of a test plan

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -438,7 +438,6 @@ final class TestService { // swiftlint:disable:this type_body_length
                   let target = project.targets[$0.target.name] else { return nil }
             return GraphTarget(path: $0.path, target: target, project: project)
         }
-        print(testedGraphTargets)
         try await fileHandler.inTemporaryDirectory { _ in
             let allTestedTargets: Set<Target> = Set(
                 graphTraverser.allTargetDependencies(traversingFromTargets: testedGraphTargets)

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1495,19 +1495,78 @@ final class TestServiceTests: TuistUnitTestCase {
             .willReturn(.default)
         let testPlan = "TestPlan"
         let testPlanPath = try AbsolutePath(validating: "/testPlan/\(testPlan)")
+        let projectPath = try temporaryPath().appending(component: "Project")
+        let projectTestableSchemes = [
+            Scheme.test(
+                name: "TestScheme",
+                testAction: .test(
+                    targets: [
+                        .test(
+                            // This target's hash should _not_ be stored
+                            // as only targets in the test plan were tested.
+                            target: TargetReference(
+                                projectPath: projectPath,
+                                name: "TargetB"
+                            )
+                        ),
+                    ],
+                    testPlans: [
+                        .init(
+                            path: testPlanPath,
+                            testTargets: [
+                                .test(
+                                    target: TargetReference(
+                                        projectPath: projectPath,
+                                        name: "TargetA"
+                                    )
+                                ),
+                            ],
+                            isDefault: true
+                        ),
+                    ]
+                )
+            ),
+        ]
+
+        let graph: Graph = .test(
+            workspace: .test(
+                schemes: [
+                    Scheme.test(name: "App-Workspace"),
+                ]
+            ),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(
+                            name: "TargetA",
+                            bundleId: "io.tuist.TargetA"
+                        ),
+                        .test(
+                            name: "TargetB",
+                            bundleId: "io.tuist.TargetB"
+                        ),
+                    ],
+                    schemes: projectTestableSchemes
+                ),
+            ]
+        )
+
+        var environment = MapperEnvironment()
+        environment.initialGraph = graph
+        given(generator)
+            .generateWithGraph(path: .any)
+            .willProduce { path in
+                (
+                    path,
+                    graph,
+                    environment
+                )
+            }
+
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
-            .willReturn(
-                [
-                    Scheme.test(name: "App-Workspace"),
-                    Scheme.test(
-                        name: "TestScheme",
-                        testAction: .test(
-                            testPlans: [.init(path: testPlanPath, testTargets: [], isDefault: true)]
-                        )
-                    ),
-                ]
-            )
+            .willReturn(projectTestableSchemes)
         given(buildGraphInspector)
             .testableTarget(
                 scheme: .any,
@@ -1526,24 +1585,10 @@ final class TestServiceTests: TuistUnitTestCase {
         given(buildGraphInspector)
             .workspaceSchemes(graphTraverser: .any)
             .willReturn([])
-        given(generator)
-            .generateWithGraph(path: .any)
-            .willProduce { path in
-                (
-                    path,
-                    .test(
-                        workspace: .test(
-                            schemes: [
-                                .test(
-                                    name: "TestScheme",
-                                    testAction: .test(targets: [.test()])
-                                ),
-                            ]
-                        )
-                    ),
-                    MapperEnvironment()
-                )
-            }
+        environment.testsCacheUntestedHashes = [
+            .test(name: "TargetA", bundleId: "io.tuist.TargetA"): "hash-a",
+            .test(name: "TargetB", bundleId: "io.tuist.TargetB"): "hash-b",
+        ]
         var testedSchemes: [String] = []
         given(xcodebuildController)
             .test(
@@ -1574,6 +1619,16 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(testedSchemes, ["TestScheme"])
+        verify(cacheStorage)
+            .store(
+                .value(
+                    [
+                        CacheStorableItem(name: "TargetA", hash: "hash-a"): [],
+                    ]
+                ),
+                cacheCategory: .value(.selectiveTests)
+            )
+            .called(1)
     }
 
     func test_run_test_plan_failure() async throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6692

### Short description 📝
As described in the issue, running `tuist test --test-plan MyTestPlan` won't cache the results for the targets that are part of the plan. This is because in the `testActionTargets` method we were only looping through the scheme's test targets, not through the targets of the test plan.

The fix is to loop through the test plan's targets when a test plan was specified.

### How to test the changes locally 🧐

Run `tuist test --test-plan MyTestPlan` in `app_with_test_plan`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
