### PR TITLE
Migrate more hashers to return a merkle tree node

### DIFF
--- a/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Path
 import TuistCore
 import XcodeGraph
 
 public protocol CopyFilesContentHashing {
-    func hash(identifier: String, copyFiles: [CopyFilesAction]) throws -> MerkleNode
+    func hash(identifier: String, copyFiles: [CopyFilesAction], sourceRootPath: AbsolutePath) throws -> MerkleNode
 }
 
 /// `CopyFilesContentHasher`
@@ -21,7 +22,7 @@ public final class CopyFilesContentHasher: CopyFilesContentHashing {
 
     // MARK: - CopyFilesContentHashing
 
-    public func hash(identifier: String, copyFiles: [CopyFilesAction]) throws -> MerkleNode {
+    public func hash(identifier: String, copyFiles: [CopyFilesAction], sourceRootPath: AbsolutePath) throws -> MerkleNode {
         let children = try copyFiles.map { action in
             var actionChildren: [MerkleNode] = [
                 MerkleNode(hash: try contentHasher.hash(action.name), identifier: "name"),
@@ -41,7 +42,7 @@ public final class CopyFilesContentHasher: CopyFilesContentHashing {
                 }
                 return MerkleNode(
                     hash: try contentHasher.hash(fileChildren),
-                    identifier: file.path.pathString,
+                    identifier: file.path.relative(to: sourceRootPath).pathString,
                     children: fileChildren
                 )
             }

--- a/Sources/TuistHasher/CoreDataModelsContentHasher.swift
+++ b/Sources/TuistHasher/CoreDataModelsContentHasher.swift
@@ -26,7 +26,7 @@ public final class CoreDataModelsContentHasher: CoreDataModelsContentHashing {
              Since the directory being hashed through the attribute "path" contains the rest of the attributes, we are implicitly hashing them
              and therefore it's not necessary to hash them.
              */
-            var coreDataModelChildren = [
+            let coreDataModelChildren = [
                 MerkleNode(hash: try contentHasher.hash(path: coreDataModel.path), identifier: "content"),
             ]
             return MerkleNode(

--- a/Sources/TuistHasher/CoreDataModelsContentHasher.swift
+++ b/Sources/TuistHasher/CoreDataModelsContentHasher.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Path
 import TuistCore
 import XcodeGraph
 
 public protocol CoreDataModelsContentHashing {
-    func hash(identifier: String, coreDataModels: [CoreDataModel]) throws -> MerkleNode
+    func hash(identifier: String, coreDataModels: [CoreDataModel], sourceRootPath: AbsolutePath) throws -> MerkleNode
 }
 
 /// `CoreDataModelsContentHasher`
@@ -19,15 +20,19 @@ public final class CoreDataModelsContentHasher: CoreDataModelsContentHashing {
 
     // MARK: - CoreDataModelsContentHashing
 
-    public func hash(identifier: String, coreDataModels: [CoreDataModel]) throws -> MerkleNode {
+    public func hash(identifier: String, coreDataModels: [CoreDataModel], sourceRootPath: AbsolutePath) throws -> MerkleNode {
         let children = try coreDataModels.map { coreDataModel in
             /**
              Since the directory being hashed through the attribute "path" contains the rest of the attributes, we are implicitly hashing them
              and therefore it's not necessary to hash them.
              */
+            var coreDataModelChildren = [
+                MerkleNode(hash: try contentHasher.hash(path: coreDataModel.path), identifier: "content"),
+            ]
             return MerkleNode(
-                hash: try contentHasher.hash(path: coreDataModel.path),
-                identifier: coreDataModel.path.pathString
+                hash: try contentHasher.hash(coreDataModelChildren),
+                identifier: coreDataModel.path.relative(to: sourceRootPath).pathString,
+                children: coreDataModelChildren
             )
         }
 

--- a/Sources/TuistHasher/PlatformConditionContentHasher.swift
+++ b/Sources/TuistHasher/PlatformConditionContentHasher.swift
@@ -19,16 +19,15 @@ public struct PlatformConditionContentHasher: PlatformConditionContentHashing {
     }
 
     public func hash(identifier: String, platformCondition: PlatformCondition) throws -> MerkleNode {
-        let children = try platformCondition.platformFilters.sorted().map { filter in
+        let children = try platformCondition.platformFilters.sorted().map {
             MerkleNode(
-                hash: try contentHasher.hash(filter.xcodeprojValue),
-                identifier: filter.xcodeprojValue,
-                children: []
+                hash: try contentHasher.hash($0.xcodeprojValue),
+                identifier: "\($0)"
             )
         }
 
         return MerkleNode(
-            hash: try contentHasher.hash(children.map(\.hash)),
+            hash: try contentHasher.hash(children),
             identifier: identifier,
             children: children
         )

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -87,20 +87,82 @@ public final class TargetContentHasher: TargetContentHashing {
         hashedPaths: inout [AbsolutePath: String],
         additionalStrings: [String] = []
     ) throws -> String {
-        let sourcesHash = try sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash
-        let resourcesHash = try resourcesContentHasher.hash(identifier: "resources", resources: graphTarget.target.resources).hash
-        let copyFilesHash = try copyFilesContentHasher.hash(identifier: "copyFiles", copyFiles: graphTarget.target.copyFiles).hash
+//        public var name: String
+//
+//        public var destinations: XcodeGraph.Destinations
+//
+//        public var product: XcodeGraph.Product
+//
+//        public var bundleId: String
+//
+//        public var productName: String
+//
+//        public var deploymentTargets: XcodeGraph.DeploymentTargets
+//
+//        public var infoPlist: XcodeGraph.InfoPlist?
+//
+//        public var entitlements: XcodeGraph.Entitlements?
+//
+//        public var settings: XcodeGraph.Settings?
+//
+//        public var dependencies: [XcodeGraph.TargetDependency]
+//
+//        public var headers: XcodeGraph.Headers?
+//
+//        public var scripts: [XcodeGraph.TargetScript]
+//
+//        public var environmentVariables: [String : XcodeGraph.EnvironmentVariable]
+//
+//        public var launchArguments: [XcodeGraph.LaunchArgument]
+//
+//        public var filesGroup: XcodeGraph.ProjectGroup
+//
+//        public var rawScriptBuildPhases: [XcodeGraph.RawScriptBuildPhase]
+//
+//        public var playgrounds: [Path.AbsolutePath]
+//
+//        public let additionalFiles: [XcodeGraph.FileElement]
+//
+//        public var buildRules: [XcodeGraph.BuildRule]
+//
+//        public var prune: Bool
+//
+//        public let mergedBinaryType: XcodeGraph.MergedBinaryType
+//
+//        public let mergeable: Bool
+//
+//        public let onDemandResourcesTags: XcodeGraph.OnDemandResourcesTags?
+
+        let sourceRootPath = graphTarget.project.sourceRootPath
+        let sourcesHash = try sourceFilesContentHasher.hash(
+            identifier: "sources",
+            sources: graphTarget.target.sources,
+            sourceRootPath: sourceRootPath
+        ).hash
+
+        let resourcesHash = try resourcesContentHasher.hash(
+            identifier: "resources",
+            resources: graphTarget.target.resources,
+            sourceRootPath: sourceRootPath
+        ).hash
+        let copyFilesHash = try copyFilesContentHasher.hash(
+            identifier: "copyFiles",
+            copyFiles: graphTarget.target.copyFiles,
+            sourceRootPath: sourceRootPath
+        ).hash
         let coreDataModelHash = try coreDataModelsContentHasher.hash(
             identifier: "coreDataModels",
-            coreDataModels: graphTarget.target.coreDataModels
+            coreDataModels: graphTarget.target.coreDataModels,
+            sourceRootPath: sourceRootPath
+        ).hash
+        let scriptsHash = try targetScriptsContentHasher.hash(
+            identifier: "scripts",
+            targetScripts: graphTarget.target.scripts,
+            sourceRootPath: sourceRootPath
         ).hash
 
         // NEXT
 
-        let targetScriptsHash = try targetScriptsContentHasher.hash(
-            targetScripts: graphTarget.target.scripts,
-            sourceRootPath: graphTarget.project.sourceRootPath
-        )
         let dependenciesHash = try dependenciesContentHasher.hash(
             graphTarget: graphTarget,
             hashedTargets: &hashedTargets,
@@ -117,7 +179,7 @@ public final class TargetContentHasher: TargetContentHashing {
             resourcesHash,
             copyFilesHash,
             coreDataModelHash,
-            targetScriptsHash,
+            scriptsHash,
             environmentHash,
         ]
 

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -87,52 +87,6 @@ public final class TargetContentHasher: TargetContentHashing {
         hashedPaths: inout [AbsolutePath: String],
         additionalStrings: [String] = []
     ) throws -> String {
-//        public var name: String
-//
-//        public var destinations: XcodeGraph.Destinations
-//
-//        public var product: XcodeGraph.Product
-//
-//        public var bundleId: String
-//
-//        public var productName: String
-//
-//        public var deploymentTargets: XcodeGraph.DeploymentTargets
-//
-//        public var infoPlist: XcodeGraph.InfoPlist?
-//
-//        public var entitlements: XcodeGraph.Entitlements?
-//
-//        public var settings: XcodeGraph.Settings?
-//
-//        public var dependencies: [XcodeGraph.TargetDependency]
-//
-//        public var headers: XcodeGraph.Headers?
-//
-//        public var scripts: [XcodeGraph.TargetScript]
-//
-//        public var environmentVariables: [String : XcodeGraph.EnvironmentVariable]
-//
-//        public var launchArguments: [XcodeGraph.LaunchArgument]
-//
-//        public var filesGroup: XcodeGraph.ProjectGroup
-//
-//        public var rawScriptBuildPhases: [XcodeGraph.RawScriptBuildPhase]
-//
-//        public var playgrounds: [Path.AbsolutePath]
-//
-//        public let additionalFiles: [XcodeGraph.FileElement]
-//
-//        public var buildRules: [XcodeGraph.BuildRule]
-//
-//        public var prune: Bool
-//
-//        public let mergedBinaryType: XcodeGraph.MergedBinaryType
-//
-//        public let mergeable: Bool
-//
-//        public let onDemandResourcesTags: XcodeGraph.OnDemandResourcesTags?
-
         let sourceRootPath = graphTarget.project.sourceRootPath
         let sourcesHash = try sourceFilesContentHasher.hash(
             identifier: "sources",

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -90,7 +90,13 @@ public final class TargetContentHasher: TargetContentHashing {
         let sourcesHash = try sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash
         let resourcesHash = try resourcesContentHasher.hash(identifier: "resources", resources: graphTarget.target.resources).hash
         let copyFilesHash = try copyFilesContentHasher.hash(identifier: "copyFiles", copyFiles: graphTarget.target.copyFiles).hash
-        let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
+        let coreDataModelHash = try coreDataModelsContentHasher.hash(
+            identifier: "coreDataModels",
+            coreDataModels: graphTarget.target.coreDataModels
+        ).hash
+
+        // NEXT
+
         let targetScriptsHash = try targetScriptsContentHasher.hash(
             targetScripts: graphTarget.target.scripts,
             sourceRootPath: graphTarget.project.sourceRootPath

--- a/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
@@ -51,7 +51,11 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 0 ... 100 {
-            results.insert(try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction]).hash)
+            results.insert(try subject.hash(
+                identifier: "copyFilesActions",
+                copyFiles: [copyFilesAction],
+                sourceRootPath: temporaryDirectory
+            ).hash)
         }
 
         // Then
@@ -78,7 +82,11 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction])
+        let got = try subject.hash(
+            identifier: "copyFilesActions",
+            copyFiles: [copyFilesAction],
+            sourceRootPath: temporaryDirectory
+        )
 
         // Then
         XCTAssertEqual(got, MerkleNode(
@@ -106,7 +114,7 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
                             children: [
                                 MerkleNode(
                                     hash: "7178d66b2f9f58b50207c4ac3eef73d4",
-                                    identifier: filePath.pathString,
+                                    identifier: filePath.relative(to: temporaryDirectory).pathString,
                                     children: [
                                         MerkleNode(
                                             hash: "d41d8cd98f00b204e9800998ecf8427e",

--- a/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
@@ -26,7 +26,8 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
     func test_hash_isDeterministic() async throws {
         // Given
         let fileSystem = FileSystem()
-        let coreDataModelPath = (try temporaryPath()).appending(component: "Test.xcdatamodeld")
+        let temporaryDirectory = try temporaryPath()
+        let coreDataModelPath = temporaryDirectory.appending(component: "Test.xcdatamodeld")
         let v1 = coreDataModelPath.appending(component: "v1.xcdatamodel")
         let v2 = coreDataModelPath.appending(component: "v2.xcdatamodel")
         let xccurrentVersionPath = coreDataModelPath.appending(component: ".xccurrentversion")
@@ -44,7 +45,11 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 1 ... 100 {
-            hashes.insert(try subject.hash(identifier: "coreDataModels", coreDataModels: coreDataModels).hash)
+            hashes.insert(try subject.hash(
+                identifier: "coreDataModels",
+                coreDataModels: coreDataModels,
+                sourceRootPath: temporaryDirectory
+            ).hash)
         }
 
         // Then
@@ -54,7 +59,8 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
     func test_hash_returnsAValidTree() async throws {
         // Given
         let fileSystem = FileSystem()
-        let coreDataModelPath = (try temporaryPath()).appending(component: "Test.xcdatamodeld")
+        let temporaryDirectory = try temporaryPath()
+        let coreDataModelPath = temporaryDirectory.appending(component: "Test.xcdatamodeld")
         let v1 = coreDataModelPath.appending(component: "v1.xcdatamodel")
         let v2 = coreDataModelPath.appending(component: "v2.xcdatamodel")
         let xccurrentVersionPath = coreDataModelPath.appending(component: ".xccurrentversion")
@@ -70,17 +76,29 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
         )]
 
         // When
-        let got = try subject.hash(identifier: "coreDataModels", coreDataModels: coreDataModels)
+        let got = try subject.hash(
+            identifier: "coreDataModels",
+            coreDataModels: coreDataModels,
+            sourceRootPath: temporaryDirectory
+        )
+
+        print(got)
 
         // Then
         XCTAssertEqual(got, MerkleNode(
-            hash: "687ce1ef085fe7374f5f5a57a8583643",
+            hash: "aca4c8d17d460a3213495d3e704827ed",
             identifier: "coreDataModels",
             children: [
                 MerkleNode(
-                    hash: "9d54ac3c04cee9afeb00227788035726-98bf7d8c15784f0a3d63204441e1e2aa-98bf7d8c15784f0a3d63204441e1e2aa",
-                    identifier: coreDataModelPath.pathString,
-                    children: []
+                    hash: "687ce1ef085fe7374f5f5a57a8583643",
+                    identifier: coreDataModelPath.relative(to: temporaryDirectory).pathString,
+                    children: [
+                        MerkleNode(
+                            hash: "9d54ac3c04cee9afeb00227788035726-98bf7d8c15784f0a3d63204441e1e2aa-98bf7d8c15784f0a3d63204441e1e2aa",
+                            identifier: "content",
+                            children: []
+                        ),
+                    ]
                 ),
             ]
         ))

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -49,7 +49,11 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 0 ..< 100 {
-            hashes.insert(try subject.hash(identifier: "resources", resources: resourceFileElements).hash)
+            hashes.insert(try subject.hash(
+                identifier: "resources",
+                resources: resourceFileElements,
+                sourceRootPath: temporaryDirectory
+            ).hash)
         }
 
         // Then
@@ -77,7 +81,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         ], privacyManifest: privacyManifest)
 
         // When
-        let got = try subject.hash(identifier: "resources", resources: resourceFileElements)
+        let got = try subject.hash(identifier: "resources", resources: resourceFileElements, sourceRootPath: temporaryDirectory)
 
         // Then
         XCTAssertEqual(got, MerkleNode(
@@ -86,7 +90,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
             children: [
                 MerkleNode(
                     hash: "069310d0d484da1c8bcc98386a1f36e7",
-                    identifier: resource1.pathString,
+                    identifier: resource1.relative(to: temporaryDirectory).pathString,
                     children: [
                         MerkleNode(
                             hash: "c4ca4238a0b923820dcc509a6f75849b",
@@ -118,7 +122,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
                 ),
                 MerkleNode(
                     hash: "09eb77e7eb4c9f21384c143fc399c5ca",
-                    identifier: resource2.parentDirectory.pathString,
+                    identifier: resource2.parentDirectory.relative(to: temporaryDirectory).pathString,
                     children: [
                         MerkleNode(
                             hash: "c81e728d9d4c2f636f067f89cc14862c",

--- a/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
@@ -42,11 +42,12 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_when_sourcesHaveAHashSet() throws {
         // Given
+        let temporaryDir = try temporaryPath()
         let sourceFile1 = SourceFile(path: sourceFile1Path, contentHash: "first")
         let sourceFile2 = SourceFile(path: sourceFile2Path, contentHash: "second")
 
         // When
-        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
+        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2], sourceRootPath: temporaryDir)
 
         // Then
         XCTAssertEqual(node, MerkleNode(
@@ -55,12 +56,12 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
             children: [
                 MerkleNode(
                     hash: "first",
-                    identifier: sourceFile1.path.pathString,
+                    identifier: sourceFile1.path.relative(to: temporaryDir).pathString,
                     children: []
                 ),
                 MerkleNode(
                     hash: "second",
-                    identifier: sourceFile2.path.pathString,
+                    identifier: sourceFile2.path.relative(to: temporaryDir).pathString,
                     children: []
                 ),
             ]
@@ -69,6 +70,7 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_when_sourcesHaveNoHashSet() async throws {
         // Given
+        let temporaryDir = try temporaryPath()
         let sourceFile1 = SourceFile(
             path: sourceFile1Path,
             compilerFlags: "-fno-objc-arc;",
@@ -83,16 +85,17 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
         try await fileSystem.writeText("sourceFile2", at: sourceFile2Path)
 
         // When
-        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
+        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2], sourceRootPath: temporaryDir)
 
         // Then
+        print(node)
         XCTAssertEqual(node, MerkleNode(
             hash: "a399dc1a1cf69cb55d7b7dda76b62e0a",
             identifier: "sources",
             children: [
                 MerkleNode(
                     hash: "0921d026fd1854efd0b5735265bec941",
-                    identifier: sourceFile1Path.pathString,
+                    identifier: sourceFile1Path.relative(to: temporaryDir).pathString,
                     children: [
                         MerkleNode(
                             hash: "082b4a6d39b5f89e0c48bac6bc6c157b",
@@ -124,7 +127,7 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
                 ),
                 MerkleNode(
                     hash: "8b0b259086f1d24e1a0340e1abbae3b5",
-                    identifier: sourceFile2Path.pathString,
+                    identifier: sourceFile2Path.relative(to: temporaryDir).pathString,
                     children: [
                         MerkleNode(
                             hash: "ea109ebc1d271b006a1e76824e55df15",

--- a/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import MockableTest
 import Path
@@ -11,214 +12,421 @@ import XCTest
 
 final class TargetScriptsContentHasherTests: TuistUnitTestCase {
     private var subject: TargetScriptsContentHasher!
-    private var contentHasher: MockContentHashing!
-    private var temporaryDirectory: TemporaryDirectory!
 
-    override func setUp() {
-        super.setUp()
-        contentHasher = .init()
-        subject = TargetScriptsContentHasher(contentHasher: contentHasher)
-        do {
-            temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
-        } catch {
-            XCTFail("Error while creating temporary directory")
-        }
-        given(contentHasher)
-            .hash(Parameter<String>.any)
-            .willProduce { $0 + "-hash" }
-        given(contentHasher)
-            .hash(Parameter<[String]>.any)
-            .willProduce { $0.joined(separator: ";") }
+    override func setUp() async throws {
+        try await super.setUp()
+        subject = TargetScriptsContentHasher(contentHasher: ContentHasher())
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         subject = nil
-        temporaryDirectory = nil
-        contentHasher = nil
-
-        super.tearDown()
+        try await super.tearDown()
     }
 
-    private func makeTargetScript(
-        name: String = "1",
-        order: TargetScript.Order = .pre,
-        tool: String = "tool1",
-        arguments: [String] = ["arg1", "arg2"],
-        inputPaths: [AbsolutePath] = [try! AbsolutePath(validating: "/inputPaths1")],
-        inputFileListPaths: [AbsolutePath] = [try! AbsolutePath(validating: "/inputFileListPaths1")],
-        outputPaths: [AbsolutePath] = [try! AbsolutePath(validating: "/outputPaths1")],
-        outputFileListPaths: [AbsolutePath] = [try! AbsolutePath(validating: "/outputFileListPaths1")],
-        dependencyFile: AbsolutePath = try! AbsolutePath(validating: "/dependencyFile1")
-    ) -> TargetScript {
-        TargetScript(
-            name: name,
-            order: order,
-            script: .tool(path: tool, args: arguments),
-            inputPaths: inputPaths.map(\.pathString),
-            inputFileListPaths: inputFileListPaths,
-            outputPaths: outputPaths.map(\.pathString),
-            outputFileListPaths: outputFileListPaths,
-            dependencyFile: dependencyFile
-        )
-    }
-
-    // MARK: - Tests
-
-    func test_hash_targetAction_withBuildVariables_callsMockHasherWithOnlyPathWithoutBuildVariable() throws {
+    func test_hash_isDeterministic() async throws {
         // Given
-        let inputFileListPaths1 = "inputFileListPaths1-hash"
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputFileListPaths1")))
-            .willReturn(inputFileListPaths1)
-        let targetScript = makeTargetScript(
-            inputPaths: [try AbsolutePath(validating: "/$(SRCROOT)/inputPaths1")],
-            inputFileListPaths: [try AbsolutePath(validating: "/inputFileListPaths1")],
-            outputPaths: [try AbsolutePath(validating: "/$(DERIVED_FILE_DIR)/outputPaths1")],
-            outputFileListPaths: [try AbsolutePath(validating: "/outputFileListPaths1")],
-            dependencyFile: try AbsolutePath(validating: "/$(DERIVED_FILE_DIR)/file.d")
-        )
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let dependencyFile = temporaryDirectory.appending(component: "dependency.d")
+        try await fileSystem.touch(dependencyFile)
+        let targetScripts: [TargetScript] = [
+            TargetScript(
+                name: "script",
+                order: .pre,
+                script: .embedded("echo 'foo'"),
+                inputPaths: [],
+                inputFileListPaths: [],
+                outputPaths: [],
+                outputFileListPaths: [],
+                showEnvVarsInLog: true,
+                basedOnDependencyAnalysis: true,
+                runForInstallBuildsOnly: true,
+                shellPath: "/bin/env bash",
+                dependencyFile: dependencyFile
+            ),
+        ]
+        var hashes: Set<String> = Set()
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        for _ in 0 ... 100 {
+            hashes.insert(try subject.hash(
+                identifier: "targetScripts",
+                targetScripts: targetScripts,
+                sourceRootPath: temporaryDirectory
+            ).hash)
+        }
 
         // Then
-        let expected = [
-            "$(SRCROOT)/inputPaths1",
-            "$(DERIVED_FILE_DIR)/file.d",
-            inputFileListPaths1,
-            "$(DERIVED_FILE_DIR)/outputPaths1",
-            "outputFileListPaths1",
-            "1",
-            "tool1",
-            "pre",
-            "arg1",
-            "arg2",
-        ]
-
-        verify(contentHasher)
-            .hash(.value(expected))
-            .called(1)
+        XCTAssertEqual(hashes.count, 1)
     }
 
-    func test_hash_targetAction_callsMockHasherWithExpectedStrings() throws {
+    func test_hash_returnsACorrectValue_when_embedded() async throws {
         // Given
-        let inputPaths1Hash = "inputPaths1-hash"
-        let inputFileListPaths1 = "inputFileListPaths1-hash"
-        let dependencyFileHash = "dependencyFile1-hash"
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputPaths1")))
-            .willReturn(inputPaths1Hash)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputFileListPaths1")))
-            .willReturn(inputFileListPaths1)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/dependencyFile1")))
-            .willReturn(dependencyFileHash)
-        let targetScript = makeTargetScript()
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let inputFilePath = temporaryDirectory.appending(component: "input")
+        let inputFileListPath = temporaryDirectory.appending(component: "input.xcfilelist")
+        let dependencyFilePath = temporaryDirectory.appending(component: "dependency.d")
+        let outputFileListPath = temporaryDirectory.appending(component: "output.xcfilelist")
+
+        try await fileSystem.touch(inputFilePath)
+        try await fileSystem.touch(inputFileListPath)
+        try await fileSystem.touch(dependencyFilePath)
+        try await fileSystem.touch(outputFileListPath)
+
+        let targetScripts: [TargetScript] = [
+            TargetScript(
+                name: "script",
+                order: .pre,
+                script: .embedded("echo 'foo'"),
+                inputPaths: [inputFilePath.pathString],
+                inputFileListPaths: [inputFileListPath],
+                outputPaths: ["$(DERIVED_FILE_DIR)/output"],
+                outputFileListPaths: [outputFileListPath],
+                showEnvVarsInLog: true,
+                basedOnDependencyAnalysis: true,
+                runForInstallBuildsOnly: true,
+                shellPath: "/bin/env bash",
+                dependencyFile: dependencyFilePath
+            ),
+        ]
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        let got = try subject.hash(identifier: "targetScripts", targetScripts: targetScripts, sourceRootPath: temporaryDirectory)
 
         // Then
-        let expected = [
-            inputPaths1Hash,
-            inputFileListPaths1,
-            dependencyFileHash,
-            "outputPaths1",
-            "outputFileListPaths1",
-            "1",
-            "tool1",
-            "pre",
-            "arg1",
-            "arg2",
-        ]
-        verify(contentHasher)
-            .hash(.value(expected))
-            .called(1)
+
+        XCTAssertBetterEqual(got, MerkleNode(
+            hash: "f998595a4c29c055986eea0f161c2414",
+            identifier: "targetScripts",
+            children: [
+                MerkleNode(
+                    hash: "4f46d0a08b22aa87400cf7d42f11b2eb",
+                    identifier: "script",
+                    children: [
+                        MerkleNode(
+                            hash: "3205c0ded576131ea255ad2bd38b0fb2",
+                            identifier: "name",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "6bf9e70a1f928aba143ef1eebe2720b5",
+                            identifier: "order",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "arguments",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "showEnvVarsInLog",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "runForInstallBuildsOnly",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "7c8004fdd34501290a365abf0a8075af",
+                            identifier: "shellPath",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "e7fb3c7d0d873bd34060e7dd99ab2f0c",
+                            identifier: "embeddedScript",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "basedOnDependencyAnalysis",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "e7fb3c7d0d873bd34060e7dd99ab2f0c",
+                            identifier: "embeddedScript",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "dependency.d",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputFileListPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "outputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "ea2b5501efdb4691fb32d16a029e5dea",
+                            identifier: "outputFileListPaths",
+                            children: []
+                        ),
+                    ]
+                ),
+            ]
+        ))
     }
 
-    func test_hash_targetAction_when_path_nil_callsMockHasherWithExpectedStrings() throws {
+    func test_hash_returnsACorrectValue_when_tool() async throws {
         // Given
-        let inputPaths1Hash = "inputPaths1-hash"
-        let inputFileListPaths1 = "inputFileListPaths1-hash"
-        let dependencyFileHash = "dependencyFile1-hash"
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputPaths1")))
-            .willReturn(inputPaths1Hash)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputFileListPaths1")))
-            .willReturn(inputFileListPaths1)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/dependencyFile1")))
-            .willReturn(dependencyFileHash)
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let inputFilePath = temporaryDirectory.appending(component: "input")
+        let inputFileListPath = temporaryDirectory.appending(component: "input.xcfilelist")
+        let dependencyFilePath = temporaryDirectory.appending(component: "dependency.d")
+        let outputFileListPath = temporaryDirectory.appending(component: "output.xcfilelist")
 
-        let targetScript = makeTargetScript()
+        try await fileSystem.touch(inputFilePath)
+        try await fileSystem.touch(inputFileListPath)
+        try await fileSystem.touch(dependencyFilePath)
+        try await fileSystem.touch(outputFileListPath)
+
+        let targetScripts: [TargetScript] = [
+            TargetScript(
+                name: "script",
+                order: .pre,
+                script: .tool(path: "tool", args: ["foo", "bar"]),
+                inputPaths: [inputFilePath.pathString],
+                inputFileListPaths: [inputFileListPath],
+                outputPaths: ["$(DERIVED_FILE_DIR)/output"],
+                outputFileListPaths: [outputFileListPath],
+                showEnvVarsInLog: true,
+                basedOnDependencyAnalysis: true,
+                runForInstallBuildsOnly: true,
+                shellPath: "/bin/env bash",
+                dependencyFile: dependencyFilePath
+            ),
+        ]
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        let got = try subject.hash(identifier: "targetScripts", targetScripts: targetScripts, sourceRootPath: temporaryDirectory)
 
         // Then
-        let expected = [
-            inputPaths1Hash,
-            inputFileListPaths1,
-            dependencyFileHash,
-            "outputPaths1",
-            "outputFileListPaths1",
-            "1",
-            "tool1",
-            "pre",
-            "arg1",
-            "arg2",
-        ]
-        verify(contentHasher)
-            .hash(.value(expected))
-            .called(1)
+        XCTAssertBetterEqual(got, MerkleNode(
+            hash: "6195645d6ce4841d46aaef61e288b0fc",
+            identifier: "targetScripts",
+            children: [
+                MerkleNode(
+                    hash: "98a2441ccd73e19dd9147555b9f20b44",
+                    identifier: "script",
+                    children: [
+                        MerkleNode(
+                            hash: "3205c0ded576131ea255ad2bd38b0fb2",
+                            identifier: "name",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "6bf9e70a1f928aba143ef1eebe2720b5",
+                            identifier: "order",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3858f62230ac3c915f300c664312c63f",
+                            identifier: "arguments",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "showEnvVarsInLog",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "runForInstallBuildsOnly",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "7c8004fdd34501290a365abf0a8075af",
+                            identifier: "shellPath",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "39ab32c5aeb56c9f5ae17f073ce31023",
+                            identifier: "tool",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3858f62230ac3c915f300c664312c63f",
+                            identifier: "arguments",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "basedOnDependencyAnalysis",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "39ab32c5aeb56c9f5ae17f073ce31023",
+                            identifier: "tool",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "dependency.d",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputFileListPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "outputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "ea2b5501efdb4691fb32d16a029e5dea",
+                            identifier: "outputFileListPaths",
+                            children: []
+                        ),
+                    ]
+                ),
+            ]
+        ))
     }
 
-    func test_hash_targetAction_valuesAreNotHarcoded() throws {
+    func test_hash_returnsACorrectValue_when_script() async throws {
         // Given
-        let inputPaths2Hash = "inputPaths2-hash"
-        let inputFileListPaths2 = "inputFileListPaths2-hash"
-        let dependencyFileHash = "/dependencyFilePath4-hash"
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputPaths2")))
-            .willReturn(inputPaths2Hash)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/inputFileListPaths2")))
-            .willReturn(inputFileListPaths2)
-        given(contentHasher)
-            .hash(path: .value(try AbsolutePath(validating: "/dependencyFilePath4")))
-            .willReturn(dependencyFileHash)
+        let fileSystem = FileSystem()
+        let temporaryDirectory = try temporaryPath()
+        let scriptPath = temporaryDirectory.appending(component: "script")
+        let inputFilePath = temporaryDirectory.appending(component: "input")
+        let inputFileListPath = temporaryDirectory.appending(component: "input.xcfilelist")
+        let dependencyFilePath = temporaryDirectory.appending(component: "dependency.d")
+        let outputFileListPath = temporaryDirectory.appending(component: "output.xcfilelist")
 
-        let targetScript = makeTargetScript(
-            name: "2",
-            order: .post,
-            tool: "tool2",
-            inputPaths: [try AbsolutePath(validating: "/inputPaths2")],
-            inputFileListPaths: [try AbsolutePath(validating: "/inputFileListPaths2")],
-            outputPaths: [try AbsolutePath(validating: "/outputPaths2")],
-            outputFileListPaths: [try AbsolutePath(validating: "/outputFileListPaths2")],
-            dependencyFile: try AbsolutePath(validating: "/dependencyFilePath4")
-        )
+        try await fileSystem.writeText("script", at: scriptPath)
+        try await fileSystem.touch(inputFilePath)
+        try await fileSystem.touch(inputFileListPath)
+        try await fileSystem.touch(dependencyFilePath)
+        try await fileSystem.touch(outputFileListPath)
+
+        let targetScripts: [TargetScript] = [
+            TargetScript(
+                name: "script",
+                order: .pre,
+                script: .scriptPath(path: scriptPath, args: ["foo", "bar"]),
+                inputPaths: [inputFilePath.pathString],
+                inputFileListPaths: [inputFileListPath],
+                outputPaths: ["$(DERIVED_FILE_DIR)/output"],
+                outputFileListPaths: [outputFileListPath],
+                showEnvVarsInLog: true,
+                basedOnDependencyAnalysis: true,
+                runForInstallBuildsOnly: true,
+                shellPath: "/bin/env bash",
+                dependencyFile: dependencyFilePath
+            ),
+        ]
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        let got = try subject.hash(identifier: "targetScripts", targetScripts: targetScripts, sourceRootPath: temporaryDirectory)
 
         // Then
-        let expected = [
-            inputPaths2Hash,
-            inputFileListPaths2,
-            dependencyFileHash,
-            "outputPaths2",
-            "outputFileListPaths2",
-            "2",
-            "tool2",
-            "post",
-            "arg1",
-            "arg2",
-        ]
-        verify(contentHasher)
-            .hash(.value(expected))
-            .called(1)
+        XCTAssertBetterEqual(got, MerkleNode(
+            hash: "46223dd29e214ec27955fc296754bb6c",
+            identifier: "targetScripts",
+            children: [
+                MerkleNode(
+                    hash: "e42251f58a728466cf96d5e032550493",
+                    identifier: "script",
+                    children: [
+                        MerkleNode(
+                            hash: "3205c0ded576131ea255ad2bd38b0fb2",
+                            identifier: "name",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "6bf9e70a1f928aba143ef1eebe2720b5",
+                            identifier: "order",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3858f62230ac3c915f300c664312c63f",
+                            identifier: "arguments",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "showEnvVarsInLog",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "runForInstallBuildsOnly",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "7c8004fdd34501290a365abf0a8075af",
+                            identifier: "shellPath",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3205c0ded576131ea255ad2bd38b0fb2",
+                            identifier: "script",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3858f62230ac3c915f300c664312c63f",
+                            identifier: "arguments",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "c4ca4238a0b923820dcc509a6f75849b",
+                            identifier: "basedOnDependencyAnalysis",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "3205c0ded576131ea255ad2bd38b0fb2",
+                            identifier: "script",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "dependency.d",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "74be16979710d4c4e7c6647856088456",
+                            identifier: "inputFileListPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "d41d8cd98f00b204e9800998ecf8427e",
+                            identifier: "outputPaths",
+                            children: []
+                        ),
+                        MerkleNode(
+                            hash: "ea2b5501efdb4691fb32d16a029e5dea",
+                            identifier: "outputFileListPaths",
+                            children: []
+                        ),
+                    ]
+                ),
+            ]
+        ))
     }
 }


### PR DESCRIPTION
### Short description 📝
Continuing with the effort to enhance the debugging of the hashing logic, I'm updating some hashers to return a merkle tree node.

### How to test the changes locally 🧐
Tests should pass, and running the `tuist cache --print-hashes` against an existing protect should yield deterministic results.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
