### PR TITLE
Add support of swift language mode SPM target build setting

### DIFF
--- a/Sources/TuistLoader/Models/PackageInfo.swift
+++ b/Sources/TuistLoader/Models/PackageInfo.swift
@@ -371,7 +371,7 @@ extension PackageInfo.Target {
 
         /// The name of the build setting.
         public enum SettingName: String, Codable, Hashable {
-            case swiftVersion
+            case swiftLanguageMode
             case headerSearchPath
             case define
             case linkedLibrary
@@ -459,7 +459,7 @@ extension PackageInfo.Target {
                         name = .enableExperimentalFeature
                         self.value = [value]
                     case let .swiftLanguageMode(value):
-                        name = .swiftVersion
+                        name = .swiftLanguageMode
                         self.value = [value]
                     }
                 } else {
@@ -488,7 +488,7 @@ extension PackageInfo.Target {
                     try container.encode(Kind.enableUpcomingFeature(value.first!), forKey: .kind)
                 case .enableExperimentalFeature:
                     try container.encode(Kind.enableExperimentalFeature(value.first!), forKey: .kind)
-                case .swiftVersion:
+                case .swiftLanguageMode:
                     try container.encode(Kind.swiftLanguageMode(value.first!), forKey: .kind)
                 }
             }

--- a/Sources/TuistLoader/Models/PackageInfo.swift
+++ b/Sources/TuistLoader/Models/PackageInfo.swift
@@ -371,6 +371,7 @@ extension PackageInfo.Target {
 
         /// The name of the build setting.
         public enum SettingName: String, Codable, Hashable {
+            case swiftVersion
             case headerSearchPath
             case define
             case linkedLibrary
@@ -419,6 +420,7 @@ extension PackageInfo.Target {
 
             // Xcode 14 format
             private enum Kind: Codable, Equatable {
+                case swiftLanguageMode(String)
                 case headerSearchPath(String)
                 case define(String)
                 case linkedLibrary(String)
@@ -456,6 +458,9 @@ extension PackageInfo.Target {
                     case let .enableExperimentalFeature(value):
                         name = .enableExperimentalFeature
                         self.value = [value]
+                    case let .swiftLanguageMode(value):
+                        name = .swiftVersion
+                        self.value = [value]
                     }
                 } else {
                     name = try container.decode(SettingName.self, forKey: .name)
@@ -483,6 +488,8 @@ extension PackageInfo.Target {
                     try container.encode(Kind.enableUpcomingFeature(value.first!), forKey: .kind)
                 case .enableExperimentalFeature:
                     try container.encode(Kind.enableExperimentalFeature(value.first!), forKey: .kind)
+                case .swiftVersion:
+                    try container.encode(Kind.swiftLanguageMode(value.first!), forKey: .kind)
                 }
             }
         }

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -542,7 +542,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                         .linker,
                         .define
                     ),
-                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature):
+                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
                         return nil
                     }
                 } catch {
@@ -971,7 +971,7 @@ extension ProjectDescription.TargetDependency {
                     .linker,
                     .define
                 ),
-                (.linker, .unsafeFlags), (_, .enableExperimentalFeature):
+                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
                     return nil
                 }
             } catch {

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -971,7 +971,7 @@ extension ProjectDescription.TargetDependency {
                     .linker,
                     .define
                 ),
-                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
+                (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
                     return nil
                 }
             } catch {

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -542,7 +542,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                         .linker,
                         .define
                     ),
-                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
+                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftLanguageMode):
                         return nil
                     }
                 } catch {
@@ -971,7 +971,7 @@ extension ProjectDescription.TargetDependency {
                     .linker,
                     .define
                 ),
-                (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftVersion):
+                (.linker, .unsafeFlags), (_, .enableExperimentalFeature), (_, .swiftLanguageMode):
                     return nil
                 }
             } catch {

--- a/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -87,6 +87,8 @@ struct SettingsMapper {
             case (.swift, .enableExperimentalFeature):
                 swiftFlags.append("-enable-experimental-feature \"\(setting.value[0])\"")
             case (.swift, .swiftVersion):
+                // TODO: Use -language-mode instead of -swift-version when Xcode 15 support is removed.
+                // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0441-formalize-language-mode-terminology.md#swift-compiler-option
                 swiftFlags.append("-swift-version \(setting.value[0])")
             case (.linker, .unsafeFlags):
                 linkerFlags.append(contentsOf: setting.value)

--- a/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -86,6 +86,8 @@ struct SettingsMapper {
                 swiftFlags.append("-enable-upcoming-feature \"\(setting.value[0])\"")
             case (.swift, .enableExperimentalFeature):
                 swiftFlags.append("-enable-experimental-feature \"\(setting.value[0])\"")
+            case (.swift, .swiftVersion):
+                swiftFlags.append("-swift-version \(setting.value[0])")
             case (.linker, .unsafeFlags):
                 linkerFlags.append(contentsOf: setting.value)
             case (.linker, .linkedFramework), (.linker, .linkedLibrary):
@@ -94,7 +96,7 @@ struct SettingsMapper {
             case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                  (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
                  (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature),
-                 (_, .enableExperimentalFeature):
+                (_, .enableExperimentalFeature), (_, .swiftVersion):
                 throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
             }
         }

--- a/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -96,7 +96,7 @@ struct SettingsMapper {
             case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                  (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
                  (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature),
-                (_, .enableExperimentalFeature), (_, .swiftVersion):
+                 (_, .enableExperimentalFeature), (_, .swiftVersion):
                 throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
             }
         }

--- a/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -86,7 +86,7 @@ struct SettingsMapper {
                 swiftFlags.append("-enable-upcoming-feature \"\(setting.value[0])\"")
             case (.swift, .enableExperimentalFeature):
                 swiftFlags.append("-enable-experimental-feature \"\(setting.value[0])\"")
-            case (.swift, .swiftVersion):
+            case (.swift, .swiftLanguageMode):
                 // TODO: Use -language-mode instead of -swift-version when Xcode 15 support is removed.
                 // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0441-formalize-language-mode-terminology.md#swift-compiler-option
                 swiftFlags.append("-swift-version \(setting.value[0])")
@@ -98,7 +98,7 @@ struct SettingsMapper {
             case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                  (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
                  (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature),
-                 (_, .enableExperimentalFeature), (_, .swiftVersion):
+                 (_, .enableExperimentalFeature), (_, .swiftLanguageMode):
                 throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
             }
         }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -2379,6 +2379,49 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
+    func testMap_whenSettingsContainsSwiftLanguageMode_mapsToOtherSwiftFlags() throws {
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+        let project = try subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            settings: [
+                                .init(tool: .swift, name: .swiftLanguageMode, condition: nil, value: ["5"]),
+                            ]
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertBetterEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: "Package",
+                targets: [
+                    .test(
+                        "Target1",
+                        basePath: basePath,
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["$(inherited)", "-swift-version 5"]]
+                    ),
+                ]
+            )
+        )
+    }
+
     func testMap_whenSettingsContainsLinkerUnsafeFlags_mapsToOtherLdFlags() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))

--- a/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -144,6 +144,7 @@ final class SettingsMapperTests: XCTestCase {
             .init(tool: .swift, name: .unsafeFlags, condition: nil, value: ["ArbitraryFlag"]),
             .init(tool: .swift, name: .enableUpcomingFeature, condition: nil, value: ["NewFeature"]),
             .init(tool: .swift, name: .enableExperimentalFeature, condition: nil, value: ["Experimental"]),
+            .init(tool: .swift, name: .swiftLanguageMode, condition: nil, value: ["5"]),
         ]
 
         let mapper = SettingsMapper(
@@ -161,6 +162,7 @@ final class SettingsMapperTests: XCTestCase {
                 "ArbitraryFlag",
                 "-enable-upcoming-feature \"NewFeature\"",
                 "-enable-experimental-feature \"Experimental\"",
+                "-swift-version 5",
             ])
         )
     }

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a18b44e37498cdc083fe1514666ea3bbc090f84d03b3b5888bf4d09314e4a1db",
+  "originHash" : "38140789c069d40cf43f4a55edc3a0c2ddd53bc53a8639441f41c99678e0f2e2",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "9fa31f4403da54855f1e2aeaeff478f4f0e40b13",
+        "version" : "1.0.2"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
+        "revision" : "642e6aab8e03e5f992d9c83e38c5be98cfad5078",
+        "version" : "1.5.5"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "b9b24b69e2adda099a1fa381cda1eeec272d5b53",
+        "version" : "1.0.5"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "115fe5af41d333b6156d4924d7c7058bc77fd580",
-        "version" : "1.9.2"
+        "revision" : "8013f1a72af8ccb2b1735d7aed831a8dc07c6fd0",
+        "version" : "1.15.0"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "6ea3b1b6a4957806d72030a32360d4bcb155a0d2",
-        "version" : "1.2.0"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -276,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
-        "version" : "1.2.2"
+        "revision" : "fd1fb25b68fdb9756cd61d23dbd9e2614b340085",
+        "version" : "1.4.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-        "version" : "1.0.0"
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
       }
     },
     {
@@ -305,6 +305,15 @@
       "state" : {
         "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "e834b3760731160d7d448509ee6a1408c8582a6b",
+        "version" : "2.2.0"
       }
     },
     {
@@ -330,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "83fc3d89676b33f1c3d49e9268e76ef62430339f",
-        "version" : "1.1.3"
+        "revision" : "bc67aa8e461351c97282c2419153757a446ae1c9",
+        "version" : "1.3.5"
       }
     },
     {
@@ -353,15 +362,6 @@
       }
     },
     {
-      "identity" : "swiftui-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
-      "state" : {
-        "revision" : "d9e72f3083c08375794afa216fb2f89c0114f303",
-        "version" : "1.2.1"
-      }
-    },
-    {
       "identity" : "uickeychainstore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kishikawakatsumi/UICKeyChainStore",
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b58e6627149808b40634c4552fcf2f44d0b3ca87",
-        "version" : "1.1.0"
+        "revision" : "bc2a151366f2cd0e347274544933bc2acb00c9fe",
+        "version" : "1.4.0"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     name: "PackageName",
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.8.0"),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.9.2")),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.15.0")),
         .package(url: "https://github.com/ZipArchive/ZipArchive", .upToNextMajor(from: "2.5.5")),
         .package(url: "https://github.com/jpsim/Yams", .upToNextMajor(from: "5.0.6")),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", .upToNextMajor(from: "7.0.0")),


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6729>

### Short description 📝

I debugged this issue and found out that the following part of dump-package command JSON output causes issues, when parsed:

```json
{
          "kind" : {
            "swiftLanguageMode" : {
              "_0" : "5"
            }
          },
          "tool" : "swift"
        },
```

This is a new setting described here:

https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/swift6mode/

As far as I understand this guide we can either map this by adding a swift flag or setting `SWIFT_VERSION` in the build settings dictionary.

### How to test the changes locally 🧐

Go through the steps in the linked issue or try to generate or cache anything with TCA version 1.15.0 or probably any SPM dependency with a swift language mode build setting.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
