### PR TITLE
Render GMMapsView in the app_with_google_maps fixture

### DIFF
--- a/fixtures/app_with_google_maps/App/Sources/AppDelegate.swift
+++ b/fixtures/app_with_google_maps/App/Sources/AppDelegate.swift
@@ -1,4 +1,5 @@
 import DynamicFramework
+import GoogleMaps
 import UIKit
 
 @main
@@ -15,7 +16,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white
-        viewController.view.addSubview(Mapper(frame: viewController.view.bounds))
+        let mapper = Mapper(frame: viewController.view.bounds)
+        viewController.view.addSubview(mapper)
+        mapper.mapView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate(
+            [
+                mapper.mapView.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+                mapper.mapView.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+                mapper.mapView.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor),
+                mapper.mapView.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            ]
+        )
+
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
 

--- a/fixtures/app_with_google_maps/DynamicFramework/Sources/DynamicFramework.swift
+++ b/fixtures/app_with_google_maps/DynamicFramework/Sources/DynamicFramework.swift
@@ -7,12 +7,15 @@ public class Mapper: UIView {
         GMSServices.provideAPIKey(key)
     }
 
+    public let mapView: GMSMapView!
+
     override public init(frame: CGRect) {
+        mapView = GMSMapView()
+
         super.init(frame: frame)
 
-        let mapView = GMSMapView()
-        mapView.delegate = self
         addSubview(mapView)
+        mapView.delegate = self
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
### Short description 📝

Updating the fixture to render the `GMSMapView` – once the API key in the `AppDelegate` was provided.

![Screenshot 2024-09-16 at 16 05 08](https://github.com/user-attachments/assets/842d93b2-95f1-43be-8351-f6503fc2bdd0)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
