### PR TITLE
fix: Manifests Packages module build error when using Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version:5.10
 
-import PackageDescription
+@preconcurrency import PackageDescription
 
 let swiftToolsSupportDependency: Target.Dependency = .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
 let pathDependency: Target.Dependency = .product(name: "Path", package: "Path")
@@ -8,7 +8,7 @@ let loggingDependency: Target.Dependency = .product(name: "Logging", package: "s
 let argumentParserDependency: Target.Dependency = .product(name: "ArgumentParser", package: "swift-argument-parser")
 let swiftGenKitDependency: Target.Dependency = .product(name: "SwiftGenKit", package: "SwiftGen")
 
-var targets: [Target] = [
+let targets: [Target] = [
     .executableTarget(
         name: "tuistbenchmark",
         dependencies: [
@@ -334,7 +334,7 @@ var targets: [Target] = [
 ]
 
 #if TUIST
-    import struct ProjectDescription.PackageSettings
+@preconcurrency import struct ProjectDescription.PackageSettings
 
     let packageSettings = PackageSettings(
         productTypes: [

--- a/Templates/default/Package.stencil
+++ b/Templates/default/Package.stencil
@@ -1,8 +1,8 @@
 // swift-tools-version: 5.9
-import PackageDescription
+@preconcurrency import PackageDescription
 
 #if TUIST
-    import ProjectDescription
+    @preconcurrency import ProjectDescription
 
     let packageSettings = PackageSettings(
         // Customize the product types for specific package product


### PR DESCRIPTION

### Short description 📝

> Describe here the purpose of your PR.

<img width="300" alt="Screenshot of Xcode at Sep 17, 2024 at 22_34_29" src="https://github.com/user-attachments/assets/a3a2236c-d4e9-4ea3-b8d4-dc3c1faba728">

add`@preconcurrency` to `import PackageDescription` in the `Package.swift` and `Package.stencil` files.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

1. setup Xcode 16
2. tuist edit
3. build

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
