### PR TITLE
Allow embedding `.extensionKitExtension` targets into macOS apps

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -620,8 +620,8 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
             LintableTarget(platform: .macOS, product: .framework),
             LintableTarget(platform: .macOS, product: .staticFramework),
-            LintableTarget(platform: .macOS, product: .xpc),
             LintableTarget(platform: .macOS, product: .macro),
+            LintableTarget(platform: .macOS, product: .xpc),
         ],
         LintableTarget(platform: .tvOS, product: .app): [
             LintableTarget(platform: .tvOS, product: .staticLibrary),

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -615,6 +615,13 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .framework),
             LintableTarget(platform: .macOS, product: .macro),
         ],
+        LintableTarget(platform: .macOS, product: .extensionKitExtension): [
+            LintableTarget(platform: .macOS, product: .staticLibrary),
+            LintableTarget(platform: .macOS, product: .dynamicLibrary),
+            LintableTarget(platform: .macOS, product: .framework),
+            LintableTarget(platform: .macOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .macro),
+        ],
         LintableTarget(platform: .tvOS, product: .app): [
             LintableTarget(platform: .tvOS, product: .staticLibrary),
             LintableTarget(platform: .tvOS, product: .dynamicLibrary),

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -543,6 +543,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .xpc),
             LintableTarget(platform: .macOS, product: .systemExtension),
             LintableTarget(platform: .macOS, product: .macro),
+            LintableTarget(platform: .macOS, product: .extensionKitExtension),
         ],
         LintableTarget(platform: .macOS, product: .bundle): [
             LintableTarget(platform: .iOS, product: .app),

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -620,6 +620,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
             LintableTarget(platform: .macOS, product: .framework),
             LintableTarget(platform: .macOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .xpc),
             LintableTarget(platform: .macOS, product: .macro),
         ],
         LintableTarget(platform: .tvOS, product: .app): [

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -2143,4 +2143,97 @@ final class GraphLinterTests: TuistUnitTestCase {
             )]
         )
     }
+    
+    func test_extensionKitExtension_canBeEmbeddedToTheApp_includingDependencies() throws {
+        let platforms: [Platform] = [.macOS, .iOS]
+        
+        for platform in platforms {
+            // Given
+            let path = try temporaryPath()
+            
+            /* extension kit target is under test */
+            let sut = Target.test(name: "Extension", platform: platform, product: .extensionKitExtension)
+            
+            /* app embedding the extension */
+            let app = Target.test(name: "App", platform: platform, product: .app)
+            
+            /* extension dependencies */
+            let dynamicFramework = Target.test(name: "DynamicFramework", platform: platform, product: .framework)
+            let staticFramework = Target.test(name: "StaticFramework", platform: platform, product: .staticFramework)
+            let dynamicLibrary = Target.test(name: "DynamicLibrary", platform: platform, product: .dynamicLibrary)
+            let staticLibrary = Target.test(name: "StaticLibrary", platform: platform, product: .staticLibrary)
+            let macro = Target.test(name: "Macro", platform: .macOS, product: .macro)
+            
+            let project = Project.test(
+                path: path,
+                targets: [
+                    app,
+                    sut,
+                    dynamicFramework,
+                    staticFramework,
+                    dynamicLibrary,
+                    staticLibrary,
+                    macro
+                ]
+            )
+            
+            let graph = Graph.test(
+                projects: [path: project],
+                dependencies: [
+                    .target(name: app.name, path: path): [
+                        .target(name: sut.name, path: path)
+                    ],
+                    .target(name: sut.name, path: path): [
+                        .target(name: dynamicFramework.name, path: path),
+                        .target(name: staticFramework.name, path: path),
+                        .target(name: dynamicLibrary.name, path: path),
+                        .target(name: staticLibrary.name, path: path),
+                        .target(name: macro.name, path: path)
+                    ]
+                ]
+            )
+            let config = Config.test()
+            let graphTraverser = GraphTraverser(graph: graph)
+            
+            // When
+            let results = subject.lint(graphTraverser: graphTraverser, config: config)
+            
+            // Then
+            XCTAssertTrue(results.isEmpty, "Expected to get no lint failures on \(platform), got \(results)")
+        }
+    }
+    
+    func test_extensionKitExtension_macOS_canEmbedAnXPCService() throws {
+        // Given
+        let path = try temporaryPath()
+        
+        let sut = Target.test(name: "Extension", platform: .macOS, product: .extensionKitExtension)
+        let xpcService = Target.test(name: "XPCService", platform: .macOS, product: .xpc)
+        
+        let project = Project.test(
+            path: path,
+            targets: [
+                sut,
+                xpcService
+            ]
+        )
+        
+        let graph = Graph.test(
+            projects: [path: project],
+            dependencies: [
+                .target(name: sut.name, path: path): [
+                    .target(name: xpcService.name, path: path)
+                ]
+            ]
+        )
+        
+        let config = Config.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        
+        // When
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
+        
+        // Then
+        XCTAssertTrue(results.isEmpty, "Expected to get no lint failures, got \(results)")
+    }
 }

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -2143,27 +2143,27 @@ final class GraphLinterTests: TuistUnitTestCase {
             )]
         )
     }
-    
+
     func test_extensionKitExtension_canBeEmbeddedToTheApp_includingDependencies() throws {
         let platforms: [Platform] = [.macOS, .iOS]
-        
+
         for platform in platforms {
             // Given
             let path = try temporaryPath()
-            
+
             /* extension kit target is under test */
             let sut = Target.test(name: "Extension", platform: platform, product: .extensionKitExtension)
-            
+
             /* app embedding the extension */
             let app = Target.test(name: "App", platform: platform, product: .app)
-            
+
             /* extension dependencies */
             let dynamicFramework = Target.test(name: "DynamicFramework", platform: platform, product: .framework)
             let staticFramework = Target.test(name: "StaticFramework", platform: platform, product: .staticFramework)
             let dynamicLibrary = Target.test(name: "DynamicLibrary", platform: platform, product: .dynamicLibrary)
             let staticLibrary = Target.test(name: "StaticLibrary", platform: platform, product: .staticLibrary)
             let macro = Target.test(name: "Macro", platform: .macOS, product: .macro)
-            
+
             let project = Project.test(
                 path: path,
                 targets: [
@@ -2173,66 +2173,66 @@ final class GraphLinterTests: TuistUnitTestCase {
                     staticFramework,
                     dynamicLibrary,
                     staticLibrary,
-                    macro
+                    macro,
                 ]
             )
-            
+
             let graph = Graph.test(
                 projects: [path: project],
                 dependencies: [
                     .target(name: app.name, path: path): [
-                        .target(name: sut.name, path: path)
+                        .target(name: sut.name, path: path),
                     ],
                     .target(name: sut.name, path: path): [
                         .target(name: dynamicFramework.name, path: path),
                         .target(name: staticFramework.name, path: path),
                         .target(name: dynamicLibrary.name, path: path),
                         .target(name: staticLibrary.name, path: path),
-                        .target(name: macro.name, path: path)
-                    ]
+                        .target(name: macro.name, path: path),
+                    ],
                 ]
             )
             let config = Config.test()
             let graphTraverser = GraphTraverser(graph: graph)
-            
+
             // When
             let results = subject.lint(graphTraverser: graphTraverser, config: config)
-            
+
             // Then
             XCTAssertTrue(results.isEmpty, "Expected to get no lint failures on \(platform), got \(results)")
         }
     }
-    
+
     func test_extensionKitExtension_macOS_canEmbedAnXPCService() throws {
         // Given
         let path = try temporaryPath()
-        
+
         let sut = Target.test(name: "Extension", platform: .macOS, product: .extensionKitExtension)
         let xpcService = Target.test(name: "XPCService", platform: .macOS, product: .xpc)
-        
+
         let project = Project.test(
             path: path,
             targets: [
                 sut,
-                xpcService
+                xpcService,
             ]
         )
-        
+
         let graph = Graph.test(
             projects: [path: project],
             dependencies: [
                 .target(name: sut.name, path: path): [
-                    .target(name: xpcService.name, path: path)
-                ]
+                    .target(name: xpcService.name, path: path),
+                ],
             ]
         )
-        
+
         let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
-        
+
         // When
         let results = subject.lint(graphTraverser: graphTraverser, config: config)
-        
+
         // Then
         XCTAssertTrue(results.isEmpty, "Expected to get no lint failures, got \(results)")
     }

--- a/fixtures/macos_app_with_extensions/App/Resources/App.appextensionpoint
+++ b/fixtures/macos_app_with_extensions/App/Resources/App.appextensionpoint
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>io.tuist.app.extension-point</key>
+    <dict>
+        <key>EXPresentsUserInterface</key>
+        <false/>
+    </dict>
+</dict>
+</plist>

--- a/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
+++ b/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
@@ -8,7 +8,7 @@ final class VendorExtension: NSObject, AppExtension {
 }
 
 struct Config: AppExtensionConfiguration {
-    func accept(connection: NSXPCConnection) -> Bool {
+    func accept(connection _: NSXPCConnection) -> Bool {
         true
     }
 }

--- a/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
+++ b/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
@@ -1,0 +1,14 @@
+import ExtensionKit
+
+@main
+final class VendorExtension: NSObject, AppExtension {
+    var configuration: Config {
+        return Config()
+    }
+}
+
+struct Config: AppExtensionConfiguration {
+    func accept(connection: NSXPCConnection) -> Bool {
+        true
+    }
+}

--- a/fixtures/macos_app_with_extensions/Project.swift
+++ b/fixtures/macos_app_with_extensions/Project.swift
@@ -22,7 +22,22 @@ let project = Project(
             bundleId: "io.tuist.app",
             infoPlist: .default,
             sources: "App/**",
-            dependencies: [.target(name: "Workflow")]
+            copyFiles: [
+                .productsDirectory(
+                    name: "Embed Extension Points",
+                    subpath: "App.app/Contents/Extensions",
+                    files: [
+                        "App/Resources/App.appextensionpoint"
+                    ]
+                )
+            ],
+            dependencies: [
+                .target(name: "Workflow"),
+                .target(name: "ExtensionKitExtension")
+            ],
+            additionalFiles: [
+                "App/Resources/App.appextensionpoint"
+            ]
         ),
         .target(
             name: "Workflow",
@@ -38,6 +53,21 @@ let project = Project(
             settings: .settings(configurations: [
                 .debug(name: "Debug", settings: workflowExtensionSettings, xcconfig: nil),
                 .release(name: "Release", settings: workflowExtensionSettings, xcconfig: nil),
+            ])
+        ),
+        .target(
+            name: "ExtensionKitExtension",
+            destinations: .macOS,
+            product: .extensionKitExtension,
+            bundleId: "io.tuist.app.extensionKitExtension",
+            infoPlist: .extendingDefault(with: [
+                "EXAppExtensionAttributes": [
+                    "EXExtensionPointIdentifier": "io.tuist.app.extension-point",
+                ],
+            ]),
+            sources: "ExtensionKitExtension/Sources/**",
+            entitlements: .dictionary([
+                "com.apple.security.app-sandbox": .boolean(true),
             ])
         ),
     ]

--- a/fixtures/macos_app_with_extensions/Project.swift
+++ b/fixtures/macos_app_with_extensions/Project.swift
@@ -27,16 +27,16 @@ let project = Project(
                     name: "Embed Extension Points",
                     subpath: "App.app/Contents/Extensions",
                     files: [
-                        "App/Resources/App.appextensionpoint"
+                        "App/Resources/App.appextensionpoint",
                     ]
-                )
+                ),
             ],
             dependencies: [
                 .target(name: "Workflow"),
-                .target(name: "ExtensionKitExtension")
+                .target(name: "ExtensionKitExtension"),
             ],
             additionalFiles: [
-                "App/Resources/App.appextensionpoint"
+                "App/Resources/App.appextensionpoint",
             ]
         ),
         .target(


### PR DESCRIPTION
### Short description 📝

Greeting y'all!

The current PR extends the support for [ExtensionKit](https://developer.apple.com/documentation/extensionkit) extension targets implemented in #5005 by allowing their embedding into macOS apps.

The main changes are:
* `.macOS` application targets can now depend on extension targets. The resulting `.appex` artifact is copied to the `Contents/Extensions` directory of the app bundle by a build phase.
* Extensions are executable bundles, so they can depend on all common dependency types, such as macros, static and dynamic libraries, and frameworks.
* Additionally, on macOS, extension targets can contain embedded XPC services, which is crucial for extending the functionality in non-sandbox apps.

The implementation contains the following parts:
* All the project generation functionality is already in place, so I only had to tweak a GraphLinter to extend linting rules for a product type `.extensionKitExtension` on the `.macOS` platform.
* Added some unit tests for GraphLinter, covering rules for both iOS and macOS.
* Updated the `macos_app_with_extensions` fixture, adding an extension target for basic validation in acceptance tests.

The functionality seems to be purely additive and should not cause any compatibility issues.
I am looking forward to your comments on the PR changes and hope you will find this contribution useful.

### How to test the changes locally 🧐

* Ensure you have installed the `WorkflowExtensionsSDK.pkg` from `fixtures/resources` (it is not a subject of the current PR but required by another target of the same fixture project)
* Generate the `fixtures/macos_app_with_extensions` project as described in [the guilde](https://docs.tuist.io/contributors/get-started#from-xcode)
* Observe the build phases of the `App` target to check that it correctly embeds the extension target:
  <img width="600" alt="Screenshot 2024-09-19 at 12 30 46" src="https://github.com/user-attachments/assets/f6277c0a-2215-4851-a701-79ab817dcfb7">

* Build the project

Alternatively, you can run the acceptance test case `GenerateAcceptanceTestmacOSAppWithExtension.`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
