### PR TITLE
Remove confusing, unnecessary function in GraphTraverser.swift

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1074,12 +1074,6 @@ public class GraphTraverser: GraphTraversing {
         return !target.target.mergeable
     }
 
-    func isDependencyStaticTarget(dependency: GraphDependency) -> Bool {
-        guard case let GraphDependency.target(name, path) = dependency,
-              let target = target(path: path, name: name) else { return false }
-        return target.target.product.isStatic
-    }
-
     func isDependencyStatic(dependency: GraphDependency) -> Bool {
         switch dependency {
         case .macro:


### PR DESCRIPTION
### Short description 📝

In [GraphTraverser.swift](https://github.com/tuist/tuist/blob/69f4e6e7d7fb99cf48466f41e40b3e01f221e8b1/Sources/TuistCore/Graph/GraphTraverser.swift#L1077-L1099), two functions with similar names `isDependencyStatic`, `isDependencyStaticTarget` are designed to do the same thing, but the implementation is different and seems to be causing confusion. Remove `isDependencyStaticTarget` it is not used.

### How to test the changes locally 🧐


### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
