### PR TITLE
Fix missing metal resources in the Tuist SPM integration

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -922,6 +922,7 @@ extension ProjectDescription.ResourceFileElements {
         "xcmappingmodel",
         "xcassets",
         "strings",
+        "metal",
     ])
 
     private static func defaultResourcePaths(

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1298,10 +1298,18 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
     func testMap_whenHasDefaultResources() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
-        let defaultResourcePath = sourcesPath.appending(try RelativePath(validating: "Resources/file.xib"))
+        let defaultResourcePaths = try Set([
+            "xib",
+            "storyboard",
+            "xcdatamodeld",
+            "xcmappingmodel",
+            "xcassets",
+            "strings",
+            "metal",
+        ].map { sourcesPath.appending(try RelativePath(validating: "Resouces/file.\($0)")) })
         try fileHandler.createFolder(sourcesPath)
         fileHandler.stubFiles = { _, _, _, _ in
-            return [defaultResourcePath]
+            return defaultResourcePaths
         }
 
         let project = try subject.map(
@@ -1331,13 +1339,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        resources: [
-                            .glob(
-                                pattern: .path(defaultResourcePath.pathString),
-                                excluding: [],
-                                tags: []
-                            ),
-                        ]
+                        resources: defaultResourcePaths.map {
+                            ResourceFileElement.glob(pattern: .path($0.pathString), excluding: [], tags: [])
+                        }
                     ),
                 ]
             )


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6752>

### Short description 📝

Include ‘metal’ file extension in default SPM resource file extensions

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

[TestProject.zip](https://github.com/user-attachments/files/17084724/TestProject.zip)
1. install & generate
2. build

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
