### PR TITLE
Do not put Resources  Bundle in the Products folder when archiving

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -55,6 +55,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 settings: Settings(
                     base: [
                         "CODE_SIGNING_ALLOWED": "NO",
+                        "SKIP_INSTALL": "YES",
                     ],
                     configurations: [:]
                 ),

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -82,6 +82,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.filesGroup, target.filesGroup)
         XCTAssertEqual(resourcesTarget.resources.resources, resources)
         XCTAssertEqual(resourcesTarget.settings?.base, [
+            "SKIP_INSTALL": "YES",
             "CODE_SIGNING_ALLOWED": "NO",
         ])
     }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

> Describe here the purpose of your PR.
- When archiving, resource bundles from static framework will be put in the "Products" directory, along with the Application itself
- This basically creates incorrect 'archive' which cannot be used for the App Store Submissio
- This PR makes sure that Resource Bundles won't be included in the result 'Products' dir

*Before*
![image](https://github.com/user-attachments/assets/230a78cd-2878-4ee6-9d5a-cf1c1e6dede6)
*After*
![image](https://github.com/user-attachments/assets/761732bd-b291-495a-a757-a6e4e2400a40)



### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).
- create an app
- cerate a static framework with the resources, and make sure that resource accessorsa re generated
- archive the app
- make sure that only app will be in the result archive


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry