### PR TITLE
Fix integrating static xcframeworks linked through dynamic xcframeworks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8e1703d069c5e0f37fabdedc93006016d67867bc5a0129a7d2e4118026f89730",
+  "originHash" : "9e28765468ba7cc21698d26df0b60db8d98945c52a21af3fe468c9e7d950f07c",
   "pins" : [
     {
       "identity" : "aexml",
@@ -276,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "9235c3335f9a3809f8a47b6def05e2f54dce0a10",
-        "version" : "0.12.0"
+        "revision" : "12462c8fff97fc5efb8476ef4625f434acd5058f",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -472,7 +472,7 @@ let package = Package(
             url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
-        .package(url: "https://github.com/tuist/XcodeGraph.git", exact: "0.12.0"),
+        .package(url: "https://github.com/tuist/XcodeGraph.git", exact: "0.12.1"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: targets

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -273,6 +273,15 @@ public protocol GraphTraversing {
     ///   - path: Path to the directory that contains the project.
     ///   - name: Target name.
     func allSwiftPluginExecutables(path: AbsolutePath, name: String) -> Set<String>
+
+    /// Given a target's project path and name, it returns all XCFramework dependencies that linked by a dynamic XCFramework.
+    /// - Parameters:
+    ///   - path: Project path.
+    ///   - name: Target name.
+    func staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+        path: AbsolutePath,
+        name: String
+    ) -> Set<GraphDependency>
 }
 
 extension GraphTraversing {

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -59,6 +59,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
             mappers.append(ExplicitDependencyGraphMapper())
         }
         mappers.append(TreeShakePrunedTargetsGraphMapper())
+        mappers.append(StaticXCFrameworkModuleMapGraphMapper())
         return mappers
     }
 }

--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Path
+import TuistCore
+import TuistSupport
+import XcodeGraph
+
+public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
+    private let fileHandler: FileHandling
+
+    public init(
+        fileHandler: FileHandling = FileHandler.shared
+    ) {
+        self.fileHandler = fileHandler
+    }
+
+    public func map(graph: Graph, environment: MapperEnvironment) throws -> (Graph, [SideEffectDescriptor], MapperEnvironment) {
+        let derivedDirectory = derivedDirectory(graph: graph)
+
+        var sideEffects: [SideEffectDescriptor] = []
+        var settingsToPropagate: [GraphDependency: SettingsDictionary] = [:]
+
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        for project in graph.projects.values {
+            for target in project.targets.values {
+                let staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+                    .staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+                        path: project.path,
+                        name: target.name
+                    )
+                    .compactMap { dependency -> GraphDependency.XCFramework? in
+                        switch dependency {
+                        case let .xcframework(xcframework):
+                            return xcframework
+                        default:
+                            return nil
+                        }
+                    }
+
+                guard !staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.isEmpty else { continue }
+
+                sideEffects += try self.sideEffects(
+                    for: staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies,
+                    derivedDirectory: derivedDirectory
+                )
+
+                settingsToPropagate[.target(name: target.name, path: project.path)] = [
+                    "OTHER_SWIFT_FLAGS": .array(
+                        staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
+                            [
+                                "-Xcc",
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    ),
+                    "OTHER_C_FLAGS": .array(
+                        staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
+                            [
+                                moduleMapFlag(
+                                    for: xcframework,
+                                    derivedDirectory: derivedDirectory,
+                                    project: project
+                                ),
+                            ]
+                        }
+                    ),
+                    "HEADER_SEARCH_PATHS": .array(
+                        staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.flatMap { xcframework -> [String] in
+                            guard let moduleMap = xcframework.path.glob("**/module.modulemap").first
+                            else { return [] }
+                            return [
+                                "\"$(SRCROOT)/\(moduleMap.parentDirectory.relative(to: project.path).pathString)\"",
+                            ]
+                        }
+                    ),
+                ]
+            }
+        }
+
+        return (
+            try propagateSettings(graph: graph, settings: settingsToPropagate),
+            sideEffects,
+            environment
+        )
+    }
+
+    private func moduleMapFlag(
+        for xcframework: GraphDependency.XCFramework,
+        derivedDirectory: AbsolutePath,
+        project: Project
+    ) -> String {
+        let name = xcframework.path.basenameWithoutExt
+        return "-fmodule-map-file=\"$(SRCROOT)/\(derivedDirectory.appending(components: name, "Headers", "module.modulemap").relative(to: project.path).pathString)\""
+    }
+
+    private func derivedDirectory(graph: Graph) -> AbsolutePath {
+        let packageDirectoryPath: AbsolutePath
+        if fileHandler.exists(graph.path.appending(component: Constants.SwiftPackageManager.packageSwiftName)) {
+            packageDirectoryPath = graph.path
+        } else {
+            packageDirectoryPath = graph.path.appending(component: Constants.tuistDirectoryName)
+        }
+
+        return packageDirectoryPath
+            .appending(
+                components: [
+                    Constants.SwiftPackageManager.packageBuildDirectoryName,
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                ]
+            )
+    }
+
+    private func sideEffects(
+        for staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies: [GraphDependency.XCFramework],
+        derivedDirectory: AbsolutePath
+    ) throws -> [SideEffectDescriptor] {
+        try staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies
+            .flatMap { xcframework -> [SideEffectDescriptor] in
+                guard let moduleMap = xcframework.path.glob("**/module.modulemap").first
+                else { return [] }
+                let name = xcframework.path.basenameWithoutExt
+                let umbrellaHeader = moduleMap.parentDirectory.appending(component: "\(name).h")
+                guard fileHandler.exists(umbrellaHeader)
+                else { return [] }
+                return [
+                    .directory(DirectoryDescriptor(path: derivedDirectory.appending(components: name, "Headers"))),
+                    .file(
+                        FileDescriptor(
+                            path: derivedDirectory.appending(components: name, "Headers", "module.modulemap"),
+                            contents: try fileHandler.readFile(moduleMap)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedDirectory.appending(components: name, "Headers", "\(name).h"),
+                            contents: String(data: try fileHandler.readFile(umbrellaHeader), encoding: .utf8)?
+                                .replacingOccurrences(of: "<\(name)/", with: "<")
+                                .data(using: .utf8)
+                        )
+                    ),
+                ]
+            }
+    }
+
+    private func propagateSettings(
+        graph: Graph,
+        settings: [GraphDependency: SettingsDictionary]
+    ) throws -> Graph {
+        var graph = graph
+        var settings = settings
+        let targets = try GraphTraverser(graph: graph).allTargetsTopologicalSorted()
+        for target in targets {
+            guard let dependencies = graph.dependencies[.target(name: target.target.name, path: target.path)] else { continue }
+            for dependency in dependencies {
+                let targetDependency: GraphDependency = .target(name: target.target.name, path: target.path)
+                settings[targetDependency] = (settings[targetDependency] ?? [:]).combine(with: settings[dependency] ?? [:])
+            }
+        }
+        graph.projects = graph.projects.mapValues { project in
+            var project = project
+            project.targets = project.targets.mapValues { target in
+                var target = target
+                let targetSettings = target.settings ?? Settings(
+                    base: [:],
+                    configurations: [:],
+                    defaultSettings: project.settings.defaultSettings
+                )
+                target.settings = targetSettings.with(
+                    base: targetSettings.base
+                        .combine(with: settings[.target(name: target.name, path: project.path)] ?? SettingsDictionary())
+                )
+                return target
+            }
+            return project
+        }
+        return graph
+    }
+}

--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -5,8 +5,8 @@ import TuistLoader
 import TuistSupport
 import XcodeGraph
 
-/// This mapper is to set the right setting for downstream targets that depend on a static xcframework linked by a dynamic
-/// xcframework.
+/// This mapper sets the right setting for downstream targets that depend on static xcframeworks linked by dynamic
+/// xcframeworks.
 /// See this PR for more context: https://github.com/tuist/tuist/pull/6757
 public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
     private let fileHandler: FileHandling
@@ -21,7 +21,7 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
     }
 
     public func map(graph: Graph, environment: MapperEnvironment) throws -> (Graph, [SideEffectDescriptor], MapperEnvironment) {
-        guard  let packageManifest = manifestFilesLocator.locatePackageManifest(at: graph.path)
+        guard let packageManifest = manifestFilesLocator.locatePackageManifest(at: graph.path)
         else { return (graph, [], environment) }
         let derivedDirectory = packageManifest
             .parentDirectory

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Path
 import TuistSupport
@@ -8,6 +9,20 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class GraphTraverserTests: TuistUnitTestCase {
+    private var fileSystem: FileSysteming!
+
+    override func setUp() {
+        super.setUp()
+
+        fileSystem = FileSystem()
+    }
+
+    override func tearDown() {
+        fileSystem = nil
+
+        super.tearDown()
+    }
+
     func test_dependsOnXCTest_when_is_framework() {
         // Given
         let target = Target.test(
@@ -1952,12 +1967,16 @@ final class GraphTraverserTests: TuistUnitTestCase {
     }
 
     func test_linkableAndEmbeddableDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticXCFrameworkDependency(
-    ) throws {
+    ) async throws {
         // App ---(depends on)---> Dynamic XCFramework ----> Static XCFramework (A) ----> Static XCFramework (B)
 
         // Given
         let target = Target.test(name: "Main")
         let project = Project.test(targets: [target])
+        let staticFrameworkAPath = try temporaryPath()
+            .appending(component: "StaticFrameworkA.xcframework")
+        let staticFrameworkBPath = try temporaryPath()
+            .appending(component: "StaticFrameworkB.xcframework")
 
         // Given: Value Graph
         let dependencyDynamicXCFramework = GraphDependency.testXCFramework(
@@ -1965,12 +1984,20 @@ final class GraphTraverserTests: TuistUnitTestCase {
             linking: .dynamic
         )
         let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
-            path: "/test/StaticFrameworkA.xcframework",
+            path: staticFrameworkAPath,
             linking: .static
         )
+        try await fileSystem.makeDirectory(at: staticFrameworkAPath)
+        try await fileSystem.touch(
+            staticFrameworkAPath.appending(component: "StaticFrameworkA.swiftmodule")
+        )
         let dependencyStaticXCFrameworkB = GraphDependency.testXCFramework(
-            path: "/test/StaticFrameworkB.xcframework",
+            path: staticFrameworkBPath,
             linking: .static
+        )
+        try await fileSystem.makeDirectory(at: staticFrameworkBPath)
+        try await fileSystem.touch(
+            staticFrameworkBPath.appending(component: "StaticFrameworkB.swiftmodule")
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
@@ -2003,8 +2030,51 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_linkableDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticObjcXCFrameworkDependency(
+    ) async throws {
+        // App ---(depends on)---> Dynamic XCFramework ----> Static Objective-C XCFramework (A)
+
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let staticFrameworkAPath = try temporaryPath()
+            .appending(component: "StaticFrameworkA.xcframework")
+
+        // Given: Value Graph
+        let dependencyDynamicXCFramework = GraphDependency.testXCFramework(
+            path: "/test/DynamicFramework.xcframework",
+            linking: .dynamic
+        )
+        let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
+            path: staticFrameworkAPath,
+            linking: .static
+        )
+        try await fileSystem.makeDirectory(at: staticFrameworkAPath)
+        try await fileSystem.touch(
+            staticFrameworkAPath.appending(component: "StaticFrameworkB.modulemap")
+        )
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: target.name, path: project.path): Set(arrayLiteral: dependencyDynamicXCFramework),
+            dependencyDynamicXCFramework: Set(arrayLiteral: dependencyStaticXCFrameworkA),
+        ]
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.linkableDependencies(path: project.path, name: target.name).sorted()
+
+        // Then
+        XCTAssertEqual(got, [
+            GraphDependencyReference(dependencyDynamicXCFramework),
+        ])
+    }
+
     func test_linkableAndEmbeddableDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticXCFrameworkDependencyWithALinkedSystemLibrary(
-    ) throws {
+    ) async throws {
         // App ---(depends on)---> Dynamic XCFramework ----> Static XCFramework (A) ----> libc++.tbd
 
         // Given
@@ -2016,9 +2086,15 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: "/test/DynamicFramework.xcframework",
             linking: .dynamic
         )
+        let staticFrameworkAPath = try temporaryPath()
+            .appending(component: "StaticFrameworkA.xcframework")
         let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
-            path: "/test/StaticFrameworkA.xcframework",
+            path: staticFrameworkAPath,
             linking: .static
+        )
+        try await fileSystem.makeDirectory(at: staticFrameworkAPath)
+        try await fileSystem.touch(
+            staticFrameworkAPath.appending(component: "StaticFrameworkA.swiftmodule")
         )
         let dependencyLibCpp = GraphDependency.testSDK(
             name: "libc++.tbd",
@@ -5045,6 +5121,95 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(got.sorted(), [
             "\(precompiledMacroPath.pathString)#\(precompiledMacroPath.basename.replacingOccurrences(of: ".macro", with: ""))",
         ])
+    }
+
+    func test_staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticObjcXCFrameworkDependency(
+    ) async throws {
+        // App ---(depends on)---> Dynamic XCFramework ----> Static Objective-C XCFramework (A)
+
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let staticFrameworkAPath = try temporaryPath()
+            .appending(component: "StaticFrameworkA.xcframework")
+
+        // Given: Value Graph
+        let dependencyDynamicXCFramework = GraphDependency.testXCFramework(
+            path: "/test/DynamicFramework.xcframework",
+            linking: .dynamic
+        )
+        let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
+            path: staticFrameworkAPath,
+            linking: .static
+        )
+        try await fileSystem.makeDirectory(at: staticFrameworkAPath)
+        try await fileSystem.touch(
+            staticFrameworkAPath.appending(component: "StaticFrameworkB.modulemap")
+        )
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: target.name, path: project.path): Set(arrayLiteral: dependencyDynamicXCFramework),
+            dependencyDynamicXCFramework: Set(arrayLiteral: dependencyStaticXCFrameworkA),
+        ]
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(path: project.path, name: target.name)
+            .sorted()
+
+        // Then
+        XCTAssertEqual(got, [
+            .testXCFramework(
+                path: staticFrameworkAPath,
+                linking: .static
+            ),
+        ])
+    }
+
+    func test_staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies_when_appDependensOnPrecompiledDynamicXCFrameworkWithStaticSwiftXCFrameworkDependency(
+    ) async throws {
+        // App ---(depends on)---> Dynamic XCFramework ----> Static Swift XCFramework (A)
+
+        // Given
+        let target = Target.test(name: "Main")
+        let project = Project.test(targets: [target])
+        let staticFrameworkAPath = try temporaryPath()
+            .appending(component: "StaticFrameworkA.xcframework")
+
+        // Given: Value Graph
+        let dependencyDynamicXCFramework = GraphDependency.testXCFramework(
+            path: "/test/DynamicFramework.xcframework",
+            linking: .dynamic
+        )
+        let dependencyStaticXCFrameworkA = GraphDependency.testXCFramework(
+            path: staticFrameworkAPath,
+            linking: .static
+        )
+        try await fileSystem.makeDirectory(at: staticFrameworkAPath)
+        try await fileSystem.touch(
+            staticFrameworkAPath.appending(component: "StaticFrameworkB.swiftmodule")
+        )
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: target.name, path: project.path): Set(arrayLiteral: dependencyDynamicXCFramework),
+            dependencyDynamicXCFramework: Set(arrayLiteral: dependencyStaticXCFrameworkA),
+        ]
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(path: project.path, name: target.name)
+            .sorted()
+
+        // Then
+        XCTAssertEmpty(got)
     }
 
     // MARK: - Helpers

--- a/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -1,7 +1,9 @@
 import FileSystem
 import Foundation
+import MockableTest
 import Path
 import TuistCore
+import TuistLoader
 import TuistSupport
 import TuistSupportTesting
 import XcodeGraph
@@ -11,16 +13,21 @@ import XCTest
 final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
     private var subject: StaticXCFrameworkModuleMapGraphMapper!
     private var fileSystem: FileSystem!
+    private var manifestFilesLocator: MockManifestFilesLocating!
 
     override func setUp() {
         super.setUp()
 
         fileSystem = FileSystem()
-        subject = StaticXCFrameworkModuleMapGraphMapper()
+        manifestFilesLocator = MockManifestFilesLocating()
+        subject = StaticXCFrameworkModuleMapGraphMapper(
+            manifestFilesLocator: manifestFilesLocator
+        )
     }
 
     override func tearDown() {
         fileSystem = nil
+        manifestFilesLocator = nil
         subject = nil
 
         super.tearDown()
@@ -30,6 +37,11 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         // Given
         let projectPath = try temporaryPath()
             .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
         let googleMapsPath = projectPath
             .parentDirectory
             .appending(component: "GoogleMaps.xcframework")
@@ -148,6 +160,11 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         // Given
         let projectPath = try temporaryPath()
             .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
         let googleMapsPath = projectPath
             .parentDirectory
             .appending(component: "GoogleMaps.xcframework")
@@ -262,6 +279,11 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         // Given
         let projectPath = try temporaryPath()
             .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
         let googleMapsPath = projectPath
             .parentDirectory
             .appending(component: "GoogleMaps.xcframework")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6609

### Short description 📝

This PR fixes issue https://github.com/tuist/tuist/issues/6609, more specifically [this](https://github.com/tuist/tuist/issues/6609#issuecomment-2336861272) comment.

The comment refers to the following graph:
```
App -> Dynamic framework -> GoogleMaps (Static xcframework)
```

Running `GoogleMaps` only works when `Dynamic framework` is pulled in as sources. But when using `tuist cache`, replacing `Dynamic framework` leads to duplicated GoogleMaps symbols – in which case, the GoogleMaps library breaks.

Why do we have duplicated symbols in the first place?

That business logic was introduced in https://github.com/tuist/tuist/pull/6613 to try and solve build issues that boil down to linking a static xcframework through a dynamic xcframework (see more [here](https://forums.swift.org/t/issue-with-third-party-dependencies-inside-a-xcframework-through-swiftpm/41977/3)).

Instead of duplicate linking the static xcframework, we can point the downstream targets (in our case, `App`) to the relevant symbols using extra linking flags that point to the headers and the relevant modulemap (the relevant settings are `OTHER_SWIFT_FLAGS`, `OTHER_C_FLAGS`, and `HEADER_SEARCH_PATHS`). The xcframework contains headers and modulemaps for all architectures, but both _should_ be the same across all of the available archs – so we only point to one.

This strategy only works for Objective C dependencies – something similar should be feasible also for Swift modules, but we'd need to point to the `.swiftmodule` instead of `.modulemap` which is meant for Objective C consumers. Since there have been no complaints around Swift modules that would be affected by this scenario, we decided to keep the duplicate linking for Swift modules – for now, at least.

### How to test the changes locally 🧐

In `app_with_google_maps`, run:
- `tuist cache`
- `tuist generate App`
- Run the app -> there should be no duplicate symbol warnings and the map should render correctly.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
