### PR TITLE
Add links to server status and live metrics to docs

### DIFF
--- a/docs/.vitepress/sidebars.mjs
+++ b/docs/.vitepress/sidebars.mjs
@@ -178,6 +178,14 @@ export const serverSidebar = [
     text: "API Documentation",
     link: "https://cloud.tuist.io/api/docs",
   },
+  {
+    text: "Status",
+    link: "https://status.tuist.io",
+  },
+  {
+    text: "Metrics Dashboard",
+    link: "https://tuist.grafana.net/public-dashboards/1f85f1c3895e48febd02cc7350ade2d9",
+  },
 ];
 
 export const guidesSidebar = [


### PR DESCRIPTION
### Short description 📝

I'm adding links to our new [public dashboard metrics](https://tuist.grafana.net/public-dashboards/1f85f1c3895e48febd02cc7350ade2d9) and the server status page to the docs:

![image](https://github.com/user-attachments/assets/0bf8348e-937d-48ed-bf7d-cc7b57040266)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
