### PR TITLE
Fix tuist test failing due to a conflict when uploading test results

### DIFF
--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -2418,6 +2418,19 @@ public struct Client: APIProtocol {
             },
             deserializer: { response in
                 switch response.statusCode {
+                case 200:
+                    let headers: Operations.uploadCacheActionItem.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.uploadCacheActionItem.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.CacheActionItem.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
                 case 201:
                     let headers: Operations.uploadCacheActionItem.Output.Created.Headers = .init()
                     try converter.validateContentTypeIfPresent(

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -7105,6 +7105,37 @@ public enum Operations {
             }
         }
         @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.uploadCacheActionItem.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.CacheActionItem)
+                }
+                /// Received HTTP response body
+                public var body: Operations.uploadCacheActionItem.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.uploadCacheActionItem.Output.Ok.Headers = .init(),
+                    body: Operations.uploadCacheActionItem.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The request is valid but the cache action item already exists
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/post(uploadCacheActionItem)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.uploadCacheActionItem.Output.Ok)
             public struct Created: Sendable, Equatable, Hashable {
                 public struct Headers: Sendable, Equatable, Hashable {
                     /// Creates a new `Headers`.

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -1950,6 +1950,12 @@ paths:
         description: Cache action item upload params
         required: false
       responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CacheActionItem'
+          description: The request is valid but the cache action item already exists
         201:
           content:
             application/json:

--- a/Sources/TuistServer/Services/UploadCacheActionItemService.swift
+++ b/Sources/TuistServer/Services/UploadCacheActionItemService.swift
@@ -83,6 +83,11 @@ public final class UploadCacheActionItemService: UploadCacheActionItemServicing 
             case let .json(cacheActionItem):
                 return ServerCacheActionItem(cacheActionItem)
             }
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(cacheActionItem):
+                return ServerCacheActionItem(cacheActionItem)
+            }
         case let .paymentRequired(paymentRequiredResponse):
             switch paymentRequiredResponse.body {
             case let .json(error):


### PR DESCRIPTION
### Short description 📝

`main` is currently sometimes failing because of a conflict when uploading test results. Server now returns 201 for `4.28.0` CLI version. For newer versions, the server will return `:ok` which is a more correct HTTP response when the item already exists.

### How to test the changes locally 🧐

It's a bit difficult to reproduce this one without changing the server code. CI should be enough here.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
