### PR TITLE
Fix compiling swift-syntax in Swift 6 language mode

### DIFF
--- a/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -1,8 +1,10 @@
 import Foundation
+import Mockable
 import Path
 import TSCUtility
 
 /// Protocol that defines an interface to interact with the Swift Package Manager.
+@Mockable
 public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
     /// - Parameters:


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6769

### Short description 📝

This PR fixes compiling `swift-syntax` in the Swift 6 language mode.

This was a fun exploration. When comparing the vanilla SPM integration and Xcode integration, the only difference I could find was that we add `-package-name swift-syntax` whereas the SPM integration does _not_.

The `@retroactive` annotation needs to know whether a module is external or not – and it looks like that it doesn't consider a module to be external if the `-package-name` is the same. Which is exactly our case where `SwiftSyntax` and `SwiftSyntaxBuilder` are in the same package (albeit different modules).

Without the `-package-name`, the compilation succeeds. Turns out we add `-package-name` regardless of the package's `swift-tools-version`, but SPM only adds that flag on [Swift 5.9 and higher](https://github.com/swiftlang/swift-package-manager/blob/740a6c552bf90fd76fdea77ba3334ac5c909ef91/Sources/PackageModel/PackageModel.swift#L136).

The solution here is to respect the package's `swift-tools-version` instead of adding `-package-name` regardless of the value.

That being said, I **believe there is a bug in SPM**. When I update the `swift-syntax` to `5.9`, as I did [here](https://github.com/fortmarek/swift-syntax/commit/84abf89424b0a141ae62deab579d1b8cf7106414), a vanilla Xcode project that depends on that forked version does _not_ build either.

I will be reporting the issue to Apple since as soon as `swift-syntax` bumps their `swift-tools-version` will no longer build.

We will be doing a patch release with the fix here as it's blocking people from using `swift-syntax` with Swift 6 lang mode and Tuist.

### How to test the changes locally 🧐

Follow the repro steps from this issue: https://github.com/tuist/tuist/issues/6769

When running `tuist generate` from this branch, the project should successfully build.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
