### PR TITLE
Bump Xcode requirement in Get started

### DIFF
--- a/docs/docs/contributors/get-started.md
+++ b/docs/docs/contributors/get-started.md
@@ -18,7 +18,7 @@ If you don’t have any experience with Swift, we recommend [Apple’s official 
 To contribute to Tuist, minimum requirements are:
 
 - macOS 14.0+
-- Xcode 15.0+
+- Xcode 16.0+
 
 ## Set up the project locally
 
@@ -63,4 +63,3 @@ Although `tuist` provides a `tuist run` it does not support CLIs yet. Therefore,
 swift build --product ProjectDescription
 swift run tuist generate --path /path/to/project --no-open
 ```
-


### PR DESCRIPTION
### Short description 📝

Follow-up PR to: https://github.com/tuist/tuist/pull/6761

The requirement for contributors is now to use Xcode 16 or higher.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
