### PR TITLE
Add type conformance to avoid Xcode 16 warnings.

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -156,7 +156,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     }
 }
 
-extension PlatformCondition?: Comparable {
+extension PlatformCondition?: Swift.Comparable {
     public static func < (lhs: Optional, rhs: Optional) -> Bool {
         guard let lhs else { return false }
         guard let rhs else { return true }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -1,7 +1,6 @@
 import ArgumentParser
 import Foundation
 import Path
-import TSCUtility
 import TuistServer
 import TuistSupport
 import XcodeGraph
@@ -194,7 +193,7 @@ public struct BuildCommand: AsyncParsableCommand {
     }
 }
 
-extension XcodeGraph.Platform: ExpressibleByArgument {
+extension XcodeGraph.Platform: ArgumentParser.ExpressibleByArgument {
     public init?(argument: String) {
         self.init(commandLineValue: argument)
     }

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -114,7 +114,7 @@ enum GraphFormat: String, ExpressibleByArgument, CaseIterable {
     case dot, json, png, svg
 }
 
-extension GraphViz.LayoutAlgorithm: ExpressibleByArgument {
+extension GraphViz.LayoutAlgorithm: ArgumentParser.ExpressibleByArgument {
     public static var allValueStrings: [String] {
         [
             LayoutAlgorithm.dot.rawValue,

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -277,7 +277,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 }
 
-extension TestIdentifier: ExpressibleByArgument {
+extension TestIdentifier: ArgumentParser.ExpressibleByArgument {
     public init?(argument: String) {
         do {
             try self.init(string: argument)


### PR DESCRIPTION
### Short description 📝

Fixes the warning in the new Swift version solved here:
https://github.com/swiftlang/swift/pull/36068
Without adding the `@retroactive`, which does not compile in Xcode 15. This way, extensions that declares a conformance to a type where both are from another module will compile without warning in Xcode 16, as the conformed type is declared to be explicitly from the imported module, which suppresses the warning.

### How to test the changes locally 🧐

- The code compiles on both Xcode 15 and Xcode 16
- The changed lines no longer result in warnings in Xcode 16

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both - NO NEED
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated - NOT USER FACING

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
