### PR TITLE
Fix tuist commands failing due to a git error

### DIFF
--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -28,7 +28,9 @@ public final class CommandEventFactory {
     ) throws -> CommandEvent {
         let gitCommitSHA: String?
         let gitRemoteURLOrigin: String?
-        if gitController.isInGitRepository(workingDirectory: path) {
+        if gitController.isInGitRepository(workingDirectory: path),
+           gitController.hasCurrentBranchCommits(workingDirectory: path)
+        {
             gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path)
             gitRemoteURLOrigin = try gitController.urlOrigin(workingDirectory: path)
         } else {

--- a/Sources/TuistSupport/Utils/GitController.swift
+++ b/Sources/TuistSupport/Utils/GitController.swift
@@ -50,6 +50,9 @@ public protocol GitControlling {
 
     /// - Returns: `true` if we recognize that we're in a `git` repository
     func isInGitRepository(workingDirectory: AbsolutePath) -> Bool
+
+    /// - Returns: `true` if there are commits in the current branch.
+    func hasCurrentBranchCommits(workingDirectory: AbsolutePath) -> Bool
 }
 
 /// An implementation of `GitControlling`.
@@ -104,6 +107,15 @@ public final class GitController: GitControlling {
     public func isInGitRepository(workingDirectory: AbsolutePath) -> Bool {
         do {
             try run(command: "git", "-C", workingDirectory.pathString, "rev-parse")
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    public func hasCurrentBranchCommits(workingDirectory: AbsolutePath) -> Bool {
+        do {
+            try run(command: "git", "-C", workingDirectory.pathString, "log", "-1")
             return true
         } catch {
             return false

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -83,6 +83,10 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             .isInGitRepository(workingDirectory: .any)
             .willReturn(true)
 
+        given(gitController)
+            .hasCurrentBranchCommits(workingDirectory: .any)
+            .willReturn(true)
+
         // When
         let event = try subject.make(
             from: info,
@@ -124,6 +128,45 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
 
         given(gitController)
             .isInGitRepository(workingDirectory: .any)
+            .willReturn(false)
+
+        given(gitController)
+            .ref(environment: .any)
+            .willReturn(nil)
+
+        // When
+        let event = try subject.make(
+            from: info,
+            path: path
+        )
+
+        // Then
+        XCTAssertEqual(event.gitCommitSHA, nil)
+        XCTAssertEqual(event.gitRemoteURLOrigin, nil)
+        XCTAssertEqual(event.gitRef, nil)
+    }
+
+    func test_make_when_is_in_git_repository_and_branch_has_no_commits() throws {
+        // Given
+        let path = try temporaryPath()
+        let info = TrackableCommandInfo(
+            runId: "run-id",
+            name: "cache",
+            subcommand: "warm",
+            parameters: ["foo": "bar"],
+            commandArguments: ["cache", "warm"],
+            durationInMs: 5000,
+            status: .failure("Failed!"),
+            targetHashes: nil,
+            graphPath: nil
+        )
+
+        given(gitController)
+            .isInGitRepository(workingDirectory: .any)
+            .willReturn(true)
+
+        given(gitController)
+            .hasCurrentBranchCommits(workingDirectory: .any)
             .willReturn(false)
 
         given(gitController)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6736

### Short description 📝

We currently assume that if we are in a git repository, we can get the SHA of `HEAD`. However, that's not the case when a given repository has no commits, yet.

This PR fixes that issue by checking that a commit exists by running `git log -1`.

### How to test the changes locally 🧐

Run arbitrary tuist command inside a project that has a git initialized, but no commit, yet.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
