### PR TITLE
Fix acceptance tests regression in a macos_app_with_extensions fixture

### DIFF
--- a/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
+++ b/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
@@ -2,7 +2,9 @@ import ExtensionKit
 
 @main
 final class VendorExtension: NSObject, AppExtension {
-    override init() {}
+    override init() {
+        super.init()
+    }
     
     var configuration: Config {
         return Config()

--- a/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
+++ b/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
@@ -2,6 +2,8 @@ import ExtensionKit
 
 @main
 final class VendorExtension: NSObject, AppExtension {
+    override init() {}
+    
     var configuration: Config {
         return Config()
     }

--- a/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
+++ b/fixtures/macos_app_with_extensions/ExtensionKitExtension/Sources/Extension.swift
@@ -5,7 +5,7 @@ final class VendorExtension: NSObject, AppExtension {
     override init() {
         super.init()
     }
-    
+
     var configuration: Config {
         return Config()
     }


### PR DESCRIPTION
### Short description 📝

The PR fixes a regression in acceptance tests for a `macos_app_with_extensions` fixture project and related to changes introduced in #6745 

The issue is that the extension class in the fixture conforming to `ExtensionFoundation.AppExtension` must explicitly specify the `init` method required by a protocol under Xcode 16.

Under Xcode 15.3, it was possible to have this conformance implicitly.

### How to test the changes locally 🧐

Run a `GenerateAcceptanceTestmacOSAppWithExtensions.test_macos_app_with_extensions`
Note that to successfully run this test case, you might need to install the `fixtures/resources/WorkflowExtensionsSDK.pkg` locally.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
