### PR TITLE
Inspect implicit imports on lint

### DIFF
--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -4,3 +4,4 @@ set -euo pipefail
 
 swiftformat $MISE_PROJECT_ROOT --lint
 swiftlint lint --quiet --config $MISE_PROJECT_ROOT/.swiftlint.yml $MISE_PROJECT_ROOT/Sources
+tuist inspect implicit-imports --path $MISE_PROJECT_ROOT

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -12,6 +12,8 @@ workflows:
         script: |
           curl https://mise.run | sh
           mise install
+      - name: Install Tuist dependencies
+        script: mise x -- tuist install
       - name: Lint
         script: mise run lint
     triggering: &branch_triggering

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -14,6 +14,8 @@ workflows:
           mise install
       - name: Install Tuist dependencies
         script: mise x -- tuist install
+      - name: Generate the Tuist project
+        script: mise x -- tuist generate --no-binary-cache
       - name: Lint
         script: mise run lint
     triggering: &branch_triggering


### PR DESCRIPTION
### Short description 📝

We should run `tuist inspect implicit-imports` to ensure we don't add any implicit imports.

Kudos to @rofle100lvl for this very useful command ❤️ 

### How to test the changes locally 🧐

- Introduce an implicit dependency
- Run `mise run lint`
- The command should fail

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
