### PR TITLE
fix: rename macOS app build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         working-directory: app
         env:
           TUIST_APP_PRIVATE_SPARKLE_KEY: ${{ secrets.TUIST_APP_PRIVATE_SPARKLE_KEY }}
-        run: echo "$TUIST_APP_PRIVATE_SPARKLE_KEY" | .build/artifacts/sparkle/Sparkle/bin/generate_appcast --link https://github.com/tuist/tuist/releases --download-url-prefix https://github.com/tuist/tuist/releases/download/${{ steps.next-version.outputs.NEXT_VERSION }}/app.dmg -o appcast.xml build/artifacts --ed-key-file -
+        run: echo "$TUIST_APP_PRIVATE_SPARKLE_KEY" | .build/artifacts/sparkle/Sparkle/bin/generate_appcast --link https://github.com/tuist/tuist/releases --download-url-prefix https://github.com/tuist/tuist/releases/download/${{ steps.next-version.outputs.NEXT_VERSION }}/Tuist.dmg -o appcast.xml build/artifacts --ed-key-file -
       - name: Commit changes
         id: auto-commit-action
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -130,6 +130,6 @@ jobs:
           body: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
           target_commitish: ${{ steps.auto-commit-action.outputs.commit_hash }}
           files: |
-            app/build/artifacts/app.dmg
+            app/build/artifacts/Tuist.dmg
             app/build/artifacts/SHASUMS256.txt
             app/build/artifacts/SHASUMS512.txt

--- a/.mise/tasks/bundle/app
+++ b/.mise/tasks/bundle/app
@@ -59,7 +59,7 @@ codesign --force --timestamp --options runtime --sign "Developer ID Application:
 print_status "Submitting the Tuist App for notarization..."
 mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
-BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/app.dmg
+BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
 create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
 codesign --force --timestamp --options runtime --sign "Developer ID Application: Tuist GmbH (U6LC622NKF)" --identifier "io.tuist.app.tuist-app-dmg" "$BUILD_DMG_PATH"
 

--- a/app/appcast.xml
+++ b/app/appcast.xml
@@ -9,7 +9,7 @@
             <sparkle:version>0.1.1</sparkle:version>
             <sparkle:shortVersionString>0.1.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.1.1/app.dmg" length="18611983" type="application/octet-stream" sparkle:edSignature="M61HZ/Y6N1eTfHkcmcD+J5NgLZ+pQZgJ4XHDc4ASyw9gt/p/SQKIXfWZola/L4xPFrwG16lZ5i9zprU369W8DA=="/>
+            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.1.1/Tuist.dmg" length="18611983" type="application/octet-stream" sparkle:edSignature="M61HZ/Y6N1eTfHkcmcD+J5NgLZ+pQZgJ4XHDc4ASyw9gt/p/SQKIXfWZola/L4xPFrwG16lZ5i9zprU369W8DA=="/>
         </item>
         <item>
             <title>0.1.0</title>
@@ -18,7 +18,7 @@
             <sparkle:version>0.1.0</sparkle:version>
             <sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.1.0/app.dmg" length="19931739" type="application/octet-stream" sparkle:edSignature="t5Hv9oeN884WuBA9dkTi3xakkajOKhDSePBF+8uoWmtrzZTmJ88N9KZGfBe9LkiLW0YanOgiv6w2IVOu+BX9CQ=="/>
+            <enclosure url="https://github.com/tuist/tuist/releases/download/app@0.1.0/Tuist.dmg" length="19931739" type="application/octet-stream" sparkle:edSignature="t5Hv9oeN884WuBA9dkTi3xakkajOKhDSePBF+8uoWmtrzZTmJ88N9KZGfBe9LkiLW0YanOgiv6w2IVOu+BX9CQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6801

### Short description 📝

When download Tuist macOS app i got lost finding the app in the downloads then realized it's just named "app.dmg" and not "Tuist.dmg" or something relatable.

This renames the Tuist macOS app from "app.dmg" to "Tuist.dmg".

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
