### PR TITLE
Fix regression when including directories that are considered source like DocC catalogs.

### DIFF
--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -106,8 +106,18 @@ extension Target {
                 .subtracting(excluded)
                 .filter { path in
                     guard let `extension` = path.extension else { return false }
-                    return Target.validSourceExtensions
+
+                    let hasValidSourceExtensions = Target.validSourceExtensions
                         .contains(where: { $0.caseInsensitiveCompare(`extension`) == .orderedSame })
+
+                    if hasValidSourceExtensions {
+                        // Addition check to prevent folders with name like `Foo.Swift` to be considered as source files.
+                        return !FileHandler.shared.isFolder(path)
+                    } else {
+                        // There are extensions should be considered as source files even if they are folders.
+                        return Target.validSourceCompatibleFolderExtensions
+                            .contains(where: { $0.caseInsensitiveCompare(`extension`) == .orderedSame })
+                    }
                 }
                 .forEach { sourceFiles[$0] = SourceFile(
                     path: $0,

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -495,14 +495,17 @@ final class GenerateAcceptanceTestiOSAppWithExtensions: TuistAcceptanceTestCase 
         try await setUpFixture(.iosAppWithExtensions)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
-        
+
         let xcodeproj = try XcodeProj(
             pathString: xcodeprojPath.pathString
         )
         let target = try XCTUnwrapTarget("App", in: xcodeproj)
         let sourceFileNames = try target.sourceFiles().compactMap(\.path)
-        
-        XCTAssertTrue(sourceFileNames.contains(where: { $0.hasSuffix("Documentation.docc") }), "Expected Documentation to be included in generated project")
+
+        XCTAssertTrue(
+            sourceFileNames.contains(where: { $0.hasSuffix("Documentation.docc") }),
+            "Expected Documentation to be included in generated project"
+        )
 
         try await XCTAssertProductWithDestinationContainsExtension(
             "App.app",

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -495,6 +495,14 @@ final class GenerateAcceptanceTestiOSAppWithExtensions: TuistAcceptanceTestCase 
         try await setUpFixture(.iosAppWithExtensions)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
+        
+        let xcodeproj = try XcodeProj(
+            pathString: xcodeprojPath.pathString
+        )
+        let target = try XCTUnwrapTarget("App", in: xcodeproj)
+        let sourceFileNames = try target.sourceFiles().compactMap(\.path)
+        
+        XCTAssertTrue(sourceFileNames.contains(where: { $0.hasSuffix("Documentation.docc") }), "Expected Documentation to be included in generated project")
 
         try await XCTAssertProductWithDestinationContainsExtension(
             "App.app",

--- a/fixtures/ios_app_with_extensions/Sources/Documentation.docc/Documentation.md
+++ b/fixtures/ios_app_with_extensions/Sources/Documentation.docc/Documentation.md
@@ -1,0 +1,13 @@
+# ``App``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->


### PR DESCRIPTION
Supersedes #6198

### Short description 📝

 The changing in tuist/XcodeGraph#36 caused a regression in projects that included directories that are considered source files like `DocC` documentation catalogs.  Recent versions of Tuist will not include DocC and other formats in generated Xcode projects.

### How to test the changes locally 🧐

PR includes a test update that checks for the issue. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
