### PR TITLE
Do not set redundant DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER build setting

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -373,7 +373,6 @@ final class ConfigGenerator: ConfigGenerating {
 
             if target.destinations.contains(.macCatalyst) {
                 settings["SUPPORTS_MACCATALYST"] = "YES"
-                settings["DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER"] = "YES"
             } else {
                 settings["SUPPORTS_MACCATALYST"] = "NO"
             }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -417,7 +417,6 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "TARGETED_DEVICE_FAMILY": "1,2",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.1",
             "SUPPORTS_MACCATALYST": "YES",
-            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "YES",
             "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "NO",
             "SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD": "NO",
         ]


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6799>

### Short description 📝

Currently, if `destinations` contains `.macCatalyst`, the target in Xcode will include `DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER`, which is an error. Catalyst apps can now share the same bundle identifier as the iOS app.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
