### PR TITLE
Migrate FileHandler to FileSystem in TuistHasher

### DIFF
--- a/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -74,7 +74,7 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
             graph: graph
         )
 
-        let hashes = try graphContentHasher.contentHashes(
+        let hashes = try await graphContentHasher.contentHashes(
             for: graph,
             include: {
                 self.isGraphTargetHashable(

--- a/Sources/TuistCore/Cache/FileContentHashing.swift
+++ b/Sources/TuistCore/Cache/FileContentHashing.swift
@@ -2,5 +2,5 @@ import Foundation
 import Path
 
 public protocol FileContentHashing {
-    func hash(path: AbsolutePath) throws -> String
+    func hash(path: AbsolutePath) async throws -> String
 }

--- a/Sources/TuistCore/ContentHashing/ContentHashing.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHashing.swift
@@ -9,5 +9,5 @@ public protocol ContentHashing: FileContentHashing {
     func hash(_ boolean: Bool) throws -> String
     func hash(_ strings: [String]) throws -> String
     func hash(_ dictionary: [String: String]) throws -> String
-    func hash(path: AbsolutePath) throws -> String
+    func hash(path: AbsolutePath) async throws -> String
 }

--- a/Sources/TuistHasher/CachedContentHasher.swift
+++ b/Sources/TuistHasher/CachedContentHasher.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Path
 import TuistCore
+import TuistSupport
 
 /// `CachedContentHasher`
 /// is a wrapper on top of `ContentHasher` that adds an in-memory cache to avoid re-computing the same hashes
@@ -8,7 +9,7 @@ public final class CachedContentHasher: ContentHashing {
     private let contentHasher: ContentHashing
 
     // In memory cache for files that have already been hashed
-    private var hashesCache: [AbsolutePath: String] = [:]
+    private var hashesCache: ThreadSafe<[AbsolutePath: String]> = ThreadSafe([:])
 
     public init(contentHasher: ContentHashing = ContentHasher()) {
         self.contentHasher = contentHasher
@@ -34,12 +35,12 @@ public final class CachedContentHasher: ContentHashing {
         try contentHasher.hash(dictionary)
     }
 
-    public func hash(path filePath: AbsolutePath) throws -> String {
-        if let cachedHash = hashesCache[filePath] {
+    public func hash(path filePath: AbsolutePath) async throws -> String {
+        if let cachedHash = hashesCache.value[filePath] {
             return cachedHash
         }
-        let hash = try contentHasher.hash(path: filePath)
-        hashesCache[filePath] = hash
+        let hash = try await contentHasher.hash(path: filePath)
+        hashesCache.mutate { $0[filePath] = hash }
         return hash
     }
 }

--- a/Sources/TuistHasher/DependenciesContentHasher.swift
+++ b/Sources/TuistHasher/DependenciesContentHasher.swift
@@ -7,9 +7,14 @@ import XcodeGraph
 public protocol DependenciesContentHashing {
     func hash(
         graphTarget: GraphTarget,
-        hashedTargets: inout [GraphHashedTarget: String],
-        hashedPaths: inout [AbsolutePath: String]
-    ) throws -> String
+        hashedTargets: [GraphHashedTarget: String],
+        hashedPaths: [AbsolutePath: String]
+    ) async throws -> DependenciesContentHash
+}
+
+public struct DependenciesContentHash {
+    public let hashedPaths: [AbsolutePath: String]
+    public let hash: String
 }
 
 enum DependenciesContentHasherError: FatalError, Equatable {
@@ -57,12 +62,27 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     public func hash(
         graphTarget: GraphTarget,
-        hashedTargets: inout [GraphHashedTarget: String],
-        hashedPaths: inout [AbsolutePath: String]
-    ) throws -> String {
-        let hashes = try graphTarget.target.dependencies
-            .map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths) }
-        return hashes.sorted().compactMap { $0 }.joined()
+        hashedTargets: [GraphHashedTarget: String],
+        hashedPaths: [AbsolutePath: String]
+    ) async throws -> DependenciesContentHash {
+        let hashedTargets = hashedTargets
+        var hashedPaths = hashedPaths
+        var hashes: [String] = []
+
+        for dependency in graphTarget.target.dependencies {
+            let result = try await hash(
+                graphTarget: graphTarget,
+                dependency: dependency,
+                hashedTargets: hashedTargets,
+                hashedPaths: hashedPaths
+            )
+            hashes.append(result.hash)
+            hashedPaths.merge(result.hashedPaths, uniquingKeysWith: { _, newValue in newValue })
+        }
+        return DependenciesContentHash(
+            hashedPaths: hashedPaths,
+            hash: hashes.sorted().compactMap { $0 }.joined()
+        )
     }
 
     // MARK: - Private
@@ -70,9 +90,10 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
     private func hash(
         graphTarget: GraphTarget,
         dependency: TargetDependency,
-        hashedTargets: inout [GraphHashedTarget: String],
-        hashedPaths: inout [AbsolutePath: String]
-    ) throws -> String {
+        hashedTargets: [GraphHashedTarget: String],
+        hashedPaths: [AbsolutePath: String]
+    ) async throws -> DependenciesContentHash {
+        var hashedPaths = hashedPaths
         switch dependency {
         case let .target(targetName, _, _):
             guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: graphTarget.path, targetName: targetName)]
@@ -83,7 +104,10 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
                     dependencyTargetName: targetName
                 )
             }
-            return dependencyHash
+            return DependenciesContentHash(
+                hashedPaths: hashedPaths,
+                hash: dependencyHash
+            )
         case let .project(targetName, projectPath, _, _):
             guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: projectPath, targetName: targetName)] else {
                 throw DependenciesContentHasherError.missingProjectTargetHash(
@@ -93,34 +117,61 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
                     dependencyTargetName: targetName
                 )
             }
-            return dependencyHash
+            return DependenciesContentHash(
+                hashedPaths: hashedPaths,
+                hash: dependencyHash
+            )
         case let .framework(path, _, _), let .xcframework(path, _, _):
-            return try cachedHash(path: path, hashedPaths: &hashedPaths)
-        case let .library(path, publicHeaders, swiftModuleMap, _):
-            let libraryHash = try cachedHash(path: path, hashedPaths: &hashedPaths)
-            let publicHeadersHash = try contentHasher.hash(path: publicHeaders)
-            if let swiftModuleMap {
-                let swiftModuleHash = try contentHasher.hash(path: swiftModuleMap)
-                return try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)-\(swiftModuleHash)")
+            if let pathHash = hashedPaths[path] {
+                return DependenciesContentHash(
+                    hashedPaths: hashedPaths,
+                    hash: pathHash
+                )
             } else {
-                return try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)")
+                let pathHash = try await contentHasher.hash(path: path)
+                hashedPaths[path] = pathHash
+                return DependenciesContentHash(
+                    hashedPaths: hashedPaths,
+                    hash: pathHash
+                )
+            }
+        case let .library(path, publicHeaders, swiftModuleMap, _):
+            let libraryHash: String
+            if let pathHash = hashedPaths[path] {
+                libraryHash = pathHash
+            } else {
+                let pathHash = try await contentHasher.hash(path: path)
+                hashedPaths[path] = pathHash
+                libraryHash = pathHash
+            }
+            let publicHeadersHash = try await contentHasher.hash(path: publicHeaders)
+            if let swiftModuleMap {
+                let swiftModuleHash = try await contentHasher.hash(path: swiftModuleMap)
+                return DependenciesContentHash(
+                    hashedPaths: hashedPaths,
+                    hash: try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)-\(swiftModuleHash)")
+                )
+            } else {
+                return DependenciesContentHash(
+                    hashedPaths: hashedPaths,
+                    hash: try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)")
+                )
             }
         case let .package(product, type, _):
-            return try contentHasher.hash("package-\(product)-\(type.rawValue)")
+            return DependenciesContentHash(
+                hashedPaths: hashedPaths,
+                hash: try contentHasher.hash("package-\(product)-\(type.rawValue)")
+            )
         case let .sdk(name, status, _):
-            return try contentHasher.hash("sdk-\(name)-\(status)")
+            return DependenciesContentHash(
+                hashedPaths: hashedPaths,
+                hash: try contentHasher.hash("sdk-\(name)-\(status)")
+            )
         case .xctest:
-            return try contentHasher.hash("xctest")
-        }
-    }
-
-    private func cachedHash(path: AbsolutePath, hashedPaths: inout [AbsolutePath: String]) throws -> String {
-        if let pathHash = hashedPaths[path] {
-            return pathHash
-        } else {
-            let pathHash = try contentHasher.hash(path: path)
-            hashedPaths[path] = pathHash
-            return pathHash
+            return DependenciesContentHash(
+                hashedPaths: hashedPaths,
+                hash: try contentHasher.hash("xctest")
+            )
         }
     }
 }

--- a/Sources/TuistHasher/HeadersContentHasher.swift
+++ b/Sources/TuistHasher/HeadersContentHasher.swift
@@ -3,12 +3,12 @@ import TuistCore
 import XcodeGraph
 
 public protocol HeadersContentHashing {
-    func hash(headers: Headers) throws -> String
+    func hash(headers: Headers) async throws -> String
 }
 
 /// `HeadersContentHashing`
 /// is responsible for computing a hash that uniquely identifies a list of headers
-public final class HeadersContentHasher: HeadersContentHashing {
+public struct HeadersContentHasher: HeadersContentHashing {
     private let contentHasher: ContentHashing
 
     // MARK: - Init
@@ -19,9 +19,9 @@ public final class HeadersContentHasher: HeadersContentHashing {
 
     // MARK: - HeadersContentHashing
 
-    public func hash(headers: Headers) throws -> String {
+    public func hash(headers: Headers) async throws -> String {
         let allHeaders = headers.public + headers.private + headers.project
-        let headersContent = try allHeaders.map { try contentHasher.hash(path: $0) }
+        let headersContent = try await allHeaders.serialMap { try await contentHasher.hash(path: $0) }
         return try contentHasher.hash(headersContent)
     }
 }

--- a/Sources/TuistHasher/PlistContentHasher.swift
+++ b/Sources/TuistHasher/PlistContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import XcodeGraph
 
 public protocol PlistContentHashing {
-    func hash(plist: Plist) throws -> String
+    func hash(plist: Plist) async throws -> String
 }
 
 /// `PlistContentHasher`
@@ -19,12 +19,12 @@ public final class PlistContentHasher: PlistContentHashing {
 
     // MARK: - PlistContentHashing
 
-    public func hash(plist: Plist) throws -> String {
+    public func hash(plist: Plist) async throws -> String {
         switch plist {
         case let .infoPlist(infoPlist):
             switch infoPlist {
             case let .file(path):
-                return try contentHasher.hash(path: path)
+                return try await contentHasher.hash(path: path)
             case let .dictionary(dictionary), let .extendingDefault(dictionary):
                 var dictionaryString: String = ""
                 for key in dictionary.keys.sorted() {
@@ -40,7 +40,7 @@ public final class PlistContentHasher: PlistContentHashing {
             case let .variable(variable):
                 return try contentHasher.hash(variable)
             case let .file(path):
-                return try contentHasher.hash(path: path)
+                return try await contentHasher.hash(path: path)
             case let .dictionary(dictionary):
                 var dictionaryString: String = ""
                 for key in dictionary.keys.sorted() {

--- a/Sources/TuistHasher/ResourcesContentHasher.swift
+++ b/Sources/TuistHasher/ResourcesContentHasher.swift
@@ -3,19 +3,19 @@ import TuistCore
 import XcodeGraph
 
 public protocol ResourcesContentHashing {
-    func hash(identifier: String, resources: ResourceFileElements) throws -> MerkleNode
+    func hash(identifier: String, resources: ResourceFileElements) async throws -> MerkleNode
 }
 
 /// `ResourcesContentHasher`
 /// is responsible for computing a unique hash that identifies a list of resources
-public final class ResourcesContentHasher: ResourcesContentHashing {
+public struct ResourcesContentHasher: ResourcesContentHashing {
     private let contentHasher: ContentHashing
     private let privacyManifestContentHasher: PrivacyManifestContentHasher
     private let platformConditionContentHasher: PlatformConditionContentHashing
 
     // MARK: - Init
 
-    public convenience init(contentHasher: ContentHashing) {
+    public init(contentHasher: ContentHashing) {
         self.init(
             contentHasher: contentHasher,
             privacyManifestContentHasher: PrivacyManifestContentHasher(contentHasher: contentHasher),
@@ -35,10 +35,10 @@ public final class ResourcesContentHasher: ResourcesContentHashing {
 
     // MARK: - ResourcesContentHashing
 
-    public func hash(identifier: String, resources: ResourceFileElements) throws -> MerkleNode {
-        var children: [MerkleNode] = try resources.resources
+    public func hash(identifier: String, resources: ResourceFileElements) async throws -> MerkleNode {
+        var children: [MerkleNode] = try await resources.resources
             .sorted(by: { $0.path < $1.path })
-            .map { try hashResourceFileElement(element: $0) }
+            .concurrentMap { try await hashResourceFileElement(element: $0) }
 
         if let privacyManifest = resources.privacyManifest {
             children.append(try privacyManifestContentHasher.hash(
@@ -54,9 +54,9 @@ public final class ResourcesContentHasher: ResourcesContentHashing {
         )
     }
 
-    private func hashResourceFileElement(element: ResourceFileElement) throws -> MerkleNode {
+    private func hashResourceFileElement(element: ResourceFileElement) async throws -> MerkleNode {
         var children: [MerkleNode] = [
-            MerkleNode(hash: try contentHasher.hash(path: element.path), identifier: "content"),
+            MerkleNode(hash: try await contentHasher.hash(path: element.path), identifier: "content"),
             MerkleNode(hash: try contentHasher.hash(element.isReference), identifier: "isReference"),
             MerkleNode(hash: try contentHasher.hash(element.tags), identifier: "tags"),
         ]

--- a/Sources/TuistHasher/SettingsContentHasher.swift
+++ b/Sources/TuistHasher/SettingsContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import XcodeGraph
 
 public protocol SettingsContentHashing {
-    func hash(settings: Settings) throws -> String
+    func hash(settings: Settings) async throws -> String
 }
 
 /// `SettingsContentHasher`
@@ -19,20 +19,20 @@ public final class SettingsContentHasher: SettingsContentHashing {
 
     // MARK: - SettingsContentHashing
 
-    public func hash(settings: Settings) throws -> String {
+    public func hash(settings: Settings) async throws -> String {
         let baseSettingsHash = try hash(settings.base)
-        let configurationHash = try hash(settings.configurations)
+        let configurationHash = try await hash(settings.configurations)
         let defaultSettingsHash = try hash(settings.defaultSettings)
         return try contentHasher.hash([baseSettingsHash, configurationHash, defaultSettingsHash])
     }
 
-    private func hash(_ configurations: [BuildConfiguration: Configuration?]) throws -> String {
+    private func hash(_ configurations: [BuildConfiguration: Configuration?]) async throws -> String {
         var configurationHashes: [String] = []
         for buildConfiguration in configurations.keys.sorted() {
             var configurationHash = buildConfiguration.name + buildConfiguration.variant.rawValue
             if let configuration = configurations[buildConfiguration] {
                 if let configuration {
-                    configurationHash += try hash(configuration)
+                    configurationHash += try await hash(configuration)
                 }
             }
             configurationHashes.append(configurationHash)
@@ -47,10 +47,10 @@ public final class SettingsContentHasher: SettingsContentHashing {
         return try contentHasher.hash(sortedAndNormalizedSettings)
     }
 
-    private func hash(_ configuration: Configuration) throws -> String {
+    private func hash(_ configuration: Configuration) async throws -> String {
         var configurationHash = try hash(configuration.settings)
         if let xcconfigPath = configuration.xcconfig {
-            let xcconfigHash = try contentHasher.hash(path: xcconfigPath)
+            let xcconfigHash = try await contentHasher.hash(path: xcconfigPath)
             configurationHash += xcconfigHash
         }
         return configurationHash

--- a/Sources/TuistHasher/SourceFilesContentHasher.swift
+++ b/Sources/TuistHasher/SourceFilesContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import XcodeGraph
 
 public protocol SourceFilesContentHashing {
-    func hash(identifier: String, sources: [SourceFile]) throws -> MerkleNode
+    func hash(identifier: String, sources: [SourceFile]) async throws -> MerkleNode
 }
 
 /// `SourceFilesContentHasher`
@@ -29,7 +29,7 @@ public final class SourceFilesContentHasher: SourceFilesContentHashing {
     /// are always sorted the same way.
     /// Then it hashes again all partial hashes to get a unique identifier that represents a group of source files together with
     /// their compiler flags
-    public func hash(identifier: String, sources: [SourceFile]) throws -> MerkleNode {
+    public func hash(identifier: String, sources: [SourceFile]) async throws -> MerkleNode {
         var children: [MerkleNode] = []
 
         for source in sources.sorted(by: { $0.path < $1.path }) {
@@ -42,7 +42,7 @@ public final class SourceFilesContentHasher: SourceFilesContentHashing {
             } else {
                 var sourceChildren: [MerkleNode] = []
                 sourceChildren.append(MerkleNode(
-                    hash: try contentHasher.hash(path: source.path),
+                    hash: try await contentHasher.hash(path: source.path),
                     identifier: "content",
                     children: []
                 ))

--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -148,7 +148,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
     ///   - atomically: whether to write atomically
     func writeIfDifferent(moduleMapContent: String, to path: AbsolutePath, atomically: Bool) async throws {
         let newContentHash = try contentHasher.hash(moduleMapContent)
-        let currentContentHash = try? contentHasher.hash(path: path)
+        let currentContentHash = try? await contentHasher.hash(path: path)
         if currentContentHash != newContentHash {
             try FileHandler.shared.write(moduleMapContent, path: path, atomically: true)
         }

--- a/Sources/TuistSupport/Extensions/Array+ExecutionContext.swift
+++ b/Sources/TuistSupport/Extensions/Array+ExecutionContext.swift
@@ -244,6 +244,30 @@ extension Sequence {
     }
 
     /// Transform the sequence into an array of new values using
+    /// an async closure that non-optional values.
+    ///
+    /// The closure calls will be performed in order, by waiting for
+    /// each call to complete before proceeding with the next one. If
+    /// any of the closure calls throw an error, then the iteration
+    /// will be terminated and the error rethrown.
+    ///
+    /// - parameter transform: The transform to run on each element.
+    /// - returns: The transformed values as an array. The order of
+    ///   the transformed values will match the original sequence.
+    /// - throws: Rethrows any error thrown by the passed closure.
+    public func serialMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+
+        for element in self {
+            values.append(try await transform(element))
+        }
+
+        return values
+    }
+
+    /// Transform the sequence into an array of new values using
     /// an async closure that returns sequences. The returned sequences
     /// will be flattened into the array returned from this function.
     ///

--- a/Tests/TuistCoreTests/ContentHashing/ContentHasherTests.swift
+++ b/Tests/TuistCoreTests/ContentHashing/ContentHasherTests.swift
@@ -54,39 +54,40 @@ final class ContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(hash, expectedHash)
     }
 
-    func test_hashFile_hashesTheExpectedFile() throws {
+    func test_hashFile_hashesTheExpectedFile() async throws {
         // Given
         let path = try writeToTemporaryPath(content: "foo")
 
         // When
-        let hash = try subject.hash(path: path)
+        let hash = try await subject.hash(path: path)
 
         // Then
         XCTAssertEqual(hash, "acbd18db4cc2f85cedef654fccc4a4d8") // This is the md5 of "foo"
     }
 
-    func test_hashFile_isNotHarcoded() throws {
+    func test_hashFile_isNotHarcoded() async throws {
         // Given
         let path = try writeToTemporaryPath(content: "bar")
 
         // When
-        let hash = try subject.hash(path: path)
+        let hash = try await subject.hash(path: path)
 
         // Then
         XCTAssertEqual(hash, "37b51d194a7513e45b56f6524f2d51f2") // This is the md5 of "bar"
     }
 
-    func test_hashFile_whenFileDoesntExist_itThrowsFileNotFound() throws {
+    func test_hashFile_whenFileDoesntExist_itThrowsFileNotFound() async throws {
         // Given
         let wrongPath = try AbsolutePath(validating: "/shakirashakira")
 
         // Then
-        XCTAssertThrowsError(try subject.hash(path: wrongPath)) { error in
-            XCTAssertEqual(error as? FileHandlerError, FileHandlerError.fileNotFound(wrongPath))
-        }
+        await XCTAssertThrowsSpecific(
+            try await subject.hash(path: wrongPath),
+            FileHandlerError.fileNotFound(wrongPath)
+        )
     }
 
-    func test_hash_sortedContentsOfADirectorySkippingDSStore() throws {
+    func test_hash_sortedContentsOfADirectorySkippingDSStore() async throws {
         // given
         let folderPath = try temporaryPath().appending(component: "assets.xcassets")
         try mockFileHandler.createFolder(folderPath)
@@ -101,7 +102,7 @@ final class ContentHasherTests: TuistUnitTestCase {
         try writeFiles(to: folderPath, files: files)
 
         // When
-        let hash = try subject.hash(path: folderPath)
+        let hash = try await subject.hash(path: folderPath)
 
         // Then
         XCTAssertEqual(hash, "37b51d194a7513e45b56f6524f2d51f2-224e2539f52203eb33728acd228b4432")

--- a/Tests/TuistHasherTests/CachedContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CachedContentHasherTests.swift
@@ -61,7 +61,7 @@ final class CachedContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hashpath_callsContentHasherWithExpectedPath() throws {
+    func test_hashpath_callsContentHasherWithExpectedPath() async throws {
         // Given
         let path = try AbsolutePath(validating: "/foo")
         given(contentHasher)
@@ -69,7 +69,7 @@ final class CachedContentHasherTests: TuistUnitTestCase {
             .willReturn("foo-hash")
 
         // When
-        _ = try subject.hash(path: path)
+        _ = try await subject.hash(path: path)
 
         // Then
         verify(contentHasher)
@@ -77,7 +77,7 @@ final class CachedContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hashpath_secondTime_doesntCallContentHasher() throws {
+    func test_hashpath_secondTime_doesntCallContentHasher() async throws {
         // Given
         let path = try AbsolutePath(validating: "/foo")
         given(contentHasher)
@@ -85,8 +85,8 @@ final class CachedContentHasherTests: TuistUnitTestCase {
             .willReturn("foo-hash")
 
         // When
-        let hash = try subject.hash(path: path)
-        let cachedHash = try subject.hash(path: path)
+        let hash = try await subject.hash(path: path)
+        let cachedHash = try await subject.hash(path: path)
 
         // Then
         verify(contentHasher)

--- a/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
@@ -51,7 +51,7 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 0 ... 100 {
-            results.insert(try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction]).hash)
+            results.insert(try await subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction]).hash)
         }
 
         // Then
@@ -78,7 +78,7 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction])
+        let got = try await subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction])
 
         // Then
         XCTAssertEqual(got, MerkleNode(

--- a/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
@@ -40,7 +40,7 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_hash_returnsSameValue() throws {
+    func test_hash_returnsSameValue() async throws {
         // Given
         coreDataModel = try buildCoreDataModel(versions: ["v1", "v2"], currentVersion: "currentV1")
         given(contentHasher)
@@ -48,13 +48,13 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
             .willProduce { $0.basename }
 
         // When
-        let hash = try subject.hash(coreDataModels: [coreDataModel])
+        let hash = try await subject.hash(coreDataModels: [coreDataModel])
 
         // Then
         XCTAssertEqual(hash, "fixed-hash;currentV1;v1;v2")
     }
 
-    func test_hash_fileContentChangesHash() throws {
+    func test_hash_fileContentChangesHash() async throws {
         // Given
         let name = "CoreDataModel"
         coreDataModel = try buildCoreDataModel()
@@ -67,13 +67,13 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
             .willReturn("different-hash")
 
         // When
-        let hash = try subject.hash(coreDataModels: [coreDataModel])
+        let hash = try await subject.hash(coreDataModels: [coreDataModel])
 
         // Then
         XCTAssertNotEqual(hash, defaultValuesHash)
     }
 
-    func test_hash_currentVersionChangesHash() throws {
+    func test_hash_currentVersionChangesHash() async throws {
         // Given
         coreDataModel = try buildCoreDataModel(currentVersion: "2")
         given(contentHasher)
@@ -81,12 +81,12 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
             .willProduce { $0.basename }
 
         // When
-        let hash = try subject.hash(coreDataModels: [coreDataModel])
+        let hash = try await subject.hash(coreDataModels: [coreDataModel])
 
         XCTAssertNotEqual(hash, defaultValuesHash)
     }
 
-    func test_hash_versionsChangeHash() throws {
+    func test_hash_versionsChangeHash() async throws {
         // Given
         coreDataModel = try buildCoreDataModel(versions: ["1", "2", "3"])
         given(contentHasher)
@@ -94,7 +94,7 @@ final class CoreDataModelsContentHasherTests: TuistUnitTestCase {
             .willProduce { $0.basename }
 
         // When
-        let hash = try subject.hash(coreDataModels: [coreDataModel])
+        let hash = try await subject.hash(coreDataModels: [coreDataModel])
 
         // Then
         XCTAssertNotEqual(hash, defaultValuesHash)

--- a/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
@@ -43,7 +43,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_hash_whenDependencyIsTarget_returnsTheRightHash() throws {
+    func test_hash_whenDependencyIsTarget_returnsTheRightHash() async throws {
         // Given
         let dependency = TargetDependency.target(name: "foo")
 
@@ -55,13 +55,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
                 targetName: "foo"
             )
         ] = "target-foo-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
     }
 
-    func test_hash_whenDependencyIsTarget_throwsWhenTheDependencyHasntBeenHashed() throws {
+    func test_hash_whenDependencyIsTarget_throwsWhenTheDependencyHasntBeenHashed() async throws {
         // Given
         let dependency = TargetDependency.target(name: "foo")
 
@@ -72,13 +72,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: graphTarget.path,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(
-            try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths),
+        await XCTAssertThrowsSpecific(
+            try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash,
             expectedError
         )
     }
 
-    func test_hash_whenDependencyIsProject_returnsTheRightHash() throws {
+    func test_hash_whenDependencyIsProject_returnsTheRightHash() async throws {
         // Given
         let dependency = TargetDependency.project(target: "foo", path: filePath1)
 
@@ -90,13 +90,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
                 targetName: "foo"
             )
         ] = "project-file-hashed-foo-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
     }
 
-    func test_hash_whenDependencyIsProjectWithACondition_returnsTheRightHash() throws {
+    func test_hash_whenDependencyIsProjectWithACondition_returnsTheRightHash() async throws {
         // Given
         let dependency = TargetDependency.project(target: "foo", path: filePath1, condition: .when([.ios]))
 
@@ -108,13 +108,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
                 targetName: "foo"
             )
         ] = "project-file-hashed-foo-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
     }
 
-    func test_hash_whenDependencyIsProject_throwsAnErrorIfTheDependencyHashDoesntExist() throws {
+    func test_hash_whenDependencyIsProject_throwsAnErrorIfTheDependencyHashDoesntExist() async throws {
         // Given
         let dependency = TargetDependency.project(target: "foo", path: filePath1)
 
@@ -126,13 +126,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: filePath1,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(
-            try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths),
+        await XCTAssertThrowsSpecific(
+            try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash,
             expectedError
         )
     }
 
-    func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.framework(path: filePath1, status: .required)
         given(contentHasher)
@@ -141,7 +141,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -150,7 +150,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsXCFramework_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsXCFramework_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.xcframework(path: filePath1, status: .required)
         given(contentHasher)
@@ -159,7 +159,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -168,7 +168,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsLibrary_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsLibrary_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.library(
             path: filePath1,
@@ -187,7 +187,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-file3-hashed-hash")
@@ -199,7 +199,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsLibrary_swiftModuleMapIsNil_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsLibrary_swiftModuleMapIsNil_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.library(
             path: filePath1,
@@ -215,7 +215,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-hash")
@@ -227,13 +227,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsPackage_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsPackage_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.package(product: "foo", type: .runtime)
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "package-foo-runtime-hash")
@@ -242,13 +242,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsOptionalSDK_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsOptionalSDK_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.sdk(name: "foo", status: .optional)
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-optional-hash")
@@ -257,13 +257,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsRequiredSDK_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsRequiredSDK_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.sdk(name: "foo", status: .required)
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-required-hash")
@@ -272,13 +272,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_whenDependencyIsXCTest_callsContentHasherAsExpected() throws {
+    func test_hash_whenDependencyIsXCTest_callsContentHasherAsExpected() async throws {
         // Given
         let dependency = TargetDependency.xctest
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "xctest-hash")
@@ -287,7 +287,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_sorts_dependency_hashes() throws {
+    func test_hash_sorts_dependency_hashes() async throws {
         // Given
         let dependencyFoo = TargetDependency.target(name: "foo")
         let dependencyBar = TargetDependency.target(name: "bar")
@@ -306,7 +306,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
                 targetName: "bar"
             )
         ] = "target-bar-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
+        let hash = try await subject.hash(graphTarget: graphTarget, hashedTargets: hashedTargets, hashedPaths: hashedPaths).hash
 
         // Then
         XCTAssertEqual(hash, "target-bar-hashtarget-foo-hash")

--- a/Tests/TuistHasherTests/GraphContentHasherTests.swift
+++ b/Tests/TuistHasherTests/GraphContentHasherTests.swift
@@ -20,18 +20,18 @@ final class GraphContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_contentHashes_emptyGraph() throws {
+    func test_contentHashes_emptyGraph() async throws {
         // Given
         let graph = Graph.test()
 
         // When
-        let hashes = try subject.contentHashes(for: graph, include: { _ in true }, additionalStrings: [])
+        let hashes = try await subject.contentHashes(for: graph, include: { _ in true }, additionalStrings: [])
 
         // Then
         XCTAssertEqual(hashes, Dictionary())
     }
 
-    func test_contentHashes_returnsOnlyFrameworks() throws {
+    func test_contentHashes_returnsOnlyFrameworks() async throws {
         // Given
         let path: AbsolutePath = "/project"
         let frameworkATarget: Target = .test(
@@ -87,7 +87,7 @@ final class GraphContentHasherTests: TuistUnitTestCase {
         let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget].sorted(by: { $0.target.name < $1.target.name })
 
         // When
-        let hashes = try subject.contentHashes(
+        let hashes = try await subject.contentHashes(
             for: graph,
             include: {
                 $0.target.product == .framework

--- a/Tests/TuistHasherTests/HeadersContentHasherTests.swift
+++ b/Tests/TuistHasherTests/HeadersContentHasherTests.swift
@@ -31,7 +31,7 @@ final class HeadersContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_hash_callsContentHasherWithTheExpectedParameters() throws {
+    func test_hash_callsContentHasherWithTheExpectedParameters() async throws {
         // Given
         given(contentHasher)
             .hash(path: .value(filePath1))
@@ -63,7 +63,7 @@ final class HeadersContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        let hash = try subject.hash(headers: headers)
+        let hash = try await subject.hash(headers: headers)
         XCTAssertEqual(hash, "1;2;3;4;5;6")
         verify(contentHasher)
             .hash(path: .any)

--- a/Tests/TuistHasherTests/PlistContentHasherTests.swift
+++ b/Tests/TuistHasherTests/PlistContentHasherTests.swift
@@ -29,7 +29,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_hash_whenPlistIsFile_tellsContentHasherToHashFileContent() throws {
+    func test_hash_whenPlistIsFile_tellsContentHasherToHashFileContent() async throws {
         // Given
         let infoPlist = InfoPlist.file(path: filePath1)
         given(contentHasher)
@@ -37,7 +37,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
             .willReturn("stubHash")
 
         // When
-        let hash = try subject.hash(plist: .infoPlist(infoPlist))
+        let hash = try await subject.hash(plist: .infoPlist(infoPlist))
 
         // Then
         verify(contentHasher)
@@ -46,7 +46,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(hash, "stubHash")
     }
 
-    func test_hash_whenPlistIsGeneratedFile_tellsContentHasherToHashFileContent() throws {
+    func test_hash_whenPlistIsGeneratedFile_tellsContentHasherToHashFileContent() async throws {
         // Given
         let infoPlist = InfoPlist.generatedFile(
             path: filePath1,
@@ -57,7 +57,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
             .willProduce { $0.base64EncodedString() + "-hash" }
 
         // When
-        let hash = try subject.hash(plist: .infoPlist(infoPlist))
+        let hash = try await subject.hash(plist: .infoPlist(infoPlist))
 
         // Then
         verify(contentHasher)
@@ -66,7 +66,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(hash, "stubHash-hash")
     }
 
-    func test_hash_whenPlistIsDictionary_allDictionaryValuesAreConsideredForHash() throws {
+    func test_hash_whenPlistIsDictionary_allDictionaryValuesAreConsideredForHash() async throws {
         // Given
         let infoPlist = InfoPlist.dictionary([
             "1": 23,
@@ -77,7 +77,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
             "6": ["6a": "6value"],
         ])
         // When
-        let hash = try subject.hash(plist: .infoPlist(infoPlist))
+        let hash = try await subject.hash(plist: .infoPlist(infoPlist))
 
         // Then
         verify(contentHasher)
@@ -89,7 +89,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         )
     }
 
-    func test_hash_whenPlistIsExtendingDefault_allDictionaryValuesAreConsideredForHash() throws {
+    func test_hash_whenPlistIsExtendingDefault_allDictionaryValuesAreConsideredForHash() async throws {
         // Given
         let infoPlist = InfoPlist.extendingDefault(with: [
             "1": 23,
@@ -101,7 +101,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         ])
 
         // When
-        let hash = try subject.hash(plist: .infoPlist(infoPlist))
+        let hash = try await subject.hash(plist: .infoPlist(infoPlist))
 
         // Then
         verify(contentHasher)

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -49,7 +49,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // When
         for _ in 0 ..< 100 {
-            hashes.insert(try subject.hash(identifier: "resources", resources: resourceFileElements).hash)
+            hashes.insert(try await subject.hash(identifier: "resources", resources: resourceFileElements).hash)
         }
 
         // Then
@@ -77,7 +77,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         ], privacyManifest: privacyManifest)
 
         // When
-        let got = try subject.hash(identifier: "resources", resources: resourceFileElements)
+        let got = try await subject.hash(identifier: "resources", resources: resourceFileElements)
 
         // Then
         XCTAssertEqual(got, MerkleNode(

--- a/Tests/TuistHasherTests/SettingsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/SettingsContentHasherTests.swift
@@ -35,7 +35,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_hash_whenRecommended_withXCConfig_callsContentHasherWithExpectedStrings() throws {
+    func test_hash_whenRecommended_withXCConfig_callsContentHasherWithExpectedStrings() async throws {
         given(contentHasher)
             .hash(path: .value(filePath1))
             .willReturn("xconfigHash")
@@ -51,7 +51,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        let hash = try subject.hash(settings: settings)
+        let hash = try await subject.hash(settings: settings)
 
         // Then
         XCTAssertEqual(
@@ -60,7 +60,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
         )
     }
 
-    func test_hash_whenEssential_withoutXCConfig_callsContentHasherWithExpectedStrings() throws {
+    func test_hash_whenEssential_withoutXCConfig_callsContentHasherWithExpectedStrings() async throws {
         given(contentHasher)
             .hash(path: .value(filePath1))
             .willReturn("xconfigHash")
@@ -76,7 +76,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        let hash = try subject.hash(settings: settings)
+        let hash = try await subject.hash(settings: settings)
 
         // Then
         XCTAssertEqual(hash, "CURRENT_PROJECT_VERSION:string(\"2\")-hash;prodreleaseSWIFT_VERSION:string(\"5\")-hash;essential")

--- a/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
@@ -37,13 +37,13 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_hash_when_sourcesHaveAHashSet() throws {
+    func test_hash_when_sourcesHaveAHashSet() async throws {
         // Given
         let sourceFile1 = SourceFile(path: sourceFile1Path, contentHash: "first")
         let sourceFile2 = SourceFile(path: sourceFile2Path, contentHash: "second")
 
         // When
-        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
+        let node = try await subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
 
         // Then
         XCTAssertEqual(node, MerkleNode(
@@ -80,7 +80,7 @@ final class SourceFilesContentHasherTests: TuistUnitTestCase {
         try await fileSystem.writeText("sourceFile2", at: sourceFile2Path)
 
         // When
-        let node = try subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
+        let node = try await subject.hash(identifier: "sources", sources: [sourceFile1, sourceFile2])
 
         // Then
         XCTAssertEqual(node, MerkleNode(

--- a/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -64,7 +64,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
 
     // MARK: - Tests
 
-    func test_hash_targetAction_withBuildVariables_callsMockHasherWithOnlyPathWithoutBuildVariable() throws {
+    func test_hash_targetAction_withBuildVariables_callsMockHasherWithOnlyPathWithoutBuildVariable() async throws {
         // Given
         let inputFileListPaths1 = "inputFileListPaths1-hash"
         given(contentHasher)
@@ -79,7 +79,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        _ = try await subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
@@ -100,7 +100,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_targetAction_callsMockHasherWithExpectedStrings() throws {
+    func test_hash_targetAction_callsMockHasherWithExpectedStrings() async throws {
         // Given
         let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
@@ -117,7 +117,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let targetScript = makeTargetScript()
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        _ = try await subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
@@ -137,7 +137,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_targetAction_when_path_nil_callsMockHasherWithExpectedStrings() throws {
+    func test_hash_targetAction_when_path_nil_callsMockHasherWithExpectedStrings() async throws {
         // Given
         let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
@@ -155,7 +155,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let targetScript = makeTargetScript()
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        _ = try await subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
@@ -175,7 +175,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_hash_targetAction_valuesAreNotHarcoded() throws {
+    func test_hash_targetAction_valuesAreNotHarcoded() async throws {
         // Given
         let inputPaths2Hash = "inputPaths2-hash"
         let inputFileListPaths2 = "inputFileListPaths2-hash"
@@ -202,7 +202,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
+        _ = try await subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [


### PR DESCRIPTION
### Short description 📝

Another piece of the puzzle to migrate `FileSystem` to `FileHandler`, this time in `TuistHasher`. The migration got a little bit more complex as we can't use `inout` parameters in an asynchronous context.

### How to test the changes locally 🧐

`tuist cache --print-hashes` should stay stable with the values before this PR  was merged (also checked by our acceptance tests)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
