### PR TITLE
Remove CFBundleExecutable from resource bundle

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -51,7 +51,14 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 productName: bundleName,
                 bundleId: "\(target.bundleId).resources",
                 deploymentTargets: target.deploymentTargets,
-                infoPlist: .extendingDefault(with: [:]),
+
+                // This is only for cases where the resources target does not contain actual code.
+                // By default, `CFBundleExecutable` is set to `BundleName`
+                // But setting a non-empty executable without providing actual code will result in a validation failure
+                // when submitting to the App Store.
+                infoPlist: .extendingDefault(with: [
+                    "CFBundleExecutable": "",
+                ]),
                 settings: Settings(
                     base: [
                         "CODE_SIGNING_ALLOWED": "NO",

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -85,6 +85,10 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             "SKIP_INSTALL": "YES",
             "CODE_SIGNING_ALLOWED": "NO",
         ])
+
+        XCTAssertEqual(resourcesTarget.infoPlist, .extendingDefault(with: [
+            "CFBundleExecutable": "",
+        ]))
     }
 
     func test_map_when_an_external_objc_target_that_has_resources_and_supports_them() throws {


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝
By default, Resource bundle generated by the Tuist has non-empty `CFBundleExecutable` value in the `Info.plist`.

This leads to vailed validation when submitting to the App Store, since one of the validation phases is to check `CFBundleExecutable` location, and probably, verify it's signature.

```
[Application Loader Error Output]: [ContentDelivery.Uploader.600000dc0080] Asset validation failed (90261) Bad CFBundleExecutable. Cannot find executable file that matches the value of CFBundleExecutable in the nested bundle Features_XXX [Path_To_Bundle/Features_XXX.bundle] property list file. (ID: bad40b6f-c1d8-40af-8918-8fad1e176336)
```

> Describe here the purpose of your PR.

This PR removes the `CFBundleExecutable` key from the generated Resource Bundle

Somewhat related issue with the similar approach:
https://stackoverflow.com/questions/32096130/unexpected-cfbundleexecutable-key

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).
- Create a project with a static framework with Resources
- Make sure that generated XXX.bundle files does not contain `CFBundleExecutable` value in the .plist

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
