### PR TITLE
Fix tuist init due to missing ProjectDescriptionHelpers

### DIFF
--- a/Sources/TuistCore/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistCore/Utils/RootDirectoryLocator.swift
@@ -62,7 +62,7 @@ public final class RootDirectoryLocator: RootDirectoryLocating {
             return try await locate(from: path.parentDirectory, source: source)
         } else if let cachedDirectory = cached(path: path) {
             return cachedDirectory
-        } else if try await fileSystem.exists(path.appending(component: Constants.tuistDirectoryName)) {
+        } else if try await fileSystem.exists(path.appending(component: Constants.tuistDirectoryName), isDirectory: true) {
             cache(rootDirectory: path, for: source)
             return path
         } else if try await fileSystem.exists(path.appending(component: "Plugin.swift")) {

--- a/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
@@ -58,6 +58,20 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         XCTAssertEqual(got, temporaryDirectory.appending(try RelativePath(validating: "this")))
     }
 
+    func test_locate_when_a_tuist_file_is_present_not_directory() async throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders(["this/is/a/directory"])
+        try createFiles(["this/is/a/directory/tuist"])
+
+        // When
+        let got = try await subject
+            .locate(from: temporaryDirectory.appending(try RelativePath(validating: "this/is/a/directory")))
+
+        // Then
+        XCTAssertNil(got)
+    }
+
     func test_locate_when_multiple_tuist_directories_exists() async throws {
         // Given
         let temporaryDirectory = try temporaryPath()


### PR DESCRIPTION
### Short description 📝

I missed a case in the last PR trying to fix `tuist init` when the `RootDirectoryLocator` does find a `Tuist` file/directory, but it's the executable, not the actual Tuist directory.

### How to test the changes locally 🧐

It's a bit difficult to test this out. The easiest would be to bundle tuist and run `tuist init` with that.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
