### PR TITLE
Remove NYTPhotoViewer from the app_with_spm_dependencies fixture

### DIFF
--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -41,7 +41,6 @@ let project = Project(
                 .external(name: "AppCenterAnalytics"),
                 .external(name: "AppCenterCrashes"),
                 .external(name: "libzstd"),
-                .external(name: "NYTPhotoViewer"),
                 .external(name: "SVProgressHUD"),
                 .external(name: "MarkdownUI"),
                 .external(name: "GoogleMobileAds"),

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -8,7 +8,6 @@ import GoogleMobileAds
 import GoogleSignIn
 import libzstd
 import MarkdownUI
-import NYTPhotoViewer
 import Sentry
 import SVProgressHUD
 import Yams
@@ -35,13 +34,12 @@ public enum AppKit {
         _ = DDOSLogger.sharedInstance
 
         // Use AppCenter
-        AppCenter.start(withAppSecret: "{Your App Secret}", services: [Analytics.self, Crashes.self])
+        AppCenter.start(
+            withAppSecret: "{Your App Secret}", services: [Analytics.self, Crashes.self]
+        )
 
         // Use libzstd
         _ = ZDICT_isError(0)
-
-        // Use NYTPhotoViewer
-        _ = NYTPhotosOverlayView()
 
         // Use SVProgressHUD
         SVProgressHUD.show()

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f5380001e57a3fe0ecdfcd40afedcd1bd885142cd4e4232aa8a78a8a1e60e9f8",
+  "originHash" : "de5a39263681a457f5ae8b66c966e957674db1a5f0df7a4d6b21efe02017a4f2",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -125,15 +125,6 @@
       "state" : {
         "revision" : "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
         "version" : "13.2.0"
-      }
-    },
-    {
-      "identity" : "nytphotoviewer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/NYTPhotoViewer",
-      "state" : {
-        "branch" : "develop",
-        "revision" : "e4acd0988c43e3df0908fc463104e567098f9dfc"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -22,11 +22,14 @@ let package = Package(
         .package(url: "https://github.com/jpsim/Yams", .upToNextMajor(from: "5.0.6")),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "8.32.0")),
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", .upToNextMajor(from: "3.8.4")),
+        .package(
+            url: "https://github.com/CocoaLumberjack/CocoaLumberjack", .upToNextMajor(from: "3.8.4")
+        ),
         .package(url: "https://github.com/facebook/zstd", exact: "1.5.5"),
-        .package(url: "https://github.com/microsoft/appcenter-sdk-apple", .upToNextMajor(from: "5.0.4")),
+        .package(
+            url: "https://github.com/microsoft/appcenter-sdk-apple", .upToNextMajor(from: "5.0.4")
+        ),
         // Has SWIFTPM_MODULE_BUNDLE
-        .package(url: "https://github.com/tuist/NYTPhotoViewer", branch: "develop"),
         .package(url: "https://github.com/Quick/Quick", exact: "7.4.0"),
         .package(url: "https://github.com/Quick/Nimble", exact: "13.2.0"),
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", exact: "2.3.1"),
@@ -34,7 +37,10 @@ let package = Package(
         .package(url: "https://github.com/braze-inc/braze-swift-sdk.git", exact: "8.4.0"),
         // Has an umbrella header where moduleName must be sanitized
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
-        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "11.1.0"),
+        .package(
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads",
+            from: "11.1.0"
+        ),
         .package(url: "https://github.com/apple/swift-testing", .upToNextMajor(from: "0.6.0")),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),


### PR DESCRIPTION
### Short description 📝

We accidentally removed the fork of `NYTPhotoViewer` at https://github.com/tuist/NYTPhotoViewer. The fork was added in: https://github.com/tuist/tuist/pull/5945. We have other packages testing that scenario, so we no longer think it's important to test this specific dependency E2E.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
