### PR TITLE
Fix caching for unused platforms

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -919,6 +919,8 @@ public class GraphTraverser: GraphTraversing {
                 .map { GraphDependency.target(name: $0.target.name, path: $0.project.path) }
         )
 
+        let externalTargetSupportedPlatforms = externalTargetSupportedPlatforms()
+
         let allTargetExternalDependendedUponTargets = filterDependencies(
             from: graphDependenciesWithExternalDependencies
         )
@@ -929,7 +931,14 @@ public class GraphTraverser: GraphTraversing {
                 else {
                     return nil
                 }
-                return GraphTarget(path: path, target: target, project: project)
+                let graphTarget = GraphTarget(path: path, target: target, project: project)
+
+                if externalTargetSupportedPlatforms[graphTarget]?.isEmpty == false {
+                    return graphTarget
+                } else {
+                    return nil
+                }
+
             } else {
                 return nil
             }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6700

### Short description 📝

The graph from the issue boils down to:
```
App -> Nimble -> (macOS) CwlPreconditionTesting
```

Where `App`'s platforms are `.iOS`.

This means that `CwlPreconditionTesting` is effectively an orphan target. While `App` depends on `CwlPreconditionTesting` transitively through `Nimble`, the condition makes that dependency impossible to realize.

### How to test the changes locally 🧐

`tuist cache --print-hashes` in the project from the attached issue should print `No cacheable targets`. Right now, it would try to cache `CwlPreconditionTesting` for _all_ platforms.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
