### PR TITLE
Migrate FileHandler.resolveSymlink to FileSystem

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -70,13 +70,6 @@ open class TuistAcceptanceTestCase: XCTestCase {
             .appending(component: "fixtures")
 
         fixturePath = fixtureTemporaryDirectory.path.appending(component: fixture.path)
-        if fixturePath.components[1] == "var" {
-            // `resolveSymlinks` doesn't seem to properly resolve /var to /private/var when running the fixture in a temporary
-            // directory.
-            // The project needs to be reference by its full absolute path without symlinks.
-            fixturePath = try AbsolutePath(validating: "/private")
-                .appending(components: Array(fixturePath.components.dropFirst()))
-        }
 
         try FileHandler.shared.copy(
             from: fixturesPath.appending(component: fixture.path),

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -86,7 +86,6 @@ public protocol FileHandling: AnyObject {
     func urlSafeBase64MD5(path: Path.AbsolutePath) throws -> String
     func fileSize(path: Path.AbsolutePath) throws -> UInt64
     func changeExtension(path: Path.AbsolutePath, to newExtension: String) throws -> Path.AbsolutePath
-    func resolveSymlinks(_ path: Path.AbsolutePath) throws -> Path.AbsolutePath
     func fileAttributes(at path: Path.AbsolutePath) throws -> [FileAttributeKey: Any]
     func filesAndDirectoriesContained(in path: Path.AbsolutePath) throws -> [Path.AbsolutePath]?
     func zipItem(at sourcePath: Path.AbsolutePath, to destinationPath: Path.AbsolutePath) throws
@@ -351,10 +350,6 @@ public class FileHandler: FileHandling {
 
     public func createSymbolicLink(at path: Path.AbsolutePath, destination: Path.AbsolutePath) throws {
         try fileManager.createSymbolicLink(atPath: path.pathString, withDestinationPath: destination.pathString)
-    }
-
-    public func resolveSymlinks(_ path: Path.AbsolutePath) throws -> Path.AbsolutePath {
-        try .init(validating: TSCBasic.resolveSymlinks(.init(validating: path.pathString)).pathString)
     }
 
     public func fileAttributes(at path: Path.AbsolutePath) throws -> [FileAttributeKey: Any] {

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -405,10 +405,6 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
             []
         }
 
-        func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
-            path
-        }
-
         func fileAttributes(at _: AbsolutePath) throws -> [FileAttributeKey: Any] {
             [:]
         }

--- a/Tests/TuistKitAcceptanceTests/RunAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/RunAcceptanceTests.swift
@@ -8,8 +8,6 @@ import XCTest
 final class RunAcceptanceTestCommandLineToolBasic: TuistAcceptanceTestCase {
     func test_command_line_tool_basic() async throws {
         try await setUpFixture(.commandLineToolBasic)
-        fixturePath = try AbsolutePath(validating: "/")
-            .appending(components: Array(fixturePath.components.dropFirst(2)))
         try await run(InstallCommand.self)
         try await run(RunCommand.self, "CommandLineTool")
     }

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -240,6 +240,10 @@ final class ProjectEditorTests: TuistUnitTestCase {
             directory.appending(components: "C", "Plugin.swift"),
             directory.appending(components: "D", "Plugin.swift"),
         ]
+        for pluginManifest in pluginManifests {
+            try await fileSystem.makeDirectory(at: pluginManifest.parentDirectory)
+            try await fileSystem.touch(pluginManifest)
+        }
         let tuistPath = try AbsolutePath(validating: ProcessInfo.processInfo.arguments.first!)
 
         // When


### PR DESCRIPTION
### Short description 📝

Migrates `FileHandler.resolveSymlink` to `FileSystem.resolveSymbolicLink` and removes the method from `FileHandler`.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
