### PR TITLE
Migrate FileHandler.move to FileSystem

### DIFF
--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -303,7 +303,7 @@ public struct PluginService: PluginServicing {
                 if try await fileSystem.exists(downloadZipPath) {
                     try await fileSystem.remove(downloadZipPath)
                 }
-                try FileHandler.shared.move(from: downloadPath, to: downloadZipPath)
+                try await fileSystem.move(from: downloadPath, to: downloadZipPath)
 
                 // Unzip
                 let unarchivedContents = try FileHandler.shared.contentsOfDirectory(
@@ -312,7 +312,7 @@ public struct PluginService: PluginServicing {
 
                 try FileHandler.shared.createFolder(pluginReleaseDirectory)
                 for unarchivedContent in unarchivedContents {
-                    try FileHandler.shared.move(
+                    try await fileSystem.move(
                         from: unarchivedContent,
                         to: pluginReleaseDirectory.appending(component: unarchivedContent.basename)
                     )

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -49,7 +49,6 @@ public protocol FileHandling: AnyObject {
     var homeDirectory: Path.AbsolutePath { get }
 
     func replace(_ to: Path.AbsolutePath, with: Path.AbsolutePath) throws
-    func move(from: Path.AbsolutePath, to: Path.AbsolutePath) throws
     func copy(from: Path.AbsolutePath, to: Path.AbsolutePath) throws
     func readFile(_ at: Path.AbsolutePath) throws -> Data
     func readTextFile(_ at: Path.AbsolutePath) throws -> String
@@ -85,7 +84,6 @@ public protocol FileHandling: AnyObject {
     func contentsOfDirectory(_ path: Path.AbsolutePath) throws -> [Path.AbsolutePath]
     func urlSafeBase64MD5(path: Path.AbsolutePath) throws -> String
     func fileSize(path: Path.AbsolutePath) throws -> UInt64
-    func changeExtension(path: Path.AbsolutePath, to newExtension: String) throws -> Path.AbsolutePath
     func resolveSymlinks(_ path: Path.AbsolutePath) throws -> Path.AbsolutePath
     func fileAttributes(at path: Path.AbsolutePath) throws -> [FileAttributeKey: Any]
     func filesAndDirectoriesContained(in path: Path.AbsolutePath) throws -> [Path.AbsolutePath]?
@@ -200,10 +198,6 @@ public class FileHandler: FileHandling {
 
     public func copy(from: Path.AbsolutePath, to: Path.AbsolutePath) throws {
         try fileManager.copyItem(atPath: from.pathString, toPath: to.pathString)
-    }
-
-    public func move(from: Path.AbsolutePath, to: Path.AbsolutePath) throws {
-        try fileManager.moveItem(atPath: from.pathString, toPath: to.pathString)
     }
 
     public func readFile(_ at: Path.AbsolutePath) throws -> Data {
@@ -384,16 +378,6 @@ public class FileHandler: FileHandling {
     }
 
     // MARK: - Extension
-
-    public func changeExtension(path: Path.AbsolutePath, to fileExtension: String) throws -> Path.AbsolutePath {
-        guard isFolder(path) == false else { throw FileHandlerError.expectedAFile(path) }
-        let sanitizedExtension = fileExtension.starts(with: ".") ? String(fileExtension.dropFirst()) : fileExtension
-        guard path.extension != sanitizedExtension else { return path }
-
-        let newPath = path.removingLastComponent().appending(component: "\(path.basenameWithoutExt).\(sanitizedExtension)")
-        try move(from: path, to: newPath)
-        return newPath
-    }
 
     public func zipItem(at sourcePath: Path.AbsolutePath, to destinationPath: Path.AbsolutePath) throws {
         try fileManager.zipItem(

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -471,10 +471,6 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
             0
         }
 
-        func changeExtension(path: AbsolutePath, to newExtension: String) throws -> AbsolutePath {
-            path.removingLastComponent().appending(component: "\(path.basenameWithoutExt).\(newExtension)")
-        }
-
         func zipItem(at _: AbsolutePath, to _: AbsolutePath) throws {}
 
         func unzipItem(at _: AbsolutePath, to _: AbsolutePath) throws {}

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -87,25 +87,6 @@ final class FileHandlerTests: TuistUnitTestCase {
         XCTAssertEqual(result, "X0vsGS0PGIT9z0l1s3Bn3A==")
     }
 
-    func test_changeExtension() throws {
-        // Given
-        let temporaryDirectory = try temporaryPath()
-        let testZippedFrameworkPath = temporaryDirectory.appending(component: "uUI.xcframework.zip")
-        try FileHandler.shared.copy(
-            from: fixturePath(path: try RelativePath(validating: "uUI.xcframework.zip")),
-            to: testZippedFrameworkPath
-        )
-
-        // When
-        let result = try subject.changeExtension(path: testZippedFrameworkPath, to: "txt")
-
-        // Then
-        XCTAssertEqual(result.pathString.dropLast(4), testZippedFrameworkPath.pathString.dropLast(4))
-        XCTAssertEqual(result.basenameWithoutExt, testZippedFrameworkPath.basenameWithoutExt)
-        XCTAssertEqual(result.basename, "\(testZippedFrameworkPath.basenameWithoutExt).txt")
-        _ = try subject.changeExtension(path: result, to: "zip")
-    }
-
     func test_readPlistFile_throwsAnError_when_invalidPlist() throws {
         // Given
         let temporaryDirectory = try temporaryPath()


### PR DESCRIPTION
### Short description 📝

Migrate FileHandler.move to FileSystem. The `changeExtension` method was not used anywhere, so I removed it.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
