### PR TITLE
Fix ios_app_with_frameworks tests

### DIFF
--- a/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -16,6 +16,11 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
         try await run(TestCommand.self, "App", "--", "-testLanguage", "en")
     }
 
+    func test_with_ios_app_with_frameworks() async throws {
+        try await setUpFixture(.iosAppWithFrameworks)
+        try await run(TestCommand.self)
+    }
+
     func test_with_app_with_test_plan() async throws {
         try await setUpFixture(.appWithTestPlan)
         try await run(TestCommand.self)

--- a/fixtures/ios_app_with_frameworks/App/Sources/MyApp.swift
+++ b/fixtures/ios_app_with_frameworks/App/Sources/MyApp.swift
@@ -10,10 +10,10 @@ struct MyApp: SwiftUI.App {
         let framework2Objc = MyPublicClass()
 
         print(hello())
-        print("AppDelegate -> \(framework1.hello())")
-        print("AppDelegate -> \(framework1.helloFromFramework2())")
-        print("AppDelegate -> \(framework2.hello())")
-        print("AppDelegate -> \(framework2Objc.hello())")
+        print("MyApp -> \(framework1.hello())")
+        print("MyApp -> \(framework1.helloFromFramework2())")
+        print("MyApp -> \(framework2.hello())")
+        print("MyApp -> \(framework2Objc.hello())")
     }
 
     var body: some Scene {
@@ -23,6 +23,6 @@ struct MyApp: SwiftUI.App {
     }
 
     func hello() -> String {
-        "AppDelegate.hello()"
+        "MyApp.hello()"
     }
 }

--- a/fixtures/ios_app_with_frameworks/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_frameworks/App/Tests/AppDelegateTests.swift
@@ -2,10 +2,10 @@ import XCTest
 
 @testable import App
 
-class AppDelegateTests: XCTestCase {
+class MyAppTests: XCTestCase {
     func testHello() {
-        let sut = AppDelegate()
+        let sut = MyApp()
 
-        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+        XCTAssertEqual("MyApp.hello()", sut.hello())
     }
 }


### PR DESCRIPTION
### Short description 📝

In one of the recent PRs, we accidentally broke the tests of the `ios_app_with_frameworks` fixture. I fixed them and added an acceptance test, so this doesn't happen in the future.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
