### PR TITLE
feat: add .none linking status

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -7,6 +7,9 @@ public enum LinkingStatus: String, Codable, Hashable, Sendable {
 
     /// Optional dependency (weakly linked)
     case optional
+
+    /// Skip linking
+    case none
 }
 
 @available(*, deprecated, renamed: "LinkingStatus")

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -46,6 +46,7 @@ public enum TuistAcceptanceFixtures {
     case iosAppWithLocalBinarySwiftPackage
     case iosAppWithLocalSwiftPackage
     case iosAppWithMultiConfigs
+    case iosAppWithNoneLinkingStatusFramework
     case iosAppWithOnDemandResources
     case iosAppWithPluginsAndTemplates
     case iosAppWithPrivacyManifest
@@ -175,6 +176,8 @@ public enum TuistAcceptanceFixtures {
             return "ios_app_with_local_swift_package"
         case .iosAppWithMultiConfigs:
             return "ios_app_with_multi_configs"
+        case .iosAppWithNoneLinkingStatusFramework:
+            return "ios_app_with_none_linking_status_framework"
         case .iosAppWithOnDemandResources:
             return "ios_app_with_on_demand_resources"
         case .iosAppWithSpmDependencies:

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -398,6 +398,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             condition: PlatformCondition?,
             status: LinkingStatus = .required
         ) throws {
+            guard status != .none else { return }
             guard let fileRef = fileElements.file(path: path) else {
                 throw LinkGeneratorError.missingReference(path: path)
             }
@@ -422,6 +423,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             case .bundle, .macro:
                 break
             case let .product(dependencyTarget, _, status, condition):
+                guard status != .none else { return }
                 guard let fileRef = fileElements.product(target: dependencyTarget) else {
                     throw LinkGeneratorError.missingProduct(name: dependencyTarget)
                 }
@@ -431,6 +433,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 pbxproj.add(object: buildFile)
                 buildPhase.files?.append(buildFile)
             case let .sdk(sdkPath, sdkStatus, _, condition):
+                guard sdkStatus != .none else { return }
                 guard let fileRef = fileElements.sdk(path: sdkPath) else {
                     throw LinkGeneratorError.missingReference(path: sdkPath)
                 }

--- a/Sources/TuistLoader/Models+ManifestMappers/LinkingStatus+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/LinkingStatus+ManifestMapper.swift
@@ -13,6 +13,8 @@ extension XcodeGraph.LinkingStatus {
             return .required
         case .optional:
             return .optional
+        case .none:
+            return .none
         }
     }
 }

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -876,6 +876,25 @@ final class GenerateAcceptanceTestmacOSAppWithExtensions: TuistAcceptanceTestCas
     }
 }
 
+final class GenerateAcceptanceTestiOSAppWithNoneLinkingStatusFramework: TuistAcceptanceTestCase {
+    func test_ios_app_with_none_linking_status_framework() async throws {
+        try await setUpFixture(.iosAppWithNoneLinkingStatusFramework)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App")
+
+        let xcodeproj = try XcodeProj(
+            pathString: xcodeprojPath.pathString
+        )
+        let target = try XCTUnwrapTarget("App", in: xcodeproj)
+        let frameworksBuildPhase = try target.frameworksBuildPhase()
+        guard let frameworkFiles = frameworksBuildPhase?.files else {
+            XCTFail("A linking dependencies phase should exist even though empty")
+            return
+        }
+        XCTAssertEmpty(frameworkFiles)
+    }
+}
+
 final class GenerateAcceptanceTestiOSAppWithWeaklyLinkedFramework: TuistAcceptanceTestCase {
     func test_ios_app_with_weakly_linked_framework() async throws {
         try await setUpFixture(.iosAppWithWeaklyLinkedFramework)

--- a/fixtures/ios_app_with_none_linking_status_framework/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/App/Sources/AppDelegate.swift
@@ -1,0 +1,12 @@
+// importing MyFramework would not work, because it is not linked
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func applicationDidFinishLaunching(_: UIApplication) {
+        // let myFramework = MyFramework() // Things we can't do
+        print("myFramework.hello()")
+    }
+}

--- a/fixtures/ios_app_with_none_linking_status_framework/MyFramework/Sources/MyFramework.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/MyFramework/Sources/MyFramework.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public class MyFramework {
+    public init() {}
+    public func hello() -> String {
+        return "MyFramework.hello()"
+    }
+}

--- a/fixtures/ios_app_with_none_linking_status_framework/Project.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/Project.swift
@@ -1,0 +1,33 @@
+import ProjectDescription
+
+let project = Project(
+    name: "iOS app with none LinkingStatus framework",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .target(name: "MyFramework", status: .none),
+            ]
+        ),
+        .target(
+            name: "MyFramework",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.MyFramework",
+            sources: ["MyFramework/Sources/**"],
+            dependencies: []
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_none_linking_status_framework/Tuist/Config.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/Tuist/Config.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let config = Config()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6751

### Short description 📝

Adds a `.none` to the `LinkingStatus` which is used when generating the Xcode project to stop it from linking the target.

Depends on https://github.com/tuist/XcodeGraph/pull/60

### How to test the changes locally 🧐

Acceptance tests added.

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
