### PR TITLE
Fix tuist generate failing due to too many files being opened

### DIFF
--- a/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -62,7 +62,7 @@ public struct ContentHasher: ContentHashing {
             return try await fileHandler.contentsOfDirectory(filePath)
                 .filter { filesFilter($0) }
                 .sorted(by: { $0 < $1 })
-                .concurrentMap { try await hash(path: $0) }
+                .serialMap { try await hash(path: $0) }
                 .joined(separator: "-")
         }
 


### PR DESCRIPTION
### Short description 📝

This fixes an issue where file system handles are exhausted in a large project when calculating content hashes:
> too many file descriptors are open. ('open' system call failed with '(24) Too many open files'.)

This is intended to be a temporary fix as this will degrade performance. This was discussed with @fortmarek on Slack.

The underlying reason here is that NIOFileSystem does nothing to protect against unbounded opening of file handles. The implementation in NIOFileSystem asynchronously reads the contents of the file in chunks, so each of those chunked reads is a suspension point that allows for more files to be opened. This could be considered a design flaw in NIOFileSystem as it's so easy to exhaust file system handles with it currently. Not to mention that the implementation will leak the file handle as well in case reading a chunk fails. 😬 

Perhaps a better solution here could be to ensure that `ContentHasher` only has a specific number of files open at a given time.

### How to test the changes locally 🧐

Currently not possible, but perhaps a fixture with a lot of files included in content hashing could be created to reproduce this?

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
