### PR TITLE
Change contact link to community forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: Get help in GitHub Discussions
-    url: https://github.com/tuist/tuist/discussions/
-    about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on Tuist's GitHub Discussions!
+  - name: Get help on the Tuist Community Forum
+    url: https://community.tuist.io/
+    about: Have a question? Not sure if your issue is reproducible? The quickest way to get help is on the Tuist Community Forum!


### PR DESCRIPTION
### Short description 📝

We no longer recommend using GitHub discussions for questions and troubleshooting. You can find the reasoning [here](https://github.com/tuist/tuist/discussions/6723).

To reflect this, I'm updating the issue template to point to the community forum instead of GitHub discussions.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x]  In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
