### PR TITLE
feat: add support for .ipa in Tuist Previews

### DIFF
--- a/Sources/TuistKit/Commands/ShareCommand.swift
+++ b/Sources/TuistKit/Commands/ShareCommand.swift
@@ -11,7 +11,7 @@ public struct ShareCommand: AsyncParsableCommand, HasTrackableParameters {
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "share",
-            abstract: "Generate a link to share your app. Only simulator builds supported."
+            abstract: "Generate a link to share your app."
         )
     }
 
@@ -23,7 +23,7 @@ public struct ShareCommand: AsyncParsableCommand, HasTrackableParameters {
     var path: String?
 
     @Argument(
-        help: "The app names to be looked up in the built products directory or the paths to the app bundles.",
+        help: "The app names to be looked up in the built products directory or the paths to the app bundles or application zip archives.",
         envKey: .shareApp
     )
     var apps: [String] = []

--- a/Sources/TuistKit/Commands/ShareCommand.swift
+++ b/Sources/TuistKit/Commands/ShareCommand.swift
@@ -23,7 +23,7 @@ public struct ShareCommand: AsyncParsableCommand, HasTrackableParameters {
     var path: String?
 
     @Argument(
-        help: "The app names to be looked up in the built products directory or the paths to the app bundles or application zip archives.",
+        help: "The app name to be looked up in the built products directory or the paths to the app bundles or an .ipa archive.",
         envKey: .shareApp
     )
     var apps: [String] = []

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -189,10 +189,13 @@ final class RunService {
 
         try await fileSystem.remove(archivePath)
 
-        let apps = try await fileHandler.glob(unarchivedDirectory, glob: "*.app")
-            .concurrentMap {
-                try await self.appBundleLoader.load($0)
-            }
+        let apps = try await (
+            fileHandler.glob(unarchivedDirectory, glob: "*.app") + fileHandler
+                .glob(unarchivedDirectory, glob: "*/*.app")
+        )
+        .concurrentMap {
+            try await self.appBundleLoader.load($0)
+        }
 
         try await appRunner.runApp(
             apps,

--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -16,6 +16,7 @@ enum ShareServiceError: Equatable, FatalError {
     case multipleAppsSpecified([String])
     case platformsNotSpecified
     case fullHandleNotFound
+    case appBundleInIPANotFound(AbsolutePath)
 
     var description: String {
         switch self {
@@ -31,13 +32,15 @@ enum ShareServiceError: Equatable, FatalError {
             return "You specified multiple apps to share: \(apps.joined(separator: " ")). You cannot specify multiple apps when using `tuist share`."
         case .fullHandleNotFound:
             return "You are missing full handle in your Config.swift."
+        case let .appBundleInIPANotFound(ipaPath):
+            return "No app found in the in the .ipa archive at \(ipaPath). Make sure the .ipa is a valid application archive."
         }
     }
 
     var type: ErrorType {
         switch self {
         case .projectOrWorkspaceNotFound, .noAppsFound, .appNotSpecified, .platformsNotSpecified, .multipleAppsSpecified,
-             .fullHandleNotFound:
+             .fullHandleNotFound, .appBundleInIPANotFound:
             return .abort
         }
     }
@@ -56,6 +59,7 @@ struct ShareService {
     private let userInputReader: UserInputReading
     private let defaultConfigurationFetcher: DefaultConfigurationFetching
     private let appBundleLoader: AppBundleLoading
+    private let fileArchiverFactory: FileArchivingFactorying
 
     init() {
         let manifestLoader = ManifestLoaderFactory()
@@ -78,7 +82,8 @@ struct ShareService {
             manifestGraphLoader: manifestGraphLoader,
             userInputReader: UserInputReader(),
             defaultConfigurationFetcher: DefaultConfigurationFetcher(),
-            appBundleLoader: AppBundleLoader()
+            appBundleLoader: AppBundleLoader(),
+            fileArchiverFactory: FileArchivingFactory()
         )
     }
 
@@ -94,7 +99,8 @@ struct ShareService {
         manifestGraphLoader: ManifestGraphLoading,
         userInputReader: UserInputReading,
         defaultConfigurationFetcher: DefaultConfigurationFetching,
-        appBundleLoader: AppBundleLoading
+        appBundleLoader: AppBundleLoading,
+        fileArchiverFactory: FileArchivingFactorying
     ) {
         self.fileHandler = fileHandler
         self.fileSystem = fileSystem
@@ -108,6 +114,7 @@ struct ShareService {
         self.userInputReader = userInputReader
         self.defaultConfigurationFetcher = defaultConfigurationFetcher
         self.appBundleLoader = appBundleLoader
+        self.fileArchiverFactory = fileArchiverFactory
     }
 
     func run(
@@ -131,29 +138,30 @@ struct ShareService {
             )
         }
 
-        if !apps.isEmpty, apps.allSatisfy({ $0.hasSuffix(".app") }) {
-            let appPaths = try apps.map {
-                try AbsolutePath(
-                    validating: $0,
-                    relativeTo: fileHandler.currentPath
+        let appPaths = try await apps.concurrentMap {
+            try AbsolutePath(
+                validating: $0,
+                relativeTo: try await fileSystem.currentWorkingDirectory()
+            )
+        }
+        if !apps.isEmpty, try await appPaths
+            .concurrentMap({ try await fileSystem.exists($0) })
+            .allSatisfy({ $0 })
+        {
+            if appPaths.contains(where: { $0.extension == "ipa" }) {
+                try await shareIPA(
+                    appPaths,
+                    fullHandle: fullHandle,
+                    serverURL: serverURL
+                )
+            } else {
+                try await shareAppBundles(
+                    appPaths,
+                    fullHandle: fullHandle,
+                    serverURL: serverURL
                 )
             }
 
-            let appBundles = try await appPaths.concurrentMap {
-                try await appBundleLoader.load($0)
-            }
-
-            let appNames = appBundles.map(\.infoPlist.name).uniqued()
-            guard appNames.count == 1,
-                  let appName = appNames.first else { throw ShareServiceError.multipleAppsSpecified(appNames) }
-
-            let preview = try await previewsUploadService.uploadPreviews(
-                displayName: appName,
-                previewPaths: appPaths,
-                fullHandle: fullHandle,
-                serverURL: serverURL
-            )
-            logger.notice("\(appName) uploaded – share it with others using the following link: \(preview.url.absoluteString)")
         } else if try await manifestLoader.hasRootManifest(at: path) {
             guard apps.count < 2 else { throw ShareServiceError.multipleAppsSpecified(apps) }
 
@@ -226,6 +234,57 @@ struct ShareService {
         }
     }
 
+    private func shareIPA(
+        _ appPaths: [AbsolutePath],
+        fullHandle: String,
+        serverURL: URL
+    ) async throws {
+        guard appPaths.count == 1,
+              let ipaPath = appPaths.first else { throw ShareServiceError.multipleAppsSpecified(appPaths.map(\.pathString)) }
+
+        guard let appBundlePath = try fileArchiverFactory.makeFileUnarchiver(for: ipaPath).unzip().glob("**/*.app").first
+        else { throw ShareServiceError.appBundleInIPANotFound(ipaPath) }
+        let appBundle = try await appBundleLoader.load(appBundlePath)
+        let displayName = appBundle.infoPlist.name
+
+        let preview = try await previewsUploadService.uploadPreviews(
+            .ipa(ipaPath),
+            displayName: displayName,
+            version: appBundle.infoPlist.version.description,
+            bundleIdentifier: appBundle.infoPlist.bundleId,
+            fullHandle: fullHandle,
+            serverURL: serverURL
+        )
+        logger
+            .notice(
+                "\(displayName) uploaded – share it with others using the following link: \(preview.url.absoluteString)"
+            )
+    }
+
+    private func shareAppBundles(
+        _ appPaths: [AbsolutePath],
+        fullHandle: String,
+        serverURL: URL
+    ) async throws {
+        let appBundles = try await appPaths.concurrentMap {
+            try await appBundleLoader.load($0)
+        }
+
+        let appNames = appBundles.map(\.infoPlist.name).uniqued()
+        guard appNames.count == 1,
+              let appName = appNames.first else { throw ShareServiceError.multipleAppsSpecified(appNames) }
+
+        let preview = try await previewsUploadService.uploadPreviews(
+            .appBundle(appPaths),
+            displayName: appName,
+            version: appBundles.compactMap(\.infoPlist.version.description).first,
+            bundleIdentifier: appBundles.compactMap(\.infoPlist.bundleId).first,
+            fullHandle: fullHandle,
+            serverURL: serverURL
+        )
+        logger.notice("\(appName) uploaded – share it with others using the following link: \(preview.url.absoluteString)")
+    }
+
     private func copyAppBundle(
         for destinationType: DestinationType,
         app: String,
@@ -294,8 +353,10 @@ struct ShareService {
             }
 
             let preview = try await previewsUploadService.uploadPreviews(
+                .appBundle(appPaths),
                 displayName: app,
-                previewPaths: appPaths,
+                version: nil,
+                bundleIdentifier: nil,
                 fullHandle: fullHandle,
                 serverURL: serverURL
             )

--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -141,7 +141,7 @@ struct ShareService {
         let appPaths = try await apps.concurrentMap {
             try AbsolutePath(
                 validating: $0,
-                relativeTo: try await fileSystem.currentWorkingDirectory()
+                relativeTo: path
             )
         }
         if !apps.isEmpty, try await appPaths
@@ -247,6 +247,7 @@ struct ShareService {
         let appBundle = try await appBundleLoader.load(appBundlePath)
         let displayName = appBundle.infoPlist.name
 
+        logger.notice("Uploading \(displayName)...")
         let preview = try await previewsUploadService.uploadPreviews(
             .ipa(ipaPath),
             displayName: displayName,
@@ -274,8 +275,9 @@ struct ShareService {
         guard appNames.count == 1,
               let appName = appNames.first else { throw ShareServiceError.multipleAppsSpecified(appNames) }
 
+        logger.notice("Uploading \(appName)...")
         let preview = try await previewsUploadService.uploadPreviews(
-            .appBundle(appPaths),
+            .appBundles(appPaths),
             displayName: appName,
             version: appBundles.compactMap(\.infoPlist.version.description).first,
             bundleIdentifier: appBundles.compactMap(\.infoPlist.bundleId).first,
@@ -352,8 +354,9 @@ struct ShareService {
                 throw ShareServiceError.noAppsFound(app: app, configuration: configuration)
             }
 
+            logger.notice("Uploading \(app)...")
             let preview = try await previewsUploadService.uploadPreviews(
-                .appBundle(appPaths),
+                .appBundles(appPaths),
                 displayName: app,
                 version: nil,
                 bundleIdentifier: nil,

--- a/Sources/TuistServer/Models/PreviewType.swift
+++ b/Sources/TuistServer/Models/PreviewType.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum PreviewType {
+    case ipa
+    case appBundle
+}

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -8266,18 +8266,75 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json`.
                 public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// The bundle identifier of the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json/bundle_identifier`.
+                    public var bundle_identifier: Swift.String?
                     /// The display name of the preview.
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json/display_name`.
                     public var display_name: Swift.String?
+                    /// The type of the preview to upload.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json/type`.
+                    @frozen
+                    public enum _typePayload: RawRepresentable, Codable, Equatable, Hashable,
+                        Sendable, _AutoLosslessStringConvertible, CaseIterable
+                    {
+                        case app_bundle
+                        case ipa
+                        /// Parsed a raw value that was not defined in the OpenAPI document.
+                        case undocumented(String)
+                        public init?(rawValue: String) {
+                            switch rawValue {
+                            case "app_bundle": self = .app_bundle
+                            case "ipa": self = .ipa
+                            default: self = .undocumented(rawValue)
+                            }
+                        }
+                        public var rawValue: String {
+                            switch self {
+                            case let .undocumented(string): return string
+                            case .app_bundle: return "app_bundle"
+                            case .ipa: return "ipa"
+                            }
+                        }
+                        public static var allCases: [_typePayload] { [.app_bundle, .ipa] }
+                    }
+                    /// The type of the preview to upload.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json/type`.
+                    public var _type:
+                        Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload._typePayload?
+                    /// The version of the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/json/version`.
+                    public var version: Swift.String?
                     /// Creates a new `jsonPayload`.
                     ///
                     /// - Parameters:
+                    ///   - bundle_identifier: The bundle identifier of the preview.
                     ///   - display_name: The display name of the preview.
-                    public init(display_name: Swift.String? = nil) {
+                    ///   - _type: The type of the preview to upload.
+                    ///   - version: The version of the preview.
+                    public init(
+                        bundle_identifier: Swift.String? = nil,
+                        display_name: Swift.String? = nil,
+                        _type: Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload
+                            ._typePayload? = nil,
+                        version: Swift.String? = nil
+                    ) {
+                        self.bundle_identifier = bundle_identifier
                         self.display_name = display_name
+                        self._type = _type
+                        self.version = version
                     }
-                    public enum CodingKeys: String, CodingKey { case display_name }
+                    public enum CodingKeys: String, CodingKey {
+                        case bundle_identifier
+                        case display_name
+                        case _type = "type"
+                        case version
+                    }
                 }
                 case json(Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload)
             }

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -2250,8 +2250,21 @@ paths:
           application/json:
             schema:
               properties:
+                bundle_identifier:
+                  description: The bundle identifier of the preview.
+                  type: string
                 display_name:
                   description: The display name of the preview.
+                  type: string
+                type:
+                  default: app_bundle
+                  description: The type of the preview to upload.
+                  enum:
+                    - app_bundle
+                    - ipa
+                  type: string
+                version:
+                  description: The version of the preview.
                   type: string
               type: object
         description: Preview upload request params

--- a/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
@@ -5,7 +5,10 @@ import TuistSupport
 @Mockable
 public protocol MultipartUploadStartPreviewsServicing {
     func startPreviewsMultipartUpload(
+        type: PreviewType,
         displayName: String,
+        version: String?,
+        bundleIdentifier: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload
@@ -52,12 +55,23 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
     }
 
     public func startPreviewsMultipartUpload(
+        type: PreviewType,
         displayName: String,
+        version: String?,
+        bundleIdentifier: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload {
         let client = Client.authenticated(serverURL: serverURL)
         let handles = try fullHandleService.parse(fullHandle)
+        let type: Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload
+            ._typePayload = switch type
+        {
+        case .appBundle:
+            .app_bundle
+        case .ipa:
+            .ipa
+        }
         let response = try await client.startPreviewsMultipartUpload(
             .init(
                 path: .init(
@@ -65,7 +79,12 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
                     project_handle: handles.projectHandle
                 ),
                 body: .json(
-                    .init(display_name: displayName)
+                    .init(
+                        bundle_identifier: bundleIdentifier,
+                        display_name: displayName,
+                        _type: type,
+                        version: version
+                    )
                 )
             )
         )

--- a/Sources/TuistServer/Services/PreviewsUploadService.swift
+++ b/Sources/TuistServer/Services/PreviewsUploadService.swift
@@ -7,7 +7,7 @@ import XcodeGraph
 
 public enum PreviewUploadType: Equatable {
     case ipa(AbsolutePath)
-    case appBundle([AbsolutePath])
+    case appBundles([AbsolutePath])
 }
 
 @Mockable
@@ -77,7 +77,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         case let .ipa(ipaPath):
             buildPath = ipaPath
             previewType = .ipa
-        case let .appBundle(previewPaths):
+        case let .appBundles(previewPaths):
             buildPath = try await fileArchiver.makeFileArchiver(for: previewPaths).zip(name: "previews.zip")
             previewType = .appBundle
         }

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -22,6 +22,8 @@ final class ShareServiceTests: TuistUnitTestCase {
     private var userInputReader: MockUserInputReading!
     private var defaultConfigurationFetcher: MockDefaultConfigurationFetching!
     private var appBundleLoader: MockAppBundleLoading!
+    private var fileUnarchiver: MockFileUnarchiving!
+    private let shareURL: URL = .test()
 
     override func setUp() {
         super.setUp()
@@ -36,6 +38,13 @@ final class ShareServiceTests: TuistUnitTestCase {
         userInputReader = .init()
         defaultConfigurationFetcher = .init()
         appBundleLoader = .init()
+        fileUnarchiver = .init()
+
+        let fileArchiverFactory = MockFileArchivingFactorying()
+        given(fileArchiverFactory)
+            .makeFileUnarchiver(for: .any)
+            .willReturn(fileUnarchiver)
+
         subject = ShareService(
             fileHandler: fileHandler,
             fileSystem: fileSystem,
@@ -48,12 +57,24 @@ final class ShareServiceTests: TuistUnitTestCase {
             manifestGraphLoader: manifestGraphLoader,
             userInputReader: userInputReader,
             defaultConfigurationFetcher: defaultConfigurationFetcher,
-            appBundleLoader: appBundleLoader
+            appBundleLoader: appBundleLoader,
+            fileArchiverFactory: fileArchiverFactory
         )
 
         given(serverURLService)
             .url(configServerURL: .any)
             .willReturn(Constants.URLs.production)
+
+        given(previewsUploadService)
+            .uploadPreviews(
+                .any,
+                displayName: .any,
+                version: .any,
+                bundleIdentifier: .any,
+                fullHandle: .any,
+                serverURL: .any
+            )
+            .willReturn(.test(url: shareURL))
 
         Matcher.register([GraphTarget].self)
     }
@@ -194,16 +215,6 @@ final class ShareServiceTests: TuistUnitTestCase {
             .willReturn(try temporaryPath().appending(component: "visionOS"))
         try fileHandler.touch(visionOSPath.appending(component: "App.app"))
 
-        let shareURL: URL = .test()
-        given(previewsUploadService)
-            .uploadPreviews(
-                displayName: .any,
-                previewPaths: .any,
-                fullHandle: .any,
-                serverURL: .any
-            )
-            .willReturn(.test(url: shareURL))
-
         // When
         try await subject.run(
             path: nil,
@@ -216,8 +227,10 @@ final class ShareServiceTests: TuistUnitTestCase {
         // Then
         verify(previewsUploadService)
             .uploadPreviews(
+                .any,
                 displayName: .any,
-                previewPaths: .any,
+                version: .any,
+                bundleIdentifier: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -383,16 +396,6 @@ final class ShareServiceTests: TuistUnitTestCase {
             .willReturn(try temporaryPath().appending(component: "iphoneos"))
         try fileHandler.touch(iosPath.appending(component: "AppTwo.app"))
 
-        let shareURL: URL = .test()
-        given(previewsUploadService)
-            .uploadPreviews(
-                displayName: .any,
-                previewPaths: .any,
-                fullHandle: .any,
-                serverURL: .any
-            )
-            .willReturn(.test(url: shareURL))
-
         // When
         try await subject.run(
             path: nil,
@@ -405,8 +408,10 @@ final class ShareServiceTests: TuistUnitTestCase {
         // Then
         verify(previewsUploadService)
             .uploadPreviews(
+                .any,
                 displayName: .any,
-                previewPaths: .any,
+                version: .any,
+                bundleIdentifier: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -544,16 +549,6 @@ final class ShareServiceTests: TuistUnitTestCase {
             .willReturn(try temporaryPath().appending(component: "iphoneos"))
         try fileHandler.touch(iosPath.appending(component: "App.app"))
 
-        let shareURL: URL = .test()
-        given(previewsUploadService)
-            .uploadPreviews(
-                displayName: .any,
-                previewPaths: .any,
-                fullHandle: .any,
-                serverURL: .any
-            )
-            .willReturn(.test(url: shareURL))
-
         // When
         try await subject.run(
             path: path.pathString,
@@ -566,8 +561,10 @@ final class ShareServiceTests: TuistUnitTestCase {
         // Then
         verify(previewsUploadService)
             .uploadPreviews(
+                .any,
                 displayName: .any,
-                previewPaths: .any,
+                version: .any,
+                bundleIdentifier: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -586,6 +583,8 @@ final class ShareServiceTests: TuistUnitTestCase {
 
         let appOne = try temporaryPath().appending(component: "AppOne.app")
         let appTwo = try temporaryPath().appending(component: "AppTwo.app")
+        try await fileSystem.makeDirectory(at: appOne)
+        try await fileSystem.makeDirectory(at: appTwo)
 
         given(appBundleLoader)
             .load(.value(appOne))
@@ -611,7 +610,7 @@ final class ShareServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_share_apps() async throws {
+    func test_share_app_bundles() async throws {
         // Given
         given(configLoader)
             .loadConfig(path: .any)
@@ -619,6 +618,8 @@ final class ShareServiceTests: TuistUnitTestCase {
 
         let iosApp = try temporaryPath().appending(components: "iOS", "App.app")
         let visionOSApp = try temporaryPath().appending(components: "visionOs", "App.app")
+        try await fileSystem.makeDirectory(at: iosApp)
+        try await fileSystem.makeDirectory(at: visionOSApp)
 
         given(appBundleLoader)
             .load(.value(iosApp))
@@ -627,16 +628,6 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(appBundleLoader)
             .load(.value(visionOSApp))
             .willReturn(.test(infoPlist: .test(name: "App")))
-
-        let shareURL: URL = .test()
-        given(previewsUploadService)
-            .uploadPreviews(
-                displayName: .any,
-                previewPaths: .any,
-                fullHandle: .any,
-                serverURL: .any
-            )
-            .willReturn(.test(url: shareURL))
 
         // When
         try await subject.run(
@@ -653,8 +644,10 @@ final class ShareServiceTests: TuistUnitTestCase {
         // Then
         verify(previewsUploadService)
             .uploadPreviews(
+                .value(.appBundle([iosApp, visionOSApp])),
                 displayName: .value("App"),
-                previewPaths: .value([iosApp, visionOSApp]),
+                version: .any,
+                bundleIdentifier: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -662,6 +655,118 @@ final class ShareServiceTests: TuistUnitTestCase {
 
         XCTAssertStandardOutput(
             pattern: "App uploaded – share it with others using the following link: \(shareURL.absoluteString)"
+        )
+    }
+
+    func test_share_ipa() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let ipaPath = try temporaryPath().appending(components: "App.ipa")
+        let payloadPath = try temporaryPath().appending(components: "Payload")
+        let appBundlePath = payloadPath.appending(components: "App.app")
+        try await fileSystem.makeDirectory(at: ipaPath)
+        try await fileSystem.makeDirectory(at: payloadPath)
+        try await fileSystem.makeDirectory(at: appBundlePath)
+        given(fileUnarchiver)
+            .unzip()
+            .willReturn(payloadPath)
+
+        given(appBundleLoader)
+            .load(.value(appBundlePath))
+            .willReturn(
+                .test(
+                    infoPlist: .test(
+                        version: Version(1, 0, 0),
+                        name: "App",
+                        bundleId: "com.tuist.app"
+                    )
+                )
+            )
+
+        // When
+        try await subject.run(
+            path: nil,
+            apps: [
+                ipaPath.pathString,
+            ],
+            configuration: nil,
+            platforms: [],
+            derivedDataPath: nil
+        )
+
+        // Then
+        verify(previewsUploadService)
+            .uploadPreviews(
+                .value(.ipa(ipaPath)),
+                displayName: .value("App"),
+                version: .value("1.0.0"),
+                bundleIdentifier: .value("com.tuist.app"),
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .value(Constants.URLs.production)
+            )
+            .called(1)
+
+        XCTAssertStandardOutput(
+            pattern: "App uploaded – share it with others using the following link: \(shareURL.absoluteString)"
+        )
+    }
+
+    func test_share_ipa_when_it_does_not_contain_any_app_bundle() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let ipaPath = try temporaryPath().appending(components: "App.ipa")
+        let payloadPath = try temporaryPath().appending(components: "Payload")
+        try await fileSystem.makeDirectory(at: ipaPath)
+        try await fileSystem.makeDirectory(at: payloadPath)
+        given(fileUnarchiver)
+            .unzip()
+            .willReturn(payloadPath)
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await subject.run(
+                path: nil,
+                apps: [
+                    ipaPath.pathString,
+                ],
+                configuration: nil,
+                platforms: [],
+                derivedDataPath: nil
+            ),
+            ShareServiceError.appBundleInIPANotFound(ipaPath)
+        )
+    }
+
+    func test_share_multiple_ipas() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let ipaPath = try temporaryPath().appending(components: "App.ipa")
+        let watchOSIpaPath = try temporaryPath().appending(component: "WatchOSApp.ipa")
+        try await fileSystem.makeDirectory(at: ipaPath)
+        try await fileSystem.makeDirectory(at: watchOSIpaPath)
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await subject.run(
+                path: nil,
+                apps: [
+                    ipaPath.pathString,
+                    watchOSIpaPath.pathString,
+                ],
+                configuration: nil,
+                platforms: [],
+                derivedDataPath: nil
+            ),
+            ShareServiceError.multipleAppsSpecified([ipaPath.pathString, watchOSIpaPath.pathString])
         )
     }
 }

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -416,6 +416,8 @@ final class ShareServiceTests: TuistUnitTestCase {
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
 
+        manifestLoader.reset()
+
         given(manifestLoader)
             .hasRootManifest(at: .any)
             .willReturn(false)
@@ -438,6 +440,8 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        manifestLoader.reset()
 
         given(manifestLoader)
             .hasRootManifest(at: .any)
@@ -462,6 +466,8 @@ final class ShareServiceTests: TuistUnitTestCase {
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
 
+        manifestLoader.reset()
+
         given(manifestLoader)
             .hasRootManifest(at: .any)
             .willReturn(false)
@@ -484,6 +490,8 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        manifestLoader.reset()
 
         given(manifestLoader)
             .hasRootManifest(at: .any)
@@ -509,6 +517,8 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        manifestLoader.reset()
 
         given(manifestLoader)
             .hasRootManifest(at: .any)
@@ -604,13 +614,14 @@ final class ShareServiceTests: TuistUnitTestCase {
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
 
-        let ipaPath = try temporaryPath().appending(component: "App.ipa")
+        let currentPath = try temporaryPath()
+        let ipaPath = currentPath.appending(component: "App.ipa")
         try await fileSystem.makeDirectory(at: ipaPath)
 
         // When / Then
         await XCTAssertThrowsSpecific(
             try await subject.run(
-                path: nil,
+                path: currentPath.pathString,
                 apps: [
                     ipaPath.pathString,
                     "AppTarget",
@@ -619,7 +630,10 @@ final class ShareServiceTests: TuistUnitTestCase {
                 platforms: [],
                 derivedDataPath: nil
             ),
-            ShareServiceError.multipleAppsSpecified([ipaPath.pathString, "AppTarget"])
+            ShareServiceError.multipleAppsSpecified([
+                ipaPath.pathString,
+                currentPath.appending(component: "AppTarget").pathString,
+            ])
         )
     }
 

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -61,6 +61,10 @@ final class ShareServiceTests: TuistUnitTestCase {
             fileArchiverFactory: fileArchiverFactory
         )
 
+        given(manifestLoader)
+            .hasRootManifest(at: .any)
+            .willReturn(true)
+
         given(serverURLService)
             .url(configServerURL: .any)
             .willReturn(Constants.URLs.production)
@@ -102,10 +106,6 @@ final class ShareServiceTests: TuistUnitTestCase {
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
 
-        given(manifestLoader)
-            .hasRootManifest(at: .any)
-            .willReturn(true)
-
         // When / Then
         await XCTAssertThrowsSpecific(
             try await subject.run(
@@ -124,10 +124,6 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
-
-        given(manifestLoader)
-            .hasRootManifest(at: .any)
-            .willReturn(true)
 
         let projectPath = try temporaryPath()
         let appTarget: Target = .test(
@@ -247,10 +243,6 @@ final class ShareServiceTests: TuistUnitTestCase {
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
 
-        given(manifestLoader)
-            .hasRootManifest(at: .any)
-            .willReturn(true)
-
         let projectPath = try temporaryPath()
         let appTarget: Target = .test(
             name: "AppTarget",
@@ -329,10 +321,6 @@ final class ShareServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(fullHandle: "tuist/tuist"))
-
-        given(manifestLoader)
-            .hasRootManifest(at: .any)
-            .willReturn(true)
 
         let projectPath = try temporaryPath()
         let appTarget: Target = .test(
@@ -610,6 +598,31 @@ final class ShareServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_share_ipa_and_app_target_name() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist"))
+
+        let ipaPath = try temporaryPath().appending(component: "App.ipa")
+        try await fileSystem.makeDirectory(at: ipaPath)
+
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await subject.run(
+                path: nil,
+                apps: [
+                    ipaPath.pathString,
+                    "AppTarget",
+                ],
+                configuration: nil,
+                platforms: [],
+                derivedDataPath: nil
+            ),
+            ShareServiceError.multipleAppsSpecified([ipaPath.pathString, "AppTarget"])
+        )
+    }
+
     func test_share_app_bundles() async throws {
         // Given
         given(configLoader)
@@ -644,7 +657,7 @@ final class ShareServiceTests: TuistUnitTestCase {
         // Then
         verify(previewsUploadService)
             .uploadPreviews(
-                .value(.appBundle([iosApp, visionOSApp])),
+                .value(.appBundles([iosApp, visionOSApp])),
                 displayName: .value("App"),
                 version: .any,
                 bundleIdentifier: .any,

--- a/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
@@ -101,7 +101,7 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
 
         // When
         let got = try await subject.uploadPreviews(
-            .appBundle([preview]),
+            .appBundles([preview]),
             displayName: "App",
             version: nil,
             bundleIdentifier: nil,

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -800,6 +800,7 @@ public enum Module: String, CaseIterable {
         }
 
         let settings = Settings.settings(
+            base: settings.base,
             configurations: [
                 .debug(
                     name: "Debug",

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -167,7 +167,10 @@ final class DevicesViewModel: Sendable {
         let fileUnarchiver = try fileArchiverFactory.makeFileUnarchiver(for: archivePath)
         let unarchivedDirectory = try fileUnarchiver.unzip()
 
-        let apps = try await fileHandler.glob(unarchivedDirectory, glob: "*.app").concurrentMap {
+        let apps = try await (
+            fileHandler.glob(unarchivedDirectory, glob: "*.app") + fileHandler
+                .glob(unarchivedDirectory, glob: "*/*.app")
+        ).concurrentMap {
             try await self.appBundleLoader.load($0)
         }
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/6847

### Short description 📝

For more details, see the attached issue.

This PR adds support for sharing and running `.ipa`s in Tuist Previews. You can run these previews using the macOS menu bar app, the tuist CLI or directly from your device.

Here's a demo of this feature in action:

https://github.com/user-attachments/assets/504948c7-075e-45bf-91eb-3ae4cf25df26



The web UI is subject to change as described here: https://github.com/tuist/tuist/issues/6851

### How to test the changes locally 🧐

- Go to `ios_app_with_frameworks`
- Create an `ipa` by archiving the app and then exporting the archive
- Run `tuist share path-to-ipa.ipa`
- Run `tuist run --device "My iPhone" {url}`
- Open the link in your browser – the app should run on your selected device using the macOS menu bar app

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
