### PR TITLE
Fix Tuist Previews not posted in the GitHub PR comment

### DIFF
--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -366,8 +366,8 @@ struct ShareService {
         let preview = try await previewsUploadService.uploadPreviews(
             previewUploadType,
             displayName: displayName,
-            version: nil,
-            bundleIdentifier: nil,
+            version: version,
+            bundleIdentifier: bundleIdentifier,
             fullHandle: fullHandle,
             serverURL: serverURL
         )

--- a/docs/docs/en/guides/share/previews.md
+++ b/docs/docs/en/guides/share/previews.md
@@ -31,6 +31,7 @@ tuist share App
 xcodebuild -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
 xcodebuild -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Debug --platforms iOS
+tuist share App.ipa # Share an existing .ipa file
 ```
 :::
 
@@ -38,8 +39,11 @@ The command will generate a link that you can share with anyone to run the app â
 
 ```bash
 tuist run {url}
-tuist run {url} --device "My iPhone" # Run the app on a specific device
+tuist run --device "My iPhone" {url} # Run the app on a specific device
 ```
+
+When sharing an `.ipa` file, you can download the app directly from the mobile device using the Preview link.
+The links to `.ipa` previews are by default _public_. In the future, you will have an option to make them private, so that the recipient of the link would need to authenticate with their Tuist account to download the app.
 
 > [!IMPORTANT] PREVIEWS' VISIBILITY
 > Only people with access to the organization the project belongs to can access the previews. We plan to add support for expiring links.


### PR DESCRIPTION
### Short description 📝

When testing out https://github.com/tuist/tuist/issues/6852, I've noticed the links to Previews are no longer posted by the GitHub app. Turns out we don't send the `preview_id` when sharing the `.ipa` that the GitHub app relies on.

### How to test the changes locally 🧐

- Run `tuist share App.ipa`. The request to upload the `tuist share` command event should include the `preview_id`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
