### PR TITLE
fix: getting devices when a device is unavailable, improve the menu tappable area

### DIFF
--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -146,7 +146,7 @@ private struct DeviceList: Codable {
                 }
 
                 let transportType: TransportType?
-                let tunnelState: TunnelState
+                let tunnelState: TunnelState?
             }
 
             struct DeviceProperties: Codable {
@@ -186,7 +186,7 @@ extension PhysicalDevice {
 
         let connectionState: PhysicalDevice.ConnectionState = switch device.connectionProperties.tunnelState {
         case .connected: .connected
-        case .disconnected, .unavailable: .disconnected
+        case .disconnected, .unavailable, .none: .disconnected
         }
 
         self.init(

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -8,20 +8,20 @@ import XcodeGraph
 
 enum DeviceControllerError: FatalError {
     case applicationVerificationFailed
-    case listDecodeFailed
+    case fetchingDevicesFailed
 
     var description: String {
         switch self {
         case .applicationVerificationFailed:
             "The app could not be installed because the verification failed. Make sure that your device is registered in your Apple Developer account."
-        case .listDecodeFailed:
+        case .fetchingDevicesFailed:
             "Fetching the list of devices failed."
         }
     }
 
     var type: ErrorType {
         switch self {
-        case .applicationVerificationFailed, .listDecodeFailed:
+        case .applicationVerificationFailed, .fetchingDevicesFailed:
             .abort
         }
     }
@@ -72,7 +72,7 @@ public final class DeviceController: DeviceControlling {
                     from: try await fileSystem.readFile(at: devicesListOutputPath)
                 )
             } catch {
-                throw DeviceControllerError.listDecodeFailed
+                throw DeviceControllerError.fetchingDevicesFailed
             }
 
             return deviceList.result.devices

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -131,7 +131,7 @@ private struct DeviceList: Codable {
 
             struct DeviceProperties: Codable {
                 let name: String
-                let osVersionNumber: String
+                let osVersionNumber: String?
             }
 
             struct HardwareProperties: Codable {
@@ -162,7 +162,7 @@ extension PhysicalDevice {
             id: device.hardwareProperties.udid,
             name: device.deviceProperties.name,
             platform: platform,
-            osVersion: device.deviceProperties.osVersionNumber
+            osVersion: device.deviceProperties.osVersionNumber ?? "Unknown"
         )
     }
 }

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -134,7 +134,19 @@ private struct DeviceList: Codable {
             let identifier: String
 
             struct ConnectionProperties: Codable {
-                let transportType: String?
+                enum TransportType: String, Codable {
+                    case localNetwork
+                    case wired
+                }
+
+                enum TunnelState: String, Codable {
+                    case connected
+                    case disconnected
+                    case unavailable
+                }
+
+                let transportType: TransportType?
+                let tunnelState: TunnelState
             }
 
             struct DeviceProperties: Codable {
@@ -166,11 +178,24 @@ extension PhysicalDevice {
         case .watchOS: .watchOS
         }
 
+        let transportType: PhysicalDevice.TransportType = switch device.connectionProperties.transportType {
+        case .localNetwork: .wifi
+        case .wired: .usb
+        default: .unknown
+        }
+
+        let connectionState: PhysicalDevice.ConnectionState = switch device.connectionProperties.tunnelState {
+        case .connected: .connected
+        default: .disconnected
+        }
+
         self.init(
             id: device.hardwareProperties.udid,
             name: device.deviceProperties.name,
             platform: platform,
-            osVersion: device.deviceProperties.osVersionNumber
+            osVersion: device.deviceProperties.osVersionNumber,
+            transportType: transportType,
+            connectionState: connectionState
         )
     }
 }

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -170,7 +170,7 @@ extension PhysicalDevice {
             id: device.hardwareProperties.udid,
             name: device.deviceProperties.name,
             platform: platform,
-            osVersion: device.deviceProperties.osVersionNumber ?? "Unknown"
+            osVersion: device.deviceProperties.osVersionNumber
         )
     }
 }

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -181,12 +181,12 @@ extension PhysicalDevice {
         let transportType: PhysicalDevice.TransportType = switch device.connectionProperties.transportType {
         case .localNetwork: .wifi
         case .wired: .usb
-        default: .unknown
+        case .none: .unknown
         }
 
         let connectionState: PhysicalDevice.ConnectionState = switch device.connectionProperties.tunnelState {
         case .connected: .connected
-        default: .disconnected
+        case .disconnected, .unavailable: .disconnected
         }
 
         self.init(

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -140,6 +140,7 @@ private struct DeviceList: Codable {
                 }
 
                 enum TunnelState: String, Codable {
+                    case connecting
                     case connected
                     case disconnected
                     case unavailable
@@ -186,7 +187,7 @@ extension PhysicalDevice {
 
         let connectionState: PhysicalDevice.ConnectionState = switch device.connectionProperties.tunnelState {
         case .connected: .connected
-        case .disconnected, .unavailable, .none: .disconnected
+        case .connecting, .disconnected, .unavailable, .none: .disconnected
         }
 
         self.init(

--- a/Sources/TuistAutomation/Device/DeviceController.swift
+++ b/Sources/TuistAutomation/Device/DeviceController.swift
@@ -178,10 +178,10 @@ extension PhysicalDevice {
         case .watchOS: .watchOS
         }
 
-        let transportType: PhysicalDevice.TransportType = switch device.connectionProperties.transportType {
+        let transportType: PhysicalDevice.TransportType? = switch device.connectionProperties.transportType {
         case .localNetwork: .wifi
         case .wired: .usb
-        case .none: .unknown
+        case .none: .none
         }
 
         let connectionState: PhysicalDevice.ConnectionState = switch device.connectionProperties.tunnelState {

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -41,21 +41,5 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
                 connectionState: connectionState
             )
         }
-
-        public func modified(
-            name: String? = nil,
-            osVersion: String? = nil,
-            transportType: TransportType? = nil,
-            connectionState: ConnectionState? = nil
-        ) -> PhysicalDevice {
-            .init(
-                id: id,
-                name: name ?? self.name,
-                platform: platform,
-                osVersion: osVersion ?? self.osVersion,
-                transportType: transportType ?? self.transportType,
-                connectionState: connectionState ?? self.connectionState
-            )
-        }
     }
 #endif

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -41,5 +41,21 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
                 connectionState: connectionState
             )
         }
+
+        public func modified(
+            name: String? = nil,
+            osVersion: String? = nil,
+            transportType: TransportType? = nil,
+            connectionState: ConnectionState? = nil
+        ) -> PhysicalDevice {
+            .init(
+                id: id,
+                name: name ?? self.name,
+                platform: platform,
+                osVersion: osVersion ?? self.osVersion,
+                transportType: transportType ?? self.transportType,
+                connectionState: connectionState ?? self.connectionState
+            )
+        }
     }
 #endif

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -3,16 +3,23 @@ import XcodeGraph
 
 /// Represents a physical device, such as an iPhone
 public struct PhysicalDevice: Codable, Equatable, Identifiable {
+    public enum TransportType: String, Codable {
+        case wifi
+        case usb
+        case unknown
+    }
+
+    public enum ConnectionState: String, Codable {
+        case connected
+        case disconnected
+    }
+
     public let id: String
     public let name: String
     public let platform: Platform
     public let osVersion: String?
-}
-
-extension PhysicalDevice {
-    public var isReachable: Bool {
-        osVersion != nil
-    }
+    public let transportType: TransportType
+    public let connectionState: ConnectionState
 }
 
 #if DEBUG
@@ -21,13 +28,17 @@ extension PhysicalDevice {
             id: String = "id",
             name: String = "My iPhone",
             platform: Platform = .iOS,
-            osVersion: String? = "17.4.1"
+            osVersion: String? = "17.4.1",
+            transportType: TransportType = .wifi,
+            connectionState: ConnectionState = .connected
         ) -> Self {
             .init(
                 id: id,
                 name: name,
                 platform: platform,
-                osVersion: osVersion
+                osVersion: osVersion,
+                transportType: transportType,
+                connectionState: connectionState
             )
         }
     }

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -6,7 +6,6 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
     public enum TransportType: String, Codable {
         case wifi
         case usb
-        case unknown
     }
 
     public enum ConnectionState: String, Codable {
@@ -18,7 +17,7 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
     public let name: String
     public let platform: Platform
     public let osVersion: String?
-    public let transportType: TransportType
+    public let transportType: TransportType?
     public let connectionState: ConnectionState
 }
 

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -9,6 +9,12 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
     public let osVersion: String?
 }
 
+extension PhysicalDevice {
+    public var isReachable: Bool {
+        osVersion != nil
+    }
+}
+
 #if DEBUG
     extension PhysicalDevice {
         public static func test(

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -6,7 +6,7 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
     public let id: String
     public let name: String
     public let platform: Platform
-    public let osVersion: String
+    public let osVersion: String?
 }
 
 #if DEBUG
@@ -15,7 +15,7 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
             id: String = "id",
             name: String = "My iPhone",
             platform: Platform = .iOS,
-            osVersion: String = "17.4.1"
+            osVersion: String? = "17.4.1"
         ) -> Self {
             .init(
                 id: id,

--- a/Sources/TuistAutomation/Device/PhysicalDevice.swift
+++ b/Sources/TuistAutomation/Device/PhysicalDevice.swift
@@ -28,7 +28,7 @@ public struct PhysicalDevice: Codable, Equatable, Identifiable {
             name: String = "My iPhone",
             platform: Platform = .iOS,
             osVersion: String? = "17.4.1",
-            transportType: TransportType = .wifi,
+            transportType: TransportType? = .wifi,
             connectionState: ConnectionState = .connected
         ) -> Self {
             .init(

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -79,6 +79,12 @@ final class DeviceControllerTests: TuistUnitTestCase {
                     platform: .iOS,
                     osVersion: "17.6.1"
                 ),
+                PhysicalDevice(
+                    id: "00008301-F856EAF4350DA92F",
+                    name: "My Watch",
+                    platform: .watchOS,
+                    osVersion: nil
+                ),
             ],
             got
         )
@@ -348,6 +354,50 @@ final class DeviceControllerTests: TuistUnitTestCase {
               "udid" : "00008120-001109881103C01E"
             },
             "identifier" : "E5E85238-76F2-4F59-A60F-0B4D08F33764",
+            "tags" : [
+
+            ],
+            "visibilityClass" : "default"
+          },
+          {
+            "capabilities" : [
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.unpairdevice",
+                "name" : "Unpair Device"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.connectdevice",
+                "name" : "Connect to Device"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.acquireusageassertion",
+                "name" : "Acquire Usage Assertion"
+              }
+            ],
+            "connectionProperties" : {
+              "authenticationType" : "manualPairing",
+              "isMobileDeviceOnly" : false,
+              "pairingState" : "paired",
+              "potentialHostnames" : [
+                "00008301-F856EAF4350DA92F.coredevice.local",
+                "497621AE-9F6E-0515-BF34-974F61E542E6.coredevice.local"
+              ],
+              "transportType" : "localNetwork",
+              "tunnelState" : "disconnected",
+              "tunnelTransportProtocol" : "tcp"
+            },
+            "deviceProperties" : {
+              "ddiServicesAvailable" : false,
+              "name" : "My Watch"
+            },
+            "hardwareProperties" : {
+              "deviceType" : "appleWatch",
+              "ecid" : 17819358193419324013,
+              "platform" : "watchOS",
+              "productType" : "Watch6,15",
+              "udid" : "00008301-F856EAF4350DA92F"
+            },
+            "identifier" : "497621AE-9F6E-0515-BF34-974F61E542E6",
             "tags" : [
 
             ],

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -682,7 +682,7 @@ final class DeviceControllerTests: TuistUnitTestCase {
             },
             "identifier" : "890F8E81-A295-89D1-AF02-9F890A89089E",
             "tags" : [
-    
+
             ],
             "visibilityClass" : "default"
           }

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -82,6 +82,14 @@ final class DeviceControllerTests: TuistUnitTestCase {
                     transportType: .wifi,
                     connectionState: .disconnected
                 ),
+                PhysicalDevice(
+                    id: "00008120-A9123890F89EA35B",
+                    name: "My Watch S8",
+                    platform: .watchOS,
+                    osVersion: "11.0.1",
+                    transportType: nil,
+                    connectionState: .disconnected
+                ),
             ],
             got
         )
@@ -625,6 +633,56 @@ final class DeviceControllerTests: TuistUnitTestCase {
             "identifier" : "497621AE-9F6E-0515-BF34-974F61E542E6",
             "tags" : [
 
+            ],
+            "visibilityClass" : "default"
+          },
+          {
+            "capabilities" : [
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.unpairdevice",
+                "name" : "Unpair Device"
+              }
+            ],
+            "connectionProperties" : {
+              "authenticationType" : "manualPairing",
+              "isMobileDeviceOnly" : false,
+              "lastConnectionDate" : "2024-10-12T14:40:44.703Z",
+              "pairingState" : "paired",
+              "potentialHostnames" : [
+                "00008120-A9123890F89EA35B.coredevice.local",
+                "890F8E81-A295-89D1-AF02-9F890A89089E.coredevice.local"
+              ],
+              "tunnelState" : "unavailable"
+            },
+            "deviceProperties" : {
+              "ddiServicesAvailable" : false,
+              "developerModeStatus" : "disabled",
+              "hasInternalOSBuild" : false,
+              "name" : "My Watch S8",
+              "osBuildUpdate" : "22R361",
+              "osVersionNumber" : "11.0.1"
+            },
+            "hardwareProperties" : {
+              "cpuType" : {
+                "name" : "arm64_32",
+                "subType" : 1,
+                "type" : 33554444
+              },
+              "deviceType" : "appleWatch",
+              "ecid" : 17129084317543758948,
+              "hardwareModel" : "N197bAP",
+              "isProductionFused" : true,
+              "marketingName" : "Apple Watch Series 8",
+              "platform" : "watchOS",
+              "productType" : "Watch6,15",
+              "reality" : "physical",
+              "serialNumber" : "K29F36127F",
+              "thinningProductType" : "Watch6,15",
+              "udid" : "00008120-A9123890F89EA35B"
+            },
+            "identifier" : "890F8E81-A295-89D1-AF02-9F890A89089E",
+            "tags" : [
+    
             ],
             "visibilityClass" : "default"
           }

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -90,7 +90,7 @@ final class DeviceControllerTests: TuistUnitTestCase {
         )
     }
 
-    func test_findAvailableDevices_when_list_decode_failed() async throws {
+    func test_findAvailableDevices_when_fetching_devices_failed() async throws {
         // Given
         var devicesListOutputPath: AbsolutePath?
 
@@ -127,7 +127,7 @@ final class DeviceControllerTests: TuistUnitTestCase {
         // When / Then
         await XCTAssertThrowsSpecific(
             try await subject.findAvailableDevices(),
-            DeviceControllerError.listDecodeFailed
+            DeviceControllerError.fetchingDevicesFailed
         )
     }
 

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -54,19 +54,33 @@ final class DeviceControllerTests: TuistUnitTestCase {
                     id: "00008027-0018084C1122002E",
                     name: "Marek iPad",
                     platform: .iOS,
-                    osVersion: "17.6.1"
+                    osVersion: "17.6.1",
+                    transportType: .wifi,
+                    connectionState: .disconnected
                 ),
                 PhysicalDevice(
                     id: "00008120-001109881103C01E",
                     name: "Marek\'s iPhone",
                     platform: .iOS,
-                    osVersion: "17.6.1"
+                    osVersion: "17.6.1",
+                    transportType: .wifi,
+                    connectionState: .disconnected
+                ),
+                PhysicalDevice(
+                    id: "00008132-0103524335E2F624",
+                    name: "My iPhone",
+                    platform: .iOS,
+                    osVersion: "17.3.1",
+                    transportType: .usb,
+                    connectionState: .connected
                 ),
                 PhysicalDevice(
                     id: "00008301-F856EAF4350DA92F",
                     name: "My Watch",
                     platform: .watchOS,
-                    osVersion: nil
+                    osVersion: nil,
+                    transportType: .wifi,
+                    connectionState: .disconnected
                 ),
             ],
             got
@@ -364,6 +378,207 @@ final class DeviceControllerTests: TuistUnitTestCase {
               "udid" : "00008120-001109881103C01E"
             },
             "identifier" : "E5E85238-76F2-4F59-A60F-0B4D08F33764",
+            "tags" : [
+
+            ],
+            "visibilityClass" : "default"
+          },
+          {
+            "capabilities" : [
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.unpairdevice",
+                "name" : "Unpair Device"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.capturesysdiagnose",
+                "name" : "Capture Sysdiagnose"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.fetchddimetadata",
+                "name" : "Fetch Developer Disk Image Services Metadata"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.sendsignaltoprocess",
+                "name" : "Send Signal to Process"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.querymobilegestalt",
+                "name" : "Query MobileGestalt"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.monitorprocesstermination",
+                "name" : "Monitor Process for Termination"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.fetchappicons",
+                "name" : "Fetch Application Icons"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.rebootdevice",
+                "name" : "Reboot Device"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.spawnexecutable",
+                "name" : "Spawn Executable"
+              },
+              {
+                "featureIdentifier" : "com.apple.dt.remoteFetchSymbols.dyldSharedCacheFiles",
+                "name" : "com.apple.dt.remoteFetchSymbols"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.transferFiles",
+                "name" : "Transfer Files"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.disconnectdevice",
+                "name" : "Disconnect from Device"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.installroot",
+                "name" : "Install Root"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.listapps",
+                "name" : "List Applications"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.installapp",
+                "name" : "Install Application"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.listroots",
+                "name" : "List Roots"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.sendmemorywarningtoprocess",
+                "name" : "Send Memory Warning to Process"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.getdeviceinfo",
+                "name" : "Fetch Extended Device Info"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.acquireusageassertion",
+                "name" : "Acquire Usage Assertion"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.uninstallroot",
+                "name" : "Uninstall Root"
+              },
+              {
+                "featureIdentifier" : "com.apple.dt.profile",
+                "name" : "Service Hub Profile"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.getlockstate",
+                "name" : "Get Lock State"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.disableddiservices",
+                "name" : "Disable Developer Disk Image Services"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.launchapplication",
+                "name" : "Launch Application"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.viewdevicescreen",
+                "name" : "View Device Screen"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.listprocesses",
+                "name" : "List Processes"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.debugserverproxy",
+                "name" : "com.apple.internal.dt.remote.debugproxy"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.getdisplayinfo",
+                "name" : "Get Display Information"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.uninstallapp",
+                "name" : "Uninstall Application"
+              }
+            ],
+            "connectionProperties" : {
+              "authenticationType" : "manualPairing",
+              "isMobileDeviceOnly" : false,
+              "lastConnectionDate" : "2024-10-17T22:50:28.991Z",
+              "localHostnames" : [
+                "My-iPhone.coredevice.local",
+                "00008132-0103524335E2F624.coredevice.local",
+                "7F6E5352-0E68-3152-A82F-89CF6EDA9531E.coredevice.local"
+              ],
+              "pairingState" : "paired",
+              "potentialHostnames" : [
+                "00008132-0103524335E2F624.coredevice.local",
+                "7F6E5352-0E68-3152-A82F-89CF6EDA9531E.coredevice.local"
+              ],
+              "transportType" : "wired",
+              "tunnelIPAddress" : "fa42:7efa:3e2f::1",
+              "tunnelState" : "connected",
+              "tunnelTransportProtocol" : "tcp"
+            },
+            "deviceProperties" : {
+              "bootedFromSnapshot" : true,
+              "bootedSnapshotName" : "com.apple.os.update-9898FE99999900120346FF9F8EA12E00F9898FE99999900120346FF9F8EA12E00FE089892190FE89A890809809FE9E0A",
+              "bootState" : "booted",
+              "ddiServicesAvailable" : true,
+              "developerModeStatus" : "enabled",
+              "hasInternalOSBuild" : false,
+              "name" : "My iPhone",
+              "osBuildUpdate" : "21D61",
+              "osVersionNumber" : "17.3.1",
+              "rootFileSystemIsWritable" : false,
+              "screenViewingURL" : "devices://device/open?id=7F6E5352-0E68-3152-A82F-89CF6EDA9531E"
+            },
+            "hardwareProperties" : {
+              "cpuType" : {
+                "name" : "arm64e",
+                "subType" : 2,
+                "type" : 16777228
+              },
+              "deviceType" : "iPhone",
+              "ecid" : 1992940239409430,
+              "hardwareModel" : "N104AP",
+              "internalStorageCapacity" : 128000000000,
+              "isProductionFused" : true,
+              "marketingName" : "iPhone 11",
+              "platform" : "iOS",
+              "productType" : "iPhone12,1",
+              "reality" : "physical",
+              "serialNumber" : "A5906FE3A639",
+              "supportedCPUTypes" : [
+                {
+                  "name" : "arm64e",
+                  "subType" : 2,
+                  "type" : 16777228
+                },
+                {
+                  "name" : "arm64",
+                  "subType" : 0,
+                  "type" : 16777228
+                },
+                {
+                  "name" : "arm64",
+                  "subType" : 1,
+                  "type" : 16777228
+                },
+                {
+                  "name" : "arm64_32",
+                  "subType" : 1,
+                  "type" : 33554444
+                }
+              ],
+              "supportedDeviceFamilies" : [
+                1
+              ],
+              "thinningProductType" : "iPhone12,1",
+              "udid" : "00008132-0103524335E2F624"
+            },
+            "identifier" : "7F6E5352-0E68-3152-A82F-89CF6EDA9531E",
             "tags" : [
 
             ],

--- a/app/TuistApp/Resources/Assets.xcassets/MenuBarIcon.imageset/Contents.json
+++ b/app/TuistApp/Resources/Assets.xcassets/MenuBarIcon.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
+++ b/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
@@ -18,7 +18,6 @@ extension View {
 }
 
 struct MenuItemButtonStyle: ButtonStyle {
-
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
+++ b/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
@@ -17,7 +17,7 @@ extension View {
     }
 }
 
-struct MenuItemButtonStyle: ButtonStyle {
+private struct MenuItemButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
+++ b/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
@@ -4,8 +4,7 @@ import SwiftUI
 private struct MenuItemSyle: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .buttonStyle(.plain)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .buttonStyle(MenuItemButtonStyle())
             .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
             .hoverStyle()
             .cornerRadius(5.0)
@@ -15,5 +14,14 @@ private struct MenuItemSyle: ViewModifier {
 extension View {
     func menuItemStyle() -> some View {
         modifier(MenuItemSyle())
+    }
+}
+
+struct MenuItemButtonStyle: ButtonStyle {
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
     }
 }

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesView.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesView.swift
@@ -1,6 +1,7 @@
 import Combine
 import Path
 import SwiftUI
+import TuistAutomation
 import TuistCore
 import TuistServer
 import TuistSupport
@@ -8,6 +9,7 @@ import TuistSupport
 struct DevicesView: View, ErrorViewHandling {
     @State var viewModel = DevicesViewModel()
     @EnvironmentObject var errorHandling: ErrorHandling
+    @State var isRefreshing = false
     @State var isExpanded = false
     private var cancellables = Set<AnyCancellable>()
 
@@ -39,39 +41,7 @@ struct DevicesView: View, ErrorViewHandling {
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 4) {
-                if !viewModel.devices.isEmpty || !viewModel.pinnedSimulators.isEmpty {
-                    Text("Devices")
-                        .font(.headline)
-                        .fontWeight(.medium)
-                        .padding(.leading, 4)
-                }
-
-                VStack(spacing: 0) {
-                    if !viewModel.devices.isEmpty {
-                        ForEach(viewModel.devices) { device in
-                            let selected = switch viewModel.selectedDevice {
-                            case let .device(selectedDevice):
-                                selectedDevice.id == device.id
-                            case .simulator, .none:
-                                false
-                            }
-
-                            return PhysicalDeviceRow(
-                                device: device,
-                                selected: selected,
-                                onSelected: viewModel.selectPhysicalDevice
-                            )
-                        }
-                    }
-
-                    if !viewModel.pinnedSimulators.isEmpty {
-                        simulators(viewModel.pinnedSimulators)
-                    }
-                }
-
-                if !viewModel.devices.isEmpty || !viewModel.pinnedSimulators.isEmpty {
-                    Divider()
-                }
+                pinnedDevicesSection()
 
                 HStack {
                     Text("Other devices")
@@ -94,9 +64,96 @@ struct DevicesView: View, ErrorViewHandling {
                     }
                 }
             }
-            .padding([.leading, .trailing], 8)
         }
         .frame(height: isExpanded ? NSScreen.main.map { $0.visibleFrame.size.height - 300 } ?? 500 : nil)
+    }
+
+    @ViewBuilder
+    private func pinnedDevicesSection() -> some View {
+        if !viewModel.devices.isEmpty || !viewModel.pinnedSimulators.isEmpty {
+            HStack {
+                Text("Devices")
+                    .font(.headline)
+                    .fontWeight(.medium)
+                    .padding(.leading, 4)
+
+                Spacer()
+
+                Button {
+                    withAnimation(.linear(duration: 0.8)) {
+                        isRefreshing = true
+                        Task {
+                            try await viewModel.onAppear()
+                            await MainActor.run {
+                                isRefreshing = false
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                        .rotationEffect(isRefreshing ? .degrees(360) : .zero)
+                }
+                .buttonStyle(.borderless)
+                .disabled(isRefreshing)
+            }
+
+            Divider()
+
+            let (connectedDevices, disconnectedDevices) = viewModel.devices
+                .reduce(
+                    into: (connected: [PhysicalDevice](), disconnected: [PhysicalDevice]())
+                ) { partialResult, device in
+                    switch device.connectionState {
+                    case .connected:
+                        partialResult.connected.append(device)
+                    case .disconnected:
+                        partialResult.disconnected.append(device)
+                    }
+                }
+
+            VStack(alignment: .leading, spacing: 0) {
+                deviceList("Connected", devices: connectedDevices)
+                deviceList("Disconnected", devices: disconnectedDevices)
+
+                if !viewModel.pinnedSimulators.isEmpty {
+                    Text("Simulators")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .padding(4)
+
+                    simulators(viewModel.pinnedSimulators)
+                }
+            }
+
+            Divider()
+        }
+    }
+
+    @ViewBuilder
+    private func deviceList(_ titleKey: LocalizedStringKey, devices: [PhysicalDevice]) -> some View {
+        if !devices.isEmpty {
+            Text(titleKey)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .padding(4)
+
+            ForEach(devices) { device in
+                let selected = switch viewModel.selectedDevice {
+                case let .device(selectedDevice):
+                    selectedDevice.id == device.id
+                case .simulator, .none:
+                    false
+                }
+
+                PhysicalDeviceRow(
+                    device: device,
+                    selected: selected,
+                    onSelected: viewModel.selectPhysicalDevice
+                )
+            }
+        }
     }
 
     private func simulators(_ simulators: [SimulatorDeviceAndRuntime]) -> some View {

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -123,7 +123,7 @@ final class DevicesViewModel: Sendable {
     }
 
     func onAppear() async throws {
-        devices = try await deviceController.findAvailableDevices()
+        devices = try await deviceController.findAvailableDevices().filter(\.isReachable)
 
         let simulators = try await simulatorController.devicesAndRuntimes()
             .sorted()

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -123,7 +123,7 @@ final class DevicesViewModel: Sendable {
     }
 
     func onAppear() async throws {
-        devices = try await deviceController.findAvailableDevices().filter(\.isReachable)
+        devices = try await deviceController.findAvailableDevices()
 
         let simulators = try await simulatorController.devicesAndRuntimes()
             .sorted()

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -146,14 +146,8 @@ final class DevicesViewModel: Sendable {
     func refreshDevices() async throws {
         isRefreshing = true
 
-        do {
-            try await onAppear()
-        } catch {
-            isRefreshing = false
-            throw error
-        }
-
-        isRefreshing = false
+       defer { isRefreshing = false }
+       try await onAppear()
     }
 
     func onAppear() async throws {

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -66,12 +66,15 @@ enum SelectedDevice: Codable, Equatable {
 
 @Observable
 final class DevicesViewModel: Sendable {
-    private(set) var devices: [PhysicalDevice] = [] {
-        didSet { categorizeDevices() }
+    private(set) var devices: [PhysicalDevice] = []
+
+    var connectedDevices: [PhysicalDevice] {
+        devices.filter { $0.connectionState == .connected }
     }
 
-    private(set) var connectedDevices: [PhysicalDevice] = []
-    private(set) var disconnectedDevices: [PhysicalDevice] = []
+    var disconnectedDevices: [PhysicalDevice] {
+        devices.filter { $0.connectionState == .disconnected }
+    }
 
     private(set) var pinnedSimulators: [SimulatorDeviceAndRuntime] = []
     private(set) var unpinnedSimulators: [SimulatorDeviceAndRuntime] = []
@@ -241,20 +244,6 @@ final class DevicesViewModel: Sendable {
             try await deviceController.installApp(at: app.path, device: device)
             try await deviceController.launchApp(bundleId: app.infoPlist.bundleId, device: device)
         }
-    }
-
-    private func categorizeDevices() {
-        (connectedDevices, disconnectedDevices) = devices
-            .reduce(
-                into: (connected: [PhysicalDevice](), disconnected: [PhysicalDevice]())
-            ) { partialResult, device in
-                switch device.connectionState {
-                case .connected:
-                    partialResult.connected.append(device)
-                case .disconnected:
-                    partialResult.disconnected.append(device)
-                }
-            }
     }
 }
 

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -12,7 +12,7 @@ enum SimulatorsViewModelError: FatalError, Equatable {
     case invalidDeeplink(String)
     case invalidDownloadURL(String)
     case appDownloadFailed(String)
-    case appNotFound(SelectedDevice, [Platform])
+    case appNotFound(Device, [Platform])
 
     var description: String {
         switch self {
@@ -22,10 +22,10 @@ enum SimulatorsViewModelError: FatalError, Equatable {
             return "The preview download url \(url) is invalid."
         case let .appDownloadFailed(url):
             return "The app at \(url) was not found."
-        case let .appNotFound(selectedDevice, platforms):
+        case let .appNotFound(device, platforms):
             let name: String
             let platform: String
-            switch selectedDevice {
+            switch device {
             case let .simulator(simulator):
                 name = simulator.device.name
                 platform = simulator.runtime.platform?.caseValue ?? simulator.runtime.name
@@ -55,24 +55,18 @@ struct PinnedSimulatorsKey: AppStorageKey {
 }
 
 struct SelectedDeviceKey: AppStorageKey {
-    static let key = "selectedSimulator"
-    static let defaultValue: ReducedDevice? = nil
+    static let key = "selectedDevice"
+    static let defaultValue: SelectedDevice? = nil
 }
 
-enum SelectedDevice: Codable, Equatable {
+enum Device: Codable, Equatable {
     case simulator(SimulatorDeviceAndRuntime)
     case device(PhysicalDevice)
 }
 
-enum ReducedDevice: Codable, Equatable {
+enum SelectedDevice: Codable, Equatable {
     case simulator(id: String)
     case device(id: String)
-
-    var id: String {
-        switch self {
-        case let .simulator(id), let .device(id): id
-        }
-    }
 }
 
 @Observable
@@ -87,9 +81,16 @@ final class DevicesViewModel: Sendable {
         devices.filter { $0.connectionState == .disconnected }
     }
 
+    private(set) var simulators: [SimulatorDeviceAndRuntime] = []
     private(set) var pinnedSimulators: [SimulatorDeviceAndRuntime] = []
-    private(set) var unpinnedSimulators: [SimulatorDeviceAndRuntime] = []
-    private(set) var selectedDevice: SelectedDevice?
+    var unpinnedSimulators: [SimulatorDeviceAndRuntime] {
+        Set(simulators)
+            .subtracting(Set(pinnedSimulators))
+            .map { $0 }
+            .sorted()
+    }
+
+    private(set) var selectedDevice: Device?
 
     private(set) var isRefreshing: Bool = false
 
@@ -135,48 +136,25 @@ final class DevicesViewModel: Sendable {
     func simulatorPinned(_ simulator: SimulatorDeviceAndRuntime, pinned: Bool) {
         if pinned {
             pinnedSimulators = (pinnedSimulators + [simulator]).sorted()
-            unpinnedSimulators = unpinnedSimulators.filter { $0.device.udid != simulator.device.udid }
         } else {
-            pinnedSimulators = pinnedSimulators.filter { $0.device.udid != simulator.device.udid }
-            unpinnedSimulators = (unpinnedSimulators + [simulator]).sorted()
+            pinnedSimulators = pinnedSimulators.filter { $0.id != simulator.id }
         }
         try? appStorage.set(PinnedSimulatorsKey.self, value: pinnedSimulators)
     }
 
     func refreshDevices() async throws {
         isRefreshing = true
-
-       defer { isRefreshing = false }
-       try await onAppear()
+        defer { isRefreshing = false }
+        try await onAppear()
     }
 
     func onAppear() async throws {
         devices = try await deviceController.findAvailableDevices()
-
-        let simulators = try await simulatorController.devicesAndRuntimes()
-            .sorted()
+        simulators = try await simulatorController.devicesAndRuntimes().sorted()
 
         pinnedSimulators = try appStorage.get(PinnedSimulatorsKey.self)
 
-        unpinnedSimulators = Set(simulators)
-            .subtracting(Set(pinnedSimulators))
-            .map { $0 }
-            .sorted()
-
-        func getSelectedDevice(reduced device: ReducedDevice) -> SelectedDevice? {
-            switch device {
-            case let .simulator(id):
-                simulators.first(where: { $0.id == id }).map { .simulator($0) }
-            case let .device(id):
-                devices.first(where: { $0.id == id }).map { .device($0) }
-            }
-        }
-
-        if let selectedDevice = (try? appStorage.get(SelectedDeviceKey.self)).map(getSelectedDevice(reduced:)) {
-            self.selectedDevice = selectedDevice
-        } else {
-            selectedDevice = simulators.first(where: { !$0.device.isShutdown }).map { .simulator($0) }
-        }
+        selectedDevice = storedSelectedDevice() ?? simulators.first(where: { !$0.device.isShutdown }).map { .simulator($0) }
     }
 
     func onChangeOfURL(_ url: URL?) async throws {
@@ -257,6 +235,16 @@ final class DevicesViewModel: Sendable {
         case let .device(device):
             try await deviceController.installApp(at: app.path, device: device)
             try await deviceController.launchApp(bundleId: app.infoPlist.bundleId, device: device)
+        }
+    }
+
+    private func storedSelectedDevice() -> Device? {
+        guard let selectedDevice = try? appStorage.get(SelectedDeviceKey.self) else { return nil }
+        switch selectedDevice {
+        case let .simulator(id):
+            return simulators.first(where: { $0.id == id }).map { .simulator($0) }
+        case let .device(id):
+            return devices.first(where: { $0.id == id }).map { .device($0) }
         }
     }
 }

--- a/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
+++ b/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
@@ -20,32 +20,20 @@ struct MenuBarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Tuist")
-                .font(.title3)
-                .bold()
-                .background(Color.clear)
-                .padding([.leading, .trailing], 8)
-
-            Divider()
-                .padding([.leading, .trailing], 8)
-
             simulatorsView
 
             Divider()
-                .padding([.leading, .trailing], 8)
 
             Button("Check for updates", action: viewModel.checkForUpdates)
                 .disabled(!viewModel.canCheckForUpdates)
                 .menuItemStyle()
-                .padding([.leading, .trailing], 8)
 
             Button("Quit Tuist") {
                 NSApplication.shared.terminate(nil)
             }
             .menuItemStyle()
-            .padding([.leading, .trailing], 8)
         }
-        .padding([.top, .bottom], 8)
+        .padding(8)
         .environmentObject(errorHandling)
     }
 }

--- a/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
+++ b/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
@@ -49,11 +49,16 @@ struct PhysicalDeviceRow: View {
             }
             Spacer()
 
-            if device.transportType == .wifi {
-                Image(systemName: "network")
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
+            Group {
+                switch device.transportType {
+                case .wifi:
+                    Image(systemName: "network")
+                case .usb, .unknown:
+                    EmptyView()
+                }
             }
+            .font(.title3)
+            .foregroundStyle(.secondary)
         }
         .menuItemStyle()
         .onTapGesture {

--- a/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
+++ b/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
@@ -45,7 +45,7 @@ struct PhysicalDeviceRow: View {
             VStack(alignment: .leading) {
                 Text(device.name)
                     .font(.title3)
-                Text(device.osVersion)
+                device.osVersion.map { Text($0) }
             }
             Spacer()
         }

--- a/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
+++ b/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
@@ -53,7 +53,7 @@ struct PhysicalDeviceRow: View {
                 switch device.transportType {
                 case .wifi:
                     Image(systemName: "network")
-                case .usb, .unknown:
+                case .usb, .none:
                     EmptyView()
                 }
             }

--- a/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
+++ b/app/TuistApp/Sources/Views/PhysicalDeviceRow/PhysicalDeviceRow.swift
@@ -48,6 +48,12 @@ struct PhysicalDeviceRow: View {
                 device.osVersion.map { Text($0) }
             }
             Spacer()
+
+            if device.transportType == .wifi {
+                Image(systemName: "network")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
         }
         .menuItemStyle()
         .onTapGesture {

--- a/app/TuistApp/Tests/DevicesViewModelTests.swift
+++ b/app/TuistApp/Tests/DevicesViewModelTests.swift
@@ -110,7 +110,6 @@ final class DevicesViewModelTests: TuistUnitTestCase {
         Matcher.register(SimulatorDeviceAndRuntime?.self)
         Matcher.register([SimulatorDeviceAndRuntime].self)
         Matcher.register(SelectedDevice?.self)
-        Matcher.register(ReducedDevice?.self)
     }
 
     override func tearDown() {

--- a/app/TuistApp/Tests/DevicesViewModelTests.swift
+++ b/app/TuistApp/Tests/DevicesViewModelTests.swift
@@ -75,7 +75,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
 
         given(appStorage)
             .get(.any as Parameter<SelectedDeviceKey.Type>)
-            .willReturn(.simulator(iPhone15))
+            .willReturn(.simulator(id: iPhone15.id))
 
         given(appStorage)
             .set(.any as Parameter<SelectedDeviceKey.Type>, value: .any)
@@ -110,6 +110,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
         Matcher.register(SimulatorDeviceAndRuntime?.self)
         Matcher.register([SimulatorDeviceAndRuntime].self)
         Matcher.register(SelectedDevice?.self)
+        Matcher.register(ReducedDevice?.self)
     }
 
     override func tearDown() {
@@ -220,7 +221,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
 
         given(appStorage)
             .get(.any as Parameter<SelectedDeviceKey.Type>)
-            .willReturn(.simulator(appleTV))
+            .willReturn(.simulator(id: appleTV.id))
 
         // When
         try await subject.onAppear()
@@ -258,7 +259,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
 
         let watchS9 = PhysicalDevice.test(
             name: "Watch S9",
-            transportType: .unknown,
+            transportType: nil,
             connectionState: .disconnected
         )
 
@@ -286,7 +287,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
         verify(appStorage)
             .set(
                 .any as Parameter<SelectedDeviceKey.Type>,
-                value: .value(.simulator(iPhone15Pro))
+                value: .value(.simulator(id: iPhone15Pro.id))
             )
             .called(1)
     }
@@ -311,7 +312,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
         verify(appStorage)
             .set(
                 .any as Parameter<SelectedDeviceKey.Type>,
-                value: .value(.device(myiPhone))
+                value: .value(.device(id: myiPhone.id))
             )
             .called(1)
     }

--- a/app/TuistApp/Tests/DevicesViewModelTests.swift
+++ b/app/TuistApp/Tests/DevicesViewModelTests.swift
@@ -235,7 +235,6 @@ final class DevicesViewModelTests: TuistUnitTestCase {
         // Given
         appStorage.reset()
         deviceController.reset()
-        simulatorController.reset()
 
         given(appStorage)
             .get(.any as Parameter<PinnedSimulatorsKey.Type>)
@@ -245,23 +244,19 @@ final class DevicesViewModelTests: TuistUnitTestCase {
             .get(.any as Parameter<SelectedDeviceKey.Type>)
             .willReturn(nil)
 
-        given(simulatorController)
-            .devicesAndRuntimes()
-            .willReturn([])
-
-        var iPhone11 = PhysicalDevice.test(
+        let iPhone11 = PhysicalDevice.test(
             name: "iPhone 11",
-            transportType: .wifi,
-            connectionState: .disconnected
+            transportType: .usb,
+            connectionState: .connected
         )
 
-        var iPhone12 = PhysicalDevice.test(
+        let iPhone12 = PhysicalDevice.test(
             name: "iPhone 12",
             transportType: .wifi,
             connectionState: .connected
         )
 
-        var watchS9 = PhysicalDevice.test(
+        let watchS9 = PhysicalDevice.test(
             name: "Watch S9",
             transportType: .unknown,
             connectionState: .disconnected
@@ -272,44 +267,11 @@ final class DevicesViewModelTests: TuistUnitTestCase {
             .willReturn([iPhone11, iPhone12, watchS9])
 
         // When
-        try await subject.onAppear()
-
-        // Then
-        XCTAssertEqual(subject.connectedDevices, [iPhone12])
-        XCTAssertEqual(subject.disconnectedDevices, [iPhone11, watchS9])
-
-        // Given
-        deviceController.reset([.given])
-
-        iPhone11 = iPhone11.modified(
-            transportType: .usb,
-            connectionState: .connected
-        )
-
-        iPhone12 = iPhone12.modified(
-            transportType: .wifi,
-            connectionState: .disconnected
-        )
-
-        watchS9 = watchS9.modified(
-            transportType: .wifi,
-            connectionState: .connected
-        )
-
-        given(deviceController)
-            .findAvailableDevices()
-            .willReturn([iPhone11, iPhone12, watchS9])
-
-        given(appStorage)
-            .get(.any as Parameter<SelectedDeviceKey.Type>)
-            .willReturn(nil)
-
-        // When
         try await subject.refreshDevices()
 
         // Then
-        XCTAssertEqual(subject.connectedDevices, [iPhone11, watchS9])
-        XCTAssertEqual(subject.disconnectedDevices, [iPhone12])
+        XCTAssertEqual(subject.connectedDevices, [iPhone11, iPhone12])
+        XCTAssertEqual(subject.disconnectedDevices, [watchS9])
     }
 
     func test_selectSimulator() async throws {


### PR DESCRIPTION
### Short description 📝

The output of `xcrun devicectl list devices` may include devices with an empty `osVersionNumber` property, as shown below (possibly because the device is locked?):

```json
"deviceProperties" : {
  "ddiServicesAvailable" : false,
  "name" : "My Apple Watch"
}
```

This caused a `keyNotFound` error, presenting an alert with the message: "The data couldn’t be read because it is missing." when launching the Tuist app.

---

The menu bar doesn't recognize tap gestures when tapping on empty space.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
