### PR TITLE
Fix running framework previews with resources

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -231,9 +231,12 @@ public class GraphTraverser: GraphTraversing {
         let externalBundles = filterDependencies(
             from: .target(name: name, path: path),
             test: { dependency in
-                isDependencyResourceBundle(dependency: dependency) &&
-                    (isDependencyExternal(dependency) || dependency.isPrecompiled) &&
-                    canEmbedBundles(target: target)
+                guard isDependencyResourceBundle(dependency: dependency) else { return false }
+                // Precompiled bundles are embedded to any downstream target that supports resources to ensure Xcode previews work
+                // reliably.
+                // See this issue for more details: https://github.com/tuist/tuist/pull/6865
+                return (dependency.isPrecompiled && target.supportsResources) ||
+                    (isDependencyExternal(dependency) && canEmbedBundles(target: target))
             },
             skip: canDependencyEmbedBundles
         )

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -811,7 +811,12 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 .bundle(path: bundlePath),
             ]
         )
-        XCTAssertEqual(frameworkResults, [])
+        XCTAssertEqual(
+            frameworkResults,
+            [
+                .bundle(path: bundlePath),
+            ]
+        )
     }
 
     func test_target_from_dependency() {

--- a/fixtures/app_with_previews/App/Sources/App.swift
+++ b/fixtures/app_with_previews/App/Sources/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_previews/App/Sources/ContentView.swift
+++ b/fixtures/app_with_previews/App/Sources/ContentView.swift
@@ -1,0 +1,13 @@
+import PreviewsFramework
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/fixtures/app_with_previews/Project.swift
+++ b/fixtures/app_with_previews/Project.swift
@@ -1,8 +1,18 @@
 import ProjectDescription
 
 let project = Project(
-    name: "PreviewsFramework",
+    name: "AppWithPreviews",
     targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            sources: "App/Sources/**",
+            dependencies: [
+                .target(name: "PreviewsFramework"),
+            ]
+        ),
         .target(
             name: "PreviewsFramework",
             destinations: .iOS,

--- a/fixtures/app_with_previews/Tuist/Package.swift
+++ b/fixtures/app_with_previews/Tuist/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version: 5.9
 
-import PackageDescription
+@preconcurrency import PackageDescription
 
 let package = Package(
     name: "project_with_previews_crash",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6863

### Short description 📝

As reported in the attached [issue](https://github.com/tuist/tuist/issues/6863), running the Xcode preview in the `app_with_previews` doesn't work.

The fixture has the following graph:
```
App -> PreviewsFramework (dynamic framework) -> ResourcesFramework (static framework with resources)
```

The Xcode previews work when no binaries are used. When building the `PreviewsFramework` previews, the `DerivedData` has the following contents:
- `Debug-iphonesimulator`
	- `PreviewsFramework.framework`
	- `ResourcesFramework.bundle`
	- `ResourcesFramework.framework`

The bundle finder of `ResourcesFramework` looks at the parent directory from where the symbols end up being – in this case, the `Debug-iphonesimulator`.

However, when we turn `ResourcesFramework` into a binary, the `DerivedData` looks like this:
- `Debug-iphonesimulator`
	- `PreviewsFramework.framework`

The bundle is nowhere to be found (nor in the `PreviewsFramework.framework`). This is because in [this PR](https://github.com/tuist/tuist/pull/6565), we aligned with the SPM and embed external and precompiled bundles only into "runnable" products like `.app`. But when running Xcode previews, `PreviewsFramework` is technically a runnable product in the context of previews – but the bundle is embedded only into `.app`.

I thought of two solutions:
- Add a build phase to `PreviewsFramework` to copy the bundle to its parent directory. This way, the `ResourcesFramework.bundle` would end up in the `Debug-iphonesimulator`. And when building the `.app` product, we would copy it to the same location as where it ends up being when `.app` embeds the framework.
- Embed `ResourcesFramework.bundle` into `App` and `PreviewsFramework`

The latter feels like a more stable solution – it does lead to the bundle being duplicated and increasing the binary size. But the bundle would be embedded twice when it is precompiled – and this can only happen when using Tuist Cache that's not recommended for AppStore builds. For debug builds, the binary size shouldn't matter, so we think this is a good workaround for the time being.

### How to test the changes locally 🧐

- Run `tuist cache` in `app_with_previews` fixture
- Run `tuist generate`
- `Click to read file from bundle` in the `TestView` in the `PreviewsFramework`
- The preview should not crash

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
