### PR TITLE
Do not include CFBundleExecutable for bundle targets without sources

### DIFF
--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -130,17 +130,29 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
     }
 
     func bundleExecutable(_ target: Target) -> [String: Any] {
-        // Bundles on iOS, tvOS, and watchOS do not support sources so we exclude `CFBundleExecutable`
-        let shouldIncludeBundleExecutableKey = target
-            .product != .bundle || (target.product == .bundle && target.isExclusiveTo(.macOS))
-
-        if shouldIncludeBundleExecutableKey {
+        if shouldIncludeBundleExecutable(for: target) {
             return [
                 "CFBundleExecutable": "$(EXECUTABLE_NAME)",
             ]
         } else {
             return [:]
         }
+    }
+
+    private func shouldIncludeBundleExecutable(for target: Target) -> Bool {
+        // Bundles on iOS, tvOS, and watchOS do not support sources so we exclude `CFBundleExecutable`
+        if target.product != .bundle {
+            return true
+        }
+
+        if !target.isExclusiveTo(.macOS) {
+            return false
+        }
+
+        // For macOS, we should additionally check if there are sources in it
+        let hasSources = !target.sources.isEmpty
+
+        return hasSources
     }
 
     /// Returns the default Info.plist content that iOS apps should have.

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -134,7 +134,33 @@ final class InfoPlistContentProviderTests: XCTestCase {
         ])
     }
 
-    func test_content_whenMacosFramework() {
+    func test_content_whenMacosFrameworkWithSources() {
+        // Given
+        let target = Target.test(destinations: .macOS, product: .framework, sources: ["/Example.swift"])
+
+        // When
+        let got = subject.content(
+            project: .empty(),
+            target: target,
+            extendedWith: ["ExtraAttribute": "Value"]
+        )
+
+        // Then
+        assertEqual(got, [
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+            "CFBundleVersion": "1",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "ExtraAttribute": "Value",
+            "CFBundlePackageType": "FMWK",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleName": "$(PRODUCT_NAME)",
+        ])
+    }
+
+    func test_content_whenMacosFrameworkWithoutSources() {
         // Given
         let target = Target.test(destinations: .macOS, product: .framework)
 
@@ -155,6 +181,31 @@ final class InfoPlistContentProviderTests: XCTestCase {
             "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
             "ExtraAttribute": "Value",
             "CFBundlePackageType": "FMWK",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleName": "$(PRODUCT_NAME)",
+        ])
+    }
+
+    func test_content_whenMacosBundleWithoutSources() {
+        // Given
+        let target = Target.test(destinations: .macOS, product: .bundle)
+
+        // When
+        let got = subject.content(
+            project: .empty(),
+            target: target,
+            extendedWith: ["ExtraAttribute": "Value"]
+        )
+
+        // Then
+        assertEqual(got, [
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleVersion": "1",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "ExtraAttribute": "Value",
+            "CFBundlePackageType": "BNDL",
             "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
             "CFBundleName": "$(PRODUCT_NAME)",
         ])


### PR DESCRIPTION


### Short description 📝
By default, Resource bundle generated by the Tuist has non-empty `CFBundleExecutable` value in the `Info.plist`.

This leads to vailed validation when submitting to the App Store, since one of the validation phases is to check `CFBundleExecutable` location, and probably, verify it's signature.

```
[Application Loader Error Output]: [ContentDelivery.Uploader.600000dc0080] Asset validation failed (90261) Bad CFBundleExecutable. Cannot find executable file that matches the value of CFBundleExecutable in the nested bundle Features_XXX [Path_To_Bundle/Features_XXX.bundle] property list file. (ID: bad40b6f-c1d8-40af-8918-8fad1e176336)
```

- With this PR generated `Info.plist`s won't contain `CFBundleExectuable` if the target doesn't contain sources

This PR is, basically alternative approach for the #6812.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).
- Create a project with a static framework with Resources
- Make sure that generated XXX.bundle files does not contain `CFBundleExecutable` value in the .plist

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
