### PR TITLE
Fix failing mise install due to http_timeout value type mismatch

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,5 +14,5 @@ create-dmg = "https://github.com/tuist/asdf-create-dmg.git"
 
 [settings]
 jobs = 6
-http_timeout = 30
+http_timeout = "60"
 experimental = true


### PR DESCRIPTION
### Short description 📝

`mise` apparently assume the `http_timeout` value will be a string instead of a number: https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/670cf904267cad9e7da2ce8f#step:4:26:0

I wonder if we should pin the `mise` version that we install on the CI. We need mise for mise 😅 


### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
