### PR TITLE
Fix failing `mise install` because Mise introduced a breaking change

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -14,5 +14,5 @@ create-dmg = "https://github.com/tuist/asdf-create-dmg.git"
 
 [settings]
 jobs = 6
-http_timeout = "60"
+http_timeout = 60
 experimental = true


### PR DESCRIPTION
They introduced a breaking change in `mise` in a minor version that caused `mise install` to fail in this repository. This PR fixes it.