### PR TITLE
Deprecate enforceExplicitDependencies in favor of tuist inspect implicit-imports

### DIFF
--- a/Sources/ProjectDescription/ConfigGenerationOptions.swift
+++ b/Sources/ProjectDescription/ConfigGenerationOptions.swift
@@ -44,7 +44,31 @@ extension Config {
             disablePackageVersionLocking: Bool = false,
             clonedSourcePackagesDirPath: Path? = nil,
             staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all,
-            enforceExplicitDependencies: Bool = false,
+            defaultConfiguration: String? = nil,
+            optionalAuthentication: Bool = false
+        ) -> Self {
+            self.init(
+                resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
+                disablePackageVersionLocking: disablePackageVersionLocking,
+                clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+                staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
+                enforceExplicitDependencies: false,
+                defaultConfiguration: defaultConfiguration,
+                optionalAuthentication: optionalAuthentication
+            )
+        }
+
+        @available(
+            *,
+            deprecated,
+            message: "enforceExplicitDependencies is deprecated. Use the new tuist inspect implicit-imports instead."
+        )
+        public static func options(
+            resolveDependenciesWithSystemScm: Bool = false,
+            disablePackageVersionLocking: Bool = false,
+            clonedSourcePackagesDirPath: Path? = nil,
+            staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all,
+            enforceExplicitDependencies: Bool,
             defaultConfiguration: String? = nil,
             optionalAuthentication: Bool = false
         ) -> Self {

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -898,22 +898,6 @@ final class GenerateAcceptanceTestiOSAppWithWeaklyLinkedFramework: TuistAcceptan
     }
 }
 
-final class GenerateAcceptanceTestiOSAppWithImplicitDependencies: TuistAcceptanceTestCase {
-    func test_ios_app_with_implicit_dependencies() async throws {
-        try await setUpFixture(.iosAppWithImplicitDependencies)
-        try await run(GenerateCommand.self)
-        try await run(BuildCommand.self, "FrameworkC")
-        do {
-            try await run(BuildCommand.self, "App")
-            XCTFail("Building app should fail as FrameworkA has an implicit dependency on FrameworkB")
-        } catch let error as FatalError {
-            XCTAssertTrue(
-                error.description.contains("The 'xcodebuild' command exited with error code 65 and message")
-            )
-        }
-    }
-}
-
 final class GenerateAcceptanceTestSPMPackage: TuistAcceptanceTestCase {
     func test_spm_package() async throws {
         try await setUpFixture(.spmPackage)

--- a/fixtures/ios_app_with_implicit_dependencies/Tuist/Config.swift
+++ b/fixtures/ios_app_with_implicit_dependencies/Tuist/Config.swift
@@ -1,7 +1,3 @@
 import ProjectDescription
 
-let config = Config(
-    generationOptions: .options(
-        enforceExplicitDependencies: true
-    )
-)
+let config = Config()


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/6696

### Short description 📝

`main` is [failing](https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/670d0545267cad9e7da32f8b#step:8) due to `GenerateAcceptanceTestiOSAppWithImplicitDependencies.test_ios_app_with_implicit_dependencies()`. I'm not 100 % sure if it's flaky or if a merge of an outdated branch caused things to break, but we can remove that test regardless and deprecate the property as users should use the `tuist inspect implicit-imports` command instead. 

### How to test the changes locally 🧐

Use the `enforceExplicitDependencies` option and edit the project. You should see a deprecation warning:
![image](https://github.com/user-attachments/assets/a0813767-d682-4eaa-8f1b-3ac57248a9ce)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
