### PR TITLE
Use map instead of compactMap in ShareService

### DIFF
--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -269,8 +269,8 @@ struct ShareService {
         try await uploadPreviews(
             .appBundles(appPaths),
             displayName: appName,
-            version: appBundles.compactMap(\.infoPlist.version.description).first,
-            bundleIdentifier: appBundles.compactMap(\.infoPlist.bundleId).first,
+            version: appBundles.map(\.infoPlist.version.description).first,
+            bundleIdentifier: appBundles.map(\.infoPlist.bundleId).first,
             fullHandle: fullHandle,
             serverURL: serverURL
         )


### PR DESCRIPTION
### Short description 📝

A small refactor of moving from unnecessary `compactMap` to `map`. The `compactMap` seems to be causing issues when releasing `tuist/tuist` using Xcode 15.3.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
