### PR TITLE
Fix regression in StaticXCFrameworkModuleMapGraphMapper invalid FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -77,10 +77,10 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                 settings["FRAMEWORK_SEARCH_PATHS"] = .array(
                     staticObjcXCFrameworksWithoutLibrariesLinkedByDynamicXCFrameworkDependencies
                         .compactMap {
-                            if let libraryPath = $0.infoPlist.libraries
-                                .first(where: { target.supportedPlatforms.contains($0.platform.graphPlatform) })?.path
+                            if let library = $0.infoPlist.libraries
+                                .first(where: { target.supportedPlatforms.contains($0.platform.graphPlatform) })
                             {
-                                return "\"$(SRCROOT)/\($0.path.appending(libraryPath).parentDirectory.parentDirectory.relative(to: project.path).pathString)\""
+                                return "\"$(SRCROOT)/\($0.path.appending(component: library.identifier).relative(to: project.path).pathString)\""
                             } else {
                                 return nil
                             }

--- a/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -210,6 +210,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         infoPlist: .test(
                             libraries: [
                                 .test(
+                                    identifier: "ios-arm64",
                                     path: try RelativePath(validating: "GoogleMaps.framework/GoogleMaps")
                                 ),
                             ]
@@ -230,7 +231,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         settings: .test(
                             base: [
                                 "FRAMEWORK_SEARCH_PATHS": [
-                                    "\"$(SRCROOT)/../GoogleMaps.xcframework\"",
+                                    "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64\"",
                                 ],
                             ]
                         )


### PR DESCRIPTION
### Short description 📝

This PR https://github.com/tuist/tuist/pull/6414 caused a regression in integrating static xcframeworks linked via dynamic xcframeworks. The `FRAMEWORK_SEARCH_PATHS` would point to directly to the `.xcframework` – that's not correct. Instead, the `FRAMEWORK_SEARCH_PATHS` should point to an arbitrary `.framework` in the `.xcframework`. That is, instead of e.g. `$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework`, the path should be `$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework/ios-arm64` or `$(SRCROOT)/Tuist/.build/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework/ios-arm64_x86_64-simulator`. The exact framework does not matter as during the build, it's used only to find symbols, the right binary is included in the dynamic xcframework.

### How to test the changes locally 🧐

`tuist cache && tuist build App` in `ios_app_with_dynamic_frameworks_linking_static_frameworks` should succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
