### PR TITLE
Fix failing git operation when git repo has commits but no origin

### DIFF
--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -29,16 +29,16 @@ public final class CommandEventFactory {
         path: AbsolutePath,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> CommandEvent {
-        let gitCommitSHA: String?
-        let gitRemoteURLOrigin: String?
-        if gitController.isInGitRepository(workingDirectory: path),
-           gitController.hasCurrentBranchCommits(workingDirectory: path)
-        {
-            gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path)
-            gitRemoteURLOrigin = try gitController.urlOrigin(workingDirectory: path)
-        } else {
-            gitCommitSHA = nil
-            gitRemoteURLOrigin = nil
+        var gitCommitSHA: String?
+        var gitRemoteURLOrigin: String?
+        if gitController.isInGitRepository(workingDirectory: path) {
+            if gitController.hasCurrentBranchCommits(workingDirectory: path) {
+                gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path)
+            }
+
+            if try gitController.hasUrlOrigin(workingDirectory: path) {
+                gitRemoteURLOrigin = try gitController.urlOrigin(workingDirectory: path)
+            }
         }
         let commandEvent = CommandEvent(
             runId: info.runId,

--- a/Sources/TuistSupport/Utils/GitController.swift
+++ b/Sources/TuistSupport/Utils/GitController.swift
@@ -45,6 +45,9 @@ public protocol GitControlling {
     /// Return the git URL origin
     func urlOrigin(workingDirectory: AbsolutePath) throws -> String
 
+    /// - Returns: `true` if the `git` repository has a remote `origin`.
+    func hasUrlOrigin(workingDirectory: AbsolutePath) throws -> Bool
+
     /// - Returns: A git ref based on the CI environment value. Returns `nil` in non-CI environments.
     func ref(environment: [String: String]) -> String?
 
@@ -93,6 +96,12 @@ public final class GitController: GitControlling {
     public func currentCommitSHA(workingDirectory: AbsolutePath) throws -> String {
         try capture(command: "git", "-C", workingDirectory.pathString, "rev-parse", "HEAD")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func hasUrlOrigin(workingDirectory: AbsolutePath) throws -> Bool {
+        try capture(command: "git", "-C", workingDirectory.pathString, "remote")
+            .components(separatedBy: .newlines)
+            .contains("origin")
     }
 
     public func urlOrigin(workingDirectory: AbsolutePath) throws -> String {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6736

### Short description 📝

We assume that if `git` repo has commits that it also has a url origin. That's not always true as highlighted [here](https://github.com/tuist/tuist/issues/6736#issuecomment-2411538798). We should only try to get the URL of `origin` when we know `origin` exists. We can use `git remote` and see if the output contains `origin`.

As a follow-up, we should not even try to save command events to disk if the Tuist server is not configured as flagged [here](https://github.com/tuist/tuist/issues/6876). 

### How to test the changes locally 🧐

Follow repro steps from [here](https://github.com/tuist/tuist/issues/6736#issuecomment-2411538798). With changes from this branch, running arbitrary Swift commands when there are no commits 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
