### PR TITLE
Skip storing analytics events to disk when the project is not connected to the server

### DIFF
--- a/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -49,7 +49,9 @@ public class TrackableCommand: TrackableParametersDelegate {
         self.fileHandler = fileHandler
     }
 
-    public func run() async throws {
+    public func run(
+        analyticsEnabled: Bool
+    ) async throws {
         let runId: String
         let timer = clock.startTimer()
         if let command = command as? HasTrackableParameters & ParsableCommand {
@@ -72,9 +74,23 @@ public class TrackableCommand: TrackableParametersDelegate {
             } else {
                 try command.run()
             }
-            try dispatchCommandEvent(timer: timer, status: .success, runId: runId, path: path)
+            if analyticsEnabled {
+                try dispatchCommandEvent(
+                    timer: timer,
+                    status: .success,
+                    runId: runId,
+                    path: path
+                )
+            }
         } catch {
-            try dispatchCommandEvent(timer: timer, status: .failure("\(error)"), runId: runId, path: path)
+            if analyticsEnabled {
+                try dispatchCommandEvent(
+                    timer: timer,
+                    status: .failure("\(error)"),
+                    runId: runId,
+                    path: path
+                )
+            }
             throw error
         }
     }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -75,6 +75,7 @@ public struct TuistCommand: AsyncParsableCommand {
 
         let config = try await ConfigLoader().loadConfig(path: path)
         let url = try ServerURLService().url(configServerURL: config.url)
+        let analyticsEnabled: Bool
         if let fullHandle = config.fullHandle {
             let backend = TuistAnalyticsServerBackend(
                 fullHandle: fullHandle,
@@ -82,6 +83,9 @@ public struct TuistCommand: AsyncParsableCommand {
             )
             let dispatcher = TuistAnalyticsDispatcher(backend: backend)
             try TuistAnalytics.bootstrap(dispatcher: dispatcher)
+            analyticsEnabled = true
+        } else {
+            analyticsEnabled = false
         }
 
         try await CacheDirectoriesProvider.bootstrap()
@@ -103,7 +107,9 @@ public struct TuistCommand: AsyncParsableCommand {
                     command: command,
                     commandArguments: processedArguments
                 )
-                try await trackableCommand.run()
+                try await trackableCommand.run(
+                    analyticsEnabled: analyticsEnabled
+                )
             }
         } catch {
             parsedError = error

--- a/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -61,7 +61,7 @@ final class TrackableCommandTests: TuistTestCase {
         let expectedParams: [String: AnyCodable] = ["flag": true]
 
         // When
-        try await subject.run()
+        try await subject.run(analyticsEnabled: true)
 
         // Then
         XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)
@@ -75,7 +75,7 @@ final class TrackableCommandTests: TuistTestCase {
         makeSubject(flag: false)
         let expectedParams: [String: AnyCodable] = ["flag": false]
         // When
-        try await subject.run()
+        try await subject.run(analyticsEnabled: true)
 
         // Then
         XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)
@@ -88,7 +88,7 @@ final class TrackableCommandTests: TuistTestCase {
         // Given
         makeSubject(flag: false, shouldFail: true)
         // When
-        await XCTAssertThrowsSpecific(try await subject.run(), TestCommand.TestError.commandFailed)
+        await XCTAssertThrowsSpecific(try await subject.run(analyticsEnabled: true), TestCommand.TestError.commandFailed)
 
         // Then
         XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)
@@ -102,7 +102,7 @@ final class TrackableCommandTests: TuistTestCase {
         makeSubject(commandArguments: ["cache", "warm", "--path", "/my-path"])
 
         // When
-        try await subject.run()
+        try await subject.run(analyticsEnabled: true)
 
         // Then
         XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)
@@ -111,12 +111,26 @@ final class TrackableCommandTests: TuistTestCase {
             .called(1)
     }
 
+    func test_whenPathIsInArguments_and_analytics_are_disabled() async throws {
+        // Given
+        makeSubject(commandArguments: ["cache", "warm", "--path", "/my-path"])
+
+        // When
+        try await subject.run(analyticsEnabled: false)
+
+        // Then
+        XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 0)
+        verify(gitController)
+            .isInGitRepository(workingDirectory: .value(try AbsolutePath(validating: "/my-path")))
+            .called(0)
+    }
+
     func test_whenPathIsNotInArguments() async throws {
         // Given
         makeSubject(commandArguments: ["cache", "warm"])
 
         // When
-        try await subject.run()
+        try await subject.run(analyticsEnabled: true)
 
         // Then
         XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6876

### Short description 📝

As described in the issue, we are indefinitely storing the analytics events on disk when the project is not connected to the server. This PR remedies that by completely skipping dispatching command events when the project is not connected.

### How to test the changes locally 🧐

- Clean `~/.tuist/Queue`
- Run `tuist generate` in a project that's not connected to the Tuist server
- Ensure no event was added to the queue

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
