### PR TITLE
Fix documentation build link

### DIFF
--- a/docs/.vitepress/sidebars.mjs
+++ b/docs/.vitepress/sidebars.mjs
@@ -280,7 +280,7 @@ export function guidesSidebar(locale) {
         },
         {
           text: `<span style="display: flex; flex-direction: row; align-items: center; gap: 7px;">Build ${dataIcon()}</span>`,
-          link: "/guides/develop/build",
+          link: `/${locale}/guides/develop/build`,
           collapsed: true,
           items: [
             {


### PR DESCRIPTION
### Short description 📝
A user reported that the `Build` link was broken. It turns out that the link is missing the locale prefix.