### PR TITLE
chore: update Mockable to 0.0.11

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "86e4400b0c992290ab17b8e8fb4b78a3493a4114ae8e3d7ac6269abc4bee10b5",
+  "originHash" : "8e54877419979362becf54ca7927d92369c57adeca98e768c821cfcb627acdad",
   "pins" : [
     {
       "identity" : "aexml",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "da977ecb20974c4b1cf185f5fd38771b2d4674fb",
-        "version" : "0.0.10"
+        "revision" : "a9e5e1d222035567069ed6fff8429c327229b5f6",
+        "version" : "0.0.11"
       }
     },
     {
@@ -206,6 +206,15 @@
       "state" : {
         "revision" : "f8d3495325bfd1a53f37ece5a244f28d1d857879",
         "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-issue-reporting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "state" : {
+        "revision" : "770f990d3e4eececb57ac04a6076e22f8c97daeb",
+        "version" : "1.4.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let targets: [Target] = [
             "Mockable",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -80,7 +80,7 @@ let targets: [Target] = [
             .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .executableTarget(
@@ -111,7 +111,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -151,7 +151,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -175,7 +175,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -192,7 +192,7 @@ let targets: [Target] = [
             "Command",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -207,7 +207,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -221,7 +221,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -237,7 +237,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -252,7 +252,7 @@ let targets: [Target] = [
             "ProjectDescription",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -278,7 +278,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -293,7 +293,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -309,7 +309,7 @@ let targets: [Target] = [
         ],
         exclude: ["OpenAPI/server.yml"],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -322,7 +322,7 @@ let targets: [Target] = [
             "XcodeGraph",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
     .target(
@@ -336,7 +336,7 @@ let targets: [Target] = [
             "TuistHasher",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug)),
+            .define("MOCKING", .when(configuration: .debug))
         ]
     ),
 ]
@@ -353,7 +353,6 @@ let targets: [Target] = [
             "TSCLibc": .staticFramework,
             "ArgumentParser": .staticFramework,
             "Mockable": .staticFramework,
-            "MockableTest": .staticFramework,
         ],
         baseSettings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES"])
     )
@@ -468,7 +467,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj", exact: "8.19.0"),
         .package(url: "https://github.com/cpisciotta/xcbeautify", .upToNextMajor(from: "2.5.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
-        .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.10"),
+        .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.11"),
         .package(
             url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let targets: [Target] = [
             "Mockable",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -80,7 +80,7 @@ let targets: [Target] = [
             .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .executableTarget(
@@ -111,7 +111,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -151,7 +151,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -175,7 +175,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -192,7 +192,7 @@ let targets: [Target] = [
             "Command",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -207,7 +207,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -221,7 +221,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -237,7 +237,7 @@ let targets: [Target] = [
             "FileSystem",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -252,7 +252,7 @@ let targets: [Target] = [
             "ProjectDescription",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -278,7 +278,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -293,7 +293,7 @@ let targets: [Target] = [
             pathDependency,
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -309,7 +309,7 @@ let targets: [Target] = [
         ],
         exclude: ["OpenAPI/server.yml"],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -322,7 +322,7 @@ let targets: [Target] = [
             "XcodeGraph",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
     .target(
@@ -336,7 +336,7 @@ let targets: [Target] = [
             "TuistHasher",
         ],
         swiftSettings: [
-            .define("MOCKING", .when(configuration: .debug))
+            .define("MOCKING", .when(configuration: .debug)),
         ]
     ),
 ]

--- a/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueuePersistorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
+++ b/Tests/TuistAsyncQueueTests/AsyncQueueTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Queuer
 import TuistCore
 import TuistSupport

--- a/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -1,6 +1,6 @@
 import Command
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistSupportTesting
 import XCTest

--- a/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistSupportTesting
 import XcodeGraph

--- a/Tests/TuistAutomationTests/Utilities/AppRunnerTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppRunnerTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import struct TSCUtility.Version
 import TuistCore
 import TuistSupport

--- a/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistAutomationTesting
 import TuistCore

--- a/Tests/TuistAutomationTests/Utilities/TargetRunnerTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/TargetRunnerTests.swift
@@ -1,5 +1,5 @@
 import FileSystem
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistAutomationTesting

--- a/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
+++ b/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import XCTest
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TSCBasic
 import struct TSCUtility.Version

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupportTesting

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceSettingsDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceSettingsDescriptorGeneratorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistCore

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import struct TSCUtility.Version
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistHasherTests/CachedContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CachedContentHasherTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/CoreDataModelsContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/DependenciesContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/DeploymentTargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/DeploymentTargetContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/HeadersContentHasherTests.swift
+++ b/Tests/TuistHasherTests/HeadersContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/PlatformConditionContentHasherTests.swift
+++ b/Tests/TuistHasherTests/PlatformConditionContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/PlistContentHasherTests.swift
+++ b/Tests/TuistHasherTests/PlistContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/ResourcesContentHasherTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/SettingsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/SettingsContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
+++ b/Tests/TuistHasherTests/SourceFilesContentHasherTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistSupport
 import XCTest

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
 import Foundation
-import MockableTest
+import Mockable
 import TuistAnalytics
 import TuistCore
 import TuistSupport

--- a/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -1,7 +1,7 @@
 import AnyCodable
 import ArgumentParser
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistAnalytics
 import TuistAsyncQueueTesting

--- a/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TSCUtility
 import TuistCore

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/AuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/AuthServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TSCUtility
 import TuistAutomation

--- a/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import Path
 import TuistCache
 import TuistCore

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistKitTests/Services/EditServiceTests.swift
+++ b/Tests/TuistKitTests/Services/EditServiceTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/GraphServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GraphServiceTests.swift
@@ -1,7 +1,7 @@
 import DOT
 import Foundation
 import GraphViz
-import MockableTest
+import Mockable
 import Path
 import ProjectAutomation
 import TuistCore

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -1,7 +1,6 @@
 import FileSystem
 import Foundation
 import Mockable
-import MockableTest
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TSCUtility
 import TuistCore

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/LogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/LogoutServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistKitTests/Services/Organization/OrganizationInviteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationInviteServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Organization/OrganizationRemoveSSOServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationRemoveSSOServiceTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Plugin/PluginArchiveServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Plugin/PluginArchiveServiceTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistLoader
 import TuistSupport

--- a/Tests/TuistKitTests/Services/Project/ProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectDeleteServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Services/Project/ProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectListServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistCore
 import TuistLoader
 import TuistServer

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensCreateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensCreateServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensListServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensRevokeServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensRevokeServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupportTesting

--- a/Tests/TuistKitTests/Services/Project/ProjectUpdateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectUpdateServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistLoader
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import struct TSCUtility.Version
 import TuistAutomation

--- a/Tests/TuistKitTests/Services/ScaffoldServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ScaffoldServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/SessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/SessionServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistAutomation
 import TuistCore
 import TuistLoader

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistAutomation
 import TuistCore

--- a/Tests/TuistKitTests/Services/TuistServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TuistServiceTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistLoader
 import TuistPlugin

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -1,6 +1,5 @@
 import FileSystem
 import Mockable
-import Mockable
 import TuistCore
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Mockable
-import MockableTest
+import Mockable
 import TuistCore
 import TuistServer
 import TuistSupport

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
@@ -1,5 +1,5 @@
 import FileSystem
-import MockableTest
+import Mockable
 import TuistAnalytics
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TuistCore

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TuistCore

--- a/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TSCUtility
 import TuistCore

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TuistCore

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import TuistCore
 import TuistSupport
 import TuistSupportTesting

--- a/Tests/TuistLoaderTests/Loaders/TemplateGitLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/TemplateGitLoaderTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TuistCore

--- a/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Workspace+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Workspace+ManifestMapperTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistCore
 import TuistLoader
 import TuistSupportTesting

--- a/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
+++ b/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistSupport

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TuistCore

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1,5 +1,5 @@
 import FileSystem
-import MockableTest
+import Mockable
 import Path
 import ProjectDescription
 import TSCUtility

--- a/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import TuistCoreTesting

--- a/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import Path
 import TuistCore
 import XCTest

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -1,4 +1,4 @@
-import MockableTest
+import Mockable
 import Path
 import struct ProjectDescription.Plugin
 import struct ProjectDescription.PluginLocation

--- a/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import OpenAPIRuntime
 import TuistSupport
 import TuistSupportTesting

--- a/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistCore
 import TuistSupport
 import TuistSupportTesting

--- a/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistSupport
 import TuistSupportTesting
 import XcodeGraph

--- a/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import MockableTest
 import Path
 import TuistSupport
 import XCTest

--- a/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
+++ b/Tests/TuistServerTests/Utilities/RetryProviderTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistSupportTesting
 import XCTest
 

--- a/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistSupport
 import TuistSupportTesting
 import XCTest

--- a/Tests/TuistServerTests/Utilities/XCResultControllerTests.swift
+++ b/Tests/TuistServerTests/Utilities/XCResultControllerTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import struct TSCUtility.Version
 import TuistSupportTesting
 import XCTest

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -37,12 +37,13 @@ public enum Module: String, CaseIterable {
         var targets: [Target] = []
 
         if let acceptanceTestsTargetName {
-            targets.append(target(
-                name: acceptanceTestsTargetName,
-                product: .unitTests,
-                dependencies: acceptanceTestDependencies,
-                isTestingTarget: false
-            ))
+            targets.append(
+                target(
+                    name: acceptanceTestsTargetName,
+                    product: .unitTests,
+                    dependencies: acceptanceTestDependencies,
+                    isTestingTarget: false
+                ))
         }
 
         return targets
@@ -106,7 +107,7 @@ public enum Module: String, CaseIterable {
                 product: product,
                 dependencies: dependencies + (isStaticProduct ? [.external(name: "Mockable")] : []),
                 isTestingTarget: isTestingTarget
-            ),
+            )
         ]
     }
 
@@ -128,8 +129,9 @@ public enum Module: String, CaseIterable {
 
     public var testingTargetName: String? {
         switch self {
-        case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .kit, .projectAutomation, .projectDescription, .analytics,
-             .dependencies, .acceptanceTesting, .server, .hasher, .cache, .scaffold:
+        case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .kit, .projectAutomation,
+            .projectDescription, .analytics,
+            .dependencies, .acceptanceTesting, .server, .hasher, .cache, .scaffold:
             return nil
         default:
             return "\(rawValue)Testing"
@@ -138,8 +140,9 @@ public enum Module: String, CaseIterable {
 
     public var unitTestsTargetName: String? {
         switch self {
-        case .analytics, .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation, .projectDescription,
-             .acceptanceTesting:
+        case .analytics, .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation,
+            .projectDescription,
+            .acceptanceTesting:
             return nil
         default:
             return "\(rawValue)Tests"
@@ -148,9 +151,10 @@ public enum Module: String, CaseIterable {
 
     public var integrationTestsTargetName: String? {
         switch self {
-        case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation, .projectDescription,
-             .asyncQueue,
-             .plugin, .analytics, .dependencies, .acceptanceTesting, .server, .hasher:
+        case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation,
+            .projectDescription,
+            .asyncQueue,
+            .plugin, .analytics, .dependencies, .acceptanceTesting, .server, .hasher:
             return nil
         default:
             return "\(rawValue)IntegrationTests"
@@ -173,41 +177,42 @@ public enum Module: String, CaseIterable {
     }
 
     public var acceptanceTestDependencies: [TargetDependency] {
-        let dependencies: [TargetDependency] = switch self {
-        case .generator:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.acceptanceTesting.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeProj"),
-            ]
-        case .automation:
-            [
-                .target(name: Module.acceptanceTesting.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.kit.targetName),
-                .target(name: Module.support.targetName),
-            ]
-        case .dependencies:
-            [
-                .target(name: Module.acceptanceTesting.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.support.targetName),
-                .external(name: "XcodeProj"),
-            ]
-        case .kit:
-            [
-                .target(name: Module.acceptanceTesting.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.kit.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.server.targetName),
-                .target(name: Module.core.targetName),
-                .external(name: "XcodeProj"),
-            ]
-        default:
-            []
-        }
+        let dependencies: [TargetDependency] =
+            switch self {
+            case .generator:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.acceptanceTesting.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeProj"),
+                ]
+            case .automation:
+                [
+                    .target(name: Module.acceptanceTesting.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.kit.targetName),
+                    .target(name: Module.support.targetName),
+                ]
+            case .dependencies:
+                [
+                    .target(name: Module.acceptanceTesting.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.support.targetName),
+                    .external(name: "XcodeProj"),
+                ]
+            case .kit:
+                [
+                    .target(name: Module.acceptanceTesting.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.kit.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.server.targetName),
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeProj"),
+                ]
+            default:
+                []
+            }
         return dependencies + sharedDependencies
     }
 
@@ -223,205 +228,206 @@ public enum Module: String, CaseIterable {
     }
 
     public var dependencies: [TargetDependency] {
-        var dependencies: [TargetDependency] = switch self {
-        case .acceptanceTesting:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.kit.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.targetName),
-                .external(name: "XcodeProj"),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-            ]
-        case .tuist:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.kit.targetName),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.automation.targetName),
-                .external(name: "GraphViz"),
-                .external(name: "ArgumentParser"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .tuistBenchmark:
-            [
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "ArgumentParser"),
-                .external(name: "FileSystem"),
-            ]
-        case .tuistFixtureGenerator:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "ArgumentParser"),
-            ]
-        case .projectAutomation, .projectDescription:
-            []
-        case .support:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "AnyCodable"),
-                .external(name: "XcodeProj"),
-                .external(name: "KeychainAccess"),
-                .external(name: "Logging"),
-                .external(name: "ZIPFoundation"),
-                .external(name: "Difference"),
-            ]
-        case .kit:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.hasher.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.generator.targetName),
-                .target(name: Module.automation.targetName),
-                .target(name: Module.server.targetName),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.projectAutomation.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.scaffold.targetName),
-                .target(name: Module.dependencies.targetName),
-                .target(name: Module.migration.targetName),
-                .target(name: Module.asyncQueue.targetName),
-                .target(name: Module.analytics.targetName),
-                .target(name: Module.plugin.targetName),
-                .target(name: Module.cache.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "XcodeGraph"),
-                .external(name: "ArgumentParser"),
-                .external(name: "GraphViz"),
-                .external(name: "AnyCodable"),
-                .external(name: "OpenAPIRuntime"),
-            ]
-        case .core:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "XcodeGraph"),
-                .external(name: "XcodeProj"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "AnyCodable"),
-                .external(name: "Command"),
-                .external(name: "FileSystem"),
-            ]
-        case .generator:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftGenKit"),
-                .external(name: "PathKit"),
-                .external(name: "StencilSwiftKit"),
-                .external(name: "XcodeProj"),
-                .external(name: "GraphViz"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "Stencil"),
-            ]
-        case .scaffold:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeGraph"),
-                .external(name: "PathKit"),
-                .external(name: "StencilSwiftKit"),
-            ]
-        case .loader:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.projectDescription.targetName),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeProj"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .asyncQueue:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeGraph"),
-                .external(name: "Queuer"),
-                .external(name: "XcodeProj"),
-            ]
-        case .plugin:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.scaffold.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .analytics:
-            [
-                .target(name: Module.asyncQueue.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "AnyCodable"),
-                .external(name: "XcodeGraph"),
-            ]
-        case .migration:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "PathKit"),
-                .external(name: "XcodeProj"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-            ]
-        case .dependencies:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "XcodeGraph"),
-            ]
-        case .automation:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "Command"),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeProj"),
-                .external(name: "XcbeautifyLib"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .server:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.cache.targetName),
-                .external(name: "FileSystem"),
-                .external(name: "OpenAPIRuntime"),
-                .external(name: "OpenAPIURLSession"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "XcodeGraph"),
-            ]
-        case .hasher:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .external(name: "XcodeGraph"),
-            ]
-        case .cache:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.hasher.targetName),
-                .external(name: "XcodeGraph"),
-            ]
-        }
+        var dependencies: [TargetDependency] =
+            switch self {
+            case .acceptanceTesting:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.kit.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeProj"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                ]
+            case .tuist:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.kit.targetName),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.automation.targetName),
+                    .external(name: "GraphViz"),
+                    .external(name: "ArgumentParser"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .tuistBenchmark:
+                [
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "ArgumentParser"),
+                    .external(name: "FileSystem"),
+                ]
+            case .tuistFixtureGenerator:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "ArgumentParser"),
+                ]
+            case .projectAutomation, .projectDescription:
+                []
+            case .support:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "AnyCodable"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "KeychainAccess"),
+                    .external(name: "Logging"),
+                    .external(name: "ZIPFoundation"),
+                    .external(name: "Difference"),
+                ]
+            case .kit:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.hasher.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.generator.targetName),
+                    .target(name: Module.automation.targetName),
+                    .target(name: Module.server.targetName),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.projectAutomation.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.scaffold.targetName),
+                    .target(name: Module.dependencies.targetName),
+                    .target(name: Module.migration.targetName),
+                    .target(name: Module.asyncQueue.targetName),
+                    .target(name: Module.analytics.targetName),
+                    .target(name: Module.plugin.targetName),
+                    .target(name: Module.cache.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "ArgumentParser"),
+                    .external(name: "GraphViz"),
+                    .external(name: "AnyCodable"),
+                    .external(name: "OpenAPIRuntime"),
+                ]
+            case .core:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "AnyCodable"),
+                    .external(name: "Command"),
+                    .external(name: "FileSystem"),
+                ]
+            case .generator:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftGenKit"),
+                    .external(name: "PathKit"),
+                    .external(name: "StencilSwiftKit"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "GraphViz"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "Stencil"),
+                ]
+            case .scaffold:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "PathKit"),
+                    .external(name: "StencilSwiftKit"),
+                ]
+            case .loader:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.projectDescription.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .asyncQueue:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "Queuer"),
+                    .external(name: "XcodeProj"),
+                ]
+            case .plugin:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.scaffold.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .analytics:
+                [
+                    .target(name: Module.asyncQueue.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "AnyCodable"),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .migration:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "PathKit"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                ]
+            case .dependencies:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .automation:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "Command"),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "XcbeautifyLib"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .server:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.cache.targetName),
+                    .external(name: "FileSystem"),
+                    .external(name: "OpenAPIRuntime"),
+                    .external(name: "OpenAPIURLSession"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .hasher:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .cache:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.hasher.targetName),
+                    .external(name: "XcodeGraph"),
+                ]
+            }
         if self != .projectDescription, self != .projectAutomation {
             dependencies.append(contentsOf: sharedDependencies)
         }
@@ -429,180 +435,180 @@ public enum Module: String, CaseIterable {
     }
 
     public var unitTestDependencies: [TargetDependency] {
-        var dependencies: [TargetDependency] = switch self {
-        case .tuist, .tuistBenchmark, .acceptanceTesting:
-            []
-        case .tuistFixtureGenerator:
-            [
-                .target(name: Module.projectDescription.targetName),
+        var dependencies: [TargetDependency] =
+            switch self {
+            case .tuist, .tuistBenchmark, .acceptanceTesting:
+                []
+            case .tuistFixtureGenerator:
+                [
+                    .target(name: Module.projectDescription.targetName)
+                ]
+            case .support:
+                [
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .projectDescription:
+                [
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.support.targetName),
+                ]
+            case .projectAutomation:
+                []
+            case .kit:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.automation.targetName),
+                    .target(name: Module.cache.targetName),
+                    .target(name: Module.server.targetName),
+                    .target(name: Module.scaffold.targetName),
+                    .target(name: Module.analytics.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.generator.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.projectAutomation.targetName),
+                    .target(name: Module.loader.testingTargetName!),
+                    .target(name: Module.generator.testingTargetName!),
+                    .target(name: Module.automation.testingTargetName!),
+                    .target(name: Module.migration.testingTargetName!),
+                    .target(name: Module.asyncQueue.testingTargetName!),
+                    .target(name: Module.plugin.targetName),
+                    .target(name: Module.plugin.testingTargetName!),
+                    .external(name: "ArgumentParser"),
+                    .external(name: "GraphViz"),
+                    .external(name: "AnyCodable"),
+                    .external(name: "Difference"),
+                    .external(name: "XcodeProj"),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .core:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                ]
+            case .generator:
+                [
+                    .external(name: "PathKit"),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeProj"),
+                    .external(name: "GraphViz"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .scaffold:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .external(name: "FileSystem"),
+                ]
+            case .loader:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "FileSystem"),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .asyncQueue:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .external(name: "Queuer"),
+                ]
+            case .plugin:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.scaffold.targetName),
+                    .target(name: Module.loader.testingTargetName!),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .analytics:
+                [
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                ]
+            case .migration:
+                [
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                ]
+            case .dependencies:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.loader.testingTargetName!),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .automation:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "Command"),
+                ]
+            case .server:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "OpenAPIRuntime"),
+                    .external(name: "FileSystem"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .hasher:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                ]
+            case .cache:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.hasher.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.support.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            }
+        dependencies =
+            dependencies + sharedDependencies + [
+                .target(name: targetName), .external(name: "Mockable"),
             ]
-        case .support:
-            [
-                .target(name: Module.core.targetName),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .projectDescription:
-            [
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.support.targetName),
-            ]
-        case .projectAutomation:
-            []
-        case .kit:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.automation.targetName),
-                .target(name: Module.cache.targetName),
-                .target(name: Module.server.targetName),
-                .target(name: Module.scaffold.targetName),
-                .target(name: Module.analytics.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.generator.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.projectAutomation.targetName),
-                .target(name: Module.loader.testingTargetName!),
-                .target(name: Module.generator.testingTargetName!),
-                .target(name: Module.automation.testingTargetName!),
-                .target(name: Module.migration.testingTargetName!),
-                .target(name: Module.asyncQueue.testingTargetName!),
-                .target(name: Module.plugin.targetName),
-                .target(name: Module.plugin.testingTargetName!),
-                .external(name: "ArgumentParser"),
-                .external(name: "GraphViz"),
-                .external(name: "AnyCodable"),
-                .external(name: "Difference"),
-                .external(name: "XcodeProj"),
-                .external(name: "FileSystem"),
-                .external(name: "Mockable"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .core:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-            ]
-        case .generator:
-            [
-                .external(name: "PathKit"),
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeProj"),
-                .external(name: "GraphViz"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .scaffold:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .external(name: "FileSystem"),
-            ]
-        case .loader:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "Mockable"),
-                .external(name: "FileSystem"),
-                .external(name: "XcodeGraph"),
-            ]
-        case .asyncQueue:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .external(name: "Queuer"),
-            ]
-        case .plugin:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.scaffold.targetName),
-                .target(name: Module.loader.testingTargetName!),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .analytics:
-            [
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-            ]
-        case .migration:
-            [
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-            ]
-        case .dependencies:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.loader.testingTargetName!),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeGraph"),
-            ]
-        case .automation:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "Command"),
-            ]
-        case .server:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.core.targetName),
-                .external(name: "Mockable"),
-                .external(name: "XcodeGraph"),
-                .external(name: "OpenAPIRuntime"),
-                .external(name: "FileSystem"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .hasher:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-            ]
-        case .cache:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.hasher.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.support.targetName),
-                .external(name: "Mockable"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        }
-        dependencies = dependencies + sharedDependencies + [.target(name: targetName), .external(name: "MockableTest")]
         if let testingTargetName {
             dependencies.append(.target(name: testingTargetName))
         }
@@ -610,164 +616,168 @@ public enum Module: String, CaseIterable {
     }
 
     public var testingDependencies: [TargetDependency] {
-        let dependencies: [TargetDependency] = switch self {
-        case .tuist, .projectAutomation, .projectDescription, .acceptanceTesting, .hasher, .analytics,
-             .migration, .tuistFixtureGenerator, .cache, .scaffold:
-            []
-        case .server:
-            [
-                .external(name: "FileSystem"),
-            ]
-        case .asyncQueue:
-            [
-                .target(name: Module.core.targetName),
-            ]
-        case .tuistBenchmark:
-            [
-                .external(name: "ArgumentParser"),
-            ]
-        case .support:
-            [
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.core.targetName),
-                .external(name: "XcodeGraph"),
-                .external(name: "Difference"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "FileSystem"),
-            ]
-        case .kit:
-            []
-        case .core:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.projectDescription.targetName),
-                .external(name: "XcodeGraph"),
-            ]
-        case .generator:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeProj"),
-                .external(name: "XcodeGraph"),
-            ]
-        case .loader:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.core.targetName),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeGraph"),
-            ]
-        case .plugin:
-            [
-                .target(name: Module.core.targetName),
-                .external(name: "XcodeGraph"),
-            ]
-        case .dependencies:
-            [
-                .target(name: Module.projectDescription.targetName),
-            ]
-        case .automation:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        }
+        let dependencies: [TargetDependency] =
+            switch self {
+            case .tuist, .projectAutomation, .projectDescription, .acceptanceTesting, .hasher,
+                .analytics,
+                .migration, .tuistFixtureGenerator, .cache, .scaffold:
+                []
+            case .server:
+                [
+                    .external(name: "FileSystem")
+                ]
+            case .asyncQueue:
+                [
+                    .target(name: Module.core.targetName)
+                ]
+            case .tuistBenchmark:
+                [
+                    .external(name: "ArgumentParser")
+                ]
+            case .support:
+                [
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "Difference"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "FileSystem"),
+                ]
+            case .kit:
+                []
+            case .core:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.projectDescription.targetName),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .generator:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeProj"),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .loader:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .plugin:
+                [
+                    .target(name: Module.core.targetName),
+                    .external(name: "XcodeGraph"),
+                ]
+            case .dependencies:
+                [
+                    .target(name: Module.projectDescription.targetName)
+                ]
+            case .automation:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            }
         return dependencies + sharedDependencies + [.target(name: targetName)]
     }
 
     public var integrationTestsDependencies: [TargetDependency] {
-        var dependencies: [TargetDependency] = switch self {
-        case .tuistBenchmark, .tuistFixtureGenerator, .support, .projectAutomation, .projectDescription, .acceptanceTesting,
-             .asyncQueue, .plugin, .analytics, .dependencies, .server, .hasher:
-            []
-        case .cache:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.hasher.targetName),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-            ]
-        case .tuist:
-            [
-                .target(name: Module.generator.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.support.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.loader.testingTargetName!),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "XcodeProj"),
-            ]
-        case .kit:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.loader.targetName),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.projectDescription.targetName),
-                .target(name: Module.automation.targetName),
-                .target(name: Module.loader.testingTargetName!),
-                .external(name: "XcodeProj"),
-                .external(name: "XcodeGraph"),
-                .external(name: "FileSystem"),
-            ]
-        case .core:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-            ]
-        case .generator:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.loader.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-                .target(name: Module.support.testingTargetName!),
-                .external(name: "XcodeProj"),
-                .external(name: "XcodeGraph"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "FileSystem"),
-            ]
-        case .scaffold:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-            ]
-        case .loader:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.projectDescription.targetName),
-                .external(name: "FileSystem"),
-            ]
-        case .migration:
-            [
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-                .target(name: Module.core.testingTargetName!),
-            ]
-        case .automation:
-            [
-                .target(name: Module.core.targetName),
-                .target(name: Module.support.targetName),
-                .target(name: Module.support.testingTargetName!),
-            ]
-        }
+        var dependencies: [TargetDependency] =
+            switch self {
+            case .tuistBenchmark, .tuistFixtureGenerator, .support, .projectAutomation,
+                .projectDescription, .acceptanceTesting,
+                .asyncQueue, .plugin, .analytics, .dependencies, .server, .hasher:
+                []
+            case .cache:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.hasher.targetName),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                ]
+            case .tuist:
+                [
+                    .target(name: Module.generator.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.loader.testingTargetName!),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "XcodeProj"),
+                ]
+            case .kit:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.loader.targetName),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.automation.targetName),
+                    .target(name: Module.loader.testingTargetName!),
+                    .external(name: "XcodeProj"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "FileSystem"),
+                ]
+            case .core:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                ]
+            case .generator:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.loader.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                    .target(name: Module.support.testingTargetName!),
+                    .external(name: "XcodeProj"),
+                    .external(name: "XcodeGraph"),
+                    .external(name: "SwiftToolsSupport"),
+                    .external(name: "FileSystem"),
+                ]
+            case .scaffold:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                ]
+            case .loader:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.projectDescription.targetName),
+                    .external(name: "FileSystem"),
+                ]
+            case .migration:
+                [
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                    .target(name: Module.core.testingTargetName!),
+                ]
+            case .automation:
+                [
+                    .target(name: Module.core.targetName),
+                    .target(name: Module.support.targetName),
+                    .target(name: Module.support.testingTargetName!),
+                ]
+            }
         dependencies.append(contentsOf: sharedDependencies)
         dependencies.append(.target(name: targetName))
-        dependencies.append(.external(name: "MockableTest"))
+        dependencies.append(.external(name: "Mockable"))
         if let testingTargetName {
             dependencies.append(contentsOf: [.target(name: testingTargetName)])
         }
@@ -787,7 +797,9 @@ public enum Module: String, CaseIterable {
         default:
             rootFolder = "Sources"
         }
-        var debugSettings: ProjectDescription.SettingsDictionary = ["SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"]
+        var debugSettings: ProjectDescription.SettingsDictionary = [
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
+        ]
         var releaseSettings: ProjectDescription.SettingsDictionary = [:]
         if isTestingTarget {
             debugSettings["ENABLE_TESTING_SEARCH_PATHS"] = "YES"
@@ -832,7 +844,7 @@ public enum Module: String, CaseIterable {
         case .tuist:
             return .settings(
                 base: [
-                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
+                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)"
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -43,7 +43,8 @@ public enum Module: String, CaseIterable {
                     product: .unitTests,
                     dependencies: acceptanceTestDependencies,
                     isTestingTarget: false
-                ))
+                )
+            )
         }
 
         return targets
@@ -107,7 +108,7 @@ public enum Module: String, CaseIterable {
                 product: product,
                 dependencies: dependencies + (isStaticProduct ? [.external(name: "Mockable")] : []),
                 isTestingTarget: isTestingTarget
-            )
+            ),
         ]
     }
 
@@ -130,8 +131,8 @@ public enum Module: String, CaseIterable {
     public var testingTargetName: String? {
         switch self {
         case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .kit, .projectAutomation,
-            .projectDescription, .analytics,
-            .dependencies, .acceptanceTesting, .server, .hasher, .cache, .scaffold:
+             .projectDescription, .analytics,
+             .dependencies, .acceptanceTesting, .server, .hasher, .cache, .scaffold:
             return nil
         default:
             return "\(rawValue)Testing"
@@ -141,8 +142,8 @@ public enum Module: String, CaseIterable {
     public var unitTestsTargetName: String? {
         switch self {
         case .analytics, .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation,
-            .projectDescription,
-            .acceptanceTesting:
+             .projectDescription,
+             .acceptanceTesting:
             return nil
         default:
             return "\(rawValue)Tests"
@@ -152,9 +153,9 @@ public enum Module: String, CaseIterable {
     public var integrationTestsTargetName: String? {
         switch self {
         case .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation,
-            .projectDescription,
-            .asyncQueue,
-            .plugin, .analytics, .dependencies, .acceptanceTesting, .server, .hasher:
+             .projectDescription,
+             .asyncQueue,
+             .plugin, .analytics, .dependencies, .acceptanceTesting, .server, .hasher:
             return nil
         default:
             return "\(rawValue)IntegrationTests"
@@ -441,7 +442,7 @@ public enum Module: String, CaseIterable {
                 []
             case .tuistFixtureGenerator:
                 [
-                    .target(name: Module.projectDescription.targetName)
+                    .target(name: Module.projectDescription.targetName),
                 ]
             case .support:
                 [
@@ -619,20 +620,20 @@ public enum Module: String, CaseIterable {
         let dependencies: [TargetDependency] =
             switch self {
             case .tuist, .projectAutomation, .projectDescription, .acceptanceTesting, .hasher,
-                .analytics,
-                .migration, .tuistFixtureGenerator, .cache, .scaffold:
+                 .analytics,
+                 .migration, .tuistFixtureGenerator, .cache, .scaffold:
                 []
             case .server:
                 [
-                    .external(name: "FileSystem")
+                    .external(name: "FileSystem"),
                 ]
             case .asyncQueue:
                 [
-                    .target(name: Module.core.targetName)
+                    .target(name: Module.core.targetName),
                 ]
             case .tuistBenchmark:
                 [
-                    .external(name: "ArgumentParser")
+                    .external(name: "ArgumentParser"),
                 ]
             case .support:
                 [
@@ -676,7 +677,7 @@ public enum Module: String, CaseIterable {
                 ]
             case .dependencies:
                 [
-                    .target(name: Module.projectDescription.targetName)
+                    .target(name: Module.projectDescription.targetName),
                 ]
             case .automation:
                 [
@@ -695,8 +696,8 @@ public enum Module: String, CaseIterable {
         var dependencies: [TargetDependency] =
             switch self {
             case .tuistBenchmark, .tuistFixtureGenerator, .support, .projectAutomation,
-                .projectDescription, .acceptanceTesting,
-                .asyncQueue, .plugin, .analytics, .dependencies, .server, .hasher:
+                 .projectDescription, .acceptanceTesting,
+                 .asyncQueue, .plugin, .analytics, .dependencies, .server, .hasher:
                 []
             case .cache:
                 [
@@ -798,7 +799,7 @@ public enum Module: String, CaseIterable {
             rootFolder = "Sources"
         }
         var debugSettings: ProjectDescription.SettingsDictionary = [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
         ]
         var releaseSettings: ProjectDescription.SettingsDictionary = [:]
         if isTestingTarget {
@@ -844,7 +845,7 @@ public enum Module: String, CaseIterable {
         case .tuist:
             return .settings(
                 base: [
-                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)"
+                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),

--- a/app/Package.resolved
+++ b/app/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "da977ecb20974c4b1cf185f5fd38771b2d4674fb",
-        "version" : "0.0.10"
+        "revision" : "a9e5e1d222035567069ed6fff8429c327229b5f6",
+        "version" : "0.0.11"
       }
     },
     {
@@ -218,6 +218,15 @@
       }
     },
     {
+      "identity" : "swift-issue-reporting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "state" : {
+        "revision" : "770f990d3e4eececb57ac04a6076e22f8c97daeb",
+        "version" : "1.4.2"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
@@ -303,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "12462c8fff97fc5efb8476ef4625f434acd5058f",
-        "version" : "0.12.1"
+        "revision" : "3a5d156ced35fce28d2994b8a21e73189e8b977e",
+        "version" : "0.14.1"
       }
     },
     {

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(path: "../"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.2.0")),
-        .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.0.9"),
+        .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.0.11"),
         .package(url: "https://github.com/tuist/XcodeGraph.git", from: "0.8.1"),
         .package(url: "https://github.com/tuist/Command.git", from: "0.8.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.4"),

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -17,7 +17,7 @@ let project = Project(
     name: "Tuist",
     settings: .settings(
         debug: [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
         ]
     ),
     targets: [
@@ -36,12 +36,13 @@ let project = Project(
                                 "CFBundleURLName": "io.tuist.app",
                                 "CFBundleURLSchemes": ["tuist"],
                             ]
-                        ),
+                        )
                     ],
                     "LSUIElement": true,
                     "LSApplicationCategoryType": "public.app-category.developer-tools",
                     "SUPublicEDKey": "ObyvL/hvYnFyAypkWwYaoeqE/iqB0LK6ioI3SA/Y1+k=",
-                    "SUFeedURL": "https://raw.githubusercontent.com/tuist/tuist/main/app/appcast.xml",
+                    "SUFeedURL":
+                        "https://raw.githubusercontent.com/tuist/tuist/main/app/appcast.xml",
                     "CFBundleShortVersionString": "0.3.0",
                     "CFBundleVersion": "0.3.0",
                 ]
@@ -74,7 +75,7 @@ let project = Project(
             dependencies: tuistAppDependencies() + [
                 .target(name: "Tuist"),
                 .external(name: "TuistSupportTesting"),
-                .external(name: "MockableTest"),
+                .external(name: "Mockable"),
             ]
         ),
     ]

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -17,7 +17,7 @@ let project = Project(
     name: "Tuist",
     settings: .settings(
         debug: [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
         ]
     ),
     targets: [
@@ -36,7 +36,7 @@ let project = Project(
                                 "CFBundleURLName": "io.tuist.app",
                                 "CFBundleURLSchemes": ["tuist"],
                             ]
-                        )
+                        ),
                     ],
                     "LSUIElement": true,
                     "LSApplicationCategoryType": "public.app-category.developer-tools",

--- a/app/TuistApp/Tests/DevicesViewModelTests.swift
+++ b/app/TuistApp/Tests/DevicesViewModelTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MockableTest
+import Mockable
 import TuistAutomation
 import TuistCore
 import TuistServer

--- a/app/TuistApp/Tests/SimulatorRowViewModelTests.swift
+++ b/app/TuistApp/Tests/SimulatorRowViewModelTests.swift
@@ -1,6 +1,6 @@
 import Command
 import Foundation
-import MockableTest
+import Mockable
 import TuistCore
 import TuistSupport
 import TuistSupportTesting


### PR DESCRIPTION
I'm updating Mockable to the version [0.0.11](https://github.com/Kolos65/Mockable/releases/tag/0.0.11) which removes the `MockableTest` target.