### PR TITLE
Respect overriding the TEST_HOST build setting

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -321,6 +321,16 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: SettingsDictionary = [:]
         settings["TEST_TARGET_NAME"] = .string("\(app.target.name)")
         if target.product == .unitTests {
+            if let defaultSettings = target.settings?.defaultSettings {
+                switch defaultSettings {
+                case let .essential(excludedKeys), let .recommended(excludedKeys):
+                    if excludedKeys.contains("TEST_HOST") {
+                        return [:]
+                    }
+                case .none:
+                    return [:]
+                }
+            }
             settings["TEST_HOST"] =
                 .string(
                     "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)"

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -223,10 +223,6 @@ final class ConfigGenerator: ConfigGenerating {
                 project: project
             )
         ) { $1 }
-        settings
-            .merge(testBundleTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) {
-                $1
-            }
         settings.merge(destinationsDerivedSettings(target: target)) { $1 }
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
         settings
@@ -298,45 +294,6 @@ final class ConfigGenerator: ConfigGenerating {
             settings["MERGED_BINARY_TYPE"] = .string("automatic")
         case .manual:
             settings["MERGED_BINARY_TYPE"] = .string("manual")
-        }
-
-        return settings
-    }
-
-    private func testBundleTargetDerivedSettings(
-        target: Target,
-        graphTraverser: GraphTraversing,
-        projectPath: AbsolutePath
-    ) -> SettingsDictionary {
-        guard target.product.testsBundle else {
-            return [:]
-        }
-
-        let targetDependencies = graphTraverser.directLocalTargetDependencies(path: projectPath, name: target.name).sorted()
-        let appDependency = targetDependencies.first { $0.target.product.canHostTests() }
-
-        guard let app = appDependency else {
-            return [:]
-        }
-
-        var settings: SettingsDictionary = [:]
-        settings["TEST_TARGET_NAME"] = .string("\(app.target.name)")
-        if target.product == .unitTests {
-            if let defaultSettings = target.settings?.defaultSettings {
-                switch defaultSettings {
-                case let .essential(excludedKeys), let .recommended(excludedKeys):
-                    if excludedKeys.contains("TEST_HOST") {
-                        return [:]
-                    }
-                case .none:
-                    return [:]
-                }
-            }
-            settings["TEST_HOST"] =
-                .string(
-                    "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)"
-                )
-            settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
         }
 
         return settings

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -166,7 +166,8 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: SettingsDictionary = try await defaultSettingsProvider.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser
         )
 
         updateTargetDerived(

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -998,8 +998,35 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     }
 
     func test_generateTargetConfig_when_defaultSettingsIsRecommendedWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
-        let settings = Settings.test(defaultSettings: .essential(excluding: ["TEST_HOST"]))
-        try await generateTestTargetConfigTestHostSettings(settings)
+        // Given
+        let settings = Settings.test(defaultSettings: .recommended(excluding: ["TEST_HOST"]))
+        let appTarget = Target.test(name: "App", product: .app)
+        let target = Target.test(name: "Test", product: .unitTests, settings: settings)
+        let project = Project.test(name: "Project", targets: [target, appTarget])
+        let graph = Graph.test(
+            name: project.name,
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [
+                GraphDependency
+                    .target(name: target.name, path: project.path): Set([.target(name: appTarget.name, path: project.path)]),
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: project.settings,
+            fileElements: .init(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
         let targetSettingsResult = try pbxTarget
             .buildConfigurationList?
             .buildConfigurations
@@ -1010,9 +1037,35 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     }
 
     func test_generateTargetConfig_when_defaultSettingsIsEssentialWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
+        // Given
         let settings = Settings.test(defaultSettings: .essential(excluding: ["TEST_HOST"]))
-        try await generateTestTargetConfigTestHostSettings(settings)
+        let appTarget = Target.test(name: "App", product: .app)
+        let target = Target.test(name: "Test", product: .unitTests, settings: settings)
+        let project = Project.test(name: "Project", targets: [target, appTarget])
+        let graph = Graph.test(
+            name: project.name,
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [
+                GraphDependency
+                    .target(name: target.name, path: project.path): Set([.target(name: appTarget.name, path: project.path)]),
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
 
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: project.settings,
+            fileElements: .init(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
         let targetSettingsResult = try pbxTarget
             .buildConfigurationList?
             .buildConfigurations
@@ -1023,9 +1076,35 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     }
 
     func test_generateTargetConfig_when_defaultSettingsIsNoneWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
+        // Given
         let settings = Settings.test(defaultSettings: .none)
-        try await generateTestTargetConfigTestHostSettings(settings)
+        let appTarget = Target.test(name: "App", product: .app)
+        let target = Target.test(name: "Test", product: .unitTests, settings: settings)
+        let project = Project.test(name: "Project", targets: [target, appTarget])
+        let graph = Graph.test(
+            name: project.name,
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [
+                GraphDependency
+                    .target(name: target.name, path: project.path): Set([.target(name: appTarget.name, path: project.path)]),
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
 
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: project.settings,
+            fileElements: .init(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
         let targetSettingsResult = try pbxTarget
             .buildConfigurationList?
             .buildConfigurations
@@ -1165,34 +1244,6 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             fileElements: .init(),
             graphTraverser: graphTraverser,
             sourceRootPath: dir
-        )
-    }
-
-    private func generateTestTargetConfigTestHostSettings(_ settings: Settings) async throws {
-        let appTarget = Target.test(name: "App", product: .app)
-        let target = Target.test(name: "Test", product: .unitTests, settings: settings)
-        let project = Project.test(name: "Project", targets: [target, appTarget])
-
-        let graph = Graph.test(
-            name: project.name,
-            path: project.path,
-            projects: [project.path: project],
-            dependencies: [
-                GraphDependency
-                    .target(name: target.name, path: project.path): Set([.target(name: appTarget.name, path: project.path)]),
-            ]
-        )
-        let graphTraverser = GraphTraverser(graph: graph)
-
-        _ = try await subject.generateTargetConfig(
-            target,
-            project: project,
-            pbxTarget: pbxTarget,
-            pbxproj: pbxproj,
-            projectSettings: project.settings,
-            fileElements: .init(),
-            graphTraverser: graphTraverser,
-            sourceRootPath: try AbsolutePath(validating: "/project")
         )
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -996,9 +996,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .toSettings()["MERGEABLE_LIBRARY"]
         XCTAssertEqual(targetSettingsResult, "YES")
     }
-    
+
     func test_generateTargetConfig_when_defaultSettingsIsRecommendedWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
-        
         let settings = Settings.test(defaultSettings: .essential(excluding: ["TEST_HOST"]))
         try await generateTestTargetConfigTestHostSettings(settings)
         let targetSettingsResult = try pbxTarget
@@ -1009,9 +1008,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .toSettings()["TEST_HOST"]
         XCTAssertEqual(targetSettingsResult, nil)
     }
-    
+
     func test_generateTargetConfig_when_defaultSettingsIsEssentialWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
-        
         let settings = Settings.test(defaultSettings: .essential(excluding: ["TEST_HOST"]))
         try await generateTestTargetConfigTestHostSettings(settings)
 
@@ -1023,9 +1021,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .toSettings()["TEST_HOST"]
         XCTAssertEqual(targetSettingsResult, nil)
     }
-    
+
     func test_generateTargetConfig_when_defaultSettingsIsNoneWithExcludingTEST_HOST_then_TEST_HOSTIsNil() async throws {
-        
         let settings = Settings.test(defaultSettings: .none)
         try await generateTestTargetConfigTestHostSettings(settings)
 
@@ -1037,7 +1034,6 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .toSettings()["TEST_HOST"]
         XCTAssertEqual(targetSettingsResult, nil)
     }
-    
 
     // MARK: - Helpers
 
@@ -1171,7 +1167,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             sourceRootPath: dir
         )
     }
-    
+
     private func generateTestTargetConfigTestHostSettings(_ settings: Settings) async throws {
         let appTarget = Target.test(name: "App", product: .app)
         let target = Target.test(name: "Test", product: .unitTests, settings: settings)

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -231,6 +231,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let buildConfiguration: BuildConfiguration = .debug
         let project = Project.test()
         let target = Target.test(product: .dynamicLibrary, mergeable: true)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -241,7 +242,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -254,6 +255,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let buildConfiguration: BuildConfiguration = .debug
         let project = Project.test()
         let target = Target.test(product: .app)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -264,7 +266,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -276,6 +278,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let buildConfiguration: BuildConfiguration = .debug
         let project = Project.test()
         let target = Target.test(product: .app, mergedBinaryType: .automatic)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -286,7 +289,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -298,6 +301,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let buildConfiguration: BuildConfiguration = .debug
         let project = Project.test()
         let target = Target.test(product: .app, mergedBinaryType: .manual(mergeableDependencies: Set(["Sample"])))
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -308,7 +312,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -321,6 +325,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let buildConfiguration: BuildConfiguration = .release
         let project = Project.test()
         let target = Target.test(product: .app, mergedBinaryType: .manual(mergeableDependencies: Set(["Sample"])))
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -331,7 +336,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -349,6 +354,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .app, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -359,7 +365,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -376,6 +382,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -386,7 +393,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -403,6 +410,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -413,7 +421,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -529,6 +537,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(settings: settings)
+        let graph = Graph.test(path: project.path)
+
         given(xcodeController)
             .selectedVersion()
             .willReturn(Version(11, 0, 0))
@@ -538,7 +548,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -550,6 +560,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         // Given
         let project = Project.test(settings: .test(defaultSettings: .essential))
         let target = Target.test(settings: nil)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -560,7 +571,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: .debug,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -577,6 +588,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let target = Target.test(settings: settings)
         let project = Project.test()
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -587,7 +599,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -604,6 +616,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let target = Target.test(settings: settings)
         let project = Project.test()
+        let graph = Graph.test(path: project.path)
+
         given(xcodeController)
             .selectedVersion()
             .willReturn(Version(11, 0, 0))
@@ -613,7 +627,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -630,6 +644,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let target = Target.test(product: .app, settings: settings)
         let project = Project.test()
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -640,7 +655,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -663,6 +678,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
                 ]
             )
         )
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -673,7 +689,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -690,6 +706,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let target = Target.test(product: .app, settings: settings)
         let project = Project.test()
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -700,7 +717,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -717,13 +734,14 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let target = Target.test(product: .app, settings: settings)
         let project = Project.test()
+        let graph = Graph.test(path: project.path)
 
         // When
         let got = try await subject.targetSettings(
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -743,13 +761,14 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         given(xcodeController)
             .selectedVersion()
             .willReturn(Version(11, 0, 0))
+        let graph = Graph.test(path: project.path)
 
         // When
         let got = try await subject.targetSettings(
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -767,6 +786,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -777,7 +797,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -795,6 +815,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -805,7 +826,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -823,6 +844,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -833,7 +855,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -850,13 +872,14 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         // When
         let got = try await subject.targetSettings(
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -873,6 +896,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .unitTests, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -883,7 +907,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -900,6 +924,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .uiTests, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -910,7 +935,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -927,6 +952,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .unitTests, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -937,7 +963,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -954,6 +980,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
         let project = Project.test()
         let target = Target.test(product: .uiTests, settings: settings)
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -964,7 +991,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -985,6 +1012,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             product: .framework,
             settings: settings
         )
+        let graph = Graph.test(path: project.path)
 
         given(xcodeController)
             .selectedVersion()
@@ -995,17 +1023,11 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
         XCTAssertEqual(got, multiplatformFrameworkTargetEssentialDebugSettings)
-    }
-
-    private func graphTraverser(project: Project) -> GraphTraverser {
-        let graph = Graph.test(path: project.path)
-        let graphTraverser = GraphTraverser(graph: graph)
-        return graphTraverser
     }
 }
 
@@ -1055,13 +1077,14 @@ final class DefaultSettingsProvider_MacosTests: TuistUnitTestCase {
             product: .macro,
             settings: settings
         )
+        let graph = Graph.test(path: project.path)
 
         // When
         let got = try await subject.targetSettings(
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
@@ -1082,23 +1105,18 @@ final class DefaultSettingsProvider_MacosTests: TuistUnitTestCase {
             product: .macro,
             settings: settings
         )
+        let graph = Graph.test(path: project.path)
 
         // When
         let got = try await subject.targetSettings(
             target: target,
             project: project,
             buildConfiguration: buildConfiguration,
-            graphTraverser: graphTraverser(project: project)
+            graphTraverser: GraphTraverser(graph: graph)
         )
 
         // Then
         XCTAssertEqual(got, macroTargetEssentialReleaseSettings)
-    }
-
-    private func graphTraverser(project: Project) -> GraphTraverser {
-        let graph = Graph.test(path: project.path)
-        let graphTraverser = GraphTraverser(graph: graph)
-        return graphTraverser
     }
 }
 

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -240,7 +240,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -262,7 +263,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -283,7 +285,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -304,7 +307,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -326,7 +330,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -353,7 +358,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -379,7 +385,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -405,7 +412,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -529,7 +537,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -550,7 +559,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: .debug
+            buildConfiguration: .debug,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -576,7 +586,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -601,7 +612,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -627,7 +639,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -659,7 +672,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -685,7 +699,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -707,7 +722,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -732,7 +748,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -759,7 +776,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -786,7 +804,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -813,7 +832,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -835,7 +855,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -861,7 +882,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -887,7 +909,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -913,7 +936,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -939,7 +963,8 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -969,11 +994,18 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
         XCTAssertEqual(got, multiplatformFrameworkTargetEssentialDebugSettings)
+    }
+
+    private func graphTraverser(project: Project) -> GraphTraverser {
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+        return graphTraverser
     }
 }
 
@@ -1028,7 +1060,8 @@ final class DefaultSettingsProvider_MacosTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
@@ -1054,11 +1087,18 @@ final class DefaultSettingsProvider_MacosTests: TuistUnitTestCase {
         let got = try await subject.targetSettings(
             target: target,
             project: project,
-            buildConfiguration: buildConfiguration
+            buildConfiguration: buildConfiguration,
+            graphTraverser: graphTraverser(project: project)
         )
 
         // Then
         XCTAssertEqual(got, macroTargetEssentialReleaseSettings)
+    }
+
+    private func graphTraverser(project: Project) -> GraphTraverser {
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+        return graphTraverser
     }
 }
 


### PR DESCRIPTION
…, even when using xcconfig.

Resolves <https://github.com/tuist/tuist/issues/6888>

### Short description 📝

 Fix Tuist overrides the `TEST_HOST` build setting for UnitTest targets, even when using xcconfig.


**Concerns**:
> If this issue fix is implemented, one concern is that users who have set defaultSettings to `.none` and have not explicitly provided a `TEST_HOST` in the code will face build failures in their projects.

> Personally, considering the implications of the comment regarding `defaultSettings`, it seems inconsistent to have code that overrides `TEST_HOST` with specific properties of the target, even when `defaultSettings` is set to `.none`. 
If it is `.none`, I believe users should have the right to customize their settings fully in accordance with that meaning.

>(I have personally experienced instances where I forgot the values I had previously set for properties despite using `.none`, resulting in additional debugging time.)

### How to test the changes locally 🧐


1. Write test code in ConfigGeneratorTests to ensure that when defaultSettings is either .`none` or `.recommended` and `.essential`, if `TEST_HOST` is included in `excluding`, then `TEST_HOST` should be nil.
2.  Generate the attached project with Tuist and check the `TEST_HOST` in the build settings of the unit test target (xcconfig attached).
[unittest.zip](https://github.com/user-attachments/files/17422586/unittest.zip)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
