### PR TITLE
Update XcodeProj to 8.24.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "55a9b83d2182b6878f54e055776ae8b9a1ecac4f8a185bea603686db0520b0a6",
+  "originHash" : "2853458b71d02fa2224e50cac488890d1bf050c340a7e0f569f2b9550fc2e7e4",
   "pins" : [
     {
       "identity" : "aexml",
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "75e787fb3eb5a8397c3d06d5a71e667ac2d20ac1",
-        "version" : "8.19.0"
+        "revision" : "59b6e3fe9b07e3323b4c4e97b58523bc3c5754a0",
+        "version" : "8.24.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -465,7 +465,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/GraphViz.git", exact: "0.4.2"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.6.2"),
-        .package(url: "https://github.com/tuist/XcodeProj", exact: "8.19.0"),
+        .package(url: "https://github.com/tuist/XcodeProj", exact: "8.24.4"),
         .package(url: "https://github.com/cpisciotta/xcbeautify", .upToNextMajor(from: "2.13.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
         .package(url: "https://github.com/Kolos65/Mockable.git", exact: "0.0.11"),

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -639,7 +639,7 @@ extension PBXTarget {
             buildFile.applyCondition(condition, applicableTo: target)
             pbxproj.add(object: buildFile)
 
-            packageProductDependencies.append(productDependency)
+            packageProductDependencies?.append(productDependency)
 
             // Link the product
             guard let frameworksBuildPhase = try frameworksBuildPhase() else {

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -180,6 +180,8 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             name: project.name,
             buildConfigurationList: configurationList,
             compatibilityVersion: Xcode.Default.compatibilityVersion,
+            preferredProjectObjectVersion: nil,
+            minimizedProjectReferenceProxies: nil,
             mainGroup: groups.sortedMain,
             developmentRegion: developmentRegion,
             hasScannedForEncodings: 0,

--- a/Sources/TuistGeneratorTesting/Descriptors/TestData/ProjectDescriptor+TestData.swift
+++ b/Sources/TuistGeneratorTesting/Descriptors/TestData/ProjectDescriptor+TestData.swift
@@ -18,6 +18,8 @@ extension ProjectDescriptor {
             name: "Test",
             buildConfigurationList: configurationList,
             compatibilityVersion: "1",
+            preferredProjectObjectVersion: nil,
+            minimizedProjectReferenceProxies: nil,
             mainGroup: mainGroup
         )
         let pbxproj = PBXProj(

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -927,7 +927,7 @@ extension ProjectDescription.ResourceFileElements {
                     }
                 }
             )
-            resourceFileElements += try await defaultResourcePaths(from: path) { candidateURL in
+            resourceFileElements += try defaultResourcePaths(from: path) { candidateURL in
                 let candidatePath = AbsolutePath(stringLiteral: candidateURL.path)
                 let candidateNotInExcludedDirectory = excludedPaths.allSatisfy { !$0.isAncestorOfOrEqual(to: candidatePath) }
                 return candidateNotInExcludedDirectory

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1650,6 +1650,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             name: "Project",
             buildConfigurationList: configList,
             compatibilityVersion: "0",
+            preferredProjectObjectVersion: nil,
+            minimizedProjectReferenceProxies: nil,
             mainGroup: mainGroup
         )
         pbxproj.add(object: pbxProject)

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -240,6 +240,8 @@ final class TargetGeneratorTests: XCTestCase {
             name: "Project",
             buildConfigurationList: configList,
             compatibilityVersion: "0",
+            preferredProjectObjectVersion: nil,
+            minimizedProjectReferenceProxies: nil,
             mainGroup: mainGroup
         )
         pbxproj.add(object: pbxProject)


### PR DESCRIPTION
### Short description 📝

Updates `XcodeProj` to 8.24.4. There were some breaking changes from: https://github.com/tuist/XcodeProj/pull/854

@pepicrft @danieleformichelli For next time: I'd recommend that new properties should have a default value in `init` to make those changes non-breaking.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
