### PR TITLE
Fix selective test results not being stored

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -564,18 +564,13 @@ final class TestService { // swiftlint:disable:this type_body_length
                     .union(testedGraphTargets)
             )
 
-            let cachedTargets = allTestedTargets
+            let hashes = allTestedTargets
                 .filter {
                     if let cacheItem = mapperEnvironment.targetCacheItems[$0.path]?[$0.target.name] {
                         return cacheItem.cacheCategory != .selectiveTests
                     } else {
                         return true
                     }
-                }
-
-            let hashes = allTestedTargets
-                .filter { testedTarget in
-                    !cachedTargets.contains(where: { testedTarget.path != $0.path && testedTarget.target.name != $0.target.name })
                 }
                 .compactMap { graphTarget -> (target: Target, hash: String)? in
                     guard let hash = mapperEnvironment.targetTestHashes[graphTarget.path]?[graphTarget.target.name]


### PR DESCRIPTION
### Short description 📝

Running `tuist test` in `tuist/tuist` doesn't store the selective test results.

The condition for which targets to be stored was unnecessarily convoluted – so I simplified and fixed the `filter` condition.

### How to test the changes locally 🧐

- Run `tuist test TuistUnitTests` in `tuist/tuist` two times in a row – the second time, the tests should not be run.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
