### PR TITLE
Add .woff font extension to ResourceSynthesizer

### DIFF
--- a/Sources/ProjectDescription/ResourceSynthesizer.swift
+++ b/Sources/ProjectDescription/ResourceSynthesizer.swift
@@ -152,7 +152,7 @@ public struct ResourceSynthesizer: Codable, Equatable, Sendable { // swiftlint:d
             templateType: templateType,
             parser: .fonts,
             parserOptions: parserOptions,
-            extensions: ["otf", "ttc", "ttf"]
+            extensions: ["otf", "ttc", "ttf", "woff"]
         )
     }
 

--- a/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -159,7 +159,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                     "boolValue": true,
                     "doubleValue": 1.0,
                 ],
-                extensions: ["otf", "ttc", "ttf"],
+                extensions: ["otf", "ttc", "ttf", "woff"],
                 template: .defaultTemplate("Fonts")
             ),
             .init(
@@ -425,7 +425,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .fonts,
                 parserOptions: [:],
-                extensions: ["otf", "ttc", "ttf"],
+                extensions: ["otf", "ttc", "ttf", "woff"],
                 template: .defaultTemplate("Fonts")
             ),
             .init(
@@ -568,7 +568,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .fonts,
                 parserOptions: [:],
-                extensions: ["otf", "ttc", "ttf"],
+                extensions: ["otf", "ttc", "ttf", "woff"],
                 template: .defaultTemplate("Fonts")
             ),
         ]


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝
Add .woff font extension on ResourceSynthesizer.

### How to test the changes locally 🧐
You can add a .woff font file and check if the resource is generated on Derived folder.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
