### PR TITLE
feat: Add ability to control "Find Implicit Dependencies" check on a schemes build action

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2853458b71d02fa2224e50cac488890d1bf050c340a7e0f569f2b9550fc2e7e4",
+  "originHash" : "21aac365a77e92beaa8ba6c61719a1117f5558b821d6765af455f388a3551861",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "b70c3bf22e8e2350f874a3290f7792e47867091d",
-        "version" : "0.14.0"
+        "revision" : "b8920950e66ec77723da5c17134e698f80ed3db8",
+        "version" : "0.15.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -480,7 +480,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.14.0")
+            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.15.0")
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.4.0")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Sources/ProjectDescription/BuildAction.swift
+++ b/Sources/ProjectDescription/BuildAction.swift
@@ -12,6 +12,8 @@ public struct BuildAction: Equatable, Codable, Sendable {
     public var postActions: [ExecutionAction]
     /// Whether the post actions should be run in the case of a failure
     public var runPostActionsOnFailure: Bool
+    /// Whether Xcode should be allowed to search dependencies implicitly
+    public var findImplicitDependencies: Bool
 
     /// Returns a build action.
     /// - Parameters:
@@ -19,18 +21,21 @@ public struct BuildAction: Equatable, Codable, Sendable {
     ///   - preActions: A list of actions that are executed before starting the build process.
     ///   - postActions: A list of actions that are executed after the build process.
     ///   - runPostActionsOnFailure: Whether the post actions should be run in the case of a failure
+    ///   - findImplicitDependencies: Whether Xcode should be allowed to search dependencies implicitly
     /// - Returns: Initialized build action.
     public static func buildAction(
         targets: [TargetReference],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
-        runPostActionsOnFailure: Bool = false
+        runPostActionsOnFailure: Bool = false,
+        findImplicitDependencies: Bool = true
     ) -> BuildAction {
         BuildAction(
             targets: targets,
             preActions: preActions,
             postActions: postActions,
-            runPostActionsOnFailure: runPostActionsOnFailure
+            runPostActionsOnFailure: runPostActionsOnFailure,
+            findImplicitDependencies: findImplicitDependencies
         )
     }
 }

--- a/Sources/ProjectDescription/BuildAction.swift
+++ b/Sources/ProjectDescription/BuildAction.swift
@@ -12,7 +12,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     public var postActions: [ExecutionAction]
     /// Whether the post actions should be run in the case of a failure
     public var runPostActionsOnFailure: Bool
-    /// Whether Xcode should be allowed to search dependencies implicitly
+    /// Whether Xcode should be allowed to find dependencies implicitly. The default is `true`.
     public var findImplicitDependencies: Bool
 
     /// Returns a build action.
@@ -21,7 +21,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
     ///   - preActions: A list of actions that are executed before starting the build process.
     ///   - postActions: A list of actions that are executed after the build process.
     ///   - runPostActionsOnFailure: Whether the post actions should be run in the case of a failure
-    ///   - findImplicitDependencies: Whether Xcode should be allowed to search dependencies implicitly
+    ///   - findImplicitDependencies: Whether Xcode should be allowed to find dependencies implicitly. The default is `true`.
     /// - Returns: Initialized build action.
     public static func buildAction(
         targets: [TargetReference],

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -5,6 +5,7 @@ public enum TuistAcceptanceFixtures {
     case appWithBuildRules
     case appWithComposableArchitecture
     case appWithCustomDefaultConfiguration
+    case appWithCustomScheme
     case appWithFrameworkAndTests
     case appWithGoogleMaps
     case appWithPlugins
@@ -94,6 +95,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_composable_architecture"
         case .appWithCustomDefaultConfiguration:
             return "app_with_custom_default_configuration"
+        case .appWithCustomScheme:
+            return "app_with_custom_scheme"
         case .appWithFrameworkAndTests:
             return "app_with_framework_and_tests"
         case .appWithGoogleMaps:

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -244,7 +244,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             preActions: preActions,
             postActions: postActions,
             parallelizeBuild: true,
-            buildImplicitDependencies: true,
+            buildImplicitDependencies: buildAction.findImplicitDependencies,
             runPostActionsOnFailure: buildAction.runPostActionsOnFailure ? true : nil
         )
     }

--- a/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
@@ -31,7 +31,8 @@ extension XcodeGraph.BuildAction {
             targets: targets,
             preActions: preActions,
             postActions: postActions,
-            runPostActionsOnFailure: manifest.runPostActionsOnFailure
+            runPostActionsOnFailure: manifest.runPostActionsOnFailure,
+            findImplicitDependencies: manifest.findImplicitDependencies
         )
     }
 }

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -939,6 +939,25 @@ final class GenerateAcceptanceTestAppWithDefaultConfiguration: TuistAcceptanceTe
     }
 }
 
+final class GenerateAcceptanceTestAppWithCustomScheme: TuistAcceptanceTestCase {
+    func test_app_with_custom_scheme() async throws {
+        try await setUpFixture(.appWithCustomScheme)
+        try await run(GenerateCommand.self)
+
+        let xcodeproj = try XcodeProj(
+            pathString: xcodeprojPath.pathString
+        )
+
+        let scheme = try XCTUnwrap(xcodeproj.sharedData?.schemes.first)
+        XCTAssertEqual(scheme.name, "App")
+
+        let buildAction = try XCTUnwrap(scheme.buildAction)
+        XCTAssertFalse(buildAction.buildImplicitDependencies)
+
+        try await run(BuildCommand.self)
+    }
+}
+
 final class GenerateAcceptanceTestAppWithGoogleMaps: TuistAcceptanceTestCase {
     func test_app_with_google_maps() async throws {
         try await setUpFixture(.appWithGoogleMaps)

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -70,6 +70,45 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(result.buildImplicitDependencies, true)
     }
 
+    func test_schemeBuildAction_findImplicitDependenciesFalse() throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")
+        let xcodeProjPath = projectPath.appending(component: "Project.xcodeproj")
+        let scheme = Scheme.test(
+            buildAction: BuildAction(
+                targets: [TargetReference(projectPath: projectPath, name: "App")],
+                findImplicitDependencies: false
+            )
+        )
+
+        let app = Target.test(name: "App", product: .app)
+        let targets = [app]
+
+        let project = Project.test(
+            path: projectPath,
+            xcodeProjPath: xcodeProjPath,
+            targets: targets
+        )
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeBuildAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: [
+                xcodeProjPath: generatedProject(targets: targets, projectPath: "\(xcodeProjPath)"),
+            ]
+        )
+
+        // Then
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.buildImplicitDependencies, false)
+    }
+
     func test_schemeBuildAction_whenSingleProjectAndXcodeProjPathDiffers() throws {
         // Given
         let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")

--- a/fixtures/app_with_custom_scheme/App/AppDelegate.swift
+++ b/fixtures/app_with_custom_scheme/App/AppDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/fixtures/app_with_custom_scheme/Project.swift
+++ b/fixtures/app_with_custom_scheme/Project.swift
@@ -1,0 +1,36 @@
+import ProjectDescription
+
+// MARK: - Targets of the project
+
+let appTarget: Target = .target(
+    name: "App",
+    destinations: .iOS,
+    product: .app,
+    bundleId: "io.tuist.App",
+    sources: ["App/**/*.swift"]
+)
+
+// MARK: - Schemes of the project
+
+let appScheme: Scheme = .scheme(
+    name: "App",
+    shared: true,
+    hidden: false,
+    buildAction: .buildAction(targets: ["App"], findImplicitDependencies: false),
+    testAction: nil,
+    runAction: .runAction(),
+    archiveAction: .archiveAction(configuration: "Production"),
+    profileAction: nil,
+    analyzeAction: nil
+)
+
+// MARK: - Project
+
+let project = Project(
+    name: "App",
+    organizationName: "Tuist",
+    targets: [
+        appTarget,
+    ],
+    schemes: [appScheme]
+)

--- a/fixtures/app_with_custom_scheme/README.md
+++ b/fixtures/app_with_custom_scheme/README.md
@@ -1,0 +1,3 @@
+# Application with custom scheme
+
+This example contains an example that uses a custom scheme to demonstrate how to modify schemes to ones needs.

--- a/fixtures/app_with_custom_scheme/Tuist/Config.swift
+++ b/fixtures/app_with_custom_scheme/Tuist/Config.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let config = Config()


### PR DESCRIPTION
### Short description 📝

This PR exposes the `findImplicitDependencies` property of `XcodeGraph.BuildAction` introduced with https://github.com/tuist/XcodeGraph/pull/64. This makes it possible for users to control the `Find Implicit Dependencies` checkmark in Xcode. This is especially helpful since it is recommended on the documentation to disable this feature, see here: https://docs.tuist.io/en/guides/develop/projects/cost-of-convenience#find-implicit-dependencies-in-schemes but it is not yet possible to do this via ´tuist´.

### How to test the changes locally 🧐

* Run the corresponding unit test
* Set the corresponding property in a project manifest to false 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
