### PR TITLE
Fix TestPlan validation and recognition default TestPlan of Scheme

### DIFF
--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -138,7 +138,11 @@ public final class BuildGraphInspector: BuildGraphInspecting {
 
         if let testPlanName = testPlan,
            let testPlan = scheme.testAction?.testPlans?.first(where: { $0.name == testPlanName }),
-           let target = testPlan.testTargets.first(where: { isIncluded($0) })?.target
+           let target = testPlan.testTargets.first(where: isIncluded)?.target
+        {
+            return graphTraverser.target(path: target.projectPath, name: target.name)
+        } else if let defaultTestPlan = scheme.testAction?.testPlans?.first(where: \.isDefault),
+                  let target = defaultTestPlan.testTargets.first(where: isIncluded)?.target
         {
             return graphTraverser.target(path: target.projectPath, name: target.name)
         } else if let testTarget = scheme.testAction?.targets.first {

--- a/Sources/TuistLoader/Models+ManifestMappers/TestPlan+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestPlan+ManifestMapper.swift
@@ -13,7 +13,7 @@ extension TestPlan {
             testTargets: xcTestPlan.testTargets.map { testTarget in
                 try TestableTarget(
                     target: TargetReference(
-                        projectPath: generatorPaths.resolve(path: .relativeToRoot(testTarget.target.projectPath))
+                        projectPath: generatorPaths.resolve(path: .relativeToManifest(testTarget.target.projectPath))
                             .removingLastComponent(),
                         name: testTarget.target.name
                     ),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6918

### Short description 📝

- Adds logic with the definition of the **default** `TestPlan` that is set in Scheme.
- Corrects the `projectPath` mapping of `XCTestPlan`, building the path **relative to the manifest directory**, not the root.
- Corrects and structures the validation of the scheme to meet at least one of the conditions:
1. the presence of the passed `test-plan` in the list of test plans of the scheme
2. the presence of the default testplan
3. at least one test target

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
