### PR TITLE
Documentation fixes

### DIFF
--- a/docs/.vitepress/bars.mjs
+++ b/docs/.vitepress/bars.mjs
@@ -3,13 +3,8 @@ import {
   cubeOutlineIcon,
   cube02Icon,
   cube01Icon,
-  microscopeIcon,
-  code02Icon,
-  dataIcon,
-  checkCircleIcon,
   tuistIcon,
   building07Icon,
-  cloudBlank02Icon,
   server04Icon,
   bookOpen01Icon,
   codeBrowserIcon,
@@ -266,7 +261,6 @@ export function guidesSidebar(locale) {
         locale,
         "sidebars.guides.items.quick-start.text"
       )} ${tuistIcon()}</span>`,
-      link: "/",
       items: [
         {
           text: localizedString(

--- a/docs/docs/en/guides/quick-start/install-tuist.md
+++ b/docs/docs/en/guides/quick-start/install-tuist.md
@@ -7,7 +7,7 @@ description: Learn how to install Tuist in your environment.
 
 The Tuist CLI consists of an executable, dynamic frameworks, and a set of resources (for example, templates). Although you could manually build Tuist from [the sources](https://github.com/tuist/tuist), **we recommend using one of the following installation methods to ensure a valid installation.**
 
-<h3 id="recommended-misehttpsgithubcomjdxmise">Recommended: [Mise](https://github.com/jdx/mise)</h3>
+<h3 id="recommended-mise">Recommended: <a href="https://github.com/jdx/mise">Mise</a></h3>
 
 Tuist defaults to [Mise](https://github.com/jdx/mise) as a tool to deterministically manage and activate versions of Tuist.
 If you don't have it installed on your system,
@@ -36,7 +36,7 @@ mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use -g tuist@system      # Use the system's tuist as the global default
 ```
 
-<h3 id="alternative-homebrewhttpsbrewsh">Alternative: [Homebrew](https://brew.sh)</h3>
+<h3 id="alternative-homebrew">Alternative: <a href="https://brew.sh">Homebrew</a></h3>
 
 If version pinning across environments is not a concern for you,
 you can install Tuist using [Homebrew](https://brew.sh) and [our formulas](https://github.com/tuist/homebrew-tuist):

--- a/docs/docs/ja/guides/quick-start/install-tuist.md
+++ b/docs/docs/ja/guides/quick-start/install-tuist.md
@@ -7,7 +7,7 @@ description: Learn how to install Tuist in your environment.
 
 The Tuist CLI consists of an executable, dynamic frameworks, and a set of resources (for example, templates). Although you could manually build Tuist from [the sources](https://github.com/tuist/tuist), **we recommend using one of the following installation methods to ensure a valid installation.**
 
-<h3 id="recommended-misehttpsgithubcomjdxmise">Recommended: [Mise](https://github.com/jdx/mise)</h3>
+<h3 id="recommended-mise">Recommended: <a href="https://github.com/jdx/mise">Mise</a></h3>
 
 Tuist defaults to [Mise](https://github.com/jdx/mise) as a tool to deterministically manage and activate versions of Tuist.
 If you don't have it installed on your system,
@@ -35,7 +35,7 @@ mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use -g tuist@system      # Use the system's tuist as the global default
 ```
 
-<h3 id="alternative-homebrewhttpsbrewsh">Alternative: [Homebrew](https://brew.sh)</h3>
+<h3 id="alternative-homebrew">Alternative: <a href="https://brew.sh">Homebrew</a></h3>
 
 If version pinning across environments is not a concern for you,
 you can install Tuist using [Homebrew](https://brew.sh) and [our formulas](https://github.com/tuist/homebrew-tuist):

--- a/docs/docs/ko/guides/quick-start/install-tuist.md
+++ b/docs/docs/ko/guides/quick-start/install-tuist.md
@@ -34,7 +34,7 @@ mise use -g tuist@x.y.z # 시스템의 기본값으로 tuist-x.y.z 사용
 mise use -g tuist@system # 시스템의 tuist를 전역 기본값으로 사용합니다.
 ```
 
-<h3 id="alternative-homebrewhttpsbrewsh">대안: [HomeBrew](https://brew.sh)</h3>
+<h3 id="alternative-homebrew">대안: <a href="https://brew.sh">Homebrew</a></h3>
 
 여러 환경 에서 버전 고정이 필요하지 않다면, [Homebrew](https://brew.sh)와 제공되는 [공식 패키지](https://github.com/tuist/homebrew-tuist)를 사용하여 Tuist를 설치할 수 있습니다.
 

--- a/docs/docs/ru/guides/quick-start/install-tuist.md
+++ b/docs/docs/ru/guides/quick-start/install-tuist.md
@@ -7,7 +7,7 @@ description: Learn how to install Tuist in your environment.
 
 The Tuist CLI consists of an executable, dynamic frameworks, and a set of resources (for example, templates). Although you could manually build Tuist from [the sources](https://github.com/tuist/tuist), **we recommend using one of the following installation methods to ensure a valid installation.**
 
-<h3 id="recommended-misehttpsgithubcomjdxmise">Recommended: [Mise](https://github.com/jdx/mise)</h3>
+<h3 id="recommended-mise">Recommended: <a href="https://github.com/jdx/mise">Mise</a></h3>
 
 Tuist defaults to [Mise](https://github.com/jdx/mise) as a tool to deterministically manage and activate versions of Tuist.
 If you don't have it installed on your system,
@@ -35,7 +35,7 @@ mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use -g tuist@system      # Use the system's tuist as the global default
 ```
 
-<h3 id="alternative-homebrewhttpsbrewsh">Alternative: [Homebrew](https://brew.sh)</h3>
+<h3 id="alternative-homebrew">Alternative: <a href="https://brew.sh">Homebrew</a></h3>
 
 If version pinning across environments is not a concern for you,
 you can install Tuist using [Homebrew](https://brew.sh) and [our formulas](https://github.com/tuist/homebrew-tuist):


### PR DESCRIPTION
I'm fixing the following things in the documentation site
- Misformatted headings on the quick-start page
- Invalid "next page" link due to invalid link in one of the sidebar items.