### PR TITLE
fix: When defaultSettings is set to .essential, TEST_HOST will not be created #6926

### DIFF
--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -68,6 +68,9 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES",
         "WRAPPER_EXTENSION",
         "SWIFT_VERSION",
+        "TEST_TARGET_NAME",
+        "TEST_HOST",
+        "BUNDLE_LOADER",
     ]
 
     // These are not needed or are computed elsewhere so we exclude them


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6926>

### Short description 📝

> I added `TEST_HOST` keys to the [essentialTargetSettings](https://github.com/tuist/tuist/blob/f9e4537730932e0dd47581a782cffc620c72caad/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift#L49-L70) in `DefaultSettingsProvider` so that `TEST_HOST` can be generated for essential cases even without exclusions.

### How to test the changes locally 🧐

>  1. I added test code for `essential` to `defaultSettings` alongside the [existing `TEST_HOST` ](https://github.com/tuist/tuist/blob/f9e4537730932e0dd47581a782cffc620c72caad/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift#L148-L181)generation test cases.
>  Since `recommended` already includes the existing test code that creates `TEST_HOST`, I did not add `recommended` case test code. Of course, this issue does not occur in `recommended`.
> 2. I created a project for the essential case and conducted testing. [unittest.zip](https://github.com/user-attachments/files/17519353/unittest.zip)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
