### PR TITLE
Fix tests failing when using cached TuistSupportTesting

### DIFF
--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -7,7 +7,7 @@ extension XCTestCase {
     // MARK: - Fixtures
 
     public func fixturePath(path: RelativePath) -> AbsolutePath {
-        try! AbsolutePath(validating: ProcessInfo.processInfo.environment["TUIST_CONFIG_SRCROOT"]!)
+        try! AbsolutePath(validating: ProcessInfo.processInfo.environment["TUIST_CONFIG_SRCROOT"]!) // swiftlint:disable:this force_try
             .appending(components: "Tests", "Fixtures")
             .appending(path)
     }

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -7,9 +7,13 @@ extension XCTestCase {
     // MARK: - Fixtures
 
     public func fixturePath(path: RelativePath) -> AbsolutePath {
-        try! AbsolutePath(validating: ProcessInfo.processInfo.environment["TUIST_CONFIG_SRCROOT"]!) // swiftlint:disable:this force_try
-            .appending(components: "Tests", "Fixtures")
-            .appending(path)
+        // swiftlint:disable:next force_try
+        try! AbsolutePath(
+            validating: ProcessInfo.processInfo
+                .environment["TUIST_CONFIG_SRCROOT"]!
+        )
+        .appending(components: "Tests", "Fixtures")
+        .appending(path)
     }
 
     // MARK: - XCTAssertions

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -7,8 +7,8 @@ extension XCTestCase {
     // MARK: - Fixtures
 
     public func fixturePath(path: RelativePath) -> AbsolutePath {
-        try! AbsolutePath(validating: #file) // swiftlint:disable:this force_try
-            .appending(try! RelativePath(validating: "../../../../Tests/Fixtures")) // swiftlint:disable:this force_try
+        try! AbsolutePath(validating: ProcessInfo.processInfo.environment["TUIST_CONFIG_SRCROOT"]!)
+            .appending(components: "Tests", "Fixtures")
             .appending(path)
     }
 


### PR DESCRIPTION
### Short description 📝

Using `#file` in frameworks that can be cached leads to issues because the `#file` is expanded when _warming_ the cache.

I was running into an issue with `tuist test` locally because the tests were trying to find in a fixture as if I was running things on the CI – since `TuistSupportTesting` was compiled on the CI.

The fix here is to use the environment variable for finding the path.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
