### PR TITLE
Add --no-upload flag to tuist test

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -113,6 +113,7 @@ public enum EnvKey: String, CaseIterable {
     // TEST
     case testScheme = "TUIST_TEST_SCHEME"
     case testClean = "TUIST_TEST_CLEAN"
+    case testNoUpload = "TUIST_TEST_NO_UPLOAD"
     case testPath = "TUIST_TEST_PATH"
     case testDevice = "TUIST_TEST_DEVICE"
     case testPlatform = "TUIST_TEST_PLATFORM"

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -38,7 +38,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Flag(
         name: .shortAndLong,
-        help: "When passed, selective tests are not uploaded to the remote storage.",
+        help: "When passed, the result necessary for test selection is not persisted to the server.",
         envKey: .testNoUpload
     )
     var noUpload: Bool = false

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -36,6 +36,13 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var clean: Bool = false
 
+    @Flag(
+        name: .shortAndLong,
+        help: "When passed, selective tests are not uploaded to the remote storage.",
+        envKey: .testNoUpload
+    )
+    var noUpload: Bool = false
+
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project to be tested.",
@@ -236,6 +243,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             runId: runId,
             schemeName: scheme,
             clean: clean,
+            noUpload: noUpload,
             configuration: configuration,
             path: absolutePath,
             deviceName: device,

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -88,7 +88,6 @@ final class TestService { // swiftlint:disable:this type_body_length
     init(
         generatorFactory: GeneratorFactorying = GeneratorFactory(),
         cacheStorageFactory: CacheStorageFactorying = EmptyCacheStorageFactory(),
-        analyticsDelegate _: TrackableParametersDelegate? = nil,
         xcodebuildController: XcodeBuildControlling = XcodeBuildController(),
         buildGraphInspector: BuildGraphInspecting = BuildGraphInspector(),
         simulatorController: SimulatorControlling = SimulatorController(),
@@ -163,6 +162,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         runId: String,
         schemeName: String?,
         clean: Bool,
+        noUpload: Bool,
         configuration: String?,
         path: AbsolutePath,
         deviceName: String?,
@@ -307,6 +307,7 @@ final class TestService { // swiftlint:disable:this type_body_length
                 mapperEnvironment: mapperEnvironment,
                 cacheStorage: cacheStorage,
                 clean: clean,
+                noUpload: noUpload,
                 configuration: configuration,
                 version: version,
                 deviceName: deviceName,
@@ -342,6 +343,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         mapperEnvironment: MapperEnvironment,
         cacheStorage: CacheStoring,
         clean: Bool,
+        noUpload: Bool,
         configuration: String?,
         version: Version?,
         deviceName: String?,
@@ -388,12 +390,18 @@ final class TestService { // swiftlint:disable:this type_body_length
             )
         }
 
+        let uploadCacheStorage: CacheStoring
+        if noUpload {
+            uploadCacheStorage = try await cacheStorageFactory.cacheLocalStorage()
+        } else {
+            uploadCacheStorage = cacheStorage
+        }
         try await storeSuccessfulTestHashes(
             for: testSchemes,
             testPlanConfiguration: testPlanConfiguration,
             graph: graph,
             mapperEnvironment: mapperEnvironment,
-            cacheStorage: cacheStorage
+            cacheStorage: uploadCacheStorage
         )
 
         logger.log(level: .notice, "The project tests ran successfully", metadata: .success)

--- a/Sources/TuistServer/Cache/CacheStorageFactorying.swift
+++ b/Sources/TuistServer/Cache/CacheStorageFactorying.swift
@@ -7,4 +7,6 @@ import XcodeGraph
 @Mockable
 public protocol CacheStorageFactorying {
     func cacheStorage(config: Config) async throws -> CacheStoring
+    /// - Returns: Cache storage that only works with the local cache.
+    func cacheLocalStorage() async throws -> CacheStoring
 }

--- a/Sources/TuistServer/Cache/EmptyCacheStorageFactory.swift
+++ b/Sources/TuistServer/Cache/EmptyCacheStorageFactory.swift
@@ -7,4 +7,8 @@ public final class EmptyCacheStorageFactory: CacheStorageFactorying {
     public func cacheStorage(config _: Config) throws -> any CacheStoring {
         EmptyCacheStorage()
     }
+
+    public func cacheLocalStorage() throws -> any CacheStoring {
+        EmptyCacheStorage()
+    }
 }

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -483,6 +483,7 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         // Set environment variables for TestCommand
         setVariable(.testScheme, value: "MyScheme")
         setVariable(.testClean, value: "true")
+        setVariable(.testNoUpload, value: "true")
         setVariable(.testPath, value: "/path/to/test")
         setVariable(.testDevice, value: "iPhone")
         setVariable(.testPlatform, value: "iOS")
@@ -505,6 +506,7 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         let testCommandWithEnvVars = try TestCommand.parse([])
         XCTAssertEqual(testCommandWithEnvVars.scheme, "MyScheme")
         XCTAssertTrue(testCommandWithEnvVars.clean)
+        XCTAssertTrue(testCommandWithEnvVars.noUpload)
         XCTAssertEqual(testCommandWithEnvVars.path, "/path/to/test")
         XCTAssertEqual(testCommandWithEnvVars.device, "iPhone")
         XCTAssertEqual(testCommandWithEnvVars.platform, "iOS")

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -26,8 +26,10 @@ final class TestServiceTests: TuistUnitTestCase {
     private var testsCacheTemporaryDirectory: TemporaryDirectory!
     private var cacheDirectoriesProvider: MockCacheDirectoriesProviding!
     private var configLoader: MockConfigLoading!
+    private var cacheStorageFactory: MockCacheStorageFactorying!
     private var cacheStorage: MockCacheStoring!
     private var analyticsDelegate: MockTrackableParametersDelegate!
+    private var testedSchemes: [String] = []
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -41,7 +43,7 @@ final class TestServiceTests: TuistUnitTestCase {
         analyticsDelegate = MockTrackableParametersDelegate()
         cacheStorage = .init()
 
-        let cacheStorageFactory = MockCacheStorageFactorying()
+        cacheStorageFactory = MockCacheStorageFactorying()
         given(cacheStorageFactory)
             .cacheStorage(config: .any)
             .willReturn(cacheStorage)
@@ -58,6 +60,10 @@ final class TestServiceTests: TuistUnitTestCase {
             .willReturn(runsCacheDirectory)
 
         configLoader = .init()
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.default)
 
         given(contentHasher)
             .hash(Parameter<String>.any)
@@ -91,11 +97,32 @@ final class TestServiceTests: TuistUnitTestCase {
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
         given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
-        given(buildGraphInspector)
             .workspaceSchemes(graphTraverser: .any)
             .willReturn([])
+
+        given(buildGraphInspector)
+            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
+            .willReturn(.test())
+
+        given(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+                self.testedSchemes.append(scheme)
+            }
     }
 
     override func tearDown() {
@@ -107,6 +134,9 @@ final class TestServiceTests: TuistUnitTestCase {
         generatorFactory = nil
         contentHasher = nil
         analyticsDelegate = nil
+        cacheStorageFactory = nil
+        cacheStorage = nil
+        testedSchemes = []
         subject = nil
         super.tearDown()
     }
@@ -222,10 +252,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .generateWithGraph(path: .value(path))
             .willReturn((path, .test(), MapperEnvironment()))
 
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
-
         // When
         try await testRun(
             path: path
@@ -235,9 +261,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_with_specified_arch() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -289,9 +312,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_for_only_specified_scheme() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -314,26 +334,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .willProduce { path in
                 (path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])), MapperEnvironment())
             }
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
-            }
 
         // When
         try await testRun(
@@ -348,9 +348,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_all_project_schemes() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -366,33 +363,10 @@ final class TestServiceTests: TuistUnitTestCase {
                     Scheme.test(name: "ProjectSchemeTwo"),
                 ]
             )
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
                 (path, .test(), MapperEnvironment())
-            }
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
             }
         try fileHandler.touch(
             testsCacheTemporaryDirectory.path.appending(component: "A")
@@ -416,12 +390,96 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_uploads_to_local_cache_storage_when_no_upload() async throws {
+        // Given
+        givenGenerator()
+
+        let projectPathOne = try temporaryPath().appending(component: "ProjectOne")
+        let schemeOne = Scheme.test(
+            name: "ProjectSchemeOne",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPathOne, name: "TargetA")),
+                ]
+            )
+        )
+
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([schemeOne])
+
+        var environment = MapperEnvironment()
+        environment.initialGraph = .test(
+            projects: [
+                projectPathOne: .test(
+                    path: projectPathOne,
+                    targets: [
+                        .test(name: "TargetA", bundleId: "io.tuist.TargetA"),
+                    ],
+                    schemes: [
+                        .test(
+                            name: "ProjectSchemeOne",
+                            testAction: .test(
+                                targets: [
+                                    .test(target: TargetReference(projectPath: projectPathOne, name: "TargetA")),
+                                ]
+                            )
+                        ),
+                    ]
+                ),
+            ]
+        )
+        environment.targetTestHashes = [
+            projectPathOne: [
+                "TargetA": "hash-a",
+            ],
+        ]
+        given(generator)
+            .generateWithGraph(path: .any)
+            .willProduce { path in
+                (
+                    path,
+                    .test(
+                        projects: [
+                            projectPathOne: .test(
+                                path: projectPathOne,
+                                targets: [
+                                    .test(name: "TargetA"),
+                                ],
+                                schemes: [schemeOne]
+                            ),
+                        ]
+                    ),
+                    environment
+                )
+            }
+        let localCacheStorage = MockCacheStoring()
+        given(cacheStorageFactory)
+            .cacheLocalStorage()
+            .willReturn(localCacheStorage)
+        given(localCacheStorage)
+            .store(.any, cacheCategory: .any)
+            .willReturn()
+
+        // When
+        try await testRun(
+            noUpload: true,
+            path: try temporaryPath()
+        )
+
+        // Then
+        verify(localCacheStorage)
+            .store(.any, cacheCategory: .any)
+            .called(1)
+
+        verify(cacheStorage)
+            .store(.any, cacheCategory: .any)
+            .called(0)
+    }
+
     func test_run_tests_individual_scheme() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -437,9 +495,6 @@ final class TestServiceTests: TuistUnitTestCase {
                     Scheme.test(name: "ProjectSchemeTwo"),
                 ]
             )
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -448,26 +503,6 @@ final class TestServiceTests: TuistUnitTestCase {
                     .test(workspace: .test(schemes: [.test(name: "ProjectSchemeOne"), .test(name: "ProjectSchemeTwo")])),
                     MapperEnvironment()
                 )
-            }
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
             }
         try fileHandler.touch(
             testsCacheTemporaryDirectory.path.appending(component: "A")
@@ -489,15 +524,9 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_individual_scheme_with_no_test_actions() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -506,26 +535,6 @@ final class TestServiceTests: TuistUnitTestCase {
                     .test(workspace: .test(schemes: [.test(name: "ProjectSchemeOne", testAction: .test(targets: []))])),
                     MapperEnvironment()
                 )
-            }
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
             }
         try fileHandler.touch(
             testsCacheTemporaryDirectory.path.appending(component: "A")
@@ -548,9 +557,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_throws_when_scheme_does_not_exist_and_initial_graph_is_nil() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -581,9 +587,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_throws_scheme_does_not_exist_in_initial_graph() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
@@ -625,29 +628,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_skips_running_tests_when_scheme_is_in_initial_graph_only() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
-            }
         var environment = MapperEnvironment()
         environment.initialGraph = .test(
             projects: [
@@ -713,26 +693,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 graphTraverser: .any
             )
             .willReturn(.test())
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
-            }
+
         var environment = MapperEnvironment()
         environment.initialGraph = .test(
             projects: [
@@ -841,9 +802,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_when_part_is_cached_and_scheme_is_passed() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
 
         let projectPathOne = try temporaryPath().appending(component: "ProjectOne")
         let schemeOne = Scheme.test(
@@ -875,26 +833,6 @@ final class TestServiceTests: TuistUnitTestCase {
                 graphTraverser: .any
             )
             .willReturn(.test())
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
-            }
         var environment = MapperEnvironment()
         environment.initialGraph = .test(
             projects: [
@@ -998,9 +936,6 @@ final class TestServiceTests: TuistUnitTestCase {
                 cacheStorage: .any
             )
             .willReturn(generator)
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -1015,29 +950,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .generateWithGraph(path: .any)
             .willProduce { path in
                 (path, .test(workspace: .test(schemes: [.test(name: "ProjectSchemeOneTests")])), MapperEnvironment())
-            }
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
             }
 
         // When
@@ -1054,9 +966,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_all_project_schemes_when_fails() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .workspaceSchemes(graphTraverser: .any)
             .willReturn(
@@ -1072,10 +981,7 @@ final class TestServiceTests: TuistUnitTestCase {
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
-        var testedSchemes: [String] = []
+        xcodebuildController.reset()
         given(xcodebuildController)
             .test(
                 .any,
@@ -1093,7 +999,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 passthroughXcodeBuildArguments: .any
             )
             .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
+                self.testedSchemes.append(scheme)
                 throw NSError.test()
             }
         try fileHandler.touch(
@@ -1121,12 +1027,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_tests_when_no_project_schemes_present() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
 
         let graph: Graph = .test()
         var environment = MapperEnvironment()
@@ -1135,26 +1035,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .generateWithGraph(path: .any)
             .willProduce { path in
                 (path, .test(), environment)
-            }
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
             }
 
         // When
@@ -1170,9 +1050,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_uses_resource_bundle_path() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         let expectedResourceBundlePath = try temporaryPath()
             .appending(component: "test")
         let xcresultPath = expectedResourceBundlePath.parentDirectory.appending(component: "bundle.xcresult")
@@ -1181,27 +1058,6 @@ final class TestServiceTests: TuistUnitTestCase {
             from: expectedResourceBundlePath,
             to: expectedResourceBundlePath.parentDirectory.appending(component: "bundle.xcresult")
         )
-        var resourceBundlePath: AbsolutePath?
-
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
-                resourceBundlePath = gotResourceBundlePath
-            }
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -1217,9 +1073,6 @@ final class TestServiceTests: TuistUnitTestCase {
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
 
         // When
         try await testRun(
@@ -1228,23 +1081,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(
-            resourceBundlePath,
-            expectedResourceBundlePath
-        )
-    }
-
-    func test_run_uses_resource_bundle_path_when_not_a_symlink() async throws {
-        // Given
-        givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
-        let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
-        try await fileSystem.makeDirectory(at: xcresultPath)
-        var resourceBundlePath: AbsolutePath?
-
-        given(xcodebuildController)
+        verify(xcodebuildController)
             .test(
                 .any,
                 scheme: .any,
@@ -1252,7 +1089,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 destination: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
-                resultBundlePath: .any,
+                resultBundlePath: .value(expectedResourceBundlePath),
                 arguments: .any,
                 retryCount: .any,
                 testTargets: .any,
@@ -1260,9 +1097,15 @@ final class TestServiceTests: TuistUnitTestCase {
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
             )
-            .willProduce { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
-                resourceBundlePath = gotResourceBundlePath
-            }
+            .called(1)
+    }
+
+    func test_run_uses_resource_bundle_path_when_not_a_symlink() async throws {
+        // Given
+        givenGenerator()
+        let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
+        try await fileSystem.makeDirectory(at: xcresultPath)
+
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -1283,21 +1126,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(
-            resourceBundlePath,
-            xcresultPath
-        )
-    }
-
-    func test_run_saves_resource_bundle_when_cloud_is_configured() async throws {
-        // Given
-        givenGenerator()
-        var resultBundlePath: AbsolutePath?
-        let expectedResultBundlePath = try cacheDirectoriesProvider
-            .cacheDirectory(for: .runs)
-            .appending(components: "run-id", Constants.resultBundleName)
-
-        given(xcodebuildController)
+        verify(xcodebuildController)
             .test(
                 .any,
                 scheme: .any,
@@ -1305,7 +1134,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 destination: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
-                resultBundlePath: .any,
+                resultBundlePath: .value(xcresultPath),
                 arguments: .any,
                 retryCount: .any,
                 testTargets: .any,
@@ -1313,9 +1142,17 @@ final class TestServiceTests: TuistUnitTestCase {
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
             )
-            .willProduce { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
-                resultBundlePath = gotResourceBundlePath
-            }
+            .called(1)
+    }
+
+    func test_run_saves_resource_bundle_when_cloud_is_configured() async throws {
+        // Given
+        givenGenerator()
+        configLoader.reset()
+        let expectedResultBundlePath = try cacheDirectoriesProvider
+            .cacheDirectory(for: .runs)
+            .appending(components: "run-id", Constants.resultBundleName)
+
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -1328,9 +1165,6 @@ final class TestServiceTests: TuistUnitTestCase {
                     Scheme.test(name: "ProjectScheme"),
                 ]
             )
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
@@ -1353,15 +1187,28 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(resultBundlePath, expectedResultBundlePath)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(expectedResultBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
     }
 
     func test_run_uses_resource_bundle_path_with_given_scheme() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         let expectedResourceBundlePath = try temporaryPath()
             .appending(component: "test")
         let xcresultPath = expectedResourceBundlePath.parentDirectory.appending(component: "bundle.xcresult")
@@ -1370,27 +1217,6 @@ final class TestServiceTests: TuistUnitTestCase {
             from: expectedResourceBundlePath,
             to: expectedResourceBundlePath.parentDirectory.appending(component: "bundle.xcresult")
         )
-        var resourceBundlePath: AbsolutePath?
-
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
-                resourceBundlePath = gotResourceBundlePath
-            }
 
         given(generator)
             .generateWithGraph(path: .any)
@@ -1408,9 +1234,6 @@ final class TestServiceTests: TuistUnitTestCase {
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn([])
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
 
         // When
         try await testRun(
@@ -1420,10 +1243,23 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(
-            resourceBundlePath,
-            expectedResourceBundlePath
-        )
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .value(expectedResourceBundlePath),
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
         let existsResultBundlePathInCacheDirectory = try await fileSystem.exists(
             try cacheDirectoriesProvider
                 .cacheDirectory(for: .runs)
@@ -1458,30 +1294,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .willProduce { path in
                 (path, .test(workspace: .test(schemes: [.test(name: "ProjectSchemeOne")])), MapperEnvironment())
             }
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
-
-        var passedRetryCount = 0
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
-                passedRetryCount = retryCount
-            }
 
         // When
         try await testRun(
@@ -1491,15 +1303,28 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(passedRetryCount, 3)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .value(3),
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .called(1)
     }
 
     func test_run_defaults_retry_count_to_zero() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         given(buildGraphInspector)
             .testableSchemes(graphTraverser: .any)
             .willReturn(
@@ -1519,9 +1344,6 @@ final class TestServiceTests: TuistUnitTestCase {
             .willProduce { path in
                 (path, .test(workspace: .test(schemes: [.test(name: "ProjectSchemeOne")])), MapperEnvironment())
             }
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
 
         given(xcodebuildController)
             .test(
@@ -1570,9 +1392,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_test_plan_success() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         let testPlan = "TestPlan"
         let testPlanPath = try AbsolutePath(validating: "/testPlan/\(testPlan)")
         let projectPath = try temporaryPath().appending(component: "Project")
@@ -1681,26 +1500,6 @@ final class TestServiceTests: TuistUnitTestCase {
         given(buildGraphInspector)
             .workspaceSchemes(graphTraverser: .any)
             .willReturn([])
-        var testedSchemes: [String] = []
-        given(xcodebuildController)
-            .test(
-                .any,
-                scheme: .any,
-                clean: .any,
-                destination: .any,
-                rosetta: .any,
-                derivedDataPath: .any,
-                resultBundlePath: .any,
-                arguments: .any,
-                retryCount: .any,
-                testTargets: .any,
-                skipTestTargets: .any,
-                testPlanConfiguration: .any,
-                passthroughXcodeBuildArguments: .any
-            )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
-                testedSchemes.append(scheme)
-            }
 
         // When
         try await testRun(
@@ -1740,9 +1539,6 @@ final class TestServiceTests: TuistUnitTestCase {
     func test_run_test_plan_failure() async throws {
         // Given
         givenGenerator()
-        given(configLoader)
-            .loadConfig(path: .any)
-            .willReturn(.default)
         let testPlan = "TestPlan"
         let testPlanPath = try AbsolutePath(validating: "/testPlan/\(testPlan)")
         given(buildGraphInspector)
@@ -1765,9 +1561,6 @@ final class TestServiceTests: TuistUnitTestCase {
                     Scheme.test(name: "ProjectSchemeOne"),
                 ]
             )
-        given(buildGraphInspector)
-            .testableTarget(scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any, graphTraverser: .any)
-            .willReturn(.test())
         given(generator)
             .generateWithGraph(path: .any)
             .willProduce { path in
@@ -1828,6 +1621,7 @@ final class TestServiceTests: TuistUnitTestCase {
         runId: String = "run-id",
         schemeName: String? = nil,
         clean: Bool = false,
+        noUpload: Bool = false,
         configuration: String? = nil,
         path: AbsolutePath,
         deviceName: String? = nil,
@@ -1848,6 +1642,7 @@ final class TestServiceTests: TuistUnitTestCase {
             runId: runId,
             schemeName: schemeName,
             clean: clean,
+            noUpload: noUpload,
             configuration: configuration,
             path: path,
             deviceName: deviceName,


### PR DESCRIPTION
### Short description 📝

This PR adds `--no-upload` flag as proposed [here](https://community.tuist.io/t/restrict-selective-test-results-uploads-to-specific-branch-or-environment/146).

We currently don't have multiple categories, so `--no-upload` is implemented as a flag and not an option. We can change that in the future if needed.

### How to test the changes locally 🧐

- Run `tuist test --no-upload` -> selective test results should not be uploaded.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
