### PR TITLE
Graph Performance Optimizations

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -25,6 +25,7 @@ public class GraphTraverser: GraphTraversing {
 
     private let graph: Graph
     private let conditionCache = ConditionCache()
+    private let swiftPluginExecutablesCache = GraphCache<GraphDependency, Set<String>>()
     private let systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding =
         SystemFrameworkMetadataProvider()
     private let targetDirectTargetDependenciesCache: ThreadSafe<[GraphTarget: [GraphTarget]]> =
@@ -952,70 +953,75 @@ public class GraphTraverser: GraphTraversing {
 
     // swiftlint:disable:next function_body_length
     public func allSwiftPluginExecutables(path: Path.AbsolutePath, name: String) -> Set<String> {
-        func precompiledMacroDependencies(_ graphDependency: GraphDependency) -> Set<
-            Path.AbsolutePath
-        > {
-            Set(
-                dependencies[graphDependency, default: Set()]
-                    .lazy
-                    .compactMap {
-                        if case let GraphDependency.macro(path) = $0 {
-                            return path
-                        } else {
-                            return nil
+        if let cached = swiftPluginExecutablesCache[.target(name: name, path: path)] {
+            return cached
+        } else {
+            func precompiledMacroDependencies(_ graphDependency: GraphDependency) -> Set<
+                Path.AbsolutePath
+            > {
+                Set(
+                    dependencies[graphDependency, default: Set()]
+                        .lazy
+                        .compactMap {
+                            if case let GraphDependency.macro(path) = $0 {
+                                return path
+                            } else {
+                                return nil
+                            }
                         }
-                    }
-            )
-        }
+                )
+            }
 
-        let precompiledMacroPluginExecutables = filterDependencies(
-            from: .target(name: name, path: path),
-            test: { dependency in
+            let precompiledMacroPluginExecutables = filterDependencies(
+                from: .target(name: name, path: path),
+                test: { dependency in
+                    switch dependency {
+                    case .xcframework:
+                        return !precompiledMacroDependencies(dependency).isEmpty
+                    case .macro:
+                        return true
+                    case .bundle, .library, .framework, .sdk, .target, .packageProduct:
+                        return false
+                    }
+                },
+                skip: { dependency in
+                    switch dependency {
+                    case .macro:
+                        return true
+                    case .bundle, .library, .framework, .sdk, .target, .packageProduct, .xcframework:
+                        return false
+                    }
+                }
+            )
+            .flatMap { dependency in
                 switch dependency {
                 case .xcframework:
-                    return !precompiledMacroDependencies(dependency).isEmpty
-                case .macro:
-                    return true
+                    return Array(precompiledMacroDependencies(dependency))
+                case let .macro(path):
+                    return [path]
                 case .bundle, .library, .framework, .sdk, .target, .packageProduct:
-                    return false
-                }
-            },
-            skip: { dependency in
-                switch dependency {
-                case .macro:
-                    return true
-                case .bundle, .library, .framework, .sdk, .target, .packageProduct, .xcframework:
-                    return false
+                    return []
                 }
             }
-        )
-        .flatMap { dependency in
-            switch dependency {
-            case .xcframework:
-                return Array(precompiledMacroDependencies(dependency))
-            case let .macro(path):
-                return [path]
-            case .bundle, .library, .framework, .sdk, .target, .packageProduct:
-                return []
-            }
+            .map { "\($0.pathString)#\($0.basename.replacingOccurrences(of: ".macro", with: ""))" }
+
+            let sourceMacroPluginExecutables = allSwiftMacroTargets(path: path, name: name)
+                .flatMap { target in
+                    directSwiftMacroExecutables(path: target.project.path, name: target.target.name).map
+                        { (target, $0) }
+                }
+                .compactMap { _, dependencyReference in
+                    switch dependencyReference {
+                    case let .product(_, productName, _, _):
+                        return "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(productName)#\(productName)"
+                    default:
+                        return nil
+                    }
+                }
+            let result = Set(precompiledMacroPluginExecutables + sourceMacroPluginExecutables)
+            swiftPluginExecutablesCache[.target(name: name, path: path)] = result
+            return result
         }
-        .map { "\($0.pathString)#\($0.basename.replacingOccurrences(of: ".macro", with: ""))" }
-
-        let sourceMacroPluginExecutables = allSwiftMacroTargets(path: path, name: name)
-            .flatMap { target in
-                directSwiftMacroExecutables(path: target.project.path, name: target.target.name).map
-                    { (target, $0) }
-            }
-            .compactMap { _, dependencyReference in
-                switch dependencyReference {
-                case let .product(_, productName, _, _):
-                    return "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(productName)#\(productName)"
-                default:
-                    return nil
-                }
-            }
-
-        return Set(precompiledMacroPluginExecutables + sourceMacroPluginExecutables)
     }
 
     // MARK: - Internal


### PR DESCRIPTION
Genericizes `ConditionCache` into `GraphCache` and uses it within `allSwiftPluginExecutables`.

### Short description 📝

This is a quick caching implementation in `allSwiftPluginExecutables` which should help with the performance issues identified in [this post](https://community.tuist.io/t/improve-tuists-performance/130/2)

I wanted to toss this up as an option for perf improvements but may not have the personal time to see it landed.  Open to comments about needed tests or other changes but totally fine for someone else to take this the rest of the way (and actually do things like "measure improvements" and "verify it's not actually a regression").

I'm fairly confident in this change tho since it's the same structured we used for platform conditions.

### How to test the changes locally 🧐

Everything should keep working.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
