### PR TITLE
Consistent title templates in the documentation

### DIFF
--- a/docs/docs/en/cli/[command].md
+++ b/docs/docs/en/cli/[command].md
@@ -1,6 +1,6 @@
 ---
 title: {params.command.fullCommand}
-titleTemplate: :title | CLI | Tuist
+titleTemplate: :title · CLI · Tuist
 ---
 
 <!-- @content -->

--- a/docs/docs/en/contributors/code-reviews.md
+++ b/docs/docs/en/contributors/code-reviews.md
@@ -1,6 +1,6 @@
 ---
 title: Code reviews
-titleTemplate: :title | Contributors | Tuist
+titleTemplate: :title · Contributors · Tuist
 description: Learn how to contribute to Tuist by reviewing code
 ---
 

--- a/docs/docs/en/contributors/get-started.md
+++ b/docs/docs/en/contributors/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-titleTemplate: :title | Contributors | Tuist
+titleTemplate: :title · Contributors · Tuist
 description: Get started contributing to Tuist by following this guide.
 ---
 # Get started {#get-started}

--- a/docs/docs/en/contributors/issue-reporting.md
+++ b/docs/docs/en/contributors/issue-reporting.md
@@ -1,12 +1,12 @@
 ---
 title: Issue reporting
-titleTemplate: :title | Contributors | Tuist
+titleTemplate: :title · Contributors · Tuist
 description: Learn how to contribute to Tuist by reporting bugs
 ---
 
 # Issue reporting {#issue-reporting}
 
-As user of Tuist, you might come across bugs or unexpected behaviors. 
+As user of Tuist, you might come across bugs or unexpected behaviors.
 If you do, we encourage you to report them so that we can fix them.
 
 ## GitHub issues is our ticketing platform {#github-issues-is-our-ticketing-platform}

--- a/docs/docs/en/contributors/principles.md
+++ b/docs/docs/en/contributors/principles.md
@@ -1,6 +1,6 @@
 ---
 title: Principles
-titleTemplate: :title | Contributors | Tuist
+titleTemplate: :title · Contributors · Tuist
 description: This document describes the principles that guide the development of Tuist.
 ---
 

--- a/docs/docs/en/contributors/translate.md
+++ b/docs/docs/en/contributors/translate.md
@@ -1,12 +1,12 @@
 ---
 title: Translate
-titleTemplate: :title | Contributors | Tuist
+titleTemplate: :title · Contributors · Tuist
 description: This document describes the principles that guide the development of Tuist.
 ---
 
 # Translate
 
-Languages can be barriers to understanding. We want to make sure that Tuist is accessible to as many people as possible. If you speak a language that Tuist doesn't support, you can help us by translating the various surfaces of Tuist. 
+Languages can be barriers to understanding. We want to make sure that Tuist is accessible to as many people as possible. If you speak a language that Tuist doesn't support, you can help us by translating the various surfaces of Tuist.
 
 Since maintaining translations is a continuous effort, we add languages as we see contributors willing to help us maintain them. The following languages are currently supported:
 

--- a/docs/docs/en/guides/develop/automate/continuous-integration.md
+++ b/docs/docs/en/guides/develop/automate/continuous-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Continuous Integration (CI)
-titleTemplate: ":title | Develop | Tuist"
+titleTemplate: :title · Automate · Develop · Guides · Tuist
 description: Learn how to use Tuist in your CI workflows.
 ---
 

--- a/docs/docs/en/guides/develop/automate/workflows.md
+++ b/docs/docs/en/guides/develop/automate/workflows.md
@@ -1,6 +1,6 @@
 ---
 title: Workflows
-titleTemplate: ":title | Integrate | Develop | Tuist"
+titleTemplate: :title · Automate · Develop · Guides · Tuist
 description: Integrate your changes through workflows.
 ---
 

--- a/docs/docs/en/guides/develop/build.md
+++ b/docs/docs/en/guides/develop/build.md
@@ -1,6 +1,6 @@
 ---
 title: Build
-titleTemplate: ":title | Develop | Tuist"
+titleTemplate: :title · Develop · Guides · Tuist
 description: Learn how to use Tuist to build your projects efficiently.
 ---
 

--- a/docs/docs/en/guides/develop/build/cache.md
+++ b/docs/docs/en/guides/develop/build/cache.md
@@ -1,5 +1,6 @@
 ---
 title: Cache
+titleTemplate: :title · Build · Develop · Guides · Tuist
 description: Optimize your build times by caching compiled binaries and sharing them across different environments.
 ---
 

--- a/docs/docs/en/guides/develop/inspect/implicit-dependencies.md
+++ b/docs/docs/en/guides/develop/inspect/implicit-dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: Implicit imports
+titleTemplate: :title · Inspect · Develop · Guides · Tuist
 description: Learn how to use Tuist to find implicit imports.
 ---
 

--- a/docs/docs/en/guides/develop/projects.md
+++ b/docs/docs/en/guides/develop/projects.md
@@ -1,6 +1,6 @@
 ---
 title: Projects
-titleTemplate: ":title | Develop | Tuist"
+titleTemplate: :title · Develop · Guides · Tuist
 description: Learn about Tuist's DSL for defining Xcode projects.
 ---
 

--- a/docs/docs/en/guides/develop/projects/best-practices.md
+++ b/docs/docs/en/guides/develop/projects/best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: Best practices
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about the best practices for working with Tuist and Xcode projects.
 ---
 

--- a/docs/docs/en/guides/develop/projects/code-sharing.md
+++ b/docs/docs/en/guides/develop/projects/code-sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Code sharing
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how to share code across manifest files to reduce duplications and ensure consistency
 ---
 

--- a/docs/docs/en/guides/develop/projects/cost-of-convenience.md
+++ b/docs/docs/en/guides/develop/projects/cost-of-convenience.md
@@ -1,12 +1,12 @@
 ---
 title: The cost of convenience
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about the cost of convenience in Xcode and how Tuist helps you prevent the issues that come with it.
 ---
 
 # The cost of convenience {#the-cost-of-convenience}
 
-Designing a code editor that the spectrum **from small to large-scale projects can use** is a challenging task. 
+Designing a code editor that the spectrum **from small to large-scale projects can use** is a challenging task.
 Many tools approach the problem by layering their solution and providing extensibility. The bottom-most layer is very low-level and close to the underlying build system, and the top-most layer is a high-level abstraction that's convenient to use but less flexible.
 By doing so, they make the simple things easy, and everything else possible.
 
@@ -51,7 +51,7 @@ Because all the products of a project go into the same directory,
 which is visible by default from other targets to link against,
 **you might end up with targets that implicitly depend on each other.**
 While this might not be a problem when having just a few targets,
-it might manifest as failing builds that are hard to debug when the project grows. 
+it might manifest as failing builds that are hard to debug when the project grows.
 
 The consequence of this design decision is that many projects acidentally compile with a graph that is not well-defined.
 
@@ -106,7 +106,7 @@ Going back to first principles and rethinking the design of the tools might lead
 
 Apple finds itself in a bit of a chicken-and-egg problem.
 Convenience is what helps developers get started quickly and build more apps for their ecosystem.
-But their decisions to make the experience convenience at that scale, 
+But their decisions to make the experience convenience at that scale,
 is making it hard for them to ensure some of the Xcode features work reliably.
 
 Because the future is unknown,

--- a/docs/docs/en/guides/develop/projects/dependencies.md
+++ b/docs/docs/en/guides/develop/projects/dependencies.md
@@ -1,6 +1,6 @@
 ---
 title: Dependencies
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how to declare dependencies in your Tuist project.
 ---
 

--- a/docs/docs/en/guides/develop/projects/directory-structure.md
+++ b/docs/docs/en/guides/develop/projects/directory-structure.md
@@ -1,6 +1,6 @@
 ---
 title: Directory structure
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about the structure of Tuist projects and how to organize them.
 ---
 

--- a/docs/docs/en/guides/develop/projects/dynamic-configuration.md
+++ b/docs/docs/en/guides/develop/projects/dynamic-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Dynamic configuration
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how how to use environment variables to dynamically configure your project.
 ---
 

--- a/docs/docs/en/guides/develop/projects/editing.md
+++ b/docs/docs/en/guides/develop/projects/editing.md
@@ -1,6 +1,6 @@
 ---
 title: Editing
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how to use Tuist's edit workflow to declare your project leveraging Xcode's build system and editor capabilities.
 ---
 
@@ -36,7 +36,7 @@ The project includes a `Manifests` directory that you can build to ensure all yo
 ## Edit and generate workflow {#edit-and-generate-workflow}
 
 As you might have noticed, the editing can't be done from the generated Xcode project.
-That's by design to prevent the generated project from having a dependency on Tuist, 
+That's by design to prevent the generated project from having a dependency on Tuist,
 ensuring you can move from Tuist in the future with little effort.
 
-When iterating on a project, we recommend running `tuist edit` from a terminal session to get an Xcode project to edit the project, and use another terminal session to run `tuist generate`. 
+When iterating on a project, we recommend running `tuist edit` from a terminal session to get an Xcode project to edit the project, and use another terminal session to run `tuist generate`.

--- a/docs/docs/en/guides/develop/projects/hashing.md
+++ b/docs/docs/en/guides/develop/projects/hashing.md
@@ -1,6 +1,6 @@
 ---
 title: Hashing
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about Tuist's hashing logic upon which features like binary caching and selective testing are built.
 ---
 

--- a/docs/docs/en/guides/develop/projects/manifests.md
+++ b/docs/docs/en/guides/develop/projects/manifests.md
@@ -1,6 +1,6 @@
 ---
 title: Manifests
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about the manifest files that Tuist uses to define projects and workspaces and configure the generation process.
 ---
 

--- a/docs/docs/en/guides/develop/projects/plugins.md
+++ b/docs/docs/en/guides/develop/projects/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how to create and use plugins in Tuist to extend its functionality.
 ---
 

--- a/docs/docs/en/guides/develop/projects/synthesized-files.md
+++ b/docs/docs/en/guides/develop/projects/synthesized-files.md
@@ -1,6 +1,6 @@
 ---
 title: Synthesized files
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about synthesized files in Tuist projects.
 ---
 
@@ -18,7 +18,7 @@ Xcode projects support adding resources to targets. However, they present teams 
 
 Tuist solves the problems above by **synthesizing a unified interface to access bundles and resources** that abstracts away the implementation details.
 
-> [!IMPORTANT] RECOMMENDED 
+> [!IMPORTANT] RECOMMENDED
 > Even though accessing resources through the Tuist-synthesized interface is not mandatory, we recommend it because it makes the code easier to reason about and the resources to move around.
 
 ## Resources {#resources}
@@ -99,5 +99,5 @@ you can use the `Project.resourceSynthesizers` property passing the list of reso
 let project = Project(resourceSynthesizers: [.string(), .fonts()])
 ```
 
-> [!NOTE] REFERENCE 
+> [!NOTE] REFERENCE
 > You can check out [this fixture](https://github.com/tuist/tuist/tree/main/fixtures/ios_app_with_templates) to see an example of how to use custom templates to synthesize accessors to resources.

--- a/docs/docs/en/guides/develop/projects/templates.md
+++ b/docs/docs/en/guides/develop/projects/templates.md
@@ -1,6 +1,6 @@
 ---
 title: Templates
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn how to create and use templates in Tuist to generate code in your projects.
 ---
 

--- a/docs/docs/en/guides/develop/projects/tma-architecture.md
+++ b/docs/docs/en/guides/develop/projects/tma-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: The Modular Architecture (TMA)
-titleTemplate: ":title | Projects | Tuist"
+titleTemplate: :title · Projects · Develop · Guides · Tuist
 description: Learn about The Modular Architecture (TMA) and how to structure your projects using it.
 ---
 

--- a/docs/docs/en/guides/develop/test.md
+++ b/docs/docs/en/guides/develop/test.md
@@ -1,6 +1,6 @@
 ---
 title: tuist test
-titleTemplate: ":title | Develop | Tuist"
+titleTemplate: :title · Develop · Guides · Tuist
 description: Learn how to run tests efficiently with Tuist.
 ---
 

--- a/docs/docs/en/guides/develop/test/flakiness.md
+++ b/docs/docs/en/guides/develop/test/flakiness.md
@@ -1,5 +1,6 @@
 ---
 title: Test flakiness
+titleTemplate: :title · Test · Develop · Guides · Tuist
 description: Prevent, detect, and fix flaky tests with Tuist.
 ---
 

--- a/docs/docs/en/guides/develop/test/smart-runner.md
+++ b/docs/docs/en/guides/develop/test/smart-runner.md
@@ -1,5 +1,6 @@
 ---
 title: Smart test runner
+titleTemplate: :title · Test · Develop · Guides · Tuist
 description: Use smart test selection to run only the tests that need to be run.
 ---
 

--- a/docs/docs/en/guides/quick-start/add-dependencies.md
+++ b/docs/docs/en/guides/quick-start/add-dependencies.md
@@ -1,5 +1,6 @@
 ---
 title: Add dependencies
+titleTemplate: :title · Quick-start · Guides · Tuist
 description: Learn how to add dependencies to your first Swift project
 ---
 

--- a/docs/docs/en/guides/quick-start/create-a-project.md
+++ b/docs/docs/en/guides/quick-start/create-a-project.md
@@ -1,5 +1,6 @@
 ---
 title: Create a project
+titleTemplate: :title · Quick-start · Guides · Tuist
 description: Learn how to create your first project with Tuist.
 ---
 
@@ -34,7 +35,7 @@ Tuist provides commands for the most common tasks you'll need to perform on your
 tuist build
 ```
 
-Under the hood, this command uses the platform's build system (e.g. `xcodebuild`), enriching it with Tuist's features. 
+Under the hood, this command uses the platform's build system (e.g. `xcodebuild`), enriching it with Tuist's features.
 
 ## Test the app {#test-the-app}
 

--- a/docs/docs/en/guides/quick-start/gather-insights.md
+++ b/docs/docs/en/guides/quick-start/gather-insights.md
@@ -1,5 +1,6 @@
 ---
 title: Gather insights
+titleTemplate: :title · Quick-start · Guides · Tuist
 description: Learn how to gather insights about your project.
 ---
 

--- a/docs/docs/en/guides/quick-start/install-tuist.md
+++ b/docs/docs/en/guides/quick-start/install-tuist.md
@@ -1,5 +1,6 @@
 ---
 title: Install Tuist
+titleTemplate: :title · Quick-start · Guides · Tuist
 description: Learn how to install Tuist in your environment.
 ---
 

--- a/docs/docs/en/guides/quick-start/optimize-workflows.md
+++ b/docs/docs/en/guides/quick-start/optimize-workflows.md
@@ -1,5 +1,6 @@
 ---
 title: Optimize workflows
+titleTemplate: :title · Quick-start · Guides · Tuist
 description: Learn how to optimize workflows with Tuist.
 ---
 

--- a/docs/docs/en/guides/share/previews.md
+++ b/docs/docs/en/guides/share/previews.md
@@ -1,5 +1,6 @@
 ---
 title: Previews
+titleTemplate: :title · Share · Guides · Tuist
 description: Learn how to generate and share previews of your apps with anyone.
 ---
 

--- a/docs/docs/en/guides/start/migrate/bazel-project.md
+++ b/docs/docs/en/guides/start/migrate/bazel-project.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate a Bazel project
+titleTemplate: :title · Migrate· Start · Guides · Tuist
 description: Learn how to migrate your projects from Bazel to Tuist.
 ---
 

--- a/docs/docs/en/guides/start/migrate/swift-package.md
+++ b/docs/docs/en/guides/start/migrate/swift-package.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate a Swift Package
+titleTemplate: :title · Migrate· Start · Guides · Tuist
 description: Learn how to migrate from Swift Package Manager as a solution for managing your projects to Tuist projects.
 ---
 

--- a/docs/docs/en/guides/start/migrate/xcode-project.md
+++ b/docs/docs/en/guides/start/migrate/xcode-project.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate an Xcode project
+titleTemplate: :title · Migrate· Start · Guides · Tuist
 description: Learn how to migrate an Xcode project to a Tuist project.
 ---
 

--- a/docs/docs/en/guides/start/migrate/xcodegen-project.md
+++ b/docs/docs/en/guides/start/migrate/xcodegen-project.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate an XcodeGen project
+titleTemplate: :title · Migrate· Start · Guides · Tuist
 description: Learn how to migrate your projects from XcodeGen to Tuist.
 ---
 

--- a/docs/docs/en/guides/start/new-project.md
+++ b/docs/docs/en/guides/start/new-project.md
@@ -1,5 +1,6 @@
 ---
 title: Create a new project
+titleTemplate: :title · Start · Guides · Tuist
 description: Learn how to create a new project with Tuist.
 ---
 

--- a/docs/docs/en/guides/start/swift-package.md
+++ b/docs/docs/en/guides/start/swift-package.md
@@ -1,5 +1,6 @@
 ---
 title: Use Tuist with a Swift Package
+titleTemplate: :title · Start · Guides · Tuist
 description: Learn how to use Tuist with a Swift Package.
 ---
 

--- a/docs/docs/en/references/examples/[example].md
+++ b/docs/docs/en/references/examples/[example].md
@@ -1,5 +1,6 @@
 ---
 editLink: false
+titleTemplate: :title · Examples · References · Tuist
 description: {{ $params.description }}
 ---
 

--- a/docs/docs/en/references/migrations/from-v3-to-v4.md
+++ b/docs/docs/en/references/migrations/from-v3-to-v4.md
@@ -1,5 +1,6 @@
 ---
 title: From v3 to v4
+titleTemplate: :title · Migrations · References · Tuist
 description: This page documents how to migrate the Tuist CLI from the version 3 to version 4.
 ---
 

--- a/docs/docs/en/references/project-description/[identifier].md
+++ b/docs/docs/en/references/project-description/[identifier].md
@@ -1,1 +1,6 @@
+---
+editLink: false
+titleTemplate: :title · Project Description · References · Tuist
+---
+
 <!-- @content -->


### PR DESCRIPTION
I'm aligning the title convention with the Tuist server, and making sure they are consistent throughout all the pages and with the URL of the page.