### PR TITLE
Fix SwiftLint warning in generated resource bundle accessors

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -172,28 +172,29 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
 
     // swiftlint:disable:next function_body_length
     static func fileContent(targetName _: String, bundleName: String, target: Target, in project: Project) -> String {
-        var content = """
+        let bundleAccessor = if target.supportsResources {
+            swiftFrameworkBundleAccessorString(for: target)
+        } else {
+            swiftSPMBundleAccessorString(for: target, and: bundleName)
+        }
+
+        // Add public accessors only for non external projects
+        let publicBundleAccessor = if project.isExternal || target.sourcesContainsPublicResourceClassName {
+            ""
+        } else {
+            publicBundleAccessorString(for: target)
+        }
+
+        return """
         // swiftlint:disable all
         // swift-format-ignore-file
         // swiftformat:disable all
         import Foundation
-        """
-        if !target.supportsResources {
-            content += swiftSPMBundleAccessorString(for: target, and: bundleName)
-        } else {
-            content += swiftFrameworkBundleAccessorString(for: target)
-        }
-
-        // Add public accessors only for non external projects
-        if !project.isExternal, !target.sourcesContainsPublicResourceClassName {
-            content += publicBundleAccessorString(for: target)
-        }
-
-        content += """
-        // swiftlint:enable all
+        \(bundleAccessor)
+        \(publicBundleAccessor)
         // swiftformat:enable all
+        // swiftlint:enable all
         """
-        return content
     }
 
     static func objcHeaderFileContent(


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6404>

### Short description 📝

SwiftLint generates warning:
`app/Derived/Sources/TuistBundle+MyApp.swift:16:1: warning: Trailing Newline Violation: Files should have a single trailing newline (trailing_newline)`

### How to test the changes locally 🧐

Generate any project with dynamic frameworks and resources, look at the TuistBundle+* file(s).
`// swiftlint:enable all` should be on the last line

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
