### PR TITLE
fix(docs): fix the localized string in the sidebar

### DIFF
--- a/docs/.vitepress/bars.mjs
+++ b/docs/.vitepress/bars.mjs
@@ -523,7 +523,7 @@ export function guidesSidebar(locale) {
             {
               text: localizedString(
                 locale,
-                "sidebars.guides.items.develop.items.inspect.items.implicit-imports"
+                "sidebars.guides.items.develop.items.inspect.items.implicit-imports.text"
               ),
               link: `/${locale}/guides/develop/inspect/implicit-dependencies`,
             },


### PR DESCRIPTION
### Short description 📝

- Fixed the issue where an object was rendered instead of a string.

![CleanShot 2024-10-30 at 10 30 58@2x](https://github.com/user-attachments/assets/b4ae19ac-22d7-4030-87d2-26102e2dcddc)

### How to test the changes locally 🧐

- Run `mise run docs:dev`
- Visit: http://localhost:5173/en/

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
