### PR TITLE
Fix running selective tests with a custom result bundle path when all tests are skipped

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -449,6 +449,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         resultBundlePath: AbsolutePath?
     ) async throws {
         if let runResultBundlePath, let resultBundlePath, runResultBundlePath != resultBundlePath {
+            guard try await fileSystem.exists(resultBundlePath) else { return }
             if try await !fileSystem.exists(resultBundlePath.parentDirectory) {
                 try await fileSystem.makeDirectory(at: resultBundlePath.parentDirectory)
             }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -655,6 +655,68 @@ final class TestServiceTests: TuistUnitTestCase {
         XCTAssertStandardOutput(pattern: "The scheme ProjectSchemeOne's test action has no tests to run, finishing early.")
     }
 
+    func test_skips_running_tests_when_all_tests_are_cached() async throws {
+        // Given
+        givenGenerator()
+        var environment = MapperEnvironment()
+        environment.initialGraph = .test(
+            projects: [
+                try temporaryPath(): .test(schemes: [.test(name: "ProjectSchemeOne")]),
+            ]
+        )
+        given(generator)
+            .generateWithGraph(path: .any)
+            .willProduce { path in
+                (
+                    path,
+                    .test(),
+                    environment
+                )
+            }
+
+        // When
+        try await testRun(
+            path: try temporaryPath()
+        )
+
+        // Then
+        XCTAssertEmpty(testedSchemes)
+        XCTAssertStandardOutput(pattern: "There are no tests to run, finishing early")
+    }
+
+    func test_skips_running_tests_when_all_tests_are_cached_with_a_custom_result_bundle_path() async throws {
+        // Given
+        givenGenerator()
+        var environment = MapperEnvironment()
+        environment.initialGraph = .test(
+            projects: [
+                try temporaryPath(): .test(schemes: [.test(name: "ProjectSchemeOne")]),
+            ]
+        )
+        given(generator)
+            .generateWithGraph(path: .any)
+            .willProduce { path in
+                (
+                    path,
+                    .test(),
+                    environment
+                )
+            }
+
+        let resultBundlePath = try temporaryPath()
+            .appending(component: "test.xcresult")
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            resultBundlePath: resultBundlePath
+        )
+
+        // Then
+        XCTAssertEmpty(testedSchemes)
+        XCTAssertStandardOutput(pattern: "There are no tests to run, finishing early")
+    }
+
     func test_run_tests_when_part_is_cached() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6939

### Short description 📝

We assume the result bundle always exists after running tests – that might not always be the case, for example when all tests are skipped.

The solution here is to skip copying the result bundle path if we can't find it.

### How to test the changes locally 🧐

Follow [these](https://github.com/tuist/tuist/issues/6939#issuecomment-2447216901) repro steps.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
