### PR TITLE
Improve performance by loading Swift tools version directly from Package manifests

### DIFF
--- a/Sources/TuistCore/Models/PackageSettings.swift
+++ b/Sources/TuistCore/Models/PackageSettings.swift
@@ -18,9 +18,6 @@ public struct PackageSettings: Equatable, Codable {
     /// The custom project options for each project generated from a swift package
     public let projectOptions: [String: XcodeGraph.Project.Options]
 
-    /// Swift tools version of the parsed `Package.swift`
-    public let swiftToolsVersion: Version
-
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
@@ -32,15 +29,13 @@ public struct PackageSettings: Equatable, Codable {
         productDestinations: [String: Destinations],
         baseSettings: Settings,
         targetSettings: [String: SettingsDictionary],
-        projectOptions: [String: XcodeGraph.Project.Options] = [:],
-        swiftToolsVersion: Version
+        projectOptions: [String: XcodeGraph.Project.Options] = [:]
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
-        self.swiftToolsVersion = swiftToolsVersion
     }
 }
 
@@ -51,16 +46,14 @@ public struct PackageSettings: Equatable, Codable {
             productDestinations: [String: Destinations] = [:],
             baseSettings: Settings = Settings.default,
             targetSettings: [String: SettingsDictionary] = [:],
-            projectOptions: [String: XcodeGraph.Project.Options] = [:],
-            swiftToolsVersion: Version = Version("5.4.9")
+            projectOptions: [String: XcodeGraph.Project.Options] = [:]
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,
                 productDestinations: productDestinations,
                 baseSettings: baseSettings,
                 targetSettings: targetSettings,
-                projectOptions: projectOptions,
-                swiftToolsVersion: swiftToolsVersion
+                projectOptions: projectOptions
             )
         }
     }

--- a/Sources/TuistLoader/Loaders/PackageSettingsLoader.swift
+++ b/Sources/TuistLoader/Loaders/PackageSettingsLoader.swift
@@ -46,14 +46,10 @@ public final class PackageSettingsLoader: PackageSettingsLoading {
             manifestDirectory: path,
             rootDirectory: rootDirectory
         )
-        let swiftToolsVersion = try swiftPackageManagerController.getToolsVersion(
-            at: path
-        )
 
         return try TuistCore.PackageSettings.from(
             manifest: manifest,
-            generatorPaths: generatorPaths,
-            swiftToolsVersion: swiftToolsVersion
+            generatorPaths: generatorPaths
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -15,10 +15,9 @@ extension XcodeGraph.FileElement {
     static func from(
         manifest: ProjectDescription.FileElement,
         generatorPaths: GeneratorPaths,
-        fileSystem _: FileSysteming,
+        fileSystem: FileSysteming,
         includeFiles: @escaping (AbsolutePath) -> Bool = { _ in true }
     ) async throws -> [XcodeGraph.FileElement] {
-        let fileSystem = FileSystem()
         func globFiles(_ path: AbsolutePath) async throws -> [AbsolutePath] {
             if try await fileSystem.exists(path), !FileHandler.shared.isFolder(path) { return [path] }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -11,8 +11,7 @@ extension TuistCore.PackageSettings {
     /// instance.
     static func from(
         manifest: ProjectDescription.PackageSettings,
-        generatorPaths: GeneratorPaths,
-        swiftToolsVersion: TSCUtility.Version
+        generatorPaths: GeneratorPaths
     ) throws -> Self {
         let productTypes = manifest.productTypes.mapValues { XcodeGraph.Product.from(manifest: $0) }
         let productDestinations = try manifest.productDestinations.mapValues { try XcodeGraph.Destination.from(destinations: $0) }
@@ -27,8 +26,7 @@ extension TuistCore.PackageSettings {
             productDestinations: productDestinations,
             baseSettings: baseSettings,
             targetSettings: targetSettings,
-            projectOptions: projectOptions,
-            swiftToolsVersion: .init(stringLiteral: swiftToolsVersion.description)
+            projectOptions: projectOptions
         )
     }
 }

--- a/Sources/TuistLoader/Models/PackageInfo.swift
+++ b/Sources/TuistLoader/Models/PackageInfo.swift
@@ -2,6 +2,7 @@ import Path
 import ProjectDescription
 import TSCUtility
 import TuistSupport
+import struct XcodeGraph.Version
 
 // MARK: - PackageInfo
 
@@ -30,10 +31,10 @@ public struct PackageInfo: Hashable {
     /// The supported swift language standard to use for compiling Swift sources in the package.
     public let swiftLanguageVersions: [TSCUtility.Version]?
 
-    // Ignored fields
+    /// The tools version declared in the manifest.
+    let toolsVersion: Version
 
-    // /// The tools version declared in the manifest.
-    // let toolsVersion: ToolsVersion
+    // Ignored fields
 
     // /// The pkg-config name of a system package.
     // let pkgConfig: String?
@@ -54,7 +55,8 @@ public struct PackageInfo: Hashable {
         platforms: [Platform],
         cLanguageStandard: String?,
         cxxLanguageStandard: String?,
-        swiftLanguageVersions: [TSCUtility.Version]?
+        swiftLanguageVersions: [TSCUtility.Version]?,
+        toolsVersion: Version
     ) {
         self.name = name
         self.products = products
@@ -63,6 +65,7 @@ public struct PackageInfo: Hashable {
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         self.swiftLanguageVersions = swiftLanguageVersions
+        self.toolsVersion = toolsVersion
     }
 }
 
@@ -499,8 +502,13 @@ extension PackageInfo.Target {
 // MARK: Codable conformances
 
 extension PackageInfo: Codable {
+    private struct ToolsVersion: Codable {
+        // swiftlint:disable:next identifier_name
+        let _version: String
+    }
+
     private enum CodingKeys: String, CodingKey {
-        case name, products, targets, platforms, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions
+        case name, products, targets, platforms, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions, toolsVersion
     }
 
     public init(from decoder: Decoder) throws {
@@ -514,6 +522,31 @@ extension PackageInfo: Codable {
         swiftLanguageVersions = try values
             .decodeIfPresent([String].self, forKey: .swiftLanguageVersions)?
             .compactMap { TSCUtility.Version(unformattedString: $0) }
+
+        let versionString = try values.decode(ToolsVersion.self, forKey: .toolsVersion)._version
+        guard let toolsVersion = Version(
+            string: versionString
+        ) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid Swift tools version string \(versionString)"
+                )
+            )
+        }
+        self.toolsVersion = toolsVersion
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(products, forKey: .products)
+        try container.encode(targets, forKey: .targets)
+        try container.encode(platforms, forKey: .platforms)
+        try container.encodeIfPresent(cLanguageStandard, forKey: .cLanguageStandard)
+        try container.encodeIfPresent(cxxLanguageStandard, forKey: .cxxLanguageStandard)
+        try container.encodeIfPresent(swiftLanguageVersions, forKey: .swiftLanguageVersions)
+        try container.encode(ToolsVersion(_version: toolsVersion.description), forKey: .toolsVersion)
     }
 }
 
@@ -685,7 +718,8 @@ extension PackageInfo.Target.TargetType {
             platforms: [Platform] = [],
             cLanguageStandard: String? = nil,
             cxxLanguageStandard: String? = nil,
-            swiftLanguageVersions: [TSCUtility.Version]? = nil
+            swiftLanguageVersions: [TSCUtility.Version]? = nil,
+            toolsVersion: Version = Version(5, 9, 0)
         ) -> Self {
             .init(
                 name: name,
@@ -694,7 +728,8 @@ extension PackageInfo.Target.TargetType {
                 platforms: platforms,
                 cLanguageStandard: cLanguageStandard,
                 cxxLanguageStandard: cxxLanguageStandard,
-                swiftLanguageVersions: swiftLanguageVersions
+                swiftLanguageVersions: swiftLanguageVersions,
+                toolsVersion: toolsVersion
             )
         }
 
@@ -1360,7 +1395,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: "c99",
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
 
@@ -1407,7 +1443,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
 
@@ -1439,7 +1476,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
     }
@@ -1622,7 +1660,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: ["5.0.0"]
+                swiftLanguageVersions: ["5.0.0"],
+                toolsVersion: Version(5, 9, 0)
             )
         }
     }
@@ -2075,7 +2114,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: "c99",
                 cxxLanguageStandard: "gnu++14",
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
 
@@ -2147,7 +2187,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
 
@@ -2177,7 +2218,8 @@ extension PackageInfo.Target.TargetType {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             )
         }
     }

--- a/Sources/TuistLoader/Models/PackageInfo.swift
+++ b/Sources/TuistLoader/Models/PackageInfo.swift
@@ -1396,7 +1396,7 @@ extension PackageInfo.Target.TargetType {
                 cLanguageStandard: "c99",
                 cxxLanguageStandard: nil,
                 swiftLanguageVersions: nil,
-                toolsVersion: Version(5, 9, 0)
+                toolsVersion: Version(5, 1, 0)
             )
         }
 
@@ -1661,7 +1661,7 @@ extension PackageInfo.Target.TargetType {
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
                 swiftLanguageVersions: ["5.0.0"],
-                toolsVersion: Version(5, 9, 0)
+                toolsVersion: Version(5, 1, 0)
             )
         }
     }
@@ -2115,7 +2115,7 @@ extension PackageInfo.Target.TargetType {
                 cLanguageStandard: "c99",
                 cxxLanguageStandard: "gnu++14",
                 swiftLanguageVersions: nil,
-                toolsVersion: Version(5, 9, 0)
+                toolsVersion: Version(5, 3, 0)
             )
         }
 

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -126,19 +126,13 @@ public final class PackageInfoMapper: PackageInfoMapping {
     fileprivate static let predefinedTestDirectories = ["Tests", "Sources", "Source", "src", "srcs"]
     private let moduleMapGenerator: SwiftPackageManagerModuleMapGenerating
     private let fileSystem: FileSysteming
-    private let swiftPackageManagerController: SwiftPackageManagerControlling
 
     public init(
         moduleMapGenerator: SwiftPackageManagerModuleMapGenerating = SwiftPackageManagerModuleMapGenerator(),
-        fileSystem: FileSysteming = FileSystem(),
-        swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(
-            system: System.shared,
-            fileSystem: FileSystem()
-        )
+        fileSystem: FileSysteming = FileSystem()
     ) {
         self.moduleMapGenerator = moduleMapGenerator
         self.fileSystem = fileSystem
-        self.swiftPackageManagerController = swiftPackageManagerController
     }
 
     /// Resolves all SwiftPackageManager dependencies.
@@ -319,10 +313,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
 
         let baseSettings: XcodeGraph.Settings
 
-        let swiftToolsVersion = try swiftPackageManagerController
-            .getToolsVersion(at: path)
-
-        if swiftToolsVersion >= Version(5, 9, 0) {
+        if packageInfo.toolsVersion >= Version(5, 9, 0) {
             baseSettings = packageSettings.baseSettings.with(
                 base: packageSettings.baseSettings.base.combine(
                     with: [
@@ -401,7 +392,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
             name: packageInfo.name,
             options: options,
             settings: packageInfo.projectSettings(
-                swiftToolsVersion: .init(packageSettings.swiftToolsVersion.description),
+                swiftToolsVersion: .init(packageInfo.toolsVersion.description),
                 buildConfigs: baseSettings.configurations.map { key, _ in key }
             ),
             targets: targets,

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -85,8 +85,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                 ],
                 defaultSettings: .recommended
             ),
-            targetSettings: [:],
-            swiftToolsVersion: Version(stringLiteral: "5.4.9")
+            targetSettings: [:]
         )
         verify(manifestLoader)
             .register(plugins: .any)

--- a/Tests/TuistLoaderTests/Models/PackageInfoTests.swift
+++ b/Tests/TuistLoaderTests/Models/PackageInfoTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCUtility
+import XcodeGraph
 import XCTest
 
 @testable import TuistLoader
@@ -55,7 +56,8 @@ final class PackageInfoTests: XCTestCase {
                 ],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: [Version(stringLiteral: "5.4.9")]
+                swiftLanguageVersions: [Version(stringLiteral: "5.4.9")],
+                toolsVersion: Version(5, 4, 9)
             )
         )
     }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -14,7 +14,6 @@ import XCTest
 
 final class PackageInfoMapperTests: TuistUnitTestCase {
     private var subject: PackageInfoMapper!
-    private var swiftPackageManagerController: MockSwiftPackageManagerControlling!
 
     override func setUp() {
         super.setUp()
@@ -22,13 +21,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         given(swiftVersionProvider)
             .swiftVersion()
             .willReturn("5.9")
-        swiftPackageManagerController = MockSwiftPackageManagerControlling()
-        given(swiftPackageManagerController)
-            .getToolsVersion(at: .any)
-            .willReturn(Version(6, 0, 0))
-        subject = PackageInfoMapper(
-            swiftPackageManagerController: swiftPackageManagerController
-        )
+        subject = PackageInfoMapper()
     }
 
     override func tearDown() {
@@ -42,7 +35,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
@@ -51,10 +44,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target_1", type: .binary, url: "https://binary.target.com/target1.xcframework.zip"),
                         .test(name: "Target_2"),
                     ],
-                    platforms: [.ios],
-                    cLanguageStandard: nil,
-                    cxxLanguageStandard: nil,
-                    swiftLanguageVersions: nil
+                    platforms: [.ios]
                 ),
             ],
             packageToFolder: ["Package": basePath],
@@ -82,7 +72,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
@@ -119,7 +109,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
@@ -159,7 +149,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
@@ -197,7 +187,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
@@ -220,7 +210,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "Package2": .init(
+                "Package2": .test(
                     name: "Package2",
                     products: [
                         .init(name: "Product2", type: .library(.automatic), targets: ["Target_2"]),
@@ -269,7 +259,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -292,7 +282,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "Package2": .init(
+                "Package2": .test(
                     name: "Package2",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -347,7 +337,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .createFolder(basePath.appending(try RelativePath(validating: "com.example.dep-1/Sources/com.example.dep-1")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
@@ -370,7 +360,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "com.example.dep-1": .init(
+                "com.example.dep-1": .test(
                     name: "com.example.dep-1",
                     products: [
                         .init(name: "com.example.dep-1", type: .library(.automatic), targets: ["com.example.dep-1"]),
@@ -420,7 +410,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Dependency_2")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target_1"]),
@@ -470,7 +460,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package_2/Sources/Target_3")))
         let resolvedDependencies = try subject.resolveExternalDependencies(
             packageInfos: [
-                "Package_1": .init(
+                "Package_1": .test(
                     name: "Package_1",
                     products: [
                         .init(name: "Product_1", type: .library(.automatic), targets: ["Target_1"]),
@@ -499,7 +489,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "Package_2": .init(
+                "Package_2": .test(
                     name: "Package_2",
                     products: [
                         .init(name: "Product_2", type: .library(.automatic), targets: ["Target_2"]),
@@ -560,7 +550,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -596,7 +586,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -640,7 +630,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -686,7 +676,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -734,7 +724,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 package: "Package",
                 basePath: basePath,
                 packageInfos: [
-                    "Package": .init(
+                    "Package": .test(
                         name: "Package",
                         products: [
                             .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -778,7 +768,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let project = try await subject.map(
             package: "Package",
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
@@ -806,7 +796,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
@@ -847,7 +837,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -928,7 +918,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "com.example.product-1", type: .library(.automatic), targets: ["com.example.target-1"]),
@@ -975,7 +965,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1015,7 +1005,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1", "Target2", "Target3"]),
@@ -1053,7 +1043,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1092,7 +1082,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1155,7 +1145,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1258,7 +1248,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1320,7 +1310,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1367,7 +1357,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1415,7 +1405,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1470,7 +1460,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1503,7 +1493,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1559,7 +1549,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1649,7 +1639,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1665,7 +1655,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "Package2": .init(
+                "Package2": .test(
                     name: "Package2",
                     products: [
                         .init(name: "Dependency1", type: .library(.automatic), targets: ["Dependency1"]),
@@ -1681,7 +1671,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-                "Package3": .init(
+                "Package3": .test(
                     name: "Package3",
                     products: [
                         .init(name: "Dependency2", type: .library(.automatic), targets: ["Dependency2"]),
@@ -1740,7 +1730,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1806,7 +1796,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1866,7 +1856,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1916,7 +1906,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -1966,7 +1956,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2016,7 +2006,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2057,7 +2047,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2102,7 +2092,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2146,7 +2136,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2185,7 +2175,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2225,7 +2215,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2265,7 +2255,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2309,7 +2299,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2352,7 +2342,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2395,7 +2385,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2439,7 +2429,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2481,7 +2471,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             basePath: basePath,
             packageType: .local,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2578,7 +2568,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2630,7 +2620,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2697,7 +2687,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2741,7 +2731,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2787,7 +2777,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2829,7 +2819,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2879,7 +2869,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2919,7 +2909,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -2969,7 +2959,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3018,7 +3008,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3066,7 +3056,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target4")))
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1")))
 
-        let package1 = PackageInfo(
+        let package1 = PackageInfo.test(
             name: "Package",
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3083,7 +3073,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
         )
-        let package2 = PackageInfo(
+        let package2 = PackageInfo.test(
             name: "Package2",
             products: [
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
@@ -3129,7 +3119,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target4")))
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1")))
 
-        let package1 = PackageInfo(
+        let package1 = PackageInfo.test(
             name: "Package",
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3146,7 +3136,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
         )
-        let package2 = PackageInfo(
+        let package2 = PackageInfo.test(
             name: "Package2",
             products: [
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
@@ -3193,7 +3183,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3229,7 +3219,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3265,7 +3255,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3301,7 +3291,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3337,7 +3327,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3348,19 +3338,19 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
-                    swiftLanguageVersions: ["4.0.0", "5.0.0", "4.2.0"]
+                    swiftLanguageVersions: ["5.0.0", "6.0.0", "5.9.0"],
+                    toolsVersion: Version(5, 9, 0)
                 ),
             ],
             packageSettings: .test(
-                baseSettings: .default,
-                swiftToolsVersion: "4.4.0"
+                baseSettings: .default
             )
         )
         XCTAssertEqual(
             project,
             .test(
                 name: "Package",
-                settings: .settings(base: ["SWIFT_VERSION": "4.2.0"]),
+                settings: .settings(base: ["SWIFT_VERSION": "5.9.0"]),
                 targets: [
                     .test("Target1", basePath: basePath),
                 ]
@@ -3377,7 +3367,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3395,8 +3385,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 baseSettings: Settings(
                     configurations: [.release: nil, .debug: nil, .init(name: "Custom", variant: .release): nil],
                     defaultSettings: .recommended
-                ),
-                swiftToolsVersion: "4.4.0"
+                )
             )
         )
 
@@ -3425,7 +3414,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: allTargets),
@@ -3489,7 +3478,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: "Package",
             basePath: basePath,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target1"]),
@@ -3563,7 +3552,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target2")))
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Target3")))
 
-        let package1 = PackageInfo(
+        let package1 = PackageInfo.test(
             name: "Package",
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3586,7 +3575,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
         )
-        let package2 = PackageInfo(
+        let package2 = PackageInfo.test(
             name: "Package2",
             products: [
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
@@ -3645,7 +3634,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             package: packageName,
             basePath: basePath,
             packageInfos: [
-                packageName: .init(
+                packageName: .test(
                     name: packageName,
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
@@ -3689,7 +3678,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             basePath: basePath,
             packageType: .local,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
@@ -3750,7 +3739,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             basePath: basePath,
             packageType: .local,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target"]),
@@ -3824,7 +3813,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             basePath: basePath,
             packageType: .local,
             packageInfos: [
-                "Package": .init(
+                "Package": .test(
                     name: "Package",
                     products: [
                         .init(
@@ -3988,7 +3977,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Product")))
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package2/Sources/Product")))
         let packageInfos: [String: PackageInfo] = [
-            "Package": .init(
+            "Package": .test(
                 name: "Package",
                 products: [
                     .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -4011,7 +4000,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 cxxLanguageStandard: nil,
                 swiftLanguageVersions: nil
             ),
-            "Package2": .init(
+            "Package2": .test(
                 name: "Package2",
                 products: [
                     .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -4085,7 +4074,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Product")))
         let packageInfos: [String: PackageInfo] = [
-            "Package": .init(
+            "Package": .test(
                 name: "Package",
                 products: [
                     .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -4098,13 +4087,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 platforms: [.ios],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 8, 0)
             ),
         ]
-        swiftPackageManagerController.reset()
-        given(swiftPackageManagerController)
-            .getToolsVersion(at: .any)
-            .willReturn(Version(5, 8, 0))
 
         // When
         let project = try await subject.map(
@@ -4125,7 +4111,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(try RelativePath(validating: "Package/Sources/Product")))
         let packageInfos: [String: PackageInfo] = [
-            "Package": .init(
+            "Package": .test(
                 name: "Package",
                 products: [
                     .init(name: "Product", type: .library(.automatic), targets: ["Product"]),
@@ -4138,13 +4124,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 platforms: [.ios],
                 cLanguageStandard: nil,
                 cxxLanguageStandard: nil,
-                swiftLanguageVersions: nil
+                swiftLanguageVersions: nil,
+                toolsVersion: Version(5, 9, 0)
             ),
         ]
-        swiftPackageManagerController.reset()
-        given(swiftPackageManagerController)
-            .getToolsVersion(at: .any)
-            .willReturn(Version(5, 9, 0))
 
         // When
         let project = try await subject.map(


### PR DESCRIPTION
Initiative: https://community.tuist.io/t/improve-tuists-performance/130

### Short description 📝

The `swift package tools-version` command is slow – and running that for each manifest, even on hot runs, adds up quickly.

Results using a real-world project with the current state of `main`:
```
hyperfine '"/Users/marekfort/Library/Developer/Xcode/DerivedData/TuistExt-fnvyzgrgowotpwgcllhszvqbqzxi/Build/Products/Release/tuist_ext" generate --no-open' --warmup 1
Benchmark 1: "/Users/marekfort/Library/Developer/Xcode/DerivedData/TuistExt-fnvyzgrgowotpwgcllhszvqbqzxi/Build/Products/Release/tuist_ext" generate --no-open
  Time (mean ± σ):      4.431 s ±  0.286 s    [User: 9.103 s, System: 3.453 s]
  Range (min … max):    4.188 s …  5.150 s    10 runs
```

Results with the changes from this PR:
```
hyperfine '"/Users/marekfort/Library/Developer/Xcode/DerivedData/TuistExt-fnvyzgrgowotpwgcllhszvqbqzxi/Build/Products/Release/tuist_ext" generate --no-open' --warmup 1
Benchmark 1: "/Users/marekfort/Library/Developer/Xcode/DerivedData/TuistExt-fnvyzgrgowotpwgcllhszvqbqzxi/Build/Products/Release/tuist_ext" generate --no-open
  Time (mean ± σ):      3.965 s ±  0.057 s    [User: 8.326 s, System: 3.328 s]
  Range (min … max):    3.886 s …  4.063 s    10 runs
```

That is, this change leads to around ~12 % speedup on warm runs :tada:

### How to test the changes locally 🧐

- CI should pass. You can also play with any fixture that has SPM dependencies.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
