### PR TITLE
Fix glob regression for hidden files and excluding sources

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "84403c0b8756e6e72ee27d0feb46b17981daf8220245a55a40b3c025944b1285",
+  "originHash" : "bc674a7675f52953d9de581f3b7fb99385848c4da4d322daa2c56b8799cadb5c",
   "pins" : [
     {
       "identity" : "aexml",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "02774d2e89fab072bd040abb4a6623134780aecc",
-        "version" : "0.6.2"
+        "revision" : "ef51eeb6913aba41ac7d7e05ee1723c3cfbaa6e9",
+        "version" : "0.6.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,7 @@ let package = Package(
         .package(
             url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.16.0")
         ),
-        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.2")),
+        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.4")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),
     ],
     targets: targets

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -8,6 +8,7 @@ public enum TuistAcceptanceFixtures {
     case appWithCustomDefaultConfiguration
     case appWithCustomScheme
     case appWithFrameworkAndTests
+    case appWithGlobs
     case appWithGoogleMaps
     case appWithPlugins
     case appWithPreviews
@@ -104,6 +105,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_custom_scheme"
         case .appWithFrameworkAndTests:
             return "app_with_framework_and_tests"
+        case .appWithGlobs:
+            return "app_with_globs"
         case .appWithGoogleMaps:
             return "app_with_google_maps"
         case .appWithPlugins:

--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -86,15 +86,14 @@ extension Target {
 
         for source in sources {
             let sourcePath = try AbsolutePath(validating: source.glob)
-            let base = try AbsolutePath(validating: sourcePath.dirname)
 
             // Paths that should be excluded from sources
             var excluded: [AbsolutePath] = []
             for path in source.excluding {
-                let absolute = try AbsolutePath(validating: path)
+                let path = try AbsolutePath(validating: path)
                 let globs = try await fileSystem.glob(
-                    directory: try AbsolutePath(validating: absolute.dirname),
-                    include: [absolute.basename]
+                    directory: .root,
+                    include: [String(path.pathString.dropFirst())]
                 )
                 .collect()
                 excluded.append(contentsOf: globs)

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -967,6 +967,14 @@ final class GenerateAcceptanceTestAppWithGoogleMaps: TuistAcceptanceTestCase {
     }
 }
 
+final class GenerateAcceptanceTestAppWithGlobs: TuistAcceptanceTestCase {
+    func test_app_with_globs() async throws {
+        try await setUpFixture(.appWithGlobs)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self)
+    }
+}
+
 final class GenerateAcceptanceTestFrameworkWithMacroAndPluginPackages: TuistAcceptanceTestCase {
     func test_framework_with_macro_and_plugin_packages() async throws {
         try await setUpFixture(.frameworkWithMacroAndPluginPackages)

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
@@ -41,6 +41,32 @@ final class FileElementManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model, [])
     }
 
+    func test_from_with_hidden_files() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let files = try await createFiles([
+            "Additional/.hidden.yml",
+        ])
+
+        let manifest = ProjectDescription.FileElement.glob(pattern: "**/.*.yml")
+
+        // When
+        let got = try await XcodeGraph.FileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem,
+            includeFiles: { !FileHandler.shared.isFolder($0) }
+        )
+
+        // Then
+        XCTAssertEqual(got.map(\.path), files)
+    }
+
     func test_from_outputs_a_warning_when_the_folder_reference_is_invalid() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
@@ -3,6 +3,7 @@ import Path
 import ProjectDescription
 import TuistCore
 import TuistSupport
+import XcodeGraph
 import XCTest
 
 @testable import TuistLoader
@@ -21,6 +22,54 @@ final class TargetManifestMapperErrorTests: TuistUnitTestCase {
         XCTAssertEqual(
             got,
             "The target Target has the following invalid resource globs:\n" + invalidGlobs.invalidGlobsDescription
+        )
+    }
+}
+
+final class TargetManifestMapperTests: TuistUnitTestCase {
+    func test_from() async throws {
+        // Given
+        let rootDirectory = try temporaryPath()
+        let sourcesDirectory = rootDirectory.appending(component: "Sources")
+        let firstDirectory = sourcesDirectory.appending(component: "first")
+        let secondDirectory = firstDirectory.appending(component: "second")
+        let secondSourceFile = secondDirectory.appending(component: "second.swift")
+        let secondExcludedSourceFile = secondDirectory.appending(component: "second-exclude.swift")
+        try await fileSystem.makeDirectory(at: sourcesDirectory)
+        try await fileSystem.makeDirectory(at: firstDirectory)
+        try await fileSystem.makeDirectory(at: secondDirectory)
+        try await fileSystem.touch(secondSourceFile)
+        try await fileSystem.touch(secondExcludedSourceFile)
+
+        // When
+        let got = try await XcodeGraph.Target.from(
+            manifest: .test(
+                sources: .sourceFilesList(
+                    globs: [
+                        .glob(
+                            .relativeToRoot("Sources/**"),
+                            excluding: [
+                                .relativeToRoot("Sources/**/*exclude.swift"),
+                            ]
+                        ),
+                    ]
+                ),
+                resources: .resources([])
+            ),
+            generatorPaths: GeneratorPaths(
+                manifestDirectory: try temporaryPath(),
+                rootDirectory: rootDirectory
+            ),
+            externalDependencies: [:],
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertEqual(
+            got.sources,
+            [
+                SourceFile(path: secondSourceFile),
+            ]
         )
     }
 }

--- a/fixtures/app_with_globs/App/.hidden.yml
+++ b/fixtures/app_with_globs/App/.hidden.yml
@@ -1,0 +1,11 @@
+example:
+  name: Sample YAML
+  description: This is an example of a YAML file.
+  version: 1.0
+  items:
+    - id: 1
+      name: Item One
+      price: 10.99
+    - id: 2
+      name: Item Two
+      price: 20.99

--- a/fixtures/app_with_globs/App/Sources/ContentView.swift
+++ b/fixtures/app_with_globs/App/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_globs/App/Sources/FileExcludeMe.swift
+++ b/fixtures/app_with_globs/App/Sources/FileExcludeMe.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+this isnt valid swift and compilation should fail, thats why this is excluded

--- a/fixtures/app_with_globs/App/Sources/MyApp.swift
+++ b/fixtures/app_with_globs/App/Sources/MyApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_globs/Project.swift
+++ b/fixtures/app_with_globs/Project.swift
@@ -1,0 +1,31 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: [
+                .glob(
+                    "App/Sources/**",
+                    excluding: "App/Sources/**/*ExcludeMe.swift"
+                ),
+            ],
+            dependencies: [],
+            additionalFiles: [
+                "**/.*.yml",
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_globs/README.md
+++ b/fixtures/app_with_globs/README.md
@@ -1,0 +1,3 @@
+# App with globs
+
+This app is to showcase and test complex glob patterns for sources, resources, additional files, etc.

--- a/fixtures/app_with_globs/Tuist/Config.swift
+++ b/fixtures/app_with_globs/Tuist/Config.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let config = Config(
+    //    Create an account with "tuist auth" and a project with "tuist project create"
+//    then uncomment the section below and set the project full-handle.
+//    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
+//
+//    fullHandle: "{account_handle}/{project_handle}",
+)

--- a/fixtures/app_with_globs/Tuist/Package.swift
+++ b/fixtures/app_with_globs/Tuist/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+@preconcurrency import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        // Add your own dependencies here:
+        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
+        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6969
Resolves https://github.com/tuist/tuist/issues/6966

### Short description 📝

Fixes globbing regressions for:
- MIssing hidden files
- Excluding sources

### How to test the changes locally 🧐

- The new `app_with_globs` fixture should include the `.hidden.yml` and should _not_ include the `FileExcludeMe.swift` source file

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
