### PR TITLE
Fix running tests on a device specified with -destination xcodebuild argument

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -90,7 +90,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool = false,
-        destination: XcodeBuildDestination,
+        destination: XcodeBuildDestination?,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
@@ -136,6 +136,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
             command.append(contentsOf: ["-destination", value.joined(separator: ",")])
         case .mac:
             command.append(contentsOf: ["-destination", simulatorController.macOSDestination()])
+        case nil:
+            break
         }
 
         // Derived data path

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -47,7 +47,7 @@ public protocol XcodeBuildControlling {
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool,
-        destination: XcodeBuildDestination,
+        destination: XcodeBuildDestination?,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -655,15 +655,21 @@ final class TestService { // swiftlint:disable:this type_body_length
             buildPlatform = try buildableTarget.target.servicePlatform
         }
 
-        let destination = try await XcodeBuildDestination.find(
-            for: buildableTarget.target,
-            on: buildPlatform,
-            scheme: scheme,
-            version: version,
-            deviceName: deviceName,
-            graphTraverser: graphTraverser,
-            simulatorController: simulatorController
-        )
+        let destination: XcodeBuildDestination?
+
+        if passthroughXcodeBuildArguments.contains("-destination") {
+            destination = nil
+        } else {
+            destination = try await XcodeBuildDestination.find(
+                for: buildableTarget.target,
+                on: buildPlatform,
+                scheme: scheme,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser,
+                simulatorController: simulatorController
+            )
+        }
 
         try await xcodebuildController.test(
             .workspace(graphTraverser.workspace.xcWorkspacePath),

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -254,6 +254,48 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         )
     }
 
+    func test_test_when_destination_is_specified_with_passthrough_arguments() async throws {
+        // Given
+        let path = try temporaryPath()
+        let xcworkspacePath = path.appending(component: "Project.xcworkspace")
+        let target = XcodeBuildTarget.workspace(xcworkspacePath)
+        let scheme = "Scheme"
+        let shouldOutputBeColoured = true
+        environment.shouldOutputBeColoured = shouldOutputBeColoured
+
+        var command = [
+            "/usr/bin/xcrun",
+            "xcodebuild",
+            "clean",
+            "test",
+            "-scheme",
+            scheme,
+        ]
+        command.append(contentsOf: target.xcodebuildArguments)
+        command.append(contentsOf: ["-destination", "id=device-id"])
+
+        system.succeedCommand(command, output: "output")
+
+        // When
+        try await subject.test(
+            target,
+            scheme: scheme,
+            clean: true,
+            destination: nil,
+            rosetta: false,
+            derivedDataPath: nil,
+            resultBundlePath: nil,
+            arguments: [],
+            retryCount: 0,
+            testTargets: [],
+            skipTestTargets: [],
+            testPlanConfiguration: nil,
+            passthroughXcodeBuildArguments: [
+                "-destination", "id=device-id",
+            ]
+        )
+    }
+
     func test_test_with_derived_data() async throws {
         // Given
         let path = try temporaryPath()

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -309,6 +309,50 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_tests_with_passthrough_destination() async throws {
+        // Given
+        givenGenerator()
+        given(generator)
+            .generateWithGraph(path: .any)
+            .willProduce { path in
+                (path, .test(workspace: .test(schemes: [.test(name: "TestScheme")])), MapperEnvironment())
+            }
+
+        // When
+        try await testRun(
+            schemeName: "TestScheme",
+            path: try temporaryPath(),
+            passthroughXcodeBuildArguments: ["-destination", "id=device-id"]
+        )
+
+        // Then
+        verify(simulatorController)
+            .findAvailableDevice(
+                platform: .any,
+                version: .any,
+                minVersion: .any,
+                deviceName: .any
+            )
+            .called(0)
+        verify(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .value(nil),
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .value(["-destination", "id=device-id"])
+            )
+            .called(1)
+    }
+
     func test_run_tests_for_only_specified_scheme() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6962

### Short description 📝

As reported by @anlaital-oura, `tuist test -- -destination "id=some-device-id"` doesn't respect the chosen device, instead we select the device based on the project at hand and available simulators.

### How to test the changes locally 🧐

1. Ensure that you have at least two iOS 18.0 or newer simulators set up
2. Run `xcrun simctl list` and grab one of their UUIDs
3. `cd fixtures/app_with_tests`
4. `tuist test -- -destination "id=FB2D37C7-FA93-444C-9986-19F7CE08ED97"` (replace the UUID with the one from earlier step as they will differ)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
