### PR TITLE
fix: when scrolling, scroll only the other devices section

### DIFF
--- a/app/Package.resolved
+++ b/app/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "0cda08ddcb9c9ac8c83891d83f26387cc1104029",
-        "version" : "0.5.0"
+        "revision" : "ef51eeb6913aba41ac7d7e05ee1723c3cfbaa6e9",
+        "version" : "0.6.4"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "a0bc22cc5e5113356d31540dbe66da0b653cd6d8",
-        "version" : "0.2.2"
+        "revision" : "c086760260c4bd6541ea42fdbb8cc76a9798b3fa",
+        "version" : "0.3.6"
       }
     },
     {

--- a/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
+++ b/app/TuistApp/Sources/Modifiers/MenuItemStyle.swift
@@ -5,7 +5,7 @@ private struct MenuItemSyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .buttonStyle(MenuItemButtonStyle())
-            .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+            .padding(.horizontal, 6)
             .hoverStyle()
             .cornerRadius(5.0)
     }

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesView.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesView.swift
@@ -49,30 +49,35 @@ struct DevicesView: View, ErrorViewHandling {
     }
 
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 4) {
-                pinnedDevicesSection()
+        VStack(alignment: .leading, spacing: 0) {
+            pinnedDevicesSection()
+                .padding(.horizontal, 8)
+                .padding(.bottom, 4)
 
-                HStack {
-                    Text("Other devices")
-                        .font(.headline)
-                        .fontWeight(.medium)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                        .frame(height: 16)
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    isExpanded.toggle()
-                }
-                .menuItemStyle()
+            HStack {
+                Text("Other devices")
+                    .font(.headline)
+                    .fontWeight(.medium)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .frame(height: 16)
+            }
+            .padding(.vertical, 2)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isExpanded.toggle()
+            }
+            .menuItemStyle()
+            .padding(.horizontal, 8)
 
-                if isExpanded {
-                    VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    if isExpanded {
                         simulators(viewModel.unpinnedSimulators)
                     }
                 }
+                .padding(.horizontal, 8)
             }
         }
         .frame(height: isExpanded ? NSScreen.main.map { $0.visibleFrame.size.height - 300 } ?? 500 : nil)
@@ -124,6 +129,7 @@ struct DevicesView: View, ErrorViewHandling {
                     simulators(viewModel.pinnedSimulators)
                 }
             }
+            .padding(.bottom, 2)
 
             Divider()
         }

--- a/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
+++ b/app/TuistApp/Sources/Views/DevicesView/DevicesViewModel.swift
@@ -1,3 +1,4 @@
+import Command
 import FileSystem
 import Foundation
 import PathKit

--- a/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
+++ b/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
@@ -19,21 +19,27 @@ struct MenuBarView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
             simulatorsView
 
             Divider()
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
 
             Button("Check for updates", action: viewModel.checkForUpdates)
                 .disabled(!viewModel.canCheckForUpdates)
+                .padding(.vertical, 2)
                 .menuItemStyle()
+                .padding(.horizontal, 8)
 
             Button("Quit Tuist") {
                 NSApplication.shared.terminate(nil)
             }
+            .padding(.vertical, 2)
             .menuItemStyle()
+            .padding(.horizontal, 8)
         }
-        .padding(8)
+        .padding(.vertical, 8)
         .environmentObject(errorHandling)
     }
 }


### PR DESCRIPTION
### Short description 📝

Improving the menu bar UI by:
- Making only the other devices scroll
- Fix the scroll indicator misplaced
- Small padding changes for making things better centered

Before:
<img width="344" alt="Screenshot 2024-11-01 at 16 58 42" src="https://github.com/user-attachments/assets/9e4333d7-537d-48b6-96ca-2042ab4865bb">

After:
<img width="344" alt="Screenshot 2024-11-01 at 16 58 06" src="https://github.com/user-attachments/assets/3136a12d-6983-4c12-98f7-97f9da57fc9a">


### How to test the changes locally 🧐

- Run the macOS app

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
