### PR TITLE
Ignore external inspecting

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -88,6 +88,7 @@ public enum EnvKey: String, CaseIterable {
 
     // LINT
     case lintImplicitDependenciesPath = "TUIST_LINT_IMPLICIT_DEPENDENCIES_PATH"
+    case ignoreExternalDependencies = "TUIST_LINT_IGNORE_EXPLICIT_DEPENDENCIES"
 
     // RUN
     case runBuildTests = "TUIST_RUN_BUILD_TESTS"

--- a/Sources/TuistKit/Commands/Inspect/InspectImplicitImportsCommand.swift
+++ b/Sources/TuistKit/Commands/Inspect/InspectImplicitImportsCommand.swift
@@ -17,8 +17,17 @@ struct InspectImplicitImportsCommand: AsyncParsableCommand {
     )
     var path: String?
 
+    @Flag(
+        help: "Skip inspecting external dependencies.",
+        envKey: .ignoreExternalDependencies
+    )
+    var ignoreExternalDependencies: Bool = false
+
     func run() async throws {
         try await InspectImplicitImportsService()
-            .run(path: path)
+            .run(
+                path: path,
+                ignoreExternalDependencies: ignoreExternalDependencies
+            )
     }
 }

--- a/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
@@ -46,22 +46,35 @@ final class InspectImplicitImportsService {
         self.targetScanner = targetScanner
     }
 
-    func run(path: String?) async throws {
+    func run(
+        path: String?,
+        ignoreExternalDependencies: Bool
+    ) async throws {
         let path = try self.path(path)
         let config = try await configLoader.loadConfig(path: path)
         let generator = generatorFactory.defaultGenerator(config: config, sources: [])
         let graph = try await generator.load(path: path)
-        let issues = try await lint(graphTraverser: GraphTraverser(graph: graph))
+        let issues = try await lint(
+            graphTraverser: GraphTraverser(graph: graph),
+            ignoreExternalDependencies: ignoreExternalDependencies
+        )
         guard issues.isEmpty else {
             throw InspectImplicitImportsServiceError.implicitImportsFound(issues)
         }
         logger.log(level: .info, "We did not find any implicit dependencies in your project.")
     }
 
-    private func lint(graphTraverser: GraphTraverser) async throws -> [InspectImplicitImportsServiceErrorIssue] {
+    private func lint(
+        graphTraverser: GraphTraverser,
+        ignoreExternalDependencies: Bool
+    ) async throws -> [InspectImplicitImportsServiceErrorIssue] {
         let allInternalTargets = graphTraverser
             .allInternalTargets()
-        let allTargets = allInternalTargets.union(graphTraverser.allExternalTargets())
+        var allTargets = allInternalTargets
+
+        if !ignoreExternalDependencies {
+            allTargets = allTargets.union(graphTraverser.allExternalTargets())
+        }
 
         let allTargetNames = Set(allTargets.map(\.target.productName))
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6903>

### Short description 📝

Added flag ignoreExternalDependencies to skip checking external dependencies on implicitness. 

> Describe here the purpose of your PR.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
