### PR TITLE
Fix tuist edit when a directory contains a tuist file instead of a Tuist/ directory

### DIFF
--- a/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
@@ -224,19 +224,22 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
 
     private func traverseAndLocateTuistDirectory(at locatingPath: AbsolutePath) async throws -> AbsolutePath? {
         // swiftlint:disable:next force_try
-        return try await traverseAndLocate(
+        return try await traverseAndLocateDirectory(
             at: locatingPath,
             appending: try RelativePath(validating: Constants.tuistDirectoryName)
         )
     }
 
-    private func traverseAndLocate(at locatingPath: AbsolutePath, appending subpath: RelativePath) async throws -> AbsolutePath? {
+    private func traverseAndLocateDirectory(
+        at locatingPath: AbsolutePath,
+        appending subpath: RelativePath
+    ) async throws -> AbsolutePath? {
         let manifestPath = locatingPath.appending(subpath)
 
-        if try await fileSystem.exists(manifestPath) {
+        if try await fileSystem.exists(manifestPath, isDirectory: true) {
             return manifestPath
         } else if locatingPath != .root {
-            return try await traverseAndLocate(at: locatingPath.parentDirectory, appending: subpath)
+            return try await traverseAndLocateDirectory(at: locatingPath.parentDirectory, appending: subpath)
         } else {
             return nil
         }

--- a/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
@@ -478,6 +478,17 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         XCTAssertNil(configPath)
     }
 
+    func test_locateConfig_where_tuist_file_is_not_a_directory() async throws {
+        // Given
+        try await createFiles(["tuist"])
+
+        // When
+        let configPath = try await subject.locateConfig(at: try temporaryPath())
+
+        // Then
+        XCTAssertNil(configPath)
+    }
+
     func test_locateConfig_traversing_where_config_not_exist() async throws {
         // Given
         let paths = try await createFiles([


### PR DESCRIPTION
### Short description 📝

If there's a file named "Tuist" or "tuist" in a directory where the config file is searched for, it will be wrongly identified as the "Tuist/" directory, and `tuist edit` will fail. This fixes this issue by only considering directories when searching for the "Tuist/" directory.

### How to test the changes locally 🧐

1. Create a file in the same location as your `Project.swift` or `Workspace.swift`, call it "tuist".
2. Run `git edit`, and see that it fails.
3. Update to the code after this change, and see that it passes.

One can also run the new test before the change in this PR.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated - bug 

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
