### PR TITLE
Add docs for Google SSO

### DIFF
--- a/docs/docs/en/server/introduction/authentication.md
+++ b/docs/docs/en/server/introduction/authentication.md
@@ -20,6 +20,16 @@ The command will take you through a web-based authentication flow. Once you auth
 
 The CLI will automatically look up the credentials when making requests to the server. If the access token is expired, the CLI will use the refresh token to get a new access token.
 
+### Organization SSO {#organization-sso}
+
+If you have a Google Workspace organization and you want any developer who signs in with the same Google hosted domain to be added to your Tuist organization, you can set it up with:
+```bash
+tuist organization update sso my-organization --provider google --organization-id my-domain.com
+```
+
+> [!IMPORTANT]
+> You must be authenticated with Google using an email tied to the organization whose domain you are setting up.
+
 ## As a project {#as-a-project}
 
 In non-interactive environments like continuous integrations', you can't authenticate through an interactive flow. For those environments, we recommend authenticating as a project by using a project-scoped token:


### PR DESCRIPTION
### Short description 📝

I've noticed the docs for Google SSO that were initially added to get-started via https://github.com/tuist/tuist/pull/6278 are no longer present in the docs. I do think it's important to highlight this feature in the `Authentication` page, so I'm readding the content there.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
