### PR TITLE
Fix tuist clean hanging

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f658526f7e8c043309506bfa0bedb2c4956d1dfe9a6ac8b3262578989797b14a",
+  "originHash" : "c85ee6347ab96b58a231db9d80d3d81eb6554a3e7903028b404ad57c57109954",
   "pins" : [
     {
       "identity" : "aexml",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "4b3a373f356ed2f0ebfe82982a13c4c026a24ec0",
-        "version" : "0.6.11"
+        "revision" : "3da914e10ac1f3075318d54af9446844bcf505a5",
+        "version" : "0.6.13"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,7 @@ let package = Package(
         .package(
             url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.16.0")
         ),
-        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.10")),
+        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.13")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),
     ],
     targets: targets


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6883

### Short description 📝

`tuist clean` can be _very_ slow when cleaning large directories. We've already merged a [fix for this](https://github.com/tuist/FileSystem/pull/85) in FileSystem, so we only need to update the dependency in this repo.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
