### PR TITLE
fix: handle empty state when no latest previews are available

### DIFF
--- a/app/TuistApp/Sources/Views/AppPreviews/AppPreviews.swift
+++ b/app/TuistApp/Sources/Views/AppPreviews/AppPreviews.swift
@@ -13,20 +13,26 @@ struct AppPreviews: View {
 
     var body: some View {
         Panel {
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                ForEach(viewModel.appPreviews) { appPreview in
-                    Button {
-                        Task {
-                            do {
-                                try await viewModel.launchAppPreview(appPreview)
-                            } catch {
-                                errorHandling.handle(error: error)
+            Group {
+                if viewModel.appPreviews.isEmpty {
+                    AppPreviewsEmptyStateView()
+                } else {
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
+                        ForEach(viewModel.appPreviews) { appPreview in
+                            Button {
+                                Task {
+                                    do {
+                                        try await viewModel.launchAppPreview(appPreview)
+                                    } catch {
+                                        errorHandling.handle(error: error)
+                                    }
+                                }
+                            } label: {
+                                AppPreviewTile(appPreview: appPreview)
                             }
+                            .buttonStyle(.plain)
                         }
-                    } label: {
-                        AppPreviewTile(appPreview: appPreview)
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)

--- a/app/TuistApp/Sources/Views/AppPreviews/AppPreviewsEmptyStateView.swift
+++ b/app/TuistApp/Sources/Views/AppPreviews/AppPreviewsEmptyStateView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct AppPreviewsEmptyStateView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: 4) {
+            Text("No Previews")
+
+            Text("Install latest previews with one click.")
+                .font(.caption2)
+                .opacity(0.8)
+                .foregroundColor(.secondary)
+        }
+        .padding(.bottom, 4)
+        .frame(minWidth: 0, maxWidth: .infinity)
+        .multilineTextAlignment(.center)
+    }
+}


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

In the latest [PR](https://github.com/tuist/tuist/pull/7001) adding latest previews in the Tuist App, I forgot to deal with the empty state when there are no latest previews.

Before:
![image](https://github.com/user-attachments/assets/10724b1b-7aa6-4c70-80eb-dbea41b51d2e)

After:
![image](https://github.com/user-attachments/assets/84387042-f4c2-4c4d-8bef-a6006e2e8ba0)


### How to test the changes locally 🧐

- Run Tuist App when no previews are enabled and observe the empty state

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
