### PR TITLE
feat: Update the default server URL to `tuist.dev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1320,7 +1320,7 @@
 
 - Flatten the workspace groups hierarchy for dependencies [#5575](https://github.com/tuist/tuist/pull/5575) by [@pepicrft](https://github.com/pepicrft)
 - Automatically use the github-actions renderer [#5577](https://github.com/tuist/tuist/pull/5577) by [@pepicrft](https://github.com/pepicrft)
-- Config.swift defaults to `https://tuist.dev` as the Tuist Cloud URL [#5581](https://github.com/tuist/tuist/pull/5581) by [@pepicrft](https://github.com/pepicrft)
+- Config.swift defaults to `https://cloud.tuist.io` as the Tuist Cloud URL [#5581](https://github.com/tuist/tuist/pull/5581) by [@pepicrft](https://github.com/pepicrft)
 
 ## 3.33.0 - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1320,7 +1320,7 @@
 
 - Flatten the workspace groups hierarchy for dependencies [#5575](https://github.com/tuist/tuist/pull/5575) by [@pepicrft](https://github.com/pepicrft)
 - Automatically use the github-actions renderer [#5577](https://github.com/tuist/tuist/pull/5577) by [@pepicrft](https://github.com/pepicrft)
-- Config.swift defaults to `https://cloud.tuist.io` as the Tuist Cloud URL [#5581](https://github.com/tuist/tuist/pull/5581) by [@pepicrft](https://github.com/pepicrft)
+- Config.swift defaults to `https://tuist.dev` as the Tuist Cloud URL [#5581](https://github.com/tuist/tuist/pull/5581) by [@pepicrft](https://github.com/pepicrft)
 
 ## 3.33.0 - 2023-11-15
 

--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -25,7 +25,7 @@ public struct Cloud: Codable, Equatable, Sendable {
     ///   - options: Cloud options.
     /// - Returns: A Cloud instance.
     @available(*, deprecated, message: "Use the `fullHandle` and `url` properties directly in the `Config`")
-    public static func cloud(projectId: String, url: String = "https://cloud.tuist.io", options: [Option] = []) -> Cloud {
+    public static func cloud(projectId: String, url: String = "https://tuist.dev", options: [Option] = []) -> Cloud {
         Cloud(url: url, projectId: projectId, options: options)
     }
 }

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -69,7 +69,7 @@ public struct Config: Codable, Equatable, Sendable {
         compatibleXcodeVersions: CompatibleXcodeVersions = .all,
         cloud: Cloud? = nil,
         fullHandle: String? = nil,
-        url: String = "https://cloud.tuist.io",
+        url: String = "https://tuist.dev",
         swiftVersion: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: GenerationOptions = .options(),

--- a/Sources/TuistServer/Models/Preview.swift
+++ b/Sources/TuistServer/Models/Preview.swift
@@ -25,10 +25,10 @@ extension Preview {
     extension Preview {
         public static func test(
             id: String = "preview-id",
-            url: URL = URL(string: "https://cloud.tuist.io/tuist/tuist/previews/preview-id")!,
+            url: URL = URL(string: "https://tuist.dev/tuist/tuist/previews/preview-id")!,
             // swiftlint:disable:this force_try,
             qrCodeURL: URL =
-                URL(string: "https://cloud.tuist.io/tuist/tuist/previews/preview-id/qr-code.svg")!,
+                URL(string: "https://tuist.dev/tuist/tuist/previews/preview-id/qr-code.svg")!,
             // swiftlint:disable:this force_try
             bundleIdentifier: String? = "com.tuist.app",
             displayName: String? = "App"

--- a/Sources/TuistServer/Models/ServerCommandEvent.swift
+++ b/Sources/TuistServer/Models/ServerCommandEvent.swift
@@ -66,7 +66,7 @@ extension Components.Schemas.CommandEventArtifact._typePayload {
         public static func test(
             id: Int = 0,
             name: String = "generate",
-            url: URL = URL(string: "https://cloud.tuist.io/tuist-org/tuist/runs/10")!
+            url: URL = URL(string: "https://tuist.dev/tuist-org/tuist/runs/10")!
         ) -> Self {
             .init(
                 id: id,

--- a/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
+++ b/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
@@ -88,7 +88,10 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
                 return nil
             }
         } else {
-            let credentials = try await credentialsStore.read(serverURL: serverURL)
+            var credentials: ServerCredentials? = try await credentialsStore.read(serverURL: serverURL)
+            if isTuistDevURL(serverURL), credentials == nil {
+                credentials = try await credentialsStore.read(serverURL: URL(string: "https://cloud.tuist.io")!)
+            }
             return try credentials.map {
                 if let refreshToken = $0.refreshToken {
                     return .user(
@@ -106,6 +109,10 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
                 }
             }
         }
+    }
+
+    func isTuistDevURL(_ serverURL: URL) -> Bool {
+        return serverURL == URL(string: "https://tuist.dev")
     }
 
     private func parseJWT(_ jwt: String) throws -> JWT {

--- a/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
+++ b/Sources/TuistServer/Utilities/ServerAuthenticationController.swift
@@ -112,7 +112,8 @@ public final class ServerAuthenticationController: ServerAuthenticationControlli
     }
 
     func isTuistDevURL(_ serverURL: URL) -> Bool {
-        return serverURL == URL(string: "https://tuist.dev")
+        // URL fails if one of the URLs has a trailing slash and the other not.
+        return serverURL.absoluteString.hasPrefix("https://tuist.dev")
     }
 
     private func parseJWT(_ jwt: String) throws -> JWT {

--- a/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
+++ b/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
@@ -29,6 +29,18 @@ public struct ServerCredentials: Codable, Equatable {
     }
 }
 
+#if DEBUG
+    extension ServerCredentials {
+        public static func test(
+            token: String? = nil,
+            accessToken: String? = nil,
+            refreshToken: String? = nil
+        ) -> ServerCredentials {
+            return ServerCredentials(token: token, accessToken: accessToken, refreshToken: refreshToken)
+        }
+    }
+#endif
+
 @Mockable
 public protocol ServerCredentialsStoring {
     /// It stores the credentials for the server with the given URL.

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -76,6 +76,6 @@ public enum Constants {
     }
 
     public enum URLs {
-        public static let production = URL(string: "https://cloud.tuist.io")!
+        public static let production = URL(string: "https://tuist.dev")!
     }
 }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -198,7 +198,7 @@ final class DumpServiceTests: TuistTestCase {
           "plugins": [
 
           ],
-          "url": "https://cloud.tuist.io"
+          "url": "https://tuist.dev"
         }
 
         """

--- a/Tests/TuistKitTests/Services/AuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/AuthServiceTests.swift
@@ -26,7 +26,7 @@ final class AuthServiceTests: TuistUnitTestCase {
         super.setUp()
         serverSessionController = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         authenticateService = .init()
         serverCredentialsStore = .init()
         serverURLService = .init()

--- a/Tests/TuistKitTests/Services/LogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/LogoutServiceTests.swift
@@ -23,7 +23,7 @@ final class LogoutServiceTests: TuistUnitTestCase {
         super.setUp()
         serverSessionController = MockServerSessionControlling()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = LogoutService(
             serverSessionController: serverSessionController,

--- a/Tests/TuistKitTests/Services/Organization/OrganizationInviteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationInviteServiceTests.swift
@@ -19,7 +19,7 @@ final class OrganizationInviteServiceTests: TuistUnitTestCase {
 
         createOrganizationInviteService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = OrganizationInviteService(
             createOrganizationInviteService: createOrganizationInviteService,

--- a/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationListServiceTests.swift
@@ -18,7 +18,7 @@ final class OrganizationListServiceTests: TuistUnitTestCase {
 
         listOrganizationsService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
 
         subject = OrganizationListService(

--- a/Tests/TuistKitTests/Services/Organization/OrganizationRemoveSSOServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationRemoveSSOServiceTests.swift
@@ -18,7 +18,7 @@ final class OrganizationRemoveSSOServiceTests: TuistUnitTestCase {
 
         updateOrganizationService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
 
         subject = OrganizationRemoveSSOService(

--- a/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
@@ -20,7 +20,7 @@ final class OrganizationShowServiceTests: TuistUnitTestCase {
         getOrganizationService = .init()
         getOrganizationUsageService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = OrganizationShowService(
             getOrganizationService: getOrganizationService,

--- a/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
@@ -18,7 +18,7 @@ final class OrganizationUpdateSSOServiceTests: TuistUnitTestCase {
 
         updateOrganizationService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
 
         subject = OrganizationUpdateSSOService(

--- a/Tests/TuistKitTests/Services/Project/ProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectDeleteServiceTests.swift
@@ -24,7 +24,7 @@ final class ProjectDeleteServiceTests: TuistUnitTestCase {
         deleteProjectService = .init()
         credentialsStore = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = ProjectDeleteService(
             deleteProjectService: deleteProjectService,

--- a/Tests/TuistKitTests/Services/Project/ProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectListServiceTests.swift
@@ -17,7 +17,7 @@ final class ProjectListServiceTests: TuistUnitTestCase {
         super.setUp()
         listProjectsService = .init()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = ProjectListService(
             listProjectsService: listProjectsService,

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensCreateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensCreateServiceTests.swift
@@ -20,7 +20,7 @@ final class ProjectTokensCreateServiceTests: TuistUnitTestCase {
         createProjectTokenService = .init()
         serverURLService = .init()
         configLoader = .init()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(url: serverURL))

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensListServiceTests.swift
@@ -20,7 +20,7 @@ final class ProjectTokensListServiceTests: TuistUnitTestCase {
         listProjectTokensService = .init()
         serverURLService = .init()
         configLoader = .init()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(url: serverURL))

--- a/Tests/TuistKitTests/Services/Project/ProjectTokensRevokeServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectTokensRevokeServiceTests.swift
@@ -20,7 +20,7 @@ final class ProjectTokensRevokeServiceTests: TuistUnitTestCase {
         revokeProjectTokenService = .init()
         serverURLService = .init()
         configLoader = .init()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(url: serverURL))

--- a/Tests/TuistKitTests/Services/SessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/SessionServiceTests.swift
@@ -23,7 +23,7 @@ final class SessionServiceTests: TuistUnitTestCase {
         super.setUp()
         serverSessionController = MockServerSessionControlling()
         configLoader = MockConfigLoading()
-        serverURL = URL(string: "https://test.cloud.tuist.io")!
+        serverURL = URL(string: "https://test.tuist.dev")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(url: serverURL))
         subject = SessionService(
             serverSessionController: serverSessionController,

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -516,7 +516,7 @@ final class ShareServiceTests: TuistUnitTestCase {
               "bundleIdentifier": "com.tuist.app",
               "displayName": "App",
               "id": "preview-id",
-              "qrCodeURL": "https://cloud.tuist.io/tuist/tuist/previews/preview-id/qr-code.svg",
+              "qrCodeURL": "https://tuist.dev/tuist/tuist/previews/preview-id/qr-code.svg",
               "url": "https://test.tuist.io"
             }
             """

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
@@ -64,7 +64,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
             .willReturn(
                 .test(
                     id: 10,
-                    url: URL(string: "https://cloud.tuist.io/tuist-org/tuist/runs/10")!
+                    url: URL(string: "https://tuist.dev/tuist-org/tuist/runs/10")!
                 )
             )
 
@@ -72,7 +72,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
         try await subject.send(commandEvent: event)
 
         // Then
-        XCTAssertPrinterOutputNotContains("You can view a detailed report at: https://cloud.tuist.io/tuist-org/tuist/runs/10")
+        XCTAssertPrinterOutputNotContains("You can view a detailed report at: https://tuist.dev/tuist-org/tuist/runs/10")
     }
 
     func test_send_when_is_ci() async throws {
@@ -93,7 +93,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
             .willReturn(
                 .test(
                     id: 10,
-                    url: URL(string: "https://cloud.tuist.io/tuist-org/tuist/runs/10")!
+                    url: URL(string: "https://tuist.dev/tuist-org/tuist/runs/10")!
                 )
             )
 
@@ -101,7 +101,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
         try await subject.send(commandEvent: event)
 
         // Then
-        XCTAssertStandardOutput(pattern: "You can view a detailed report at: https://cloud.tuist.io/tuist-org/tuist/runs/10")
+        XCTAssertStandardOutput(pattern: "You can view a detailed report at: https://tuist.dev/tuist-org/tuist/runs/10")
     }
 
     func test_send_when_is_ci_and_result_bundle_exists() async throws {
@@ -119,7 +119,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
             .willReturn(
                 .test(
                     id: 10,
-                    url: URL(string: "https://cloud.tuist.io/tuist-org/tuist/runs/10")!
+                    url: URL(string: "https://tuist.dev/tuist-org/tuist/runs/10")!
                 )
             )
 
@@ -146,7 +146,7 @@ final class TuistAnalyticsServerBackendTests: TuistUnitTestCase {
         try await subject.send(commandEvent: event)
 
         // Then
-        XCTAssertStandardOutput(pattern: "You can view a detailed report at: https://cloud.tuist.io/tuist-org/tuist/runs/10")
+        XCTAssertStandardOutput(pattern: "You can view a detailed report at: https://tuist.dev/tuist-org/tuist/runs/10")
         let exists = try await fileSystem.exists(resultBundle)
         XCTAssertFalse(exists)
     }

--- a/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -73,6 +73,49 @@ final class ServerAuthenticationControllerTests: TuistUnitTestCase {
         XCTAssertNil(got)
     }
 
+    func test_when_config_token_is_present_and_is_not_ci_and_tuist_dev_credentials_are_missing() async throws {
+        // Given
+        environment.tuistVariables[
+            Constants.EnvironmentVariables.token
+        ] = "project-token"
+        let credentials = ServerCredentials.test(token: "access-token")
+        given(ciChecker)
+            .isCI()
+            .willReturn(false)
+        given(credentialsStore)
+            .read(serverURL: .value(URL(string: "https://tuist.dev")!))
+            .willReturn(nil)
+        given(credentialsStore)
+            .read(serverURL: .value(URL(string: "https://cloud.tuist.io")!))
+            .willReturn(credentials)
+
+        // When
+        let got = try await subject.authenticationToken(serverURL: URL(string: "https://tuist.dev")!)
+
+        // Then
+        XCTAssertEqual(got?.value, credentials.token)
+    }
+
+    func test_when_config_token_is_present_and_is_not_ci_and_tuist_dev_credentials_are_present() async throws {
+        // Given
+        environment.tuistVariables[
+            Constants.EnvironmentVariables.token
+        ] = "project-token"
+        let credentials = ServerCredentials.test(token: "access-token")
+        given(ciChecker)
+            .isCI()
+            .willReturn(false)
+        given(credentialsStore)
+            .read(serverURL: .value(URL(string: "https://tuist.dev")!))
+            .willReturn(credentials)
+
+        // When
+        let got = try await subject.authenticationToken(serverURL: URL(string: "https://tuist.dev")!)
+
+        // Then
+        XCTAssertEqual(got?.value, credentials.token)
+    }
+
     func test_when_deprecated_config_token_is_present_and_is_ci() async throws {
         // Given
         environment.tuistVariables[

--- a/app/TuistApp/Tests/Services/DeviceServiceTests.swift
+++ b/app/TuistApp/Tests/Services/DeviceServiceTests.swift
@@ -21,7 +21,7 @@ final class DeviceServiceTests: TuistUnitTestCase {
 
     private let previewURL =
         URL(
-            string: "tuist:open-preview?server_url=https://cloud.tuist.io&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53&full_handle=tuist/ios_app_with_frameworks"
+            string: "tuist:open-preview?server_url=https://tuist.dev&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53&full_handle=tuist/ios_app_with_frameworks"
         )!
 
     private let iPhone15: SimulatorDeviceAndRuntime = .test(
@@ -561,7 +561,7 @@ final class DeviceServiceTests: TuistUnitTestCase {
         try await subject.loadDevices()
 
         let invalidDeeplinkURL =
-            "tuist:open-preview?server_url=https://cloud.tuist.io&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53"
+            "tuist:open-preview?server_url=https://tuist.dev&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53"
 
         // When / Then
         await XCTAssertThrowsSpecific(

--- a/app/TuistApp/Tests/ViewModels/DevicesViewModelTests.swift
+++ b/app/TuistApp/Tests/ViewModels/DevicesViewModelTests.swift
@@ -14,7 +14,7 @@ final class DevicesViewModelTests: TuistUnitTestCase {
 
     private let previewURL =
         URL(
-            string: "tuist:open-preview?server_url=https://cloud.tuist.io&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53&full_handle=tuist/ios_app_with_frameworks"
+            string: "tuist:open-preview?server_url=https://tuist.dev&preview_id=01912892-3778-7297-8ca9-d66ac7ee2a53&full_handle=tuist/ios_app_with_frameworks"
         )!
 
     private let iPhone15: SimulatorDeviceAndRuntime = .test(


### PR DESCRIPTION
### Short description 📝
We've consolidated the https://tuist.io and https://cloud.tuist.io URLs into https://tuist.dev. This PR updates the CLI defaults and some test references.
Once we release this new version, the server will include a warning for people who have already updated and have the old value `https://cloud.tuist.io` hardcoded in their configuration files.

> [!NOTE]
> Since the user credentials are persisted associated with the origin, this means users will have to re-authenticate after they update to the version of the CLI, including these changes. The alternative to prevent that would have been some migration logic, but since the `tuist auth` command is frictionless, I lean on not absorbing that migration logic.

### How to test the changes locally 🧐
The tests should pass and commands that interact with the server like `tuist cache` should send requests to the new URL.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
