### PR TITLE
Add convenience arguments for running Tuist from Xcode

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -13,6 +13,19 @@ func releaseSettings() -> SettingsDictionary {
     baseSettings
 }
 
+func launchArgumentsFor(_ module: Module) -> [LaunchArgument] {
+    switch module {
+    case .tuist:
+        return [
+            .launchArgument(name: "install", isEnabled: false),
+            .launchArgument(name: "generate", isEnabled: false),
+            .launchArgument(name: "--no-open", isEnabled: false),
+        ]
+    default:
+        return []
+    }
+}
+
 func acceptanceTestsEnvironmentVariables() -> [String: EnvironmentVariable] {
     [
         "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
@@ -80,7 +93,8 @@ func schemes() -> [Scheme] {
                     environmentVariables: [
                         "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
                         "TUIST_FRAMEWORK_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
-                    ]
+                    ],
+                    launchArguments: launchArgumentsFor($0)
                 )
             )
         )


### PR DESCRIPTION
Adds a small set of default disabled run arguments so that they are easy to use after running `tuist generate`.  

### How to test the changes locally 🧐

Run `tuist generate` and observe the `tuist` scheme has disabled launch arguments

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
