### PR TITLE
fix: macro compiling when user script sandboxing is enabled

### DIFF
--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -470,7 +470,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         copySwiftMacrosBuildPhase.inputPaths = executableNames.map { "$BUILD_DIR/$CONFIGURATION/\($0)" }
 
         copySwiftMacrosBuildPhase.outputPaths = executableNames.map { executable in
-            "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)"
+            "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)"
         }
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -469,8 +469,11 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
         copySwiftMacrosBuildPhase.inputPaths = executableNames.map { "$BUILD_DIR/$CONFIGURATION/\($0)" }
 
-        copySwiftMacrosBuildPhase.outputPaths = executableNames.map { executable in
-            "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)"
+        copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
+            [
+                "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",
+                "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)"
+            ]
         }
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -472,7 +472,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
             [
                 "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",
-                "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)"
+                "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)",
             ]
         }
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1595,8 +1595,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(
             buildPhase?.outputPaths,
             [
+                "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
                 "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
-                "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)"
             ]
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1594,7 +1594,10 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertTrue(buildPhase?.inputPaths.contains("$BUILD_DIR/$CONFIGURATION/\(macroExecutable.productName)") == true)
         XCTAssertEqual(
             buildPhase?.outputPaths,
-            ["$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)"]
+            [
+                "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
+                "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)"
+            ]
         )
     }
 

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -1,6 +1,13 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+#if TUIST
+import ProjectDescription
+
+let packageSettings = PackageSettings(baseSettings: .settings(base: ["ENABLE_USER_SCRIPT_SANDBOXING": true]))
+
+#endif
+
 let package = Package(
     name: "Dependencies",
     dependencies: [

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -2,9 +2,15 @@
 import PackageDescription
 
 #if TUIST
-import ProjectDescription
+    import ProjectDescription
 
-let packageSettings = PackageSettings(baseSettings: .settings(base: ["ENABLE_USER_SCRIPT_SANDBOXING": true]))
+    let packageSettings = PackageSettings(
+        baseSettings: .settings(
+            base: [
+                "ENABLE_USER_SCRIPT_SANDBOXING": true,
+            ]
+        )
+    )
 
 #endif
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

This PR fixes an issue where the specified output path name inadvertently included an extra `-`, causing it to mismatch the actual output path and leading to permission errors when user script sandboxing is enabled.

### How to test the changes locally 🧐
Run Tuist on a project with a framework with a macro target and `enableUserScriptSandboxing` set to true. Ensure thatt the framework now compiles.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
