### PR TITLE
Fix glob for opaque directories like xcassets

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -33,7 +33,6 @@ extension XcodeGraph.ResourceFileElement {
             let files = try await fileSystem
                 .throwingGlob(directory: .root, include: [String(path.pathString.dropFirst())])
                 .collect()
-                .filter { !$0.isInOpaqueDirectory }
                 .filter(includeFiles)
                 .filter { !excluded.contains($0) }
 
@@ -47,6 +46,8 @@ extension XcodeGraph.ResourceFileElement {
             }
 
             return files
+                .compactMap { $0.opaqueParentDirectory() ?? $0 }
+                .uniqued()
         }
 
         func folderReferences(_ path: AbsolutePath) async throws -> [AbsolutePath] {

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -36,16 +36,23 @@ extension AbsolutePath {
         return utType.conforms(to: UTType.package)
     }
 
-    /// An opaque directory is a directory that should be treated like a file, therefor ignoring its content.
+    /// An opaque directory is a directory that should be treated like a file, therefore ignoring its content.
     /// I.e.: .xcassets, .xcdatamodeld, etc...
     /// This property returns true when a file is contained in such directory.
     public var isInOpaqueDirectory: Bool {
+        parentDirectory.opaqueParentDirectory() != nil
+    }
+
+    /// An opaque directory is a directory that should be treated like a file, therefore ignoring its content.
+    /// I.e.: .xcassets, .xcdatamodeld, etc...
+    /// This property returns the first such parent directory if it exists. It returns `nil` otherwise.
+    public func opaqueParentDirectory() -> AbsolutePath? {
         var currentDirectory = parentDirectory
         while currentDirectory != .root {
-            if currentDirectory.isOpaqueDirectory { return true }
+            if currentDirectory.isOpaqueDirectory { return currentDirectory }
             currentDirectory = currentDirectory.parentDirectory
         }
-        return false
+        return nil
     }
 
     /// An opaque directory is a directory that should be treated like a file, therefor ignoring its content.

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -40,7 +40,7 @@ extension AbsolutePath {
     /// I.e.: .xcassets, .xcdatamodeld, etc...
     /// This property returns true when a file is contained in such directory.
     public var isInOpaqueDirectory: Bool {
-        parentDirectory.opaqueParentDirectory() != nil
+        opaqueParentDirectory() != nil
     }
 
     /// An opaque directory is a directory that should be treated like a file, therefore ignoring its content.

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -41,6 +41,95 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model, [])
     }
 
+    func test_from_outputs_a_warning_when_no_files_found() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+
+        try await fileSystem.makeDirectory(at: rootDirectory.appending(component: "Resources"))
+
+        let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/**")
+
+        // When
+        let model = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains(
+            "No files found at: \(rootDirectory.appending(components: "Resources", "**"))"
+        )
+        XCTAssertEqual(model, [])
+    }
+
+    func test_from_outputs_a_warning_when_no_files_found_in_opaque_directory() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+
+        let assetsDirectory = rootDirectory.appending(components: "Resources", "Assets.xcassets")
+        try await fileSystem.makeDirectory(at: assetsDirectory)
+
+        let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/Assets.xcassets/**")
+
+        // When
+        let model = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains(
+            "No files found at: \(assetsDirectory.appending(components: "**"))"
+        )
+        XCTAssertEqual(model, [])
+    }
+
+    func test_from_when_files_found_in_opaque_directory() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+
+        let assetsDirectory = rootDirectory.appending(components: "Resources", "Assets.xcassets")
+        try await fileSystem.makeDirectory(at: assetsDirectory)
+        try await fileSystem.touch(assetsDirectory.appending(component: "image.png"))
+
+        let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/Assets.xcassets/**")
+
+        // When
+        let model = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertPrinterOutputNotContains(
+            "No files found at: \(assetsDirectory.appending(components: "**"))"
+        )
+        XCTAssertEqual(
+            model,
+            [
+                .file(path: assetsDirectory, tags: [], inclusionCondition: nil),
+            ]
+        )
+    }
+
     func test_from_outputs_a_warning_when_the_folder_reference_is_invalid() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/AbsolutePath+ExtrasTests.swift
@@ -81,4 +81,36 @@ final class AbsolutePathExtrasTests: TuistUnitTestCase {
         XCTAssertTrue(try AbsolutePath(validating: "/test/directory.playground/file.png").isInOpaqueDirectory)
         XCTAssertTrue(try AbsolutePath(validating: "/test/directory.xcmappingmodel/file.png").isInOpaqueDirectory)
     }
+
+    func test_opaqueDirectory() async throws {
+        for directory in [
+            "/test/directory.bundle",
+            "/test/directory.xcassets",
+            "/test/directory.scnassets",
+            "/test/directory.xcdatamodeld",
+            "/test/directory.docc",
+            "/test/directory.xcmappingmodel",
+        ] as [AbsolutePath] {
+            XCTAssertEqual(directory.opaqueParentDirectory(), nil)
+        }
+
+        XCTAssertEqual(try AbsolutePath(validating: "/").opaqueParentDirectory(), nil)
+        XCTAssertEqual(try AbsolutePath(validating: "/test/directory.notopaque/file.notopaque").opaqueParentDirectory(), nil)
+        XCTAssertEqual(try AbsolutePath(validating: "/test/directory.notopaque/directory.bundle").opaqueParentDirectory(), nil)
+        XCTAssertEqual(
+            try AbsolutePath(validating: "/test/directory.notopaque/directory.bundle/file.png").opaqueParentDirectory(),
+            try AbsolutePath(validating: "/test/directory.notopaque/directory.bundle")
+        )
+
+        for file in [
+            "/test/directory.bundle/file.png",
+            "/test/directory.xcassets/file.png",
+            "/test/directory.scnassets/file.png",
+            "/test/directory.xcdatamodeld/file.png",
+            "/test/directory.docc/file.png",
+            "/test/directory.xcmappingmodel/file.png",
+        ] as [AbsolutePath] {
+            XCTAssertEqual(file.opaqueParentDirectory(), file.parentDirectory)
+        }
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6994

### Short description 📝

When a glob with directory globstar is defined where the directory is an opaque one, we should generate the project with the opaque directory instead of skipping it.

### How to test the changes locally 🧐

- See the repro steps from the attached issue

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
