### PR TITLE
Fix glob with extension options

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "3da914e10ac1f3075318d54af9446844bcf505a5",
-        "version" : "0.6.13"
+        "revision" : "0e3e93afb4642a862b95c808a4182a76fcf984b4",
+        "version" : "0.6.15"
       }
     },
     {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7026

### Short description 📝

Fix regression when globbing patterns such as `App/Configs/*.{entitlements,xcconfig}`. The fix was done in `FileSystem` via https://github.com/tuist/FileSystem/pull/88, so we only need to update the `FileSystem` dependency to fix the issue.

### How to test the changes locally 🧐

- See the original issue fore repro steps

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
