### PR TITLE
Update the canary URL

### DIFF
--- a/Sources/TuistAcceptanceTesting/ServerAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/ServerAcceptanceTestCase.swift
@@ -26,7 +26,7 @@ open class ServerAcceptanceTestCase: TuistAcceptanceTestCase {
 
             let config = Config(
                 fullHandle: "\(fullHandle)",
-                url: "\(ProcessInfo.processInfo.environment["TUIST_URL"] ?? "https://canary.tuist.io")"
+                url: "\(ProcessInfo.processInfo.environment["TUIST_URL"] ?? "https://canary.tuist.dev")"
             )
             """,
             path: fixturePath.appending(components: Constants.tuistManifestFileName),

--- a/fixtures/ios_app_with_frameworks/Tuist/Config.swift
+++ b/fixtures/ios_app_with_frameworks/Tuist/Config.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 let config = Config(
     fullHandle: "tuist/ios_app_with_frameworks",
-    url: "https://canary.tuist.io",
+    url: "https://canary.tuist.dev",
     generationOptions: .options(
         optionalAuthentication: true
     )

--- a/fixtures/multiplatform_app_with_extension/Tuist/Config.swift
+++ b/fixtures/multiplatform_app_with_extension/Tuist/Config.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 let config = Config(
     fullHandle: "tuist/multiplatform_app_with_extension",
-    url: "https://canary.tuist.io",
+    url: "https://canary.tuist.dev",
     generationOptions: .options(
         optionalAuthentication: true
     )

--- a/fixtures/xcode_app/Tuist.swift
+++ b/fixtures/xcode_app/Tuist.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 let config = Config(
     fullHandle: "tuist/xcode_app",
-    url: "https://canary.tuist.io",
+    url: "https://canary.tuist.dev",
     generationOptions: .options(
         optionalAuthentication: true
     )


### PR DESCRIPTION
### Short description 📝

The URL for canary environments was updated on the server, but not in `tuist/tuist` leading to acceptance tests failures since we don't have a fallback to getting credentials from `canary.tuist.io`.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
