### PR TITLE
Add support for Okta organization SSO

### DIFF
--- a/Sources/TuistKit/Commands/Organization/OrganizationUpdateSSOCommand.swift
+++ b/Sources/TuistKit/Commands/Organization/OrganizationUpdateSSOCommand.swift
@@ -4,7 +4,7 @@ import Path
 import TuistSupport
 
 enum SSOProvider: String, ExpressibleByArgument, CaseIterable {
-    case google
+    case google, okta
 }
 
 struct OrganizationUpdateSSOCommand: AsyncParsableCommand {
@@ -30,7 +30,7 @@ struct OrganizationUpdateSSOCommand: AsyncParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "Organization ID for your SSO provider. For Google, this is your Google domain (for example, if your email is tuist@tuist.io, the domain would be tuist.io)",
+        help: "Organization ID for your SSO provider. For Google, this is your Google domain (for example, if your email is tuist@tuist.io, the domain would be tuist.io). For Okta, it's the organization domain (such as my-org.okta.com)",
         envKey: .organizationUpdateSSOOrganizationId
     )
     var organizationId: String

--- a/Sources/TuistKit/Services/Organization/OrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationShowService.swift
@@ -89,6 +89,8 @@ final class OrganizationShowService: OrganizationShowServicing {
             switch ssoOrganization {
             case let .google(organizationId):
                 baseInfo.append("SSO: Google (\(organizationId))")
+            case let .okta(organizationId):
+                baseInfo.append("SSO: Okta (\(organizationId))")
             }
         }
 

--- a/Sources/TuistKit/Services/Organization/OrganizationUpdateService.swift
+++ b/Sources/TuistKit/Services/Organization/OrganizationUpdateService.swift
@@ -46,6 +46,8 @@ final class OrganizationUpdateSSOService: OrganizationUpdateSSOServicing {
         switch provider {
         case .google:
             ssoOrganization = .google(organizationId)
+        case .okta:
+            ssoOrganization = .okta(organizationId)
         }
 
         let serverURL = try serverURLService.url(configServerURL: config.url)

--- a/Sources/TuistServer/Models/SSOOrganization.swift
+++ b/Sources/TuistServer/Models/SSOOrganization.swift
@@ -2,4 +2,5 @@ import Foundation
 
 public enum SSOOrganization: Codable, Equatable {
     case google(String)
+    case okta(String)
 }

--- a/Sources/TuistServer/Models/ServerOrganization.swift
+++ b/Sources/TuistServer/Models/ServerOrganization.swift
@@ -102,6 +102,8 @@ extension ServerOrganization {
             switch ssoProvider {
             case .google:
                 ssoOrganization = .google(ssoOrganizationId)
+            case .okta:
+                ssoOrganization = .okta(ssoOrganizationId)
             }
         } else {
             ssoOrganization = nil

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -1520,6 +1520,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/Organization/sso_provider`.
             internal enum sso_providerPayload: String, Codable, Hashable, Sendable, CaseIterable {
                 case google = "google"
+                case okta = "okta"
             }
             /// The SSO provider set up for the organization
             ///
@@ -5956,6 +5957,7 @@ internal enum Operations {
                     /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/PATCH/requestBody/json/sso_provider`.
                     internal enum sso_providerPayload: String, Codable, Hashable, Sendable, CaseIterable {
                         case google = "google"
+                        case okta = "okta"
                         case none = "none"
                     }
                     /// The SSO provider to set up for the organization
@@ -6335,6 +6337,7 @@ internal enum Operations {
                     /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/PUT/requestBody/json/sso_provider`.
                     internal enum sso_providerPayload: String, Codable, Hashable, Sendable, CaseIterable {
                         case google = "google"
+                        case okta = "okta"
                         case none = "none"
                     }
                     /// The SSO provider to set up for the organization

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -316,6 +316,7 @@ components:
           description: The SSO provider set up for the organization
           enum:
             - google
+            - okta
           type: string
       required:
         - id
@@ -1430,6 +1431,7 @@ paths:
                   description: The SSO provider to set up for the organization
                   enum:
                     - google
+                    - okta
                     - none
                   type: string
               type: object
@@ -1493,6 +1495,7 @@ paths:
                   description: The SSO provider to set up for the organization
                   enum:
                     - google
+                    - okta
                     - none
                   type: string
               type: object

--- a/Sources/TuistServer/Services/UpdateOrganizationService.swift
+++ b/Sources/TuistServer/Services/UpdateOrganizationService.swift
@@ -56,6 +56,9 @@ public final class UpdateOrganizationService: UpdateOrganizationServicing {
             case let .google(organizationId):
                 ssoProvider = .google
                 ssoOrganizationId = organizationId
+            case let .okta(organizationId):
+                ssoProvider = .okta
+                ssoOrganizationId = organizationId
             }
         } else {
             ssoOrganizationId = nil

--- a/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationShowServiceTests.swift
@@ -99,7 +99,7 @@ final class OrganizationShowServiceTests: TuistUnitTestCase {
         """)
     }
 
-    func test_organization_show_when_has_sso_provider() async throws {
+    func test_organization_show_when_has_google_as_sso_provider() async throws {
         // Given
         given(getOrganizationService)
             .getOrganization(organizationName: .any, serverURL: .any)
@@ -128,6 +128,39 @@ final class OrganizationShowServiceTests: TuistUnitTestCase {
             Name: test-one
             Plan: Pro
             SSO: Google (tuist.io)
+            """
+        )
+    }
+
+    func test_organization_show_when_has_okta_as_sso_provider() async throws {
+        // Given
+        given(getOrganizationService)
+            .getOrganization(organizationName: .any, serverURL: .any)
+            .willReturn(
+                .test(
+                    name: "test-one",
+                    plan: .pro,
+                    ssoOrganization: .okta("tuist.okta.com")
+                )
+            )
+        given(getOrganizationUsageService)
+            .getOrganizationUsage(organizationName: .any, serverURL: .any)
+            .willReturn(.test())
+
+        // When
+        try await subject.run(
+            organizationName: "tuist",
+            json: false,
+            directory: nil
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains(
+            """
+            \(TerminalStyle.bold.open)Organization\(TerminalStyle.reset.open)
+            Name: test-one
+            Plan: Pro
+            SSO: Okta (tuist.okta.com)
             """
         )
     }

--- a/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Organization/OrganizationUpdateSSOServiceTests.swift
@@ -58,4 +58,28 @@ final class OrganizationUpdateSSOServiceTests: TuistUnitTestCase {
         tuist now uses Google SSO with tuist.io. Users authenticated with the tuist.io SSO organization will automatically have access to the tuist projects.
         """)
     }
+
+    func test_organization_update_sso_with_okta() async throws {
+        // Given
+        given(updateOrganizationService)
+            .updateOrganization(
+                organizationName: .value("tuist"),
+                serverURL: .value(serverURL),
+                ssoOrganization: .value(.okta("tuist.okta.com"))
+            )
+            .willReturn(.test())
+
+        // When
+        try await subject.run(
+            organizationName: "tuist",
+            provider: .okta,
+            organizationId: "tuist.okta.com",
+            directory: nil
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains("""
+        tuist now uses Okta SSO with tuist.okta.com. Users authenticated with the tuist.okta.com SSO organization will automatically have access to the tuist projects.
+        """)
+    }
 }

--- a/docs/docs/en/server/introduction/authentication.md
+++ b/docs/docs/en/server/introduction/authentication.md
@@ -24,7 +24,12 @@ The CLI will automatically look up the credentials when making requests to the s
 
 If you have a Google Workspace organization and you want any developer who signs in with the same Google hosted domain to be added to your Tuist organization, you can set it up with:
 ```bash
-tuist organization update sso my-organization --provider google --organization-id my-domain.com
+tuist organization update sso my-organization --provider google --organization-id my-google-domain.com
+```
+
+For on-premise customers that have Okta set up, you can get the same behavior as for Google by running:
+```bash
+tuist organization update sso my-organization --provider okta --organization-id my-okta-domain.com
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6999

### Short description 📝

Adds support for Okta organization SSO, so that organization admins don't have to manually add users in on-premise environment when the organization already has Okta set up.

### How to test the changes locally 🧐

- Run `tuist organization update sso your-org --provider okta --organization-id your.okta-domain.com`
- Note the command will only work once the related server PR is merged.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
