### PR TITLE
Fix caching failing due to tree-shaking logic not pruning dependencies

### DIFF
--- a/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -178,13 +178,13 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
             }
 
             if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget,
-                !sourceTargets.contains(expandVariableFromTarget)
+               !sourceTargets.contains(expandVariableFromTarget)
             {
                 return nil
             }
 
             if let expandVariableFromTarget = scheme.testAction?.expandVariableFromTarget,
-                !sourceTargets.contains(expandVariableFromTarget)
+               !sourceTargets.contains(expandVariableFromTarget)
             {
                 return nil
             }

--- a/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -85,18 +85,20 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
              Since we have target.dependencies and graph.dependencies (duplicated), we have to apply the changes in both sides.
              Once we refactor the code to only depend on graph.dependencies, we can get rid of these duplications.
              */
-            target.dependencies = target.dependencies.filter({ dependency in
+            target.dependencies = target.dependencies.filter { dependency in
                 switch dependency {
                 case let .target(targetDependencyName, _, _condition):
                     return sourceTargets.contains(TargetReference(projectPath: path, name: targetDependencyName))
                 case let .project(targetDependencyName, targetDependencyProjectPath, _status, _condition):
-                    return sourceTargets.contains(TargetReference(projectPath: targetDependencyProjectPath, name: targetDependencyName))
+                    return sourceTargets.contains(TargetReference(
+                        projectPath: targetDependencyProjectPath,
+                        name: targetDependencyName
+                    ))
                 default:
                     return true
                 }
-            })
+            }
             treeShakedTargets.append(target)
-
 
             if let targetGraphDependency = dependencies.keys.first(where: { dependency -> Bool in
                 switch dependency {
@@ -110,14 +112,17 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
                     dependencies[targetGraphDependency, default: Set()]
                         .compactMap { dependency in
                             switch dependency {
-                            case let .target(dependencyName, _, _):
+                            case let .target(dependencyName, dependencyProjectPath, _):
                                 /**
                                  If a target dependency a target depends on is tree-shaked, that dependency should be removed.
                                  This happens in scenarios where a external target (iOS and tvOS framework) conditionally depends on
                                  framework based on the platform. We have logic to prune unneceessary platforms from the external
                                  part of the graph.
                                  */
-                                if sourceTargets.contains(TargetReference(projectPath: path, name: dependencyName)) {
+                                if sourceTargets.contains(TargetReference(
+                                    projectPath: dependencyProjectPath,
+                                    name: dependencyName
+                                )) {
                                     return dependency
                                 } else {
                                     return nil

--- a/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -311,4 +311,47 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(gotGraph.projects.first?.value, expectedProject)
     }
+    
+    func test_map_remotes_pruned_dependencies() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPhone], product: .app)
+        let frameworkA = Target.test(name: "A", destinations: [.iPhone], product: .framework)
+        let frameworkBiOS = Target.test(name: "BiOS", destinations: [.iPhone], product: .framework)
+        
+        // This one has been marked to prune by Tuist because it's not needed if we filter down the platforms from the entry-point
+        // nodes of the graph.
+        let frameworkBtvOS = Target.test(name: "BtvOS", destinations: [.appleTv], product: .framework, prune: true)
+        let project = Project.test(targets: [app, frameworkA, frameworkBiOS, frameworkBtvOS])
+        
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: app.name, path: project.path): Set([.target(name: frameworkA.name, path: project.path)]),
+                .target(name: frameworkA.name, path: project.path): Set([.target(name: frameworkBiOS.name, path: project.path), .target(name: frameworkBtvOS.name, path: project.path)])
+            ],
+            dependencyConditions: [
+                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBiOS.name, path: project.path)): try .test([.ios])!,
+                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBtvOS.name, path: project.path)): try .test([.tvos])!
+            ]
+        )
+        
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+        
+        // Then
+        let expectedGraph = Graph.test(
+            path: project.path,
+            projects: [project.path: Project.test(targets: [app, frameworkA, frameworkBiOS])],
+            dependencies: [
+                .target(name: app.name, path: project.path): Set([.target(name: frameworkA.name, path: project.path)]),
+                .target(name: frameworkA.name, path: project.path): Set([.target(name: frameworkBiOS.name, path: project.path)])
+            ],
+            dependencyConditions: [
+                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBiOS.name, path: project.path)): try .test([.ios])!,
+                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBtvOS.name, path: project.path)): try .test([.tvos])!
+            ]
+        )
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+    }
 }

--- a/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -311,45 +311,60 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(gotGraph.projects.first?.value, expectedProject)
     }
-    
+
     func test_map_remotes_pruned_dependencies() throws {
         // Given
         let app = Target.test(name: "App", destinations: [.iPhone], product: .app)
         let frameworkA = Target.test(name: "A", destinations: [.iPhone], product: .framework)
         let frameworkBiOS = Target.test(name: "BiOS", destinations: [.iPhone], product: .framework)
-        
+
         // This one has been marked to prune by Tuist because it's not needed if we filter down the platforms from the entry-point
         // nodes of the graph.
         let frameworkBtvOS = Target.test(name: "BtvOS", destinations: [.appleTv], product: .framework, prune: true)
         let project = Project.test(targets: [app, frameworkA, frameworkBiOS, frameworkBtvOS])
-        
+
         let graph = Graph.test(
             path: project.path,
             projects: [project.path: project],
             dependencies: [
                 .target(name: app.name, path: project.path): Set([.target(name: frameworkA.name, path: project.path)]),
-                .target(name: frameworkA.name, path: project.path): Set([.target(name: frameworkBiOS.name, path: project.path), .target(name: frameworkBtvOS.name, path: project.path)])
+                .target(name: frameworkA.name, path: project.path): Set([
+                    .target(name: frameworkBiOS.name, path: project.path),
+                    .target(name: frameworkBtvOS.name, path: project.path),
+                ]),
             ],
             dependencyConditions: [
-                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBiOS.name, path: project.path)): try .test([.ios])!,
-                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBtvOS.name, path: project.path)): try .test([.tvos])!
+                GraphEdge(
+                    from: .target(name: frameworkA.name, path: project.path),
+                    to: .target(name: frameworkBiOS.name, path: project.path)
+                ): try .test([.ios])!,
+                GraphEdge(
+                    from: .target(name: frameworkA.name, path: project.path),
+                    to: .target(name: frameworkBtvOS.name, path: project.path)
+                ): try .test([.tvos])!,
             ]
         )
-        
+
         // When
         let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
-        
+
         // Then
         let expectedGraph = Graph.test(
             path: project.path,
             projects: [project.path: Project.test(targets: [app, frameworkA, frameworkBiOS])],
             dependencies: [
                 .target(name: app.name, path: project.path): Set([.target(name: frameworkA.name, path: project.path)]),
-                .target(name: frameworkA.name, path: project.path): Set([.target(name: frameworkBiOS.name, path: project.path)])
+                .target(name: frameworkA.name, path: project.path): Set([.target(name: frameworkBiOS.name, path: project.path)]),
             ],
             dependencyConditions: [
-                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBiOS.name, path: project.path)): try .test([.ios])!,
-                GraphEdge(from: .target(name: frameworkA.name, path: project.path), to: .target(name: frameworkBtvOS.name, path: project.path)): try .test([.tvos])!
+                GraphEdge(
+                    from: .target(name: frameworkA.name, path: project.path),
+                    to: .target(name: frameworkBiOS.name, path: project.path)
+                ): try .test([.ios])!,
+                GraphEdge(
+                    from: .target(name: frameworkA.name, path: project.path),
+                    to: .target(name: frameworkBtvOS.name, path: project.path)
+                ): try .test([.tvos])!,
             ]
         )
         XCTAssertBetterEqual(expectedGraph, gotGraph)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6199

### Short description 📝
[Caching](https://github.com/tuist/tuist/issues/6199) fails because the logic to calculate the hashes traverses edges that lead to non-existing nodes that have been pruned. It turns out that our tree-shaking mapper only tree-shakes nodes but not edges. This PR addresses that.

> [!NOTE]
> In the particular scenario in the issue, the pruned targets are from external Swift packages whose targets are removed because their platforms don't overlap with the ones needed for the project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
