### PR TITLE
Tuist Macro Improvements

### DIFF
--- a/Sources/ProjectAutomation/TargetDependency.swift
+++ b/Sources/ProjectAutomation/TargetDependency.swift
@@ -14,6 +14,7 @@ typealias SDKStatus = LinkingStatus
 
 public enum TargetDependency: Equatable, Hashable, Codable, Sendable {
     case target(name: String, status: LinkingStatus)
+    case macro(name: String)
     case project(target: String, path: String, status: LinkingStatus)
     case framework(path: String, status: LinkingStatus)
     case xcframework(path: String, status: LinkingStatus)

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -59,6 +59,12 @@ public enum TargetDependency: Codable, Hashable, Sendable {
     ///   - status: The dependency status (optional dependencies are weakly linked)
     ///   - condition: condition under which to use this dependency, `nil` if this should always be used
     case target(name: String, status: LinkingStatus = .required, condition: PlatformCondition? = nil)
+    
+    /// Dependency on a macro target within the same project
+    ///
+    /// - Parameters:
+    ///   - name: Name of the target to depend on
+    case macro(name: String)
 
     /// Dependency on a target within another project
     ///
@@ -149,6 +155,8 @@ public enum TargetDependency: Codable, Hashable, Sendable {
         switch self {
         case .target:
             return "target"
+        case .macro:
+            return "macro"
         case .project:
             return "project"
         case .framework:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -59,7 +59,7 @@ public enum TargetDependency: Codable, Hashable, Sendable {
     ///   - status: The dependency status (optional dependencies are weakly linked)
     ///   - condition: condition under which to use this dependency, `nil` if this should always be used
     case target(name: String, status: LinkingStatus = .required, condition: PlatformCondition? = nil)
-    
+
     /// Dependency on a macro target within the same project
     ///
     /// - Parameters:

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -38,6 +38,12 @@ extension XcodeGraph.TargetDependency {
                 status: .from(manifest: status),
                 condition: condition?.asGraphCondition
             )]
+        case let .macro(name: name):
+            return [.target(
+                name: name,
+                status: .required,
+                condition: nil
+            )]
         case let .project(target, projectPath, status, condition):
             return [.project(
                 target: target,

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1026,6 +1026,8 @@ extension ProjectDescription.Settings {
             "MockableTest", // https://github.com/Kolos65/Mockable.git
             "Testing", // https://github.com/apple/swift-testing
             "Cuckoo", // https://github.com/Brightify/Cuckoo
+            "_SwiftSyntaxTestSupport", // https://github.com/swiftlang/swift-syntax
+            "SwiftSyntaxMacrosTestSupport", // https://github.com/swiftlang/swift-syntax
         ]
 
         let resolvedSettings = try mapper.mapSettings()

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -157,7 +157,7 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "MacroPackageProduct")
         XCTAssertEqual(type, .macro)
     }
-    
+
     func test_from_when_package_plugin() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.package(product: "PluginPackageProduct", type: .plugin)
@@ -201,7 +201,6 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(name, "MacroProduct")
         XCTAssertEqual(linkerStatus, .required)
     }
-
 
     func test_from_when_sdkLibrary() throws {
         // Given

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -157,7 +157,7 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "MacroPackageProduct")
         XCTAssertEqual(type, .macro)
     }
-
+    
     func test_from_when_package_plugin() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.package(product: "PluginPackageProduct", type: .plugin)
@@ -179,6 +179,29 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "PluginPackageProduct")
         XCTAssertEqual(type, .plugin)
     }
+
+    func test_from_when_macro() throws {
+        // Given
+        let dependency = ProjectDescription.TargetDependency.macro(name: "MacroProduct")
+        let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"), rootDirectory: "/")
+
+        // When
+        let got = try XcodeGraph.TargetDependency.from(
+            manifest: dependency,
+            generatorPaths: generatorPaths,
+            externalDependencies: [:]
+        )
+
+        // Then
+        XCTAssertEqual(got.count, 1)
+        guard case let .target(name, linkerStatus, _) = got[0] else {
+            XCTFail("Dependency should be package")
+            return
+        }
+        XCTAssertEqual(name, "MacroProduct")
+        XCTAssertEqual(linkerStatus, .required)
+    }
+
 
     func test_from_when_sdkLibrary() throws {
         // Given

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ModuleA
 
 struct ContentView: View {
     var body: some View {
@@ -7,6 +8,7 @@ struct ContentView: View {
                 .imageScale(.large)
                 .foregroundColor(.accentColor)
             Text("Hello, world!")
+            Text("\(#stringify(1+1))")
         }
     }
 }

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import ModuleA
+import SwiftUI
 
 struct ContentView: View {
     var body: some View {
@@ -8,7 +8,7 @@ struct ContentView: View {
                 .imageScale(.large)
                 .foregroundColor(.accentColor)
             Text("Hello, world!")
-            Text("\(#stringify(1+1))")
+            Text("\(#stringify(1 + 1))")
         }
     }
 }

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
@@ -14,7 +14,7 @@ public struct StringifyMacro: ExpressionMacro {
         of node: some FreestandingMacroExpansionSyntax,
         in _: some MacroExpansionContext
     ) -> ExprSyntax {
-        guard let argument = node.argumentList.first?.expression else {
+        guard let argument = node.arguments.first?.expression else {
             fatalError("compiler bug: the macro does not have any arguments")
         }
 

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
@@ -1,0 +1,23 @@
+import SwiftSyntax
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct ModuleAMacros: CompilerPlugin {
+    var providingMacros: [Macro.Type] = [
+        StringifyMacro.self,
+    ]
+}
+
+public struct StringifyMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        guard let argument = node.argumentList.first?.expression else {
+            fatalError("compiler bug: the macro does not have any arguments")
+        }
+
+        return "(\(argument), \(literal: argument.description))"
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Sources/Macros.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
 import SwiftCompilerPlugin
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 @main
@@ -12,7 +12,7 @@ struct ModuleAMacros: CompilerPlugin {
 public struct StringifyMacro: ExpressionMacro {
     public static func expansion(
         of node: some FreestandingMacroExpansionSyntax,
-        in context: some MacroExpansionContext
+        in _: some MacroExpansionContext
     ) -> ExprSyntax {
         guard let argument = node.argumentList.first?.expression else {
             fatalError("compiler bug: the macro does not have any arguments")

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Tests/MacrosTests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Tests/MacrosTests.swift
@@ -1,0 +1,23 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+import ModuleA
+
+final class APIv3ModelMacroTests: XCTestCase {
+    let testMacros: [String: Macro.Type] = [
+        "Stringify": StringifyMacro.self,
+    ]
+    
+    func testStringifyStruct() throws {
+        assertMacroExpansion(
+                 """
+                 #stringify(1+1)
+                 """,
+                 expandedSource: """
+                 (1+1, "1+1")
+                 """,
+                 macros: testMacros
+        )
+    }
+    
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Tests/MacrosTests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Macros/Tests/MacrosTests.swift
@@ -1,23 +1,22 @@
+import ModuleA
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
-import ModuleA
 
 final class APIv3ModelMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
         "Stringify": StringifyMacro.self,
     ]
-    
+
     func testStringifyStruct() throws {
         assertMacroExpansion(
-                 """
-                 #stringify(1+1)
-                 """,
-                 expandedSource: """
-                 (1+1, "1+1")
-                 """,
-                 macros: testMacros
+            """
+            #stringify(1+1)
+            """,
+            expandedSource: """
+            (1+1, "1+1")
+            """,
+            macros: testMacros
         )
     }
-    
 }

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Sources/Macros.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Sources/Macros.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "ModuleAMacros", type: "StringifyMacro")

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
@@ -1,7 +1,7 @@
-@testable import ModuleAMacros_Testable
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
+@testable import ModuleAMacros_Testable
 
 final class StringifyMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
@@ -1,11 +1,11 @@
-import ModuleA
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
+import ModuleAMacros_testable
 
-final class APIv3ModelMacroTests: XCTestCase {
+final class StringifyMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
-        "Stringify": StringifyMacro.self,
+        "stringify": StringifyMacro.self,
     ]
 
     func testStringifyStruct() throws {
@@ -14,7 +14,7 @@ final class APIv3ModelMacroTests: XCTestCase {
             #stringify(1+1)
             """,
             expandedSource: """
-            (1+1, "1+1")
+            (1 + 1, "1+1")
             """,
             macros: testMacros
         )

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
@@ -1,4 +1,4 @@
-import ModuleAMacros_testable
+@testable import ModuleAMacros_Testable
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Tests/ModuleATests.swift
@@ -1,7 +1,7 @@
+import ModuleAMacros_testable
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
-import ModuleAMacros_testable
 
 final class StringifyMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -56,6 +56,7 @@ let project = Project(
             ],
             dependencies: [
                 .target(name: "ModuleAMacros"),
+                .macro(name: "ModuleAMacros"),
             ]
         ),
         .target(
@@ -71,22 +72,6 @@ let project = Project(
             dependencies: [
                 .external(name: "SwiftSyntaxMacros"),
                 .external(name: "SwiftCompilerPlugin"),
-            ]
-        ),
-        .target(
-            name: "ModuleAMacrosTests",
-            destinations: .macOS,
-            product: .unitTests,
-            productName: "ModuleAMacros",
-            bundleId: "io.tuist.moduleamacros.tests",
-            deploymentTargets: .macOS("14.0"),
-            sources: [
-                "Modules/ModuleA/Macros/Tests/**",
-            ],
-            dependencies: [
-                .target(name: "ModuleAMacros"),
-                .external(name: "SwiftSyntaxMacros"),
-                .external(name: "SwiftSyntaxMacrosTestSupport"),
             ]
         ),
     ]

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -70,7 +70,7 @@ let project = Project(
             ],
             dependencies: [
                 .external(name: "SwiftSyntaxMacros"),
-                .external(name: "SwiftCompilerPlugin")
+                .external(name: "SwiftCompilerPlugin"),
             ]
         ),
     ]

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -71,7 +71,7 @@ let project = Project(
             dependencies: [
                 .target(name: "ModuleA"),
                 .target(name: "ModuleAMacros_Testable"),
-                .external(name: "SwiftSyntaxMacrosTestSupport")
+                .external(name: "SwiftSyntaxMacrosTestSupport"),
             ]
         ),
         .target(

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -56,7 +56,22 @@ let project = Project(
             ],
             dependencies: [
                 .external(name: "CasePaths"),
-                .macro(name: "ModuleAMacros"),
+                .target(name: "ModuleAMacros"),
+            ]
+        ),
+        .target(
+            name: "ModuleATests",
+            destinations: [.iPhone, .appleVision, .appleWatch],
+            product: .unitTests,
+            productName: "ModuleATests",
+            bundleId: "io.tuist.moduleatests",
+            sources: [
+                "Modules/ModuleA/Tests/**",
+            ],
+            dependencies: [
+                .target(name: "ModuleA"),
+                .target(name: "ModuleAMacros_Testable"),
+                .external(name: "SwiftSyntaxMacrosTestSupport")
             ]
         ),
         .target(
@@ -66,6 +81,20 @@ let project = Project(
             productName: "ModuleAMacros",
             bundleId: "io.tuist.moduleamacros",
             deploymentTargets: .macOS("14.0"),
+            sources: [
+                "Modules/ModuleA/Macros/Sources/**",
+            ],
+            dependencies: [
+                .external(name: "SwiftSyntaxMacros"),
+                .external(name: "SwiftCompilerPlugin"),
+            ]
+        ),
+        .target(
+            name: "ModuleAMacros_Testable",
+            destinations: [.iPhone, .appleVision, .appleWatch], // Must match platform of the test target
+            product: .framework, // Must match be a linkable product
+            productName: "ModuleAMacros_testable",
+            bundleId: "io.tuist.moduleamacros.testable",
             sources: [
                 "Modules/ModuleA/Macros/Sources/**",
             ],

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -55,7 +55,7 @@ let project = Project(
                 "Modules/ModuleA/Sources/**",
             ],
             dependencies: [
-                .target(name: "ModuleAMacros"),
+                .external(name: "CasePaths"),
                 .macro(name: "ModuleAMacros"),
             ]
         ),

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -105,4 +105,3 @@ let project = Project(
         ),
     ]
 )
-

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -93,7 +93,7 @@ let project = Project(
             name: "ModuleAMacros_Testable",
             destinations: [.iPhone, .appleVision, .appleWatch], // Must match platform of the test target
             product: .framework, // Must match be a linkable product
-            productName: "ModuleAMacros_testable",
+            productName: "ModuleAMacros_Testable",
             bundleId: "io.tuist.moduleamacros.testable",
             sources: [
                 "Modules/ModuleA/Macros/Sources/**",
@@ -105,3 +105,4 @@ let project = Project(
         ),
     ]
 )
+

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -65,6 +65,7 @@ let project = Project(
             product: .macro,
             productName: "ModuleAMacros",
             bundleId: "io.tuist.moduleamacros",
+            deploymentTargets: .macOS("14.0"),
             sources: [
                 "Modules/ModuleA/Macros/**",
             ],

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -55,8 +55,7 @@ let project = Project(
                 "Modules/ModuleA/Sources/**",
             ],
             dependencies: [
-                .external(name: "CasePaths"),
-                .macro(name: "ModuleAMacros"),
+                .target(name: "ModuleAMacros"),
             ]
         ),
         .target(
@@ -67,11 +66,27 @@ let project = Project(
             bundleId: "io.tuist.moduleamacros",
             deploymentTargets: .macOS("14.0"),
             sources: [
-                "Modules/ModuleA/Macros/**",
+                "Modules/ModuleA/Macros/Sources/**",
             ],
             dependencies: [
                 .external(name: "SwiftSyntaxMacros"),
                 .external(name: "SwiftCompilerPlugin"),
+            ]
+        ),
+        .target(
+            name: "ModuleAMacrosTests",
+            destinations: .macOS,
+            product: .unitTests,
+            productName: "ModuleAMacros",
+            bundleId: "io.tuist.moduleamacros.tests",
+            deploymentTargets: .macOS("14.0"),
+            sources: [
+                "Modules/ModuleA/Macros/Tests/**",
+            ],
+            dependencies: [
+                .target(name: "ModuleAMacros"),
+                .external(name: "SwiftSyntaxMacros"),
+                .external(name: "SwiftSyntaxMacrosTestSupport"),
             ]
         ),
     ]

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -56,6 +56,21 @@ let project = Project(
             ],
             dependencies: [
                 .external(name: "CasePaths"),
+                .macro(name: "ModuleAMacros"),
+            ]
+        ),
+        .target(
+            name: "ModuleAMacros",
+            destinations: .macOS,
+            product: .macro,
+            productName: "ModuleAMacros",
+            bundleId: "io.tuist.moduleamacros",
+            sources: [
+                "Modules/ModuleA/Macros/**",
+            ],
+            dependencies: [
+                .external(name: "SwiftSyntaxMacros"),
+                .external(name: "SwiftCompilerPlugin")
             ]
         ),
     ]

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.resolved
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
+        "revision" : "bc92c4b27f9a84bfb498cdbfdf35d5a357e9161f",
+        "version" : "1.5.6"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
-        "version" : "1.1.1"
+        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
+        "version" : "1.4.3"
       }
     }
   ],

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -18,6 +18,6 @@ let package = Package(
     name: "Dependencies",
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0-prerelease")
+        .package(url: "https://github.com/apple/swift-syntax", "509.0.0" ..< "601.0.0-prerelease"),
     ]
 )

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -18,5 +18,6 @@ let package = Package(
     name: "Dependencies",
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0-prerelease")
     ]
 )

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -7,10 +7,17 @@ import PackageDescription
     let packageSettings = PackageSettings(
         baseSettings: .settings(
             base: [
-                "OTHER_LDFLAGS": "-framework XCTest",
                 "ENABLE_USER_SCRIPT_SANDBOXING": true,
             ]
-        )
+        ),
+        targetSettings: [
+            "SwiftSyntaxMacrosTestSupport" : [
+                "OTHER_LDFLAGS": "-framework XCTest"
+            ],
+            "_SwiftSyntaxTestSupport" : [
+                "OTHER_LDFLAGS": "-framework XCTest"
+            ]
+        ]
     )
 
 #endif
@@ -18,7 +25,7 @@ import PackageDescription
 let package = Package(
     name: "Dependencies",
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-syntax", "509.0.0" ..< "601.0.0-prerelease"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.6"),
+        .package(url: "https://github.com/apple/swift-syntax", "510.0.3" ..< "601.0.0-prerelease"),
     ]
 )

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -7,6 +7,7 @@ import PackageDescription
     let packageSettings = PackageSettings(
         baseSettings: .settings(
             base: [
+                "OTHER_LDFLAGS": "-framework XCTest",
                 "ENABLE_USER_SCRIPT_SANDBOXING": true,
             ]
         )

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -9,15 +9,7 @@ import PackageDescription
             base: [
                 "ENABLE_USER_SCRIPT_SANDBOXING": true,
             ]
-        ),
-        targetSettings: [
-            "SwiftSyntaxMacrosTestSupport" : [
-                "OTHER_LDFLAGS": "-framework XCTest"
-            ],
-            "_SwiftSyntaxTestSupport" : [
-                "OTHER_LDFLAGS": "-framework XCTest"
-            ]
-        ]
+        )
     )
 
 #endif


### PR DESCRIPTION
### Short description 📝

Add `ProjectDescription.TargetDependency.macro`  as a more explicit dependency declaration (vs `.target() or .project()`)
We had a need to differentiate between macro dependencies and regular `.target` dependencies in our own implementation and this distinction seemed valuable from a usability perspective as well.  In the end it resolves to an XcodeGraph.TargetDependency in the same way as before and is mostly and end-user facing change.  using `.target` or `.project` to link to a macro would still work but `.macro` feels more explicit and helps keep macros and frameworks colocated in the same project.   Feedback very welcome on this part of the PR.

Updates a fixture with an example macro implementation using Tuist declarations.

> Describe here the purpose of your PR.

Change is tested with the fixture update.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
