### PR TITLE
Fix ProjectDescription failing to compile on Xcode 15.3 with release configuration

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1292,9 +1292,15 @@ extension PackageInfo {
         settingsDictionary.merge(.from(settingsDictionary: baseSettings.base), uniquingKeysWith: { $1 })
 
         if toolsVersion >= Version(5, 9, 0) {
-            settingsDictionary = settingsDictionary.combine(with: [
-                "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", name.quotedIfContainsSpaces],
-            ])
+            let packageNameValues = ["$(inherited)", "-package-name", name.quotedIfContainsSpaces]
+            settingsDictionary["OTHER_SWIFT_FLAGS"] = switch settingsDictionary["OTHER_SWIFT_FLAGS"] {
+            case let .array(swiftFlags):
+                .array(swiftFlags + packageNameValues)
+            case let .string(swiftFlags):
+                .array(swiftFlags.split(separator: " ").map(String.init) + packageNameValues)
+            case .none:
+                .array(packageNameValues)
+            }
         }
 
         if let cLanguageStandard {


### PR DESCRIPTION
### Short description 📝

Fix ProjectDescription failing to compile on Xcode 15.3 with release configuration. Looks like a bug in the Swift compiler not being able to discern between `ProjectDescription.SettingsDictionary` and `XcodeGraph.SettingsDictionary`.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
