### PR TITLE
Fix building tuist/tuist by removing GENERATE_MASTER_OBJECT_FILE setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -384,8 +384,7 @@ let targets: [Target] = [
             "TSCLibc": .staticFramework,
             "ArgumentParser": .staticFramework,
             "Mockable": .staticFramework,
-        ],
-        baseSettings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES"])
+        ]
     )
 
 #endif


### PR DESCRIPTION
### Short description 📝

It looks like this [PR](https://github.com/tuist/tuist/pull/7009) caused a regression for `tuist/tuist`. We get the following error for libraries with no sources, such as `swift-nio__NIOFileSystem`:
```
	Command MasterObjectLink failed with a nonzero exit code
	Testing cancelled because the build failed.
```

The error goes away if:
- `GENERATE_MASTER_OBJECT_FILE` is not set to `YES` to those targets (i.e., the value is `NO`)
- Or those targets have any source file

It actually looks like the setting works _correctly_ now – since the value is set as `baseSettings` in `PackageSettings`, I'd have expected on `4.33.0` that all package targets would have the value set to `YES`. But that's only the case on Tuist `4.34.0`.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
