### PR TITLE
Downgrade tuist to 4.33.0 to fix build issues

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.34.0"
+tuist = "4.33.0"
 swiftlint = "0.54.0"
 swiftformat = "0.53.3"
 pnpm = "8.15.6"


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

Supersedes https://github.com/tuist/tuist/pull/7049

Fixes issues on `main` as explained in the attached PR. There's not an easy way we can fix this issue by staying on `4.34.0` as:
- We want to keep `GENERATE_MASTER_OBJECT_FILE` to `YES` as a base setting
- We don't want the value to propagate to the generated resources target

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
