### PR TITLE
Override GENERATE_MASTER_OBJECT_FILE to NO for the generated resources target

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -56,6 +56,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                     base: [
                         "CODE_SIGNING_ALLOWED": "NO",
                         "SKIP_INSTALL": "YES",
+                        "GENERATE_MASTER_OBJECT_FILE": "NO",
                     ],
                     configurations: [:]
                 ),

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -84,6 +84,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.settings?.base, [
             "SKIP_INSTALL": "YES",
             "CODE_SIGNING_ALLOWED": "NO",
+            "GENERATE_MASTER_OBJECT_FILE": "NO",
         ])
     }
 

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -796,13 +796,6 @@ public enum Module: String, CaseIterable {
         dependencies: [TargetDependency],
         isTestingTarget: Bool
     ) -> Target {
-        let rootFolder: String
-        switch product {
-        case .unitTests:
-            rootFolder = "Tests"
-        default:
-            rootFolder = "Sources"
-        }
         var debugSettings: ProjectDescription.SettingsDictionary = [
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
         ]
@@ -815,6 +808,15 @@ public enum Module: String, CaseIterable {
         if let strictConcurrencySetting, product == .framework {
             debugSettings["SWIFT_STRICT_CONCURRENCY"] = .string(strictConcurrencySetting)
             releaseSettings["SWIFT_STRICT_CONCURRENCY"] = .string(strictConcurrencySetting)
+        }
+
+        let rootFolder: String
+        switch product {
+        case .unitTests:
+            rootFolder = "Tests"
+            debugSettings["CODE_SIGN_IDENTITY"] = ""
+        default:
+            rootFolder = "Sources"
         }
 
         let settings = Settings.settings(


### PR DESCRIPTION
### Short description 📝

This [PR](https://github.com/tuist/tuist/pull/7009) changed the behavior of the base settings, so that it's set on the project level, not individual SPM targets.

That means, the settings implicitly also override the generated resources target. Since the resources target has no sources, the `GENERATE_MASTER_OBJECT_FILE` should never be set to `YES`.

### How to test the changes locally 🧐

- The generated tuist project should be buildable

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
