### PR TITLE
Speed up hashing-dependent features like caching or selective testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4af4b834e070130398d29772b9d2bd895fac258294e6559c648fbc17aef8a873",
+  "originHash" : "964644ab7dd2a576412bdd491b65bc6071ecea0f6017177883f5733d82aac3e2",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "3c4ec4bf0aa97dadc80cba7f7ddec057e5566196",
-        "version" : "0.17.0"
+        "branch" : "project-type",
+        "revision" : "f634488f9403456934b81604b06fa87cf3bfb21e"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "964644ab7dd2a576412bdd491b65bc6071ecea0f6017177883f5733d82aac3e2",
+  "originHash" : "0c4b619908d73514638b34a4d5802dccd9b38f85af5d614a77b1f2a614831dc5",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "branch" : "project-type",
-        "revision" : "f634488f9403456934b81604b06fa87cf3bfb21e"
+        "revision" : "d263b467aa4700a9e4c103a877c5158f5b26bed7",
+        "version" : "0.18.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -510,7 +510,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.17.0")
+            url: "https://github.com/tuist/XcodeGraph.git", branch: "project-type"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -510,7 +510,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", branch: "project-type"
+            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.18.0")
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol CopyFilesContentHashing {
     func hash(identifier: String, copyFiles: [CopyFilesAction]) async throws -> MerkleNode
 }

--- a/Sources/TuistHasher/CoreDataModelsContentHasher.swift
+++ b/Sources/TuistHasher/CoreDataModelsContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol CoreDataModelsContentHashing {
     func hash(coreDataModels: [CoreDataModel]) async throws -> String
 }

--- a/Sources/TuistHasher/DependenciesContentHasher.swift
+++ b/Sources/TuistHasher/DependenciesContentHasher.swift
@@ -1,9 +1,11 @@
 import Foundation
+import Mockable
 import Path
 import TuistCore
 import TuistSupport
 import XcodeGraph
 
+@Mockable
 public protocol DependenciesContentHashing {
     func hash(
         graphTarget: GraphTarget,

--- a/Sources/TuistHasher/DeploymentTargetsContentHasher.swift
+++ b/Sources/TuistHasher/DeploymentTargetsContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol DeploymentTargetsContentHashing {
     func hash(deploymentTargets: DeploymentTargets) throws -> String
 }

--- a/Sources/TuistHasher/HeadersContentHasher.swift
+++ b/Sources/TuistHasher/HeadersContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol HeadersContentHashing {
     func hash(headers: Headers) async throws -> String
 }

--- a/Sources/TuistHasher/PlistContentHasher.swift
+++ b/Sources/TuistHasher/PlistContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol PlistContentHashing {
     func hash(plist: Plist) async throws -> String
 }

--- a/Sources/TuistHasher/ResourcesContentHasher.swift
+++ b/Sources/TuistHasher/ResourcesContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol ResourcesContentHashing {
     func hash(identifier: String, resources: ResourceFileElements) async throws -> MerkleNode
 }

--- a/Sources/TuistHasher/SettingsContentHasher.swift
+++ b/Sources/TuistHasher/SettingsContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol SettingsContentHashing {
     func hash(settings: Settings) async throws -> String
 }

--- a/Sources/TuistHasher/SourceFilesContentHasher.swift
+++ b/Sources/TuistHasher/SourceFilesContentHasher.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Mockable
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol SourceFilesContentHashing {
     func hash(identifier: String, sources: [SourceFile]) async throws -> MerkleNode
 }

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -92,6 +92,9 @@ public final class TargetContentHasher: TargetContentHashing {
         hashedPaths: [AbsolutePath: String],
         additionalStrings: [String] = []
     ) async throws -> TargetContentHash {
+        if let projectType = graphTarget.project.type, case let XcodeGraph.ProjectType.external(hash) = projectType, let hash {
+            return TargetContentHash(hash: hash, hashedPaths: [:])
+        }
         var hashedPaths = hashedPaths
         let sourcesHash = try await sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash
         let resourcesHash = try await resourcesContentHasher

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -92,8 +92,14 @@ public final class TargetContentHasher: TargetContentHashing {
         hashedPaths: [AbsolutePath: String],
         additionalStrings: [String] = []
     ) async throws -> TargetContentHash {
-        if let projectType = graphTarget.project.type, case let XcodeGraph.ProjectType.external(hash) = projectType, let hash {
-            return TargetContentHash(hash: hash, hashedPaths: [:])
+        let projectHash: String? = switch graphTarget.project.type {
+        case let .external(hash: hash): hash
+        case .local: nil
+        case .none:
+            nil
+        }
+        if let projectHash {
+            return TargetContentHash(hash: projectHash, hashedPaths: [:])
         }
         var hashedPaths = hashedPaths
         let sourcesHash = try await sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash

--- a/Sources/TuistHasher/TargetScriptsContentHasher.swift
+++ b/Sources/TuistHasher/TargetScriptsContentHasher.swift
@@ -1,8 +1,10 @@
 import Foundation
+import Mockable
 import Path
 import TuistCore
 import XcodeGraph
 
+@Mockable
 public protocol TargetScriptsContentHashing {
     func hash(targetScripts: [TargetScript], sourceRootPath: AbsolutePath) async throws -> String
 }

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -120,11 +120,11 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
                 with: plugins
             )
 
-            let manifest = try await swiftPackageManagerGraphLoader.load(
+            let manifestsDependencyGraph = try await swiftPackageManagerGraphLoader.load(
                 packagePath: packagePath,
                 packageSettings: loadedPackageSettings
             )
-            dependenciesGraph = try await converter.convert(manifest: manifest, path: path)
+            dependenciesGraph = try await converter.convert(dependenciesGraph: manifestsDependencyGraph, path: path)
             packageSettings = loadedPackageSettings
         } else {
             packageSettings = nil
@@ -199,7 +199,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
                 path: $0.path,
                 plugins: plugins,
                 externalDependencies: externalDependencies,
-                isExternal: false
+                type: .local
             )
         }
     }

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -101,7 +101,8 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 name: String,
                 folder: AbsolutePath,
                 targetToArtifactPaths: [String: AbsolutePath],
-                info: PackageInfo
+                info: PackageInfo,
+                hash: String?
             )
         ]
         packageInfos = try await workspaceState.object.dependencies.concurrentMap { dependency in
@@ -140,7 +141,8 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 name: name,
                 folder: packageFolder,
                 targetToArtifactPaths: targetToArtifactPaths,
-                info: packageInfo
+                info: packageInfo,
+                hash: dependency.state?.checkoutState?.revision
             )
         }
 
@@ -184,8 +186,9 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         let packageModuleAliases = mutablePackageModuleAliases
         let mappedPackageInfos = try await packageInfos.concurrentMap { packageInfo in
             (
-                packageInfo,
-                try await self.packageInfoMapper.map(
+                packageInfo: packageInfo,
+                hash: packageInfo.hash,
+                projectManifest: try await self.packageInfoMapper.map(
                     packageInfo: packageInfo.info,
                     path: packageInfo.folder,
                     packageType: .external(artifactPaths: packageToTargetsToArtifactPaths[packageInfo.name] ?? [:]),
@@ -194,9 +197,15 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 )
             )
         }
-        let externalProjects: [Path: ProjectDescription.Project] = mappedPackageInfos
-            .reduce(into: [:]) { result, mappedPackageInfo in
-                result[.path(mappedPackageInfo.0.folder.pathString)] = mappedPackageInfo.1
+        let externalProjects: [Path: DependenciesGraph.ExternalProject] = mappedPackageInfos
+            .reduce(into: [:]) { result, item in
+                let (packageInfo, hash, projectManifest) = item
+                if let projectManifest {
+                    result[.path(packageInfo.folder.pathString)] = DependenciesGraph.ExternalProject(
+                        manifest: projectManifest,
+                        hash: hash
+                    )
+                }
             }
 
         return DependenciesGraph(

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -21,7 +21,7 @@ extension XcodeGraph.Project {
         plugins: Plugins,
         externalDependencies: [String: [XcodeGraph.TargetDependency]],
         resourceSynthesizerPathLocator: ResourceSynthesizerPathLocating,
-        isExternal: Bool,
+        type: XcodeGraph.ProjectType,
         fileSystem: FileSysteming
     ) async throws -> XcodeGraph.Project {
         let name = manifest.name
@@ -86,7 +86,7 @@ extension XcodeGraph.Project {
             additionalFiles: additionalFiles,
             resourceSynthesizers: resourceSynthesizers,
             lastUpgradeCheck: nil,
-            isExternal: isExternal
+            type: type
         )
     }
 }

--- a/Sources/TuistLoader/Models/DependenciesGraph.swift
+++ b/Sources/TuistLoader/Models/DependenciesGraph.swift
@@ -2,21 +2,28 @@ import ProjectDescription
 
 /// A directed acyclic graph (DAG) that Tuist uses to represent the dependency tree.
 public struct DependenciesGraph: Equatable, Codable {
+    public struct ExternalProject: Equatable, Codable {
+        public var manifest: ProjectDescription.Project
+        public var hash: String?
+
+        public init(manifest: ProjectDescription.Project, hash: String?) {
+            self.manifest = manifest
+            self.hash = hash
+        }
+    }
+
     /// A dictionary of Platforms to a dictionary where the keys are the names of dependencies, and the values are the
     /// dependencies themselves.
     public let externalDependencies: [String: [TargetDependency]]
 
     /// A dictionary where the keys are the folder of external projects, and the values are the projects themselves.
-    public let externalProjects: [Path: Project]
+    public let externalProjects: [Path: ExternalProject]
 
     /// Create an instance of `DependenciesGraph` model.
-    public init(externalDependencies: [String: [TargetDependency]], externalProjects: [Path: Project]) {
+    public init(externalDependencies: [String: [TargetDependency]], externalProjects: [Path: ExternalProject]) {
         self.externalDependencies = externalDependencies
         self.externalProjects = externalProjects
     }
-
-    /// An empty `DependenciesGraph`.
-    public static let none: DependenciesGraph = .init(externalDependencies: [:], externalProjects: [:])
 }
 
 #if DEBUG
@@ -43,7 +50,7 @@ public struct DependenciesGraph: Equatable, Codable {
 
         public static func test(
             externalDependencies: [String: [TargetDependency]] = [:],
-            externalProjects: [Path: Project] = [:]
+            externalProjects: [Path: ExternalProject] = [:]
         ) -> Self {
             .init(externalDependencies: externalDependencies, externalProjects: externalProjects)
         }
@@ -147,7 +154,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "test",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -169,7 +176,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -231,7 +238,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "a-dependency",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -250,7 +257,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -289,7 +296,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "another-dependency",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -308,7 +315,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -355,7 +362,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "Alamofire",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -369,7 +376,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -485,7 +492,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "GoogleAppMeasurement",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -508,7 +515,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -607,7 +614,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "GoogleUtilities",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -626,7 +633,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }
@@ -665,7 +672,7 @@ public struct DependenciesGraph: Equatable, Codable {
             return .init(
                 externalDependencies: externalDependencies,
                 externalProjects: [
-                    packageFolder: .init(
+                    packageFolder: ExternalProject(manifest: Project(
                         name: "nanopb",
                         options: .options(
                             automaticSchemesOptions: .disabled,
@@ -684,7 +691,7 @@ public struct DependenciesGraph: Equatable, Codable {
                         ),
                         targets: targets,
                         resourceSynthesizers: .default
-                    ),
+                    ), hash: nil),
                 ]
             )
         }

--- a/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
+++ b/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
@@ -15,11 +15,23 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
     }
 
     struct Dependency: Decodable, Equatable {
+        struct State: Decodable, Equatable {
+            struct CheckoutState: Decodable, Equatable {
+                let revision: String?
+            }
+
+            /// The revision a package has been resolved to.
+            let checkoutState: CheckoutState?
+        }
+
         /// The package reference of the dependency
         let packageRef: PackageRef
 
         /// The path of the remote dependency, relative to the checkouts folder
         let subpath: String
+
+        /// The state of the dependency.
+        let state: State?
     }
 
     struct Artifact: Decodable, Equatable {

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -9,18 +9,18 @@ import XCTest
 @testable import TuistHasher
 
 final class TargetContentHasherTests: TuistUnitTestCase {
-    var contentHasher: MockContentHashing!
-    var coreDataModelsContentHasher: MockCoreDataModelsContentHashing!
-    var sourceFilesContentHasher: MockSourceFilesContentHashing!
-    var targetScriptsContentHasher: MockTargetScriptsContentHashing!
-    var resourcesContentHasher: MockResourcesContentHashing!
-    var copyFilesContentHasher: MockCopyFilesContentHashing!
-    var headersContentHasher: MockHeadersContentHashing!
-    var deploymentTargetContentHasher: MockDeploymentTargetsContentHashing!
-    var plistContentHasher: MockPlistContentHashing!
-    var settingsContentHasher: MockSettingsContentHashing!
-    var dependenciesContentHasher: MockDependenciesContentHashing!
-    var subject: TargetContentHasher!
+    private var contentHasher: MockContentHashing!
+    private var coreDataModelsContentHasher: MockCoreDataModelsContentHashing!
+    private var sourceFilesContentHasher: MockSourceFilesContentHashing!
+    private var targetScriptsContentHasher: MockTargetScriptsContentHashing!
+    private var resourcesContentHasher: MockResourcesContentHashing!
+    private var copyFilesContentHasher: MockCopyFilesContentHashing!
+    private var headersContentHasher: MockHeadersContentHashing!
+    private var deploymentTargetContentHasher: MockDeploymentTargetsContentHashing!
+    private var plistContentHasher: MockPlistContentHashing!
+    private var settingsContentHasher: MockSettingsContentHashing!
+    private var dependenciesContentHasher: MockDependenciesContentHashing!
+    private var subject: TargetContentHasher!
 
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Mockable
+import Path
+import TuistCore
+import TuistSupportTesting
+import XcodeGraph
+import XCTest
+
+@testable import TuistHasher
+
+final class TargetContentHasherTests: TuistUnitTestCase {
+    var contentHasher: MockContentHashing!
+    var coreDataModelsContentHasher: MockCoreDataModelsContentHashing!
+    var sourceFilesContentHasher: MockSourceFilesContentHashing!
+    var targetScriptsContentHasher: MockTargetScriptsContentHashing!
+    var resourcesContentHasher: MockResourcesContentHashing!
+    var copyFilesContentHasher: MockCopyFilesContentHashing!
+    var headersContentHasher: MockHeadersContentHashing!
+    var deploymentTargetContentHasher: MockDeploymentTargetsContentHashing!
+    var plistContentHasher: MockPlistContentHashing!
+    var settingsContentHasher: MockSettingsContentHashing!
+    var dependenciesContentHasher: MockDependenciesContentHashing!
+    var subject: TargetContentHasher!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        contentHasher = MockContentHashing()
+        coreDataModelsContentHasher = MockCoreDataModelsContentHashing()
+        sourceFilesContentHasher = MockSourceFilesContentHashing()
+        targetScriptsContentHasher = MockTargetScriptsContentHashing()
+        resourcesContentHasher = MockResourcesContentHashing()
+        copyFilesContentHasher = MockCopyFilesContentHashing()
+        headersContentHasher = MockHeadersContentHashing()
+        deploymentTargetContentHasher = MockDeploymentTargetsContentHashing()
+        plistContentHasher = MockPlistContentHashing()
+        settingsContentHasher = MockSettingsContentHashing()
+        dependenciesContentHasher = MockDependenciesContentHashing()
+        subject = TargetContentHasher(
+            contentHasher: contentHasher,
+            sourceFilesContentHasher: sourceFilesContentHasher,
+            targetScriptsContentHasher: targetScriptsContentHasher,
+            coreDataModelsContentHasher: coreDataModelsContentHasher,
+            resourcesContentHasher: resourcesContentHasher,
+            copyFilesContentHasher: copyFilesContentHasher,
+            headersContentHasher: headersContentHasher,
+            deploymentTargetContentHasher: deploymentTargetContentHasher,
+            plistContentHasher: plistContentHasher,
+            settingsContentHasher: settingsContentHasher,
+            dependenciesContentHasher: dependenciesContentHasher
+        )
+    }
+
+    override func tearDown() async throws {
+        contentHasher = nil
+        coreDataModelsContentHasher = nil
+        sourceFilesContentHasher = nil
+        targetScriptsContentHasher = nil
+        resourcesContentHasher = nil
+        copyFilesContentHasher = nil
+        headersContentHasher = nil
+        plistContentHasher = nil
+        settingsContentHasher = nil
+        dependenciesContentHasher = nil
+        subject = nil
+        try await super.tearDown()
+    }
+
+    func test_hash_when_targetBelongsToExternalProjectWithHash() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test(type: .external(hash: "hash")))
+
+        // When
+        let got = try await subject.contentHash(for: target, hashedTargets: [:], hashedPaths: [:])
+
+        // Then
+        XCTAssertEqual(got.hash, "hash")
+    }
+}

--- a/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
@@ -57,7 +57,7 @@ final class ManifestModelConverterTests: TuistUnitTestCase {
             path: temporaryPath,
             plugins: .none,
             externalDependencies: [:],
-            isExternal: false
+            type: .local
         )
 
         // Then
@@ -92,7 +92,7 @@ final class ManifestModelConverterTests: TuistUnitTestCase {
             path: temporaryPath,
             plugins: .none,
             externalDependencies: [:],
-            isExternal: false
+            type: .local
         )
 
         // Then
@@ -135,7 +135,7 @@ final class ManifestModelConverterTests: TuistUnitTestCase {
             path: temporaryPath,
             plugins: .none,
             externalDependencies: [:],
-            isExternal: false
+            type: .local
         )
 
         // Then
@@ -165,7 +165,7 @@ final class ManifestModelConverterTests: TuistUnitTestCase {
             path: temporaryPath,
             plugins: .none,
             externalDependencies: [:],
-            isExternal: false
+            type: .local
         )
 
         // Then
@@ -193,7 +193,7 @@ final class ManifestModelConverterTests: TuistUnitTestCase {
             path: temporaryPath,
             plugins: .none,
             externalDependencies: [:],
-            isExternal: false
+            type: .local
         )
 
         // Then

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Project+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Project+ManifestMapperTests.swift
@@ -52,7 +52,7 @@ final class ProjectManifestMapperTests: TuistUnitTestCase {
             plugins: .none,
             externalDependencies: [:],
             resourceSynthesizerPathLocator: MockResourceSynthesizerPathLocator(),
-            isExternal: false,
+            type: .local,
             fileSystem: fileSystem
         )
 
@@ -91,7 +91,7 @@ final class ProjectManifestMapperTests: TuistUnitTestCase {
                 additionalFiles: [.file(path: swiftFilePath)],
                 resourceSynthesizers: [],
                 lastUpgradeCheck: nil,
-                isExternal: false
+                type: .local
             )
         )
     }

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a6e24b070aa78532dbb80a41191cc4ad7642db968e619c88009323d1998c775",
+  "originHash" : "2fe7bf57c30f6c9b922cb028dcc0c2626a880cb72f465fbd21a96226807e3786",
   "pins" : [
     {
       "identity" : "appauth-ios",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/NetworkImage",
       "state" : {
-        "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
-        "version" : "6.0.0"
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7018
XcodeGraph PR https://github.com/tuist/XcodeGraph/pull/74

### Short description 📝
This PR prevents [this scenario](https://github.com/tuist/tuist/issues/7018) from happening and speeds up the performance of hashing since we can obtain the hash of external targets using the resolved reference of the package they represent.

### How to test the changes locally 🧐
Reproducing [this](https://github.com/tuist/tuist/issues/7018) is a bit tricky since it requires creating a release version and running it from iTerm or the macOS terminal. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
