### PR TITLE
Fix obtaining pull request number in CircleCI environments

### DIFF
--- a/Sources/TuistSupport/Utils/GitController.swift
+++ b/Sources/TuistSupport/Utils/GitController.swift
@@ -155,8 +155,6 @@ public final class GitController: GitControlling {
         "AC_PULL_NUMBER",
         // Xcode Cloud
         "CI_PULL_REQUEST_NUMBER",
-        // CircleCI
-        "CIRCLE_PR_NUMBER",
         // Buildkite
         "BUILDKITE_PULL_REQUEST",
     ]
@@ -164,6 +162,11 @@ public final class GitController: GitControlling {
     public func ref(environment: [String: String]) -> String? {
         if let githubRef = environment["GITHUB_REF"] {
             return githubRef
+        } else if let circleCIRef = environment["CIRCLE_PULL_REQUEST"] {
+            guard let url = URL(string: circleCIRef),
+                  let pullRequestID = url.pathComponents.last
+            else { return nil }
+            return "refs/pull/\(pullRequestID)/merge"
         } else if let pullRequestID = Self.pullRequestIDEnvironmentVariables
             .compactMap({ environment[$0] })
             .first(where: { !$0.isEmpty })

--- a/Tests/TuistSupportTests/Utils/GitControllerTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitControllerTests.swift
@@ -164,6 +164,18 @@ final class GitControllerTests: TuistUnitTestCase {
         XCTAssertEqual(got, "refs/pull/2/merge")
     }
 
+    func test_ref_when_circle_pull_request() throws {
+        // When
+        let got = subject.ref(
+            environment: [
+                "CIRCLE_PULL_REQUEST": "https://github.com/tuist/tuist/pull/6740",
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(got, "refs/pull/6740/merge")
+    }
+
     func test_inGitRepository_when_rev_parse_succeeds() throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
### Short description 📝

In CircleCI environments, we are currently using the `CIRCLE_PR_NUMBER` environment variable. But as documented [here](https://circleci.com/docs/variables/#built-in-environment-variables), that variable is defined in forks only.

Instead, we should use `CIRCLE_PULL_REQUEST`. This environment variable is the full PR URL, such as `https://github.com/tuist/tuist/pull/6740`, so we need to parse the URL to obtain the PR number.

### How to test the changes locally 🧐

- CI should pass. To test this E2E, we'd need to set up a CircleCI environment.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
