### PR TITLE
Disable "file_name" SwiftLint rule in synthesized resources

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -187,6 +187,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         }
 
         return """
+        // swiftlint:disable:this file_name
         // swiftlint:disable all
         // swift-format-ignore-file
         // swiftformat:disable all

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -1,6 +1,7 @@
 // swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let assetsTemplate = """
+    // swiftlint:disable:this file_name
     // swiftlint:disable all
     // swift-format-ignore-file
     // swiftformat:disable all

--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -1,5 +1,6 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let filesTemplate = """
+    // swiftlint:disable:this file_name
     // swiftlint:disable all
     // swift-format-ignore-file
     // swiftformat:disable all

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -1,5 +1,6 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let fontsTemplate = """
+    // swiftlint:disable:this file_name
     // swiftlint:disable all
     // swift-format-ignore-file
     // swiftformat:disable all

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -1,5 +1,6 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let plistsTemplate = """
+    // swiftlint:disable:this file_name
     // swiftlint:disable all
     // swift-format-ignore-file
     // swiftformat:disable all

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -1,5 +1,6 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let stringsTemplate = """
+    // swiftlint:disable:this file_name
     // swiftlint:disable all
     // swift-format-ignore-file
     // swiftformat:disable all

--- a/fixtures/app_with_plugins/Tuist/ResourceSynthesizers/Lottie.stencil
+++ b/fixtures/app_with_plugins/Tuist/ResourceSynthesizers/Lottie.stencil
@@ -1,3 +1,4 @@
+// swiftlint:disable:this file_name
 // swiftformat:disable all
 // swiftlint:disable all
 {% if files %}


### PR DESCRIPTION
### Problem

If you use SwiftLint rule "file_name", then you will catch "File Name Violation" errors / warnings for each synthesized file. Even you have "swiftlint:disable all" at the top of file.

Example:

<img width="700" alt="Screenshot 2024-11-19 at 12 33 13" src="https://github.com/user-attachments/assets/1a89ebd6-39e1-481e-aefa-a01a8f1c14e5">

### Solution

I found related issue in SwiftLint repo - https://github.com/realm/SwiftLint/issues/2277. Users suggest add this line to the start of file `// swiftlint:disable:this file_name`

In this PR I added this line to the each template. All errors and warnings solved. 
Also I checked that with disabled rule `file_name` was not any superfluous_disable_command errors

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
