### PR TITLE
feat: when running latest preview, filter supported platforms

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c4b619908d73514638b34a4d5802dccd9b38f85af5d614a77b1f2a614831dc5",
+  "originHash" : "d26ce37a1e3640c35d9f812c6ebc576e3091aec939ffb89030180bffa98522ce",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "d263b467aa4700a9e4c103a877c5158f5b26bed7",
-        "version" : "0.18.0"
+        "revision" : "cd2c44640039c0b06f327a4dfc8052d871a088cc",
+        "version" : "0.19.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -510,7 +510,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.18.0")
+            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.19.1")
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -184,6 +184,8 @@ final class RunService {
             guard let preview = try await listPreviewsService.listPreviews(
                 displayName: displayName,
                 specifier: specifier,
+                // `tuist run` currently supports only simulator builds
+                supportedPlatforms: Platform.allCases.map(DestinationType.simulator),
                 page: 1,
                 pageSize: 1,
                 distinctField: nil,

--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -46,6 +46,7 @@ enum ShareServiceError: Equatable, FatalError {
     }
 }
 
+// swiftlint:disable:next type_body_length
 struct ShareService {
     private let fileHandler: FileHandling
     private let fileSystem: FileSysteming
@@ -262,6 +263,7 @@ struct ShareService {
             version: appBundle.infoPlist.version.description,
             bundleIdentifier: appBundle.infoPlist.bundleId,
             icon: iconPaths(for: appBundle).first,
+            supportedPlatforms: appBundle.infoPlist.supportedPlatforms,
             fullHandle: fullHandle,
             serverURL: serverURL,
             json: json
@@ -292,6 +294,7 @@ struct ShareService {
             icon: appBundles
                 .concurrentFlatMap { try await iconPaths(for: $0) }
                 .first,
+            supportedPlatforms: appBundles.flatMap(\.infoPlist.supportedPlatforms),
             fullHandle: fullHandle,
             serverURL: serverURL,
             json: json
@@ -378,6 +381,7 @@ struct ShareService {
                 icon: appBundles
                     .concurrentFlatMap { try await iconPaths(for: $0) }
                     .first,
+                supportedPlatforms: appBundles.flatMap(\.infoPlist.supportedPlatforms),
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -400,6 +404,7 @@ struct ShareService {
         version: String?,
         bundleIdentifier: String?,
         icon: AbsolutePath?,
+        supportedPlatforms: [DestinationType],
         fullHandle: String,
         serverURL: URL,
         json: Bool
@@ -411,6 +416,7 @@ struct ShareService {
             version: version,
             bundleIdentifier: bundleIdentifier,
             icon: icon,
+            supportedPlatforms: supportedPlatforms,
             fullHandle: fullHandle,
             serverURL: serverURL
         )

--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -3909,6 +3909,13 @@ internal struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
+                    name: "supported_platforms",
+                    value: input.query.supported_platforms
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
                     name: "page_size",
                     value: input.query.page_size
                 )

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -1563,6 +1563,20 @@ internal enum Components {
                 case sso_provider
             }
         }
+        /// The supported platforms of the preview.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PreviewSupportedPlatform`.
+        internal enum PreviewSupportedPlatform: String, Codable, Hashable, Sendable, CaseIterable {
+            case ios = "ios"
+            case ios_simulator = "ios_simulator"
+            case tvos = "tvos"
+            case tvos_simulator = "tvos_simulator"
+            case watchos = "watchos"
+            case watchos_simulator = "watchos_simulator"
+            case visionos = "visionos"
+            case visionos_simulator = "visionos_simulator"
+            case macos = "macos"
+        }
         /// It represents an artifact that's associated with a command event (e.g. result bundles)
         ///
         /// - Remark: Generated from `#/components/schemas/CommandEventArtifact`.
@@ -10884,6 +10898,10 @@ internal enum Operations {
                 internal var specifier: Swift.String?
                 ///
                 ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/GET/query/supported_platforms`.
+                internal var supported_platforms: [Components.Schemas.PreviewSupportedPlatform]?
+                ///
+                ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/GET/query/page_size`.
                 internal var page_size: Swift.Int?
                 ///
@@ -10903,18 +10921,21 @@ internal enum Operations {
                 /// - Parameters:
                 ///   - display_name: The display name of previews.
                 ///   - specifier: The preview version specifier. Currently, accepts a commit SHA, branch name, or latest.
+                ///   - supported_platforms:
                 ///   - page_size:
                 ///   - page:
                 ///   - distinct_field: Distinct fields – no two previews will be returned with this field having the same value.
                 internal init(
                     display_name: Swift.String? = nil,
                     specifier: Swift.String? = nil,
+                    supported_platforms: [Components.Schemas.PreviewSupportedPlatform]? = nil,
                     page_size: Swift.Int? = nil,
                     page: Swift.Int? = nil,
                     distinct_field: Operations.listPreviews.Input.Query.distinct_fieldPayload? = nil
                 ) {
                     self.display_name = display_name
                     self.specifier = specifier
+                    self.supported_platforms = supported_platforms
                     self.page_size = page_size
                     self.page = page
                     self.distinct_field = distinct_field
@@ -11866,6 +11887,10 @@ internal enum Operations {
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/display_name`.
                     internal var display_name: Swift.String?
+                    /// The supported platforms of the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/supported_platforms`.
+                    internal var supported_platforms: [Components.Schemas.PreviewSupportedPlatform]?
                     /// The type of the preview to upload.
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/type`.
@@ -11886,22 +11911,26 @@ internal enum Operations {
                     /// - Parameters:
                     ///   - bundle_identifier: The bundle identifier of the preview.
                     ///   - display_name: The display name of the preview.
+                    ///   - supported_platforms: The supported platforms of the preview.
                     ///   - _type: The type of the preview to upload.
                     ///   - version: The version of the preview.
                     internal init(
                         bundle_identifier: Swift.String? = nil,
                         display_name: Swift.String? = nil,
+                        supported_platforms: [Components.Schemas.PreviewSupportedPlatform]? = nil,
                         _type: Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload._typePayload? = nil,
                         version: Swift.String? = nil
                     ) {
                         self.bundle_identifier = bundle_identifier
                         self.display_name = display_name
+                        self.supported_platforms = supported_platforms
                         self._type = _type
                         self.version = version
                     }
                     internal enum CodingKeys: String, CodingKey {
                         case bundle_identifier
                         case display_name
+                        case supported_platforms
                         case _type = "type"
                         case version
                     }

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -327,6 +327,21 @@ components:
       title: Organization
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Organization
+    PreviewSupportedPlatform:
+      description: The supported platforms of the preview.
+      enum:
+        - ios
+        - ios_simulator
+        - tvos
+        - tvos_simulator
+        - watchos
+        - watchos_simulator
+        - visionos
+        - visionos_simulator
+        - macos
+      title: PreviewSupportedPlatform
+      type: string
+      x-struct: Elixir.TuistWeb.API.Schemas.PreviewSupportedPlatform
     CommandEventArtifact:
       description: It represents an artifact that's associated with a command event (e.g. result bundles)
       properties:
@@ -2196,6 +2211,15 @@ paths:
             type: string
         - description: ''
           in: query
+          name: supported_platforms
+          required: false
+          schema:
+            description: The supported platforms of the preview.
+            items:
+              $ref: '#/components/schemas/PreviewSupportedPlatform'
+            type: array
+        - description: ''
+          in: query
           name: page_size
           required: false
           schema:
@@ -2408,6 +2432,11 @@ paths:
                 display_name:
                   description: The display name of the preview.
                   type: string
+                supported_platforms:
+                  description: The supported platforms of the preview.
+                  items:
+                    $ref: '#/components/schemas/PreviewSupportedPlatform'
+                  type: array
                 type:
                   default: app_bundle
                   description: The type of the preview to upload.

--- a/Sources/TuistServer/Services/ListPreviewsService.swift
+++ b/Sources/TuistServer/Services/ListPreviewsService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Mockable
+import TuistCore
 import TuistSupport
 
 public enum ListPreviewsDistinctField {
@@ -11,6 +12,7 @@ public protocol ListPreviewsServicing {
     func listPreviews(
         displayName: String?,
         specifier: String?,
+        supportedPlatforms: [DestinationType],
         page: Int?,
         pageSize: Int?,
         distinctField: ListPreviewsDistinctField?,
@@ -61,6 +63,7 @@ public final class ListPreviewsService: ListPreviewsServicing {
     public func listPreviews(
         displayName: String?,
         specifier: String?,
+        supportedPlatforms: [DestinationType],
         page: Int?,
         pageSize: Int?,
         distinctField: ListPreviewsDistinctField?,
@@ -78,6 +81,7 @@ public final class ListPreviewsService: ListPreviewsServicing {
                 query: .init(
                     display_name: displayName,
                     specifier: specifier,
+                    supported_platforms: supportedPlatforms.map(Components.Schemas.PreviewSupportedPlatform.init),
                     page_size: pageSize,
                     page: page,
                     distinct_field: distinctField.map {
@@ -106,6 +110,39 @@ public final class ListPreviewsService: ListPreviewsServicing {
             switch unauthorized.body {
             case let .json(error):
                 throw ListPreviewsServiceError.unauthorized(error.message)
+            }
+        }
+    }
+}
+
+extension Components.Schemas.PreviewSupportedPlatform {
+    init(_ supportedPlatform: DestinationType) {
+        switch supportedPlatform {
+        case let .device(platform):
+            switch platform {
+            case .iOS:
+                self = .ios
+            case .macOS:
+                self = .macos
+            case .tvOS:
+                self = .tvos
+            case .watchOS:
+                self = .watchos
+            case .visionOS:
+                self = .visionos
+            }
+        case let .simulator(platform):
+            switch platform {
+            case .iOS:
+                self = .ios_simulator
+            case .macOS:
+                self = .macos
+            case .tvOS:
+                self = .tvos_simulator
+            case .watchOS:
+                self = .watchos_simulator
+            case .visionOS:
+                self = .visionos_simulator
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Mockable
+import TuistCore
 import TuistSupport
 
 @Mockable
@@ -9,6 +10,7 @@ public protocol MultipartUploadStartPreviewsServicing {
         displayName: String,
         version: String?,
         bundleIdentifier: String?,
+        supportedPlatforms: [DestinationType],
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload
@@ -59,6 +61,7 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
         displayName: String,
         version: String?,
         bundleIdentifier: String?,
+        supportedPlatforms: [DestinationType],
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload {
@@ -82,6 +85,7 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
                     .init(
                         bundle_identifier: bundleIdentifier,
                         display_name: displayName,
+                        supported_platforms: supportedPlatforms.map(Components.Schemas.PreviewSupportedPlatform.init),
                         _type: type,
                         version: version
                     )

--- a/Sources/TuistServer/Services/PreviewsUploadService.swift
+++ b/Sources/TuistServer/Services/PreviewsUploadService.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Mockable
 import Path
+import TuistCore
 import TuistSupport
 import XcodeGraph
 
@@ -18,6 +19,7 @@ public protocol PreviewsUploadServicing {
         version: String?,
         bundleIdentifier: String?,
         icon: AbsolutePath?,
+        supportedPlatforms: [DestinationType],
         fullHandle: String,
         serverURL: URL
     ) async throws -> Preview
@@ -74,6 +76,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         version: String?,
         bundleIdentifier: String?,
         icon: AbsolutePath?,
+        supportedPlatforms: [DestinationType],
         fullHandle: String,
         serverURL: URL
     ) async throws -> Preview {
@@ -94,6 +97,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
                 displayName: displayName,
                 version: version,
                 bundleIdentifier: bundleIdentifier,
+                supportedPlatforms: supportedPlatforms,
                 fullHandle: fullHandle,
                 serverURL: serverURL
             )

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -422,6 +422,7 @@ final class RunServiceTests: TuistUnitTestCase {
             .listPreviews(
                 displayName: .value("App"),
                 specifier: .value("latest"),
+                supportedPlatforms: .any,
                 page: .value(1),
                 pageSize: .value(1),
                 distinctField: .any,
@@ -470,6 +471,7 @@ final class RunServiceTests: TuistUnitTestCase {
             .listPreviews(
                 displayName: .value("App"),
                 specifier: .value("latest"),
+                supportedPlatforms: .any,
                 page: .value(1),
                 pageSize: .value(1),
                 distinctField: .any,

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -80,6 +80,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .any,
                 bundleIdentifier: .any,
                 icon: .any,
+                supportedPlatforms: .any,
                 fullHandle: .any,
                 serverURL: .any
             )
@@ -239,6 +240,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .any,
                 bundleIdentifier: .any,
                 icon: .any,
+                supportedPlatforms: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -407,7 +409,8 @@ final class ShareServiceTests: TuistUnitTestCase {
                 .test(
                     infoPlist: .test(
                         version: Version(1, 0, 0),
-                        bundleId: "com.tuist.app"
+                        bundleId: "com.tuist.app",
+                        supportedPlatforms: [.simulator(.iOS)]
                     )
                 )
             )
@@ -430,6 +433,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .value("1.0.0"),
                 bundleIdentifier: .value("com.tuist.app"),
                 icon: .any,
+                supportedPlatforms: .value([.simulator(.iOS)]),
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -776,6 +780,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .any,
                 bundleIdentifier: .any,
                 icon: .any,
+                supportedPlatforms: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -908,6 +913,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .any,
                 bundleIdentifier: .any,
                 icon: .value(iosIconPath),
+                supportedPlatforms: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )
@@ -976,6 +982,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 version: .value("1.0.0"),
                 bundleIdentifier: .value("com.tuist.app"),
                 icon: .value(iconPath),
+                supportedPlatforms: .any,
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(Constants.URLs.production)
             )

--- a/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
@@ -108,6 +108,7 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
                 displayName: .value("App"),
                 version: .any,
                 bundleIdentifier: .any,
+                supportedPlatforms: .value([.simulator(.iOS)]),
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(serverURL)
             )
@@ -124,6 +125,7 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
             version: nil,
             bundleIdentifier: nil,
             icon: nil,
+            supportedPlatforms: [.simulator(.iOS)],
             fullHandle: "tuist/tuist",
             serverURL: serverURL
         )
@@ -154,6 +156,7 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
                 displayName: .value("App"),
                 version: .value("1.0.0"),
                 bundleIdentifier: .value("com.my.app"),
+                supportedPlatforms: .value([.device(.iOS)]),
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .value(serverURL)
             )
@@ -177,6 +180,7 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
             version: "1.0.0",
             bundleIdentifier: "com.my.app",
             icon: icon,
+            supportedPlatforms: [.device(.iOS)],
             fullHandle: "tuist/tuist",
             serverURL: serverURL
         )

--- a/app/TuistApp/Sources/Extensions/DestinationType+Extras.swift
+++ b/app/TuistApp/Sources/Extensions/DestinationType+Extras.swift
@@ -1,0 +1,12 @@
+import TuistCore
+
+extension Device {
+    var destinationType: DestinationType? {
+        switch self {
+        case let .device(physicalDevice):
+            .device(physicalDevice.platform)
+        case let .simulator(simulator):
+            simulator.runtime.platform.map(DestinationType.simulator)
+        }
+    }
+}

--- a/app/TuistApp/Sources/Views/AppPreviews/AppPreviewsModel.swift
+++ b/app/TuistApp/Sources/Views/AppPreviews/AppPreviewsModel.swift
@@ -61,6 +61,7 @@ final class AppPreviewsViewModel: Sendable {
             try await listPreviewsService.listPreviews(
                 displayName: nil,
                 specifier: "latest",
+                supportedPlatforms: [],
                 page: nil,
                 pageSize: nil,
                 distinctField: .bundleIdentifier,
@@ -88,6 +89,7 @@ final class AppPreviewsViewModel: Sendable {
         let previews = try await listPreviewsService.listPreviews(
             displayName: nil,
             specifier: "latest",
+            supportedPlatforms: [deviceService.selectedDevice?.destinationType].compactMap { $0 },
             page: nil,
             pageSize: 1,
             distinctField: nil,

--- a/app/TuistApp/Tests/ViewModels/AppPreviewsViewModelTests.swift
+++ b/app/TuistApp/Tests/ViewModels/AppPreviewsViewModelTests.swift
@@ -31,6 +31,16 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             appStorage: appStorage
         )
 
+        given(deviceService)
+            .selectedDevice
+            .willReturn(
+                .device(
+                    .test(
+                        platform: .iOS
+                    )
+                )
+            )
+
         given(serverURLService)
             .serverURL()
             .willReturn(.test())
@@ -76,6 +86,7 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .listPreviews(
                 displayName: .any,
                 specifier: .any,
+                supportedPlatforms: .any,
                 page: .any,
                 pageSize: .any,
                 distinctField: .any,
@@ -131,6 +142,7 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .listPreviews(
                 displayName: .any,
                 specifier: .any,
+                supportedPlatforms: .any,
                 page: .any,
                 pageSize: .any,
                 distinctField: .any,
@@ -159,6 +171,7 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .listPreviews(
                 displayName: .any,
                 specifier: .any,
+                supportedPlatforms: .any,
                 page: .any,
                 pageSize: .any,
                 distinctField: .any,
@@ -186,6 +199,19 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
         verify(deviceService)
             .launchPreview(
                 with: .value("preview-id"),
+                fullHandle: .any,
+                serverURL: .any
+            )
+            .called(1)
+
+        verify(listPreviewsService)
+            .listPreviews(
+                displayName: .any,
+                specifier: .any,
+                supportedPlatforms: .value([.device(.iOS)]),
+                page: .any,
+                pageSize: .any,
+                distinctField: .any,
                 fullHandle: .any,
                 serverURL: .any
             )


### PR DESCRIPTION
### Short description 📝

Currently, running the latest preview from the macOS app or via `tuist run App@latest` will get the latest preview regardless of the platform. We should get the latest preview for the selected device instead.

### How to test the changes locally 🧐

- Share an iOS bundle and then an `.ipa`
- Run `tuist share App@latest` - the preview should be run on a simulator
- Run the latest preview via the macOS app when a simulator is selected

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
