### PR TITLE
Migrate Project.isExternal to Project.type

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c4b619908d73514638b34a4d5802dccd9b38f85af5d614a77b1f2a614831dc5",
+  "originHash" : "0cf92ac6b58cc83342cf25391d9b8755939071435982d45406526c0f42f0232c",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "d263b467aa4700a9e4c103a877c5158f5b26bed7",
-        "version" : "0.18.0"
+        "revision" : "aa1eaa209cbd308d1b8f6162b4d020ae8bd36058",
+        "version" : "0.19.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -510,7 +510,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.18.0")
+            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.19.3")
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -934,13 +934,21 @@ public class GraphTraverser: GraphTraversing {
     public func directTargetExternalDependencies(path: Path.AbsolutePath, name: String) -> Set<
         GraphTargetReference
     > {
-        directTargetDependencies(path: path, name: name).filter(\.graphTarget.project.isExternal)
+        directTargetDependencies(path: path, name: name)
+            .filter {
+                switch $0.graphTarget.project.type {
+                case .local:
+                    return false
+                case .external:
+                    return true
+                }
+            }
     }
 
     public func allExternalTargets() -> Set<GraphTarget> {
         Set(
             graph.projects.flatMap { path, project -> [GraphTarget] in
-                guard project.isExternal else { return [] }
+                guard case .external = project.type else { return [] }
                 return project.targets.values.map {
                     GraphTarget(path: path, target: $0, project: project)
                 }
@@ -1267,7 +1275,12 @@ public class GraphTraverser: GraphTraversing {
         guard let targetDependency = dependency.targetDependency,
               let project = graph.projects[targetDependency.path]
         else { return false }
-        return project.isExternal
+        switch project.type {
+        case .external:
+            return true
+        case .local:
+            return false
+        }
     }
 
     func isDependencyPrecompiledMacro(_ dependency: GraphDependency) -> Bool {
@@ -1543,7 +1556,7 @@ public class GraphTraverser: GraphTraversing {
     private func allTargets(excludingExternalTargets: Bool) -> Set<GraphTarget> {
         Set(
             projects.flatMap { projectPath, project -> [GraphTarget] in
-                if excludingExternalTargets, project.isExternal { return [] }
+                if excludingExternalTargets, case .external = project.type { return [] }
                 return project.targets.values.map { target in
                     GraphTarget(path: projectPath, target: target, project: project)
                 }

--- a/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
@@ -42,7 +42,7 @@ extension Project {
     }
 
     public func derivedDirectoryPath(for target: Target) -> AbsolutePath {
-        if isExternal,
+        if case .external = type,
            path.pathString
            .contains("\(Constants.SwiftPackageManager.packageBuildDirectoryName)/checkouts")
         {

--- a/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -20,7 +20,7 @@ public final class ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
     // MARK: - Helpers
 
     private func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
-        guard project.isExternal,
+        guard case .external = project.type,
               // We don't want to update local packages (which are defined outside the `checkouts` directory in `.build`
               project.path.parentDirectory.parentDirectory.basename == Constants.SwiftPackageManager.packageBuildDirectoryName
         else { return (project, []) }

--- a/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -19,7 +19,16 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
         logger.debug("Transforming graph \(graph.name): Aligning external target platforms with locals'")
 
         // If the project has no external dependencies we skip this.
-        if graph.projects.values.first(where: { $0.isExternal }) == nil {
+        if graph.projects.values.first(
+            where: {
+                switch $0.type {
+                case .external:
+                    return true
+                case .local:
+                    return false
+                }
+            }
+        ) == nil {
             return (graph, [], environment)
         }
 
@@ -52,7 +61,7 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
          */
         var target = target
         let graphTarget = GraphTarget(path: project.path, target: target, project: project)
-        if project.isExternal, let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
+        if case .external = project.type, let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
             target.destinations = target.destinations.filter { destination in
                 targetFilteredPlatforms.contains(destination.platform)
             }

--- a/Sources/TuistGenerator/Extensions/Graph+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Graph+Extras.swift
@@ -41,7 +41,7 @@ extension XcodeGraph.Graph {
         )
 
         return filteredTargetsAndDependencies.reduce(into: [GraphTarget: Set<GraphDependency>]()) { result, target in
-            if skipExternalDependencies, target.project.isExternal { return }
+            if skipExternalDependencies, case .external = target.project.type { return }
 
             guard let targetDependencies = graphTraverser
                 .dependencies[.target(name: target.target.name, path: target.path)]
@@ -63,7 +63,11 @@ extension GraphDependency {
     fileprivate func isExternal(_ projects: [Path.AbsolutePath: XcodeGraph.Project]) -> Bool {
         switch self {
         case let .target(_, path, _):
-            return projects[path]?.isExternal ?? false
+            if case .external = projects[path]?.type {
+                return true
+            } else {
+                return false
+            }
         case .framework, .xcframework, .library, .bundle, .packageProduct, .sdk, .macro:
             return true
         }

--- a/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
@@ -71,7 +71,7 @@ public struct ExplicitDependencyGraphMapper: GraphMapping {
             "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
         ]
 
-        if graphTarget.project.isExternal {
+        if case .external = graphTarget.project.type {
             additionalSettings["FRAMEWORK_SEARCH_PATHS"] = .array(["$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)"])
         } else if !frameworkSearchPaths.isEmpty {
             additionalSettings["FRAMEWORK_SEARCH_PATHS"] = .array(frameworkSearchPaths)

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -87,7 +87,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
             sideEffects.append(sideEffect)
         }
 
-        if project.isExternal,
+        if case .external = project.type,
            target.supportsSources,
            target.sources.containsObjcFiles,
            target.resources.containsBundleAccessedResources,
@@ -180,10 +180,15 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         }
 
         // Add public accessors only for non external projects
-        let publicBundleAccessor = if project.isExternal || target.sourcesContainsPublicResourceClassName {
+        let publicBundleAccessor = switch project.type {
+        case .external:
             ""
-        } else {
-            publicBundleAccessorString(for: target)
+        case .local:
+            if target.sourcesContainsPublicResourceClassName {
+                ""
+            } else {
+                publicBundleAccessorString(for: target)
+            }
         }
 
         return """

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -95,8 +95,6 @@ public final class TargetContentHasher: TargetContentHashing {
         let projectHash: String? = switch graphTarget.project.type {
         case let .external(hash: hash): hash
         case .local: nil
-        case .none:
-            nil
         }
         if let projectHash {
             return TargetContentHash(hash: projectHash, hashedPaths: [:])

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -226,13 +226,11 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         }
 
         defer {
-            var parameters: [String: AnyCodable] = [
-                "no_binary_cache": AnyCodable(!binaryCache),
-                "no_selective_testing": AnyCodable(!selectiveTesting),
-            ]
-
             TestCommand.analyticsDelegate?.addParameters(
-                parameters
+                [
+                    "no_binary_cache": AnyCodable(!binaryCache),
+                    "no_selective_testing": AnyCodable(!selectiveTesting),
+                ]
             )
         }
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -358,7 +358,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             additionalFiles: [],
             resourceSynthesizers: [],
             lastUpgradeCheck: nil,
-            isExternal: false
+            type: .local
         )
     }
 
@@ -455,7 +455,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             additionalFiles: [],
             resourceSynthesizers: [],
             lastUpgradeCheck: nil,
-            isExternal: false
+            type: .local
         )
     }
 

--- a/Sources/TuistKit/Services/ProjectAutomation+ManifestMapper.swift
+++ b/Sources/TuistKit/Services/ProjectAutomation+ManifestMapper.swift
@@ -41,10 +41,17 @@ extension ProjectAutomation.Project {
             ProjectAutomation.Target.from(target)
         }
 
+        let isExternal = switch project.type {
+        case .external:
+            true
+        case .local:
+            false
+        }
+
         return ProjectAutomation.Project(
             name: project.name,
             path: project.path.pathString,
-            isExternal: project.isExternal,
+            isExternal: isExternal,
             packages: packages,
             targets: Array(targets.values),
             schemes: schemes

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -343,7 +343,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: try! AbsolutePath(validating: "/ExternalProject"),
             targets: [staticLibrary, bundle],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
@@ -394,7 +394,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: try! AbsolutePath(validating: "/ExternalProject"),
             targets: [staticLibrary, bundle],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
@@ -4669,7 +4669,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
             targets: [directPackageProduct, transitivePackageProduct, packageDevProduct],
-            isExternal: true
+            type: .external(hash: nil)
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
         let transitivePackageProductDependency = GraphDependency.target(
@@ -4707,7 +4707,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
             targets: [directPackageProduct],
-            isExternal: true
+            type: .external(hash: nil)
         )
         let directPackageProductDependency = GraphDependency.target(
             name: directPackageProduct.name,
@@ -4759,7 +4759,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
             targets: [directPackageProduct],
-            isExternal: true
+            type: .external(hash: nil)
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
 
@@ -4792,7 +4792,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
             targets: [directPackageProduct],
-            isExternal: true
+            type: .external(hash: nil)
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
 
@@ -4833,7 +4833,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [externalPackage, externalPackageTargetB],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
@@ -4890,7 +4890,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [directExternalPackage, transitiveExternalPackage],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
@@ -4943,7 +4943,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [externalMacroFramework, externalMacroExecutable],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
@@ -4998,7 +4998,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [externalFramework],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)

--- a/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -44,7 +44,7 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
             sourceRootPath: externalProjectPath,
             xcodeProjPath: externalProjectPath.appending(component: "ExternalDependency.xcodeproj"),
             name: "ExternalDependency",
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let workspace = Workspace.test(
@@ -88,7 +88,7 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
                             "SRCROOT": .string(externalProjectPath.pathString),
                         ]
                     ),
-                    isExternal: true
+                    type: .external(hash: nil)
                 ),
             ]
         )

--- a/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -32,7 +32,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         )
 
         let project = Project.test(path: directory, targets: [appTarget])
-        let externalProject = Project.test(path: packagesDirectory, targets: [externalPackage], isExternal: true)
+        let externalProject = Project.test(path: packagesDirectory, targets: [externalPackage], type: .external(hash: nil))
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
         let externalPackageDependency = GraphDependency.target(name: externalPackage.name, path: externalProject.path)
@@ -76,7 +76,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         )
 
         let project = Project.test(path: directory, targets: [appTarget])
-        let externalProject = Project.test(path: packagesDirectory, targets: [externalPackage], isExternal: true)
+        let externalProject = Project.test(path: packagesDirectory, targets: [externalPackage], type: .external(hash: nil))
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
         let externalPackageDependency = GraphDependency.target(name: externalPackage.name, path: externalProject.path)
@@ -137,7 +137,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [directExternalPackage, transitiveExternalPackage],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
@@ -197,7 +197,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         let externalProject = Project.test(
             path: packagesDirectory,
             targets: [externalMacroFramework, externalMacroExecutable],
-            isExternal: true
+            type: .external(hash: nil)
         )
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)

--- a/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
@@ -42,7 +42,7 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
                 transitivePackageProductWithNoDestinations,
                 packageDevProduct,
             ],
-            isExternal: true
+            type: .external(hash: nil)
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
         let transitivePackageProductDependency = GraphDependency.target(

--- a/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -436,7 +436,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
             additionalFiles: [],
             resourceSynthesizers: [],
             lastUpgradeCheck: nil,
-            isExternal: false
+            type: .local
         )
     }
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/TestModelGenerator.swift
@@ -165,7 +165,7 @@ final class TestModelGenerator {
             additionalFiles: try createAdditionalFiles(path: path),
             resourceSynthesizers: [],
             lastUpgradeCheck: nil,
-            isExternal: false
+            type: .local
         )
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -42,7 +42,7 @@ final class ProjectGroupsTests: XCTestCase {
             additionalFiles: [],
             resourceSynthesizers: [],
             lastUpgradeCheck: nil,
-            isExternal: false
+            type: .local
         )
         pbxproj = PBXProj()
     }

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -228,7 +228,11 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         let externalTarget = GraphTarget.test(path: externalProjectPath, target: externalTargetTarget)
         let project = Project.test(path: projectPath, targets: [iOSAppTarget, watchAppTarget])
         let coreProject = Project.test(path: coreProjectPath, targets: [coreTarget, coreTestsTarget])
-        let externalProject = Project.test(path: "/Tuist/Dependencies", targets: [externalTargetTarget], isExternal: true)
+        let externalProject = Project.test(
+            path: "/Tuist/Dependencies",
+            targets: [externalTargetTarget],
+            type: .external(hash: nil)
+        )
         let externalDependency = GraphDependency.target(name: externalTarget.target.name, path: externalTarget.path)
 
         let graph = XcodeGraph.Graph.test(

--- a/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
@@ -66,7 +66,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     targets: [
                         externalFrameworkC,
                     ],
-                    isExternal: true
+                    type: .external(hash: nil)
                 ),
             ],
             dependencies: [
@@ -275,7 +275,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     targets: [
                         externalFrameworkB,
                     ],
-                    isExternal: true
+                    type: .external(hash: nil)
                 ),
             ],
             dependencies: [

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -92,7 +92,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .framework, sources: ["/Absolute/File.m"], resources: .init(resources))
-        project = Project.test(targets: [target], isExternal: true)
+        project = Project.test(targets: [target], type: .external(hash: nil))
 
         // Got
         let (gotProject, gotSideEffects) = try subject.map(project: project)
@@ -351,7 +351,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = []
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: true)
+        project = Project.test(
+            path: try AbsolutePath(validating: "/AbsolutePath/Project"),
+            targets: [target],
+            type: .external(hash: nil)
+        )
 
         // Got
         let (gotProject, gotSideEffects) = try subject.map(project: project)
@@ -366,7 +370,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = []
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: false)
+        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
 
         // Got
         let (gotProject, gotSideEffects) = try subject.map(project: project)
@@ -381,7 +385,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: true)
+        project = Project.test(
+            path: try AbsolutePath(validating: "/AbsolutePath/Project"),
+            targets: [target],
+            type: .external(hash: nil)
+        )
 
         // Got
         let (_, gotSideEffects) = try subject.map(project: project)
@@ -395,7 +403,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: false)
+        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
 
         // Got
         let (_, gotSideEffects) = try subject.map(project: project)
@@ -409,7 +417,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: true)
+        project = Project.test(
+            path: try AbsolutePath(validating: "/AbsolutePath/Project"),
+            targets: [target],
+            type: .external(hash: nil)
+        )
 
         // Got
         let (gotProject, gotSideEffects) = try subject.map(project: project)
@@ -428,7 +440,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
-        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], isExternal: false)
+        project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
 
         // Got
         let (gotProject, gotSideEffects) = try subject.map(project: project)

--- a/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -50,7 +50,7 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         let projectPath = try temporaryPath().appending(component: "Project")
         let externalProjectPath = try temporaryPath().appending(component: "ExternalProject")
         let project = Project.test(path: projectPath, targets: [aTarget, bTarget, cTarget])
-        let externalProject = Project.test(path: externalProjectPath, targets: [dTarget, eTarget], isExternal: true)
+        let externalProject = Project.test(path: externalProjectPath, targets: [dTarget, eTarget], type: .external(hash: nil))
         let graph = Graph.test(
             projects: [
                 project.path: project,

--- a/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -70,7 +70,7 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         let app = Target.test(name: "App", product: .app)
         let project = Project.test(path: path, targets: [app])
         let testTarget = Target.test(name: "PackageTarget", product: .app)
-        let externalProject = Project.test(path: path, targets: [testTarget], isExternal: true)
+        let externalProject = Project.test(path: path, targets: [testTarget], type: .external(hash: nil))
         let graph = Graph.test(
             path: path,
             projects: [path: project, "/a": externalProject]


### PR DESCRIPTION
### Short description 📝

There's tons of warnings in the Tuist project due to us using `isExternal`.

I'm moving the usage to `Project.type` instead and upgrading the `XcodeGraph` that favors to use the new property if `isExternal` is not specified.

### How to test the changes locally 🧐

- Generate the project – you should see fewer warnings.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
