### PR TITLE
Fix data race when refreshing an access token

### DIFF
--- a/Sources/TuistServer/Utilities/CachedValueStore.swift
+++ b/Sources/TuistServer/Utilities/CachedValueStore.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Mockable
+
+@Mockable
+/// Actor that caches a piece of work asynchronously in a thread-safe manner.
+protocol CachedValueStoring: Sendable {
+    func getValue<Value>(key: String, computeIfNeeded: @escaping () async throws -> Value) async throws -> Value
+}
+
+actor CachedValueStore: CachedValueStoring {
+    static let shared = CachedValueStore()
+
+    private var tasks: [String: Task<Any, any Error>] = [:]
+
+    func getValue<Value>(key: String, computeIfNeeded: @escaping () async throws -> Value) async throws -> Value {
+        tasks[key] = tasks[key] ?? Task { try await computeIfNeeded() }
+        // swiftlint:disable:next force_unwrapping, force_cast
+        return try await tasks[key]!.value as! Value
+    }
+}

--- a/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -14,6 +14,7 @@ final class ServerClientAuthenticationMiddlewareTests: TuistUnitTestCase {
     private var serverCredentialsStore: MockServerCredentialsStoring!
     private var refreshAuthTokenService: MockRefreshAuthTokenServicing!
     private var dateService: MockDateServicing!
+    private var cachedValueStore: MockCachedValueStoring!
 
     override func setUp() {
         super.setUp()
@@ -26,7 +27,8 @@ final class ServerClientAuthenticationMiddlewareTests: TuistUnitTestCase {
             serverAuthenticationController: serverAuthenticationController,
             serverCredentialsStore: serverCredentialsStore,
             refreshAuthTokenService: refreshAuthTokenService,
-            dateService: dateService
+            dateService: dateService,
+            cachedValueStore: CachedValueStore()
         )
     }
 


### PR DESCRIPTION
### Short description 📝

I've noticed (and got reports from multiple users) that the Tuist session gets invalidated surprisingly often.

When we start multiple server requests at once and the access token is invalid, we'd try to refresh the access token at the same time multiple times.

Instead, when the access token is invalid, we should try to refresh it just once per CLI run.

### How to test the changes locally 🧐

- Have an expired token
- Run a command that uses cache (in those cases, we try to refresh the token at the same time from multiple threads)
- Observer the refresh happens only four times (1 + 3 number of retries)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
