### PR TITLE
fix: honor platform-specific package settings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0cf92ac6b58cc83342cf25391d9b8755939071435982d45406526c0f42f0232c",
+  "originHash" : "3a379b24984107847f21f4adabe9b978a4f67d21dcf18b9537875af1e3d25659",
   "pins" : [
     {
       "identity" : "aexml",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "aa1eaa209cbd308d1b8f6162b4d020ae8bd36058",
-        "version" : "0.19.3"
+        "branch" : "fix/overlay-settings",
+        "revision" : "2d860d0dc4464305d9484d3ab7c0bd4f8e61bce5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -510,7 +510,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", .upToNextMajor(from: "0.19.3")
+            url: "https://github.com/tuist/XcodeGraph.git", branch: "fix/overlay-settings"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -199,27 +199,6 @@ final class SettingsHelpersTests: XCTestCase {
         ]])
     }
 
-    func testOverlay_addsPlatformSpecifierWhenSettingsDiffer() {
-        // Given
-        settings["A"] = "a value"
-        settings["B"] = "b value"
-
-        // When
-        settings.overlay(with: [
-            "A": "overlayed value",
-            "B": "b value",
-            "C": "c value",
-        ], for: .macOS)
-
-        // Then
-        XCTAssertEqual(settings, [
-            "A[sdk=macosx*]": "overlayed value",
-            "A": "a value",
-            "B": "b value",
-            "C": "c value",
-        ])
-    }
-
     func testSettingsProviderPlatform() {
         XCTAssertEqual(subject.settingsProviderPlatform(.iOS), .iOS)
         XCTAssertEqual(subject.settingsProviderPlatform(.macOS), .macOS)

--- a/fixtures/app_with_revenue_cat/Tuist/Package.swift
+++ b/fixtures/app_with_revenue_cat/Tuist/Package.swift
@@ -1,16 +1,6 @@
 // swift-tools-version: 6.0
 @preconcurrency import PackageDescription
 
-#if TUIST
-    import struct ProjectDescription.PackageSettings
-
-    let packageSettings = PackageSettings(
-        targetSettings: [
-            "RevenueCat": .settings(base: ["SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited)"]),
-        ]
-    )
-#endif
-
 let package = Package(
     name: "App",
     dependencies: [


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7076

### Short description 📝

The actual fix can is in `XcodeGraph`: https://github.com/tuist/XcodeGraph/pull/79

This PR updates `XcodeGraph` and removes the workaround from the RevenueCat SDK that's no longer necessary.

### How to test the changes locally 🧐

- `tuist build` in `app_with_revenue_cat` should succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
