### PR TITLE
fix: when hashing packages, hash should include extra metadata like Swift compiler version

### DIFF
--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -97,7 +97,10 @@ public final class TargetContentHasher: TargetContentHashing {
         case .local: nil
         }
         if let projectHash {
-            return TargetContentHash(hash: projectHash, hashedPaths: [:])
+            return TargetContentHash(
+                hash: try contentHasher.hash([projectHash] + additionalStrings),
+                hashedPaths: [:]
+            )
         }
         var hashedPaths = hashedPaths
         let sourcesHash = try await sourceFilesContentHasher.hash(identifier: "sources", sources: graphTarget.target.sources).hash

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -48,6 +48,10 @@ final class TargetContentHasherTests: TuistUnitTestCase {
             settingsContentHasher: settingsContentHasher,
             dependenciesContentHasher: dependenciesContentHasher
         )
+
+        given(contentHasher)
+            .hash(Parameter<[String]>.any)
+            .willProduce { $0.joined(separator: "-") }
     }
 
     override func tearDown() async throws {
@@ -74,5 +78,21 @@ final class TargetContentHasherTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got.hash, "hash")
+    }
+
+    func test_hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test(type: .external(hash: "hash")))
+
+        // When
+        let got = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            additionalStrings: ["additional_string_one", "additional_string_two"]
+        )
+
+        // Then
+        XCTAssertEqual(got.hash, "hash-additional_string_one-additional_string_two")
     }
 }


### PR DESCRIPTION
### Short description 📝

Follow-up to: https://github.com/tuist/tuist/pull/7060

The hash for package targets is currently missing extra metadata like Swift compiler version. Without including those, compiling the project when using binaries with non-matching Swift compiler versions or macOS SDKs will fail.

### How to test the changes locally 🧐

- The hash of SPM targets should change based on Swift compiler, etc.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
