### PR TITLE
feat: add appleVisionWithiPadDesign to the iOS destinations default

### DIFF
--- a/Sources/ProjectDescription/Destination.swift
+++ b/Sources/ProjectDescription/Destination.swift
@@ -6,8 +6,7 @@ public typealias Destinations = Set<Destination>
 /// Convenience collections of destinations mapped to platforms terminology.
 extension Destinations {
     public static let watchOS: Destinations = [.appleWatch]
-    /// Currently we omit `.visionOSwithiPadDesign` from our default because `visionOS` is unreleased.
-    public static let iOS: Destinations = [.iPhone, .iPad, .macWithiPadDesign]
+    public static let iOS: Destinations = [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign]
     public static let macOS: Destinations = [.mac]
     public static let tvOS: Destinations = [.appleTv]
     public static let visionOS: Destinations = [.appleVision]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6462

### Short description 📝

Adding `visionOSWithIpadDesign` to the default of `iOS` destinations as visionOS has been released for quite some time.

### How to test the changes locally 🧐

- visionOS with ipad design should be included if you use `.iOS` for your destination.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
