### PR TITLE
Detect and use the Cirrus cache URL

### DIFF
--- a/Sources/TuistServer/Services/ServerURLService.swift
+++ b/Sources/TuistServer/Services/ServerURLService.swift
@@ -37,7 +37,7 @@ public final class ServerURLService: ServerURLServicing {
     public func url(configServerURL: URL, envVariables: [String: String]) throws -> URL {
         return try (
             envVariableURL("TUIST_URL", envVariables: envVariables) ??
-                envVariableURL("CIRRUS_TUIST_CACHE_URL", envVariables: envVariables) ?? configServerURL
+                envVariableURL(Constants.EnvironmentVariables.cirrusTuistCacheURL, envVariables: envVariables) ?? configServerURL
         )
     }
 

--- a/Sources/TuistServer/Services/ServerURLService.swift
+++ b/Sources/TuistServer/Services/ServerURLService.swift
@@ -2,21 +2,21 @@ import Foundation
 import Mockable
 import TuistSupport
 
-enum ServerURLServiceError: FatalError {
-    case invalidServerURL
+enum ServerURLServiceError: FatalError, Equatable {
+    case invalidEnvVariableServerURL(envVariable: String, value: String)
 
     /// Error description.
     var description: String {
         switch self {
-        case .invalidServerURL:
-            return "The server URL is invalid."
+        case let .invalidEnvVariableServerURL(envVariable, value):
+            return "The server environment variable '\(envVariable)' has an invalid URL value '\(value)'"
         }
     }
 
     /// Error type.
     var type: ErrorType {
         switch self {
-        case .invalidServerURL:
+        case .invalidEnvVariableServerURL:
             return .bug
         }
     }
@@ -31,12 +31,23 @@ public final class ServerURLService: ServerURLServicing {
     public init() {}
 
     public func url(configServerURL: URL) throws -> URL {
-        guard let serverURL = ProcessInfo.processInfo.environment["TUIST_URL"]
-            .map(URL.init(string:)) ?? configServerURL
-        else {
-            throw ServerURLServiceError.invalidServerURL
-        }
+        return try url(configServerURL: configServerURL, envVariables: ProcessInfo.processInfo.environment)
+    }
 
-        return serverURL
+    public func url(configServerURL: URL, envVariables: [String: String]) throws -> URL {
+        return try (
+            envVariableURL("TUIST_URL", envVariables: envVariables) ??
+                envVariableURL("CIRRUS_TUIST_CACHE_URL", envVariables: envVariables) ?? configServerURL
+        )
+    }
+
+    private func envVariableURL(_ envVariable: String, envVariables: [String: String]) throws -> URL? {
+        guard let envVariableString = envVariables[envVariable] else {
+            return nil
+        }
+        guard let envVariableURL = URL(string: envVariableString) else {
+            throw ServerURLServiceError.invalidEnvVariableServerURL(envVariable: envVariableString, value: envVariableString)
+        }
+        return envVariableURL
     }
 }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -76,6 +76,7 @@ public enum Constants {
         @available(*, deprecated, message: "Use `token` instead")
         public static let deprecatedToken = "TUIST_CONFIG_CLOUD_TOKEN"
         public static let quiet = "TUIST_CONFIG_QUIET"
+        public static let cirrusTuistCacheURL = "CIRRUS_TUIST_CACHE_URL"
     }
 
     public enum URLs {

--- a/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -28,7 +28,8 @@ final class ServerClientAuthenticationMiddlewareTests: TuistUnitTestCase {
             serverCredentialsStore: serverCredentialsStore,
             refreshAuthTokenService: refreshAuthTokenService,
             dateService: dateService,
-            cachedValueStore: CachedValueStore()
+            cachedValueStore: CachedValueStore(),
+            envVariables: [:]
         )
     }
 
@@ -39,6 +40,42 @@ final class ServerClientAuthenticationMiddlewareTests: TuistUnitTestCase {
         dateService = nil
         subject = nil
         super.tearDown()
+    }
+
+    func test_when_cirrus_env_variable_is_present() async throws {
+        // Given
+        subject = .init(
+            serverAuthenticationController: serverAuthenticationController,
+            serverCredentialsStore: serverCredentialsStore,
+            refreshAuthTokenService: refreshAuthTokenService,
+            dateService: dateService,
+            cachedValueStore: CachedValueStore(),
+            envVariables: [Constants.EnvironmentVariables.cirrusTuistCacheURL: "https://cirrus.dev"]
+        )
+        let url = URL(string: "https://test.tuist.io")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
+        let response = HTTPResponse(
+            status: 200
+        )
+        var gotRequest: HTTPRequest!
+
+        // When
+        let (gotResponse, _) = try await subject.intercept(
+            request,
+            body: nil,
+            baseURL: url,
+            operationID: "123"
+        ) { request, body, _ in
+            gotRequest = request
+            return (response, body)
+        }
+
+        // Then
+        XCTAssertEqual(gotResponse, response)
+        XCTAssertEqual(
+            gotRequest.headerFields,
+            [:]
+        )
     }
 
     func test_when_authentication_token_is_nil() async throws {

--- a/Tests/TuistServerTests/Services/ServerURLServiceTests.swift
+++ b/Tests/TuistServerTests/Services/ServerURLServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mockable
 import Testing
+import TuistSupport
 @testable import TuistServer
 
 struct ServerURLServiceTests {
@@ -21,7 +22,7 @@ struct ServerURLServiceTests {
         // Given
         let tuistURLString = "https://cirrus.dev"
         let tuistURL = URL(string: tuistURLString)!
-        let envVariables = ["CIRRUS_TUIST_CACHE_URL": tuistURLString]
+        let envVariables = [Constants.EnvironmentVariables.cirrusTuistCacheURL: tuistURLString]
         let configURL = URL(string: "https://tuist.config")!
 
         // When

--- a/Tests/TuistServerTests/Services/ServerURLServiceTests.swift
+++ b/Tests/TuistServerTests/Services/ServerURLServiceTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Mockable
+import Testing
+@testable import TuistServer
+
+struct ServerURLServiceTests {
+    let subject = ServerURLService()
+
+    @Test func returns_the_value_from_tuist_url_env_variable_when_present_and_valid() throws {
+        // Given
+        let tuistURLString = "https://tuist.dev"
+        let tuistURL = URL(string: tuistURLString)!
+        let envVariables = ["TUIST_URL": tuistURLString]
+        let configURL = URL(string: "https://tuist.config")!
+
+        // When
+        #expect(try subject.url(configServerURL: configURL, envVariables: envVariables) == tuistURL)
+    }
+
+    @Test func returns_the_value_from_cirrus_tuist_cache_url_env_variable_when_present_and_valid() throws {
+        // Given
+        let tuistURLString = "https://cirrus.dev"
+        let tuistURL = URL(string: tuistURLString)!
+        let envVariables = ["CIRRUS_TUIST_CACHE_URL": tuistURLString]
+        let configURL = URL(string: "https://tuist.config")!
+
+        // When
+        #expect(try subject.url(configServerURL: configURL, envVariables: envVariables) == tuistURL)
+    }
+
+    @Test func returns_the_value_from_the_config_when_no_env_variables_are_present() throws {
+        // Given
+        let envVariables: [String: String] = [:]
+        let configURL = URL(string: "https://tuist.config")!
+
+        // When
+        #expect(try subject.url(configServerURL: configURL, envVariables: envVariables) == configURL)
+    }
+}


### PR DESCRIPTION
### Short description 📝
We are partnering with Cirrus Labs to provide cache to their customers. To make it work in their CI environments we need to do two things:
- Use the URL exposed by a conventional environment.
- Skip the authentication since Cirrus environments don't require authentication.

### How to test the changes locally 🧐
It's a bit tricky to test. My plan is to get this in the next release and test it with a real Cirrus environment.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
