### PR TITLE
fix: be less aggresive truncating longer app names

### DIFF
--- a/app/TuistApp/Sources/AppPreviewTile.swift
+++ b/app/TuistApp/Sources/AppPreviewTile.swift
@@ -17,6 +17,8 @@ struct AppPreviewTile: View {
                 .font(.caption)
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .frame(maxWidth: 60)
+                .fixedSize()
         }
     }
 }


### PR DESCRIPTION
### Short description 📝

We should allow longer app names, but still truncating them when they're too long. I cap them now at 60 px.

Before:
![Screenshot 2024-11-21 at 17 19 09](https://github.com/user-attachments/assets/6f4c7354-f7e8-4c70-b956-92dfbc7a158e)

After:
![Screenshot 2024-11-21 at 17 18 47](https://github.com/user-attachments/assets/55970202-2759-4697-a644-1b0818a9dcba)


### How to test the changes locally 🧐

- Run the Tuist macOS app when you have access to previews of an app that has a relatively longer name.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
