### PR TITLE
Add guide for adding a Tuist Preview README badge

### DIFF
--- a/docs/docs/en/guides/share/previews.md
+++ b/docs/docs/en/guides/share/previews.md
@@ -84,6 +84,17 @@ Testing new functionality should be a part of any code review. But having to bui
 Once your Tuist project is connected with your Git platform such as [GitHub](https://github.com), add a <LocalizedLink href="/cli/share">`tuist share MyApp`</LocalizedLink> to your CI workflow. Tuist will then post a Preview link directly in your pull requests:
 ![GitHub app comment with a Tuist Preview link](/images/guides/share/github-app-with-preview.png)
 
+## README badge {#readme-badge}
+
+To make Tuist Previews more visible in your repository, you can add a badge to your `README` file that points to the latest Tuist Preview:
+
+[![Tuist Preview](https://tuist.dev/Dimillian/IcySky/previews/latest/badge.svg)](https://tuist.dev/Dimillian/IcySky/previews/latest)
+
+To add the badge to your `README`, use the following markdown and replace the account and project handles with your own:
+```
+[![Tuist Preview](https://tuist.dev/{account-handle}/{project-handle}/previews/latest/badge.svg)](https://tuist.dev/{account-handle}/{project-handle}/previews/latest)
+```
+
 ## Automations {#automations}
 
 You can use the `--json` flag to get a JSON output from the `tuist share` command:


### PR DESCRIPTION
### Short description 📝

Adding guide for adding the new `README` badge:
![image](https://github.com/user-attachments/assets/ea6747d4-acc4-43e7-a412-8584b68922f0)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
