### PR TITLE
feat: focus Tuist menu bar window when running Tuist Preview deeplink

### DIFF
--- a/app/TuistApp/Sources/Services/DeviceService.swift
+++ b/app/TuistApp/Sources/Services/DeviceService.swift
@@ -58,6 +58,7 @@ final class DeviceService: DeviceServicing {
     private let remoteArtifactDownloader: RemoteArtifactDownloading
     private let fileSystem: FileSysteming
     private let appBundleLoader: AppBundleLoading
+    private let menuBarFocusService: MenuBarFocusServicing
 
     init(
         taskStatusReporter: any TaskStatusReporting,
@@ -68,7 +69,8 @@ final class DeviceService: DeviceServicing {
         fileArchiverFactory: FileArchivingFactorying = FileArchivingFactory(),
         remoteArtifactDownloader: RemoteArtifactDownloading = RemoteArtifactDownloader(),
         fileSystem: FileSysteming = FileSystem(),
-        appBundleLoader: AppBundleLoading = AppBundleLoader()
+        appBundleLoader: AppBundleLoading = AppBundleLoader(),
+        menuBarFocusService: MenuBarFocusServicing = MenuBarFocusService()
     ) {
         self.taskStatusReporter = taskStatusReporter
         self.appStorage = appStorage
@@ -79,6 +81,7 @@ final class DeviceService: DeviceServicing {
         self.remoteArtifactDownloader = remoteArtifactDownloader
         self.fileSystem = fileSystem
         self.appBundleLoader = appBundleLoader
+        self.menuBarFocusService = menuBarFocusService
     }
 
     @MainActor func selectDevice(_ newDevice: Device?) {
@@ -108,6 +111,7 @@ final class DeviceService: DeviceServicing {
     }
 
     func launchPreviewDeeplink(with previewDeeplinkURL: URL) async throws {
+        await menuBarFocusService.focus()
         let urlComponents = URLComponents(url: previewDeeplinkURL, resolvingAgainstBaseURL: false)
         guard let previewId = urlComponents?.queryItems?.first(where: { $0.name == "preview_id" })?.value,
               let fullHandle = urlComponents?.queryItems?.first(where: { $0.name == "full_handle" })?.value,

--- a/app/TuistApp/Sources/Services/MenuBarFocusService.swift
+++ b/app/TuistApp/Sources/Services/MenuBarFocusService.swift
@@ -1,0 +1,16 @@
+import AppKit
+import Foundation
+import Mockable
+
+@Mockable
+protocol MenuBarFocusServicing {
+    /// Focus on the menu bar window, in other words, it puts the menu bar window to the foreground
+    func focus() async
+}
+
+struct MenuBarFocusService: MenuBarFocusServicing {
+    func focus() async {
+        let statusItem = await NSApp.windows.first?.value(forKey: "statusItem") as? NSStatusItem
+        await statusItem?.button?.performClick(nil)
+    }
+}

--- a/app/TuistApp/Tests/Services/DeviceServiceTests.swift
+++ b/app/TuistApp/Tests/Services/DeviceServiceTests.swift
@@ -19,6 +19,7 @@ final class DeviceServiceTests: TuistUnitTestCase {
     private var appStorage: MockAppStoring!
     private var deviceController: MockDeviceControlling!
     private var taskStatusReporter: MockTaskStatusReporting!
+    private var menuBarFocusService: MockMenuBarFocusServicing!
 
     private let previewURL =
         URL(
@@ -55,6 +56,7 @@ final class DeviceServiceTests: TuistUnitTestCase {
         appStorage = .init()
         deviceController = .init()
         taskStatusReporter = .init()
+        menuBarFocusService = MockMenuBarFocusServicing()
 
         subject = DeviceService(
             taskStatusReporter: taskStatusReporter,
@@ -65,7 +67,8 @@ final class DeviceServiceTests: TuistUnitTestCase {
             fileArchiverFactory: fileArchiverFactory,
             remoteArtifactDownloader: remoteArtifactDownloader,
             fileSystem: fileSystem,
-            appBundleLoader: appBundleLoader
+            appBundleLoader: appBundleLoader,
+            menuBarFocusService: menuBarFocusService
         )
 
         given(deviceController)
@@ -103,6 +106,10 @@ final class DeviceServiceTests: TuistUnitTestCase {
                 bundleId: .any,
                 device: .any
             )
+            .willReturn()
+
+        given(menuBarFocusService)
+            .focus()
             .willReturn()
 
         fileUnarchiver = MockFileUnarchiving()
@@ -410,6 +417,9 @@ final class DeviceServiceTests: TuistUnitTestCase {
                 device: .value(iPhone15.device),
                 arguments: .value([])
             )
+            .called(1)
+        verify(menuBarFocusService)
+            .focus()
             .called(1)
     }
 


### PR DESCRIPTION
### Short description 📝

Based on feedback from @hiltonc: https://community.tuist.dev/t/my-wish-list-for-tuist-previews/220

> When I click Run on a Tuist Preview from the web, I don’t see an indication that anything is happening. If I click the menu bar app I see that it is installing. When I click Run I’d prefer to see a dialog pop up, and I’d prefer to see a download/installation/running progress bar, along with an option to cancel.

This doesn't fully address the issues, but we at least indicate `Run` did something by opening the menu bar window.

Instead of a new window, we can iterate on the progress indicator in the top right by:
- Adding download percentage
- Add the ability to cancel the download when clicking on the loading indicator (with an appropriate hover state)

Before:
https://github.com/user-attachments/assets/65fc398c-4ea2-48c8-bcf5-0f00d69f5606

After:
https://github.com/user-attachments/assets/4dbf631c-62a8-4e68-ab5e-07228dd76493


### How to test the changes locally 🧐

- Run the Tuist app
- Click on `Run` in a preview detail page
- The menu bar app should be immediately focused.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
