### PR TITLE
Add project update --visibility option

### DIFF
--- a/Sources/TuistKit/Commands/Project/ProjectUpdateCommand.swift
+++ b/Sources/TuistKit/Commands/Project/ProjectUpdateCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import Path
+import TuistServer
 
 struct ProjectUpdateCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
@@ -27,6 +28,11 @@ struct ProjectUpdateCommand: AsyncParsableCommand {
     var repositoryURL: String?
 
     @Option(
+        help: "Set the project's visibility. When private, only project's members have access to the project. Public projects are accessible by anyone."
+    )
+    var visibility: ServerProject.Visibility?
+
+    @Option(
         name: .shortAndLong,
         help: "The path to the Tuist project.",
         completion: .directory
@@ -39,7 +45,10 @@ struct ProjectUpdateCommand: AsyncParsableCommand {
                 fullHandle: fullHandle,
                 defaultBranch: defaultBranch,
                 repositoryURL: repositoryURL,
+                visibility: visibility,
                 path: path
             )
     }
 }
+
+extension ServerProject.Visibility: ExpressibleByArgument {}

--- a/Sources/TuistKit/Services/Project/ProjectShowService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectShowService.swift
@@ -72,6 +72,7 @@ struct ProjectShowService {
             }
 
             projectInfo.append("Default branch: \(project.defaultBranch)")
+            projectInfo.append("Visibility: \(project.visibility.rawValue)")
 
             logger.info("\(projectInfo.joined(separator: "\n"))")
         }

--- a/Sources/TuistKit/Services/Project/ProjectUpdateService.swift
+++ b/Sources/TuistKit/Services/Project/ProjectUpdateService.swift
@@ -44,6 +44,7 @@ struct ProjectUpdateService {
         fullHandle: String?,
         defaultBranch: String?,
         repositoryURL: String?,
+        visibility: ServerProject.Visibility?,
         path: String?
     ) async throws {
         let path = try self.path(path)
@@ -57,7 +58,8 @@ struct ProjectUpdateService {
             fullHandle: fullHandle,
             serverURL: serverURL,
             defaultBranch: defaultBranch,
-            repositoryURL: repositoryURL
+            repositoryURL: repositoryURL,
+            visibility: visibility
         )
 
         logger.notice("The project \(fullHandle) was successfully updated 🎉", metadata: .success)

--- a/Sources/TuistServer/Client/ServerClientVerboseLoggingMiddleware.swift
+++ b/Sources/TuistServer/Client/ServerClientVerboseLoggingMiddleware.swift
@@ -27,6 +27,8 @@ struct ServerClientVerboseLoggingMiddleware: ClientMiddleware {
 
         logger.debug("""
         Received HTTP response from Tuist:
+          - URL: \(baseURL.absoluteString)
+          - Path: \(request.path ?? "")
           - Status: \(response.status.code)
           - Body: \(responseBodyToLog)
           - Headers: \(response.headerFields)

--- a/Sources/TuistServer/Models/ServerProject.swift
+++ b/Sources/TuistServer/Models/ServerProject.swift
@@ -2,22 +2,29 @@ import Foundation
 
 /// Server project
 public struct ServerProject: Codable {
+    public enum Visibility: String, Codable {
+        case `public`, `private`
+    }
+
     public init(
         id: Int,
         fullName: String,
         defaultBranch: String,
-        repositoryURL: String?
+        repositoryURL: String?,
+        visibility: Visibility
     ) {
         self.id = id
         self.fullName = fullName
         self.defaultBranch = defaultBranch
         self.repositoryURL = repositoryURL
+        self.visibility = visibility
     }
 
     public let id: Int
     public let fullName: String
     public let defaultBranch: String
     public let repositoryURL: String?
+    public let visibility: Visibility
 }
 
 extension ServerProject {
@@ -26,6 +33,12 @@ extension ServerProject {
         fullName = project.full_name
         defaultBranch = project.default_branch
         repositoryURL = project.repository_url
+        visibility = switch project.visibility {
+        case ._private:
+            .private
+        case ._public:
+            .public
+        }
     }
 }
 
@@ -35,13 +48,15 @@ extension ServerProject {
             id: Int = 0,
             fullName: String = "test/test",
             defaultBranch: String = "main",
-            repositoryURL: String? = nil
+            repositoryURL: String? = nil,
+            visibility: Visibility = .private
         ) -> Self {
             .init(
                 id: id,
                 fullName: fullName,
                 defaultBranch: defaultBranch,
-                repositoryURL: repositoryURL
+                repositoryURL: repositoryURL,
+                visibility: visibility
             )
         }
     }

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -1344,6 +1344,17 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/Project/token`.
             @available(*, deprecated)
             internal var token: Swift.String
+            /// The visibility of the project
+            ///
+            /// - Remark: Generated from `#/components/schemas/Project/visibility`.
+            internal enum visibilityPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case _private = "private"
+                case _public = "public"
+            }
+            /// The visibility of the project
+            ///
+            /// - Remark: Generated from `#/components/schemas/Project/visibility`.
+            internal var visibility: Components.Schemas.Project.visibilityPayload
             /// Creates a new `Project`.
             ///
             /// - Parameters:
@@ -1352,18 +1363,21 @@ internal enum Components {
             ///   - id: ID of the project
             ///   - repository_url: The URL of the connected git repository, such as https://github.com/tuist/tuist or https://github.com/tuist/tuist.git
             ///   - token: The token that should be used to authenticate the project. For CI only.
+            ///   - visibility: The visibility of the project
             internal init(
                 default_branch: Swift.String,
                 full_name: Swift.String,
                 id: Swift.Double,
                 repository_url: Swift.String? = nil,
-                token: Swift.String
+                token: Swift.String,
+                visibility: Components.Schemas.Project.visibilityPayload
             ) {
                 self.default_branch = default_branch
                 self.full_name = full_name
                 self.id = id
                 self.repository_url = repository_url
                 self.token = token
+                self.visibility = visibility
             }
             internal enum CodingKeys: String, CodingKey {
                 case default_branch
@@ -1371,6 +1385,7 @@ internal enum Components {
                 case id
                 case repository_url
                 case token
+                case visibility
             }
         }
         /// - Remark: Generated from `#/components/schemas/Invitation`.
@@ -1563,8 +1578,6 @@ internal enum Components {
                 case sso_provider
             }
         }
-        /// The supported platforms of the preview.
-        ///
         /// - Remark: Generated from `#/components/schemas/PreviewSupportedPlatform`.
         internal enum PreviewSupportedPlatform: String, Codable, Hashable, Sendable, CaseIterable {
             case ios = "ios"
@@ -9436,21 +9449,36 @@ internal enum Operations {
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/PUT/requestBody/json/repository_url`.
                     internal var repository_url: Swift.String?
+                    /// The visibility of the project. Public projects are visible to everyone, private projects are only visible to the project's members.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/PUT/requestBody/json/visibility`.
+                    internal enum visibilityPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                        case _public = "public"
+                        case _private = "private"
+                    }
+                    /// The visibility of the project. Public projects are visible to everyone, private projects are only visible to the project's members.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/PUT/requestBody/json/visibility`.
+                    internal var visibility: Operations.updateProject.Input.Body.jsonPayload.visibilityPayload?
                     /// Creates a new `jsonPayload`.
                     ///
                     /// - Parameters:
                     ///   - default_branch: The default branch for the project.
                     ///   - repository_url: The repository URL for the project.
+                    ///   - visibility: The visibility of the project. Public projects are visible to everyone, private projects are only visible to the project's members.
                     internal init(
                         default_branch: Swift.String? = nil,
-                        repository_url: Swift.String? = nil
+                        repository_url: Swift.String? = nil,
+                        visibility: Operations.updateProject.Input.Body.jsonPayload.visibilityPayload? = nil
                     ) {
                         self.default_branch = default_branch
                         self.repository_url = repository_url
+                        self.visibility = visibility
                     }
                     internal enum CodingKeys: String, CodingKey {
                         case default_branch
                         case repository_url
+                        case visibility
                     }
                 }
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/PUT/requestBody/content/application\/json`.

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -217,11 +217,18 @@ components:
           deprecated: true
           description: The token that should be used to authenticate the project. For CI only.
           type: string
+        visibility:
+          description: The visibility of the project
+          enum:
+            - private
+            - public
+          type: string
       required:
         - id
         - full_name
         - token
         - default_branch
+        - visibility
       title: Project
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Project
@@ -328,7 +335,6 @@ components:
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Organization
     PreviewSupportedPlatform:
-      description: The supported platforms of the preview.
       enum:
         - ios
         - ios_simulator
@@ -618,7 +624,7 @@ info:
   version: 0.1.0
   x-logo:
     altText: Tuist logo
-    url: http://localhost:8080/images/open-graph.png
+    url: http://localhost:8080/images/open-graph/squared.png
 openapi: 3.0.0
 paths:
   /api/analytics:
@@ -1966,6 +1972,12 @@ paths:
                   type: string
                 repository_url:
                   description: The repository URL for the project.
+                  type: string
+                visibility:
+                  description: The visibility of the project. Public projects are visible to everyone, private projects are only visible to the project's members.
+                  enum:
+                    - public
+                    - private
                   type: string
               type: object
         description: Project update params

--- a/Sources/TuistServer/Services/UpdateProjectService.swift
+++ b/Sources/TuistServer/Services/UpdateProjectService.swift
@@ -9,7 +9,8 @@ public protocol UpdateProjectServicing {
         fullHandle: String,
         serverURL: URL,
         defaultBranch: String?,
-        repositoryURL: String?
+        repositoryURL: String?,
+        visibility: ServerProject.Visibility?
     ) async throws -> ServerProject
 }
 
@@ -58,11 +59,21 @@ public final class UpdateProjectService: UpdateProjectServicing {
         fullHandle: String,
         serverURL: URL,
         defaultBranch: String?,
-        repositoryURL: String?
+        repositoryURL: String?,
+        visibility: ServerProject.Visibility?
     ) async throws -> ServerProject {
         let client = Client.authenticated(serverURL: serverURL)
 
         let handles = try fullHandleService.parse(fullHandle)
+
+        let visibility: Operations.updateProject.Input.Body.jsonPayload.visibilityPayload? = switch visibility {
+        case .private:
+            ._private
+        case .public:
+            ._public
+        case .none:
+            .none
+        }
 
         let response = try await client.updateProject(
             .init(
@@ -73,7 +84,8 @@ public final class UpdateProjectService: UpdateProjectServicing {
                 body: .json(
                     .init(
                         default_branch: defaultBranch,
-                        repository_url: repositoryURL
+                        repository_url: repositoryURL,
+                        visibility: visibility
                     )
                 )
             )

--- a/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
@@ -6,12 +6,12 @@ final class CacheAcceptanceTestiOSAppWithFrameworks: TuistAcceptanceTestCase {
         try await setUpFixture(.iosAppWithFrameworks)
         try await run(CacheCommand.self, "--print-hashes")
         XCTAssertStandardOutput(pattern: """
-        Framework1 - 0f2c49475bb14354dc625bd72fa7c98d
-        Framework2-iOS - aca6c7f05052db078890952bfc66a9da
-        Framework2-macOS - 91dbbb8ff59075cf6bdfae3e457e5edc
-        Framework3 - 69b9571d2f28b09136160b15d3d5ad94
-        Framework4 - 9f8a6fbe6785a9d9cb1a0d9181e7bf14
-        Framework5 - 1d764f2e0bc3a6e51c4cd01a1ad9e8fb
+        Framework1 - 50b2bcb1b8b22700ca49ba724de1c5a5
+        Framework2-iOS - aef2838a4963ec267e2af27071d72cf4
+        Framework2-macOS - 723f7c59d7aadc1ef067a73041015745
+        Framework3 - 1d186e71f96c0d710b10d879e579b992
+        Framework4 - 0a7127fc247684c40d47983f26ba609e
+        Framework5 - 87d7cde12833307e37cad3189e20441b
         """)
     }
 }

--- a/Tests/TuistKitAcceptanceTests/ProjectAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ProjectAcceptanceTests.swift
@@ -60,6 +60,26 @@ final class ProjectAcceptanceTestProjectDefaultBranch: ServerAcceptanceTestCase 
     }
 }
 
+final class ProjectAcceptanceTestProjectVisibility: ServerAcceptanceTestCase {
+    func test_update_visibility() async throws {
+        try await setUpFixture(.iosAppWithFrameworks)
+        try await run(ProjectShowCommand.self, fullHandle)
+        XCTAssertStandardOutput(
+            pattern: """
+            Visibility: private
+            """
+        )
+        try await run(ProjectUpdateCommand.self, fullHandle, "--visibility", "public")
+        TestingLogHandler.reset()
+        try await run(ProjectShowCommand.self, fullHandle)
+        XCTAssertStandardOutput(
+            pattern: """
+            Visibility: public
+            """
+        )
+    }
+}
+
 final class ProjectAcceptanceTestProjectRepository: ServerAcceptanceTestCase {
     func test_update_repository() async throws {
         try await setUpFixture(.iosAppWithFrameworks)

--- a/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectShowServiceTests.swift
@@ -119,6 +119,60 @@ final class ProjectShowServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_when_project_is_public() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test())
+        given(getProjectService)
+            .getProject(
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any
+            )
+            .willReturn(
+                .test(
+                    visibility: .public
+                )
+            )
+
+        // When
+        try await subject.run(fullHandle: "tuist/tuist", web: false, path: nil)
+
+        // Then
+        XCTAssertStandardOutput(
+            pattern: """
+            Visibility: public
+            """
+        )
+    }
+
+    func test_run_when_project_is_private() async throws {
+        // Given
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test())
+        given(getProjectService)
+            .getProject(
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any
+            )
+            .willReturn(
+                .test(
+                    visibility: .private
+                )
+            )
+
+        // When
+        try await subject.run(fullHandle: "tuist/tuist", web: false, path: nil)
+
+        // Then
+        XCTAssertStandardOutput(
+            pattern: """
+            Visibility: private
+            """
+        )
+    }
+
     func test_run_when_repositoryURL_is_defined() async throws {
         // Given
         given(configLoader)

--- a/Tests/TuistKitTests/Services/Project/ProjectUpdateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Project/ProjectUpdateServiceTests.swift
@@ -31,6 +31,16 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
         given(serverURLService)
             .url(configServerURL: .any)
             .willReturn(Constants.URLs.production)
+
+        given(updateProjectService)
+            .updateProject(
+                fullHandle: .any,
+                serverURL: .any,
+                defaultBranch: .any,
+                repositoryURL: .any,
+                visibility: .any
+            )
+            .willReturn(.test())
     }
 
     override func tearDown() {
@@ -51,20 +61,13 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
                     fullHandle: "tuist/tuist"
                 )
             )
-        given(updateProjectService)
-            .updateProject(
-                fullHandle: .any,
-                serverURL: .any,
-                defaultBranch: .any,
-                repositoryURL: .any
-            )
-            .willReturn(.test())
 
         // When
         try await subject.run(
             fullHandle: nil,
             defaultBranch: "new-default-branch",
             repositoryURL: "https://github.com/tuist/tuist",
+            visibility: .public,
             path: nil
         )
 
@@ -74,7 +77,8 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .any,
                 defaultBranch: .value("new-default-branch"),
-                repositoryURL: .value("https://github.com/tuist/tuist")
+                repositoryURL: .value("https://github.com/tuist/tuist"),
+                visibility: .value(.public)
             )
             .called(1)
         XCTAssertStandardOutput(pattern: "The project tuist/tuist was successfully updated 🎉")
@@ -89,14 +93,6 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
                     fullHandle: nil
                 )
             )
-        given(updateProjectService)
-            .updateProject(
-                fullHandle: .any,
-                serverURL: .any,
-                defaultBranch: .any,
-                repositoryURL: .any
-            )
-            .willReturn(.test())
 
         // When / Then
         await XCTAssertThrowsSpecific(
@@ -104,6 +100,7 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
                 fullHandle: nil,
                 defaultBranch: "new-default-branch",
                 repositoryURL: nil,
+                visibility: nil,
                 path: nil
             ),
             ProjectUpdateServiceError.missingFullHandle
@@ -115,20 +112,13 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test())
-        given(updateProjectService)
-            .updateProject(
-                fullHandle: .any,
-                serverURL: .any,
-                defaultBranch: .any,
-                repositoryURL: .any
-            )
-            .willReturn(.test())
 
         // When
         try await subject.run(
             fullHandle: "tuist/tuist",
             defaultBranch: "new-default-branch",
             repositoryURL: nil,
+            visibility: nil,
             path: nil
         )
 
@@ -138,7 +128,8 @@ final class ProjectUpdateServiceTests: TuistUnitTestCase {
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .any,
                 defaultBranch: .value("new-default-branch"),
-                repositoryURL: .value(nil)
+                repositoryURL: .value(nil),
+                visibility: .value(nil)
             )
             .called(1)
         XCTAssertStandardOutput(pattern: "The project tuist/tuist was successfully updated 🎉")

--- a/fixtures/app_with_composable_architecture/Tuist/Package.resolved
+++ b/fixtures/app_with_composable_architecture/Tuist/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "8013f1a72af8ccb2b1735d7aed831a8dc07c6fd0",
-        "version" : "1.15.0"
+        "revision" : "69247baf7be2fd6f5820192caef0082d01849cd0",
+        "version" : "1.16.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "d1bdbd8a5d1d1dfd2e4bb1f5e2f6facb631404d4",
-        "version" : "2.2.1"
+        "revision" : "16a27ab7ae0abfefbbcba73581b3e2380b47a579",
+        "version" : "2.2.2"
       }
     },
     {

--- a/fixtures/app_with_composable_architecture/Tuist/Package.swift
+++ b/fixtures/app_with_composable_architecture/Tuist/Package.swift
@@ -15,6 +15,6 @@
 let package = Package(
     name: "App",
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.15.0")),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.16.1")),
     ]
 )


### PR DESCRIPTION
### Short description 📝

Adding a new option to `tuist project update`:
```sh
tuist project update {full-handle} --visibility public
```

That allows maintainers of opensource projects to make their projects accessible without us needing to configure that in the database.

### How to test the changes locally 🧐

- Run `tuist project update {full-handle} --visibility public` for an existing project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
