### PR TITLE
fix: error on menu bar startup when logged out

### DIFF
--- a/app/TuistApp/Sources/Services/AppCredentialsService.swift
+++ b/app/TuistApp/Sources/Services/AppCredentialsService.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Mockable
+import TuistServer
+import TuistSupport
+
+@Mockable
+protocol AppCredentialsServicing: ObservableObject {
+    var authenticationState: AuthenticationState { get }
+    var accountHandle: String? { get }
+
+    func loadCredentials()
+    func login() async throws
+    func logout() async throws
+    func updateAuthenticationState() async throws
+}
+
+final class AppCredentialsService: AppCredentialsServicing {
+    @Published
+    private(set) var authenticationState: AuthenticationState = .loggedOut
+
+    var accountHandle: String? {
+        switch authenticationState {
+        case let .loggedIn(accountHandle):
+            accountHandle
+        case .loggedOut:
+            nil
+        }
+    }
+
+    private let appStorage: AppStoring
+    private let serverSessionController: ServerSessionControlling
+    private let serverURLService: ServerURLServicing
+
+    init(
+        appStorage: AppStoring = AppStorage(),
+        serverSessionController: ServerSessionControlling = ServerSessionController(),
+        serverURLService: ServerURLServicing = ServerURLService()
+    ) {
+        self.appStorage = appStorage
+        self.serverSessionController = serverSessionController
+        self.serverURLService = serverURLService
+    }
+
+    func loadCredentials() {
+        authenticationState = (try? appStorage.get(AuthenticationStateKey.self)) ?? .loggedOut
+    }
+
+    func login() async throws {
+        let serverSessionController = serverSessionController
+        let serverURL = serverURLService.serverURL()
+        try await withTimeout(
+            .seconds(2 * 60),
+            onTimeout: {
+                logger.warning("Login timed out")
+            }
+        ) {
+            try await serverSessionController.authenticate(
+                serverURL: serverURL,
+                deviceCodeType: .app,
+                onOpeningBrowser: { _ in },
+                onAuthWaitBegin: {}
+            )
+        }
+        try await updateAuthenticationState()
+    }
+
+    func logout() async throws {
+        try await serverSessionController.logout(serverURL: serverURLService.serverURL())
+        try await updateAuthenticationState()
+    }
+
+    @MainActor
+    func updateAuthenticationState() async throws {
+        if let accountHandle = try await serverSessionController.whoami(serverURL: serverURLService.serverURL()) {
+            authenticationState = .loggedIn(accountHandle: accountHandle)
+        } else {
+            authenticationState = .loggedOut
+        }
+        try? appStorage.set(AuthenticationStateKey.self, value: authenticationState)
+    }
+}

--- a/app/TuistApp/Sources/TuistApp.swift
+++ b/app/TuistApp/Sources/TuistApp.swift
@@ -6,6 +6,7 @@ struct TuistApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     private let updaterController: SPUStandardUpdaterController
+    private let appCredentialsService = AppCredentialsService()
 
     init() {
         updaterController = SPUStandardUpdaterController(
@@ -21,6 +22,7 @@ struct TuistApp: App {
                 appDelegate: appDelegate,
                 updaterController: updaterController
             )
+            .environmentObject(appCredentialsService)
         }
         .menuBarExtraStyle(.window)
     }

--- a/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
+++ b/app/TuistApp/Sources/Views/MenuBarView/MenuBarView.swift
@@ -8,6 +8,8 @@ struct MenuBarView: View {
     @State var canCheckForUpdates = false
     private let errorHandling: ErrorHandling
     private let deviceService: DeviceService
+    @EnvironmentObject
+    private var appCredentialsService: AppCredentialsService
     @State var viewModel: MenuBarViewModel
     private var cancellables = Set<AnyCancellable>()
     private let taskStatusReporter: TaskStatusReporter
@@ -65,11 +67,14 @@ struct MenuBarView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             MenuHeader(
-                accountHandle: viewModel.accountHandle
+                accountHandle: appCredentialsService.accountHandle
             )
 
             AppPreviews(
-                viewModel: AppPreviewsViewModel(deviceService: deviceService)
+                viewModel: AppPreviewsViewModel(
+                    appCredentialsService: appCredentialsService,
+                    deviceService: deviceService
+                )
             )
             .padding(.horizontal, 8)
             .padding(.top, 4)
@@ -84,14 +89,14 @@ struct MenuBarView: View {
                 .padding(.vertical, 4)
 
             Group {
-                switch viewModel.authenticationState {
+                switch appCredentialsService.authenticationState {
                 case .loggedIn:
                     Button("Log out") {
-                        errorHandling.fireAndHandleError(viewModel.logout)
+                        errorHandling.fireAndHandleError(appCredentialsService.logout)
                     }
                 case .loggedOut:
                     Button("Log in") {
-                        errorHandling.fireAndHandleError(viewModel.login)
+                        errorHandling.fireAndHandleError(appCredentialsService.login)
                     }
                 }
             }
@@ -119,8 +124,8 @@ struct MenuBarView: View {
         .environmentObject(deviceService)
         .environmentObject(taskStatusReporter)
         .onAppear {
-            viewModel.loadInitialData()
-            errorHandling.fireAndHandleError(viewModel.updateAuthenticationState)
+            appCredentialsService.loadCredentials()
+            errorHandling.fireAndHandleError(appCredentialsService.updateAuthenticationState)
         }
     }
 }

--- a/app/TuistApp/Sources/Views/MenuBarView/MenuBarViewModel.swift
+++ b/app/TuistApp/Sources/Views/MenuBarView/MenuBarViewModel.swift
@@ -6,69 +6,8 @@ import TuistSupport
 @Observable
 final class MenuBarViewModel: ObservableObject {
     private(set) var canCheckForUpdates: Bool = false
-    private(set) var authenticationState: AuthenticationState = .loggedOut
-    var accountHandle: String? {
-        switch authenticationState {
-        case let .loggedIn(accountHandle):
-            accountHandle
-        case .loggedOut:
-            nil
-        }
-    }
-
-    private let serverURLService: ServerURLServicing
-    private let serverSessionController: ServerSessionControlling
-    private let appStorage: AppStoring
-    private var cancellables = Set<AnyCancellable>()
-
-    init(
-        serverURLService: ServerURLServicing = ServerURLService(),
-        serverSessionController: ServerSessionControlling = ServerSessionController(),
-        appStorage: AppStoring = AppStorage()
-    ) {
-        self.serverURLService = serverURLService
-        self.serverSessionController = serverSessionController
-        self.appStorage = appStorage
-    }
 
     func canCheckForUpdatesValueChanged(_ newValue: Bool) {
         canCheckForUpdates = newValue
-    }
-
-    func loadInitialData() {
-        authenticationState = (try? appStorage.get(AuthenticationStateKey.self)) ?? .loggedOut
-    }
-
-    func login() async throws {
-        let serverSessionController = serverSessionController
-        let serverURL = serverURLService.serverURL()
-        try await withTimeout(
-            .seconds(2 * 60),
-            onTimeout: {
-                logger.warning("Login timed out")
-            }
-        ) {
-            try await serverSessionController.authenticate(
-                serverURL: serverURL,
-                deviceCodeType: .app,
-                onOpeningBrowser: { _ in },
-                onAuthWaitBegin: {}
-            )
-        }
-        try await updateAuthenticationState()
-    }
-
-    func logout() async throws {
-        try await serverSessionController.logout(serverURL: serverURLService.serverURL())
-        try await updateAuthenticationState()
-    }
-
-    func updateAuthenticationState() async throws {
-        if let accountHandle = try await serverSessionController.whoami(serverURL: serverURLService.serverURL()) {
-            authenticationState = .loggedIn(accountHandle: accountHandle)
-        } else {
-            authenticationState = .loggedOut
-        }
-        try? appStorage.set(AuthenticationStateKey.self, value: authenticationState)
     }
 }

--- a/app/TuistApp/Tests/Services/AppCredentialsServiceTests.swift
+++ b/app/TuistApp/Tests/Services/AppCredentialsServiceTests.swift
@@ -5,8 +5,8 @@ import class TuistServer.MockServerSessionControlling
 
 @testable import TuistApp
 
-@Suite struct MenuBarViewModelTests {
-    private let subject: MenuBarViewModel
+@Suite struct AppCredentialsServiceTests {
+    private let subject: AppCredentialsService
     private let serverURLService: MockServerURLServicing
     private let appStorage: MockAppStoring
     private let serverSessionController: MockServerSessionControlling
@@ -15,10 +15,10 @@ import class TuistServer.MockServerSessionControlling
         serverURLService = MockServerURLServicing()
         appStorage = MockAppStoring()
         serverSessionController = MockServerSessionControlling()
-        subject = MenuBarViewModel(
-            serverURLService: serverURLService,
+        subject = AppCredentialsService(
+            appStorage: appStorage,
             serverSessionController: serverSessionController,
-            appStorage: appStorage
+            serverURLService: serverURLService
         )
 
         Matcher.register(AuthenticationStateKey.Type.self, match: { _, _ in true })
@@ -36,7 +36,7 @@ import class TuistServer.MockServerSessionControlling
             .willReturn(.loggedOut)
 
         // When
-        subject.loadInitialData()
+        subject.loadCredentials()
 
         // Then
         #expect(subject.authenticationState == .loggedOut)
@@ -50,7 +50,7 @@ import class TuistServer.MockServerSessionControlling
             .willReturn(.loggedIn(accountHandle: "tuist"))
 
         // When
-        subject.loadInitialData()
+        subject.loadCredentials()
 
         // Then
         #expect(subject.authenticationState == .loggedIn(accountHandle: "tuist"))

--- a/app/TuistApp/Tests/ViewModels/AppPreviewsViewModelTests.swift
+++ b/app/TuistApp/Tests/ViewModels/AppPreviewsViewModelTests.swift
@@ -1,29 +1,30 @@
 import Foundation
 import Mockable
+import Testing
 import class TuistApp.MockServerURLServicing
 import TuistServer
 import TuistSupportTesting
-import XCTest
 
 @testable import TuistApp
 
-final class AppPreviewsViewModelTests: TuistUnitTestCase {
-    private var subject: AppPreviewsViewModel!
-    private var deviceService: MockDeviceServicing!
-    private var appStorage: MockAppStoring!
-    private var listPreviewsService: MockListPreviewsServicing!
-    private var listProjectsService: MockListProjectsServicing!
-    private var serverURLService: MockServerURLServicing!
+@Suite struct AppPreviewsViewModelTests {
+    private let subject: AppPreviewsViewModel
+    private let appCredentialsService: MockAppCredentialsServicing
+    private let deviceService: MockDeviceServicing
+    private let appStorage: MockAppStoring
+    private let listPreviewsService: MockListPreviewsServicing
+    private let listProjectsService: MockListProjectsServicing
+    private let serverURLService: MockServerURLServicing
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
+        appCredentialsService = MockAppCredentialsServicing()
         deviceService = MockDeviceServicing()
         listPreviewsService = MockListPreviewsServicing()
         listProjectsService = MockListProjectsServicing()
         serverURLService = MockServerURLServicing()
         appStorage = MockAppStoring()
         subject = AppPreviewsViewModel(
+            appCredentialsService: appCredentialsService,
             deviceService: deviceService,
             listProjectsService: listProjectsService,
             listPreviewsService: listPreviewsService,
@@ -46,31 +47,24 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .willReturn(.test())
     }
 
-    override func tearDown() {
-        deviceService = nil
-        listPreviewsService = nil
-        listProjectsService = nil
-        serverURLService = nil
-        appStorage = nil
-        subject = nil
-
-        super.tearDown()
-    }
-
-    func test_load_app_previews_from_cache() {
+    @Test func load_app_previews_from_cache() {
         // Given
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
             .willReturn([.test()])
 
+        given(appStorage)
+            .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
+            .willReturn()
+
         // When
         subject.loadAppPreviewsFromCache()
 
         // Then
-        XCTAssertEqual(subject.appPreviews, [.test()])
+        #expect(subject.appPreviews == [.test()])
     }
 
-    func test_on_appear_updates_app_previews() async throws {
+    @Test func on_appear_updates_app_previews_when_logged_in() async throws {
         // Given
         given(listProjectsService)
             .listProjects(serverURL: .any)
@@ -108,13 +102,16 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
             .willReturn()
 
+        given(appCredentialsService)
+            .authenticationState
+            .willReturn(.loggedIn(accountHandle: "tuistrocks"))
+
         // When
         try await subject.onAppear()
 
         // Then
-        XCTAssertEqual(
-            subject.appPreviews,
-            [
+        #expect(
+            subject.appPreviews == [
                 .test(
                     displayName: "App_A"
                 ),
@@ -129,12 +126,36 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_launch_preview_when_no_preview_found() async throws {
+    @Test func update_app_previews_is_skipped_when_logged_out() async throws {
+        // Given
+        given(appStorage)
+            .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
+            .willReturn()
+
+        given(appCredentialsService)
+            .authenticationState
+            .willReturn(.loggedOut)
+
+        // When
+        try await subject.onAppear()
+
+        // Then
+        verify(listProjectsService)
+            .listProjects(serverURL: .any)
+            .called(0)
+        #expect(subject.appPreviews == [])
+    }
+
+    @Test func launch_preview_when_no_preview_found() async throws {
         // Given
         let appPreview: AppPreview = .test()
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
             .willReturn([appPreview])
+
+        given(appStorage)
+            .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
+            .willReturn()
 
         subject.loadAppPreviewsFromCache()
 
@@ -152,18 +173,21 @@ final class AppPreviewsViewModelTests: TuistUnitTestCase {
             .willReturn([])
 
         // When / Then
-        await XCTAssertThrowsSpecific(
-            try await subject.launchAppPreview(appPreview),
-            AppPreviewsModelError.previewNotFound(appPreview.displayName)
-        )
+        await #expect(throws: AppPreviewsModelError.previewNotFound(appPreview.displayName)) {
+            try await subject.launchAppPreview(appPreview)
+        }
     }
 
-    func test_launch_preview() async throws {
+    @Test func launch_preview() async throws {
         // Given
         let appPreview: AppPreview = .test()
         given(appStorage)
             .get(.any as Parameter<AppPreviewsKey.Type>)
             .willReturn([appPreview])
+
+        given(appStorage)
+            .set(.any as Parameter<AppPreviewsKey.Type>, value: .any)
+            .willReturn()
 
         subject.loadAppPreviewsFromCache()
 


### PR DESCRIPTION
### Short description 📝

There are two issues with how we try to load available app previews:
- We try to load them eagerly even when the user is logged out – this leads to an error as soon you download and open the menu bar
- We don't update the list _after_ you logged in

Both issues are solved by:
- Moving app credentials to be stored in an `AppCredentialsService`, so that the credentials updates can be reflected in multiple views
- We skip loading previews when the user is logged out.

### How to test the changes locally 🧐

- Open the app when logged out – you should see no error
- After you log in, you should see app previews (if you have any available)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
