### PR TITLE
Fix stale external dependencies hash

### DIFF
--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -96,9 +96,24 @@ public final class TargetContentHasher: TargetContentHashing {
         case let .external(hash: hash): hash
         case .local: nil
         }
+        let settingsHash: String?
+        if let settings = graphTarget.target.settings {
+            settingsHash = try await settingsContentHasher.hash(settings: settings)
+        } else {
+            settingsHash = nil
+        }
+
+        let destinations = graphTarget.target.destinations.map(\.rawValue).sorted()
+
         if let projectHash {
             return TargetContentHash(
-                hash: try contentHasher.hash([projectHash] + additionalStrings),
+                hash: try contentHasher.hash(
+                    [
+                        projectHash,
+                        graphTarget.target.product.rawValue,
+                        settingsHash,
+                    ].compactMap { $0 } + destinations + additionalStrings
+                ),
                 hashedPaths: [:]
             )
         }
@@ -132,7 +147,7 @@ public final class TargetContentHasher: TargetContentHashing {
             coreDataModelHash,
             targetScriptsHash,
             environmentHash,
-        ]
+        ] + destinations
 
         stringsToHash.append(contentsOf: graphTarget.target.destinations.map(\.rawValue).sorted())
 
@@ -152,11 +167,10 @@ public final class TargetContentHasher: TargetContentHashing {
             let entitlementsHash = try await plistContentHasher.hash(plist: .entitlements(entitlements))
             stringsToHash.append(entitlementsHash)
         }
-        if let settings = graphTarget.target.settings {
-            let settingsHash = try await settingsContentHasher.hash(settings: settings)
+
+        if let settingsHash {
             stringsToHash.append(settingsHash)
         }
-        stringsToHash += additionalStrings
 
         return TargetContentHash(
             hash: try contentHasher.hash(stringsToHash),

--- a/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
@@ -190,8 +190,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(contentHash[framework1], "b4887fb8385832284a3b63443347aa08")
-        XCTAssertEqual(contentHash[framework2], "b5eeaecaf3561f20c10e4bbe047e111e")
+        XCTAssertEqual(contentHash[framework1], "016ae6716191d22c40e34653a9cf186b")
+        XCTAssertEqual(contentHash[framework2], "1ce6a321d6bd60cf7731d57c754e1b69")
     }
 
     // MARK: - Resources

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -52,6 +52,10 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         given(contentHasher)
             .hash(Parameter<[String]>.any)
             .willProduce { $0.joined(separator: "-") }
+
+        given(settingsContentHasher)
+            .hash(settings: .any)
+            .willReturn("settings_hash")
     }
 
     override func tearDown() async throws {
@@ -77,7 +81,7 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         let got = try await subject.contentHash(for: target, hashedTargets: [:], hashedPaths: [:])
 
         // Then
-        XCTAssertEqual(got.hash, "hash")
+        XCTAssertEqual(got.hash, "hash-app-settings_hash-iPad-iPhone")
     }
 
     func test_hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
@@ -93,6 +97,6 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(got.hash, "hash-additional_string_one-additional_string_two")
+        XCTAssertEqual(got.hash, "hash-app-settings_hash-iPad-iPhone-additional_string_one-additional_string_two")
     }
 }

--- a/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
@@ -6,12 +6,12 @@ final class CacheAcceptanceTestiOSAppWithFrameworks: TuistAcceptanceTestCase {
         try await setUpFixture(.iosAppWithFrameworks)
         try await run(CacheCommand.self, "--print-hashes")
         XCTAssertStandardOutput(pattern: """
-        Framework1 - 50b2bcb1b8b22700ca49ba724de1c5a5
-        Framework2-iOS - aef2838a4963ec267e2af27071d72cf4
-        Framework2-macOS - 723f7c59d7aadc1ef067a73041015745
-        Framework3 - 1d186e71f96c0d710b10d879e579b992
-        Framework4 - 0a7127fc247684c40d47983f26ba609e
-        Framework5 - 87d7cde12833307e37cad3189e20441b
+        Framework1 - 39b332c21093295281416a7beddd77e5
+        Framework2-iOS - 165a7dfd3612fb5b00e94c21403efb75
+        Framework2-macOS - 6b0b13c52190c558b100ff68ad16344f
+        Framework3 - c7f4df07addce358f436c242daf393f1
+        Framework4 - dd8f3348392c4cf4d3afff09adea6e6e
+        Framework5 - 787bba0da894622ad1a7be01167f6526
         """)
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/7111

### Short description 📝

When we made the move to using the hash from `Package.resolved`, we have not taken into account that developers can adjust their external dependencies using `PackageSettings`. All `PackageSettings` properties should now be reflected in the hash of external dependencies.

### How to test the changes locally 🧐

- Go to `app_with_alamofire` fixture
- Get the hash using `tuist cache --print-hashes`
- Update the product type or settings of `Alamofire`
- The hash of `Alamofire` in the `tuist cache --print-hashes` output should be different now.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
