### PR TITLE
Automate Tuist app homebrew cask release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,6 @@ jobs:
             app/build/artifacts/Tuist.dmg
             app/build/artifacts/SHASUMS256.txt
             app/build/artifacts/SHASUMS512.txt
+      - name: Release Homebrew cask
+        if: env.should-release == 'true'
+        run: mise run workspace:release-homebrew-cask --version ${{ steps.semvers.outputs.version }} --github-token ${{ secrets.TUIST_HOMEBREW_APP_CASK_RELEASE_TOKEN }} --sha256 ${{ steps.sha256.outputs.sha256 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,4 +136,4 @@ jobs:
             app/build/artifacts/SHASUMS512.txt
       - name: Release Homebrew cask
         if: env.should-release == 'true'
-        run: mise run workspace:release-homebrew-cask --version ${{ steps.semvers.outputs.version }} --github-token ${{ secrets.TUIST_HOMEBREW_APP_CASK_RELEASE_TOKEN }} --sha256 ${{ steps.sha256.outputs.sha256 }}
+        run: mise run workspace:release:homebrew-cask --version ${{ steps.semvers.outputs.version }} --github-token ${{ secrets.TUIST_HOMEBREW_APP_CASK_RELEASE_TOKEN }} --sha256 ${{ steps.sha256.outputs.sha256 }}

--- a/.mise/tasks/workspace/release/homebrew-cask
+++ b/.mise/tasks/workspace/release/homebrew-cask
@@ -1,0 +1,40 @@
+#!/bin/bash
+# mise description="Triggers the GitHub Actions workflow to release a new version of the Homebrew cask."
+set -euo pipefail
+
+# Parse command line arguments
+VERSION=""
+GITHUB_TOKEN=""
+SHA256=""
+
+usage() {
+    echo "Usage: $0 --version VERSION --github-token TOKEN --sha256 SHA256"
+    exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --version) VERSION="$2"; shift ;;
+        --github-token) GITHUB_TOKEN="$2"; shift ;;
+        --sha256) SHA256="$2"; shift ;;
+        *) ;;
+    esac
+    shift
+done
+
+# Check if VERSION, GITHUB_TOKEN, and SHA256 are provided
+if [ -z "$VERSION" ] || [ -z "$GITHUB_TOKEN" ] || [ -z "$SHA256" ]; then
+    echo "Error: Missing required options."
+    usage
+fi
+
+OWNER="tuist"
+REPO="homebrew-tuist"
+WORKFLOW_ID="130356792"
+
+# Trigger the workflow
+curl -v X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_ID/dispatches" \
+  -d "{\"ref\": \"main\", \"inputs\": {\"version\": \"$VERSION\", \"sha256\": \"$SHA256\"}}"

--- a/docs/docs/en/guides/share/previews.md
+++ b/docs/docs/en/guides/share/previews.md
@@ -66,7 +66,9 @@ tuist run App@00dde7f56b1b8795a26b8085a781fb3715e834be # Runs latest App preview
     <img src="/images/guides/share/menu-bar-app.png" style="width: 300px;" />
 </div>
 
-To make running Tuist Previews even easier, we developed a Tuist macOS menu bar app. Instead of running Previews via the Tuist CLI, you can [download](https://cloud.tuist.io/download) the macOS app. When you open a Preview link in the browser, the app will automatically launch on your currently selected device.
+To make running Tuist Previews even easier, we developed a Tuist macOS menu bar app. Instead of running Previews via the Tuist CLI, you can [download](https://tuist.dev/download) the macOS app. You can also install the app by running `brew install --cask tuist/tuist/tuist`.
+
+When you now click on "Run" in the Preview page, the macOS app will automatically launch it on your currently selected device.
 
 > [!IMPORTANT] REQUIREMENTS
 > To download Previews, you need to first authenticate with the `tuist auth` command.


### PR DESCRIPTION
### Short description 📝

Update the Tuist App release job to update the cask at https://github.com/tuist/homebrew-tuist/tree/main/Casks.

### How to test the changes locally 🧐

I tested things in a fork of mine: https://github.com/fortmarek/homebrew-fortmarek/actions/runs/12068564307

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
