### PR TITLE
Attempt to reproduce "duplicated task" issue when depending on the `FacebookCore` package

### DIFF
--- a/fixtures/ios_app_with_facebook_sdk_dependency/.gitignore
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/.gitignore
@@ -68,3 +68,5 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+
+graph.png

--- a/fixtures/ios_app_with_facebook_sdk_dependency/.gitignore
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Sources/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Sources/IosAppWithFacebookSdkDependencyApp.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Sources/IosAppWithFacebookSdkDependencyApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct IosAppWithFacebookSdkDependencyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/App/Tests/IosAppWithFacebookSdkDependencyTests.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/App/Tests/IosAppWithFacebookSdkDependencyTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class IosAppWithFacebookSdkDependencyTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2+2, 4)
+    }
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Project.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Project.swift
@@ -18,7 +18,9 @@ let project = Project(
             ),
             sources: ["App/Sources/**"],
             resources: ["App/Resources/**"],
-            dependencies: []
+            dependencies: [
+                .external(name: "FacebookCore")
+            ]
         ),
         .target(
             name: "AppTests",

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Project.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Project.swift
@@ -1,0 +1,34 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.ios-app-with-facebook-sdk-dependency",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            resources: ["App/Resources/**"],
+            dependencies: []
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.ios-app-with-facebook-sdk-dependencyTests",
+            infoPlist: .default,
+            sources: ["App/Tests/**"],
+            resources: [],
+            dependencies: [.target(name: "App")]
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Tuist.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Tuist.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let tuist = Tuist(
+//    Create an account with "tuist auth" and a project with "tuist project create"
+//    then uncomment the section below and set the project full-handle.
+//    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
+//
+//    fullHandle: "{account_handle}/{project_handle}",
+)

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "2c0d4e81f8c3f6f5b2e20319fc27074baaa21c68f3c71b8b2eb57e52e6f848cc",
+  "pins" : [
+    {
+      "identity" : "facebook-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/facebook-ios-sdk",
+      "state" : {
+        "revision" : "3cebc3b1d13dbe85868cc04f5bed63648e8c410c",
+        "version" : "17.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "ios_app_with_facebook_sdk_dependency",
+    dependencies: [
+        // Add your own dependencies here:
+        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
+        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
+    ]
+)

--- a/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.swift
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/Tuist/Package.swift
@@ -15,6 +15,7 @@ import PackageDescription
 let package = Package(
     name: "ios_app_with_facebook_sdk_dependency",
     dependencies: [
+        .package(url: "https://github.com/facebook/facebook-ios-sdk", exact: "17.1.0")
         // Add your own dependencies here:
         // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
         // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies

--- a/fixtures/ios_app_with_facebook_sdk_dependency/archive.sh
+++ b/fixtures/ios_app_with_facebook_sdk_dependency/archive.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+
+tuist generate --no-open --path $SCRIPT_DIR
+
+for i in {1..10}; do
+  echo "Running xcodebuild: iteration $i"
+  xcodebuild -scheme "App" -workspace "${SCRIPT_DIR}/App.xcworkspace" \
+             clean archive \
+             CODE_SIGNING_ALLOWED=NO \
+             CODE_SIGN_IDENTITY=""
+done


### PR DESCRIPTION
A user reported "duplicated task" issues when integrating packages like `FacebookCore`, which have a transitive XCFramework. In this case, the issue happens intermittently. What seems to be happening is that the internal build graph that Xcode generates creates the same task to process the XCFramework more than once, and Xcode refuses to compile it.

The goal of this PR is to find what could be causing that internal graph state, and then explore what are the possible things that we can do at Tuist to address it.