### PR TITLE
Update implicit dependencies tip in cost of convenience

### DIFF
--- a/docs/docs/en/guides/develop/projects/cost-of-convenience.md
+++ b/docs/docs/en/guides/develop/projects/cost-of-convenience.md
@@ -55,8 +55,8 @@ it might manifest as failing builds that are hard to debug when the project grow
 
 The consequence of this design decision is that many projects acidentally compile with a graph that is not well-defined.
 
-> [!TIP] TUIST ENFORCEMENT OF EXPLICIT DEPENDENCIES
-> Tuist provides a generation configuration option to disallow implicit dependencies. When enabled, if a target tries to import a dependencies that's not explicitly declared, the build will fail.
+> [!TIP] TUIST DETECTION OF IMPLICIT DEPENDENCIES
+> Tuist provides a [command](../inspect/implicit-dependencies) to detect implicit dependencies. You can use the command to validate in CI that all your dependencies are explicit.
 
 ### Find implicit dependencies in schemes {#find-implicit-dependencies-in-schemes}
 


### PR DESCRIPTION
### Short description 📝

As pointed out [here](https://github.com/tuist/tuist/issues/6696#issuecomment-2508534223), the current tip in the cost of convenience docs was still referring to the deprecated `enforceExplicitDependencies` option.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
