### PR TITLE
Remove duplicate Path dependency to fix warning.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let targets: [Target] = [
             pathDependency,
             swiftToolsSupportDependency,
             "FileSystem",
-            "Path",
         ]
     ),
     .executableTarget(
@@ -96,10 +95,10 @@ let targets: [Target] = [
         dependencies: [
             "TuistKit",
             "TuistSupport",
-            "Path",
             "TuistLoader",
             "ProjectDescription",
             "ProjectAutomation",
+            pathDependency,
             swiftToolsSupportDependency,
         ]
     ),


### PR DESCRIPTION
The tuistbenchmark target defined a dependency on Path twice. Also, the tuist executable target was using a different style to import the Path library than all other targets.

Resolves https://github.com/tuist/tuist/issues/7130

### Short description 📝

Fix a warning when including Tuist via SPM

### How to test the changes locally 🧐

1. Create Swift Package
2. Add Tuist as a dependency
3. Resolve packages

No warnings should appear.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
