### PR TITLE
Fix bundle access synthesized interface for static libraries with Objective-C code

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -240,18 +240,18 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
 
         NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
             NSString *bundleName = @"\(bundleName)";
-            
+
             NSURL *bundleURL = [[NSBundle bundleForClass:\(targetName)BundleFinder.self] resourceURL];
             NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
                                           [[NSBundle mainBundle] resourceURL],
                                           bundleURL,
                                           [[NSBundle mainBundle] bundleURL],
                                           nil];
-            
+
             NSString* override = [[[NSProcessInfo processInfo] environment] objectForKey:@"PACKAGE_RESOURCE_BUNDLE_PATH"];
             if (override) {
                 [candidates addObject:override];
-                
+
                 NSString *subpaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:override error:nil];
                 if (subpaths) {
                     for (NSString *subpath in subpaths) {
@@ -261,15 +261,15 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                     }
                 }
             }
-            
+
             #if __has_include(<XCTest/XCTest.h>)
             [candidates addObject:[bundleURL URLByAppendingPathComponent:@".."]];
             #endif
-            
+
             for (NSURL *candidate in candidates) {
                 NSURL *bundlePath = [candidate URLByAppendingPathComponent:[NSString stringWithFormat:@"%@%@", bundleName, @".bundle"]];
                 NSBundle *bundle = [NSBundle bundleWithURL:bundlePath];
-                
+
                 if (bundle) {
                     return bundle;
                 }


### PR DESCRIPTION
### Short description 📝

> When connecting libraries written in objc with resources and launching a target without a host application (for example, a test target) that accesses this library, the bundle cannot be found. The reason is that the mainBundle is different than usual when running the target without a host application. Logic is taken from `swiftSPMBMBundleAccessorString`

### How to test the changes locally 🧐

> can be reproduced using the https://github.com/SRGSSR/srgappearance-apple.git library.
1) Create an iOS application and use this library inside of it
2) Make a test target that doesn't have a host application, and try to run some tests that use this main application
~3)~ Without the changes we get an error because the accessor tries to get the library bundle via mainBundle, which in turn is equal to `file:///Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/`
3) The test runs successfully

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
