### PR TITLE
Fix not hashing additional strings such as configuration

### DIFF
--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -147,7 +147,7 @@ public final class TargetContentHasher: TargetContentHashing {
             coreDataModelHash,
             targetScriptsHash,
             environmentHash,
-        ] + destinations
+        ] + destinations + additionalStrings
 
         stringsToHash.append(contentsOf: graphTarget.target.destinations.map(\.rawValue).sorted())
 

--- a/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
@@ -190,8 +190,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(contentHash[framework1], "016ae6716191d22c40e34653a9cf186b")
-        XCTAssertEqual(contentHash[framework2], "1ce6a321d6bd60cf7731d57c754e1b69")
+        XCTAssertEqual(contentHash[framework1], "73294b8f7af85fb40f2b33f6e8cab8f2")
+        XCTAssertEqual(contentHash[framework2], "801057d42dff92e23a86de21c9e71eff")
     }
 
     // MARK: - Resources

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -99,4 +99,47 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(got.hash, "hash-app-settings_hash-iPad-iPhone-additional_string_one-additional_string_two")
     }
+
+    func test_hash_with_additional_strings() async throws {
+        // Given
+        let target = GraphTarget.test(project: .test())
+        given(sourceFilesContentHasher)
+            .hash(identifier: .any, sources: .any)
+            .willReturn(MerkleNode(hash: "sources_hash", identifier: "sources"))
+        given(resourcesContentHasher)
+            .hash(identifier: .any, resources: .any)
+            .willReturn(MerkleNode(hash: "resources_hash", identifier: "resources"))
+        given(copyFilesContentHasher)
+            .hash(identifier: .any, copyFiles: .any)
+            .willReturn(MerkleNode(hash: "copy_files_hash", identifier: "copy_files"))
+        given(coreDataModelsContentHasher!)
+            .hash(coreDataModels: .any)
+            .willReturn("core_data_models_hash")
+        given(dependenciesContentHasher)
+            .hash(graphTarget: .any, hashedTargets: .any, hashedPaths: .any)
+            .willReturn(DependenciesContentHash(hashedPaths: [:], hash: "dependencies_hash"))
+        given(targetScriptsContentHasher)
+            .hash(targetScripts: .any, sourceRootPath: .any)
+            .willReturn("target_scripts_hash")
+        given(contentHasher)
+            .hash(Parameter<[String: String]>.any)
+            .willReturn("dictionary_hash")
+        given(deploymentTargetContentHasher)
+            .hash(deploymentTargets: .any)
+            .willReturn("deployment_targets_hash")
+
+        // When
+        let got = try await subject.contentHash(
+            for: target,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            additionalStrings: ["additional_string"]
+        )
+
+        // Then
+        XCTAssertEqual(
+            got.hash,
+            "Target-app-io.tuist.Target-Target-dependencies_hash-sources_hash-resources_hash-copy_files_hash-core_data_models_hash-target_scripts_hash-dictionary_hash-iPad-iPhone-additional_string-iPad-iPhone-deployment_targets_hash-settings_hash"
+        )
+    }
 }

--- a/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
@@ -6,12 +6,12 @@ final class CacheAcceptanceTestiOSAppWithFrameworks: TuistAcceptanceTestCase {
         try await setUpFixture(.iosAppWithFrameworks)
         try await run(CacheCommand.self, "--print-hashes")
         XCTAssertStandardOutput(pattern: """
-        Framework1 - 39b332c21093295281416a7beddd77e5
-        Framework2-iOS - 165a7dfd3612fb5b00e94c21403efb75
-        Framework2-macOS - 6b0b13c52190c558b100ff68ad16344f
-        Framework3 - c7f4df07addce358f436c242daf393f1
-        Framework4 - dd8f3348392c4cf4d3afff09adea6e6e
-        Framework5 - 787bba0da894622ad1a7be01167f6526
+        Framework1 - f8feceb31f42a34ebcce8b80496b4933
+        Framework2-iOS - 464281b69abc95f4f2824efc01f58348
+        Framework2-macOS - 2e787be6f1ac74b7db40e9cedebbac1f
+        Framework3 - a4e947f548f5f16bd805719517eb7d47
+        Framework4 - 5fbc3d8985c9ac2104b6100119ca61db
+        Framework5 - 05a2ec5f66ed485ced57f57d6dec507a
         """)
     }
 }


### PR DESCRIPTION
### Short description 📝

I have accidentally removed hashing of `additionalStrings`: https://github.com/tuist/tuist/commit/4dc39add3e967d45bffbda29c00ad4110b8259e2#diff-32431afe82d2d4f4297314d870dbc19f88876581169623d5449fedd1f1a2a50cL159

This PR adds those back along with a unit test.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
