### PR TITLE
Do not output warnings for cache xcframeworks linked mulitple times

### DIFF
--- a/Sources/TuistCore/Graph/Mappers/MapperEnvironmentKeys.swift
+++ b/Sources/TuistCore/Graph/Mappers/MapperEnvironmentKeys.swift
@@ -12,6 +12,10 @@ private struct InitialGraphKey: MapperEnvironmentKey {
     static var defaultValue: Graph?
 }
 
+private struct InitialGraphWithSourcesKey: MapperEnvironmentKey {
+    static var defaultValue: Graph?
+}
+
 private struct TargetTestHashesKey: MapperEnvironmentKey {
     static var defaultValue: [AbsolutePath: [String: String]] = [:]
 }
@@ -39,6 +43,11 @@ extension MapperEnvironment {
     public var initialGraph: Graph? {
         get { self[InitialGraphKey.self] }
         set { self[InitialGraphKey.self] = newValue }
+    }
+
+    public var initialGraphWithSources: Graph? {
+        get { self[InitialGraphWithSourcesKey.self] }
+        set { self[InitialGraphWithSourcesKey.self] = newValue }
     }
 
     public var targetHashes: [CommandEventGraphTarget: String] {

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -57,7 +57,10 @@ public class Generator: Generating {
         let graphTraverser = GraphTraverser(graph: graph)
 
         // Lint
-        try await lint(graphTraverser: graphTraverser)
+        // When mutating the graph to use cache, we currently end up double linking some frameworks.
+        // To workaround those false positive warnings, we lint the graph before we replace source modules with xcframeworks
+        // And assume the changes in the mapper are correct.
+        try await lint(graphTraverser: GraphTraverser(graph: environment.initialGraphWithSources ?? graph))
 
         // Generate
         let workspaceDescriptor = try await generator.generateWorkspace(graphTraverser: graphTraverser)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6841
Resolves https://github.com/tuist/tuist/issues/7050

### Short description 📝

Back in https://github.com/tuist/tuist/pull/6520, we've made the decision to relink static xcframeworks linked through dynamic xcframeworks to make those symbols available to downstream dependencies. 

Since then, we removed the duplicate linking for objc xcframeworks in https://github.com/tuist/tuist/pull/6757, however, we kept the initial logic for Swift static xcframeworks.

While, ideally, we don't relink xcframeworks in this scenario, we currently don't have a better solution and we haven't seen it causing issues (and we don't recommend using cache for release builds where the multiple linking would increase the binary size).

Since we are fine with the current scenario, we shouldn't output warnings for it. I'm updating the linter to lint the graph _before_ we map source modules into xcframeworks. That way, we ignore warnings caused by our decision to link xcframeworks multiple times.

### How to test the changes locally 🧐

See repro steps in: https://github.com/tuist/tuist/issues/6841

Note this can't be tested in the open source version since it depends on the private mapper to xcframeworks.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
