### PR TITLE
Fix XcodeProj-based integration of packages with dashes in their name e.g. swift-cmark

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -17,6 +17,7 @@ public enum TuistAcceptanceFixtures {
     case appWithRevenueCat
     case appWithSpmDependencies
     case appWithSpmModuleAliases
+    case appWithSwiftCMark
     case appWithLocalSPMModuleWithRemoteDependencies
     case appWithTestPlan
     case appWithTests
@@ -127,6 +128,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_spm_dependencies"
         case .appWithSpmModuleAliases:
             return "app_with_spm_module_aliases"
+        case .appWithSwiftCMark:
+            return "app_with_swift_cmark"
         case .appWithLocalSPMModuleWithRemoteDependencies:
             return "app_with_local_spm_module_with_remote_dependencies"
         case .appWithTestPlan:

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -546,8 +546,14 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         }
 
+        let targetName = packageModuleAliases[packageInfo.name]?[target.name] ?? target.name
+        let productName = PackageInfoMapper
+            .sanitize(targetName: targetName)
+            .replacingOccurrences(of: "-", with: "_")
+
         let settings = try await Settings.from(
             target: target,
+            productName: productName,
             packageFolder: packageFolder,
             settings: target.settings,
             moduleMap: moduleMap,
@@ -555,15 +561,11 @@ public final class PackageInfoMapper: PackageInfoMapping {
             dependencyModuleAliases: dependencyModuleAliases
         )
 
-        let targetName = packageModuleAliases[packageInfo.name]?[target.name] ?? target.name
-
         return .target(
             name: PackageInfoMapper.sanitize(targetName: targetName),
             destinations: destinations,
             product: product,
-            productName: PackageInfoMapper
-                .sanitize(targetName: targetName)
-                .replacingOccurrences(of: "-", with: "_"),
+            productName: productName,
             bundleId: targetName
                 .replacingOccurrences(of: "_", with: ".").replacingOccurrences(of: "/", with: "."),
             deploymentTargets: deploymentTargets,
@@ -982,6 +984,7 @@ extension ProjectDescription.Settings {
     // swiftlint:disable:next function_body_length
     fileprivate static func from(
         target: PackageInfo.Target,
+        productName: String,
         packageFolder: AbsolutePath,
         settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
         moduleMap: ModuleMap?,
@@ -1049,10 +1052,10 @@ extension ProjectDescription.Settings {
                 settingsDictionary["DEFINES_MODULE"] = "NO"
                 switch settingsDictionary["OTHER_CFLAGS"] ?? .array(["$(inherited)"]) {
                 case let .array(values):
-                    settingsDictionary["OTHER_CFLAGS"] = .array(values + ["-fmodule-name=\(target.name)"])
+                    settingsDictionary["OTHER_CFLAGS"] = .array(values + ["-fmodule-name=\(productName)"])
                 case let .string(value):
                     settingsDictionary["OTHER_CFLAGS"] = .array(
-                        value.split(separator: " ").map(String.init) + ["-fmodule-name=\(target.name)"]
+                        value.split(separator: " ").map(String.init) + ["-fmodule-name=\(productName)"]
                     )
                 }
             case .none:

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1033,6 +1033,15 @@ final class GenerateAcceptanceTestAppWithRevenueCat: TuistAcceptanceTestCase {
     }
 }
 
+final class GenerateAcceptanceTestAppWithSwiftCMark: TuistAcceptanceTestCase {
+    func test_app_with_swift_cmark() async throws {
+        try await setUpFixture(.appWithSwiftCMark)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self)
+    }
+}
+
 final class GenerateAcceptanceTestAppWithSPMModuleAliases: TuistAcceptanceTestCase {
     func test_app_with_spm_module_aliases() async throws {
         try await setUpFixture(.appWithSpmModuleAliases)

--- a/fixtures/app_with_swift_cmark/App/Sources/ContentView.swift
+++ b/fixtures/app_with_swift_cmark/App/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_swift_cmark/App/Sources/MyApp.swift
+++ b/fixtures/app_with_swift_cmark/App/Sources/MyApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_swift_cmark/Project.swift
+++ b/fixtures/app_with_swift_cmark/Project.swift
@@ -1,0 +1,26 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .external(name: "cmark-gfm"),
+                .external(name: "cmark-gfm-extensions"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_swift_cmark/Tuist.swift
+++ b/fixtures/app_with_swift_cmark/Tuist.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let tuist = Tuist(
+    //    Create an account with "tuist auth" and a project with "tuist project create"
+//    then uncomment the section below and set the project full-handle.
+//    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
+//
+//    fullHandle: "{account_handle}/{project_handle}",
+)

--- a/fixtures/app_with_swift_cmark/Tuist/Package.resolved
+++ b/fixtures/app_with_swift_cmark/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "391bfa801fcd6e17d73983e6ef94854dabbc96cb5740d696bfb6fb6578d103fd",
+  "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/app_with_swift_cmark/Tuist/Package.swift
+++ b/fixtures/app_with_swift_cmark/Tuist/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+@preconcurrency import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-cmark", exact: "0.5.0"),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6879

### Short description 📝

We are already sanitizing the product name of SwiftPM products to replace dashes with underscores [here](https://github.com/tuist/tuist/blob/main/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift#L564-L566). However, we were using the non-sanitized variant when referencing the module name in the `OTHER_CFLAGS` build option. 

A generated project with a dependency like `swift-cmark` that has a modulemap would then fail as the modulemap assumes that the module name will be sanitized: https://github.com/swiftlang/swift-cmark/blob/gfm/extensions/include/module.modulemap#L2 

### How to test the changes locally 🧐

- `tuist generate && tuist build` in `app_with_swift_cmark` should work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
