### PR TITLE
Update Synthesized files to Comply with Xcode auto generated code for image assets

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -307,20 +307,49 @@ extension SynthesizedResourceInterfaceTemplates {
             #endif
        }
     }
-
-
+    
+    // swiftlint:disable identifier_name line_length nesting type_body_length type_name
     extension {{imageType}} {
+      {% if catalogs.count > 1 or param.forceFileNameEnum %}
+
+      {% macro nameSpacedSingleImagesBlock1 catalogName assets %}
+      {% for asset in assets %}
+      {% if asset.type == "image" %}
+      static let {{catalogName|swiftIdentifier:"pretty"|lowercase|escapeReservedKeywords}}_{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{param.name}}Asset.{{catalogName|swiftIdentifier:"pretty"|escapeReservedKeywords}}.{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}
+      {% elif asset.type == "symbol" %}
+      static let {{catalogName|swiftIdentifier:"pretty"|lowercase|escapeReservedKeywords}}_{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{param.name}}Asset.{{catalogName|swiftIdentifier:"pretty"|escapeReservedKeywords}}.{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}
+      {% elif asset.items %}
+      {% call nameSpacedSingleImagesBlock1 catalogName asset.items %}
+      {% endif %}
+      {% endfor %}
+      {% endmacro %}
+
+      {% macro nameSpacedImagesBlock1 catalogs %}
+      {% for catalog in catalogs %}
+      {% call nameSpacedSingleImagesBlock1 catalog.name catalog.assets %}
+      {% endfor %}
+      {% endmacro %}
+
+      {% call nameSpacedImagesBlock1 catalogs %}
+
+      {% else %}
+
       {% macro imagesBlock assets %}
       {% for asset in assets %}
       {% if asset.type == "image" %}
+      static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{param.name}}Asset.{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}
+      {% elif asset.type == "symbol" %}
       static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{param.name}}Asset.{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}
       {% elif asset.items %}
       {% call imagesBlock asset.items %}
       {% endif %}
       {% endfor %}
       {% endmacro %}
+
       {% call imagesBlock catalogs.first.assets %}
+      {% endif %}
     }
+    // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
     {% endif %}
     {% else %}

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -277,6 +277,16 @@ extension SynthesizedResourceInterfaceTemplates {
         let bundle = Bundle.module
         self.init(asset.name, bundle: bundle, label: label)
       }
+    
+      init(_ asset: {{imageType}}) {
+        let bundle = Bundle.module
+        self.init(asset.name, bundle: bundle)
+      }
+    
+      init(_ asset: {{imageType}}, label: Text) {
+        let bundle = Bundle.module
+        self.init(asset.name, bundle: bundle)
+      }
 
       init(decorative asset: {{imageType}}) {
         let bundle = Bundle.module
@@ -284,6 +294,33 @@ extension SynthesizedResourceInterfaceTemplates {
       }
     }
     #endif
+    
+    @available(iOS 11.0, tvOS 11.0,*)
+    @available(watchOS, unavailable)
+    extension UIKit.UIImage {
+       /// Initialize `UIImage` with a Tuist generated image resource
+       convenience init(resource asset: {{imageType}}) {
+            #if !os(watchOS)
+                self.init(named: asset.name, in: Bundle.module, compatibleWith: nil)! 
+            #else
+                self.init()
+            #endif
+       }
+    }
+
+
+    extension {{imageType}} {
+      {% macro imagesBlock assets %}
+      {% for asset in assets %}
+      {% if asset.type == "image" %}
+      static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{param.name}}Asset.{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}
+      {% elif asset.items %}
+      {% call imagesBlock asset.items %}
+      {% endif %}
+      {% endfor %}
+      {% endmacro %}
+      {% call imagesBlock catalogs.first.assets %}
+    }
 
     {% endif %}
     {% else %}

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -307,7 +307,7 @@ extension SynthesizedResourceInterfaceTemplates {
             #endif
        }
     }
-    
+
     // swiftlint:disable identifier_name line_length nesting type_body_length type_name
     extension {{imageType}} {
       {% if catalogs.count > 1 or param.forceFileNameEnum %}

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -277,12 +277,12 @@ extension SynthesizedResourceInterfaceTemplates {
         let bundle = Bundle.module
         self.init(asset.name, bundle: bundle, label: label)
       }
-    
+
       init(_ asset: {{imageType}}) {
         let bundle = Bundle.module
         self.init(asset.name, bundle: bundle)
       }
-    
+
       init(_ asset: {{imageType}}, label: Text) {
         let bundle = Bundle.module
         self.init(asset.name, bundle: bundle)
@@ -294,7 +294,7 @@ extension SynthesizedResourceInterfaceTemplates {
       }
     }
     #endif
-    
+
     @available(iOS 11.0, tvOS 11.0,*)
     @available(watchOS, unavailable)
     extension UIKit.UIImage {

--- a/fixtures/ios_app_with_framework_and_resources/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Sources/AppDelegate.swift
@@ -36,13 +36,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             resourcesStaticFramework3.loadImage() != nil,
             "Failed to load image bundled in \(String(describing: resourcesStaticFramework3))"
         )
-        precondition(
-            resourcesStaticFramework3.loadUIImageWithSynthesizedAccessors() != nil,
-            "Failed to load UIImage bundled in \(String(describing: resourcesStaticFramework3))"
+        print(
+            "StaticFramework3Resource UIImage: \(String(describing: resourcesStaticFramework3.loadUIImageWithSynthesizedAccessors()))"
         )
-        precondition(
-            resourcesStaticFramework3.loadImageWithSynthesizedAccessors() != nil,
-            "Failed to load SwiftUI Image bundled in \(String(describing: resourcesStaticFramework3))"
+        print(
+            "StaticFramework3Resource SwiftUI Image: \(String(describing: resourcesStaticFramework3.loadImageWithSynthesizedAccessors()))"
         )
         print(
             "StaticFramework3Resource asset catalogue image: \(String(describing: StaticFramework3Asset.assetCatalogLogo.image))"
@@ -53,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
         precondition(
             UIImage(named: "StaticFramework5Resources-tuist", in: StaticFramework5Resources.bundle, compatibleWith: nil) != nil,
-            "Failed to load UIImage bundled in \(String(describing: StaticFramework5Resources))"
+            "Failed to load UIImage bundled in \(String(describing: StaticFramework5Resources.self))"
         )
     }
 

--- a/fixtures/ios_app_with_framework_and_resources/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Sources/AppDelegate.swift
@@ -27,14 +27,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("String dicts: \(AppStrings.App.appleCount(1))")
         print("Font: \(AppFontFamily.SFProDisplay.bold.name)")
         print("StaticFrameworkResource image: \(String(describing: staticFrameworkResources.tuist))")
-        print("StaticFramework2Resource image: \(String(describing: staticFramework2Resources.loadImage()))")
-        print("StaticFramework3Resource image: \(String(describing: resourcesStaticFramework3.loadImage()))")
+        precondition(
+            staticFramework2Resources.loadImage() != nil,
+            "Failed to load image bundled in \(String(describing: staticFramework2Resources))"
+        )
+
+        precondition(
+            resourcesStaticFramework3.loadImage() != nil,
+            "Failed to load image bundled in \(String(describing: resourcesStaticFramework3))"
+        )
+        precondition(
+            resourcesStaticFramework3.loadUIImageWithSynthesizedAccessors() != nil,
+            "Failed to load UIImage bundled in \(String(describing: resourcesStaticFramework3))"
+        )
+        precondition(
+            resourcesStaticFramework3.loadImageWithSynthesizedAccessors() != nil,
+            "Failed to load SwiftUI Image bundled in \(String(describing: resourcesStaticFramework3))"
+        )
         print(
             "StaticFramework3Resource asset catalogue image: \(String(describing: StaticFramework3Asset.assetCatalogLogo.image))"
         )
-        print("StaticFramework4Resource image: \(String(describing: resourcesStaticFramework4.loadImage()))")
-        print(
-            "StaticFramework5Resource image: \(String(describing: UIImage(named: "StaticFramework5Resources-tuist", in: StaticFramework5Resources.bundle, compatibleWith: nil)))"
+        precondition(
+            resourcesStaticFramework4.loadImage() != nil,
+            "Failed to load image bundled in \(String(describing: resourcesStaticFramework4))"
+        )
+        precondition(
+            UIImage(named: "StaticFramework5Resources-tuist", in: StaticFramework5Resources.bundle, compatibleWith: nil) != nil,
+            "Failed to load UIImage bundled in \(String(describing: StaticFramework5Resources))"
         )
     }
 

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Project.swift
@@ -2,6 +2,7 @@ import ProjectDescription
 
 let project = Project(
     name: "StaticFramework3",
+    options: .options(),
     targets: [
         .target(
             name: "StaticFramework3",

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Resources/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
@@ -14,11 +14,11 @@ public class ResourcesStaticFramework3 {
         )
     }
 
-    public func loadUIImageWithSynthisizeAccessors() -> UIImage {
+    public func loadUIImageWithSynthesizedAccessors() -> UIImage {
         UIImage(resource: .assetCatalogLogo)
     }
 
-    public func loadImageWithSynthisizedAccessors() -> Image {
+    public func loadImageWithSynthesizedAccessors() -> Image {
         Image(.assetCatalogLogo)
     }
 }

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
@@ -1,6 +1,6 @@
 import Foundation
 import UIKit
-
+import SwiftUI
 public class ResourcesStaticFramework3 {
     public let name = "StaticFramework3Resources"
     public init() {}
@@ -11,5 +11,13 @@ public class ResourcesStaticFramework3 {
             in: .module,
             compatibleWith: nil
         )
+    }
+    
+    public func loadUIImageWithSynthisizeAccessors() -> UIImage {
+        UIImage(resource: .assetCatalogLogo)
+    }
+
+    public func loadImageWithSynthisizedAccessors() -> Image {
+        Image(.assetCatalogLogo)
     }
 }

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Sources/ResourcesStaticFramework3.swift
@@ -1,6 +1,7 @@
 import Foundation
-import UIKit
 import SwiftUI
+import UIKit
+
 public class ResourcesStaticFramework3 {
     public let name = "StaticFramework3Resources"
     public init() {}
@@ -12,7 +13,7 @@ public class ResourcesStaticFramework3 {
             compatibleWith: nil
         )
     }
-    
+
     public func loadUIImageWithSynthisizeAccessors() -> UIImage {
         UIImage(resource: .assetCatalogLogo)
     }

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Symbol.symbolset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Symbol.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Preview Content/Preview Assets.xcassets/Image.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Preview Content/Preview Assets.xcassets/Image.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "image"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/ContentView.swift
@@ -4,8 +4,14 @@ public struct ContentView: View {
     public init() {}
 
     public var body: some View {
-        Text("Hello, World!")
-            .padding()
+        VStack {
+            Text("Hello, World!")
+                .padding()
+            HStack {
+                Image(.assets_image)
+                Image(.assets_nestedimage)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

Update Synthesized files to Comply with Xcode auto generated code for image assets

When linked statically, the `Asset Catalog Compiler - Option` build option, would not be available nor relevant for such targets.

As this is the default behavior for Tuist I think this could be very useful extension. Moreover, as we creates our own types, I don't foresee type collision or compile issues (even if the targets are linked dynamically and the relevant build settings are set (ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS etc)

This will allow to keep compatibility switching between static to dynamic linkage, and using vanila SPM.

While I'm sure I didn't covered all the code generation options Xcode offers, I feel like its a good starting point - I'm open to extend this.

Lastly I chose to keep those symbols internal to the target, and don't expose them publicly. 

### How to test the changes locally 🧐

Generate and build the `ios_app_with_framework_and_resources` fixture.
This fixture is also part of the acceptence tests, as such the build is tested automatically

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
