### PR TITLE
Add "Example" Suffix to targetSchemesGrouping.

### DIFF
--- a/Sources/ProjectDescription/ProjectOptions.swift
+++ b/Sources/ProjectDescription/ProjectOptions.swift
@@ -73,7 +73,7 @@ extension Project.Options {
             targetSchemesGrouping: TargetSchemesGrouping = .byNameSuffix(
                 build: ["Implementation", "Interface", "Mocks", "Testing"],
                 test: ["Tests", "IntegrationTests", "UITests", "SnapshotTests"],
-                run: ["App", "Demo"]
+                run: ["App", "Demo", "Example"]
             ),
             codeCoverageEnabled: Bool = false,
             testingOptions: TestingOptions = [],


### PR DESCRIPTION
Relates to #4093 

### Short description 📝
I'm creating and using modules based on TMA, and I've created a demo app module named Example, following the module naming conventions as described [here](https://docs.tuist.dev/en/guides/develop/projects/tma-architecture#what-is-a-module).

However, I realized that it's actually a scheme grouping only if you suffix it with "Demo".
For now, I added the “Example” suffix without removing the existing “Demo” suffix, but I think we should consider replacing “Demo” with “Example” entirely.

<img width="713" alt="Screenshot 2024-12-14 at 3 18 37 PM" src="https://github.com/user-attachments/assets/ad78d437-9012-4a5c-af09-c172c31049cc" />

### How to test the changes locally 🧐

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
