### PR TITLE
Fix missing package-name setting when a custom OTHER_SWIFT_FLAGS value is defined

### DIFF
--- a/Sources/TuistLoader/Models/DependenciesGraph.swift
+++ b/Sources/TuistLoader/Models/DependenciesGraph.swift
@@ -162,7 +162,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "tuist",
                             baseSettings: .settings(
                                 base: [
@@ -246,7 +246,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "a-dependency",
                             baseSettings: .settings(
                                 configurations: [
@@ -304,7 +304,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "another-dependency",
                             baseSettings: .settings(
                                 configurations: [
@@ -370,7 +370,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "Alamofire",
                             baseSettings: .settings(base: ["SWIFT_VERSION": "5.0.0"])
                         ),
@@ -500,7 +500,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "GoogleAppMeasurement",
                             baseSettings: .settings(
                                 base: [
@@ -622,7 +622,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "GoogleUtilities",
                             baseSettings: .settings(
                                 configurations: [
@@ -680,7 +680,7 @@ public struct DependenciesGraph: Equatable, Codable {
                             disableSynthesizedResourceAccessors: true,
                             textSettings: .textSettings(usesTabs: nil, indentWidth: nil, tabWidth: nil, wrapsLines: nil)
                         ),
-                        settings: Self.spmProjectSettings(
+                        settings: Self.swiftpmProjectSettings(
                             packageName: "nanopb",
                             baseSettings: .settings(
                                 configurations: [
@@ -706,7 +706,7 @@ public struct DependenciesGraph: Equatable, Codable {
             Path("\(spmFolder.pathString)/checkouts/\(packageName)")
         }
 
-        public static func spmProjectSettings(
+        public static func swiftpmProjectSettings(
             packageName: String,
             baseSettings: Settings = .settings(),
             with customSettings: SettingsDictionary = [:]

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1009,7 +1009,9 @@ extension ProjectDescription.Settings {
             settings: settings
         )
 
-        var settingsDictionary: XcodeGraph.SettingsDictionary = [:]
+        var settingsDictionary: XcodeGraph.SettingsDictionary = [
+            "OTHER_SWIFT_FLAGS": ["$(inherited)"],
+        ]
 
         // Force enable testing search paths
         let forceEnabledTestingSearchPath: Set<String> = [

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -903,6 +903,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 // Not escaped
                                 "FOO3=3",
                             ],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ]
                     ),
                 ]
@@ -1387,6 +1390,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Target1/include"],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1438,6 +1444,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/target-with-dashes/include"],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=target_with_dashes"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/target-with-dashes/include/module.modulemap"
                     ),
@@ -1488,6 +1497,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/module.modulemap"
                     ),
@@ -1575,6 +1587,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "MODULEMAP_FILE": .string("$(SRCROOT)/Derived/Target1.modulemap"),
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ]
                     ),
                 ]
@@ -1640,6 +1655,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1654,6 +1672,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Dependency1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/module.modulemap"
                     ),
@@ -1667,6 +1688,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Dependency2"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency2/include/module.modulemap"
                     ),
@@ -1759,6 +1783,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1833,6 +1860,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Custom/Headers"],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Target1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Custom/Headers/module.modulemap"
                     ),
@@ -1893,6 +1923,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "HEADER_SEARCH_PATHS": ["$(inherited)", "$(SRCROOT)/Sources/Dependency1/include"],
                             "DEFINES_MODULE": "NO",
                             "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-name=Dependency1"]),
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ],
                         moduleMap: "$(SRCROOT)/Derived/Dependency1.modulemap"
                     ),
@@ -2046,11 +2079,16 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["HEADER_SEARCH_PATHS": [
-                            "$(inherited)",
-                            "$(SRCROOT)/Sources/Target1/value",
-                            "\"$(SRCROOT)/Sources/Target1/White Space Folder/value\"",
-                        ]]
+                        customSettings: [
+                            "HEADER_SEARCH_PATHS": [
+                                "$(inherited)",
+                                "$(SRCROOT)/Sources/Target1/value",
+                                "\"$(SRCROOT)/Sources/Target1/White Space Folder/value\"",
+                            ],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2091,10 +2129,15 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["HEADER_SEARCH_PATHS": [
-                            "$(inherited)",
-                            "$(SRCROOT)/Sources/Target1/value",
-                        ]]
+                        customSettings: [
+                            "HEADER_SEARCH_PATHS": [
+                                "$(inherited)",
+                                "$(SRCROOT)/Sources/Target1/value",
+                            ],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2139,7 +2182,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "key1=1", "key2=value", "key3="]]
+                        customSettings: [
+                            "GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "key1=1", "key2=value", "key3="],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2183,7 +2231,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "key1=1", "key2=value"]]
+                        customSettings: [
+                            "GCC_PREPROCESSOR_DEFINITIONS": ["$(inherited)", "key1=1", "key2=value"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2228,6 +2281,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["$(inherited)", "key"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ]
                     ),
                 ]
@@ -2272,7 +2328,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["OTHER_CFLAGS": ["$(inherited)", "key1", "key2", "key3"]]
+                        customSettings: [
+                            "OTHER_CFLAGS": ["$(inherited)", "key1", "key2", "key3"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2316,7 +2377,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["OTHER_CPLUSPLUSFLAGS": ["$(inherited)", "key1", "key2", "key3"]]
+                        customSettings: [
+                            "OTHER_CPLUSPLUSFLAGS": ["$(inherited)", "key1", "key2", "key3"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2534,7 +2600,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["OTHER_LDFLAGS": ["$(inherited)", "key1", "key2", "key3"]]
+                        customSettings: [
+                            "OTHER_LDFLAGS": ["$(inherited)", "key1", "key2", "key3"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
+                        ]
                     ),
                 ]
             )
@@ -2628,6 +2699,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         deploymentTargets: .iOS("12.0"),
                         customSettings: [
                             "OTHER_LDFLAGS": ["$(inherited)", "key1", "key2", "key3"],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
+                            ],
                         ]
                     ),
                 ]
@@ -2780,6 +2854,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(inherited)",
                                 "$(SRCROOT)/Sources/Target1/value",
                                 "$(SRCROOT)/Sources/Target1/otherValue",
+                            ],
+                            "OTHER_SWIFT_FLAGS": [
+                                "$(inherited)",
                             ],
                         ]
                     ),
@@ -3552,7 +3629,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 targets: [
                     .test("RxSwift", basePath: basePath, product: .framework),
                 ] + testTargets.map {
-                    let customSettings: ProjectDescription.SettingsDictionary
+                    var customSettings: ProjectDescription.SettingsDictionary
                     var customProductName: String?
                     switch $0 {
                     case "Nimble":
@@ -3566,6 +3643,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     default:
                         customSettings = ["ENABLE_TESTING_SEARCH_PATHS": "YES"]
                     }
+                    customSettings["OTHER_SWIFT_FLAGS"] = [
+                        "$(inherited)",
+                    ]
 
                     return .test(
                         $0,
@@ -4154,7 +4234,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         dependencies: [
                             .target(name: "Package2Product", condition: nil),
                         ],
-                        customSettings: ["OTHER_SWIFT_FLAGS": ["-module-alias", "Product=Package2Product"]]
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["$(inherited)", "-module-alias", "Product=Package2Product"]]
                     ),
                 ]
             )
@@ -4212,7 +4292,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertBetterEqual(
             project?.targets.first?.settings?.base["OTHER_SWIFT_FLAGS"],
-            nil
+            ["$(inherited)"]
         )
     }
 
@@ -4380,7 +4460,7 @@ extension ProjectDescription.Project {
         Project.test(
             name: name,
             options: options,
-            settings: DependenciesGraph.spmProjectSettings(
+            settings: DependenciesGraph.swiftpmProjectSettings(
                 packageName: name,
                 baseSettings: settings,
                 with: customSettings
@@ -4416,7 +4496,9 @@ extension ProjectDescription.Target {
         headers: ProjectDescription.Headers? = nil,
         dependencies: [ProjectDescription.TargetDependency] = [],
         baseSettings: ProjectDescription.Settings = .settings(),
-        customSettings: ProjectDescription.SettingsDictionary = [:],
+        customSettings: ProjectDescription.SettingsDictionary = [
+            "OTHER_SWIFT_FLAGS": ["$(inherited)"],
+        ],
         moduleMap: String? = nil
     ) -> Self {
         let sources: SourceFilesList?

--- a/fixtures/app_with_composable_architecture/Tuist/Package.swift
+++ b/fixtures/app_with_composable_architecture/Tuist/Package.swift
@@ -8,7 +8,14 @@
         // Customize the product types for specific package product
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,]
-        productTypes: [:]
+        productTypes: [:],
+        targetSettings: [
+            "SwiftNavigation": .settings(
+                base: [
+                    "OTHER_SWIFT_FLAGS": .array([]),
+                ]
+            ),
+        ]
     )
 #endif
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7052

### Short description 📝

When the `OTHER_SWIFT_FLAGS` is redefined in the `PackageSettings` and the package relies on the `-package-name` flag being passed, the build breaks.

To fix this, we add `$(inherited)` to `OTHER_SWIFT_FLAGS`, so the `-package-name` that's defined at the project level is always applied.

#### Alternatives considered

Instead of the current solution, we could either:
- Move `OTHER_SWIFT_FLAGS` definition from the project level to the target level
- Keep the current state of things and instruct developers to add the `$(inherited)` flags themselves

The former would require more code changes and I don't see any benefits to use it.

The latter is confusing for developers (see the attached issue), so I'd rather go ahead with the current fix.

### How to test the changes locally 🧐

- Building `app_with_composable_architecture` should succeed (I added a custom settings value for `SwiftNavigation` to reproduce the scenario)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
