### PR TITLE
Set ‘Optimize for Mac’ as the default interface for Mac Catalyst

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -320,6 +320,7 @@ final class ConfigGenerator: ConfigGenerating {
         if target.destinations.contains(.iPad) { deviceFamilyValues.append(2) }
         if target.destinations.contains(.appleTv) { deviceFamilyValues.append(3) }
         if target.destinations.contains(.appleWatch) { deviceFamilyValues.append(4) }
+        if target.destinations.contains(.macCatalyst) { deviceFamilyValues.append(6) }
         if target.destinations.contains(.appleVision) { deviceFamilyValues.append(7) }
 
         if !deviceFamilyValues.isEmpty {

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -511,7 +511,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let releaseConfig = configurationList?.configuration(name: "Release")
 
         let expectedSettings: SettingsDictionary = [
-            "TARGETED_DEVICE_FAMILY": "1,2",
+            "TARGETED_DEVICE_FAMILY": "1,2,6",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.1",
             "SUPPORTS_MACCATALYST": "YES",
             "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "YES",


### PR DESCRIPTION
Resolves #7146

### Short description 📝

Set ‘Optimize for Mac’ as the default interface for Mac Catalyst.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
