### PR TITLE
Add ProjectDescription scheme

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -82,6 +82,13 @@ func schemes() -> [Scheme] {
                 )
             )
         ),
+        .scheme(
+            name: "ProjectDescription",
+            buildAction: .buildAction(
+                targets: [.target(Module.projectDescription.targetName)]
+            ),
+            testAction: .targets([])
+        )
     ]
     schemes.append(contentsOf: Module.allCases.filter(\.isRunnable).map {
         .scheme(


### PR DESCRIPTION
I'm adding the `ProjectDescription` scheme to optimize the release script such that we only compile the necessary framework using `xcodebuild`.