### PR TITLE
docs: Fix configuration name in xcode-project.md

### DIFF
--- a/docs/docs/en/guides/start/migrate/xcode-project.md
+++ b/docs/docs/en/guides/start/migrate/xcode-project.md
@@ -179,7 +179,7 @@ let project = Project(
     name: "MyApp",
     settings: .settings(configurations: [
         .debug(name: "Debug", xcconfig: "./xcconfigs/Project.xcconfig"),
-        .debug(name: "Release", xcconfig: "./xcconfigs/Project.xcconfig"),
+        .release(name: "Release", xcconfig: "./xcconfigs/Project.xcconfig"),
     ]),
     targets: [
         .target( // [!code ++]


### PR DESCRIPTION
### Short description 📝

Fix the wrong configuration constructor in the the docs in `xcode-project` as pointed out by @feldblume5263 [here](https://github.com/tuist/tuist/pull/7176).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
