### PR TITLE
Add TUIST_CACHE_EXTERNAL_ONLY environment value for `tuist cache`

### DIFF
--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -24,13 +24,15 @@ public struct CacheCommand: AsyncParsableCommand, HasTrackableParameters {
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project whose targets will be cached.",
-        completion: .directory
+        completion: .directory,
+        envKey: .cachePath
     )
     var path: String?
 
     @Option(
         name: .shortAndLong,
-        help: "Configuration to use for binary caching."
+        help: "Configuration to use for binary caching.",
+        envKey: .cacheConfiguration
     )
     var configuration: String?
 
@@ -38,24 +40,28 @@ public struct CacheCommand: AsyncParsableCommand, HasTrackableParameters {
     A list of targets to cache. \
     Those and their dependant targets will be cached. \
     If no target is specified, all the project targets (excluding the external ones) and their dependencies will be cached.
-    """)
+    """,
+      envKey: .cacheTargets
+    )
     var targets: [String] = []
 
     @Flag(
         help: "If passed, the command doesn't cache the targets passed in the `--targets` argument, but only their dependencies",
-        envKey: .externalOnly
+        envKey: .cacheExternalOnly
     )
     var externalOnly: Bool = false
 
     @Flag(
         name: .long,
-        help: "When passed, it generates the project and skips warming the cache. This is useful for debugging purposes."
+        help: "When passed, it generates the project and skips warming the cache. This is useful for debugging purposes.",
+        envKey: .cacheGenerateOnly
     )
     var generateOnly: Bool = false
 
     @Flag(
         name: .long,
-        help: "When passed, the hashes of the cacheable frameworks in the given project are printed."
+        help: "When passed, the hashes of the cacheable frameworks in the given project are printed.",
+        envKey: .cachePrintHashes
     )
     var printHashes: Bool = false
 

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -42,7 +42,8 @@ public struct CacheCommand: AsyncParsableCommand, HasTrackableParameters {
     var targets: [String] = []
 
     @Flag(
-        help: "If passed, the command doesn't cache the targets passed in the `--targets` argument, but only their dependencies"
+        help: "If passed, the command doesn't cache the targets passed in the `--targets` argument, but only their dependencies",
+        envKey: .externalOnly
     )
     var externalOnly: Bool = false
 

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -36,12 +36,13 @@ public struct CacheCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var configuration: String?
 
-    @Argument(help: """
-    A list of targets to cache. \
-    Those and their dependant targets will be cached. \
-    If no target is specified, all the project targets (excluding the external ones) and their dependencies will be cached.
-    """,
-      envKey: .cacheTargets
+    @Argument(
+        help: """
+        A list of targets to cache. \
+        Those and their dependant targets will be cached. \
+        If no target is specified, all the project targets (excluding the external ones) and their dependencies will be cached.
+        """,
+        envKey: .cacheTargets
     )
     var targets: [String] = []
 

--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -238,7 +238,12 @@ public enum EnvKey: String, CaseIterable {
     case shareDerivedDataPath = "TUIST_SHARE_DERIVED_DATA_PATH"
 
     // CACHE
-    case externalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
+    case cacheExternalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
+    case cacheGenerateOnly = "TUIST_CACHE_GENERATE_ONLY"
+    case cachePrintHashes = "TUIST_CACHE_PRINT_HASHES"
+    case cacheConfiguration = "TUIST_CACHE_CONFIGURATION"
+    case cachePath = "TUIST_CACHE_PATH"
+    case cacheTargets = "TUIST_CACHE_TARGETS"
 }
 
 extension EnvKey {

--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -236,6 +236,9 @@ public enum EnvKey: String, CaseIterable {
     case sharePlatform = "TUIST_SHARE_PLATFORM"
     case shareJSON = "TUIST_SHARE_JSON"
     case shareDerivedDataPath = "TUIST_SHARE_DERIVED_DATA_PATH"
+
+    // CACHE
+    case externalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
 }
 
 extension EnvKey {

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -883,4 +883,14 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         ])
         XCTAssertEqual(commandWithArgs.path, "/new/logout/path")
     }
+    
+    func testCacheCommandUsesEnvVars() throws {
+        setVariable(.externalOnly, value: "true")
+        
+        let commandWithEnvVars = try CacheCommand.parse([])
+        XCTAssertEqual(commandWithEnvVars.externalOnly, true)
+        
+        let commandWithArgs = try CacheCommand.parse(["--external-only"])
+        XCTAssertEqual(commandWithArgs.externalOnly, true)
+    }
 }

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -885,12 +885,35 @@ final class CommandEnvironmentVariableTests: XCTestCase {
     }
     
     func testCacheCommandUsesEnvVars() throws {
-        setVariable(.externalOnly, value: "true")
+        setVariable(.cacheExternalOnly, value: "true")
+        setVariable(.cacheGenerateOnly, value: "true")
+        setVariable(.cachePrintHashes, value: "true")
+        setVariable(.cacheConfiguration, value: "CacheConfig")
+        setVariable(.cachePath, value: "/cache/path")
+        setVariable(.cacheTargets, value: "Fmk1,Fmk2")
         
         let commandWithEnvVars = try CacheCommand.parse([])
         XCTAssertEqual(commandWithEnvVars.externalOnly, true)
+        XCTAssertEqual(commandWithEnvVars.generateOnly, true)
+        XCTAssertEqual(commandWithEnvVars.printHashes, true)
+        XCTAssertEqual(commandWithEnvVars.configuration, "CacheConfig")
+        XCTAssertEqual(commandWithEnvVars.path, "/cache/path")
+        XCTAssertEqual(commandWithEnvVars.targets, ["Fmk1", "Fmk2"])
         
-        let commandWithArgs = try CacheCommand.parse(["--external-only"])
+        let commandWithArgs = try CacheCommand.parse([
+            "--external-only", 
+            "--generate-only",
+            "--print-hashes",
+            "--configuration", "CacheConfig",
+            "--path", "/cache/path",
+            "--",
+            "Fmk1", "Fmk2"
+        ])
         XCTAssertEqual(commandWithArgs.externalOnly, true)
+        XCTAssertEqual(commandWithArgs.generateOnly, true)
+        XCTAssertEqual(commandWithArgs.printHashes, true)
+        XCTAssertEqual(commandWithArgs.configuration, "CacheConfig")
+        XCTAssertEqual(commandWithArgs.path, "/cache/path")
+        XCTAssertEqual(commandWithArgs.targets, ["Fmk1", "Fmk2"])
     }
 }

--- a/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -883,7 +883,7 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         ])
         XCTAssertEqual(commandWithArgs.path, "/new/logout/path")
     }
-    
+
     func testCacheCommandUsesEnvVars() throws {
         setVariable(.cacheExternalOnly, value: "true")
         setVariable(.cacheGenerateOnly, value: "true")
@@ -891,7 +891,7 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         setVariable(.cacheConfiguration, value: "CacheConfig")
         setVariable(.cachePath, value: "/cache/path")
         setVariable(.cacheTargets, value: "Fmk1,Fmk2")
-        
+
         let commandWithEnvVars = try CacheCommand.parse([])
         XCTAssertEqual(commandWithEnvVars.externalOnly, true)
         XCTAssertEqual(commandWithEnvVars.generateOnly, true)
@@ -899,15 +899,15 @@ final class CommandEnvironmentVariableTests: XCTestCase {
         XCTAssertEqual(commandWithEnvVars.configuration, "CacheConfig")
         XCTAssertEqual(commandWithEnvVars.path, "/cache/path")
         XCTAssertEqual(commandWithEnvVars.targets, ["Fmk1", "Fmk2"])
-        
+
         let commandWithArgs = try CacheCommand.parse([
-            "--external-only", 
+            "--external-only",
             "--generate-only",
             "--print-hashes",
             "--configuration", "CacheConfig",
             "--path", "/cache/path",
             "--",
-            "Fmk1", "Fmk2"
+            "Fmk1", "Fmk2",
         ])
         XCTAssertEqual(commandWithArgs.externalOnly, true)
         XCTAssertEqual(commandWithArgs.generateOnly, true)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7182

### Short description 📝

Add `TUIST_CACHE_EXTERNAL_ONLY` environment value to set `--external-only` in `tuist cache`.

Note that I was only able to check that `CacheServicing.run` is called with `externalOnly: true`, which is good enough of a test IMO. I wasn't able to test all the way through due to the closed source nature of the caching service.

I didn't make any explicit change to the documentation as it seems autogenerated to me. Please tell me if I need to edit anything.

### How to test the changes locally 🧐

- Run `tuist cache` on a project with internal dependencies
- Notice that the cache is generated for all dependencies, including the internal ones
- Set `TUIST_CACHE_EXTERNAL_ONLY` and run `tuist cache again`
- Notice that the cache is generated for external dependencies only

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
