### PR TITLE
Document how to verify the authenticity of binaries

### DIFF
--- a/docs/docs/en/guides/quick-start/install-tuist.md
+++ b/docs/docs/en/guides/quick-start/install-tuist.md
@@ -42,14 +42,10 @@ brew install --formula tuist@x.y.z
 ```
 
 ::: tip VERIFYING THE AUTHENTICITY OF THE BINARIES
-You can verify that your installation's binaries have been built by us by running the following commands and checking that the team ID is `U6LC622NKF`:
+You can verify that your installation's binaries have been built by us by running the following command, which checks if the certificate's team is `U6LC622NKF`:
 
 ```bash
-tuist_path=$(which tuist)
-project_description_path=$(dirname "$tuist_path")/ProjectDescription.framework
-
-codesign -d --verbose=4 "$tuist_path" 2>&1 | grep "TeamIdentifier"
-codesign -d --verbose=4 "$project_description_path" 2>&1 | grep "TeamIdentifier"
+curl -fsSL "https://docs.tuist.dev/verify.sh" | bash
 ```
 :::
 

--- a/docs/docs/en/guides/quick-start/install-tuist.md
+++ b/docs/docs/en/guides/quick-start/install-tuist.md
@@ -41,12 +41,24 @@ brew install --formula tuist
 brew install --formula tuist@x.y.z
 ```
 
+::: tip VERIFYING THE AUTHENTICITY OF THE BINARIES
+You can verify that your installation's binaries have been built by us by running the following commands and checking that the team ID is `U6LC622NKF`:
+
+```bash
+tuist_path=$(which tuist)
+project_description_path=$(dirname "$tuist_path")/ProjectDescription.framework
+
+codesign -d --verbose=4 "$tuist_path" 2>&1 | grep "TeamIdentifier"
+codesign -d --verbose=4 "$project_description_path" 2>&1 | grep "TeamIdentifier"
+```
+:::
+
 ### Shell completions {#shell-completions}
 
 If you have Tuist **globally installed** (e.g., via Homebrew),
 you can install shell completions for Bash and Zsh to autocomplete commands and options.
 
-::: warning What is a global installation
+::: warning WHAT IS A GLOBAL INSTALLATION
 A global installation is an installation that's available in your shell's `$PATH` environment variable. This means you can run `tuist` from any directory in your terminal. This is the default installation method for Homebrew.
 :::
 

--- a/docs/docs/public/verify.sh
+++ b/docs/docs/public/verify.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+valid_team="U6LC622NKF"
+for path in "$(which tuist)" "$(dirname "$(which tuist)")/ProjectDescription.framework"; do
+  if ! codesign -d --verbose=4 "$path" 2>&1 | grep -q "TeamIdentifier=*$valid_team"; then
+    echo "The binary at $path is not signed by the Tuist team."
+    return 1
+  fi
+done
+echo "The Tuist binaries are valid."


### PR DESCRIPTION
### Short description 📝
Since binaries are now signed and notarized, developers can easily verify if the binaries that they installed are generated by us (assuming no malicious actor has got access to our signing certificate). This PR updates the documentation to explain how to do so:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/c6010c92-188a-4c09-826b-d2bbc86620da" />
