### PR TITLE
Set ENABLE_TESTING_SEARCH_PATHS for IssueReportingTestSupport

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1033,6 +1033,7 @@ extension ProjectDescription.Settings {
             "Cuckoo", // https://github.com/Brightify/Cuckoo
             "_SwiftSyntaxTestSupport", // https://github.com/swiftlang/swift-syntax
             "SwiftSyntaxMacrosTestSupport", // https://github.com/swiftlang/swift-syntax
+            "IssueReportingTestSupport", // https://github.com/pointfreeco/swift-issue-reporting
         ]
 
         let resolvedSettings = try mapper.mapSettings()


### PR DESCRIPTION
Added IssueReportingTestSupport for the list of hardcoded targets for which ENABLE_TESTING_SEARCH_PATHS should be set for it to build

Resolves <https://community.tuist.dev/t/dependenciestestsupport-from-swift-dependencies-does-not-build/280/3>

### Short description 📝

> Describe here the purpose of your PR.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
