### PR TITLE
Add a link to translate the website project

### DIFF
--- a/docs/docs/en/contributors/translate.md
+++ b/docs/docs/en/contributors/translate.md
@@ -23,6 +23,7 @@ Since maintaining translations is a continuous effort, we add languages as we se
 We use [Crowdin](https://crowdin.com/) to manage the translations. First, go to the project that you want to contribute to:
 
 - [Documentation](https://crowdin.com/project/tuist-documentation)
+- [Website](https://crowdin.com/project/tuist-documentation)
 
 You'll need an account to start translating. You can sign in with GitHub. Once you have access, you can start translating. You'll see the list of resources that are available for translation. When you click on a resource, the editor will open, and you'll see a split view with the resource in the source language on the left and the translation on the right. Translate the text on the right and save your changes.
 


### PR DESCRIPTION
This PR add a link where translators can go to get access to the Crowdin project to translate the website.