### PR TITLE
Fix the "UIKit not found" compilation issue due to synthesized UIKit.UIImate interface that doesn't compile for macOS

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -295,18 +295,20 @@ extension SynthesizedResourceInterfaceTemplates {
     }
     #endif
 
+    #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     @available(iOS 11.0, tvOS 11.0,*)
     @available(watchOS, unavailable)
     extension UIKit.UIImage {
        /// Initialize `UIImage` with a Tuist generated image resource
        convenience init(resource asset: {{imageType}}) {
             #if !os(watchOS)
-                self.init(named: asset.name, in: Bundle.module, compatibleWith: nil)! 
+                self.init(named: asset.name, in: Bundle.module, compatibleWith: nil)!
             #else
                 self.init()
             #endif
        }
     }
+    #endif
 
     // swiftlint:disable identifier_name line_length nesting type_body_length type_name
     extension {{imageType}} {


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/7180

### Short description 📝
[This PR](https://github.com/tuist/tuist/pull/7162) introduced an extension to `UIKit.UIImage` which fails to compile when the source code is compiled with macOS as a destination. This is causing our [CI](https://github.com/tuist/tuist/runs/34799336015) to fail.

This PR addresses it by using a compiler directive to conditionally compile the code only when the destination is not `macOS`

### How to test the changes locally 🧐
Generate and build the fixture `ios_app_with_framework_and_resources`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
