### PR TITLE
Update deprecation warning message to PackageSettings initializer

### DIFF
--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -76,7 +76,14 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
-    @available(*, deprecated, renamed: "init(productTypes:productDescriptions:baseSettings:targetSettings:projectOptions:)")
+    @available(
+        *,
+        deprecated,
+        renamed: "init(productTypes:productDestinations:baseSettings:targetSettings:projectOptions:)",
+        message: """
+        Consider using the 'Settings' type for parameter 'targetSettings' instead of 'SettingsDictionary'.
+        """
+    )
     public init(
         productTypes: [String: Product] = [:],
         productDestinations: [String: Destinations] = [:],


### PR DESCRIPTION
### Short description 📝

After updating Tuist to a version that includes the changes from PR #7009,
I encountered the following deprecated warning in my project:

```swift
'init(productTypes:productDestinations:baseSettings:targetSettings:projectOptions:)' is deprecated: replaced by 'init(productTypes:productDescriptions:baseSettings:targetSettings:projectOptions:)'
```

<img width="851" alt="CleanShot 2024-12-27 at 18 48 34@2x" src="https://github.com/user-attachments/assets/5a268004-92fb-424e-8465-20b30bc042ce" />

<br>
<br>

However, the warning message essentially repeats the same instruction to replace the initializer with the new one, without providing additional clarity.

<br>

To enhance clarity, I have updated the deprecated message to better explain the replacement and guide developers on the expected changes in parameter types.

<img width="853" alt="CleanShot 2024-12-27 at 19 10 38@2x" src="https://github.com/user-attachments/assets/5e789978-3466-443a-af93-d7448fc3b3de" />

<br>

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
