### PR TITLE
Remove unncessary Foundation imports from ProjectDescription and make the required ones @_implementationOnly

### DIFF
--- a/Sources/ProjectDescription/AnalyzeAction.swift
+++ b/Sources/ProjectDescription/AnalyzeAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that analyzes the built products.
 ///
 /// It's initialized with the `.analyzeAction` static method

--- a/Sources/ProjectDescription/ArchiveAction.swift
+++ b/Sources/ProjectDescription/ArchiveAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that archives the built products.
 ///
 /// It's initialized with the `.archiveAction` static method.

--- a/Sources/ProjectDescription/Arguments.swift
+++ b/Sources/ProjectDescription/Arguments.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A collection of arguments and environment variables.
 public struct Arguments: Equatable, Codable, Sendable {
     public var environmentVariables: [String: EnvironmentVariable]

--- a/Sources/ProjectDescription/BuildAction.swift
+++ b/Sources/ProjectDescription/BuildAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that builds products.
 ///
 /// It's initialized with the `.buildAction` static method.

--- a/Sources/ProjectDescription/BuildRule+CompilerSpec.swift
+++ b/Sources/ProjectDescription/BuildRule+CompilerSpec.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension BuildRule {
     /// The type of compiler spec which is used for a selected file type.
     /// All the values are taken from build rule options hidden under a pup-up button's menu next to a label `Using` in a target's

--- a/Sources/ProjectDescription/BuildRule+FileType.swift
+++ b/Sources/ProjectDescription/BuildRule+FileType.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension BuildRule {
     /// File types processed by a build rule.
     /// All the values are taken from build rule options hidden under a pup-up button's menu next to a label `Process` in a

--- a/Sources/ProjectDescription/BuildRule.swift
+++ b/Sources/ProjectDescription/BuildRule.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A BuildRule is used to specify a method for transforming an input file in to an output file(s).
 public struct BuildRule: Codable, Equatable, Sendable {
     /// Compiler specification for element transformation.

--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A cloud configuration, used for remote caching.
 public struct Cloud: Codable, Equatable, Sendable {
     /// Options for cloud configuration.

--- a/Sources/ProjectDescription/CompatibleXcodeVersions.swift
+++ b/Sources/ProjectDescription/CompatibleXcodeVersions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Options of compatibles Xcode versions.
 public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStringInterpolation, Codable, Equatable, Sendable {
     /// The project supports all Xcode versions.

--- a/Sources/ProjectDescription/ConfigurationName.swift
+++ b/Sources/ProjectDescription/ConfigurationName.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A configuration name.
 ///
 /// It has build-in support for ``debug`` and ``release`` configurations.

--- a/Sources/ProjectDescription/CopyFileElement.swift
+++ b/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms with an optional
 /// "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable, Sendable {

--- a/Sources/ProjectDescription/CopyFilesAction.swift
+++ b/Sources/ProjectDescription/CopyFilesAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A build phase action used to copy files.
 ///
 /// Copy files actions, represented as target copy files build phases, are useful to associate project files

--- a/Sources/ProjectDescription/CoreDataModel.swift
+++ b/Sources/ProjectDescription/CoreDataModel.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A Core Data model.
 public struct CoreDataModel: Codable, Equatable, Sendable {
     /// Relative path to the model.

--- a/Sources/ProjectDescription/DeploymentTargets.swift
+++ b/Sources/ProjectDescription/DeploymentTargets.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - DeploymentTargets
 
 /// A struct representing the minimum deployment versions for each platform.

--- a/Sources/ProjectDescription/Destination.swift
+++ b/Sources/ProjectDescription/Destination.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Set of deployment destinations
 public typealias Destinations = Set<Destination>
 

--- a/Sources/ProjectDescription/Dump.swift
+++ b/Sources/ProjectDescription/Dump.swift
@@ -1,4 +1,4 @@
-import Foundation
+@_implementationOnly import Foundation
 
 func dumpIfNeeded(_ entity: some Encodable) {
     guard !ProcessInfo.processInfo.arguments.isEmpty,

--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - Entitlements
 
 public enum Entitlements: Codable, Equatable, Sendable {

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -1,4 +1,4 @@
-import Foundation
+@_implementationOnly import Foundation
 
 /// A convenience structure to read environment variables.
 @dynamicMemberLookup

--- a/Sources/ProjectDescription/EnvironmentVariable.swift
+++ b/Sources/ProjectDescription/EnvironmentVariable.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// It represents an environment variable that is passed when running a scheme's action
 public struct EnvironmentVariable: Equatable, Codable, Hashable, ExpressibleByStringLiteral, Sendable {
     // MARK: - Attributes

--- a/Sources/ProjectDescription/ExecuteAction.swift
+++ b/Sources/ProjectDescription/ExecuteAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that can be executed as part of another action for pre or post execution.
 public struct ExecutionAction: Equatable, Codable, Sendable {
     public var title: String

--- a/Sources/ProjectDescription/FileCodeGen.swift
+++ b/Sources/ProjectDescription/FileCodeGen.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Options for source file code generation.
 public enum FileCodeGen: String, Codable, Equatable, Sendable {
     /// Public codegen

--- a/Sources/ProjectDescription/FileElement.swift
+++ b/Sources/ProjectDescription/FileElement.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A file element from a glob pattern or a folder reference.
 ///
 /// - glob: a glob pattern for files to include

--- a/Sources/ProjectDescription/FileHeaderTemplate.swift
+++ b/Sources/ProjectDescription/FileHeaderTemplate.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A header template from a file or a string.
 ///
 /// Lets you define custom file header template for built-in Xcode templates, e.g. when you create new Swift file you can

--- a/Sources/ProjectDescription/FileList.swift
+++ b/Sources/ProjectDescription/FileList.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A collection of file globs.
 ///
 /// The list of files can be initialized with a string that represents the glob pattern, or an array of strings, which represents

--- a/Sources/ProjectDescription/FileListGlob.swift
+++ b/Sources/ProjectDescription/FileListGlob.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A glob pattern that refers to files.
 public struct FileListGlob: Codable, Equatable, Sendable {
     /// The path with a glob pattern.

--- a/Sources/ProjectDescription/Headers.swift
+++ b/Sources/ProjectDescription/Headers.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A group of public, private and project headers.
 public struct Headers: Codable, Equatable, Sendable {
     /// Determine how to resolve cases, when the same files found in different header scopes

--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - InfoPlist
 
 /// A info plist from a file, a custom dictonary or a extended defaults.

--- a/Sources/ProjectDescription/LaunchArgument.swift
+++ b/Sources/ProjectDescription/LaunchArgument.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A launch argument, passed when running a scheme.
 public struct LaunchArgument: Equatable, Codable, Sendable {
     // MARK: - Attributes

--- a/Sources/ProjectDescription/LaunchStyle.swift
+++ b/Sources/ProjectDescription/LaunchStyle.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum LaunchStyle: Codable, Sendable {
     case automatically
     case waitForExecutableToBeLaunched

--- a/Sources/ProjectDescription/MetalOptions.swift
+++ b/Sources/ProjectDescription/MetalOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Options to configure scheme metal options for run and test actions.
 public struct MetalOptions: Equatable, Codable, Sendable {
     /// API Validation

--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A custom Swift Package Manager configuration
 ///
 ///

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A path represents to a file, directory, or a group of files represented by a glob expression.
 ///
 /// Paths can be relative and absolute. We discourage using absolute paths because they create a dependency with the environment

--- a/Sources/ProjectDescription/Platform.swift
+++ b/Sources/ProjectDescription/Platform.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - Platform
 
 /// A supported platform representation.

--- a/Sources/ProjectDescription/PlatformCondition.swift
+++ b/Sources/ProjectDescription/PlatformCondition.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A condition applied to an "entity" allowing it to only be used in certain circumstances
 public struct PlatformCondition: Codable, Hashable, Equatable, Sendable {
     public let platformFilters: Set<PlatformFilter>

--- a/Sources/ProjectDescription/Plist.swift
+++ b/Sources/ProjectDescription/Plist.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 // MARK: - Plist
 
 public enum Plist {

--- a/Sources/ProjectDescription/Plugin.swift
+++ b/Sources/ProjectDescription/Plugin.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A plugin representation.
 ///
 /// Supported plugins include:

--- a/Sources/ProjectDescription/PluginLocation.swift
+++ b/Sources/ProjectDescription/PluginLocation.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A location to a plugin, either local or remote.
 public struct PluginLocation: Codable, Equatable, Sendable {
     /// The type of location `local` or `git`.

--- a/Sources/ProjectDescription/PrivacyManifest.swift
+++ b/Sources/ProjectDescription/PrivacyManifest.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Describe the data your app or third-party SDK collects and the reasons required APIs it uses.
 public struct PrivacyManifest: Codable, Equatable, Sendable {
     /// A Boolean that indicates whether your app or third-party SDK uses data for tracking as defined under the App

--- a/Sources/ProjectDescription/Product.swift
+++ b/Sources/ProjectDescription/Product.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Possible products types.
 public enum Product: String, Codable, Equatable, Sendable {
     /// An application.

--- a/Sources/ProjectDescription/ProfileAction.swift
+++ b/Sources/ProjectDescription/ProfileAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that profiles the built products.
 ///
 /// It's initialized with the `.profileAction` static method

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A project representation.
 ///
 /// A project manifest needs to be defined in a `Project.swift` manifest file.

--- a/Sources/ProjectDescription/ProjectOptions.swift
+++ b/Sources/ProjectDescription/ProjectOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension Project {
     /// Options to configure a project.
     public struct Options: Codable, Equatable, Sendable {

--- a/Sources/ProjectDescription/ResourceFileElement.swift
+++ b/Sources/ProjectDescription/ResourceFileElement.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A resource file element from a glob pattern or a folder reference.
 ///
 /// - glob: a glob pattern for files to include

--- a/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/Sources/ProjectDescription/ResourceFileElements.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A collection of resource file.
 public struct ResourceFileElements: Codable, Equatable, Sendable {
     /// List of resource file elements

--- a/Sources/ProjectDescription/ResourceSynthesizer.swift
+++ b/Sources/ProjectDescription/ResourceSynthesizer.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A resource synthesizer for given file extensions.
 ///
 /// For example to synthesize resource accessors for strings, you can use:

--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that runs the built products.
 ///
 /// It's initialized with the .runAction static method.

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Options for the `RunAction` action
 public struct RunActionOptions: Equatable, Codable, Sendable {
     /// Language to use when running the app.

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A custom scheme for a project.
 ///
 /// A scheme defines a collection of targets to Build, Run, Test, Profile, Analyze and Archive.

--- a/Sources/ProjectDescription/SchemeDiagnosticsOptions.swift
+++ b/Sources/ProjectDescription/SchemeDiagnosticsOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Options to configure scheme diagnostics for run and test actions.
 public struct SchemeDiagnosticsOptions: Equatable, Codable, Sendable {
     /// Enable the address sanitizer

--- a/Sources/ProjectDescription/SchemeLanguage.swift
+++ b/Sources/ProjectDescription/SchemeLanguage.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A language to use for run and test actions.
 public struct SchemeLanguage: Codable, Equatable, ExpressibleByStringLiteral, Sendable {
     public let identifier: String

--- a/Sources/ProjectDescription/ScreenCaptureFormat.swift
+++ b/Sources/ProjectDescription/ScreenCaptureFormat.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Preferred screen capture format for UI tests results in Xcode 15+
 ///
 /// Available options are screen recordings and screenshots.

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public typealias SettingsDictionary = [String: SettingValue]
 
 /// A value or a collection of values used for settings configuration.

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension SettingsDictionary {
     public mutating func merge(_ other: SettingsDictionary) {
         merge(other) { $1 }

--- a/Sources/ProjectDescription/SimulatedLocation.swift
+++ b/Sources/ProjectDescription/SimulatedLocation.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Simulated location represents a GPS location that is used when running an app on the simulator.
 public struct SimulatedLocation: Codable, Equatable, Sendable {
     /// The identifier of the location (e.g. London, England)

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A glob pattern configuration representing source files and its compiler flags, if any.
 public struct SourceFileGlob: Codable, Equatable, Sendable {
     /// Type of the source file.

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A target of a project.
 public struct Target: Codable, Equatable, Sendable {
     /// The name of the target. Also, the product name if not specified with ``productName``.

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Dependency status used by dependencies
 public enum LinkingStatus: String, Codable, Hashable, Sendable {
     /// Required dependency

--- a/Sources/ProjectDescription/TargetReference.swift
+++ b/Sources/ProjectDescription/TargetReference.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A target reference for a specified project.
 ///
 /// The project is specified through the path and should contain the target name.

--- a/Sources/ProjectDescription/TargetScript.swift
+++ b/Sources/ProjectDescription/TargetScript.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A build phase action used to run a script.
 ///
 /// Target scripts, represented as target script build phases in the generated Xcode projects, are useful to define actions to be

--- a/Sources/ProjectDescription/Template/Template.swift
+++ b/Sources/ProjectDescription/Template/Template.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A scaffold template model.
 public struct Template: Codable, Equatable, Sendable {
     /// Description of template

--- a/Sources/ProjectDescription/TemplateString.swift
+++ b/Sources/ProjectDescription/TemplateString.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct TemplateString: Encodable, Decodable, Equatable {
     /// Contains a string that can be interpolated with options.
     let rawString: String

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// An action that tests the built products.
 ///
 /// You can create a test action with either a set of test targets or test plans using the `.targets` or `.testPlans` static

--- a/Sources/ProjectDescription/TestActionOptions.swift
+++ b/Sources/ProjectDescription/TestActionOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// The type `TestActionOptions` represents a set of options for a test action.
 public struct TestActionOptions: Equatable, Codable, Sendable {
     /// Language used to run the tests.

--- a/Sources/ProjectDescription/TestableTarget.swift
+++ b/Sources/ProjectDescription/TestableTarget.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public struct TestableTarget: Equatable, Codable, ExpressibleByStringInterpolation, Sendable {
     /// With the introduction of Swift Testing and Xcode 16, you can now choose to run your tests
     /// in parallel across either the full suite of tests in a target with `.enabled`, just those created

--- a/Sources/ProjectDescription/Workspace.swift
+++ b/Sources/ProjectDescription/Workspace.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A workspace representation.
 ///
 /// By default, `tuist generate` generates an Xcode workspace that has the same name as the current project.

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -867,6 +867,22 @@ public enum Module: String, CaseIterable {
                     .release(name: "Release", settings: [:], xcconfig: nil),
                 ]
             )
+        case .projectDescription, .projectAutomation:
+            return .settings(
+                base: ["BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"],
+                configurations: [
+                    .debug(
+                        name: "Debug",
+                        settings: [:],
+                        xcconfig: nil
+                    ),
+                    .release(
+                        name: "Release",
+                        settings: [:],
+                        xcconfig: nil
+                    ),
+                ]
+            )
         default:
             return .settings(
                 configurations: [


### PR DESCRIPTION
### Short description 📝
I noticed some models in `ProjectDescription` are importing `Foundation` when it's not needed, and others do so without `@_implementationOnly`, causing Fondation interfaces to leak through `ProjectDescription`'s ([issue](https://community.tuist.dev/t/error-redefinition-of-module-swiftbridging-after-fresh-install/297/2)).

### How to test the changes locally 🧐
The following command should succeed:

```
tuist run tuist generate --no-open --path fixtures/ios_app_with_frameworks
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
