### PR TITLE
Temporarily comment out secrets to unblock PRs from forks

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,8 +4,6 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -33,8 +31,8 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - github_credentials
+      # groups:
+      # - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -52,9 +50,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      # - tuist
+      # - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -76,9 +74,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -101,9 +99,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -168,9 +166,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -198,9 +196,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -237,9 +235,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -267,9 +265,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -296,9 +294,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      groups:
-        - tuist
-        - github_credentials
+      # groups:
+      #   - tuist
+      #   - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build


### PR DESCRIPTION
### Short description 📝

Codemagic changed their security that currently makes it impossible to use secrets in pipelines run from forks.

They are working on a solution that would allow us to keep using the secrets in PRs done in `tuist/tuist`. Until it's available, we need to remove the secrets to unblock contributions from forks.

It's obviously not ideal as we will lose access to features like selective testing and caching, but Codemagic currently doesn't provide us with a possible workaround.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
