### PR TITLE
Fix inspect implicit-imports false positives for external targets

### DIFF
--- a/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspecImplicitImportsService.swift
@@ -91,7 +91,7 @@ final class InspectImplicitImportsService {
             .directTargetDependencies(path: target.project.path, name: target.target.name)
 
         let explicitTargetDependencies = targetDependencies.map { targetDependency in
-            if targetDependency.graphTarget.project.type == .external() {
+            if case .external = targetDependency.graphTarget.project.type {
                 return graphTraverser
                     .allTargetDependencies(path: target.project.path, name: target.target.name)
             } else {

--- a/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -70,7 +70,7 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         let app = Target.test(name: "App", product: .app)
         let project = Project.test(path: path, targets: [app])
         let testTarget = Target.test(name: "PackageTarget", product: .app)
-        let externalProject = Project.test(path: path, targets: [testTarget], type: .external(hash: nil))
+        let externalProject = Project.test(path: path, targets: [testTarget], type: .external(hash: "hash"))
         let graph = Graph.test(
             path: path,
             projects: [path: project, "/a": externalProject]
@@ -96,7 +96,7 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         let app = Target.test(name: "App", product: .app)
         let project = Project.test(path: path, targets: [app])
         let testTarget = Target.test(name: "PackageTarget", product: .app)
-        let externalProject = Project.test(path: path, targets: [testTarget], type: .external())
+        let externalProject = Project.test(path: path, targets: [testTarget], type: .external(hash: "hash"))
         let graph = Graph.test(
             path: path,
             projects: [path: project, "/a": externalProject],
@@ -122,7 +122,11 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         let project = Project.test(path: path, targets: [app])
         let testTarget = Target.test(name: "PackageTarget", product: .app)
         let externalTargetDependency = Target.test(name: "PackageTargetDependency", product: .app)
-        let externalProject = Project.test(path: path, targets: [testTarget, externalTargetDependency], type: .external())
+        let externalProject = Project.test(
+            path: path,
+            targets: [testTarget, externalTargetDependency],
+            type: .external(hash: "hash")
+        )
         let graph = Graph.test(
             path: path,
             projects: [path: project, "/a": externalProject],

--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
@@ -23,6 +23,9 @@ let project = Project(
             product: .framework,
             bundleId: "io.tuist.featureOne",
             sources: ["Sources/**"],
+            dependencies: [
+                .external(name: "UICKeyChainStore"),
+            ],
             settings: .targetSettings
         ),
     ],


### PR DESCRIPTION
Resolves #7137

### Short description 📝

This PR fixes the false positives that were thrown when a project has an import statement for a target, which itself is a dependency of a package product.

### How to test the changes locally 🧐

1. `cd fixtures/app_with_spm_dependencies`
2. `tuist install`
3. `tuist inspect implicit-imports`

Before this fix, the following false positives were shown:
> The following implicit dependencies were found:
> - AppKit implicitly depends on: CrashReporter, AppCenter

With this fix applied, the command succeeds with
> We did not find any implicit dependencies in your project.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
