### PR TITLE
Update outdated note about having to use SPM to run tuist

### DIFF
--- a/docs/docs/en/contributors/get-started.md
+++ b/docs/docs/en/contributors/get-started.md
@@ -58,9 +58,8 @@ You'll also have to set the working directory to the root of the project being g
 
 ### From the terminal {#from-the-terminal}
 
-Although `tuist` provides a `tuist run` it does not support CLIs yet. Therefore, you'll have to use the Swift Package Manager to run the tool. To do that, you can run the following command:
+You can run `tuist` using Tuist itself through its `run` command:
 
 ```bash
-swift build --product ProjectDescription
-swift run tuist generate --path /path/to/project --no-open
+tuist run tuist generate --path /path/to/project --no-open
 ```

--- a/docs/docs/en/contributors/get-started.md
+++ b/docs/docs/en/contributors/get-started.md
@@ -63,3 +63,10 @@ You can run `tuist` using Tuist itself through its `run` command:
 ```bash
 tuist run tuist generate --path /path/to/project --no-open
 ```
+
+Alternatively, you can also run it through the Swift Package Manager directly:
+
+```bash
+swift build --product ProjectDescription
+swift run tuist generate --path /path/to/project --no-open
+```


### PR DESCRIPTION
I've been running my local build through `tuist run` all day yesterday and hit no obstacles, so there's no general blocker to do this. If we, in the future, find that this does have some nuances around it where in specific cases, SPM needs to be used, we can add this back for the specific cases. For now, we are not aware of any.

### Short description 📝

Updates documentation.

### How to test the changes locally 🧐

N/A

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
