### PR TITLE
Fix race condition when running multiple tuist dump commands in parallel

### DIFF
--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -286,7 +286,7 @@ public class CachedManifestLoader: ManifestLoading {
             try await write(cachedManifestContent: cachedManifestContent, to: cachedManifestPath)
         } catch let error as NIOFileSystem.FileSystemError {
             if error.code == .fileAlreadyExists {
-                ServiceContext.current?.logger?.info("The manifest at \(cachedManifestPath) is already cached, skipping...")
+                ServiceContext.current?.logger?.debug("The manifest at \(cachedManifestPath) is already cached, skipping...")
             } else {
                 throw error
             }

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -288,7 +288,7 @@ public class CachedManifestLoader: ManifestLoading {
             guard error.code == .fileAlreadyExists else {
                 throw error
             }
-            ServiceContext.current?.logger?.info("Encounter a `fileAlreadyExists` error, disregarding it")
+            ServiceContext.current?.logger?.info("Encountered a `fileAlreadyExists` error, disregarding it")
         }
     }
 

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -285,10 +285,12 @@ public class CachedManifestLoader: ManifestLoading {
         do {
             try await write(cachedManifestContent: cachedManifestContent, to: cachedManifestPath)
         } catch let error as NIOFileSystem.FileSystemError {
-            guard error.code == .fileAlreadyExists else {
+            if error.code == .fileAlreadyExists {
+                ServiceContext.current?.logger?.info("The manifest at \(cachedManifestPath) is already cached, skipping...")
+            } else {
                 throw error
             }
-            ServiceContext.current?.logger?.info("Encountered a `fileAlreadyExists` error, disregarding it")
+            
         }
     }
 

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -290,7 +290,6 @@ public class CachedManifestLoader: ManifestLoading {
             } else {
                 throw error
             }
-            
         }
     }
 

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import Foundation
+import NIOFileSystem
 import Path
 import ProjectDescription
 import ServiceContextModule
@@ -281,7 +282,17 @@ public class CachedManifestLoader: ManifestLoading {
         guard let cachedManifestContent = String(data: cachedManifestData, encoding: .utf8) else {
             throw ManifestLoaderError.manifestCachingFailed(manifest, cachedManifestPath)
         }
+        do {
+            try await write(cachedManifestContent: cachedManifestContent, to: cachedManifestPath)
+        } catch let error as NIOFileSystem.FileSystemError {
+            guard error.code == .fileAlreadyExists else {
+                throw error
+            }
+            ServiceContext.current?.logger?.info("Encounter a `fileAlreadyExists` error, disregarding it")
+        }
+    }
 
+    private func write(cachedManifestContent: String, to cachedManifestPath: AbsolutePath) async throws {
         if try await !fileSystem.exists(cachedManifestPath.parentDirectory, isDirectory: true) {
             try await fileSystem.makeDirectory(at: cachedManifestPath)
         }

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -454,7 +454,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
     }
 }
 
-extension NIOFileSystem.FileSystemError: @retroactive Equatable {
+extension NIOFileSystem.FileSystemError: Equatable {
     public static func == (lhs: _NIOFileSystem.FileSystemError, rhs: _NIOFileSystem.FileSystemError) -> Bool {
         return lhs.code == rhs.code && lhs.message == rhs.message && lhs.location == rhs.location
     }

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -1,5 +1,7 @@
+import FileSystem
 import Foundation
 import Mockable
+import NIOFileSystem
 import Path
 import ProjectDescription
 import TuistCore
@@ -316,14 +318,66 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         )
     }
 
+    func test_notThrowing_fileAlreadyExistsNIOError() async throws {
+        // Given
+        let fileSystem = MockFileSystem()
+        fileSystem.writeTextOverride = { _, _, _ in
+            throw NIOFileSystem.FileSystemError(
+                code: .fileAlreadyExists,
+                message: "",
+                cause: nil,
+                location: .init(function: "", file: "", line: 0)
+            )
+        }
+
+        subject = createSubject(fileSystem: fileSystem)
+
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try await stubProject(project, at: path)
+
+        // When
+        let result = try await subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(result, project)
+        XCTAssertEqual(result.name, "App")
+    }
+
+    func test_throwing_OtherNIOErrors() async throws {
+        // Given
+        let expectedError = NIOFileSystem.FileSystemError(
+            code: .invalidArgument,
+            message: "",
+            cause: nil,
+            location: .init(function: "", file: "", line: 0)
+        )
+        let fileSystem = MockFileSystem()
+        fileSystem.writeTextOverride = { _, _, _ in
+            throw expectedError
+        }
+
+        subject = createSubject(fileSystem: fileSystem)
+
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try await stubProject(project, at: path)
+
+        // When/Then
+        await XCTAssertThrowsSpecific(
+            { try await self.subject.loadProject(at: path) },
+            expectedError
+        )
+    }
+
     // MARK: - Helpers
 
-    private func createSubject(tuistVersion: String = "1.0") -> CachedManifestLoader {
+    private func createSubject(tuistVersion: String = "1.0", fileSystem: FileSysteming? = nil) -> CachedManifestLoader {
         CachedManifestLoader(
             manifestLoader: manifestLoader,
             projectDescriptionHelpersHasher: projectDescriptionHelpersHasher,
             helpersDirectoryLocator: helpersDirectoryLocator,
-            fileSystem: fileSystem,
+            fileSystem: fileSystem ?? self.fileSystem,
             environment: environment,
             cacheDirectoriesProvider: cacheDirectoriesProvider,
             tuistVersion: tuistVersion
@@ -397,5 +451,11 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         for filePath in try fileHandler.contentsOfDirectory(path) {
             try fileHandler.write("corruptedData", path: filePath, atomically: true)
         }
+    }
+}
+
+extension NIOFileSystem.FileSystemError: @retroactive Equatable {
+    public static func == (lhs: _NIOFileSystem.FileSystemError, rhs: _NIOFileSystem.FileSystemError) -> Bool {
+        return lhs.code == rhs.code && lhs.message == rhs.message && lhs.location == rhs.location
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -344,7 +344,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(result.name, "App")
     }
 
-    func test_throwing_OtherNIOErrors() async throws {
+    func test_throwing_otherNIOErrors() async throws {
         // Given
         let expectedError = NIOFileSystem.FileSystemError(
             code: .invalidArgument,

--- a/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
+++ b/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
@@ -1,0 +1,198 @@
+import FileSystem
+import Foundation
+import Path
+
+public class MockFileSystem: FileSysteming {
+    public var existsOverride: ((AbsolutePath) async throws -> Bool) = { _ in true }
+    public var existsInDirectoryOverride: ((AbsolutePath, Bool) async throws -> Bool) = { _, _ in true }
+    public var touchOverride: ((AbsolutePath) async throws -> Void) = { _ in }
+    public var removeOverride: ((AbsolutePath) async throws -> Void) = { _ in }
+    public var makeTemporaryDirectoryOverride: ((String) async throws -> AbsolutePath) = { prefix in
+        return try AbsolutePath(validating: "/tmp/\(prefix)\(UUID().uuidString)")
+    }
+
+    public var readFileOverride: ((AbsolutePath) async throws -> Data) = { _ in throw NSError(
+        domain: "File not found",
+        code: 404,
+        userInfo: nil
+    ) }
+    public var readTextFileOverride: ((Path.AbsolutePath, String.Encoding) async throws -> String) = { _, _ in throw NSError(
+        domain: "File not found",
+        code: 404,
+        userInfo: nil
+    ) }
+    public var writeTextOverride: ((String, AbsolutePath, String.Encoding) async throws -> Void) = { _, _, _ in }
+    public var fileSizeInBytesOverride: ((AbsolutePath) async throws -> Int64?) = { _ in return nil }
+    public var currentWorkingDirectoryOverride: (() async throws -> AbsolutePath) = {
+        return try AbsolutePath(validating: FileManager.default.currentDirectoryPath)
+    }
+
+    public var moveOverride: ((AbsolutePath, AbsolutePath, [MoveOptions]) async throws -> Void) = { _, _, _ in }
+    public var makeDirectoryOverride: ((AbsolutePath, [MakeDirectoryOptions]) async throws -> Void) = { _, _ in }
+    public var readPlistFileOverride: ((AbsolutePath, PropertyListDecoder) async throws -> Any) = { _, _ in throw NSError(
+        domain: "File not found",
+        code: 404,
+        userInfo: nil
+    ) }
+    public var writeAsPlistOverride: ((Encodable, AbsolutePath, PropertyListEncoder) async throws -> Void) = { _, _, _ in }
+    public var readJSONFileOverride: ((AbsolutePath, JSONDecoder) async throws -> Any) = { _, _ in throw NSError(
+        domain: "File not found",
+        code: 404,
+        userInfo: nil
+    ) }
+    public var writeAsJSONOverride: ((Encodable, AbsolutePath, JSONEncoder) async throws -> Void) = { _, _, _ in }
+    public var replaceOverride: ((AbsolutePath, AbsolutePath) async throws -> Void) = { _, _ in }
+    public var copyOverride: ((AbsolutePath, AbsolutePath) async throws -> Void) = { _, _ in }
+    public var locateTraversingUpOverride: ((AbsolutePath, RelativePath) async throws -> AbsolutePath?) = { _, _ in return nil }
+    public var createSymbolicLinkOverride: ((AbsolutePath, AbsolutePath) async throws -> Void) = { _, _ in }
+    public var resolveSymbolicLinkOverride: ((AbsolutePath) async throws -> AbsolutePath) = { symlinkPath in return symlinkPath }
+    public var zipFileOrDirectoryContentOverride: ((AbsolutePath, AbsolutePath) async throws -> Void) = { _, _ in }
+    public var unzipOverride: ((AbsolutePath, AbsolutePath) async throws -> Void) = { _, _ in }
+    public var globOverride: ((AbsolutePath, [String]) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath>) = { _, _ in
+        throw NSError(
+            domain: "File not found",
+            code: 404,
+            userInfo: nil
+        )
+    }
+
+    public init() {}
+
+    public func runInTemporaryDirectory<T>(
+        prefix _: String,
+        _: @Sendable (Path.AbsolutePath) async throws -> T
+    ) async throws -> T {
+        throw NSError(domain: "File not found", code: 404, userInfo: nil)
+    }
+
+    public func exists(_ path: Path.AbsolutePath) async throws -> Bool {
+        try await exists(path, isDirectory: false)
+    }
+
+    public func exists(_ path: Path.AbsolutePath, isDirectory: Bool) async throws -> Bool {
+        try await existsInDirectoryOverride(path, isDirectory)
+    }
+
+    public func touch(_ path: Path.AbsolutePath) async throws {
+        try await touchOverride(path)
+    }
+
+    public func remove(_ path: Path.AbsolutePath) async throws {
+        try await removeOverride(path)
+    }
+
+    public func makeTemporaryDirectory(prefix: String) async throws -> Path.AbsolutePath {
+        try await makeTemporaryDirectoryOverride(prefix)
+    }
+
+    public func move(from: Path.AbsolutePath, to: Path.AbsolutePath) async throws {
+        try await move(from: from, to: to, options: [])
+    }
+
+    public func move(from: Path.AbsolutePath, to: Path.AbsolutePath, options: [MoveOptions]) async throws {
+        try await moveOverride(from, to, options)
+    }
+
+    public func makeDirectory(at: Path.AbsolutePath) async throws {
+        try await makeDirectory(at: at, options: [])
+    }
+
+    public func makeDirectory(at: Path.AbsolutePath, options: [MakeDirectoryOptions]) async throws {
+        try await makeDirectoryOverride(at, options)
+    }
+
+    public func readFile(at: Path.AbsolutePath) async throws -> Data {
+        try await readFileOverride(at)
+    }
+
+    public func readTextFile(at: Path.AbsolutePath) async throws -> String {
+        try await readTextFile(at: at, encoding: .utf8)
+    }
+
+    public func readTextFile(at: Path.AbsolutePath, encoding: String.Encoding) async throws -> String {
+        try await readTextFileOverride(at, encoding)
+    }
+
+    public func writeText(_ text: String, at: Path.AbsolutePath) async throws {
+        try await writeText(text, at: at, encoding: .utf8)
+    }
+
+    public func writeText(_ text: String, at: Path.AbsolutePath, encoding: String.Encoding) async throws {
+        try await writeTextOverride(text, at, encoding)
+    }
+
+    public func readPlistFile<T>(at: Path.AbsolutePath) async throws -> T where T: Decodable {
+        try await readPlistFile(at: at, decoder: .init())
+    }
+
+    public func readPlistFile<T>(at: Path.AbsolutePath, decoder: PropertyListDecoder) async throws -> T where T: Decodable {
+        try await readPlistFileOverride(at, decoder) as! T
+    }
+
+    public func writeAsPlist(_ item: some Encodable, at: Path.AbsolutePath) async throws {
+        try await writeAsPlist(item, at: at, encoder: .init())
+    }
+
+    public func writeAsPlist(_ item: some Encodable, at: Path.AbsolutePath, encoder: PropertyListEncoder) async throws {
+        try await writeAsPlistOverride(item, at, encoder)
+    }
+
+    public func readJSONFile<T>(at: Path.AbsolutePath) async throws -> T where T: Decodable {
+        try await readJSONFile(at: at, decoder: .init())
+    }
+
+    public func readJSONFile<T>(at: Path.AbsolutePath, decoder: JSONDecoder) async throws -> T where T: Decodable {
+        try await readJSONFileOverride(at, decoder) as! T
+    }
+
+    public func writeAsJSON(_ item: some Encodable, at: Path.AbsolutePath) async throws {
+        try await writeAsJSON(item, at: at, encoder: .init())
+    }
+
+    public func writeAsJSON(_ item: some Encodable, at: Path.AbsolutePath, encoder: JSONEncoder) async throws {
+        try await writeAsJSONOverride(item, at, encoder)
+    }
+
+    public func fileSizeInBytes(at: Path.AbsolutePath) async throws -> Int64? {
+        try await fileSizeInBytesOverride(at)
+    }
+
+    public func replace(_ to: Path.AbsolutePath, with: Path.AbsolutePath) async throws {
+        try await replaceOverride(to, with)
+    }
+
+    public func copy(_ from: Path.AbsolutePath, to: Path.AbsolutePath) async throws {
+        try await copyOverride(from, to)
+    }
+
+    public func locateTraversingUp(from: Path.AbsolutePath, relativePath: Path.RelativePath) async throws -> Path.AbsolutePath? {
+        try await locateTraversingUpOverride(from, relativePath)
+    }
+
+    public func createSymbolicLink(from: Path.AbsolutePath, to: Path.AbsolutePath) async throws {
+        try await createSymbolicLinkOverride(from, to)
+    }
+
+    public func resolveSymbolicLink(_ symlinkPath: Path.AbsolutePath) async throws -> Path.AbsolutePath {
+        try await resolveSymbolicLinkOverride(symlinkPath)
+    }
+
+    public func zipFileOrDirectoryContent(at path: Path.AbsolutePath, to: Path.AbsolutePath) async throws {
+        try await zipFileOrDirectoryContentOverride(path, to)
+    }
+
+    public func unzip(_ zipPath: Path.AbsolutePath, to: Path.AbsolutePath) async throws {
+        try await unzipOverride(zipPath, to)
+    }
+
+    public func glob(
+        directory _: Path.AbsolutePath,
+        include _: [String]
+    ) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath> {
+        throw NSError()
+    }
+
+    public func currentWorkingDirectory() async throws -> Path.AbsolutePath {
+        try await currentWorkingDirectoryOverride()
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -353,6 +353,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "FileSystem"),
                     .external(name: "XcodeProj"),
                     .external(name: "SwiftToolsSupport"),
+                    .external(name: "_NIOFileSystem"),
                 ]
             case .asyncQueue:
                 [
@@ -534,6 +535,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "SwiftToolsSupport"),
                     .external(name: "FileSystem"),
                     .external(name: "XcodeGraph"),
+                    .external(name: "_NIOFileSystem"),
                 ]
             case .asyncQueue:
                 [


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7143

### Short description 📝

The migration to the new async file system introduces race conditions, when the tuist cli is used in an async fashion.
Following the description in [this issue](https://github.com/tuist/tuist/issues/7143), we decided to just disregard the `fileAlreadyExists` error that can be thrown by nio.

### How to test the changes locally 🧐

Testing it locally is a bit hard, one would need to build the tuist cli from source, and follow the steps in the issue on how to reproduce that.

Nevertheless, unit tests were added to cover the issue.

Notes - @fortmarek / @pepicrft - I have added a manual mock to the `FileSysteming` protocol. I have seen that you started to adopt the `Mockable` framework, and can definitely update the [FileSystem](https://github.com/tuist/FileSystem/tree/main) code with that, if preferred.

Moreover, I can also create some kind of integration/acceptance tests utilizing the short script I wrote to reproduce the original issue - although I think its an overkill - if you wish me to do that, can you please point me to where would be most appropriate to write that test?

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
