### PR TITLE
Revert "Temporarily remove comment out secrets to unblock PRs from forks (#7212)

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,6 +4,8 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
+      groups:
+        - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -31,8 +33,8 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      # - github_credentials
+      groups:
+        - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -50,9 +52,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      # - tuist
-      # - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     scripts:
       - name: Set environment variables
         script: |
@@ -74,9 +76,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -99,9 +101,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -166,9 +168,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -196,9 +198,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -235,9 +237,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -265,9 +267,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
@@ -294,9 +296,9 @@ workflows:
     max_build_duration: 60
     environment:
       xcode: 16.1
-      # groups:
-      #   - tuist
-      #   - github_credentials
+      groups:
+        - tuist
+        - github_credentials
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build


### PR DESCRIPTION
This reverts commit 16343369b10ecff3b1fe1c83e2b3f7a984fa3228.

### Short description 📝

Codemagic is now aligned with GitHub Actions behavior where secrets in CI runs triggered from forks are ignored instead of blocking the run. Since all our secrets are optional, we're fine with this limitation.

It does mean PRs from forks won't be able to leverage Tuist server features such as remote caching or Tuist reports. That's a shame, but a current limitation that we can't get around by.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
