### PR TITLE
Add registry support for Xcode integration of packages in Tuist Projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,12 @@ playground.xcworkspace
 # End of https://www.gitignore.io/api/swift,macos
 
 **/*.xcodeproj
-**/*.xcworkspace
+**/*.xcworkspace/*
+!**/*.xcworkspace/xcshareddata
+**/*.xcworkspace/xcshareddata/*
+!**/*.xcworkspace/xcshareddata/swiftpm
+**/*.xcworkspace/xcshareddata/swiftpm/*
+!**/*.xcworkspace/xcshareddata/swiftpm/configuration
 .byebug_history
 *.xcarchive
 tmp/

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -15,6 +15,7 @@ public enum TuistAcceptanceFixtures {
     case appWithPreviews
     case appWithRealm
     case appWithRegistryAndAlamofire
+    case appWithRegistryAndAlamofireAsXcodePackage
     case appWithRevenueCat
     case appWithSpmDependencies
     case appWithSpmModuleAliases
@@ -128,6 +129,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_realm"
         case .appWithRegistryAndAlamofire:
             return "app_with_registry_and_alamofire"
+        case .appWithRegistryAndAlamofireAsXcodePackage:
+            return "app_with_registry_and_alamofire_as_xcode_package"
         case .appWithRevenueCat:
             return "app_with_revenue_cat"
         case .appWithSpmDependencies:

--- a/Sources/TuistLoader/Models+ManifestMappers/Package+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Package+ManifestMapper.swift
@@ -16,6 +16,8 @@ extension XcodeGraph.Package {
             return .local(path: try generatorPaths.resolve(path: local))
         case let .remote(url: url, requirement: version):
             return .remote(url: url, requirement: .from(manifest: version))
+        case let .registry(identifier: identifier, requirement: version):
+            return .remote(url: identifier, requirement: .from(manifest: version))
         }
     }
 }

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -59,6 +59,16 @@ final class DependenciesAcceptanceTestAppRegistryAndAlamofire: ServerAcceptanceT
     }
 }
 
+final class DependenciesAcceptanceTestAppRegistryAndAlamofireAsXcodePackage: ServerAcceptanceTestCase {
+    func test_app_with_registry_and_alamofire() async throws {
+        try await setUpFixture(.appWithRegistryAndAlamofireAsXcodePackage)
+        try await run(RegistrySetupCommand.self)
+        try await run(RegistryLoginCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App")
+    }
+}
+
 final class DependenciesAcceptanceTestIosAppWithSPMDependencies: TuistAcceptanceTestCase {
     func test_ios_app_spm_dependencies() async throws {
         try await setUpFixture(.iosAppWithSpmDependencies)

--- a/docs/docs/en/guides/develop/build/registry.md
+++ b/docs/docs/en/guides/develop/build/registry.md
@@ -35,8 +35,28 @@ Note that Xcode currently doesn't support automatically replacing source control
 
 ### Tuist project with the Xcode default integration {#tuist-project-with-xcode-default-integration}
 
-> [!IMPORTANT] Support for Tuist projects with the Xcode default integration of packages is coming soon.
-> Follow the latest development at [our community forum](https://community.tuist.dev/t/tuist-registry-initiative/262/2).
+If you are using the <LocalizedLink href="/guides/develop/projects/dependencies#xcodes-default-integration">Xcode's default integration</LocalizedLink> of packages with Tuist Projects, you need to use the registry identifier instead of a URL when adding a package:
+```swift
+import ProjectDescription
+
+let project = Project(
+    name: "MyProject",
+    packages: [
+        // Source control resolution
+        // .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.1.0")
+        // Registry resolution
+        .package(id: "pointfreeco.swift-composable-architecture", from: "0.1.0")
+    ],
+    .target(
+        name: "App",
+        product: .app,
+        bundleId: "io.tuist.App",
+        dependencies: [
+            .package(product: "ComposableArchitecture"),
+        ]
+    )
+)
+```
 
 ### Tuist project with the XcodeProj-based integration {#tuist-project-with-xcodeproj-based-integration}
 

--- a/fixtures/.gitignore
+++ b/fixtures/.gitignore
@@ -1,2 +1,0 @@
-*.xcodeproj
-*.xcworkspace

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/.package.resolved
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/.package.resolved
@@ -1,0 +1,14 @@
+{
+  "originHash" : "27d00ed1246fb71798c0eaa84a1f4201aec0474b4cae0597bcc3f2a1bd2ee60e",
+  "pins" : [
+    {
+      "identity" : "Alamofire.Alamofire",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "5.10.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/App.xcworkspace/xcshareddata/swiftpm/configuration/registries.json
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/App.xcworkspace/xcshareddata/swiftpm/configuration/registries.json
@@ -1,0 +1,22 @@
+{
+  "security": {
+    "default": {
+      "signing": {
+        "onUnsigned": "silentAllow"
+      }
+    }
+  },
+  "authentication": {
+    "canary.tuist.dev": {
+      "loginAPIPath": "/api/accounts/tuist/registry/swift/login",
+      "type": "token"
+    }
+  },
+  "registries": {
+    "[default]": {
+      "supportsAvailability": false,
+      "url": "https://canary.tuist.dev/api/accounts/tuist/registry/swift"
+    }
+  },
+  "version": 1
+}

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/App/Sources/ContentView.swift
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/App/Sources/ContentView.swift
@@ -1,0 +1,20 @@
+import Alamofire
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {
+        // Use Alamofire to make sure it links fine
+        _ = AF.download("http://tuist.dev")
+    }
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/App/Sources/MyApp.swift
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/App/Sources/MyApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/Project.swift
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/Project.swift
@@ -1,0 +1,28 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    packages: [
+        .package(id: "Alamofire.Alamofire", exact: "5.10.2"),
+    ],
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .package(product: "Alamofire"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_registry_and_alamofire_as_xcode_package/Tuist.swift
+++ b/fixtures/app_with_registry_and_alamofire_as_xcode_package/Tuist.swift
@@ -1,0 +1,7 @@
+import ProjectDescription
+
+let tuist = Tuist(
+    fullHandle: "tuist/app_with_registry_and_alamofire_as_xcode_package",
+    url: "https://canary.tuist.dev",
+    project: .tuist()
+)


### PR DESCRIPTION
### Short description 📝

This PR adds new API to `ProjectDescription` to allow adding registry packages:
```swift
import ProjectDescription

let project = Project(
    name: "MyProject",
    packages: [
        // Source control resolution
        // .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.1.0")
        // Registry resolution -> this is new
        .package(id: "pointfreeco.swift-composable-architecture", from: "0.1.0")
    ],
    .target(
        name: "App",
        product: .app,
        bundleId: "io.tuist.App",
        dependencies: [
            .package(product: "ComposableArchitecture"),
        ]
    )
```

The new API copies the `PackageDescription` definition.

The changes were quite straightforward as the registry package identifier is represented as a package url in the `pbxproj` format. Example:
```
/* Begin XCRemoteSwiftPackageReference section */
		F8410D022D0B3F810052EC6E /* XCRemoteSwiftPackageReference "Alamofire" */ = {
			isa = XCRemoteSwiftPackageReference;
			repositoryURL = Alamofire.Alamofire;
			requirement = {
				kind = upToNextMajorVersion;
				minimumVersion = 5.10.2;
			};
		};
/* End XCRemoteSwiftPackageReference section */
```

### How to test the changes locally 🧐

- Build and run the `app_with_registry_and_alamofire_as_xcode_package` fixture

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
