### PR TITLE
Mark plugins as deprecated in the docs

### DIFF
--- a/docs/docs/en/guides/develop/projects/plugins.md
+++ b/docs/docs/en/guides/develop/projects/plugins.md
@@ -21,8 +21,8 @@ Note that plugins are designed to be a simple way to extend Tuist's functionalit
 
 If you need more flexibility, consider suggesting a feature for the tool or building your own solution upon Tuist's generation framework, [`TuistGenerator`](https://github.com/tuist/tuist/tree/main/Sources/TuistGenerator).
 
-> [!WARNING] NON-ACTIVELY-MAINTAINED
-> Our plugin infrastructure is not actively maintained. We are looking for contributors to help us improve it. If you are interested, please reach out to us on [Slack](https://slack.tuist.io/).
+> [!WARNING] DEPRECATED
+> Plugins are deprecated and we are working on a more flexible and powerful solution, <LocalizedLink href="/en/guides/develop/automate/workflows">workflows</LocalizedLink>. We recommend not developing new plugins until the new solution is available.
 
 ## Plugin types {#plugin-types}
 


### PR DESCRIPTION
### Short description 📝
We are building a more powerful solution for automation, plugins, which will supersede plugins and also solutions like Fastlane and CI pipelines. This PR adjusts the docs to recommend people not to use plugins and wait until workflows are available. 