### PR TITLE
Fix flaky test_create_list_and_revoke_project_token test

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7984de77192a3558bc85ec35f31961b92cec2437f4939e665a848bba0426dcd1",
+  "originHash" : "d6444981d701f7aa8db678d455ef339a98264a3d458b912df6de7289098a2086",
   "pins" : [
     {
       "identity" : "aexml",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "914081701062b11e3bb9e21accc379822621995e",
-        "version" : "2.76.1"
+        "revision" : "dca6594f65308c761a9c409e09fbf35f48d50d34",
+        "version" : "2.77.0"
       }
     },
     {

--- a/Tests/TuistKitAcceptanceTests/ProjectAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ProjectAcceptanceTests.swift
@@ -25,7 +25,7 @@ final class ProjectAcceptanceTestProjectTokens: ServerAcceptanceTestCase {
             try await run(ProjectTokensCreateCommand.self, fullHandle)
             try await run(ProjectTokensListCommand.self, fullHandle)
             let id = try XCTUnwrap(
-                ServiceContext.current?.testingLogHandler?.collected[.info, <=]
+                ServiceContext.current?.testingLogHandler?.collected[.notice, ==]
                     .components(separatedBy: .newlines)
                     .dropLast().last?
                     .components(separatedBy: .whitespaces)


### PR DESCRIPTION
### Short description 📝

The `test_create_list_and_revoke_project_token` has been flaky:
- [Failure](https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/677d2f2ab0bb77fa85d629c6#step:8:707:0)
- [Success](https://codemagic.io/app/65ca555c190cfbe9f5dd792f/build/677e3af0b0bb77fa85dac168#step:8)

The reason for this was that `ServiceContext.current?.testingLogHandler?.collected[.info, <=]` goes through a dictionary of logs where keys are the individual levels. However, going through the levels is _unsorted_.

Since we only care about a single level `.notice`, we can change this to `ServiceContext.current?.testingLogHandler?.collected[.notice, ==]` which doesn't seem to be flaky.

### How to test the changes locally 🧐

- Acceptance tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
