### PR TITLE
Revert embedding static framework instead of generating a resource bundle

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,5 @@
 [tools]
 tuist = "4.39.0"
-# tuist = "4.38.2"
 swiftlint = "0.54.0"
 swiftformat = "0.53.3"
 pnpm = "8.15.6"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 tuist = "4.39.0"
+# tuist = "4.38.2"
 swiftlint = "0.54.0"
 swiftformat = "0.53.3"
 pnpm = "8.15.6"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "04aa8c2b9d21653dee1d45cacbaed64cc8e12bc6926a9ecd08b3166e7b2918bd",
+  "originHash" : "2bc099daeca143141ec9aa1fcbab8e2e50f7a09bd13b937dd0eea67ada717d4d",
   "pins" : [
     {
       "identity" : "aexml",
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "branch" : "revert/supports-resources",
-        "revision" : "9d7858ef13572177c03f802435e76ae8fc43877c"
+        "revision" : "c533cf2543dc41428f0118d4f0df5c890307918a",
+        "version" : "1.3.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d6444981d701f7aa8db678d455ef339a98264a3d458b912df6de7289098a2086",
+  "originHash" : "04aa8c2b9d21653dee1d45cacbaed64cc8e12bc6926a9ecd08b3166e7b2918bd",
   "pins" : [
     {
       "identity" : "aexml",
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "0b0b0fcad094702f2df5c143d862fa2ef6bcf3a4",
-        "version" : "1.3.0"
+        "branch" : "revert/supports-resources",
+        "revision" : "9d7858ef13572177c03f802435e76ae8fc43877c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", exact: "1.3.0"
+            url: "https://github.com/tuist/XcodeGraph.git", branch: "revert/supports-resources"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", branch: "revert/supports-resources"
+            url: "https://github.com/tuist/XcodeGraph.git", exact: "1.3.2"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.6.17")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -12,11 +12,13 @@ public enum TuistAcceptanceFixtures {
     case appWithGoogleMaps
     case appWithMetalOptions
     case appWithPlugins
+    case appWithPocketSVG
     case appWithPreviews
     case appWithRealm
     case appWithRegistryAndAlamofire
     case appWithRegistryAndAlamofireAsXcodePackage
     case appWithRevenueCat
+    case appWithSBTUITestTunnel
     case appWithSpmDependencies
     case appWithSpmModuleAliases
     case appWithSwiftCMark
@@ -124,6 +126,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_metal_options"
         case .appWithPlugins:
             return "app_with_plugins"
+        case .appWithPocketSVG:
+            return "app_with_pocket_svg"
         case .appWithPreviews:
             return "app_with_previews"
         case .appWithRealm:
@@ -134,6 +138,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_registry_and_alamofire_as_xcode_package"
         case .appWithRevenueCat:
             return "app_with_revenue_cat"
+        case .appWithSBTUITestTunnel:
+            return "app_with_sbtuitesttunnel"
         case .appWithSpmDependencies:
             return "app_with_spm_dependencies"
         case .appWithSpmModuleAliases:

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -354,7 +354,7 @@ public class GraphTraverser: GraphTraversing {
         /// Precompiled frameworks
         var precompiledFrameworks = filterDependencies(
             from: .target(name: name, path: path),
-            test: \.isPrecompiledAndLinkable,
+            test: \.isPrecompiledDynamicAndLinkable,
             skip: or(canDependencyEmbedBinaries, isDependencyPrecompiledMacro)
         )
         // Skip merged precompiled libraries from merging into the runnable binary
@@ -403,10 +403,14 @@ public class GraphTraverser: GraphTraversing {
         )
 
         // Exclude any products embed in unit test host apps
-        if target.target.product == .unitTests, let hostApp = unitTestHost(path: path, name: name) {
-            references.subtract(
-                embeddableFrameworks(path: hostApp.path, name: hostApp.target.name)
-            )
+        if target.target.product == .unitTests {
+            if let hostApp = unitTestHost(path: path, name: name) {
+                references.subtract(
+                    embeddableFrameworks(path: hostApp.path, name: hostApp.target.name)
+                )
+            } else {
+                references = Set()
+            }
         }
 
         return references
@@ -1578,7 +1582,7 @@ extension GraphDependency {
         if case let .xcframework(xcframework) = self { xcframework } else { nil }
     }
 
-    fileprivate var isPrecompiledAndLinkable: Bool {
+    private var isPrecompiledAndLinkable: Bool {
         if case .xcframework = self { true } else { isPrecompiledDynamicAndLinkable }
     }
 }

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -35,7 +35,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
 
     // swiftlint:disable:next function_body_length
     public func mapTarget(_ target: Target, project: Project) throws -> ([Target], [SideEffectDescriptor]) {
-        guard target.containsResources else { return ([target], []) }
+        if target.resources.resources.isEmpty, target.coreDataModels.isEmpty { return ([target], []) }
 
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
@@ -174,12 +174,8 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
 
     // swiftlint:disable:next function_body_length
     static func fileContent(targetName _: String, bundleName: String, target: Target, in project: Project) -> String {
-        let isStaticFramework = target.product == .staticFramework
-
-        let bundleAccessor = if target.supportsResources, !isStaticFramework {
+        let bundleAccessor = if target.supportsResources {
             swiftFrameworkBundleAccessorString(for: target)
-        } else if isStaticFramework, target.containsResources {
-            swiftStaticFrameworkBundleAccessorString(for: target)
         } else {
             swiftSPMBundleAccessorString(for: target, and: bundleName)
         }
@@ -188,10 +184,12 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         let publicBundleAccessor = switch project.type {
         case .external:
             ""
-        case .local where target.sourcesContainsPublicResourceClassName:
-            ""
         case .local:
-            publicBundleAccessorString(for: target)
+            if target.sourcesContainsPublicResourceClassName {
+                ""
+            } else {
+                publicBundleAccessorString(for: target)
+            }
         }
 
         return """
@@ -286,11 +284,11 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
     private static func publicBundleAccessorString(for target: Target) -> String {
         """
         // MARK: - Objective-C Bundle Accessor
-        @objcMembers
-        public final class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
-            public static var bundle: Bundle {
-                .module
-            }
+        @objc
+        public class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
+        @objc public class var bundle: Bundle {
+            return .module
+        }
         }
         """
     }
@@ -298,41 +296,53 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
     private static func swiftSPMBundleAccessorString(for target: Target, and bundleName: String) -> String {
         """
         // MARK: - Swift Bundle Accessor - for SPM
-        private final class BundleFinder {}
+        private class BundleFinder {}
         extension Foundation.Bundle {
-        /// Since \(target.name) is a \(target.product), \
-        the bundle containing the resources is copied into the final product.
+        /// Since \(target.name) is a \(
+            target
+                .product
+        ), the bundle containing the resources is copied into the final product.
         static let module: Bundle = {
-        let bundleName = "\(bundleName)"
-        let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
-        var candidates = [
-            Bundle.main.resourceURL,
-            bundleFinderResourceURL,
-            Bundle.main.bundleURL,
-        ]
-        // This is a fix to make Previews work with bundled resources.
-        // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
-        // which is located under the derived data directory after building the project.
-        if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
-            candidates.append(URL(fileURLWithPath: override))
-            // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
-            // where the bundles are only available in the framework's directory that is actively being previewed.
-            // Since we don't know which framework this is, we also need to look in all the framework subpaths.
-            if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
-                for subpath in subpaths {
-                    if subpath.hasSuffix(".framework") {
-                        candidates.append(URL(fileURLWithPath: override + "/" + subpath))
+            let bundleName = "\(bundleName)"
+            let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
+            var candidates = [
+                Bundle.main.resourceURL,
+                bundleFinderResourceURL,
+                Bundle.main.bundleURL,
+            ]
+            // This is a fix to make Previews work with bundled resources.
+            // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
+            // which is located under the derived data directory after building the project.
+            if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
+                candidates.append(URL(fileURLWithPath: override))
+                // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
+                // where the bundles are only available in the framework's directory that is actively being previewed.
+                // Since we don't know which framework this is, we also need to look in all the framework subpaths.
+                if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
+                    for subpath in subpaths {
+                        if subpath.hasSuffix(".framework") {
+                            candidates.append(URL(fileURLWithPath: override + "/" + subpath))
+                        }
                     }
                 }
             }
-        }
 
-        \(iterateOverCandidatesString(appendingPath: "bundleName + \".bundle\""))
-        fatalError("unable to find bundle named \(bundleName)")
+            // This is a fix to make unit tests work with bundled resources.
+            // Making this change allows unit tests to search one directory up for a bundle.
+            // More context can be found in this PR: https://github.com/tuist/tuist/pull/6895
+            #if canImport(XCTest)
+            candidates.append(bundleFinderResourceURL?.appendingPathComponent(".."))
+            #endif
+
+            for candidate in candidates {
+                let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+                if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                    return bundle
+                }
+            }
+            fatalError("unable to find bundle named \(bundleName)")
         }()
         }
-
-        \(appendingPathToURLString())
         """
     }
 
@@ -341,58 +351,11 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         // MARK: - Swift Bundle Accessor for Frameworks
         private class BundleFinder {}
         extension Foundation.Bundle {
-        /// Since \(target.name) is a \(target.product), \
-        the bundle for classes within this module can be used directly.
+        /// Since \(target.name) is a \(
+            target
+                .product
+        ), the bundle for classes within this module can be used directly.
         static let module = Bundle(for: BundleFinder.self)
-        }
-        """
-    }
-
-    private static func swiftStaticFrameworkBundleAccessorString(for target: Target) -> String {
-        """
-        // MARK: - Swift Bundle Accessor for Frameworks
-        extension Foundation.Bundle {
-            /// Since \(target.name) is a \(target.product), \
-            a cut down framework is embedded, with all the resources but only a stub Mach-O image.
-            static let module: Bundle = {
-                final class BundleFinder {}
-                let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL?.appendingPath("..")
-                var candidates = [
-                    Bundle.main.privateFrameworksURL,
-                    bundleFinderResourceURL,
-                    bundleFinderResourceURL?.appendingPath("Frameworks"),
-                ]
-
-                \(iterateOverCandidatesString(appendingPath: "\"\(target.name).framework\""))
-                fatalError("unable to find \(target.product) \\"\(target.name).framework\\"")
-            }()
-        }
-
-        \(appendingPathToURLString())
-        """
-    }
-
-    private static func iterateOverCandidatesString(appendingPath: String) -> String {
-        """
-        for candidate in candidates {
-            let frameworkUrl = candidate?.appendingPath(\(appendingPath))
-            if let bundle = frameworkUrl.flatMap(Bundle.init(url:)) {
-                return bundle
-            }
-        }
-        """
-    }
-
-    private static func appendingPathToURLString() -> String {
-        """
-        private extension URL {
-            func appendingPath(_ path: String) -> URL {
-                if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
-                    appending(path: path, directoryHint: .isDirectory)
-                } else {
-                    appendingPathComponent(path)
-                }
-            }
         }
         """
     }

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -44,6 +44,15 @@ final class DependenciesAcceptanceTestAppAlamofire: TuistAcceptanceTestCase {
     }
 }
 
+final class DependenciesAcceptanceTestAppPocketSVG: TuistAcceptanceTestCase {
+    func test_app_with_pocket_svg() async throws {
+        try await setUpFixture(.appWithPocketSVG)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App")
+    }
+}
+
 final class DependenciesAcceptanceTestAppRegistryAndAlamofire: ServerAcceptanceTestCase {
     func test_app_with_registry_and_alamofire() async throws {
         try await setUpFixture(.appWithRegistryAndAlamofire)
@@ -63,6 +72,15 @@ final class DependenciesAcceptanceTestAppRegistryAndAlamofireAsXcodePackage: Ser
         try await setUpFixture(.appWithRegistryAndAlamofireAsXcodePackage)
         try await run(RegistrySetupCommand.self)
         try await run(RegistryLoginCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App")
+    }
+}
+
+final class DependenciesAcceptanceTestAppSBTUITestTunnel: TuistAcceptanceTestCase {
+    func test_app_with_sbtuitesttunnel() async throws {
+        try await setUpFixture(.appWithSBTUITestTunnel)
+        try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
     }

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -118,7 +118,7 @@ final class GenerateAcceptanceTestiOSAppWithFrameworkAndResources: TuistAcceptan
             "StaticFramework3_StaticFramework3.bundle",
             "StaticFramework4_StaticFramework4.bundle",
         ] {
-            try await XCTAssertProductWithDestinationDoesNotContainResource(
+            try await XCTAssertProductWithDestinationContainsResource(
                 "App.app",
                 destination: "Debug-iphonesimulator",
                 resource: resource
@@ -140,12 +140,12 @@ final class GenerateAcceptanceTestiOSAppWithFrameworkAndResources: TuistAcceptan
             resource: "StaticFramework2Resources-tuist.png"
         )
         try await XCTAssertProductWithDestinationContainsResource(
-            "App.app/Frameworks/StaticFramework3.framework",
+            "StaticFramework3_StaticFramework3.bundle",
             destination: "Debug-iphonesimulator",
             resource: "StaticFramework3Resources-tuist.png"
         )
         try await XCTAssertProductWithDestinationContainsResource(
-            "App.app/Frameworks/StaticFramework4.framework",
+            "StaticFramework4_StaticFramework4.bundle",
             destination: "Debug-iphonesimulator",
             resource: "StaticFramework4Resources-tuist.png"
         )
@@ -1164,9 +1164,9 @@ final class GenerateAcceptanceTestAppWithMacBundle: TuistAcceptanceTestCase {
         try await run(BuildCommand.self, "App", "--platform", "ios")
 
         try await XCTAssertProductWithDestinationContainsResource(
-            "App.app/Contents/Frameworks/ResourcesFramework.framework",
+            "App.app",
             destination: "Debug-maccatalyst",
-            resource: "greeting.txt"
+            resource: "Resources/ResourcesFramework_ResourcesFramework.bundle"
         )
         try await XCTAssertProductWithDestinationDoesNotContainResource(
             "App.app",

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -210,83 +210,78 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     }
 
     func test_map_when_a_target_that_has_resources_and_supports_them() throws {
-        for product in [Product.framework, .staticFramework] {
-            // Given
-            let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-            let target = Target.test(product: product, sources: ["/Absolute/File.swift"], resources: .init(resources))
-            project = Project.test(targets: [target])
+        // Given
+        let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], resources: .init(resources))
+        project = Project.test(targets: [target])
 
-            // Got
-            let (gotProject, gotSideEffects) = try subject.map(project: project)
+        // Got
+        let (gotProject, gotSideEffects) = try subject.map(project: project)
 
-            // Then: Side effects
-            XCTAssertEqual(gotSideEffects.count, 1)
-            let sideEffect = try XCTUnwrap(gotSideEffects.first)
-            guard case let SideEffectDescriptor.file(file) = sideEffect else {
-                XCTFail("Expected file descriptor")
-                return
-            }
-            let expectedPath = project.path
-                .appending(component: Constants.DerivedDirectory.name)
-                .appending(component: Constants.DerivedDirectory.sources)
-                .appending(component: "TuistBundle+\(target.name).swift")
-            let expectedContents = ResourcesProjectMapper
-                .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
-            XCTAssertEqual(file.path, expectedPath)
-            XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
-
-            // Then: Targets
-            XCTAssertEqual(gotProject.targets.count, 1)
-            let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().first)
-            XCTAssertEqual(gotTarget.name, target.name)
-            XCTAssertEqual(gotTarget.product, target.product)
-            XCTAssertEqual(gotTarget.resources.resources, resources)
-            XCTAssertEqual(gotTarget.sources.count, 2)
-            XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
-            XCTAssertNotNil(gotTarget.sources.last?.contentHash)
-            XCTAssertEqual(gotTarget.dependencies.count, 0)
+        // Then: Side effects
+        XCTAssertEqual(gotSideEffects.count, 1)
+        let sideEffect = try XCTUnwrap(gotSideEffects.first)
+        guard case let SideEffectDescriptor.file(file) = sideEffect else {
+            XCTFail("Expected file descriptor")
+            return
         }
+        let expectedPath = project.path
+            .appending(component: Constants.DerivedDirectory.name)
+            .appending(component: Constants.DerivedDirectory.sources)
+            .appending(component: "TuistBundle+\(target.name).swift")
+        let expectedContents = ResourcesProjectMapper
+            .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
+        XCTAssertEqual(file.path, expectedPath)
+        XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
+
+        // Then: Targets
+        XCTAssertEqual(gotProject.targets.count, 1)
+        let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().first)
+        XCTAssertEqual(gotTarget.name, target.name)
+        XCTAssertEqual(gotTarget.product, target.product)
+        XCTAssertEqual(gotTarget.resources.resources, resources)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
+        XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
     func test_map_when_a_target_that_has_core_data_models_and_supports_them() throws {
-        for product in [Product.framework, .staticFramework] {
-            // Given
-            let coreDataModels = [
-                CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1"),
-            ]
-            let target = Target.test(product: product, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
-            project = Project.test(targets: [target])
+        // Given
+        let coreDataModels: [CoreDataModel] =
+            [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
+        let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
+        project = Project.test(targets: [target])
 
-            // Got
-            let (gotProject, gotSideEffects) = try subject.map(project: project)
+        // Got
+        let (gotProject, gotSideEffects) = try subject.map(project: project)
 
-            // Then: Side effects
-            XCTAssertEqual(gotSideEffects.count, 1)
-            let sideEffect = try XCTUnwrap(gotSideEffects.first)
-            guard case let SideEffectDescriptor.file(file) = sideEffect else {
-                XCTFail("Expected file descriptor")
-                return
-            }
-            let expectedPath = project.path
-                .appending(component: Constants.DerivedDirectory.name)
-                .appending(component: Constants.DerivedDirectory.sources)
-                .appending(component: "TuistBundle+\(target.name).swift")
-            let expectedContents = ResourcesProjectMapper
-                .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
-            XCTAssertEqual(file.path, expectedPath)
-            XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
-
-            // Then: Targets
-            XCTAssertEqual(gotProject.targets.count, 1)
-            let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().first)
-            XCTAssertEqual(gotTarget.name, target.name)
-            XCTAssertEqual(gotTarget.product, target.product)
-            XCTAssertEqual(gotTarget.coreDataModels, coreDataModels)
-            XCTAssertEqual(gotTarget.sources.count, 2)
-            XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
-            XCTAssertNotNil(gotTarget.sources.last?.contentHash)
-            XCTAssertEqual(gotTarget.dependencies.count, 0)
+        // Then: Side effects
+        XCTAssertEqual(gotSideEffects.count, 1)
+        let sideEffect = try XCTUnwrap(gotSideEffects.first)
+        guard case let SideEffectDescriptor.file(file) = sideEffect else {
+            XCTFail("Expected file descriptor")
+            return
         }
+        let expectedPath = project.path
+            .appending(component: Constants.DerivedDirectory.name)
+            .appending(component: Constants.DerivedDirectory.sources)
+            .appending(component: "TuistBundle+\(target.name).swift")
+        let expectedContents = ResourcesProjectMapper
+            .fileContent(targetName: target.name, bundleName: irrelevantBundleName, target: target, in: project)
+        XCTAssertEqual(file.path, expectedPath)
+        XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
+
+        // Then: Targets
+        XCTAssertEqual(gotProject.targets.count, 1)
+        let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().first)
+        XCTAssertEqual(gotTarget.name, target.name)
+        XCTAssertEqual(gotTarget.product, target.product)
+        XCTAssertEqual(gotTarget.coreDataModels, coreDataModels)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
+        XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
     func test_map_when_a_target_has_no_resources() throws {

--- a/fixtures/app_with_pocket_svg/.gitignore
+++ b/fixtures/app_with_pocket_svg/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/app_with_pocket_svg/App/Sources/AppApp.swift
+++ b/fixtures/app_with_pocket_svg/App/Sources/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_pocket_svg/App/Sources/ContentView.swift
+++ b/fixtures/app_with_pocket_svg/App/Sources/ContentView.swift
@@ -1,0 +1,22 @@
+import PocketSVG
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {
+        let svg =
+            "<?xml version=\"1.1\" encoding=\"UTF-8\" standalone=\"no\"?> <svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0.000000, 0.000000, 732.000000, 185.000000\" width=\"732.000000\" height=\"185.000000\" > <path fill=\"none\" stroke=\"black\" stroke-width=\"2.000000\" stroke-linejoin=\"round\" stroke-linecap=\"round\" d=\"M148.0 143.0M300.0 143.0\" /> </svg>"
+        let generatedPathsFromResponse = SVGBezierPath.paths(fromSVGString: svg)
+        assert(!generatedPathsFromResponse.isEmpty)
+    }
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_pocket_svg/App/Tests/AppTests.swift
+++ b/fixtures/app_with_pocket_svg/App/Tests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class AppTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/fixtures/app_with_pocket_svg/Project.swift
+++ b/fixtures/app_with_pocket_svg/Project.swift
@@ -1,0 +1,25 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .external(name: "PocketSVG"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_pocket_svg/Tuist/Config.swift
+++ b/fixtures/app_with_pocket_svg/Tuist/Config.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let config = Config(
+    //    Create an account with "tuist auth" and a project with "tuist project create"
+//    then uncomment the section below and set the project full-handle.
+//    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
+//
+//    fullHandle: "{account_handle}/{project_handle}",
+)

--- a/fixtures/app_with_pocket_svg/Tuist/Package.resolved
+++ b/fixtures/app_with_pocket_svg/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "75887ef63d4d0c55e17201d284060ad198f87932d2aab51b0d4ab32e00a7f6b3",
+  "pins" : [
+    {
+      "identity" : "pocketsvg",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pocketsvg/PocketSVG",
+      "state" : {
+        "revision" : "10c6885e427e88d35fbb64010fbd6385cb58fef7",
+        "version" : "2.7.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/app_with_pocket_svg/Tuist/Package.swift
+++ b/fixtures/app_with_pocket_svg/Tuist/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+@preconcurrency import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: ["PocketSVG": .framework]
+    )
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/pocketsvg/PocketSVG", exact: "2.7.3"),
+    ]
+)

--- a/fixtures/app_with_sbtuitesttunnel/.gitignore
+++ b/fixtures/app_with_sbtuitesttunnel/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/app_with_sbtuitesttunnel/App/Sources/ContentView.swift
+++ b/fixtures/app_with_sbtuitesttunnel/App/Sources/ContentView.swift
@@ -1,0 +1,21 @@
+import GCDWebServer
+import SBTUITestTunnelServer
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {
+        // Use SBTUITestTunnelServer to make sure it links fine
+        _ = SBTUITestTunnelServer()
+    }
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_with_sbtuitesttunnel/App/Sources/MyApp.swift
+++ b/fixtures/app_with_sbtuitesttunnel/App/Sources/MyApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_with_sbtuitesttunnel/App/Tests/AppTests.swift
+++ b/fixtures/app_with_sbtuitesttunnel/App/Tests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class AppTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/fixtures/app_with_sbtuitesttunnel/Project.swift
+++ b/fixtures/app_with_sbtuitesttunnel/Project.swift
@@ -1,0 +1,25 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["App/Sources/**"],
+            dependencies: [
+                .external(name: "SBTUITestTunnelServer"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/app_with_sbtuitesttunnel/Tuist.swift
+++ b/fixtures/app_with_sbtuitesttunnel/Tuist.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+
+let tuist = Tuist(
+    //    Create an account with "tuist auth" and a project with "tuist project create"
+    //    then uncomment the section below and set the project full-handle.
+    //    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
+    //
+    //    fullHandle: "{account_handle}/{project_handle}",
+)

--- a/fixtures/app_with_sbtuitesttunnel/Tuist/Package.resolved
+++ b/fixtures/app_with_sbtuitesttunnel/Tuist/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "originHash" : "0c4692cc0e1ce79e8f3d1284914bf0332c20288d19dd78d7cc05319c55245c00",
+  "pins" : [
+    {
+      "identity" : "gcdwebserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Subito-it/GCDWebServer.git",
+      "state" : {
+        "revision" : "5b7f7a7d11f92a983ac5ec6c81d26c6c23376d98",
+        "version" : "4.0.0"
+      }
+    },
+    {
+      "identity" : "sbtuitesttunnel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Subito-it/SBTUITestTunnel",
+      "state" : {
+        "revision" : "81ec9c3c6e1df6b4e3d90d435e74a5e10825324e"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/app_with_sbtuitesttunnel/Tuist/Package.swift
+++ b/fixtures/app_with_sbtuitesttunnel/Tuist/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+@preconcurrency import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/Subito-it/SBTUITestTunnel", revision: "81ec9c3c6e1df6b4e3d90d435e74a5e10825324e"),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7230
Prerequisite: https://github.com/tuist/XcodeGraph/pull/94

### Short description 📝

The https://github.com/tuist/tuist/pull/7006 caused the following regressions, so I'm reverting the relevant changes until we find a proper solution:
- https://github.com/tuist/tuist/issues/7230
- Packages written in ObjC and that resources (I added two new fixtures in this PR to cover those cases)

For the latter, we need to align the generated resource accessor between Swift and ObjC. The original PR updated Swift only which is wrong (oversight from my side).

For the former, I'm not entirely sure what the fix is.

@vldalx, would you mind taking a look at what it to fix the highlighted issue, so we can bring your changes back?

### How to test the changes locally 🧐

- The new fixtures should build.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
