### PR TITLE
Add command to run to authenticate in the error message when unauthenticated

### DIFF
--- a/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -16,7 +16,7 @@ public enum ServerClientAuthenticationError: FatalError, Equatable {
     public var description: String {
         switch self {
         case .notAuthenticated:
-            return "You must be logged in to do this."
+            return "You must be logged in to do this. To log in, run 'tuist auth login'."
         }
     }
 }


### PR DESCRIPTION
### Short description 📝

We're improving the error message when unauthenticated with the exact command that developers should run to log in.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
