### PR TITLE
Add note about registry identifier when the repo name has a dot

### DIFF
--- a/docs/docs/en/guides/develop/build/registry.md
+++ b/docs/docs/en/guides/develop/build/registry.md
@@ -58,6 +58,10 @@ let project = Project(
 )
 ```
 
+> [!NOTE]
+> The registry identifier is always in the form of `{scope}.{name}`. The identifier can't contain more than one dot. If the repository name contains a dot, it's replaced with an underscore.
+> For example, the `https://github.com/groue/GRDB.swift` package would have the registry identifier `groue.GRDB_swift`.
+
 ### Tuist project with the XcodeProj-based integration {#tuist-project-with-xcodeproj-based-integration}
 
 If you are using the <LocalizedLink href="/guides/develop/projects/dependencies#tuists-xcodeprojbased-integration">XcodeProj-based integration</LocalizedLink>, you can use the ``--replace-scm-with-registry`` flag to resolve dependencies from the registry if they are available. Add it to the `installOptions` in your `Tuist.swift` file:
@@ -80,6 +84,10 @@ dependencies: [
 ]
 ```
 
+> [!NOTE]
+> The registry identifier is always in the form of `{scope}.{name}`. The identifier can't contain more than one dot. If the repository name contains a dot, it's replaced with an underscore.
+> For example, the `https://github.com/groue/GRDB.swift` package would have the registry identifier `groue.GRDB_swift`.
+
 ### Swift package {#swift-package}
 
 If you are working on a Swift package, you can use the `--replace-scm-with-registry` flag to resolve dependencies from the registry if they are available:
@@ -95,6 +103,10 @@ dependencies: [
 +   .package(id: "pointfreeco.swift-composable-architecture", from: "0.1.0")
 ]
 ```
+
+> [!NOTE]
+> The registry identifier is always in the form of `{scope}.{name}`. The identifier can't contain more than one dot. If the repository name contains a dot, it's replaced with an underscore.
+> For example, the `https://github.com/groue/GRDB.swift` package would have the registry identifier `groue.GRDB_swift`.
 
 ## Continuous Integration (CI) {#continuous-integration-ci}
 


### PR DESCRIPTION
### Short description 📝

Packages like https://github.com/groue/GRDB.swift have a dot in their name. However, a registry identifier can contain just a single dot as that's the delimiter between package's scope and name (`{scope}.{name}`).

I'm adding a note about that in the docs as `groue.grdb.swift` wouldn't work – it needs to be `groue.grdb_swift`.

I duplicated that across the sections with different setups as the reader should be able to read just the section for their own setup. If we need to add more duplicated documentation in the future, it might make sense to instead create a common documentation section to reduce the duplication.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
