### PR TITLE
Fix backwards compatibility of tuist graph --format json output

### DIFF
--- a/Sources/ProjectAutomation/Configuration.swift
+++ b/Sources/ProjectAutomation/Configuration.swift
@@ -2,10 +2,10 @@ import Foundation
 
 // MARK: - Configuration
 
-// The build Configuration of a target.
+// A the build Configuration of a target.
 
-public struct Configuration: Equatable, Codable {
-    private let settings: SettingsDictionary
+public struct Configuration: Equatable, Codable, Sendable {
+    let settings: SettingsDictionary
 
     public init(
         settings: SettingsDictionary
@@ -16,16 +16,19 @@ public struct Configuration: Equatable, Codable {
 
 // MARK: - BuildConfiguration
 
-public struct BuildConfiguration: Codable, Hashable {
-    public enum Variant: Codable {
+public struct BuildConfiguration: Equatable, Codable, Hashable, Sendable {
+    public enum Variant: String, Codable, Hashable, Sendable {
         case debug
         case release
     }
 
-    private let name: String
-    private let variant: Variant
+    public var name: String
+    public var variant: BuildConfiguration.Variant
 
-    public init(name: String, variant: Variant) {
+    public init(
+        name: String,
+        variant: BuildConfiguration.Variant
+    ) {
         self.name = name
         self.variant = variant
     }
@@ -33,7 +36,7 @@ public struct BuildConfiguration: Codable, Hashable {
 
 public typealias SettingsDictionary = [String: SettingValue]
 
-public enum SettingValue: Equatable, Codable {
+public enum SettingValue: Equatable, Codable, Sendable {
     case string(value: String)
     case array(value: [String])
 


### PR DESCRIPTION
This reverts commit 7f03d54356115b479680f156d1dd70e3f3b86b86.

Resolves https://github.com/tuist/ProjectAutomation/issues/4

### Short description 📝

I'm reverting a commit that did too much clean up and broke the `ProjectAutomation` backwards compatibility by removing some properties. We plan to deprecate `ProjectAutomation` and use `XcodeGraph` instead, so I'd try to keep `ProjectAutomation` frozen in time now.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
