### PR TITLE
Change tuist graph --format json output to XcodeGraph. Use tuist graph --format legacyJSON for legacy output.

### DIFF
--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -111,7 +111,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
 }
 
 enum GraphFormat: String, ExpressibleByArgument, CaseIterable {
-    case dot, json, png, svg
+    case dot, json, legacyJSON, png, svg
 }
 
 extension GraphViz.LayoutAlgorithm: ArgumentParser.ExpressibleByArgument {


### PR DESCRIPTION
### Short description 📝

As we are moving away from using `ProjectAutomation`, we should no longer use it in the `tuist graph --format json`. Unfortunately, the `XcodeGraph` encoded JSON looks a tiny bit different from `ProjectAutomation` ones. Primarily, the `targets` property of `ProjectAutomation` is an array of targets `[Target]` whereas in `XcodeGraph`, it is a dictionary of `[AbsolutePath: Target]`.

If there are teams using the output as part of their automation workflows, they can use a new output format that uses the deprecated `ProjectAutomation` output: `tuist graph --format legacyJSON`.

### How to test the changes locally 🧐

- Run `tuist graph --format json` and `tuist graph --format legacyJSON`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
