### PR TITLE
chore: fix mise warning

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ create-dmg = "1.2.2"
 git-cliff = "2.6.0"
 "spm:apple/swift-openapi-generator" = "1.3.1"
 
-[plugins]
+[alias]
 sourcedocs = "https://github.com/tuist/asdf-sourcedocs"
 create-dmg = "https://github.com/tuist/asdf-create-dmg.git"
 


### PR DESCRIPTION
Resolves warning:
```
mise WARN  deprecated [config_plugins]: [plugins] section of mise.toml is deprecated. Use [alias] instead. https://mise.jdx.dev/dev-tools/aliases.html

```
### Short description 📝

> Describe here the purpose of your PR.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
