### PR TITLE
Fix compilation error caused by retroactive attribute usage in environments < Swift 6

### DIFF
--- a/app/TuistApp/Sources/Extensions/SimulatorDeviceAndRuntime+Extras.swift
+++ b/app/TuistApp/Sources/Extensions/SimulatorDeviceAndRuntime+Extras.swift
@@ -2,17 +2,17 @@ import Foundation
 import TuistCore
 
 #if swift(>=6)
-extension SimulatorDeviceAndRuntime: @retroactive Comparable {
-    public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
-        if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
-        else { return lhs.device.name < rhs.device.name }
+    extension SimulatorDeviceAndRuntime: @retroactive Comparable {
+        public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
+            if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
+            else { return lhs.device.name < rhs.device.name }
+        }
     }
-}
 #else
-extension SimulatorDeviceAndRuntime: Comparable {
-    public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
-        if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
-        else { return lhs.device.name < rhs.device.name }
+    extension SimulatorDeviceAndRuntime: Comparable {
+        public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
+            if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
+            else { return lhs.device.name < rhs.device.name }
+        }
     }
-}
 #endif

--- a/app/TuistApp/Sources/Extensions/SimulatorDeviceAndRuntime+Extras.swift
+++ b/app/TuistApp/Sources/Extensions/SimulatorDeviceAndRuntime+Extras.swift
@@ -1,9 +1,18 @@
 import Foundation
 import TuistCore
 
+#if swift(>=6)
 extension SimulatorDeviceAndRuntime: @retroactive Comparable {
     public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
         if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
         else { return lhs.device.name < rhs.device.name }
     }
 }
+#else
+extension SimulatorDeviceAndRuntime: Comparable {
+    public static func < (lhs: SimulatorDeviceAndRuntime, rhs: SimulatorDeviceAndRuntime) -> Bool {
+        if lhs.device.name == rhs.device.name { return lhs.runtime.name < rhs.runtime.name }
+        else { return lhs.device.name < rhs.device.name }
+    }
+}
+#endif


### PR DESCRIPTION
### Short description 📝

When building Tuist in environments that do not use Swift 6 (e.g., Swift 5.10, currently used in Manifest), the following compilation failure occurs by attribute [retroactive](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md):

![CleanShot 2025-01-18 at 11 56 41@2x](https://github.com/user-attachments/assets/5a6dc22d-921c-45bd-a94f-330a415ef635)

To address this issue, version exception handling was added to ensure the code does not fail to compile in environments below Swift 6.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
