### PR TITLE
Fix broken `xcodebuild` output

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -299,6 +299,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
     }
 
     fileprivate func run(command: [String]) async throws {
+        let logger = ServiceContext.current?.logger
+        
         func format(_ bytes: [UInt8]) -> String {
             let string = String(decoding: bytes, as: Unicode.UTF8.self)
             if self.environment.isVerbose == true {
@@ -312,14 +314,14 @@ public final class XcodeBuildController: XcodeBuildControlling {
             let lines = format(bytes).split(separator: "\n")
             for line in lines where !line.isEmpty {
                 if isError {
-                    ServiceContext.current?.logger?.error("\(line)")
+                    logger?.error("\(line)")
                 } else {
-                    ServiceContext.current?.logger?.info("\(line)")
+                    logger?.info("\(line)")
                 }
             }
         }
         
-        ServiceContext.current?.logger?.debug("Running xcodebuild command: \(command.joined(separator: " "))")
+        logger?.debug("Running xcodebuild command: \(command.joined(separator: " "))")
         
         try system.run(command,
                        verbose: false,


### PR DESCRIPTION
Resolves [<https://github.com/tuist/tuist/issues/YYY>](https://github.com/tuist/tuist/issues/7256)

### Short description 📝

@plu reported that in 4.39.1, logs don't show up. The regression was introduced by [this PR](https://github.com/tuist/tuist/pull/7194), which changed the approach to dependency-inject the logger. Since the [`Process`](https://github.com/swiftlang/swift-tools-support-core/blob/main/Sources/TSCBasic/Process/Process.swift) implementation that `XcodeBuildController` depends on uses `Dispatch`, the logger state is not propagated through the callbacks.

To fix it, I adjusted it to get a reference to the logger, which we can then use directly from the callbacks.

### How to test the changes locally 🧐

1. Run `tuist test` against `fixtures/ios_app_with_tests`.
2. You should see `xcodebuild` logs showing up.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
