### PR TITLE
Fix remote target type for external project

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -31,13 +31,18 @@ extension XcodeGraph.Project {
         let developmentRegion = manifest.options.developmentRegion
         let options = XcodeGraph.Project.Options.from(manifest: manifest.options)
         let settings = try manifest.settings.map { try XcodeGraph.Settings.from(manifest: $0, generatorPaths: generatorPaths) }
+        let targetType = switch type {
+        case .local: TargetType.local
+        case .external: TargetType.remote
+        }
 
         let targets = try await manifest.targets.concurrentMap {
             try await XcodeGraph.Target.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,
                 externalDependencies: externalDependencies,
-                fileSystem: fileSystem
+                fileSystem: fileSystem,
+                type: targetType
             )
         }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -31,9 +31,9 @@ extension XcodeGraph.Project {
         let developmentRegion = manifest.options.developmentRegion
         let options = XcodeGraph.Project.Options.from(manifest: manifest.options)
         let settings = try manifest.settings.map { try XcodeGraph.Settings.from(manifest: $0, generatorPaths: generatorPaths) }
-        let targetType = switch type {
-        case .local: TargetType.local
-        case .external: TargetType.remote
+        let targetType: TargetType = switch type {
+        case .local: .local
+        case .external: .remote
         }
 
         let targets = try await manifest.targets.concurrentMap {

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -34,7 +34,7 @@ extension XcodeGraph.Target {
         generatorPaths: GeneratorPaths,
         externalDependencies: [String: [XcodeGraph.TargetDependency]],
         fileSystem: FileSysteming,
-        type: TargetType = .local
+        type: TargetType
     ) async throws -> XcodeGraph.Target {
         let name = manifest.name
         let destinations = try XcodeGraph.Destination.from(destinations: manifest.destinations)

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -33,7 +33,8 @@ extension XcodeGraph.Target {
         manifest: ProjectDescription.Target,
         generatorPaths: GeneratorPaths,
         externalDependencies: [String: [XcodeGraph.TargetDependency]],
-        fileSystem: FileSysteming
+        fileSystem: FileSysteming,
+        type: TargetType = .local
     ) async throws -> XcodeGraph.Target {
         let name = manifest.name
         let destinations = try XcodeGraph.Destination.from(destinations: manifest.destinations)
@@ -165,7 +166,8 @@ extension XcodeGraph.Target {
             buildRules: buildRules,
             mergedBinaryType: mergedBinaryType,
             mergeable: manifest.mergeable,
-            onDemandResourcesTags: onDemandResourcesTags
+            onDemandResourcesTags: onDemandResourcesTags,
+            type: type
         )
     }
 

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
@@ -82,7 +82,8 @@ final class TargetManifestMapperTests: TuistUnitTestCase {
                 rootDirectory: rootDirectory
             ),
             externalDependencies: [:],
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            type: .local
         )
 
         // Then
@@ -121,7 +122,8 @@ final class TargetManifestMapperTests: TuistUnitTestCase {
                     rootDirectory: rootDirectory
                 ),
                 externalDependencies: [:],
-                fileSystem: fileSystem
+                fileSystem: fileSystem,
+                type: .local
             ),
             TargetManifestMapperError.nonSpecificGeneratedResource(targetName: "Target", generatedSource: sourcePath)
         )


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/6815>

### Short description 📝

when `.systemLibrary` convert from SPM to tuist Target, it will raise an error says not source file for this target, but mostly `systemLibrary` always not provide source file, so this should be a false alarm
before we fixed this by ignore source file lint for external target, but external target type not being passed into the init function, this PR fixed this problem

### How to test the changes locally 🧐

just do pull this branch and try generate the repro project, the warning should gone

validation:
- the source file is empty warning is gone
![Screen Shot 2025-01-22 at 17 15 52@2x](https://github.com/user-attachments/assets/153b87ea-81c3-4dff-839b-bf22f33406b1)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
