### PR TITLE
Fix documentation CSP

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -184,6 +184,20 @@ export default defineConfig({
   cleanUrls: true,
   head: [
     [
+      "meta",
+      {
+        "http-equiv": "Content-Security-Policy",
+        content: "frame-src 'self' https://*.tuist.dev",
+      },
+    ],
+    [
+      "meta",
+      {
+        "http-equiv": "Content-Security-Policy",
+        content: "frame-ancestors 'self' https://*.tuist.dev",
+      },
+    ],
+    [
       "style",
       {},
       `

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -189,6 +189,7 @@ export default defineConfig({
         "http-equiv": "Content-Security-Policy",
         content: "frame-src 'self' https://*.tuist.dev",
       },
+      ``,
     ],
     [
       "meta",
@@ -196,6 +197,7 @@ export default defineConfig({
         "http-equiv": "Content-Security-Policy",
         content: "frame-ancestors 'self' https://*.tuist.dev",
       },
+      ``,
     ],
     [
       "style",


### PR DESCRIPTION
### Short description 📝
The styles of the new documentation home don't show up. I believe it's because the loading of the page fails due to the lack of a content security policy that allows loading frames from videos.tuist.dev. This PR fixes that by including the policy using a `<meta>` tag.

<img width="1853" alt="image" src="https://github.com/user-attachments/assets/92d9449e-8c2f-456d-a1d1-26066e3f8dde" />
