### PR TITLE
Fix the loading of the documentation's home

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -187,15 +187,7 @@ export default defineConfig({
       "meta",
       {
         "http-equiv": "Content-Security-Policy",
-        content: "frame-src 'self' https://*.tuist.dev",
-      },
-      ``,
-    ],
-    [
-      "meta",
-      {
-        "http-equiv": "Content-Security-Policy",
-        content: "frame-ancestors 'self' https://*.tuist.dev",
+        content: "frame-src 'self' https://videos.tuist.dev",
       },
       ``,
     ],


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7264

As detailed [here](https://github.com/tuist/tuist/issues/7264), the embedded videos fail to load due to a content-security-policy issue. This PR attempts to fix it by removing the `frame-ancestors` (this is needed when it's other sites the ones embedding our documentation) and adjusting `frame-src` to have the exact domain ` https://videos.tuist.dev`.