### PR TITLE
Fix documentation home styling

### DIFF
--- a/docs/.vitepress/theme/components/HomeCommunity.vue
+++ b/docs/.vitepress/theme/components/HomeCommunity.vue
@@ -1,0 +1,20 @@
+<script setup></script>
+
+<template>
+    <div class="community">
+        <slot></slot>
+    </div>
+</template>
+
+<style scoped>
+.community {
+    display: grid;
+    position: relative;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem;
+
+    @media (max-width: 960px) {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}
+</style>

--- a/docs/.vitepress/theme/components/HomeCommunityItem.vue
+++ b/docs/.vitepress/theme/components/HomeCommunityItem.vue
@@ -1,0 +1,62 @@
+<script setup>
+defineProps(["title", "description", "href"]);
+</script>
+
+<template>
+    <a target="_blank" class="item" :href>
+        <article>
+            <div>
+                <slot name="logo"></slot>
+            </div>
+            <div>
+                <h2>{{ title }}</h2>
+                <p>{{ description }}</p>
+            </div>
+        </article>
+    </a>
+</template>
+
+<style scoped>
+.item {
+    text-decoration: none;
+
+    & > article {
+        display: flex;
+        padding: 24px;
+        flex-direction: row;
+        gap: 1rem;
+        border: 1px solid var(--vp-c-bg-soft);
+        border-radius: 12px;
+        height: 100%;
+        background-color: var(--vp-c-bg-soft);
+        transition:
+            border-color 0.25s,
+            background-color 0.25s;
+
+        &:hover {
+            background-color: var(--vp-button-alt-hover-bg);
+            & h2 {
+                color: var(--vp-c-brand-1);
+            }
+        }
+
+        & h2 {
+            text-decoration: none;
+            margin-top: 0px;
+            padding-top: 0px;
+            border: 0px;
+            line-height: 24px;
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--vp-c-text-1);
+        }
+
+        & p {
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--vp-c-text-2);
+        }
+    }
+}
+</style>

--- a/docs/.vitepress/theme/components/HomeVideos.vue
+++ b/docs/.vitepress/theme/components/HomeVideos.vue
@@ -1,0 +1,29 @@
+<script setup>
+defineProps(["videos"]);
+</script>
+
+<template>
+    <div class="videos">
+        <slot></slot>
+        <iframe
+            v-for="[title, videoId] in videos"
+            :title
+            width="336"
+            height="189"
+            :src="`https://videos.tuist.dev/videos/embed/${videoId}`"
+            frameborder="0"
+            allowfullscreen=""
+            sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+        ></iframe>
+    </div>
+</template>
+
+<style scoped>
+.videos {
+    display: flex;
+    flex-direction: row;
+    gap: 3rem;
+    overflow: scroll;
+    padding-bottom: 2rem;
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -5,6 +5,9 @@ import Layout from "./layouts/Layout.vue";
 import LocalizedLink from "./components/LocalizedLink.vue";
 import HomeCard from "./components/HomeCard.vue";
 import HomeCards from "./components/HomeCards.vue";
+import HomeVideos from "./components/HomeVideos.vue";
+import HomeCommunity from "./components/HomeCommunity.vue";
+import HomeCommunityItem from "./components/HomeCommunityItem.vue";
 
 export default {
   Layout,
@@ -13,5 +16,8 @@ export default {
     app.component("LocalizedLink", LocalizedLink);
     app.component("HomeCard", HomeCard);
     app.component("HomeCards", HomeCards);
+    app.component("HomeVideos", HomeVideos);
+    app.component("HomeCommunity", HomeCommunity);
+    app.component("HomeCommunityItem", HomeCommunityItem);
   },
 };

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -93,106 +93,59 @@ Try out Tuist in minutes and learn how to get the most out of Tuist.
 
 Explore our team's presentations. Stay informed and gain expertise.
 
-<div class="videos">
-    <iframe title="Running latest Tuist Previews" width="336" height="189" src="https://videos.tuist.dev/videos/embed/6872527d-4225-469d-9b89-2ec562c37603" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
-    <iframe title="Inspect implicit imports to make Xcode more reliable and its builds more deterministic" width="336" height="189" src="https://videos.tuist.dev/videos/embed/88696ce1-aa08-48e8-b410-bc7a57726d67" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
-    <iframe title="Clean Xcode builds with binary XCFrameworks from Tuist Cloud" width="336" height="189" src="https://videos.tuist.dev/videos/embed/3a15bae1-a0b2-4c6e-97f2-f78457d87099" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
-</div>
+<HomeVideos :videos="[['Tuist Registry Walkthrough', '2bd2deb4-1897-4c5b-9de6-37c8acd16fb0'],['Running latest Tuist Previews', '6872527d-4225-469d-9b89-2ec562c37603'], ['Inspect implicit imports to make Xcode more reliable and its builds more deterministic', '88696ce1-aa08-48e8-b410-bc7a57726d67'], ['Clean Xcode builds with binary XCFrameworks from Tuist Cloud', '3a15bae1-a0b2-4c6e-97f2-f78457d87099']]"/>
 
 ## Join the community
 
 See the source code, connect with others, and get connected.
 
-<div class="community">
-    <a target="_blank" href="https://community.tuist.dev" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg width="30" height="30" xmlns="http://www.w3.org/2000/svg" viewBox="0 -1 104 106">
-                  <path fill="#231f20" d="M51.87 0C23.71 0 0 22.83 0 51v52.81l51.86-.05c28.16 0 51-23.71 51-51.87S80 0 51.87 0Z"/>
-                  <path fill="#fff9ae" d="M52.37 19.74a31.62 31.62 0 0 0-27.79 46.67l-5.72 18.4 20.54-4.64a31.61 31.61 0 1 0 13-60.43Z"/>
-                  <path fill="#00aeef" d="M77.45 32.12a31.6 31.6 0 0 1-38.05 48l-20.54 4.7 20.91-2.47a31.6 31.6 0 0 0 37.68-50.23Z"/>
-                  <path fill="#00a94f" d="M71.63 26.29A31.6 31.6 0 0 1 38.8 78l-19.94 6.82 20.54-4.65a31.6 31.6 0 0 0 32.23-53.88Z"/>
-                  <path fill="#f15d22" d="M26.47 67.11a31.61 31.61 0 0 1 51-35 31.61 31.61 0 0 0-52.89 34.3l-5.72 18.4Z"/>
-                  <path fill="#e31b23" d="M24.58 66.41a31.61 31.61 0 0 1 47.05-40.12 31.61 31.61 0 0 0-49 39.63l-3.76 18.9Z"/>
-                </svg>
-            </div>
-            <div>
-                <h2>Forum</h2>
-                <p>Join our forum to engage with other community members</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://slack.tuist.io/" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg height="30" style="enable-background:new 0 0 512 512;" version="1.1" viewBox="0 0 512 512" width="30" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="_x33_06-slack"><g><path d="M122.643,316.682c0,26.596-21.727,48.323-48.321,48.323c-26.593,0-48.319-21.728-48.319-48.323    c0-26.592,21.727-48.318,48.319-48.318h48.321V316.682z" style="fill:#E01E5A;"/><path d="M146.996,316.682c0-26.592,21.728-48.318,48.321-48.318c26.593,0,48.32,21.727,48.32,48.318V437.68    c0,26.592-21.728,48.319-48.32,48.319c-26.594,0-48.321-21.728-48.321-48.319V316.682z" style="fill:#E01E5A;"/><path d="M195.317,122.643c-26.594,0-48.321-21.728-48.321-48.321c0-26.593,21.728-48.32,48.321-48.32    c26.593,0,48.32,21.728,48.32,48.32v48.321H195.317L195.317,122.643z" style="fill:#36C5F0;"/><path d="M195.317,146.997c26.593,0,48.32,21.727,48.32,48.321c0,26.593-21.728,48.318-48.32,48.318H74.321    c-26.593,0-48.319-21.726-48.319-48.318c0-26.595,21.727-48.321,48.319-48.321H195.317L195.317,146.997z" style="fill:#36C5F0;"/><path d="M389.359,195.318c0-26.595,21.725-48.321,48.32-48.321c26.593,0,48.318,21.727,48.318,48.321    c0,26.593-21.726,48.318-48.318,48.318h-48.32V195.318L389.359,195.318z" style="fill:#2EB67D;"/><path d="M365.004,195.318c0,26.593-21.728,48.318-48.321,48.318c-26.593,0-48.32-21.726-48.32-48.318    V74.321c0-26.593,21.728-48.32,48.32-48.32c26.594,0,48.321,21.728,48.321,48.32V195.318L365.004,195.318z" style="fill:#2EB67D;"/><path d="M316.683,389.358c26.594,0,48.321,21.727,48.321,48.321c0,26.592-21.728,48.319-48.321,48.319    c-26.593,0-48.32-21.728-48.32-48.319v-48.321H316.683z" style="fill:#ECB22E;"/><path d="M316.683,365.005c-26.593,0-48.32-21.728-48.32-48.323c0-26.592,21.728-48.318,48.32-48.318H437.68    c26.593,0,48.318,21.727,48.318,48.318c0,26.596-21.726,48.323-48.318,48.323H316.683z" style="fill:#ECB22E;"/></g></g><g id="Layer_1"/></svg>
-            </div>
-            <div>
-                <h2>Slack</h2>
-                <p>Interact with other community members in a synchronous manner</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://videos.tuist.dev/" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg xmlns="http://www.w3.org/2000/svg" height="30" width="30" viewBox="2799 -911 512 682.688"><g stroke-width="32"><path d="m2799-911v341.344l256-170.656" fill="#211f20"/><path d="m2799-569.656v341.344l256-170.656" fill="#737373"/><path d="m3055-740.344v341.344l256-170.656" fill="#f1680d"/></g></svg>
-            </div>
-            <div>
-                <h2>Videos</h2>
-                <p>Watch talks from the Tuist team and the community</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://github.com/tuist" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 1024 1024" fill="none">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z" transform="scale(64)" fill="#1B1F23"/>
-                </svg>
-            </div>
-            <div>
-                <h2>GitHub</h2>
-                <p>Check out our contributions to open source</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://bsky.app/profile/tuist.dev" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -3.268 64 68.414" width="30" height="30"><path fill="#0085ff" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805zm36.254 0C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745z"/></svg>
-            </div>
-            <div>
-                <h2>Bluesky</h2>
-                <p>Follow us on Bluesky to stay up to date with our work</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://fosstodon.org/@tuist" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg height="30" width="30" xmlns="http://www.w3.org/2000/svg" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality" fill-rule="evenodd" clip-rule="evenodd" viewBox="0 0 480 511.476"><defs><linearGradient id="prefix__a" gradientUnits="userSpaceOnUse" x1="235.378" y1=".003" x2="235.378" y2="506.951"><stop offset="0" stop-color="#6364FF"/><stop offset="1" stop-color="#563ACC"/></linearGradient></defs><g fill-rule="nonzero"><path fill="url(#prefix__a)" d="M478.064 113.237c-7.393-54.954-55.29-98.266-112.071-106.656C356.413 5.163 320.121 0 236.045 0h-.628c-84.1 0-102.141 5.163-111.72 6.581C68.498 14.739 18.088 53.655 5.859 109.261c-5.883 27.385-6.51 57.747-5.416 85.596 1.555 39.939 1.859 79.806 5.487 119.581a562.694 562.694 0 0013.089 78.437c11.625 47.654 58.687 87.313 104.793 103.494a281.073 281.073 0 00153.316 8.09 224.345 224.345 0 0016.577-4.533c12.369-3.928 26.856-8.321 37.506-16.042.146-.107.265-.247.348-.407.086-.161.134-.339.14-.521v-38.543a1.187 1.187 0 00-.119-.491 1.122 1.122 0 00-.773-.604 1.139 1.139 0 00-.503 0 424.932 424.932 0 01-99.491 11.626c-57.664 0-73.171-27.361-77.611-38.752a120.09 120.09 0 01-6.745-30.546 1.123 1.123 0 01.877-1.152c.173-.035.349-.032.518.012a416.876 416.876 0 0097.864 11.623c7.929 0 15.834 0 23.763-.211 33.155-.928 68.103-2.626 100.722-8.997.815-.16 1.63-.3 2.326-.508 51.454-9.883 100.422-40.894 105.397-119.42.185-3.093.651-32.385.651-35.591.022-10.903 3.51-77.343-.511-118.165z"/><path fill="#fff" d="M396.545 174.981v136.53h-54.104V179.002c0-27.896-11.625-42.124-35.272-42.124-25.996 0-39.017 16.833-39.017 50.074v72.531h-53.777v-72.531c0-33.241-13.044-50.074-39.04-50.074-23.507 0-35.248 14.228-35.248 42.124v132.509H86.006v-136.53c0-27.896 7.123-50.059 21.366-66.488 14.695-16.387 33.97-24.803 57.896-24.803 27.691 0 48.617 10.647 62.568 31.917l13.464 22.597 13.484-22.597c13.951-21.27 34.877-31.917 62.521-31.917 23.902 0 43.177 8.416 57.919 24.803 14.231 16.414 21.336 38.577 21.321 66.488z"/></g></svg>
-            </div>
-            <div>
-                <h2>Mastodon</h2>
-                <p>Follow us on Bluesky to stay up to date with our work</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://www.linkedin.com/company/tuistio" class="community__target">
-        <article class="community__target__article">
-            <div>
-                <svg xmlns="http://www.w3.org/2000/svg" height="30" viewBox="0 0 72 72" width="30"><g fill="none" fill-rule="evenodd"><path d="M8,72 L64,72 C68.418278,72 72,68.418278 72,64 L72,8 C72,3.581722 68.418278,-8.11624501e-16 64,0 L8,0 C3.581722,8.11624501e-16 -5.41083001e-16,3.581722 0,8 L0,64 C5.41083001e-16,68.418278 3.581722,72 8,72 Z" fill="#007EBB"/><path d="M62,62 L51.315625,62 L51.315625,43.8021149 C51.315625,38.8127542 49.4197917,36.0245323 45.4707031,36.0245323 C41.1746094,36.0245323 38.9300781,38.9261103 38.9300781,43.8021149 L38.9300781,62 L28.6333333,62 L28.6333333,27.3333333 L38.9300781,27.3333333 L38.9300781,32.0029283 C38.9300781,32.0029283 42.0260417,26.2742151 49.3825521,26.2742151 C56.7356771,26.2742151 62,30.7644705 62,40.051212 L62,62 Z M16.349349,22.7940133 C12.8420573,22.7940133 10,19.9296567 10,16.3970067 C10,12.8643566 12.8420573,10 16.349349,10 C19.8566406,10 22.6970052,12.8643566 22.6970052,16.3970067 C22.6970052,19.9296567 19.8566406,22.7940133 16.349349,22.7940133 Z M11.0325521,62 L21.769401,62 L21.769401,27.3333333 L11.0325521,27.3333333 L11.0325521,62 Z" fill="#FFF"/></g></svg>
-            </div>
-            <div>
-                <h2>LinkedIn</h2>
-                <p>Follow Tuist on LinkedIn for news and updates</p>
-            </div>
-        </article>
-    </a>
-    <a target="_blank" href="https://www.reddit.com/r/tuist/" class="community__target">
-        <article class="community__target__article">
-            <div>
+<HomeCommunity>
+    <HomeCommunityItem title="Forum" description="Interact with other community members in a synchronous manner" href="https://community.tuist.dev">
+        <template v-slot:logo>
+            <svg width="30" height="30" xmlns="http://www.w3.org/2000/svg" viewBox="0 -1 104 106">
+              <path fill="#231f20" d="M51.87 0C23.71 0 0 22.83 0 51v52.81l51.86-.05c28.16 0 51-23.71 51-51.87S80 0 51.87 0Z"/>
+              <path fill="#fff9ae" d="M52.37 19.74a31.62 31.62 0 0 0-27.79 46.67l-5.72 18.4 20.54-4.64a31.61 31.61 0 1 0 13-60.43Z"/>
+              <path fill="#00aeef" d="M77.45 32.12a31.6 31.6 0 0 1-38.05 48l-20.54 4.7 20.91-2.47a31.6 31.6 0 0 0 37.68-50.23Z"/>
+              <path fill="#00a94f" d="M71.63 26.29A31.6 31.6 0 0 1 38.8 78l-19.94 6.82 20.54-4.65a31.6 31.6 0 0 0 32.23-53.88Z"/>
+              <path fill="#f15d22" d="M26.47 67.11a31.61 31.61 0 0 1 51-35 31.61 31.61 0 0 0-52.89 34.3l-5.72 18.4Z"/>
+              <path fill="#e31b23" d="M24.58 66.41a31.61 31.61 0 0 1 47.05-40.12 31.61 31.61 0 0 0-49 39.63l-3.76 18.9Z"/>
+            </svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="Slack" description="Interact with other community members in a synchronous manner" href="https://slack.tuist.io/">
+        <template v-slot:logo>
+        <svg height="30" style="enable-background:new 0 0 512 512;" version="1.1" viewBox="0 0 512 512" width="30" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="_x33_06-slack"><g><path d="M122.643,316.682c0,26.596-21.727,48.323-48.321,48.323c-26.593,0-48.319-21.728-48.319-48.323    c0-26.592,21.727-48.318,48.319-48.318h48.321V316.682z" style="fill:#E01E5A;"/><path d="M146.996,316.682c0-26.592,21.728-48.318,48.321-48.318c26.593,0,48.32,21.727,48.32,48.318V437.68    c0,26.592-21.728,48.319-48.32,48.319c-26.594,0-48.321-21.728-48.321-48.319V316.682z" style="fill:#E01E5A;"/><path d="M195.317,122.643c-26.594,0-48.321-21.728-48.321-48.321c0-26.593,21.728-48.32,48.321-48.32    c26.593,0,48.32,21.728,48.32,48.32v48.321H195.317L195.317,122.643z" style="fill:#36C5F0;"/><path d="M195.317,146.997c26.593,0,48.32,21.727,48.32,48.321c0,26.593-21.728,48.318-48.32,48.318H74.321    c-26.593,0-48.319-21.726-48.319-48.318c0-26.595,21.727-48.321,48.319-48.321H195.317L195.317,146.997z" style="fill:#36C5F0;"/><path d="M389.359,195.318c0-26.595,21.725-48.321,48.32-48.321c26.593,0,48.318,21.727,48.318,48.321    c0,26.593-21.726,48.318-48.318,48.318h-48.32V195.318L389.359,195.318z" style="fill:#2EB67D;"/><path d="M365.004,195.318c0,26.593-21.728,48.318-48.321,48.318c-26.593,0-48.32-21.726-48.32-48.318    V74.321c0-26.593,21.728-48.32,48.32-48.32c26.594,0,48.321,21.728,48.321,48.32V195.318L365.004,195.318z" style="fill:#2EB67D;"/><path d="M316.683,389.358c26.594,0,48.321,21.727,48.321,48.321c0,26.592-21.728,48.319-48.321,48.319    c-26.593,0-48.32-21.728-48.32-48.319v-48.321H316.683z" style="fill:#ECB22E;"/><path d="M316.683,365.005c-26.593,0-48.32-21.728-48.32-48.323c0-26.592,21.728-48.318,48.32-48.318H437.68    c26.593,0,48.318,21.727,48.318,48.318c0,26.596-21.726,48.323-48.318,48.323H316.683z" style="fill:#ECB22E;"/></g></g><g id="Layer_1"/></svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="Videos" description="Watch talks from the Tuist team and the community" href="https://videos.tuist.dev/">
+        <template v-slot:logo>
+        <svg xmlns="http://www.w3.org/2000/svg" height="30" width="30" viewBox="2799 -911 512 682.688"><g stroke-width="32"><path d="m2799-911v341.344l256-170.656" fill="#211f20"/><path d="m2799-569.656v341.344l256-170.656" fill="#737373"/><path d="m3055-740.344v341.344l256-170.656" fill="#f1680d"/></g></svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="GitHub" description="Check out our contributions to open source" href="https://github.com/tuist">
+        <template v-slot:logo>
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 1024 1024" fill="none">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z" transform="scale(64)" fill="#1B1F23"/>
+            </svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="Bluesky" description="Follow us on Bluesky to stay up to date with our work" href="https://bsky.app/profile/tuist.dev">
+        <template v-slot:logo>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -3.268 64 68.414" width="30" height="30"><path fill="#0085ff" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805zm36.254 0C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745z"/></svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="Mastodon" description="Follow us on Bluesky to stay up to date with our work" href="https://fosstodon.org/@tuist">
+        <template v-slot:logo>
+            <svg height="30" width="30" xmlns="http://www.w3.org/2000/svg" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality" fill-rule="evenodd" clip-rule="evenodd" viewBox="0 0 480 511.476"><defs><linearGradient id="prefix__a" gradientUnits="userSpaceOnUse" x1="235.378" y1=".003" x2="235.378" y2="506.951"><stop offset="0" stop-color="#6364FF"/><stop offset="1" stop-color="#563ACC"/></linearGradient></defs><g fill-rule="nonzero"><path fill="url(#prefix__a)" d="M478.064 113.237c-7.393-54.954-55.29-98.266-112.071-106.656C356.413 5.163 320.121 0 236.045 0h-.628c-84.1 0-102.141 5.163-111.72 6.581C68.498 14.739 18.088 53.655 5.859 109.261c-5.883 27.385-6.51 57.747-5.416 85.596 1.555 39.939 1.859 79.806 5.487 119.581a562.694 562.694 0 0013.089 78.437c11.625 47.654 58.687 87.313 104.793 103.494a281.073 281.073 0 00153.316 8.09 224.345 224.345 0 0016.577-4.533c12.369-3.928 26.856-8.321 37.506-16.042.146-.107.265-.247.348-.407.086-.161.134-.339.14-.521v-38.543a1.187 1.187 0 00-.119-.491 1.122 1.122 0 00-.773-.604 1.139 1.139 0 00-.503 0 424.932 424.932 0 01-99.491 11.626c-57.664 0-73.171-27.361-77.611-38.752a120.09 120.09 0 01-6.745-30.546 1.123 1.123 0 01.877-1.152c.173-.035.349-.032.518.012a416.876 416.876 0 0097.864 11.623c7.929 0 15.834 0 23.763-.211 33.155-.928 68.103-2.626 100.722-8.997.815-.16 1.63-.3 2.326-.508 51.454-9.883 100.422-40.894 105.397-119.42.185-3.093.651-32.385.651-35.591.022-10.903 3.51-77.343-.511-118.165z"/><path fill="#fff" d="M396.545 174.981v136.53h-54.104V179.002c0-27.896-11.625-42.124-35.272-42.124-25.996 0-39.017 16.833-39.017 50.074v72.531h-53.777v-72.531c0-33.241-13.044-50.074-39.04-50.074-23.507 0-35.248 14.228-35.248 42.124v132.509H86.006v-136.53c0-27.896 7.123-50.059 21.366-66.488 14.695-16.387 33.97-24.803 57.896-24.803 27.691 0 48.617 10.647 62.568 31.917l13.464 22.597 13.484-22.597c13.951-21.27 34.877-31.917 62.521-31.917 23.902 0 43.177 8.416 57.919 24.803 14.231 16.414 21.336 38.577 21.321 66.488z"/></g></svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="LinkedIn" description="Follow Tuist on LinkedIn for news and updates" href="https://www.linkedin.com/company/tuistio">
+        <template v-slot:logo>
+            <svg xmlns="http://www.w3.org/2000/svg" height="30" viewBox="0 0 72 72" width="30"><g fill="none" fill-rule="evenodd"><path d="M8,72 L64,72 C68.418278,72 72,68.418278 72,64 L72,8 C72,3.581722 68.418278,-8.11624501e-16 64,0 L8,0 C3.581722,8.11624501e-16 -5.41083001e-16,3.581722 0,8 L0,64 C5.41083001e-16,68.418278 3.581722,72 8,72 Z" fill="#007EBB"/><path d="M62,62 L51.315625,62 L51.315625,43.8021149 C51.315625,38.8127542 49.4197917,36.0245323 45.4707031,36.0245323 C41.1746094,36.0245323 38.9300781,38.9261103 38.9300781,43.8021149 L38.9300781,62 L28.6333333,62 L28.6333333,27.3333333 L38.9300781,27.3333333 L38.9300781,32.0029283 C38.9300781,32.0029283 42.0260417,26.2742151 49.3825521,26.2742151 C56.7356771,26.2742151 62,30.7644705 62,40.051212 L62,62 Z M16.349349,22.7940133 C12.8420573,22.7940133 10,19.9296567 10,16.3970067 C10,12.8643566 12.8420573,10 16.349349,10 C19.8566406,10 22.6970052,12.8643566 22.6970052,16.3970067 C22.6970052,19.9296567 19.8566406,22.7940133 16.349349,22.7940133 Z M11.0325521,62 L21.769401,62 L21.769401,27.3333333 L11.0325521,27.3333333 L11.0325521,62 Z" fill="#FFF"/></g></svg>
+        </template>
+    </HomeCommunityItem>
+    <HomeCommunityItem title="Reddit" description="Get the latest updates on r/tuist" href="https://www.reddit.com/r/tuist/">
+        <template v-slot:logo>
             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="30" height="30" viewBox="0 0 256 256" xml:space="preserve">
             <defs>
             </defs>
@@ -201,75 +154,6 @@ See the source code, connect with others, and get connected.
 	<path d="M 75.011 45 c -0.134 -3.624 -3.177 -6.454 -6.812 -6.331 c -1.611 0.056 -3.143 0.716 -4.306 1.823 c -5.123 -3.49 -11.141 -5.403 -17.327 -5.537 l 2.919 -14.038 l 9.631 2.025 c 0.268 2.472 2.483 4.262 4.955 3.993 c 2.472 -0.268 4.262 -2.483 3.993 -4.955 s -2.483 -4.262 -4.955 -3.993 c -1.421 0.145 -2.696 0.973 -3.4 2.204 L 48.68 17.987 c -0.749 -0.168 -1.499 0.302 -1.667 1.063 c 0 0.011 0 0.011 0 0.022 l -3.322 15.615 c -6.264 0.101 -12.36 2.025 -17.55 5.537 c -2.64 -2.483 -6.801 -2.36 -9.284 0.291 c -2.483 2.64 -2.36 6.801 0.291 9.284 c 0.515 0.481 1.107 0.895 1.767 1.186 c -0.045 0.66 -0.045 1.32 0 1.98 c 0 10.078 11.745 18.277 26.23 18.277 c 14.485 0 26.23 -8.188 26.23 -18.277 c 0.045 -0.66 0.045 -1.32 0 -1.98 C 73.635 49.855 75.056 47.528 75.011 45 z M 30.011 49.508 c 0 -2.483 2.025 -4.508 4.508 -4.508 c 2.483 0 4.508 2.025 4.508 4.508 s -2.025 4.508 -4.508 4.508 C 32.025 53.993 30.011 51.991 30.011 49.508 z M 56.152 62.058 v -0.179 c -3.199 2.405 -7.114 3.635 -11.119 3.468 c -4.005 0.168 -7.919 -1.063 -11.119 -3.468 c -0.425 -0.515 -0.347 -1.286 0.168 -1.711 c 0.447 -0.369 1.085 -0.369 1.544 0 c 2.707 1.98 6.007 2.987 9.362 2.83 c 3.356 0.179 6.667 -0.783 9.407 -2.74 c 0.492 -0.481 1.297 -0.47 1.779 0.022 C 56.655 60.772 56.644 61.577 56.152 62.058 z M 55.537 54.34 c -0.078 0 -0.145 0 -0.224 0 l 0.034 -0.168 c -2.483 0 -4.508 -2.025 -4.508 -4.508 s 2.025 -4.508 4.508 -4.508 s 4.508 2.025 4.508 4.508 C 59.955 52.148 58.02 54.239 55.537 54.34 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round" />
             </g>
             </svg>
-            </div>
-            <div>
-                <h2>Reddit</h2>
-                <p>Get the latest updates on r/tuist</p>
-            </div>
-        </article>
-    </a>
-</div>
-
-
-<style scoped>
-.videos {
-    display: flex;
-    flex-direction: row;
-    gap: 3rem;
-    overflow: scroll;
-}
-.community {
-    display: grid;
-    position: relative;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 2rem;
-
-    @media (max-width: 960px) {
-        grid-template-columns: repeat(1, 1fr);
-    }
-
-}
-
-.community__target {
-    text-decoration: none;
-}
-
-.community__target__article {
-    display: flex;
-    padding: 24px;
-    flex-direction: row;
-    gap: 1rem;
-    border: 1px solid var(--vp-c-bg-soft);
-    border-radius: 12px;
-    height: 100%;
-    background-color: var(--vp-c-bg-soft);
-    transition:
-        border-color 0.25s,
-        background-color 0.25s;
-
-    &:hover {
-        background-color: var(--vp-button-alt-hover-bg);
-        & h2 {
-            color: var(--vp-c-brand-1);
-        }
-    }
-
-    & h2 {
-        text-decoration: none;
-        margin-top: 0px;
-        padding-top: 0px;
-        border: 0px;
-        line-height: 24px;
-        font-size: 16px;
-        font-weight: 600;
-        color: var(--vp-c-text-1);
-    }
-
-    & p {
-        text-decoration: none;
-        font-size: 14px;
-        font-weight: 500;
-        color: var(--vp-c-text-2);
-    }
-}
-</style>
+        </template>
+    </HomeCommunityItem>
+</HomeCommunity>


### PR DESCRIPTION
This is yet another attempt to fix the styling of the documentation home page. I could not reproduce the issue locally so my assumption is that during the production build process styles are stripped away and not included in the final bundle. Since the other parts of the page worked by extracting them into components, I did the same for the sections that don't work.

### Broken style

<img width="1482" alt="image" src="https://github.com/user-attachments/assets/b2ada75a-4a74-4e2c-895e-2cc9126c2add" />


### Right style

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/a3e546ee-0a62-4cbb-8d03-24208b30641c" />
