### PR TITLE
fix: link status .none shouldn't block other dependencies from linking

### DIFF
--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -435,7 +435,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             case .bundle, .macro, .packageProduct:
                 break
             case let .product(dependencyTarget, _, status, condition):
-                guard status != .none else { return }
+                guard status != .none else { continue }
                 guard let fileRef = fileElements.product(target: dependencyTarget) else {
                     throw LinkGeneratorError.missingProduct(name: dependencyTarget)
                 }
@@ -445,7 +445,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 pbxproj.add(object: buildFile)
                 buildPhase.files?.append(buildFile)
             case let .sdk(sdkPath, sdkStatus, _, condition):
-                guard sdkStatus != .none else { return }
+                guard sdkStatus != .none else { continue }
                 guard let fileRef = fileElements.sdk(path: sdkPath) else {
                     throw LinkGeneratorError.missingReference(path: sdkPath)
                 }

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -915,12 +915,18 @@ final class GenerateAcceptanceTestiOSAppWithNoneLinkingStatusFramework: TuistAcc
             pathString: xcodeprojPath.pathString
         )
         let target = try XCTUnwrapTarget("App", in: xcodeproj)
-        let frameworksBuildPhase = try target.frameworksBuildPhase()
-        guard let frameworkFiles = frameworksBuildPhase?.files else {
-            XCTFail("A linking dependencies phase should exist even though empty")
+        guard try target.frameworksBuildPhase()?.files?
+            .contains(where: { $0.file?.nameOrPath == "MyFramework.framework" }) == false
+        else {
+            XCTFail("App shouldn't link MyFramework.framework")
             return
         }
-        XCTAssertEmpty(frameworkFiles)
+        guard try target.frameworksBuildPhase()?.files?
+            .contains(where: { $0.file?.nameOrPath == "ThyFramework.framework" }) == true
+        else {
+            XCTFail("App doesn't link ThyFramework.framework")
+            return
+        }
     }
 }
 

--- a/fixtures/ios_app_with_none_linking_status_framework/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/App/Sources/AppDelegate.swift
@@ -1,4 +1,5 @@
 // importing MyFramework would not work, because it is not linked
+import ThyFramework
 import UIKit
 
 @main
@@ -7,6 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidFinishLaunching(_: UIApplication) {
         // let myFramework = MyFramework() // Things we can't do
+        let thyFramework = ThyFramework()
         print("myFramework.hello()")
+        print(thyFramework.hello())
     }
 }

--- a/fixtures/ios_app_with_none_linking_status_framework/Project.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/Project.swift
@@ -19,6 +19,7 @@ let project = Project(
             sources: ["App/Sources/**"],
             dependencies: [
                 .target(name: "MyFramework", status: .none),
+                .target(name: "ThyFramework"),
             ]
         ),
         .target(
@@ -28,6 +29,13 @@ let project = Project(
             bundleId: "io.tuist.MyFramework",
             sources: ["MyFramework/Sources/**"],
             dependencies: []
+        ),
+        .target(
+            name: "ThyFramework",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.ThyFramework",
+            sources: ["ThyFramework/Sources/**"]
         ),
     ]
 )

--- a/fixtures/ios_app_with_none_linking_status_framework/ThyFramework/Sources/ThyFramework.swift
+++ b/fixtures/ios_app_with_none_linking_status_framework/ThyFramework/Sources/ThyFramework.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public class ThyFramework {
+    public init() {}
+    public func hello() -> String {
+        return "ThyFramework.hello()"
+    }
+}


### PR DESCRIPTION
### Short description 📝

If a target dependency is found with linking status `.none`, any subsequent dependencies will not be linked by the link generator. This is not expected behavior and it is now fixed.

### How to test the changes locally 🧐

Acceptance test has been updated.

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint-fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
