### PR TITLE
Fix tuist init platform flag completions

### DIFF
--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -24,7 +24,7 @@ public struct InitCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         help: "The platform (iOS, tvOS, visionOS, watchOS or macOS) the product will be for (Default: iOS)",
-        completion: .list(["ios", "tvos", "macos", "visionos", "watchos"]),
+        completion: .list(XcodeGraph.Platform.allValueStrings),
         envKey: .initPlatform
     )
     var platform: String?

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -24,7 +24,7 @@ public struct InitCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         help: "The platform (iOS, tvOS, visionOS, watchOS or macOS) the product will be for (Default: iOS)",
-        completion: .list(["iOS", "tvOS", "macOS", "visionOS", "watchOS"]),
+        completion: .list(["ios", "tvos", "macos", "visionos", "watchos"]),
         envKey: .initPlatform
     )
     var platform: String?


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7274>

### Short description 📝

> As described in #7274, the default completions for the fish shell (untested in other shells, but based on the code likely the same) for the `--platform` flag of `tuist init` produce errors. This PR changes the completions to all lowercase (`iOS` -> `ios`, `macOS` -> `macos`, etc.), as the rest of the CLI expects them.

### How to test the changes locally 🧐

> With this version built, you should be able to run `tuist --generate-completion-script` and whatever other [steps are needed for your shell](https://docs.tuist.dev/en/guides/quick-start/install-tuist#shell-completions). Then, typing `tuist init --project ` and hitting tab should give completions that the CLI won't error on (`

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
