### PR TITLE
Upload project path to server when submitting command events

### DIFF
--- a/Sources/TuistCore/Analytics/CommandEventProject.swift
+++ b/Sources/TuistCore/Analytics/CommandEventProject.swift
@@ -4,13 +4,16 @@ import XcodeGraph
 /// A simplified `GraphTarget` to store in `CommandEvent`.
 public struct CommandEventProject: Codable, Hashable {
     public let name: String
+    public let path: RelativePath
     public let targets: [CommandEventTarget]
 
     public init(
         name: String,
+        path: RelativePath,
         targets: [CommandEventTarget]
     ) {
         self.name = name
+        self.path = path
         self.targets = targets
     }
 }
@@ -19,10 +22,12 @@ public struct CommandEventProject: Codable, Hashable {
     extension CommandEventProject {
         public static func test(
             name: String = "Project",
+            path: RelativePath = try! RelativePath(validating: "App"),
             targets: [CommandEventTarget] = []
         ) -> Self {
             Self(
                 name: name,
+                path: path,
                 targets: targets
             )
         }

--- a/Sources/TuistCore/Analytics/CommandEventProject.swift
+++ b/Sources/TuistCore/Analytics/CommandEventProject.swift
@@ -22,6 +22,7 @@ public struct CommandEventProject: Codable, Hashable {
     extension CommandEventProject {
         public static func test(
             name: String = "Project",
+            // swiftlint:disable:next force_try
             path: RelativePath = try! RelativePath(validating: "App"),
             targets: [CommandEventTarget] = []
         ) -> Self {

--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -85,6 +85,7 @@ public final class CommandEventFactory {
             projects: graph.projects.map { project in
                 CommandEventProject(
                     name: project.value.name,
+                    path: project.value.path.relative(to: graph.path),
                     targets: project.value.targets.map { target in
                         let binaryCacheMetadata: CommandEventCacheTargetMetadata?
                         if let hash = binaryCacheAnalytics?.hashes[project.value.path]?[target.value.name] {

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -3089,6 +3089,10 @@ internal enum Operations {
                             ///
                             /// - Remark: Generated from `#/paths/api/analytics/POST/requestBody/json/xcode_graph/projectsPayload/name`.
                             internal var name: Swift.String
+                            /// Path of the project
+                            ///
+                            /// - Remark: Generated from `#/paths/api/analytics/POST/requestBody/json/xcode_graph/projectsPayload/path`.
+                            internal var path: Swift.String
                             /// - Remark: Generated from `#/paths/api/analytics/POST/requestBody/json/xcode_graph/projectsPayload/targetsPayload`.
                             internal struct targetsPayloadPayload: Codable, Hashable, Sendable {
                                 /// Binary cache metadata
@@ -3210,16 +3214,20 @@ internal enum Operations {
                             ///
                             /// - Parameters:
                             ///   - name: Name of the project
+                            ///   - path: Path of the project
                             ///   - targets: Targets present in a project
                             internal init(
                                 name: Swift.String,
+                                path: Swift.String,
                                 targets: Operations.createCommandEvent.Input.Body.jsonPayload.xcode_graphPayload.projectsPayloadPayload.targetsPayload
                             ) {
                                 self.name = name
+                                self.path = path
                                 self.targets = targets
                             }
                             internal enum CodingKeys: String, CodingKey {
                                 case name
+                                case path
                                 case targets
                             }
                         }

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -18,7 +18,7 @@ components:
       properties:
         organizations:
           items:
-            $ref: '#/components/schemas/Organization'
+            $ref: "#/components/schemas/Organization"
           type: array
       required:
         - organizations
@@ -87,7 +87,7 @@ components:
       properties:
         tokens:
           items:
-            $ref: '#/components/schemas/ProjectToken'
+            $ref: "#/components/schemas/ProjectToken"
           type: array
       required:
         - tokens
@@ -242,7 +242,7 @@ components:
           description: The email of the invitee
           type: string
         inviter:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
         organization_id:
           description: The id of the organization the invitee is invited to
           type: number
@@ -313,12 +313,12 @@ components:
         invitations:
           description: A list of organization invitations
           items:
-            $ref: '#/components/schemas/Invitation'
+            $ref: "#/components/schemas/Invitation"
           type: array
         members:
           description: A list of organization members
           items:
-            $ref: '#/components/schemas/OrganizationMember'
+            $ref: "#/components/schemas/OrganizationMember"
           type: array
         name:
           description: The organization's name
@@ -482,7 +482,7 @@ components:
         previews:
           description: Previews list.
           items:
-            $ref: '#/components/schemas/Preview'
+            $ref: "#/components/schemas/Preview"
           type: array
       required:
         - previews
@@ -784,7 +784,7 @@ paths:
           name: cache_category
           required: false
           schema:
-            $ref: '#/components/schemas/CacheCategory'
+            $ref: "#/components/schemas/CacheCategory"
         - description: The project identifier '{account_name}/{project_name}'.
           in: query
           name: project_id
@@ -850,25 +850,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It completes a multi-part upload.
       tags:
@@ -990,6 +990,9 @@ paths:
                           name:
                             description: Name of the project
                             type: string
+                          path:
+                            description: Path of the project
+                            type: string
                           targets:
                             description: Targets present in a project
                             items:
@@ -1037,6 +1040,7 @@ paths:
                             type: array
                         required:
                           - name
+                          - path
                           - targets
                       type: array
                   required:
@@ -1059,19 +1063,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommandEvent'
+                $ref: "#/components/schemas/CommandEvent"
           description: The command event was created
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You don't have permission to create command events for the project.
       summary: Create a a new command analytics event
       tags:
@@ -1108,7 +1112,7 @@ paths:
                 supported_platforms:
                   description: The supported platforms of the preview.
                   items:
-                    $ref: '#/components/schemas/PreviewSupportedPlatform'
+                    $ref: "#/components/schemas/PreviewSupportedPlatform"
                   type: array
                 type:
                   default: app_bundle
@@ -1158,19 +1162,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It initiates a multipart upload for a preview artifact.
       tags:
@@ -1203,13 +1207,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthenticationTokens'
+                $ref: "#/components/schemas/AuthenticationTokens"
           description: Successfully authenticated and returned new API tokens.
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: Invalid email or password.
       summary: Authenticate with email and password.
       tags:
@@ -1238,13 +1242,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthenticationTokens'
+                $ref: "#/components/schemas/AuthenticationTokens"
           description: Succcessfully generated new API tokens.
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to issue new tokens
       summary: Request new tokens.
       tags:
@@ -1291,7 +1295,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The request was not accepted, e.g., when the device code is expired
       summary: Get a specific device code.
       tags:
@@ -1312,7 +1316,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CommandEventArtifact'
+              $ref: "#/components/schemas/CommandEventArtifact"
         description: Artifact to upload
         required: false
       responses:
@@ -1320,25 +1324,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactUploadID'
+                $ref: "#/components/schemas/ArtifactUploadID"
           description: The upload has been started
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The command event doesn't exist
       summary: It initiates a multipart upload for a command event artifact.
       tags:
@@ -1356,7 +1360,7 @@ paths:
                 properties:
                   projects:
                     items:
-                      $ref: '#/components/schemas/Project'
+                      $ref: "#/components/schemas/Project"
                     type: array
                 required:
                   - projects
@@ -1366,7 +1370,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
       summary: List projects the authenticated user has access to.
       tags:
@@ -1400,25 +1404,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
+                $ref: "#/components/schemas/Project"
           description: The project was created
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account was not found
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
       summary: Create a new project.
       tags:
@@ -1450,7 +1454,7 @@ paths:
                 properties:
                   tokens:
                     items:
-                      $ref: '#/components/schemas/ProjectToken'
+                      $ref: "#/components/schemas/ProjectToken"
                     type: array
                 required:
                   - tokens
@@ -1461,19 +1465,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to list tokens
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authorized to list tokens
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project was not found
       summary: List all project tokens.
       tags:
@@ -1514,19 +1518,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to issue new tokens
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authorized to issue new tokens
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project was not found
       summary: Create a new project token.
       tags:
@@ -1548,25 +1552,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationUsage'
+                $ref: "#/components/schemas/OrganizationUsage"
           description: The organization usage
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization with the given name was not found
       summary: Shows the usage of an organization
       tags:
@@ -1582,7 +1586,7 @@ paths:
           name: cache_category
           required: false
           schema:
-            $ref: '#/components/schemas/CacheCategory'
+            $ref: "#/components/schemas/CacheCategory"
         - description: The project identifier '{account_name}/{project_name}'.
           in: query
           name: project_id
@@ -1606,31 +1610,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactUploadID'
+                $ref: "#/components/schemas/ArtifactUploadID"
           description: The upload has been started
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It initiates a multipart upload in the cache.
       tags:
@@ -1664,31 +1668,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CacheActionItem'
+                $ref: "#/components/schemas/CacheActionItem"
           description: The item exists in the action cache
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The item doesn't exist in the actino cache
       summary: Get a cache action item.
       tags:
@@ -1704,7 +1708,7 @@ paths:
           name: cache_category
           required: false
           schema:
-            $ref: '#/components/schemas/CacheCategory'
+            $ref: "#/components/schemas/CacheCategory"
         - description: The size in bytes of the part that will be uploaded. It's used to generate the signed URL.
           in: query
           name: content_length
@@ -1746,31 +1750,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactMultipartUploadURL'
+                $ref: "#/components/schemas/ArtifactMultipartUploadURL"
           description: The URL has been generated
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It generates a signed URL for uploading a part.
       tags:
@@ -1810,43 +1814,43 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CacheActionItem'
+                $ref: "#/components/schemas/CacheActionItem"
           description: The request is valid but the cache action item already exists
         201:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CacheActionItem'
+                $ref: "#/components/schemas/CacheActionItem"
           description: The action item was cached
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The request has missing or invalid parameters
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It uploads a given cache action item.
       tags:
@@ -1870,19 +1874,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization with the given name was not found
       summary: Deletes an organization
       tags:
@@ -1903,25 +1907,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: "#/components/schemas/Organization"
           description: The organization
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization with the given name was not found
       summary: Shows an organization
       tags:
@@ -1961,31 +1965,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: "#/components/schemas/Organization"
           description: The organization
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization could not be updated due to a validation error
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization with the given name was not found
       summary: Updates an organization
       tags:
@@ -2025,31 +2029,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: "#/components/schemas/Organization"
           description: The organization
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization could not be updated due to a validation error
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization with the given name was not found
       summary: Updates an organization
       tags:
@@ -2078,7 +2082,7 @@ paths:
             schema:
               properties:
                 multipart_upload_part:
-                  $ref: '#/components/schemas/ArtifactMultipartUploadPart'
+                  $ref: "#/components/schemas/ArtifactMultipartUploadPart"
                 preview_id:
                   description: The id of the preview.
                   type: string
@@ -2093,25 +2097,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactMultipartUploadURL'
+                $ref: "#/components/schemas/ArtifactMultipartUploadURL"
           description: The URL has been generated
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It generates a signed URL for uploading a part.
       tags:
@@ -2168,19 +2172,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to issue new tokens
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authorized to issue new tokens
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account was not found
       summary: Create a new account token.
       tags: []
@@ -2202,9 +2206,9 @@ paths:
             schema:
               properties:
                 command_event_artifact:
-                  $ref: '#/components/schemas/CommandEventArtifact'
+                  $ref: "#/components/schemas/CommandEventArtifact"
                 multipart_upload_part:
-                  $ref: '#/components/schemas/ArtifactMultipartUploadPart'
+                  $ref: "#/components/schemas/ArtifactMultipartUploadPart"
               required:
                 - command_event_artifact
                 - multipart_upload_part
@@ -2216,25 +2220,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactMultipartUploadURL'
+                $ref: "#/components/schemas/ArtifactMultipartUploadURL"
           description: The URL has been generated
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
       summary: It generates a signed URL for uploading a part.
       tags:
@@ -2263,19 +2267,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project was not found
       summary: Cleans cache for a given project
       tags:
@@ -2312,19 +2316,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The invitation with the given invitee email and organization name was not found
       summary: Cancels an invitation
       tags:
@@ -2358,31 +2362,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Invitation'
+                $ref: "#/components/schemas/Invitation"
           description: The user was invited
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The user could not be invited due to a validation error
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization was not found
       summary: Creates an invitation
       tags:
@@ -2417,16 +2421,16 @@ paths:
           required: false
           schema:
             type: string
-        - description: ''
+        - description: ""
           in: query
           name: supported_platforms
           required: false
           schema:
             description: The supported platforms of the preview.
             items:
-              $ref: '#/components/schemas/PreviewSupportedPlatform'
+              $ref: "#/components/schemas/PreviewSupportedPlatform"
             type: array
-        - description: ''
+        - description: ""
           in: query
           name: page_size
           required: false
@@ -2437,7 +2441,7 @@ paths:
             minimum: 1
             title: PreviewIndexPageSize
             type: integer
-        - description: ''
+        - description: ""
           in: query
           name: page
           required: false
@@ -2464,7 +2468,7 @@ paths:
                   previews:
                     description: Previews list.
                     items:
-                      $ref: '#/components/schemas/Preview'
+                      $ref: "#/components/schemas/Preview"
                     type: array
                 required:
                   - previews
@@ -2475,13 +2479,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
       summary: List previews.
       tags:
@@ -2497,7 +2501,7 @@ paths:
           name: cache_category
           required: false
           schema:
-            $ref: '#/components/schemas/CacheCategory'
+            $ref: "#/components/schemas/CacheCategory"
         - description: The project identifier '{account_name}/{project_name}'.
           in: query
           name: project_id
@@ -2521,31 +2525,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CacheArtifactDownloadURL'
+                $ref: "#/components/schemas/CacheArtifactDownloadURL"
           description: The artifact exists and is downloadable
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project or the cache artifact doesn't exist
       summary: Downloads an artifact from the cache.
       tags:
@@ -2568,9 +2572,9 @@ paths:
             schema:
               properties:
                 command_event_artifact:
-                  $ref: '#/components/schemas/CommandEventArtifact'
+                  $ref: "#/components/schemas/CommandEventArtifact"
                 multipart_upload_parts:
-                  $ref: '#/components/schemas/ArtifactMultipartUploadParts'
+                  $ref: "#/components/schemas/ArtifactMultipartUploadParts"
               required:
                 - command_event_artifact
                 - multipart_upload_parts
@@ -2584,25 +2588,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project doesn't exist
         500:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: An internal server error occurred
       summary: It completes a multi-part upload.
       tags:
@@ -2622,7 +2626,7 @@ paths:
                 properties:
                   organizations:
                     items:
-                      $ref: '#/components/schemas/Organization'
+                      $ref: "#/components/schemas/Organization"
                     type: array
                 required:
                   - organizations
@@ -2633,13 +2637,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
       summary: Lists the organizations
       tags:
@@ -2667,13 +2671,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: "#/components/schemas/Organization"
           description: The organization was created
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization could not be created due to a validation error
       summary: Creates an organization
       tags:
@@ -2707,25 +2711,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Preview'
+                $ref: "#/components/schemas/Preview"
           description: The preview exists and can be downloaded
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The preview does not exist
       summary: Returns a preview with a given id.
       tags:
@@ -2742,7 +2746,7 @@ paths:
           name: cache_category
           required: false
           schema:
-            $ref: '#/components/schemas/CacheCategory'
+            $ref: "#/components/schemas/CacheCategory"
         - description: The project identifier '{account_name}/{project_name}'.
           in: query
           name: project_id
@@ -2783,19 +2787,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         402:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The account has an invalid plan
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
@@ -2848,25 +2852,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The provided token ID is not valid
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project token was not found
       summary: Revokes a project token.
       tags:
@@ -2893,25 +2897,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
+                $ref: "#/components/schemas/Project"
           description: The project to show
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project was not found
       summary: Returns a project based on the handle.
       tags:
@@ -2958,31 +2962,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Project'
+                $ref: "#/components/schemas/Project"
           description: The updated project
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The request is invalid, for example when attempting to link the project to a repository the authenticated user doesn't have access to.
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project with the given account and project handles was not found
       summary: Updates a project
       tags:
@@ -3028,7 +3032,7 @@ paths:
           required: false
           schema:
             type: string
-        - description: ''
+        - description: ""
           in: query
           name: page_size
           required: false
@@ -3039,7 +3043,7 @@ paths:
             minimum: 1
             title: RunsIndexPageSize
             type: integer
-        - description: ''
+        - description: ""
           in: query
           name: page
           required: false
@@ -3057,7 +3061,7 @@ paths:
                 properties:
                   runs:
                     items:
-                      $ref: '#/components/schemas/Run'
+                      $ref: "#/components/schemas/Run"
                     type: array
                 required:
                   - runs
@@ -3067,7 +3071,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You don't have permission to access this resource
       summary: List runs associated with a given project.
       tags: []
@@ -3098,25 +3102,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The member could not be removed due to a validation error
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization or the user with the given name was not found
       summary: Removes a member from an organization
       tags:
@@ -3159,31 +3163,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationMember'
+                $ref: "#/components/schemas/OrganizationMember"
           description: The member was updated
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The member could not be updated due to a validation error
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The organization or the user with the given name was not found
       summary: Updates a member in an organization
       tags:
@@ -3217,25 +3221,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArtifactUploadURL'
+                $ref: "#/components/schemas/ArtifactUploadURL"
           description: The presigned upload URL
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project or preview doesn't exist
       summary: Uploads a preview icon.
       tags:
@@ -3265,7 +3269,7 @@ paths:
               description: The request body to complete the multipart upload of a preview.
               properties:
                 multipart_upload_parts:
-                  $ref: '#/components/schemas/ArtifactMultipartUploadParts'
+                  $ref: "#/components/schemas/ArtifactMultipartUploadParts"
                 preview_id:
                   description: The id of the preview.
                   type: string
@@ -3280,25 +3284,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Preview'
+                $ref: "#/components/schemas/Preview"
           description: The upload has been completed
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project or preview doesn't exist
       summary: It completes a multi-part upload.
       tags:
@@ -3321,19 +3325,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The project was not found
       summary: Deletes a project with a given id.
       tags:
@@ -3366,31 +3370,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Account'
+                $ref: "#/components/schemas/Account"
           description: Account successfully updated
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: An error occurred while updating the account.
         401:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to update your account.
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You don't have permission to update this account.
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: An account with this handle was not found.
       summary: Update account
       tags:
@@ -3416,7 +3420,7 @@ paths:
                 modules:
                   description: A list of modules with their metadata.
                   items:
-                    $ref: '#/components/schemas/Module'
+                    $ref: "#/components/schemas/Module"
                   type: array
               required:
                 - modules
@@ -3430,19 +3434,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: You need to be authenticated to access this resource
         403:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The authenticated subject is not authorized to perform this action
         404:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
           description: The command event doesn't exist
       summary: Completes artifacts uploads for a given command event
       tags:

--- a/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -112,6 +112,7 @@ public final class CreateCommandEventService: CreateCommandEventServicing {
             projects: graph.projects.map { project in
                 .init(
                     name: project.name,
+                    path: project.path.pathString,
                     targets: project.targets.map { target in
                         .init(
                             binary_cache_metadata: target.binaryCacheMetadata

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -4,6 +4,7 @@ import Mockable
 import TuistAnalytics
 import TuistCore
 import TuistSupport
+import Path
 import XCTest
 
 @testable import TuistKit
@@ -51,7 +52,6 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             status: .failure("Failed!"),
             graph: .test(
                 name: "Graph",
-                path: path,
                 projects: [
                     projectPath: .test(
                         path: projectPath,
@@ -132,6 +132,7 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
                 projects: [
                     .test(
                         name: "Project",
+                        path: projectPath.relative(to: "/"),
                         targets: [
                             CommandEventTarget(
                                 name: "A",

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -130,7 +130,7 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             graph: CommandEventGraph(
                 name: "Graph",
                 projects: [
-                    CommandEventProject(
+                    .test(
                         name: "Project",
                         targets: [
                             CommandEventTarget(


### PR DESCRIPTION
### Short description 📝

This is a follow up to #7278. To make graph resolution work properly on the server, we need the full project identifier to be resolvable, for which we need the project path in addition to its name.

### How to test the changes locally 🧐

Run `tuist generate` and inspect the outgoing request to the server to include the path.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
