### PR TITLE
feat: add new infoPlist case `extendingFile`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b0472b9536122cb752e6688cb17b4063f73451c1c52c46a6c61d7a40a6d51677",
+  "originHash" : "de192ef4bf646168d39a91eff930139d6d13a8cfa1f9a7478a0e91bc23a99f9a",
   "pins" : [
     {
       "identity" : "aexml",
@@ -328,10 +328,10 @@
     {
       "identity" : "xcodegraph",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeGraph.git",
+      "location" : "https://github.com/sanghyeok-kim/XcodeGraph.git",
       "state" : {
-        "revision" : "c533cf2543dc41428f0118d4f0df5c890307918a",
-        "version" : "1.3.2"
+        "branch" : "add-infoPlist-extendingFile-case",
+        "revision" : "b4d6202e5350f2196b2620102c1d26084cb0f59a"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "de192ef4bf646168d39a91eff930139d6d13a8cfa1f9a7478a0e91bc23a99f9a",
+  "originHash" : "791eb4ef250bf42d60f30dc86c8bba0bd053e22f52365521897a314f065efa74",
   "pins" : [
     {
       "identity" : "aexml",
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sanghyeok-kim/XcodeGraph.git",
       "state" : {
-        "branch" : "add-infoPlist-extendingFile-case",
-        "revision" : "b4d6202e5350f2196b2620102c1d26084cb0f59a"
+        "branch" : "add-InfoPlist-case-extendingFile",
+        "revision" : "296d47a59c998c727ffe0a31c2c9d5a50e0a2f7a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -514,7 +514,7 @@ let package = Package(
         .package(
             /// I temporarily set it to my repository and submitted a PR with the extendingFile case
             /// added to XcodeGraph’s InfoPlist.
-            url: "https://github.com/sanghyeok-kim/XcodeGraph.git", branch: "add-infoPlist-extendingFile-case"
+            url: "https://github.com/sanghyeok-kim/XcodeGraph.git", branch: "add-InfoPlist-case-extendingFile"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.0")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            url: "https://github.com/tuist/XcodeGraph.git", exact: "1.3.2"
+            /// I temporarily set it to my repository and submitted a PR with the extendingFile case added to XcodeGraph’s InfoPlist.
+            url: "https://github.com/sanghyeok-kim/XcodeGraph.git", branch: "add-infoPlist-extendingFile-case"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.0")),
         .package(url: "https://github.com/tuist/Command.git", exact: "0.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(
-            /// I temporarily set it to my repository and submitted a PR with the extendingFile case added to XcodeGraph’s InfoPlist.
+            /// I temporarily set it to my repository and submitted a PR with the extendingFile case
+            /// added to XcodeGraph’s InfoPlist.
             url: "https://github.com/sanghyeok-kim/XcodeGraph.git", branch: "add-infoPlist-extendingFile-case"
         ),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.0")),

--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -11,6 +11,10 @@ public enum InfoPlist: Codable, Equatable, Sendable {
     /// Generate an Info.plist file with the default content for the target product extended with the values in the given
     /// dictionary.
     case extendingDefault(with: [String: Plist.Value])
+    
+    /// Extend an existing Info.plist file with the given values.
+    /// If duplicate keys exist, the values in the info.plist are overridden by the given dictionary.
+    case extendingFile(path: Path, with: [String: Plist.Value])
 
     /// Generate the default content for the target the InfoPlist belongs to.
     public static var `default`: InfoPlist {

--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -11,7 +11,7 @@ public enum InfoPlist: Codable, Equatable, Sendable {
     /// Generate an Info.plist file with the default content for the target product extended with the values in the given
     /// dictionary.
     case extendingDefault(with: [String: Plist.Value])
-    
+
     /// Extend an existing Info.plist file with the given values.
     /// If duplicate keys exist, the values in the info.plist are overridden by the given dictionary.
     case extendingFile(path: Path, with: [String: Plist.Value])

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -202,13 +202,22 @@ class TargetLinter: TargetLinting {
 
     private func lintInfoplistExists(target: Target) async throws -> [LintingIssue] {
         var issues: [LintingIssue] = []
-        if let infoPlist = target.infoPlist,
-           case let InfoPlist.file(path: path) = infoPlist,
-           try await !fileSystem.exists(path)
-        {
-            issues
-                .append(LintingIssue(reason: "Info.plist file not found at path \(infoPlist.path!.pathString)", severity: .error))
+        guard let infoPlist = target.infoPlist else { return issues }
+
+        switch infoPlist {
+        case let .file(path), let .extendingFile(path, _):
+            if try await !fileSystem.exists(path) {
+                issues.append(
+                    LintingIssue(
+                        reason: "Info.plist file not found at path \(infoPlist.path!.pathString)",
+                        severity: .error
+                    )
+                )
+            }
+        default:
+            break
         }
+
         return issues
     }
 

--- a/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
@@ -106,7 +106,7 @@ public final class GenerateInfoPlistProjectMapper: ProjectMapping {
                       options: [],
                       format: nil
                   ) as? [String: Any] else { return nil }
-            
+
             let extendedDictionary = extended.mapValues { $0.value }
             return existingDictionary.merging(extendedDictionary) { _, new in new }
         default:

--- a/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
@@ -99,6 +99,16 @@ public final class GenerateInfoPlistProjectMapper: ProjectMapping {
                 return content
             }
             return nil
+        case let .extendingFile(path, extended):
+            guard let existingData = try? Data(contentsOf: path.url),
+                  let existingDictionary = try? PropertyListSerialization.propertyList(
+                      from: existingData,
+                      options: [],
+                      format: nil
+                  ) as? [String: Any] else { return nil }
+            
+            let extendedDictionary = extended.mapValues { $0.value }
+            return existingDictionary.merging(extendedDictionary) { _, new in new }
         default:
             return nil
         }

--- a/Sources/TuistHasher/PlistContentHasher.swift
+++ b/Sources/TuistHasher/PlistContentHasher.swift
@@ -34,6 +34,17 @@ public final class PlistContentHasher: PlistContentHashing {
                     dictionaryString += "\(key)=\(value);"
                 }
                 return try contentHasher.hash(dictionaryString)
+            case let .extendingFile(path, dictionary):
+                let fileHash = try await contentHasher.hash(path: path)
+                
+                var dictionaryString = ""
+                for key in dictionary.keys.sorted() {
+                    let value = dictionary[key, default: "nil"]
+                    dictionaryString += "\(key)=\(value);"
+                }
+                let dictionaryHash = try contentHasher.hash(dictionaryString)
+                
+                return try contentHasher.hash("\(fileHash)-\(dictionaryHash)")
             case let .generatedFile(_, data):
                 return try contentHasher.hash(data)
             }

--- a/Sources/TuistHasher/PlistContentHasher.swift
+++ b/Sources/TuistHasher/PlistContentHasher.swift
@@ -36,14 +36,14 @@ public final class PlistContentHasher: PlistContentHashing {
                 return try contentHasher.hash(dictionaryString)
             case let .extendingFile(path, dictionary):
                 let fileHash = try await contentHasher.hash(path: path)
-                
+
                 var dictionaryString = ""
                 for key in dictionary.keys.sorted() {
                     let value = dictionary[key, default: "nil"]
                     dictionaryString += "\(key)=\(value);"
                 }
                 let dictionaryHash = try contentHasher.hash(dictionaryString)
-                
+
                 return try contentHasher.hash("\(fileHash)-\(dictionaryHash)")
             case let .generatedFile(_, data):
                 return try contentHasher.hash(data)

--- a/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
@@ -21,6 +21,10 @@ extension XcodeGraph.InfoPlist {
                 with:
                 dictionary.mapValues { XcodeGraph.Plist.Value.from(manifest: $0) }
             )
+        case let .extendingFile(infoplistPath, dictionary):
+            let resolvedPath = try generatorPaths.resolve(path: infoplistPath)
+            let resolvedDictionary = dictionary.mapValues { XcodeGraph.Plist.Value.from(manifest: $0) }
+            return .extendingFile(path: resolvedPath, with: resolvedDictionary)
         case .none:
             return .none
         }

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
@@ -70,20 +70,20 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
         // Given
         let baseInfoPlistContent: [String: Plist.Value] = [
             "CFBundleIdentifier": .string("com.example.app"),
-            "CFBundleShortVersionString": .string("1.0")
+            "CFBundleShortVersionString": .string("1.0"),
         ]
         let extendingPlistContent: [String: Plist.Value] = [
             "CFBundleShortVersionString": .string("2.0"),
-            "NewCustomKey": .string("NewCustomValue")
+            "NewCustomKey": .string("NewCustomValue"),
         ]
         let expectedPlistContent: [String: Plist.Value] = [
             "CFBundleIdentifier": .string("com.example.app"),
             "CFBundleShortVersionString": .string("2.0"), // this must be overridden
-            "NewCustomKey": .string("NewCustomValue") // this must be added
+            "NewCustomKey": .string("NewCustomValue"), // this must be added
         ]
-        
+
         let tempPath = try temporaryPath()
-        
+
         let targetA = Target.test(
             name: "TargetA",
             infoPlist: .dictionary(baseInfoPlistContent)
@@ -92,15 +92,15 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
             path: tempPath,
             targets: [targetA]
         )
-        
+
         // When
         let (_, sideEffectsA) = try subject.map(project: projectA)
         try await sideEffectExecutor.execute(sideEffects: sideEffectsA)
-        
+
         let generatedTargetAInfoPlistFilePath = sideEffectsA.compactMap {
             if case let .file(fileDescriptor) = $0 { fileDescriptor.path } else { nil }
         }.first!
-        
+
         let targetB = Target.test(
             name: "TargetB",
             infoPlist: .extendingFile(
@@ -112,10 +112,10 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
             path: tempPath,
             targets: [targetB]
         )
-        
+
         let (mappedProjectB, sideEffectsB) = try subject.map(project: projectB)
         try await sideEffectExecutor.execute(sideEffects: sideEffectsB)
-        
+
         // Then
         try XCTAssertSideEffectsCreateDerivedInfoPlist(
             named: "TargetB-Info.plist",
@@ -123,7 +123,7 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
             projectPath: projectB.path,
             sideEffects: sideEffectsB
         )
-        
+
         XCTAssertTargetExistsWithDerivedInfoPlist(
             named: "TargetB-Info.plist",
             project: mappedProjectB


### PR DESCRIPTION
### Short description 📝

Added the `.extendingFile(path: AbsolutePath, with: [String: Plist.Value])` case to the `InfoPlist` enum provides a flexible option to extend a base Info.plist file dynamically.

It can be useful when you want to use an existing Info.plist file as a base while dynamically modifying and managing only specific key values.

For example, if you manually update the `CFBundleShortVersionString` (app version) in the Info.plist file, XML file characteristics may cause numerous unrelated changes to appear alongside the intended modification, making management cumbersome.

- Relates to XcodeGraph: https://github.com/tuist/XcodeGraph/pull/97

### How to test the changes locally 🧐

1. Specify a particular Info.plist file as the base and set its path in the `extendingFile` case.
  Then, provide the desired dictionary using the `with` parameter.

2. Verify that the properties from the base Info.plist and the dictionary specified in with are correctly merged and applied.

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
