### PR TITLE
Add a cookbook page for generated projects

### DIFF
--- a/docs/.vitepress/bars.mjs
+++ b/docs/.vitepress/bars.mjs
@@ -499,6 +499,13 @@ export function guidesSidebar(locale) {
               ),
               link: `/${locale}/guides/develop/projects/best-practices`,
             },
+            {
+              text: localizedString(
+                locale,
+                "sidebars.guides.items.develop.items.projects.items.cookbook.text",
+              ),
+              link: `/${locale}/guides/develop/projects/cookbook`,
+            },
           ],
         },
         {

--- a/docs/.vitepress/strings/en.json
+++ b/docs/.vitepress/strings/en.json
@@ -269,6 +269,9 @@
                 },
                 "best-practices": {
                   "text": "Best practices"
+                },
+                "cookbook": {
+                  "text": "Cookbook"
                 }
               }
             },

--- a/docs/docs/en/guides/develop/projects/cookbook.md
+++ b/docs/docs/en/guides/develop/projects/cookbook.md
@@ -1,0 +1,26 @@
+---
+title: Cookbook
+titleTemplate: :title · Projects · Develop · Guides · Tuist
+description: Learn some useful recipes for working with Tuist and Xcode projects.
+---
+
+# Cookbook {#cookbook}
+
+Here we are sharing a few recipes that you might find useful when working with Tuist and Xcode projects.
+
+## Generate a list with all your project dependencies {#generate-a-list-with-all-your-project-dependencies}
+
+To comply with the license of your open source dependencies (e.g. MIT-licensed),
+you might need to include a list of all the dependencies you use in your project.
+Tuist doesn't have a built-in command for that, but you can use [swift-package-list](https://github.com/FelixHerrmann/swift-package-list) for that:
+
+```bash
+mise x spm:FelixHerrmann/swift-package-list -- \
+    swift-package-list Package.swift \
+    --custom-source-packages-path .build \
+    --output-type plist \
+    --output-path Sources/Core
+```
+
+> [!TIP]
+> You can use `--output-path` to output it in a directory that contains the resources of the target from where the file will be read at runtime.


### PR DESCRIPTION
Someone asked in Slack how they could generate a list with all the dependencies of their projects so I thought I'd add a cookbook page with how to do it with the `FelixHerrmann/swift-package-list` package.