### PR TITLE
Fix default settings for multiplatform targets

### DIFF
--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -688,9 +688,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "SDKROOT": "auto",
             "TARGETED_DEVICE_FAMILY": "1,2",
             "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator macosx",
+            "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks"],
             "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": ["$(inherited)", "@executable_path/../Frameworks"],
-            "LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]": ["$(inherited)", "@executable_path/Frameworks"],
-            "LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]": ["$(inherited)", "@executable_path/Frameworks"],
         ]
 
         assert(config: debugConfig, contains: expectedSettings)

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -123,7 +123,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "SWIFT_VERSION": "5.0",
     ]
 
-    private let multiplatformFrameworkTargetEssentialDebugSettings: [String: SettingValue] = ([
+    private let multiplatformFrameworkTargetEssentialDebugSettings: [String: SettingValue] = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .array(["$(inherited)", "DEBUG"]),
         "SKIP_INSTALL": "YES",
         "VERSIONING_SYSTEM": "apple-generic",
@@ -131,9 +131,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "DYLIB_INSTALL_NAME_BASE": "@rpath",
         "PRODUCT_NAME": "$(TARGET_NAME:c99extidentifier)",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-        "LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
-        "LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]": ["$(inherited)", "@executable_path/Frameworks",
-                                                          "@loader_path/Frameworks"],
+        "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
         "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": ["$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks"],
         "DEFINES_MODULE": "YES",
         "VERSION_INFO_PREFIX": "",
@@ -141,16 +139,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Frameworks",
         "DYLIB_COMPATIBILITY_VERSION": "1",
         "SWIFT_VERSION": "5.0",
-    ] as [String: SettingValue])
-        .reduce(into: [String: SettingValue]()) { acc, element in
-            if element.key.contains("sdk") {
-                acc[element.key] = element.value
-            } else {
-                acc["\(element.key)[sdk=macosx*]"] = element.value
-                acc["\(element.key)[sdk=iphonesimulator*]"] = element.value
-                acc["\(element.key)[sdk=iphoneos*]"] = element.value
-            }
-        }
+    ]
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7289

### Short description 📝

As reported by @danibachar, generating a project with multiplatform targets leads to an Xcode warnings when opening the project due to `Unsupported Swift version`.

This is because [this PR](https://github.com/tuist/XcodeGraph/pull/79) changed the behavior of `overlay` to always include the SDK specifier. However, for default settings, that's not behavior we want as that leads to settings like `SWIFT_VERSION` to be only with the SDK specifiers without a default value.

The solution here is to bring back the old `overlay` method when applying the default settings. In other scenarios, we want to still keep using `overlay` from `XcodeGraph` and preserve the SDK specifier since in other cases, we only overlay platform-specific settings when they actually differ between platforms.

### How to test the changes locally 🧐

- Generate `multiplatform_app_with_sdk`
- You should see no Xcode alert when opening the project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
