### PR TITLE
Fix best practices about using just `Debug` and `Release` configurations

### DIFF
--- a/docs/docs/en/guides/develop/projects/best-practices.md
+++ b/docs/docs/en/guides/develop/projects/best-practices.md
@@ -19,14 +19,7 @@ Many organizations use build configurations to model different remote environmen
 - **Inconsistencies:** If there are configuration inconsistencies throughout the graph, the build system might end up using the wrong configuration for some targets.
 - **Complexity:** Projects can end up with a long list of local configurations and remote environments that are hard to reason about and maintain.
 
-Build configurations were designed to embody different build settings, and projects rarely need more than just `Debug` and `Release`. The need to model different environments can be achieved by using schemes:
+Build configurations were designed to embody different build settings, and projects rarely need more than just `Debug` and `Release`. The need to model different environments can be achieved differently:
 
-- Set a scheme environment variable: `REMOTE_ENV=production`.
-- Add a new key to the `Info.plist` of the bundle that will use the environment information (e.g., app bundle): `REMOTE_ENV=${REMOTE_ENV}`.
-- You can then read the value at runtime:
-
-    ```swift
-    let remoteEnvString = Bundle.main.object(forInfoDictionaryKey: "REMOTE_ENV") as? String
-    ```
-
-Thanks to the above, you can keep the list of configurations simple, preventing the aforementioned downsides, and give developers the flexibility to customize things like the remote environment via schemes.
+- **In Debug builds:** You can include all the configurations that should be accessible in development in the app (e.g. endpoints), and switch them at runtime. The switch can happen either using scheme launch environment variables, or with a UI within the app.
+- **In Release builds:** In case of release, you can only include the configuration that the release build is bound to, and not include the runtime logic for switching configurations by using compiler directives.


### PR DESCRIPTION
As [pointed out here](https://community.tuist.dev/t/per-endpoint-configuration/313/6), "scheme env variables" used at compile-time don't exist (I got it wrong all this time). This PR adjusts the best practice accordingly to avoid confusion.