### PR TITLE
Add missing graph to tuist xcodebuild run metadata

### DIFF
--- a/Sources/TuistKit/Services/XcodeBuildService.swift
+++ b/Sources/TuistKit/Services/XcodeBuildService.swift
@@ -92,6 +92,7 @@ struct XcodeBuildService {
             throw XcodeBuildServiceError.schemeNotPassed
         }
         let graph = try await xcodeGraphMapper.map(at: path)
+        try await ServiceContext.current?.runMetadataStorage?.update(graph: graph)
         let graphTraverser = GraphTraverser(graph: graph)
         guard let scheme = graphTraverser.schemes().first(where: {
             $0.name == schemeName

--- a/Tests/TuistKitTests/Services/XcodeBuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/XcodeBuildServiceTests.swift
@@ -264,15 +264,15 @@ struct XcodeBuildServiceTests {
                     ]
                 )
 
+                let graph: Graph = .test(
+                    projects: [
+                        temporaryPath: project,
+                    ]
+                )
+
                 given(xcodeGraphMapper)
                     .map(at: .any)
-                    .willReturn(
-                        .test(
-                            projects: [
-                                temporaryPath: project,
-                            ]
-                        )
-                    )
+                    .willReturn(graph)
 
                 given(selectiveTestingGraphHasher)
                     .hash(
@@ -366,6 +366,9 @@ struct XcodeBuildServiceTests {
                             ),
                         ],
                     ]
+                )
+                await #expect(
+                    runMetadataStorage.graph == graph
                 )
             }
         }


### PR DESCRIPTION
### Short description 📝

The Tuist dashboard relies on the `graph` to be sent to display analytics for selective testing. However, we were _not_ uploading the graph as part of the run metadata when `tuist xcodebuild test` is run. This PR fixes that omission.

### How to test the changes locally 🧐

- Run `tuist xcodebuild test`
- Ensure `graph` is part of the run metadata

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
