### PR TITLE
Update swift-issue-reporting to xctest-dynamic-overlay

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -227,15 +227,6 @@
       }
     },
     {
-      "identity" : "swift-issue-reporting",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
-      "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -350,6 +341,15 @@
       "state" : {
         "revision" : "6f90427e172da66336739801c84b9cef3e17367b",
         "version" : "8.26.6"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
+        "version" : "1.5.1"
       }
     },
     {


### PR DESCRIPTION
### Short description 📝

The pointfree's rename of `xctest-dynamic-overlay` is ... problematic, to say the least: https://github.com/pointfreeco/swift-issue-reporting/issues/134

When trying to bundle the repository for release, SwiftPM keeps resolving `xctest-dynamic-overlay` and I can't get it to use `swift-issue-reporting`. As a "fix", I'm updating the `Package.resolved` with the old library name.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
