### PR TITLE
Improve Documentation: Explicitly state flag -configuration in hashing.md

### DIFF
--- a/docs/docs/en/guides/develop/projects/hashing.md
+++ b/docs/docs/en/guides/develop/projects/hashing.md
@@ -25,8 +25,7 @@ We hash the Swift version obtained from running the command `/usr/bin/xcrun swif
 
 #### Configuration {#configuration}
 
-
-The idea behind this flag was to ensure debug binaries were not used in release builds and viceversa. However, we are still missing a mechanism to remove the other configurations from the projects to prevent them from being used.
+The idea behind the flag `-configuration` was to ensure debug binaries were not used in release builds and viceversa. However, we are still missing a mechanism to remove the other configurations from the projects to prevent them from being used.
 
 ## Debugging {#debugging}
 


### PR DESCRIPTION
### Short description 📝

The text mentions “this flag”, but it is not defined in the document:

> The idea behind this flag was to ensure debug binaries were not used in release builds and viceversa.

### How to test the changes locally 🧐

> You can take a look at the markdown [version here](https://github.com/fdiaz/tuist/blob/21cda6d88e0143a1709c35f49b29f9ed6c6190eb/docs/docs/en/guides/develop/projects/hashing.md)

### Contributor checklist ✅

- [x] (NA) The code has been linted using run `mise run lint-fix`
- [x] (NA) The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
