### PR TITLE
Rename 'Tuist project' to 'Generated project'

### DIFF
--- a/docs/docs/en/guides/develop/cache.md
+++ b/docs/docs/en/guides/develop/cache.md
@@ -7,7 +7,7 @@ description: Optimize your build times by caching compiled binaries and sharing 
 # Cache {#cache}
 
 > [!IMPORTANT] REQUIREMENTS
-> - A <LocalizedLink href="/guides/develop/projects">Tuist Project</LocalizedLink>
+> - A <LocalizedLink href="/guides/develop/projects">Generated project</LocalizedLink>
 > - A <LocalizedLink href="/server/introduction/accounts-and-projects">Tuist account and project</LocalizedLink>
 
 Xcode's build system provides [incremental builds](https://en.wikipedia.org/wiki/Incremental_build_model), enhancing efficiency under normal circumstances. However, this feature falls short in [Continuous Integration (CI) environments](https://en.wikipedia.org/wiki/Continuous_integration), where data essential for incremental builds is not shared across different builds. Additionally, **developers often reset this data locally to troubleshoot complex compilation problems**, leading to more frequent clean builds. This results in teams spending excessive time waiting for local builds to finish or for Continuous Integration pipelines to provide feedback on pull requests. Furthermore, the frequent context switching in such an environment compounds this unproductiveness.

--- a/docs/docs/en/guides/develop/cache.md
+++ b/docs/docs/en/guides/develop/cache.md
@@ -7,7 +7,7 @@ description: Optimize your build times by caching compiled binaries and sharing 
 # Cache {#cache}
 
 > [!IMPORTANT] REQUIREMENTS
-> - A <LocalizedLink href="/guides/develop/projects">Generated project</LocalizedLink>
+> - A <LocalizedLink href="/guides/develop/projects">generated project</LocalizedLink>
 > - A <LocalizedLink href="/server/introduction/accounts-and-projects">Tuist account and project</LocalizedLink>
 
 Xcode's build system provides [incremental builds](https://en.wikipedia.org/wiki/Incremental_build_model), enhancing efficiency under normal circumstances. However, this feature falls short in [Continuous Integration (CI) environments](https://en.wikipedia.org/wiki/Continuous_integration), where data essential for incremental builds is not shared across different builds. Additionally, **developers often reset this data locally to troubleshoot complex compilation problems**, leading to more frequent clean builds. This results in teams spending excessive time waiting for local builds to finish or for Continuous Integration pipelines to provide feedback on pull requests. Furthermore, the frequent context switching in such an environment compounds this unproductiveness.

--- a/docs/docs/en/guides/develop/selective-testing.md
+++ b/docs/docs/en/guides/develop/selective-testing.md
@@ -7,7 +7,7 @@ description: Use selective testing to run only the tests that have changed since
 # Selective testing {#selective-testing}
 
 > [!IMPORTANT] REQUIREMENTS
-> - A <LocalizedLink href="/guides/develop/projects">Generated project</LocalizedLink>
+> - A <LocalizedLink href="/guides/develop/projects">generated project</LocalizedLink>
 > - A <LocalizedLink href="/server/introduction/accounts-and-projects">server account and project</LocalizedLink>
 
 As your project grows, so does the amount of your tests. For a long time, running all tests on every PR or push to `main` takes tens of seconds. But this solution does not scale to thousands of tests your team might have.

--- a/docs/docs/en/guides/develop/selective-testing.md
+++ b/docs/docs/en/guides/develop/selective-testing.md
@@ -7,7 +7,7 @@ description: Use selective testing to run only the tests that have changed since
 # Selective testing {#selective-testing}
 
 > [!IMPORTANT] REQUIREMENTS
-> - A <LocalizedLink href="/guides/develop/projects">Tuist Project</LocalizedLink>
+> - A <LocalizedLink href="/guides/develop/projects">Generated project</LocalizedLink>
 > - A <LocalizedLink href="/server/introduction/accounts-and-projects">server account and project</LocalizedLink>
 
 As your project grows, so does the amount of your tests. For a long time, running all tests on every PR or push to `main` takes tens of seconds. But this solution does not scale to thousands of tests your team might have.


### PR DESCRIPTION
We abandoned the convention "Tuist Projects" for generated projects, but forgot a couple of renames. This PR addresses that.