### PR TITLE
Rename "Tuist Projects" to "Generated projects"

### DIFF
--- a/docs/docs/en/guides/develop/projects.md
+++ b/docs/docs/en/guides/develop/projects.md
@@ -6,11 +6,11 @@ description: Learn about Tuist's DSL for defining Xcode projects.
 
 # Generated projects {#generated-projects}
 
-Tuist Projects is a viable alternative that helps to overcome these challenges while keeping complexity and costs at an acceptable level. It considers Xcode projects as a fundamental element, ensuring resilience against future Xcode updates, and leverages Xcode project generation to provide teams with a modularization-focused declarative API. Tuist uses the project declaration to simplify the complexities of modularization**, optimize workflows like build or test across various environments, and facilitate and democratize the evolution of Xcode projects.
+Generated is a viable alternative that helps to overcome these challenges while keeping complexity and costs at an acceptable level. It considers Xcode projects as a fundamental element, ensuring resilience against future Xcode updates, and leverages Xcode project generation to provide teams with a modularization-focused declarative API. Tuist uses the project declaration to simplify the complexities of modularization**, optimize workflows like build or test across various environments, and facilitate and democratize the evolution of Xcode projects.
 
 ## How does it work? {#how-does-it-work}
 
-To get started with Tuist Projects, all you need is to define your project using **Tuist's Domain Specific Language (DSL)**. This entails using manifest files such as `Workspace.swift` or `Project.swift`. If you've worked with the Swift Package Manager before, the approach is very similar.
+To get started with generated projects, all you need is to define your project using **Tuist's Domain Specific Language (DSL)**. This entails using manifest files such as `Workspace.swift` or `Project.swift`. If you've worked with the Swift Package Manager before, the approach is very similar.
 
 Once you've defined your project, Tuist offers various workflows to manage and interact with it:
 


### PR DESCRIPTION
@VladislavSmolyanoy spotted some places where we still refer to "generated projects" as "Tuist projects". This PR fixes that. 