### PR TITLE
Apply platform conditions for embedded SPM dependencies.

### DIFF
--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -239,7 +239,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 buildFile.applyCondition(condition, applicableTo: target)
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
-            case let .packageProduct(product, _):
+            case let .packageProduct(product, condition):
                 guard let productRef = productRefs.first(where: { $0.productName == product }) else {
                     break
                 }
@@ -248,6 +248,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                     product: productRef,
                     settings: ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]]
                 )
+                buildFile.applyCondition(condition, applicableTo: target)
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
             case .library, .bundle, .sdk, .macro:


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7326>

### Short description 📝

Fixes the issue that platform conditions are not applied when embedding SPM dependencies.

### How to test the changes locally 🧐

* Construct an iOS + Catalyst project that integrates a dynamic SPM framework with platform conditions, take the `Project.swift` snippet attached into the issue for reference.

* Build the project on Mac Catalyst destination, it should not fail due to the dangling copy framework phase.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
