### PR TITLE
Remove default subcommand of tuist auth in favor of calling tuist auth login explicitly

### DIFF
--- a/Sources/TuistKit/Commands/Auth/AuthCommand.swift
+++ b/Sources/TuistKit/Commands/Auth/AuthCommand.swift
@@ -10,8 +10,7 @@ struct AuthCommand: ParsableCommand {
                 LoginCommand.self,
                 LogoutCommand.self,
                 WhoamiCommand.self,
-            ],
-            defaultSubcommand: LoginCommand.self
+            ]
         )
     }
 }

--- a/Templates/default/Tuist.stencil
+++ b/Templates/default/Tuist.stencil
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let tuist = Tuist(
-//    Create an account with "tuist auth" and a project with "tuist project create"
+//    Create an account with "tuist auth login" and a project with "tuist project create"
 //    then uncomment the section below and set the project full-handle.
 //    * Read more: https://docs.tuist.io/guides/quick-start/gather-insights
 //

--- a/docs/docs/en/contributors/get-started.md
+++ b/docs/docs/en/contributors/get-started.md
@@ -28,7 +28,7 @@ To start working on the project, we can follow the steps below:
 - [Install](https://mise.jdx.dev/getting-started.html) Mise to provision the development environment.
 - Run `mise install` to install the system dependencies needed by Tuist
 - Run `tuist install` to install the external dependencies needed by Tuist
-- (Optional) Run `tuist auth` to get access to the <LocalizedLink href="/guides/develop/build/cache">Tuist Cache</LocalizedLink>
+- (Optional) Run `tuist auth login` to get access to the <LocalizedLink href="/guides/develop/build/cache">Tuist Cache</LocalizedLink>
 - Run `tuist generate` to generate the Tuist Xcode project using Tuist itself
 
 **The generated project opens automatically**. If you need to open again without generating it, run open `Tuist.xcworkspace` (or use Finder).

--- a/docs/docs/en/guides/quick-start/gather-insights.md
+++ b/docs/docs/en/guides/quick-start/gather-insights.md
@@ -11,7 +11,7 @@ Tuist can integrate with a server to extend its capabilities. One of those capab
 First of all, you'll need to authenticate by running:
 
 ```bash
-tuist auth
+tuist auth login
 ```
 
 ## Create a project {#create-a-project}

--- a/docs/docs/en/guides/quick-start/optimize-workflows.md
+++ b/docs/docs/en/guides/quick-start/optimize-workflows.md
@@ -42,7 +42,7 @@ If you push your changes upstream to a remote repository, other developers can c
 
 ```bash
 tuist install
-tuist auth
+tuist auth login
 tuist generate
 ```
 

--- a/docs/docs/en/guides/share/previews.md
+++ b/docs/docs/en/guides/share/previews.md
@@ -67,7 +67,7 @@ To make running Tuist Previews even easier, we developed a Tuist macOS menu bar 
 When you now click on "Run" in the Preview page, the macOS app will automatically launch it on your currently selected device.
 
 > [!IMPORTANT] REQUIREMENTS
-> To download Previews, you need to first authenticate with the `tuist auth` command.
+> To download Previews, you need to first authenticate with the `tuist auth login` command.
 > In the future, you will be able to authenticate directly in the app.
 >
 > Additionally, you need to have Xcode locally installed.

--- a/docs/docs/en/server/introduction/authentication.md
+++ b/docs/docs/en/server/introduction/authentication.md
@@ -13,7 +13,7 @@ To interact with the server, the CLI needs to authenticate the requests using [b
 When using the CLI locally on your machine, we recommend authenticating as a user. To authenticate as a user, you need to run the following command:
 
 ```bash
-tuist auth
+tuist auth login
 ```
 
 The command will take you through a web-based authentication flow. Once you authenticate, the CLI will store a long-lived refresh token and a short-lived access token under `~/.config/tuist/credentials`. Each file in the directory represents the domain you authenticated against, which by default should be `cloud.tuist.io.json`. The information stored in that directory is sensitive, so **make sure to keep it safe**.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7325

### Short description 📝

Instead of implicitly calling `tuist auth login` when running `tuist auth`, we should enforce that command to be run explicitly as reasoned [here](https://github.com/tuist/tuist/issues/7325#issuecomment-2666370168).

### How to test the changes locally 🧐

- `tuist auth` should not implicitly run `tuist auth login`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
