### PR TITLE
Fix compiling Package.swift without @preconcurrency import modifier in project generated by tuist edit

### DIFF
--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -251,7 +251,9 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             var packagesSettings = targetBaseSettings(
                 projectFrameworkPath: projectDescriptionPath,
                 pluginHelperLibraryPaths: pluginProjectDescriptionHelpersModule.map(\.path),
-                swiftVersion: swiftVersion
+                // We have no use of strict concurrency in the Packages targets, so we're opting into the Swift 5 language mode.
+                // Otherwise, `PackageDescription` must be imported with the `@preconcurrency` modifier
+                swiftVersion: Version(5, 0, 0).description
             )
             packagesSettings.merge(
                 [

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -220,6 +220,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
                     "SWIFT_INCLUDE_PATHS": .array([
                         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI",
                     ]),
+                    "SWIFT_VERSION": "5.0.0",
                 ],
                 uniquingKeysWith: {
                     switch ($0, $1) {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -1,5 +1,5 @@
 // swift-tools-version: 6.0
-@preconcurrency import PackageDescription
+import PackageDescription
 
 #if TUIST
     import ProjectDescription


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7331

### Short description 📝

There's no need to compile the `Packages` module with the Swift 6 language mode that includes strict concurrency checks. In the Swift 6 language mode, `import PackageDescription` fails and needs to be annotated with the `@preconcurrency import` as `Package` is not set as `Sendable`. Since `PackageDescription` is outside of control, we can either:
- Change the default template to have the `@preconcurrency` modifier
- Change the Swift language mode of the `Packages` module to 6 (done in this PR)

### How to test the changes locally 🧐

- Run `tuist edit` in a project with `Package.swift`. Remove the `@preconcurrency` if present. The generated edit project should now compile even without it.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
