### PR TITLE
Explicitly use `Foundation.FileManager` to negotiate conflicting `FileManager` symbol in module itself in synthesized resource accessors

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -318,7 +318,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
                 // where the bundles are only available in the framework's directory that is actively being previewed.
                 // Since we don't know which framework this is, we also need to look in all the framework subpaths.
-                if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
+                if let subpaths = try? Foundation.FileManager.default.contentsOfDirectory(atPath: override) {
                     for subpath in subpaths {
                         if subpath.hasSuffix(".framework") {
                             candidates.append(URL(fileURLWithPath: override + "/" + subpath))


### PR DESCRIPTION
I've encountered a problem, when a dependency had its own FileManager protocol, and TuistBundle+\<modulename\> wouldn't compile.

Here is a quick fix for that.

Resolves <https://github.com/tuist/tuist/issues/7337>

### Short description 📝

> Describe here the purpose of your PR.
Change a template to include Foundation in front of FileManager to specify which FileManager to use

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
