### PR TITLE
Update XcodeGraph

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a16b399c6e431c354b77baa85cc6f324a22a268943905f5cf10926c5020f7060",
+  "originHash" : "0609f46a637f6054472a8187b1010a8a668296872c4f70a92e1ad2dfcf902651",
   "pins" : [
     {
       "identity" : "aexml",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Command.git",
       "state" : {
-        "revision" : "07846291097a593de29846c0083b758471071cdf",
-        "version" : "0.12.2"
+        "revision" : "079a7803b581d3022469b3a331bccd51d48d2fc0",
+        "version" : "0.13.0"
       }
     },
     {
@@ -348,8 +348,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph.git",
       "state" : {
-        "revision" : "bf78c0692488c743c7d5c0356f14b7fde763ec75",
-        "version" : "1.6.3"
+        "revision" : "2cbee87f4f69540223103e25c9a36936b912450a",
+        "version" : "1.7.0"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "142b7ea0a087eabf4d12207302a185a0e9d4659b",
-        "version" : "8.27.0"
+        "revision" : "cbd622399d845f7686ac96c5110cea5a784758a3",
+        "version" : "8.27.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -514,7 +514,7 @@ let package = Package(
             url: "https://github.com/apple/swift-openapi-urlsession", .upToNextMajor(from: "1.0.2")
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
-        .package(url: "https://github.com/tuist/XcodeGraph.git", exact: "1.6.3"),
+        .package(url: "https://github.com/tuist/XcodeGraph.git", exact: "1.7.0"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.7.0")),
         .package(url: "https://github.com/tuist/Command.git", .upToNextMajor(from: "0.8.0")),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.4"),

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -207,10 +207,8 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                     .map {
                         (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
                     },
-                inputFileListPaths: script.inputFileListPaths.map { $0.relative(to: sourceRootPath).pathString },
-
-                outputFileListPaths: script.outputFileListPaths.map { $0.relative(to: sourceRootPath).pathString },
-
+                inputFileListPaths: script.inputFileListPaths,
+                outputFileListPaths: script.outputFileListPaths,
                 shellPath: script.shellPath,
                 shellScript: script.shellScript(sourceRootPath: sourceRootPath),
                 runOnlyForDeploymentPostprocessing: script.runForInstallBuildsOnly,

--- a/Sources/TuistHasher/TargetScriptsContentHasher.swift
+++ b/Sources/TuistHasher/TargetScriptsContentHasher.swift
@@ -32,7 +32,8 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
             var pathsToHash: [AbsolutePath] = []
             script.path.map { pathsToHash.append($0) }
 
-            var dynamicPaths = script.inputPaths.compactMap { try? AbsolutePath(validating: $0) } + script.inputFileListPaths
+            var dynamicPaths = (script.inputPaths + script.inputFileListPaths)
+                .compactMap { try? AbsolutePath(validating: $0) }
             if let dependencyFile = script.dependencyFile {
                 dynamicPaths += [dependencyFile]
             }
@@ -49,7 +50,8 @@ public struct TargetScriptsContentHasher: TargetScriptsContentHashing {
             }
             stringsToHash.append(contentsOf: try await pathsToHash.concurrentMap { try await contentHasher.hash(path: $0) })
             stringsToHash.append(
-                contentsOf: (script.outputPaths.compactMap { try? AbsolutePath(validating: $0) } + script.outputFileListPaths)
+                contentsOf: (script.outputPaths + script.outputFileListPaths)
+                    .compactMap { try? AbsolutePath(validating: $0) }
                     .map { $0.relative(to: sourceRootPath).pathString }
             )
 

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -34,6 +34,7 @@ extension XcodeGraph.TargetScript {
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
+        .map(\.pathString)
         let outputPaths = try await absolutePaths(
             for: manifest.outputPaths,
             generatorPaths: generatorPaths,
@@ -45,6 +46,7 @@ extension XcodeGraph.TargetScript {
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
+        .map(\.pathString)
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
         let runForInstallBuildsOnly = manifest.runForInstallBuildsOnly
         let shellPath = manifest.shellPath

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -100,8 +100,8 @@ final class TargetGeneratorTests: XCTestCase {
         XCTAssertEqual(preBuildPhase.inputFileListPaths, [])
         XCTAssertEqual(preBuildPhase.outputFileListPaths, [])
 
-        XCTAssertEqual(postBuildPhase.inputFileListPaths, ["../tmp/b"])
-        XCTAssertEqual(postBuildPhase.outputFileListPaths, ["../tmp/d"])
+        XCTAssertEqual(postBuildPhase.inputFileListPaths, ["/tmp/b"])
+        XCTAssertEqual(postBuildPhase.outputFileListPaths, ["/tmp/d"])
     }
 
     func test_generateTargetDependencies() async throws {

--- a/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -55,9 +55,9 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
             order: order,
             script: .tool(path: tool, args: arguments),
             inputPaths: inputPaths.map(\.pathString),
-            inputFileListPaths: inputFileListPaths,
+            inputFileListPaths: inputFileListPaths.map(\.pathString),
             outputPaths: outputPaths.map(\.pathString),
-            outputFileListPaths: outputFileListPaths,
+            outputFileListPaths: outputFileListPaths.map(\.pathString),
             dependencyFile: dependencyFile
         )
     }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -94,7 +94,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(
             model.inputFileListPaths,
-            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift"))]
+            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift")).pathString]
         )
         XCTAssertEqual(
             model.outputPaths,
@@ -102,7 +102,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
         XCTAssertEqual(
             model.outputFileListPaths,
-            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift"))]
+            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift")).pathString]
         )
     }
 
@@ -163,7 +163,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(
             model.inputFileListPaths,
-            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift"))]
+            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift")).pathString]
         )
         XCTAssertEqual(
             model.outputPaths,
@@ -171,7 +171,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
         XCTAssertEqual(
             model.outputFileListPaths,
-            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift"))]
+            [temporaryPath.appending(try RelativePath(validating: "$(SRCROOT)/foo/bar/**/*.swift")).pathString]
         )
     }
 }


### PR DESCRIPTION
### Short description 📝

Updating XcodeGraph. There are some changes in the source code due to minor breaking changes done in https://github.com/tuist/XcodeGraph/pull/132

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
