### PR TITLE
docs: Improve readability by changing CJK fonts to sans-serif

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -14,8 +14,8 @@
     --vp-c-brand-2: #3c315b;
     --vp-c-brand-3: #622ed4;
     --vp-c-bg-soft: #fbfbfb;
-    --vp-font-family-base: "Space Grotesk", serif;
-    --vp-font-family-mono: "Space Mono", serif;
+    --vp-font-family-base: "Space Grotesk", sans-serif;
+    --vp-font-family-mono: "Space Mono", sans-serif;
 
     --vp-c-bg: #ffffff;
     --vp-c-bg-alt: #f6f6f7;


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

When you switch the Tuist documentation website to Japanese, the English font appears in sans-serif while the Japanese font displays in serif. Mixing serif fonts can make it quite difficult to read, so it would be better to unify the fonts to sans-serif.

![CleanShot 2025-02-21 at 12 33 33@2x](https://github.com/user-attachments/assets/27e493f7-3359-4f9c-9ac1-5ded9d397bf3)

### How to test the changes locally 🧐

- Run: `mise run docs:dev`
- Visit: 
	- http://localhost:5173/ja
	- http://localhost:5173/ko

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
