### PR TITLE
Improve error message on unhandled errors

### DIFF
--- a/Sources/TuistSupport/Errors/FatalError.swift
+++ b/Sources/TuistSupport/Errors/FatalError.swift
@@ -31,13 +31,15 @@ public struct UnhandledError: FatalError {
 
     /// Error description.
     public var description: String {
-        """
-        We received an error that we couldn't handle:
-            - Localized description: \(error.localizedDescription)
-            - Error: \(error)
-
-        If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
-        """
+        if let error = error as? LocalizedError {
+            error.localizedDescription
+        } else {
+            """
+            We received an error that we couldn't handle:
+                - Localized description: \(error.localizedDescription)
+                - Error: \(error)
+            """
+        }
     }
 }
 


### PR DESCRIPTION
### Short description 📝

As our plan is to move away from `FatalError` in favor using `LocalizedError`, we should improve the error message when we get one.

Current error message when a `LocalizedError` is raised, such as from `XcodeGraph`:
```
We received an error that we couldn't handle:
    - Localized description: Missing `PBXBuildFile.file` reference.
    - Error: missingFileReference
  
If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose

Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose[0m

Logs are available at /Users/marekfort/.local/state/tuist/logs/2B42C32C-41F3-45FB-9F4E-573FD87A1309.log
```

The improved error message (including removing the duplicated issue link):
```
Missing `PBXBuildFile.file` reference.

Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose[0m

Logs are available at /Users/marekfort/.local/state/tuist/logs/ED3B5E3D-34F5-4C33-92B8-C3B6AF273668.log
```

As we move to Noora, we can also make the error message a bit more visually pleasing.

### How to test the changes locally 🧐

- Trigger an unhandled error, such as when mapping a non-generated Xcode project in the `XcodeGraphMapper`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
