### PR TITLE
Remove duplicates for some settings when using binary cache

### DIFF
--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -202,7 +202,7 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
             for dependency in dependencies {
                 settings[targetDependency] = (settings[targetDependency] ?? [:])
                     .combine(with: settings[dependency] ?? [:])
-                    .removeDuplicates(for: "FRAMEWORK_SEARCH_PATHS")
+                    .removeDuplicates()
             }
         }
         graph.projects = graph.projects.mapValues { project in
@@ -217,7 +217,7 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                 target.settings = targetSettings.with(
                     base: targetSettings.base
                         .combine(with: settings[.target(name: target.name, path: project.path)] ?? SettingsDictionary())
-                        .removeDuplicates(for: "FRAMEWORK_SEARCH_PATHS")
+                        .removeDuplicates()
                 )
                 return target
             }
@@ -228,6 +228,44 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
 }
 
 extension SettingsDictionary {
+    /// There are scenarios when the combined settings introduce duplicates for these setting keys.
+    /// We don't know how to reproduce – either in a reproducible sample or via unit tests.
+    /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can at least the
+    /// method itself in isolation.
+    fileprivate func removeDuplicates() -> SettingsDictionary {
+        removeDuplicates(for: "FRAMEWORK_SEARCH_PATHS")
+            .removeDuplicates(for: "HEADER_SEARCH_PATHS")
+            .removeDuplicates(for: "OTHER_C_FLAGS")
+            .removeOtherSwiftFlagsDuplicates()
+    }
+
+    func removeOtherSwiftFlagsDuplicates() -> SettingsDictionary {
+        let key = "OTHER_SWIFT_FLAGS"
+        var settings = self
+        guard let value = settings[key] else { return settings }
+        switch value {
+        case let .string(value):
+            settings[key] = .string(value)
+        case let .array(value):
+            var seen = Set<String>()
+            let value = value.enumerated().filter {
+                if $0.element == "-Xcc" {
+                    if value.endIndex > $0.offset + 1 {
+                        return !seen.contains(value[$0.offset + 1])
+                    } else {
+                        return true
+                    }
+                } else {
+                    return seen.insert($0.element).inserted
+                }
+            }
+            settings[key] = .array(
+                value.map(\.element)
+            )
+        }
+        return settings
+    }
+
     fileprivate func removeDuplicates(for key: String) -> SettingsDictionary {
         var settings = self
         guard let value = settings[key] else { return settings }
@@ -236,11 +274,7 @@ extension SettingsDictionary {
             settings[key] = .string(value)
         case let .array(value):
             settings[key] = .array(
-                Array(
-                    Set(
-                        value
-                    )
-                )
+                value.uniqued()
             )
         }
         return settings

--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -230,7 +230,7 @@ public final class StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
 extension SettingsDictionary {
     /// There are scenarios when the combined settings introduce duplicates for these setting keys.
     /// We don't know how to reproduce – either in a reproducible sample or via unit tests.
-    /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can at least the
+    /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can at least test the
     /// method itself in isolation.
     fileprivate func removeDuplicates() -> SettingsDictionary {
         removeDuplicates(for: "FRAMEWORK_SEARCH_PATHS")

--- a/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -558,4 +558,38 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         )
         XCTAssertEmpty(gotSideEffects)
     }
+
+    func test_removeOtherSwithDuplicates() {
+        // Given
+        let settings: SettingsDictionary = [
+            "OTHER_SWIFT_FLAGS": .array(
+                [
+                    "value-one",
+                    "-Xcc", "value-two",
+                    "-Xcc", "value-three",
+                    "-Xcc", "value-two",
+                    "value-four",
+                    "value-one",
+                ]
+            ),
+        ]
+
+        // When
+        let got = settings.removeOtherSwiftFlagsDuplicates()
+
+        // Then
+        XCTAssertEqual(
+            got,
+            [
+                "OTHER_SWIFT_FLAGS": .array(
+                    [
+                        "value-one",
+                        "-Xcc", "value-two",
+                        "-Xcc", "value-three",
+                        "value-four",
+                    ]
+                ),
+            ]
+        )
+    }
 }


### PR DESCRIPTION
### Short description 📝

Follow-up to: https://github.com/tuist/tuist/pull/7341

Deduplicates values for other settings modified in the `StaticXCFrameworkModuleMapGraphMapper`

### How to test the changes locally 🧐

- We don't have a reproducer for this one, unfortunately.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
