### PR TITLE
#7345 Add command lint tool as valid target for unit tests on macOS.

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -595,6 +595,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .framework),
             LintableTarget(platform: .macOS, product: .staticFramework),
             LintableTarget(platform: .macOS, product: .macro),
+            LintableTarget(platform: .macOS, product: .commandLineTool),
         ],
         LintableTarget(platform: .macOS, product: .uiTests): [
             LintableTarget(platform: .macOS, product: .app),


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7345>

### Short description 📝

Add support for unit test targets on macOS to depend on command line tool targets/

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

1. Define a Project the following product targets... `.commandLineTool, .unitTests` on `.macOS`
2. Attempt to define `.commandLineTool` as a dependency of the `.unitTests` target.
3. Attempt to generate the project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
