### PR TITLE
Include the GITHUB_TOKEN in the environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ permissions:
   statuses: write
   packages: write
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release:
     name: Release Tuist App


### PR DESCRIPTION
Now I understand [why a token was used in the release pipeline](https://github.com/tuist/tuist/pull/7360). Mise receives a not-found when trying to install the https://github.com/tuist/asdf-create-dmg.git plugin.

I'm setting the token that GitHub Actions expose, which should (hopefully) give access to that repository too.