### PR TITLE
Fix missing OTHER_SWIFT_FLAGS such as -Xfrontend when using binary cache

### DIFF
--- a/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -249,14 +249,23 @@ extension SettingsDictionary {
         case let .array(value):
             var seen = Set<String>()
             let value = value.enumerated().filter {
-                if $0.element == "-Xcc" {
+                if $0.element.starts(with: "-X") {
                     if value.endIndex > $0.offset + 1 {
-                        return !seen.contains(value[$0.offset + 1])
+                        return !seen.contains($0.element + value[$0.offset + 1])
                     } else {
                         return true
                     }
                 } else {
-                    return seen.insert($0.element).inserted
+                    if $0.offset == 0 {
+                        return seen.insert($0.element).inserted
+                    } else {
+                        let previousElement = value[$0.offset - 1]
+                        if previousElement.starts(with: "-X") {
+                            return seen.insert(previousElement + $0.element).inserted
+                        } else {
+                            return seen.insert($0.element).inserted
+                        }
+                    }
                 }
             }
             settings[key] = .array(

--- a/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -568,6 +568,9 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                     "-Xcc", "value-two",
                     "-Xcc", "value-three",
                     "-Xcc", "value-two",
+                    "-Xfrontend", "value-five",
+                    "-Xfrontend", "value-five",
+                    "-Xfrontend", "value-two",
                     "value-four",
                     "value-one",
                 ]
@@ -586,6 +589,8 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         "value-one",
                         "-Xcc", "value-two",
                         "-Xcc", "value-three",
+                        "-Xfrontend", "value-five",
+                        "-Xfrontend", "value-two",
                         "value-four",
                     ]
                 ),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7362

### Short description 📝

I made the wrong assumption [here](https://github.com/tuist/tuist/pull/7346/files#diff-013899b66b78834c0f83cddf161f3e7ce75595ec486cd01f0ccd3af8e44d85c0R252) that only `-Xcc` flags come in pairs. However, there are a couple others that all start with `-X`, such as `-Xfrontend` or `-Xlinker`.

I'm ensuring those values are not incorrectly filtered out.

### How to test the changes locally 🧐

- See the repro steps at: https://github.com/tuist/tuist/issues/7362

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
