### PR TITLE
Another attempt to fix `main`

### DIFF
--- a/.mise/tasks/bundle/app
+++ b/.mise/tasks/bundle/app
@@ -60,7 +60,7 @@ print_status "Submitting the Tuist App for notarization..."
 mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
-create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
+curl -s https://raw.githubusercontent.com/create-dmg/create-dmg/refs/tags/v1.2.2/create-dmg | bash -s -- --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
 codesign --force --timestamp --options runtime --sign "Developer ID Application: Tuist GmbH (U6LC622NKF)" --identifier "io.tuist.app.tuist-app-dmg" "$BUILD_DMG_PATH"
 
 xcrun notarytool submit "${BUILD_DMG_PATH}" \

--- a/mise.toml
+++ b/mise.toml
@@ -5,13 +5,11 @@ swiftformat = "0.53.3"
 pnpm = "8.15.6"
 node = "20.12.0"
 sourcedocs = "2.0.2"
-create-dmg = "1.2.2"
 git-cliff = "2.6.0"
 "spm:apple/swift-openapi-generator" = "1.3.1"
 
 [alias]
 sourcedocs = "https://github.com/tuist/asdf-sourcedocs"
-create-dmg = "https://github.com/tuist/asdf-create-dmg.git"
 
 [settings]
 jobs = 6


### PR DESCRIPTION
[This fix](https://github.com/tuist/tuist/pull/7364) did not work. It could be the `.git` suffix, which we are not using for example with the plugin `asdf-sourcedocs`. Since the script is a bash script, I decided to take a different approach and use the script directly. That way we don't need to maintain an `asdf` plugin ourselves.