### PR TITLE
Make sure TuistSupport compiles for Linux and Windows

### DIFF
--- a/.mise/tasks/build-cross-platform.sh
+++ b/.mise/tasks/build-cross-platform.sh
@@ -11,7 +11,7 @@ fi
 # We'll gradually traverse the graph ensuring targets, and their dependency trees,
 # support macOS, Linux, and Windows. Once a target has been verified to compile for all platforms,
 # we'll include it below
-target_flags="--target ProjectDescription"
+target_flags="--target ProjectDescription --target TuistSupport"
 
 if [ "$usage_linux_vm" = "true" ]; then
     $CONTAINER_ENGINE run --rm \


### PR DESCRIPTION
### Short description 📝

Let's continue ensuring that our targets can target Linux and Windows as compilation targets. This time is the turn of `TuistSupport` :)

### How to test the changes locally 🧐

For Linux you can run `mise run build-cross-platform -v`. For Windows is a bit trickier. You need either a virtualized or non-virtualized Windows installation where you can pull these sources.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
