### PR TITLE
Add `build-for-testing` and `test-without-building` support to `tuist test`

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -104,6 +104,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         scheme: String,
         clean: Bool = false,
         destination: XcodeBuildDestination?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
@@ -121,7 +122,15 @@ public final class XcodeBuildController: XcodeBuildControlling {
         if clean {
             arguments.append("clean")
         }
-        arguments.append("test")
+        
+        switch action {
+        case .test:
+            arguments.append("test")
+        case .build:
+            arguments.append("build-for-testing")
+        case .testWithoutBuilding:
+            arguments.append("test-without-building")
+        }
 
         // Scheme
         arguments.append(contentsOf: ["-scheme", scheme])

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -8,6 +8,12 @@ public enum XcodeBuildDestination: Equatable {
     case macCatalyst
 }
 
+public enum XcodeBuildTestAction: Equatable {
+    case test
+    case build
+    case testWithoutBuilding
+}
+
 @Mockable
 public protocol XcodeBuildControlling {
     /// Returns an observable to build the given project using xcodebuild.
@@ -48,6 +54,7 @@ public protocol XcodeBuildControlling {
         scheme: String,
         clean: Bool,
         destination: XcodeBuildDestination?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,

--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -139,6 +139,8 @@ public enum EnvKey: String, CaseIterable {
     case testGenerateOnly = "TUIST_TEST_GENERATE_ONLY"
     case testBinaryCache = "TUIST_TEST_BINARY_CACHE"
     case testSelectiveTesting = "TUIST_TEST_SELECTIVE_TESTING"
+    case testWithoutBuilding = "TUIST_TEST_WITHOUT_BUILDING"
+    case testBuildOnly = "TUIST_TEST_BUILD_ONLY"
 
     // ORGANIZATION BILLING
     case organizationBillingOrganizationName = "TUIST_ORGANIZATION_BILLING_ORGANIZATION_NAME"

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -17,6 +17,7 @@ enum TestServiceError: FatalError, Equatable {
     case testIdentifierInvalid(value: String)
     case duplicatedTestTargets(Set<TestIdentifier>)
     case nothingToSkip(skipped: [TestIdentifier], included: [TestIdentifier])
+    case actionInvalid
 
     // Error description
     var description: String {
@@ -47,6 +48,8 @@ enum TestServiceError: FatalError, Equatable {
             return "The target identifier cannot be specified both in --test-targets and --skip-test-targets (were specified: \(targets.map(\.description).joined(separator: ", ")))"
         case let .nothingToSkip(skippedTargets, includedTargets):
             return "Some of the targets specified in --skip-test-targets (\(skippedTargets.map(\.description).joined(separator: ", "))) will always be skipped as they are not included in the targets specified (\(includedTargets.map(\.description).joined(separator: ", ")))"
+        case .actionInvalid:
+            return "Cannot specify both --build-only and --without-building"
         }
     }
 
@@ -54,7 +57,7 @@ enum TestServiceError: FatalError, Equatable {
     var type: ErrorType {
         switch self {
         case .schemeNotFound, .schemeWithoutTestableTargets, .testPlanNotFound, .testIdentifierInvalid, .duplicatedTestTargets,
-             .nothingToSkip:
+             .nothingToSkip, .actionInvalid:
             return .abort
         }
     }
@@ -172,6 +175,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         deviceName: String?,
         platform: String?,
         osVersion: String?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         skipUITests: Bool,
         resultBundlePath: AbsolutePath?,
@@ -316,6 +320,7 @@ final class TestService { // swiftlint:disable:this type_body_length
                 version: version,
                 deviceName: deviceName,
                 platform: platform,
+                action: action,
                 rosetta: rosetta,
                 resultBundlePath: resultBundlePath,
                 derivedDataPath: derivedDataPath,
@@ -352,6 +357,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         version: Version?,
         deviceName: String?,
         platform: String?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         resultBundlePath: AbsolutePath?,
         derivedDataPath: AbsolutePath?,
@@ -391,6 +397,7 @@ final class TestService { // swiftlint:disable:this type_body_length
                     version: version,
                     deviceName: deviceName,
                     platform: platform,
+                    action: action,
                     rosetta: rosetta,
                     resultBundlePath: resultBundlePath,
                     derivedDataPath: derivedDataPath,
@@ -629,6 +636,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         version: Version?,
         deviceName: String?,
         platform: String?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         resultBundlePath: AbsolutePath?,
         derivedDataPath: AbsolutePath?,
@@ -687,6 +695,7 @@ final class TestService { // swiftlint:disable:this type_body_length
             scheme: scheme.name,
             clean: clean,
             destination: destination,
+            action: action,
             rosetta: rosetta,
             derivedDataPath: derivedDataPath,
             resultBundlePath: resultBundlePath,

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -410,7 +410,8 @@ final class TestService { // swiftlint:disable:this type_body_length
             }
         } catch {
             // Check the test results and store successful test hashes for any targets that passed
-            guard let resultBundlePath, let invocationRecord = xcResultService.parse(path: resultBundlePath) else { throw error }
+            guard action != .build, let resultBundlePath,
+                  let invocationRecord = xcResultService.parse(path: resultBundlePath) else { throw error }
 
             let testTargets = testActionTargets(for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph)
 
@@ -427,12 +428,14 @@ final class TestService { // swiftlint:disable:this type_body_length
             throw error
         }
 
-        try await storeSuccessfulTestHashes(
-            for: testActionTargets(for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph),
-            graph: graph,
-            mapperEnvironment: mapperEnvironment,
-            cacheStorage: uploadCacheStorage
-        )
+        if action != .build {
+            try await storeSuccessfulTestHashes(
+                for: testActionTargets(for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph),
+                graph: graph,
+                mapperEnvironment: mapperEnvironment,
+                cacheStorage: uploadCacheStorage
+            )
+        }
 
         ServiceContext.current?.alerts?.success(.alert("The project tests ran successfully"))
     }

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -170,6 +170,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: .device("device-id"),
+            action: .test,
             rosetta: false,
             derivedDataPath: nil,
             resultBundlePath: nil,
@@ -209,6 +210,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: .device("device-id"),
+            action: .test,
             rosetta: true,
             derivedDataPath: nil,
             resultBundlePath: nil,
@@ -250,6 +252,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: .mac,
+            action: .test,
             rosetta: false,
             derivedDataPath: nil,
             resultBundlePath: nil,
@@ -290,6 +293,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: nil,
+            action: .test,
             rosetta: false,
             derivedDataPath: nil,
             resultBundlePath: nil,
@@ -333,6 +337,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: .mac,
+            action: .test,
             rosetta: false,
             derivedDataPath: derivedDataPath,
             resultBundlePath: nil,
@@ -374,9 +379,86 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             scheme: scheme,
             clean: true,
             destination: .mac,
+            action: .test,
             rosetta: false,
             derivedDataPath: nil,
             resultBundlePath: resultBundlePath,
+            arguments: [],
+            retryCount: 0,
+            testTargets: [],
+            skipTestTargets: [],
+            testPlanConfiguration: nil,
+            passthroughXcodeBuildArguments: []
+        )
+    }
+
+    func test_test_build_only() async throws {
+        // Given
+        let path = try temporaryPath()
+        let xcworkspacePath = path.appending(component: "Project.xcworkspace")
+        let target = XcodeBuildTarget.workspace(xcworkspacePath)
+        let scheme = "Scheme"
+
+        var command = [
+            "/usr/bin/xcrun",
+            "xcodebuild",
+            "build-for-testing",
+            "-scheme",
+            scheme,
+        ]
+
+        command.append(contentsOf: target.xcodebuildArguments)
+
+        system.succeedCommand(command, output: "output")
+
+        // When
+        try await subject.test(
+            target,
+            scheme: scheme,
+            clean: false,
+            destination: nil,
+            action: .build,
+            rosetta: false,
+            derivedDataPath: nil,
+            resultBundlePath: nil,
+            arguments: [],
+            retryCount: 0,
+            testTargets: [],
+            skipTestTargets: [],
+            testPlanConfiguration: nil,
+            passthroughXcodeBuildArguments: []
+        )
+    }
+
+    func test_test_only() async throws {
+        // Given
+        let path = try temporaryPath()
+        let xcworkspacePath = path.appending(component: "Project.xcworkspace")
+        let target = XcodeBuildTarget.workspace(xcworkspacePath)
+        let scheme = "Scheme"
+
+        var command = [
+            "/usr/bin/xcrun",
+            "xcodebuild",
+            "test-without-building",
+            "-scheme",
+            scheme,
+        ]
+
+        command.append(contentsOf: target.xcodebuildArguments)
+
+        system.succeedCommand(command, output: "output")
+
+        // When
+        try await subject.test(
+            target,
+            scheme: scheme,
+            clean: false,
+            destination: nil,
+            action: .testWithoutBuilding,
+            rosetta: false,
+            derivedDataPath: nil,
+            resultBundlePath: nil,
             arguments: [],
             retryCount: 0,
             testTargets: [],

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -114,6 +114,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -124,7 +125,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
             )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
                 self.testedSchemes.append(scheme)
             }
     }
@@ -293,6 +294,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .value(true),
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -344,6 +346,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .value(nil),
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -994,6 +997,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .value(xcresultPath),
@@ -1004,7 +1008,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
             )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
                 self.testedSchemes.append(scheme)
                 throw NSError.test()
             }
@@ -1246,6 +1250,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -1256,7 +1261,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 testPlanConfiguration: .any,
                 passthroughXcodeBuildArguments: .any
             )
-            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
                 self.testedSchemes.append(scheme)
                 throw NSError.test()
             }
@@ -1347,6 +1352,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .value(expectedResourceBundlePath),
@@ -1392,6 +1398,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .value(xcresultPath),
@@ -1453,6 +1460,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .value(expectedResultBundlePath),
@@ -1509,6 +1517,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .value(expectedResourceBundlePath),
@@ -1569,6 +1578,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -1611,6 +1621,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -1636,6 +1647,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -1959,6 +1971,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 scheme: .any,
                 clean: .any,
                 destination: .any,
+                action: .any,
                 rosetta: .any,
                 derivedDataPath: .any,
                 resultBundlePath: .any,
@@ -2014,6 +2027,7 @@ final class TestServiceTests: TuistUnitTestCase {
         deviceName: String? = nil,
         platform: String? = nil,
         osVersion: String? = nil,
+        action: XcodeBuildTestAction = .test,
         rosetta: Bool = false,
         skipUiTests: Bool = false,
         resultBundlePath: AbsolutePath? = nil,
@@ -2038,6 +2052,7 @@ final class TestServiceTests: TuistUnitTestCase {
                 deviceName: deviceName,
                 platform: platform,
                 osVersion: osVersion,
+                action: action,
                 rosetta: rosetta,
                 skipUITests: skipUiTests,
                 resultBundlePath: resultBundlePath,


### PR DESCRIPTION
### Short description 📝

Enable tuist test to only build the tests, or to run the tests from a previous build. This is useful for CI environments where the build and running of the tests may be separated.

### How to test the changes locally 🧐

To just build the tests run `tuist test --build-only xxx`
To just run the tests run `tuist test --without-building xxx`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
