### PR TITLE
Sort the targets before printing them

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -508,7 +508,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         if !skippedTestTargets.isEmpty {
             ServiceContext.current?.logger?
                 .notice(
-                    "The following targets have not changed since the last successful run and will be skipped: \(skippedTestTargets.map(\.target.name).joined(separator: ", "))"
+                    "The following targets have not changed since the last successful run and will be skipped: \(skippedTestTargets.map(\.target.name).sorted().joined(separator: ", "))"
                 )
         }
 

--- a/Sources/TuistKit/Services/XcodeBuildService.swift
+++ b/Sources/TuistKit/Services/XcodeBuildService.swift
@@ -180,7 +180,7 @@ struct XcodeBuildService {
         if !skipTestTargets.isEmpty {
             ServiceContext.current?.logger?
                 .info(
-                    "The following targets have not changed since the last successful run and will be skipped: \(Set(skipTestTargets.compactMap(\.target)).joined(separator: ", "))"
+                    "The following targets have not changed since the last successful run and will be skipped: \(Set(skipTestTargets.compactMap(\.target)).sorted().joined(separator: ", "))"
                 )
         }
 


### PR DESCRIPTION
Some our acceptance tests that run assertions against the logged messages started suddenly failing. It turns out that one of those logs outputs a list of targets, and since the order of the targets is non-deterministic, our tests might fail.
This PR fixes it by sorting the targets before printing them.