### PR TITLE
Fix duplicated warning alerts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5279549f9f543496b03a3439f39c255541e333e74a3b7a1d5726adaa83821f5f",
+  "originHash" : "23e049d8d71263bb6d65fb4c5d12adb4fa4443a317db209beaae269455293843",
   "pins" : [
     {
       "identity" : "aexml",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "revision" : "37f749a528483aeb6eec29e430505d7200addc30",
-        "version" : "0.31.0"
+        "revision" : "0f2ae7483d24b322619925df607b74b56f84649a",
+        "version" : "0.31.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -535,7 +535,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.0"))
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.0")),
     ],
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -535,7 +535,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.0")),
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.1")),
     ],
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -535,7 +535,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.0")),
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.31.0"))
     ],
     targets: targets
 )

--- a/Sources/TuistCore/Models/LintingIssue.swift
+++ b/Sources/TuistCore/Models/LintingIssue.swift
@@ -54,8 +54,9 @@ extension [LintingIssue] {
 
         let warningIssues = filter { $0.severity == .warning }
 
+
         for issue in warningIssues {
-            ServiceContext.current?.logger?.warning("\(issue.description)")
+            ServiceContext.current?.alerts?.warning(.alert("\(issue.description)"))
         }
     }
 }

--- a/Sources/TuistCore/Models/LintingIssue.swift
+++ b/Sources/TuistCore/Models/LintingIssue.swift
@@ -53,8 +53,6 @@ extension [LintingIssue] {
         if count == 0 { return }
 
         let warningIssues = filter { $0.severity == .warning }
-
-
         for issue in warningIssues {
             ServiceContext.current?.alerts?.warning(.alert("\(issue.description)"))
         }

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -194,7 +194,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
                 try System.shared.runAndPrint(command, verbose: false, environment: Environment.shared.manifestLoadingVariables)
                 let duration = timer.stop()
                 let time = String(format: "%.3f", duration)
-                ServiceContext.current?.alerts?.success(.alert("Built \(name) in (\(time)s)"))
+                ServiceContext.current?.logger?.debug("Built \(name) in (\(time)s)")
 
                 return module
             }

--- a/Sources/TuistSupport/Utils/AlertController.swift
+++ b/Sources/TuistSupport/Utils/AlertController.swift
@@ -3,7 +3,7 @@ import Mockable
 import Noora
 import ServiceContextModule
 
-enum Alert {
+enum Alert: Equatable, Hashable {
     case success(SuccessAlert)
     case warning(WarningAlert)
 
@@ -28,19 +28,19 @@ enum Alert {
 
 public final class AlertController: @unchecked Sendable {
     private let alertQueue = DispatchQueue(label: "io.tuist.TuistSupport.AlertController")
-    private var alerts: ThreadSafe<[Alert]> = ThreadSafe([])
+    private var alerts: ThreadSafe<Set<Alert>> = ThreadSafe([])
 
     public init() {}
 
     public func success(_ alert: SuccessAlert) {
         alerts.mutate { alerts in
-            alerts.insert(.success(alert), at: alerts.endIndex)
+            alerts.insert(.success(alert))
         }
     }
 
     public func warning(_ alert: WarningAlert) {
         alerts.mutate { alerts in
-            alerts.insert(.warning(alert), at: alerts.endIndex)
+            alerts.insert(.warning(alert))
         }
     }
 


### PR DESCRIPTION
### Short description 📝
With the adoption of `Noora` to output warnings, success, and error alerts, we introduced a regression that caused warning alerts to be duplicated.

This PR fixes them by using a set internally to collect warnings.

### How to test the changes locally 🧐
You can edit the code of a command to collect the same alert multiple times. For example:
```swift
ServiceContext.current?.alerts?.warning(.alert("Foo"))
ServiceContext.current?.alerts?.warning(.alert("Foo"))
ServiceContext.current?.alerts?.warning(.alert("Foo"))
```
You should only see one on completion.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
