### PR TITLE
Show errors using the error alert

### DIFF
--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -203,7 +203,7 @@ public struct TuistCommand: AsyncParsableCommand {
             if shouldOutputLogFilePath {
                 errorAlertNextSteps.append(logsNextStep)
             }
-            ServiceContext.current?.ui?.success(.alert(errorAlert.message, nextSteps: errorAlertNextSteps))
+            ServiceContext.current?.ui?.error(.alert(errorAlert.message, nextSteps: errorAlertNextSteps))
         } else if let successAlert = successAlerts.last {
             print("\n")
             var successAlertNextSteps = successAlert.nextSteps


### PR DESCRIPTION
### Short description 📝

Recent changes in how we show the completion messages introduced a regression causing errors to be shown as successes.
 
![image](https://github.com/user-attachments/assets/5492cb0b-7361-42cd-bc88-6e2bbf4a922f)

This PR fixes that.

### How to test the changes locally 🧐

You can run `tuist generate --path /invalid/directory` and you should see the error presented.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
