### PR TITLE
Add support for variable InfoPlist file paths

### DIFF
--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -11,6 +11,24 @@ public enum InfoPlist: Codable, Equatable, Sendable {
     /// Generate an Info.plist file with the default content for the target product extended with the values in the given
     /// dictionary.
     case extendingDefault(with: [String: Plist.Value])
+    
+    /**
+      A user defined xcconfig variable map to Info.plist file.
+
+      This should be used when the project has different Info.plist files per config (aka: debug,release,staging,etc)
+
+      .target(
+          ...
+          infoPlist: .variable("$(INFO_PLIST_FILE_VARIABLE)"),
+      )
+
+      Or as literal string
+     .target(
+         ...
+         infoPlist: $(INFO_PLIST_FILE_VARIABLE),
+     )
+    */
+    case variable(String)
 
     /// Generate the default content for the target the InfoPlist belongs to.
     public static var `default`: InfoPlist {

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -238,12 +238,16 @@ final class ConfigGenerator: ConfigGenerating {
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = .string(target.bundleId)
 
         // Info.plist
-        if let infoPlist = target.infoPlist, let path = infoPlist.path {
-            let relativePath = path.relative(to: sourceRootPath).pathString
-            if project.xcodeProjPath.parentDirectory == sourceRootPath {
-                settings["INFOPLIST_FILE"] = .string(relativePath)
-            } else {
-                settings["INFOPLIST_FILE"] = .string("$(SRCROOT)/\(relativePath)")
+        if let infoPlist = target.infoPlist {
+            if let path = infoPlist.path {
+                let relativePath = path.relative(to: sourceRootPath).pathString
+                if project.xcodeProjPath.parentDirectory == sourceRootPath {
+                    settings["INFOPLIST_FILE"] = .string(relativePath)
+                } else {
+                    settings["INFOPLIST_FILE"] = .string("$(SRCROOT)/\(relativePath)")
+                }
+            } else if case let .variable(configName, configuration: _) = infoPlist {
+                settings["INFOPLIST_FILE"] = .string(configName)
             }
         }
 

--- a/Sources/TuistHasher/PlistContentHasher.swift
+++ b/Sources/TuistHasher/PlistContentHasher.swift
@@ -25,6 +25,8 @@ public final class PlistContentHasher: PlistContentHashing {
         switch plist {
         case let .infoPlist(infoPlist):
             switch infoPlist {
+            case let .variable(variable, configuration: _):
+                return try contentHasher.hash(variable)
             case let .file(path: path, configuration: _):
                 return try await contentHasher.hash(path: path)
             case let .dictionary(dictionary, configuration: _), let .extendingDefault(dictionary, configuration: _):

--- a/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
@@ -21,6 +21,8 @@ extension XcodeGraph.InfoPlist {
                 with:
                 dictionary.mapValues { XcodeGraph.Plist.Value.from(manifest: $0) }
             )
+        case let .variable(setting):
+            return .variable(setting)
         case .none:
             return .none
         }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -144,6 +144,44 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: debugConfig, contains: expectedSettings)
         assert(config: releaseConfig, contains: expectedSettings)
     }
+    
+    func test_generateTargetConfig_whenVariableInfoPlistPath() async throws {
+        // Given
+        let sourceRootPath = try temporaryPath()
+        let project = Project.test(
+            sourceRootPath: sourceRootPath,
+            xcodeProjPath: sourceRootPath.appending(component: "Project.xcodeproj")
+        )
+        let target = Target.test(
+            infoPlist: .variable("$(INFO_PLIST_FILE_VARIABLE)")
+        )
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try await subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: .default,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: sourceRootPath
+        )
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings: SettingsDictionary = [
+            "INFOPLIST_FILE": "$(INFO_PLIST_FILE_VARIABLE)",
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
 
     func test_generateTestTargetConfiguration_iOS() async throws {
         // Given / When


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

This PR implements the support for variable InfoPlist file paths for build settings that mirrors the existing API for setting variable entitlements file paths. The issue has been described in detail here: https://github.com/tuist/tuist/issues/6727

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
