### PR TITLE
Fix inspecting workspace builds

### DIFF
--- a/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -175,20 +175,20 @@ struct InspectBuildCommandService {
             } else {
                 currentWorkingDirectory
             }
-            if let xcodeProjPath = try await fileSystem.glob(
+            if let workspacePath = try await fileSystem.glob(
+                directory: basePath,
+                include: ["*.xcworkspace"]
+            )
+            .collect()
+            .first {
+                return workspacePath
+            } else if let xcodeProjPath = try await fileSystem.glob(
                 directory: basePath,
                 include: ["*.xcodeproj"]
             )
             .collect()
             .first {
                 return xcodeProjPath
-            } else if let workspacePath = try await fileSystem.glob(
-                directory: basePath,
-                include: ["*.xcodeproj"]
-            )
-            .collect()
-            .first {
-                return workspacePath
             } else {
                 throw InspectBuildCommandServiceError.projectNotFound(basePath)
             }


### PR DESCRIPTION
### Short description 📝

As reported by @kelvinharron, `tuist inspect build` doesn't work for workspaces when run directly from the CLI. Turns out we the globs for the workspace was wrong.

### How to test the changes locally 🧐

- Build `tuist` repository via Xcode
- Run `tuist inspect build` in the `tuist` repository
- A build should be uploaded.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
