### PR TITLE
Add `Sendable` conformance to `Plugin` type in ProjectDescription

### DIFF
--- a/Sources/ProjectDescription/Plugin.swift
+++ b/Sources/ProjectDescription/Plugin.swift
@@ -6,7 +6,7 @@
 ///     - The source files for these helpers must live under a ProjectDescriptionHelpers directory in the location where `Plugin`
 /// manifest lives.
 ///
-public struct Plugin: Codable, Equatable {
+public struct Plugin: Codable, Equatable, Sendable {
     /// The name of the `Plugin`.
     public let name: String
 


### PR DESCRIPTION
### Short description 📝

When running `tuist edit`, the manifest project launched in Xcode 16.2 can emit compiler errors while trying to define the `Plugin` type in a plugin project:

<img width="1107" alt="Screenshot 2025-03-17 at 09 55 35" src="https://github.com/user-attachments/assets/797d83d4-c8e9-4ff8-9e2f-9456827d3f72" />

This change prevents the error by adding `Sendable` conformance to the `Plugin` struct

### How to test the changes locally 🧐

I didn't, I'm going to check that the CI checks pass. Let me know if that isn't sufficient. 

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
