### PR TITLE
Install create-dmg using the asdf plugin

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ node = "20.12.0"
 git-cliff = "2.6.0"
 "spm:tuist/sourcedocs" = "2.0.2"
 "spm:apple/swift-openapi-generator" = "1.3.1"
+"asdf:tuist/asdf-create-dmg" = "1.2.2"
 
 [hooks]
 postinstall = "mise run install"

--- a/mise/tasks/bundle/app
+++ b/mise/tasks/bundle/app
@@ -60,7 +60,7 @@ print_status "Submitting the Tuist App for notarization..."
 mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
-curl -s https://raw.githubusercontent.com/create-dmg/create-dmg/refs/tags/v1.2.2/create-dmg | bash -s -- --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
+create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
 codesign --force --timestamp --options runtime --sign "Developer ID Application: Tuist GmbH (U6LC622NKF)" --identifier "io.tuist.app.tuist-app-dmg" "$BUILD_DMG_PATH"
 
 xcrun notarytool submit "${BUILD_DMG_PATH}" \


### PR DESCRIPTION
CI fails in `main` because the `create-dmg` script that we curl and pipe through `bash` is not atomic. I'm reverting the implementation to use our maintained asdf plugin at https://github.com/tuist/asdf-create-dmg.

