### PR TITLE
Fix the releasing of the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
 
 jobs:
   release:


### PR DESCRIPTION
This is another attempt to fix the failing [app release pipeline](https://github.com/tuist/tuist/actions/runs/13918256582/job/38945316440).

The token automatically provided by GitHub is scoped to this repository, so it doesn't work when Mise tries to use it against other repositories.