### PR TITLE
Improve tuist share CLI output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "revision" : "ab6adb693d7f980a132ca9e7bda32ebf449a729a",
-        "version" : "0.32.0"
+        "branch" : "feat/progress-bar",
+        "revision" : "ca4c95d7ce3026f796bb900b40454952f1d599ec"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64704bf61a37d77531f325d75946c48172fa5b48ef32e3644e64b857d9bc1a7c",
+  "originHash" : "aa3e6e4f6647c868548d6fdc5522b27610aea393b53b2f5f3405f0db9613eeb6",
   "pins" : [
     {
       "identity" : "aexml",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "branch" : "feat/progress-bar",
-        "revision" : "ca4c95d7ce3026f796bb900b40454952f1d599ec"
+        "revision" : "fceb977ebeba68f0653916d15e889b7f60a448fd",
+        "version" : "0.34.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -536,7 +536,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", branch: "feat/progress-bar"),
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.0")),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -536,7 +536,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.32.0")),
+        .package(url: "https://github.com/tuist/Noora", branch: "feat/progress-bar"),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),

--- a/Sources/TuistCore/Analytics/RunMetadataStorage.swift
+++ b/Sources/TuistCore/Analytics/RunMetadataStorage.swift
@@ -27,7 +27,7 @@ public actor RunMetadataStorage {
         self.selectiveTestingCacheItems = selectiveTestingCacheItems
     }
 
-    /// Preview ID associated with the current run
+    /// Preview associated with the current run
     public private(set) var previewId: String?
     public func update(previewId: String?) {
         self.previewId = previewId

--- a/Sources/TuistKit/Commands/ShareCommand.swift
+++ b/Sources/TuistKit/Commands/ShareCommand.swift
@@ -3,7 +3,7 @@ import Foundation
 import XcodeGraph
 
 public struct ShareCommand: AsyncParsableCommand, TrackableParsableCommand {
-    public var analyticsRequired: Bool { true }
+    public var analyticsRequired: Bool { false }
 
     public init() {}
 
@@ -55,7 +55,7 @@ public struct ShareCommand: AsyncParsableCommand, TrackableParsableCommand {
     var json: Bool = false
 
     public func run() async throws {
-        try await ShareService().run(
+        try await ShareCommandService().run(
             path: path,
             apps: apps,
             configuration: configuration,

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -213,7 +213,6 @@ public struct TuistCommand: AsyncParsableCommand {
             }
             ServiceContext.current?.ui?.error(.alert(errorAlert.message, nextSteps: errorAlertNextSteps))
         } else if let successAlert = successAlerts.last {
-            print("\n")
             var successAlertNextSteps = successAlert.nextSteps
             if shouldOutputLogFilePath {
                 successAlertNextSteps.append(logsNextStep)

--- a/Sources/TuistKit/Services/ShareCommandService.swift
+++ b/Sources/TuistKit/Services/ShareCommandService.swift
@@ -9,7 +9,7 @@ import TuistServer
 import TuistSupport
 import XcodeGraph
 
-enum ShareServiceError: Equatable, FatalError {
+enum ShareCommandServiceError: Equatable, FatalError {
     case projectOrWorkspaceNotFound(path: String)
     case noAppsFound(app: String, configuration: String)
     case appNotSpecified
@@ -31,7 +31,7 @@ enum ShareServiceError: Equatable, FatalError {
         case let .multipleAppsSpecified(apps):
             return "You specified multiple apps to share: \(apps.joined(separator: " ")). You cannot specify multiple apps when using `tuist share`."
         case .fullHandleNotFound:
-            return "You are missing full handle in your \(Constants.tuistManifestFileName)"
+            return "You are missing fullHandle in your \(Constants.tuistManifestFileName). Run 'tuist init' to get started with remote Tuist features."
         case let .appBundleInIPANotFound(ipaPath):
             return "No app found in the in the .ipa archive at \(ipaPath). Make sure the .ipa is a valid application archive."
         }
@@ -47,7 +47,7 @@ enum ShareServiceError: Equatable, FatalError {
 }
 
 // swiftlint:disable:next type_body_length
-struct ShareService {
+struct ShareCommandService {
     private let fileHandler: FileHandling
     private let fileSystem: FileSysteming
     private let xcodeProjectBuildDirectoryLocator: XcodeProjectBuildDirectoryLocating
@@ -131,7 +131,7 @@ struct ShareService {
         let config = try await configLoader.loadConfig(path: path)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 
-        guard let fullHandle = config.fullHandle else { throw ShareServiceError.fullHandleNotFound }
+        guard let fullHandle = config.fullHandle else { throw ShareCommandServiceError.fullHandleNotFound }
 
         let derivedDataPath = try derivedDataPath.map {
             try AbsolutePath(
@@ -161,7 +161,7 @@ struct ShareService {
                 json: json
             )
         } else if try await manifestLoader.hasRootManifest(at: path) {
-            guard apps.count < 2 else { throw ShareServiceError.multipleAppsSpecified(apps) }
+            guard apps.count < 2 else { throw ShareCommandServiceError.multipleAppsSpecified(apps) }
 
             let (graph, _, _, _) = try await manifestGraphLoader.load(path: path)
             let graphTraverser = GraphTraverser(graph: graph)
@@ -202,9 +202,9 @@ struct ShareService {
                 json: json
             )
         } else {
-            guard !apps.isEmpty else { throw ShareServiceError.appNotSpecified }
-            guard apps.count == 1, let app = apps.first else { throw ShareServiceError.multipleAppsSpecified(apps) }
-            guard !platforms.isEmpty else { throw ShareServiceError.platformsNotSpecified }
+            guard !apps.isEmpty else { throw ShareCommandServiceError.appNotSpecified }
+            guard apps.count == 1, let app = apps.first else { throw ShareCommandServiceError.multipleAppsSpecified(apps) }
+            guard !platforms.isEmpty else { throw ShareCommandServiceError.platformsNotSpecified }
 
             let configuration = configuration ?? BuildConfiguration.debug.name
 
@@ -212,7 +212,7 @@ struct ShareService {
             let project = try await fileSystem.glob(directory: path, include: ["*.xcodeproj"]).collect().first
             guard let workspaceOrProjectPath = workspace ?? project
             else {
-                throw ShareServiceError.projectOrWorkspaceNotFound(path: path.pathString)
+                throw ShareCommandServiceError.projectOrWorkspaceNotFound(path: path.pathString)
             }
 
             try await uploadPreviews(
@@ -226,8 +226,6 @@ struct ShareService {
                 json: json
             )
         }
-
-        ServiceContext.current?.alerts?.success(.alert("Product shared successfully"))
     }
 
     // MARK: - Helpers
@@ -247,7 +245,8 @@ struct ShareService {
         json: Bool
     ) async throws {
         guard appPaths.count == 1,
-              let ipaPath = appPaths.first else { throw ShareServiceError.multipleAppsSpecified(appPaths.map(\.pathString)) }
+              let ipaPath = appPaths.first
+        else { throw ShareCommandServiceError.multipleAppsSpecified(appPaths.map(\.pathString)) }
 
         guard let appBundlePath = try await fileSystem.glob(
             directory: fileArchiverFactory.makeFileUnarchiver(for: ipaPath).unzip(),
@@ -255,7 +254,7 @@ struct ShareService {
         )
         .collect()
         .first
-        else { throw ShareServiceError.appBundleInIPANotFound(ipaPath) }
+        else { throw ShareCommandServiceError.appBundleInIPANotFound(ipaPath) }
         let appBundle = try await appBundleLoader.load(appBundlePath)
         let displayName = appBundle.infoPlist.name
 
@@ -286,7 +285,7 @@ struct ShareService {
         guard appNames.count == 1,
               let appName = appNames.first,
               appPaths.allSatisfy({ $0.extension == "app" })
-        else { throw ShareServiceError.multipleAppsSpecified(appNames) }
+        else { throw ShareCommandServiceError.multipleAppsSpecified(appNames) }
 
         try await uploadPreviews(
             .appBundles(appPaths),
@@ -372,7 +371,7 @@ struct ShareService {
             }
 
             if appPaths.isEmpty {
-                throw ShareServiceError.noAppsFound(app: app, configuration: configuration)
+                throw ShareCommandServiceError.noAppsFound(app: app, configuration: configuration)
             }
 
             try await uploadPreviews(
@@ -411,19 +410,30 @@ struct ShareService {
         serverURL: URL,
         json: Bool
     ) async throws {
-        ServiceContext.current?.logger?.notice("Uploading \(displayName)...")
-        let preview = try await previewsUploadService.uploadPreviews(
-            previewUploadType,
-            displayName: displayName,
-            version: version,
-            bundleIdentifier: bundleIdentifier,
-            icon: icon,
-            supportedPlatforms: supportedPlatforms,
-            fullHandle: fullHandle,
-            serverURL: serverURL
-        )
-        ServiceContext.current?.logger?
-            .notice("\(displayName) uploaded – share it with others using the following link: \(preview.url.absoluteString)")
+        let preview = try await ServiceContext.current!.ui!.progressBarStep(
+            message: "Uploading \(displayName)",
+            successMessage: "\(displayName) uploaded",
+            errorMessage: "Failed to load manifests"
+        ) { updateProgress in
+            try await previewsUploadService.uploadPreviews(
+                previewUploadType,
+                displayName: displayName,
+                version: version,
+                bundleIdentifier: bundleIdentifier,
+                icon: icon,
+                supportedPlatforms: supportedPlatforms,
+                fullHandle: fullHandle,
+                serverURL: serverURL,
+                updateProgress: updateProgress
+            )
+        }
+
+        ServiceContext.current?.ui?
+            .success(
+                .alert(
+                    "Share \(displayName) with others using the following link: \(preview.url.absoluteString)"
+                )
+            )
 
         await ServiceContext.current?.runMetadataStorage?.update(previewId: preview.id)
 

--- a/Sources/TuistKit/Services/ShareCommandService.swift
+++ b/Sources/TuistKit/Services/ShareCommandService.swift
@@ -9,7 +9,7 @@ import TuistServer
 import TuistSupport
 import XcodeGraph
 
-enum ShareCommandServiceError: Equatable, FatalError {
+enum ShareCommandServiceError: Equatable, LocalizedError {
     case projectOrWorkspaceNotFound(path: String)
     case noAppsFound(app: String, configuration: String)
     case appNotSpecified
@@ -18,7 +18,7 @@ enum ShareCommandServiceError: Equatable, FatalError {
     case fullHandleNotFound
     case appBundleInIPANotFound(AbsolutePath)
 
-    var description: String {
+    var errorDescription: String? {
         switch self {
         case let .projectOrWorkspaceNotFound(path):
             return "Workspace or project not found at \(path)"
@@ -428,7 +428,7 @@ struct ShareCommandService {
             )
         }
 
-        ServiceContext.current?.ui?
+        ServiceContext.current?.alerts?
             .success(
                 .alert(
                     "Share \(displayName) with others using the following link: \(preview.url.absoluteString)"

--- a/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -158,7 +158,8 @@ public final class AnalyticsArtifactUploadService: AnalyticsArtifactUploadServic
                         serverURL: serverURL,
                         contentLength: part.contentLength
                     )
-                }
+                },
+                updateProgress: { _ in }
             )
 
             try await multipartUploadCompleteAnalyticsService.uploadAnalyticsArtifact(

--- a/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Mockable
 import Path
@@ -46,67 +47,74 @@ enum MultipartUploadArtifactServiceError: FatalError {
 public protocol MultipartUploadArtifactServicing {
     func multipartUploadArtifact(
         artifactPath: AbsolutePath,
-        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String
+        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
+        updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)]
 }
 
 public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     private let urlSession: URLSession
+    private let fileSystem: FileSysteming
 
-    public init(urlSession: URLSession = .tuistShared) {
+    public init(
+        urlSession: URLSession = .tuistShared,
+        fileSystem: FileSysteming = FileSystem()
+    ) {
         self.urlSession = urlSession
+        self.fileSystem = fileSystem
     }
 
     public func multipartUploadArtifact(
         artifactPath: AbsolutePath,
-        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String
+        generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
+        updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)] {
         let partSize = 10 * 1024 * 1024
         guard let inputStream = InputStream(url: artifactPath.url) else {
             throw MultipartUploadArtifactServiceError.cannotCreateInputStream(artifactPath)
         }
 
+        let size = try await fileSystem.fileSizeInBytes(at: artifactPath) ?? 0
+        let numberOfParts = Int(ceil(Double(Int(size)) / Double(partSize)))
+
         inputStream.open()
 
-        var partNumber = 1
+        defer { inputStream.close() }
+
         var buffer = [UInt8](repeating: 0, count: partSize)
 
-        var uploadParts: [UploadPart] = []
+        let uploadedParts: ThreadSafe<[(etag: String, partNumber: Int)]> = ThreadSafe([])
+        let partNumber = ThreadSafe(1)
 
-        while inputStream.hasBytesAvailable {
-            let bytesRead = inputStream.read(&buffer, maxLength: partSize)
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            while inputStream.hasBytesAvailable {
+                let bytesRead = inputStream.read(&buffer, maxLength: partSize)
 
-            if bytesRead > 0 {
-                let partData = Data(bytes: buffer, count: bytesRead)
-                let uploadURLString = try await generateUploadURL(MultipartUploadArtifactPart(
-                    number: partNumber,
-                    contentLength: bytesRead
-                ))
-                guard let url = URL(string: uploadURLString) else {
-                    throw MultipartUploadArtifactServiceError.invalidMultipartUploadURL(uploadURLString)
+                if bytesRead > 0 {
+                    let partData = Data(bytes: buffer, count: bytesRead)
+                    let currentPartNumber = partNumber.value
+                    partNumber.mutate { $0 += 1 }
+                    group.addTask {
+                        let uploadURLString = try await generateUploadURL(MultipartUploadArtifactPart(
+                            number: currentPartNumber,
+                            contentLength: bytesRead
+                        ))
+                        guard let url = URL(string: uploadURLString) else {
+                            throw MultipartUploadArtifactServiceError.invalidMultipartUploadURL(uploadURLString)
+                        }
+
+                        let request = uploadRequest(url: url, fileSize: UInt64(bytesRead), data: partData)
+                        let etag = try await upload(for: request)
+                        uploadedParts.mutate { $0.append((etag: etag, partNumber: currentPartNumber)) }
+                        updateProgress(Double(uploadedParts.value.count) / Double(numberOfParts))
+                    }
                 }
-                uploadParts.append(
-                    UploadPart(
-                        url: url,
-                        fileSize: UInt64(bytesRead),
-                        data: partData,
-                        partNumber: partNumber
-                    )
-                )
-
-                partNumber += 1
             }
+            try await group.waitForAll()
         }
 
-        inputStream.close()
-
-        return try await uploadParts
-            .concurrentMap { partUpload in
-                let initialDate = Date()
-                let request = uploadRequest(url: partUpload.url, fileSize: partUpload.fileSize, data: partUpload.data)
-                let etag = try await upload(for: request)
-                return (etag: etag, partNumber: partUpload.partNumber)
-            }
+        return uploadedParts
+            .value
             .sorted(by: { $0.partNumber < $1.partNumber })
     }
 

--- a/Sources/TuistServer/Services/PreviewsUploadService.swift
+++ b/Sources/TuistServer/Services/PreviewsUploadService.swift
@@ -20,7 +20,8 @@ public protocol PreviewsUploadServicing {
         icon: AbsolutePath?,
         supportedPlatforms: [DestinationType],
         fullHandle: String,
-        serverURL: URL
+        serverURL: URL,
+        updateProgress: @escaping (Double) -> Void
     ) async throws -> Preview
 }
 
@@ -77,7 +78,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         icon: AbsolutePath?,
         supportedPlatforms: [DestinationType],
         fullHandle: String,
-        serverURL: URL
+        serverURL: URL,
+        updateProgress: @escaping (Double) -> Void
     ) async throws -> Preview {
         let previewType: PreviewType
         let buildPath: AbsolutePath
@@ -90,6 +92,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
             previewType = .appBundle
         }
 
+        updateProgress(0.1)
+
         let preview = try await retryProvider.runWithRetries {
             let previewUpload = try await multipartUploadStartPreviewsService.startPreviewsMultipartUpload(
                 type: previewType,
@@ -100,6 +104,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
                 fullHandle: fullHandle,
                 serverURL: serverURL
             )
+
+            updateProgress(0.2)
 
             let parts = try await multipartUploadArtifactService.multipartUploadArtifact(
                 artifactPath: buildPath,
@@ -112,6 +118,9 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
                         serverURL: serverURL,
                         contentLength: part.contentLength
                     )
+                },
+                updateProgress: {
+                    updateProgress(0.2 + $0 * 0.7)
                 }
             )
 

--- a/Sources/TuistSupportTesting/TestCase/ServiceContext+Tests.swift
+++ b/Sources/TuistSupportTesting/TestCase/ServiceContext+Tests.swift
@@ -32,7 +32,7 @@ extension ServiceContext {
         context.logger = Logger(label: label, factory: { _ in
             return testingLogHandler
         })
-        context.ui = NooraMock()
+        context.ui = NooraMock(terminal: Terminal(isInteractive: false))
         context.alerts = AlertController()
         context.recentPaths = MockRecentPathsStoring()
         try await ServiceContext.withValue(context) {

--- a/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
@@ -21,7 +21,6 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
 
             // When: Share
             try await run(ShareCommand.self)
-            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("App uploaded") == true)
             XCTAssertTrue(
                 ServiceContext.current?.recordedUI()
                     .contains("Share App with others using the following link:") == true
@@ -49,7 +48,6 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
             // When: Share App
             try await run(ShareCommand.self, "App")
             let shareLink = try previewLink("App")
-            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("App uploaded") == true)
             XCTAssertTrue(
                 ServiceContext.current?.recordedUI()
                     .contains("Share App with others using the following link:") == true
@@ -65,7 +63,6 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
             // When: Share AppClip1
             try await run(ShareCommand.self, "AppClip1")
             let appClipShareLink = try previewLink("AppClip1")
-            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("AppClip1 uploaded") == true)
             XCTAssertTrue(
                 ServiceContext.current?.recordedUI()
                     .contains("Share AppClip1 with others using the following link:") == true
@@ -99,10 +96,14 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
                 ]
             )
             try await run(ShareCommand.self, "App", "--platforms", "ios")
-            assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
+            XCTAssertTrue(
+                ServiceContext.current?.recordedUI()
+                    .contains("Share App with others using the following link:") == true
+            )
+            let previewLink = try previewLink()
             ServiceContext.current?.resetRecordedUI()
 
-            try await run(RunCommand.self, try previewLink(), "-destination", "iPhone 16 Plus")
+            try await run(RunCommand.self, previewLink, "-destination", "iPhone 16 Plus")
             XCTAssertStandardOutput(pattern: "Installing and launching App on iPhone 16 Plus")
             assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
         }
@@ -136,7 +137,13 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
                 buildDirectory.appending(component: "App.app").pathString,
                 "--platforms", "ios"
             )
-            try await run(RunCommand.self, try previewLink(), "-destination", "iPhone 16 Plus")
+            XCTAssertTrue(
+                ServiceContext.current?.recordedUI()
+                    .contains("Share App with others using the following link:") == true
+            )
+            let previewLink = try previewLink()
+            ServiceContext.current?.resetRecordedUI()
+            try await run(RunCommand.self, previewLink, "-destination", "iPhone 16 Plus")
             XCTAssertStandardOutput(pattern: "Installing and launching App on iPhone 16 Plus")
             assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
         }

--- a/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
@@ -21,11 +21,15 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
 
             // When: Share
             try await run(ShareCommand.self)
-            assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
+            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("App uploaded") == true)
+            XCTAssertTrue(
+                ServiceContext.current?.recordedUI()
+                    .contains("Share App with others using the following link:") == true
+            )
+            let shareLink = try previewLink()
             ServiceContext.current?.resetRecordedUI()
 
             // When: Run
-            let shareLink = try previewLink()
             try await run(RunCommand.self, shareLink, "-destination", "iPhone 16 Pro")
             assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
             ServiceContext.current?.resetRecordedUI()
@@ -45,8 +49,11 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
             // When: Share App
             try await run(ShareCommand.self, "App")
             let shareLink = try previewLink("App")
-            assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
-
+            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("App uploaded") == true)
+            XCTAssertTrue(
+                ServiceContext.current?.recordedUI()
+                    .contains("Share App with others using the following link:") == true
+            )
             ServiceContext.current?.resetRecordedUI()
 
             // When: Run App on iPhone 16
@@ -58,7 +65,11 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
             // When: Share AppClip1
             try await run(ShareCommand.self, "AppClip1")
             let appClipShareLink = try previewLink("AppClip1")
-            assertSnapshot(of: ServiceContext.current?.recordedUI() ?? "", as: .lines)
+            XCTAssertTrue(ServiceContext.current?.recordedUI().contains("AppClip1 uploaded") == true)
+            XCTAssertTrue(
+                ServiceContext.current?.recordedUI()
+                    .contains("Share AppClip1 with others using the following link:") == true
+            )
             ServiceContext.current?.resetRecordedUI()
 
             // When: Run AppClip1
@@ -135,9 +146,9 @@ final class ShareAcceptanceTests: ServerAcceptanceTestCase {
 extension ServerAcceptanceTestCase {
     fileprivate func previewLink(_ displayName: String = "App") throws -> String {
         try XCTUnwrap(
-            ServiceContext.current?.testingLogHandler?.collected[.notice, >=]
+            ServiceContext.current?.recordedUI()?
                 .components(separatedBy: .newlines)
-                .first(where: { $0.contains("\(displayName) uploaded – share") })?
+                .first(where: { $0.contains("Share \(displayName) with others") })?
                 .components(separatedBy: .whitespaces)
                 .last
         )

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.1.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.1.txt
@@ -1,2 +1,6 @@
+▌ ! Warning
+▌
+▌ The following items may need attention:
+▌  ▸ Target 'StaticFramework' has been linked from target 'AppClip1' and target 'AppClip1Widgets', it is a static product so may introduce unwanted side effects.
 ▌ ✔ Success
 ▌ The project built successfully

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.1.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.1.txt
@@ -1,6 +1,2 @@
-▌ ! Warning
-▌
-▌ The following items may need attention:
-▌  ▸ Target 'StaticFramework' has been linked from target 'AppClip1' and target 'AppClip1Widgets', it is a static product so may introduce unwanted side effects.
 ▌ ✔ Success
 ▌ The project built successfully

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.2.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.2.txt
@@ -1,2 +1,2 @@
 ▌ ✔ Success
-▌ Product shared successfully
+▌ App was successfully launched 📲

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.3.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_appclip.3.txt
@@ -1,2 +1,2 @@
 ▌ ✔ Success
-▌ App was successfully launched 📲
+▌ AppClip1 was successfully launched 📲

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_frameworks.2.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_ios_app_with_frameworks.2.txt
@@ -1,2 +1,2 @@
 ▌ ✔ Success
-▌ Product shared successfully
+▌ App was successfully launched 📲

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_xcode_app.1.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_xcode_app.1.txt
@@ -1,2 +1,2 @@
 ▌ ✔ Success
-▌ Product shared successfully
+▌ App was successfully launched 📲

--- a/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_xcode_app_files.1.txt
+++ b/Tests/TuistKitAcceptanceTests/__Snapshots__/ShareAcceptanceTests/test_share_xcode_app_files.1.txt
@@ -1,4 +1,2 @@
 ▌ ✔ Success
-▌ Product shared successfully
-▌ ✔ Success
 ▌ App was successfully launched 📲

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading App
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
@@ -1,0 +1,3 @@
+✔︎ App uploaded [0.0s]
+▌ ✔ Success
+▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_app_bundles.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading App
+ℹ︎ Uploading App ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading App
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
@@ -1,0 +1,3 @@
+✔︎ App uploaded [0.0s]
+▌ ✔ Success
+▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_ipa.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading App
+ℹ︎ Uploading App ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading App
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
@@ -1,0 +1,3 @@
+✔︎ App uploaded [0.0s]
+▌ ✔ Success
+▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading App
+ℹ︎ Uploading App ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading AppTwo
+ℹ︎ Uploading AppTwo ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ AppTwo uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share AppTwo with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading AppTwo
 ✔︎ AppTwo uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share AppTwo with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_app.1.txt
@@ -1,0 +1,3 @@
+✔︎ AppTwo uploaded [0.0s]
+▌ ✔ Success
+▌ Share AppTwo with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading AppClip
 ✔︎ AppClip uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share AppClip with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
@@ -1,0 +1,3 @@
+✔︎ AppClip uploaded [0.0s]
+▌ ✔ Success
+▌ Share AppClip with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_tuist_project_with_a_specified_appclip.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading AppClip
+ℹ︎ Uploading AppClip ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ AppClip uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share AppClip with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
@@ -1,3 +1,4 @@
+ℹ︎ Uploading App
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
@@ -1,0 +1,3 @@
+✔︎ App uploaded [0.0s]
+▌ ✔ Success
+▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
+++ b/Tests/TuistKitTests/Services/__Snapshots__/ShareCommandServiceTests/test_share_xcode_app.1.txt
@@ -1,4 +1,4 @@
-ℹ︎ Uploading App
+ℹ︎ Uploading App ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   0%
 ✔︎ App uploaded [0.0s]
 ▌ ✔ Success
 ▌ Share App with others using the following link: https://test.tuist.io

--- a/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/AnalyticsArtifactUploadServiceTests.swift
@@ -88,7 +88,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
                 generateUploadURL: .matching { callback in
                     generateUploadURLCallback = callback
                     return true
-                }
+                },
+                updateProgress: .any
             )
             .willReturn([(etag: "etag", partNumber: 1)])
 
@@ -115,7 +116,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadArtifactService)
             .multipartUploadArtifact(
                 artifactPath: .matching { $0.basename == "invocation_record.json" },
-                generateUploadURL: .any
+                generateUploadURL: .any,
+                updateProgress: .any
             )
             .willReturn([(etag: "etag", partNumber: 1)])
 
@@ -148,7 +150,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadArtifactService)
             .multipartUploadArtifact(
                 artifactPath: .matching { $0.basename == "\(testResultBundleObjectId).json" },
-                generateUploadURL: .any
+                generateUploadURL: .any,
+                updateProgress: .any
             )
             .willReturn([(etag: "etag", partNumber: 1)])
         let uploadPartURL = "https://tuist.io/upload-url"

--- a/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
@@ -64,7 +64,8 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
                 generateUploadURL: .matching { callback in
                     self.multipartUploadCapturedGenerateUploadURLCallback = callback
                     return true
-                }
+                },
+                updateProgress: .any
             )
             .willReturn([(etag: "etag", partNumber: 1)])
 
@@ -126,7 +127,8 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
             icon: nil,
             supportedPlatforms: [.simulator(.iOS)],
             fullHandle: "tuist/tuist",
-            serverURL: serverURL
+            serverURL: serverURL,
+            updateProgress: { _ in }
         )
 
         // Then
@@ -181,7 +183,8 @@ final class PreviewsUploadServiceTests: TuistUnitTestCase {
             icon: icon,
             supportedPlatforms: [.device(.iOS)],
             fullHandle: "tuist/tuist",
-            serverURL: serverURL
+            serverURL: serverURL,
+            updateProgress: { _ in }
         )
 
         // Then


### PR DESCRIPTION
### Short description 📝

Output before these changes:
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/e8d2d178-98fc-4f4a-8a3a-3c25c21a2298" />

What has especially been painful when uploading apps is that there's no sense of progress. See the video – the output looks outright stuck:

https://github.com/user-attachments/assets/b89b2389-3ce3-4232-96e7-8b8c83963d39

Output after these changes:
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/4d4f562c-abda-47f8-b783-d7496a41ff8a" />

And the new video recording:

https://github.com/user-attachments/assets/b27dfce3-e416-4f0d-a235-31eefbfd89de

This PR uses the new Noora components to provide a better experience.


### How to test the changes locally 🧐

- Run `tuist share` in the `ios_app_frameworks` fixture.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
