### PR TITLE
Fix: Local package not in project Package Dependencies

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -265,7 +265,8 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     }
 
     private func generateSwiftPackageReferences(project: Project, pbxproj: PBXProj, pbxProject: PBXProject) throws {
-        var packageReferences: [String: XCRemoteSwiftPackageReference] = [:]
+        var remotePackageReferences: [String: XCRemoteSwiftPackageReference] = [:]
+        var localPackageReferences: [String: XCLocalSwiftPackageReference] = [:]
 
         for package in project.packages {
             switch package {
@@ -277,6 +278,12 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
                     lastKnownFileType: "folder",
                     path: path.relative(to: project.sourceRootPath).pathString
                 )
+
+                let packageReference = XCLocalSwiftPackageReference(
+                    relativePath: path.pathString
+                )
+                pbxproj.add(object: packageReference)
+                localPackageReferences[path.pathString] = packageReference
 
                 pbxproj.add(object: reference)
 
@@ -292,12 +299,13 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
                     repositoryURL: url,
                     versionRequirement: requirement.xcodeprojValue
                 )
-                packageReferences[url] = packageReference
+                remotePackageReferences[url] = packageReference
                 pbxproj.add(object: packageReference)
             }
         }
 
-        pbxProject.remotePackages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
+        pbxProject.remotePackages = remotePackageReferences.sorted { $0.key < $1.key }.map { $1 }
+        pbxProject.localPackages = localPackageReferences.sorted { $0.key < $1.key }.map { $1 }
     }
 
     private func generateAttributes(project: Project) -> [String: Any] {

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -445,7 +445,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             "../LocalPackages/LocalPackageA",
         ])
     }
-
+    
     func test_generate_setsLastUpgradeCheck() async throws {
         // Given
         let path = try temporaryPath()
@@ -470,6 +470,95 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(attributes, [
             "BuildIndependentTargetsInParallel": "YES",
             "LastUpgradeCheck": "1251",
+        ])
+    }
+    
+    func test_generate_localSwiftPackages() async throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/Project")
+        let localPackagePath = try AbsolutePath(validating: "/LocalPackages/LocalPackageA")
+        let target = Target.test(name: "A")
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            name: "Project",
+            targets: [target, .test(name: "B", dependencies: [.package(product: "A", type: .runtime)])],
+            packages: [.local(path: localPackagePath)]
+        )
+        let graphTarget = GraphTarget(path: project.path, target: target, project: project)
+        let graph = Graph.test(
+            projects: [project.path: project],
+            packages: [
+                project.path: [
+                    "A": .local(path: localPackagePath),
+                ],
+            ],
+            dependencies: [
+                .target(name: graphTarget.target.name, path: graphTarget.path): [
+                    .packageProduct(path: project.path, product: "A", type: .runtime),
+                ],
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        given(xcodeController)
+            .selectedVersion()
+            .willReturn(Version(15, 0, 0))
+
+        // When
+        let got = try await subject.generate(project: project, graphTraverser: graphTraverser)
+
+        // Then
+        let pbxproj = got.xcodeProj.pbxproj
+        let rootObject = try XCTUnwrap(pbxproj.rootObject)
+        let localPackagePaths = rootObject.localPackages.compactMap(\.relativePath)
+        let remotePackageNames = rootObject.remotePackages.compactMap(\.name)
+        XCTAssertEqual(localPackagePaths, [
+            "/LocalPackages/LocalPackageA",
+        ])
+        XCTAssert(remotePackageNames.isEmpty)
+    }
+    
+    func test_generate_remoteSwiftPackages() async throws {
+        given(xcodeController)
+            .selectedVersion()
+            .willReturn(Version(15, 0, 0))
+
+        // Given
+        let temporaryPath = try temporaryPath()
+        let target = Target.test(name: "A")
+        let project = Project.test(
+            path: temporaryPath,
+            name: "Project",
+            targets: [target, .test(name: "B", dependencies: [.package(product: "A", type: .runtime)])],
+            packages: [.remote(url: "A", requirement: .exact("0.1"))]
+        )
+
+        let graphTarget = GraphTarget.test(path: project.path, target: target, project: project)
+        let graph = Graph.test(
+            projects: [project.path: project],
+            packages: [
+                project.path: [
+                    "A": .remote(url: "A", requirement: .exact("0.1")),
+                ],
+            ],
+            dependencies: [
+                .target(name: graphTarget.target.name, path: graphTarget.path): [
+                    .packageProduct(path: project.path, product: "A", type: .runtime),
+                ],
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try await subject.generate(project: project, graphTraverser: graphTraverser)
+
+        // Then
+        let pbxproj = got.xcodeProj.pbxproj
+        let rootObject = try XCTUnwrap(pbxproj.rootObject)
+        let remotePackageNames = rootObject.remotePackages.compactMap(\.name)
+        XCTAssertEqual(remotePackageNames, [
+            "A",
         ])
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -7,9 +7,9 @@ import TuistCoreTesting
 import TuistSupport
 import XcodeGraph
 import XCTest
-@testable import XcodeProj
 @testable import TuistGenerator
 @testable import TuistSupportTesting
+@testable import XcodeProj
 
 final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
     var subject: ProjectDescriptorGenerator!
@@ -445,7 +445,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             "../LocalPackages/LocalPackageA",
         ])
     }
-    
+
     func test_generate_setsLastUpgradeCheck() async throws {
         // Given
         let path = try temporaryPath()
@@ -472,7 +472,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             "LastUpgradeCheck": "1251",
         ])
     }
-    
+
     func test_generate_localSwiftPackages() async throws {
         // Given
         let projectPath = try AbsolutePath(validating: "/Project")
@@ -525,7 +525,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         XCTAssert(remotePackageNames.isEmpty)
         XCTAssert(remoteSwiftPackageReferenceNames.isEmpty)
     }
-    
+
     func test_generate_remoteSwiftPackages() async throws {
         given(xcodeController)
             .selectedVersion()

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -6,8 +6,8 @@ import TuistCore
 import TuistCoreTesting
 import TuistSupport
 import XcodeGraph
-import XcodeProj
 import XCTest
+@testable import XcodeProj
 @testable import TuistGenerator
 @testable import TuistSupportTesting
 
@@ -511,12 +511,19 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Then
         let pbxproj = got.xcodeProj.pbxproj
         let rootObject = try XCTUnwrap(pbxproj.rootObject)
+        let pbxobjects = try rootObject.objects()
         let localPackagePaths = rootObject.localPackages.compactMap(\.relativePath)
+        let localSwiftPackageReferencePaths = pbxobjects.localSwiftPackageReferences.values.compactMap(\.relativePath)
         let remotePackageNames = rootObject.remotePackages.compactMap(\.name)
+        let remoteSwiftPackageReferenceNames = pbxobjects.remoteSwiftPackageReferences.values.compactMap(\.name)
         XCTAssertEqual(localPackagePaths, [
             "/LocalPackages/LocalPackageA",
         ])
+        XCTAssertEqual(localSwiftPackageReferencePaths, [
+            "/LocalPackages/LocalPackageA",
+        ])
         XCTAssert(remotePackageNames.isEmpty)
+        XCTAssert(remoteSwiftPackageReferenceNames.isEmpty)
     }
     
     func test_generate_remoteSwiftPackages() async throws {
@@ -556,8 +563,17 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Then
         let pbxproj = got.xcodeProj.pbxproj
         let rootObject = try XCTUnwrap(pbxproj.rootObject)
+        let pbxobjects = try rootObject.objects()
+        let localPackagePaths = rootObject.localPackages.compactMap(\.relativePath)
+        let localSwiftPackageReferencePaths = pbxobjects.localSwiftPackageReferences.values.compactMap(\.relativePath)
         let remotePackageNames = rootObject.remotePackages.compactMap(\.name)
+        let remoteSwiftPackageReferenceNames = pbxobjects.remoteSwiftPackageReferences.values.compactMap(\.name)
+        XCTAssert(localPackagePaths.isEmpty)
+        XCTAssert(localSwiftPackageReferencePaths.isEmpty)
         XCTAssertEqual(remotePackageNames, [
+            "A",
+        ])
+        XCTAssertEqual(remoteSwiftPackageReferenceNames, [
             "A",
         ])
     }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7369>

### Short description 📝

When generating a project that has a `.local` package, the package is not included in the Xcode project Package Dependencies, which prevents the project from building in Xcode.

### How to test the changes locally 🧐

1. Create a project which refers to a package on the local filesystem. 
2. Generate the project using `tuist generate`
3. Click on the "Package Dependencies" tab in the Xcode project.
4. Check that the local package is present.
5. Build the project.

Example `Project.swift`:

```
let project = Project(
    name: "MyProject",
    packages: [
        .local(path: "../../../MyLocalPackage"),
    ],
    ....
)
```

### Contributor checklist ✅

- [Y] The code has been linted using run `mise run lint-fix`
- [B] The change is tested via unit testing or acceptance testing, or both
- [N] The title of the PR is formulated in a way that is usable as a changelog entry
- [N] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
