### PR TITLE
Update previews to the latest API

### DIFF
--- a/Sources/TuistKit/Services/ShareService.swift
+++ b/Sources/TuistKit/Services/ShareService.swift
@@ -149,6 +149,7 @@ struct ShareService {
         if appPaths.contains(where: { $0.extension == "ipa" }) {
             try await shareIPA(
                 appPaths,
+                path: path,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -156,6 +157,7 @@ struct ShareService {
         } else if appPaths.contains(where: { $0.extension == "app" }) {
             try await shareAppBundles(
                 appPaths,
+                path: path,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -197,6 +199,7 @@ struct ShareService {
                 configuration: configuration,
                 app: appTarget.target.productName,
                 derivedDataPath: derivedDataPath,
+                path: path,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -221,6 +224,7 @@ struct ShareService {
                 configuration: configuration,
                 app: app,
                 derivedDataPath: derivedDataPath,
+                path: path,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -242,6 +246,7 @@ struct ShareService {
 
     private func shareIPA(
         _ appPaths: [AbsolutePath],
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL,
         json: Bool
@@ -266,6 +271,7 @@ struct ShareService {
             bundleIdentifier: appBundle.infoPlist.bundleId,
             icon: iconPaths(for: appBundle).first,
             supportedPlatforms: appBundle.infoPlist.supportedPlatforms,
+            path: path,
             fullHandle: fullHandle,
             serverURL: serverURL,
             json: json
@@ -274,6 +280,7 @@ struct ShareService {
 
     private func shareAppBundles(
         _ appPaths: [AbsolutePath],
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL,
         json: Bool
@@ -297,6 +304,7 @@ struct ShareService {
                 .concurrentFlatMap { try await iconPaths(for: $0) }
                 .first,
             supportedPlatforms: appBundles.flatMap(\.infoPlist.supportedPlatforms),
+            path: path,
             fullHandle: fullHandle,
             serverURL: serverURL,
             json: json
@@ -338,6 +346,7 @@ struct ShareService {
         configuration: String,
         app: String,
         derivedDataPath: AbsolutePath?,
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL,
         json: Bool
@@ -384,6 +393,7 @@ struct ShareService {
                     .concurrentFlatMap { try await iconPaths(for: $0) }
                     .first,
                 supportedPlatforms: appBundles.flatMap(\.infoPlist.supportedPlatforms),
+                path: path,
                 fullHandle: fullHandle,
                 serverURL: serverURL,
                 json: json
@@ -407,6 +417,7 @@ struct ShareService {
         bundleIdentifier: String?,
         icon: AbsolutePath?,
         supportedPlatforms: [DestinationType],
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL,
         json: Bool
@@ -419,6 +430,7 @@ struct ShareService {
             bundleIdentifier: bundleIdentifier,
             icon: icon,
             supportedPlatforms: supportedPlatforms,
+            path: path,
             fullHandle: fullHandle,
             serverURL: serverURL
         )

--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -4396,6 +4396,28 @@ internal struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.downloadPreview.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
                 case 401:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.downloadPreview.Output.Unauthorized.Body

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -3816,6 +3816,14 @@ internal enum Operations {
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/display_name`.
                     internal var display_name: Swift.String?
+                    /// The git branch associated with the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/git_branch`.
+                    internal var git_branch: Swift.String?
+                    /// The git commit SHA associated with the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/git_commit_sha`.
+                    internal var git_commit_sha: Swift.String?
                     /// The supported platforms of the preview.
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/supported_platforms`.
@@ -3840,18 +3848,24 @@ internal enum Operations {
                     /// - Parameters:
                     ///   - bundle_identifier: The bundle identifier of the preview.
                     ///   - display_name: The display name of the preview.
+                    ///   - git_branch: The git branch associated with the preview.
+                    ///   - git_commit_sha: The git commit SHA associated with the preview.
                     ///   - supported_platforms: The supported platforms of the preview.
                     ///   - _type: The type of the preview to upload.
                     ///   - version: The version of the preview.
                     internal init(
                         bundle_identifier: Swift.String? = nil,
                         display_name: Swift.String? = nil,
+                        git_branch: Swift.String? = nil,
+                        git_commit_sha: Swift.String? = nil,
                         supported_platforms: [Components.Schemas.PreviewSupportedPlatform]? = nil,
                         _type: Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload._typePayload? = nil,
                         version: Swift.String? = nil
                     ) {
                         self.bundle_identifier = bundle_identifier
                         self.display_name = display_name
+                        self.git_branch = git_branch
+                        self.git_commit_sha = git_commit_sha
                         self.supported_platforms = supported_platforms
                         self._type = _type
                         self.version = version
@@ -3859,6 +3873,8 @@ internal enum Operations {
                     internal enum CodingKeys: String, CodingKey {
                         case bundle_identifier
                         case display_name
+                        case git_branch
+                        case git_commit_sha
                         case supported_platforms
                         case _type = "type"
                         case version
@@ -12864,6 +12880,57 @@ internal enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/{preview_id}/GET/responses/400/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/{preview_id}/GET/responses/400/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.downloadPreview.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.downloadPreview.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// The request is invalid
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/previews/{preview_id}/get(downloadPreview)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.downloadPreview.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            internal var badRequest: Operations.downloadPreview.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
                             response: self
                         )
                     }

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -1644,6 +1644,16 @@ paths:
                   type: string
                   x-struct:
                   x-validate:
+                git_branch:
+                  description: The git branch associated with the preview.
+                  type: string
+                  x-struct:
+                  x-validate:
+                git_commit_sha:
+                  description: The git commit SHA associated with the preview.
+                  type: string
+                  x-struct:
+                  x-validate:
                 supported_platforms:
                   description: The supported platforms of the preview.
                   items:
@@ -3457,6 +3467,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Preview'
           description: The preview exists and can be downloaded
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request is invalid
         401:
           content:
             application/json:

--- a/Sources/TuistServer/Services/GetPreviewService.swift
+++ b/Sources/TuistServer/Services/GetPreviewService.swift
@@ -11,27 +11,19 @@ public protocol GetPreviewServicing {
     ) async throws -> Preview
 }
 
-public enum GetPreviewServiceError: FatalError, Equatable {
+public enum GetPreviewServiceError: LocalizedError, Equatable {
     case unknownError(Int)
     case notFound(String)
     case forbidden(String)
     case unauthorized(String)
     case invalidPreview(String)
+    case badRequest(String)
 
-    public var type: ErrorType {
-        switch self {
-        case .unknownError, .invalidPreview:
-            return .bug
-        case .notFound, .forbidden, .unauthorized:
-            return .abort
-        }
-    }
-
-    public var description: String {
+    public var description: String? {
         switch self {
         case let .unknownError(statusCode):
             return "The preview could not be downloaded due to an unknown Tuist server response of \(statusCode)."
-        case let .notFound(message), let .forbidden(message), let .unauthorized(message):
+        case let .notFound(message), let .forbidden(message), let .unauthorized(message), let .badRequest(message):
             return message
         case let .invalidPreview(id):
             return "The preview \(id) is invalid."
@@ -95,6 +87,11 @@ public final class GetPreviewService: GetPreviewServicing {
             switch unauthorized.body {
             case let .json(error):
                 throw GetPreviewServiceError.unauthorized(error.message)
+            }
+        case let .badRequest(badRequest):
+            switch badRequest.body {
+            case let .json(error):
+                throw GetPreviewServiceError.badRequest(error.message)
             }
         }
     }

--- a/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
@@ -11,6 +11,8 @@ public protocol MultipartUploadStartPreviewsServicing {
         version: String?,
         bundleIdentifier: String?,
         supportedPlatforms: [DestinationType],
+        gitBranch: String?,
+        gitCommitSHA: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload
@@ -62,6 +64,8 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
         version: String?,
         bundleIdentifier: String?,
         supportedPlatforms: [DestinationType],
+        gitBranch: String?,
+        gitCommitSHA: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> PreviewUpload {
@@ -85,6 +89,8 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
                     .init(
                         bundle_identifier: bundleIdentifier,
                         display_name: displayName,
+                        git_branch: gitBranch,
+                        git_commit_sha: gitCommitSHA,
                         supported_platforms: supportedPlatforms.map(Components.Schemas.PreviewSupportedPlatform.init),
                         _type: type,
                         version: version

--- a/Sources/TuistServer/Services/PreviewsUploadService.swift
+++ b/Sources/TuistServer/Services/PreviewsUploadService.swift
@@ -19,6 +19,7 @@ public protocol PreviewsUploadServicing {
         bundleIdentifier: String?,
         icon: AbsolutePath?,
         supportedPlatforms: [DestinationType],
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL
     ) async throws -> Preview
@@ -33,6 +34,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
     private let multipartUploadArtifactService: MultipartUploadArtifactServicing
     private let multipartUploadCompletePreviewsService: MultipartUploadCompletePreviewsServicing
     private let uploadPreviewIconService: UploadPreviewIconServicing
+    private let gitController: GitControlling
 
     public init() {
         self.init(
@@ -45,7 +47,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
             multipartUploadArtifactService: MultipartUploadArtifactService(),
             multipartUploadCompletePreviewsService:
             MultipartUploadCompletePreviewsService(),
-            uploadPreviewIconService: UploadPreviewIconService()
+            uploadPreviewIconService: UploadPreviewIconService(),
+            gitController: GitController()
         )
     }
 
@@ -57,7 +60,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         multipartUploadGenerateURLPreviewsService: MultipartUploadGenerateURLPreviewsServicing,
         multipartUploadArtifactService: MultipartUploadArtifactServicing,
         multipartUploadCompletePreviewsService: MultipartUploadCompletePreviewsServicing,
-        uploadPreviewIconService: UploadPreviewIconServicing
+        uploadPreviewIconService: UploadPreviewIconServicing,
+        gitController: GitControlling
     ) {
         self.fileSystem = fileSystem
         self.fileArchiver = fileArchiver
@@ -67,6 +71,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         self.multipartUploadArtifactService = multipartUploadArtifactService
         self.multipartUploadCompletePreviewsService = multipartUploadCompletePreviewsService
         self.uploadPreviewIconService = uploadPreviewIconService
+        self.gitController = gitController
     }
 
     public func uploadPreviews(
@@ -76,6 +81,7 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
         bundleIdentifier: String?,
         icon: AbsolutePath?,
         supportedPlatforms: [DestinationType],
+        path: AbsolutePath,
         fullHandle: String,
         serverURL: URL
     ) async throws -> Preview {
@@ -90,6 +96,21 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
             previewType = .appBundle
         }
 
+        let gitCommitSHA: String?
+        let gitBranch: String?
+        if gitController.isInGitRepository(workingDirectory: path) {
+            if gitController.hasCurrentBranchCommits(workingDirectory: path) {
+                gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path)
+            } else {
+                gitCommitSHA = nil
+            }
+
+            gitBranch = try gitController.currentBranch(workingDirectory: path)
+        } else {
+            gitCommitSHA = nil
+            gitBranch = nil
+        }
+
         let preview = try await retryProvider.runWithRetries {
             let previewUpload = try await multipartUploadStartPreviewsService.startPreviewsMultipartUpload(
                 type: previewType,
@@ -97,6 +118,8 @@ public struct PreviewsUploadService: PreviewsUploadServicing {
                 version: version,
                 bundleIdentifier: bundleIdentifier,
                 supportedPlatforms: supportedPlatforms,
+                gitBranch: gitBranch,
+                gitCommitSHA: gitCommitSHA,
                 fullHandle: fullHandle,
                 serverURL: serverURL
             )

--- a/Tests/TuistKitTests/Services/ShareServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareServiceTests.swift
@@ -82,6 +82,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                 bundleIdentifier: .any,
                 icon: .any,
                 supportedPlatforms: .any,
+                path: .any,
                 fullHandle: .any,
                 serverURL: .any
             )
@@ -243,6 +244,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                     bundleIdentifier: .any,
                     icon: .any,
                     supportedPlatforms: .any,
+                    path: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(Constants.URLs.production)
                 )
@@ -438,6 +440,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                     bundleIdentifier: .value("com.tuist.app"),
                     icon: .any,
                     supportedPlatforms: .value([.simulator(.iOS)]),
+                    path: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(Constants.URLs.production)
                 )
@@ -791,6 +794,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                     bundleIdentifier: .any,
                     icon: .any,
                     supportedPlatforms: .any,
+                    path: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(Constants.URLs.production)
                 )
@@ -926,6 +930,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                     bundleIdentifier: .any,
                     icon: .value(iosIconPath),
                     supportedPlatforms: .any,
+                    path: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(Constants.URLs.production)
                 )
@@ -997,6 +1002,7 @@ final class ShareServiceTests: TuistUnitTestCase {
                     bundleIdentifier: .value("com.tuist.app"),
                     icon: .value(iconPath),
                     supportedPlatforms: .any,
+                    path: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(Constants.URLs.production)
                 )

--- a/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
+++ b/Tests/TuistServerTests/Services/PreviewsUploadServiceTests.swift
@@ -53,17 +53,6 @@ struct PreviewsUploadServiceTests {
             )
             .willReturn(.test(url: shareURL))
 
-        given(multipartUploadArtifactService)
-            .multipartUploadArtifact(
-                artifactPath: .any,
-                generateUploadURL: .matching { callback in
-                    self.multipartUploadCapturedGenerateUploadURLCallback = callback
-                    return true
-                },
-                updateProgress: .any
-            )
-            .willReturn([(etag: "etag", partNumber: 1)])
-
         given(multipartUploadGenerateURLPreviewsService)
             .uploadPreviews(
                 .value("preview-id"),
@@ -94,35 +83,6 @@ struct PreviewsUploadServiceTests {
             .willReturn(
                 PreviewUpload(previewId: "preview-id", uploadId: "upload-id")
             )
-
-        let shareURL = URL.test()
-
-        // When
-        let got = try await subject.uploadPreviews(
-            .appBundles([preview]),
-            displayName: "App",
-            version: nil,
-            bundleIdentifier: nil,
-            icon: nil,
-            supportedPlatforms: [.simulator(.iOS)],
-            fullHandle: "tuist/tuist",
-            serverURL: serverURL,
-            updateProgress: { _ in }
-        )
-
-        // Then
-        XCTAssertEqual(
-            got,
-            .test(
-                id: "preview-id",
-                url: shareURL
-            )
-        )
-        let gotMultipartUploadURL = try await multipartUploadCapturedGenerateUploadURLCallback(MultipartUploadArtifactPart(
-            number: 1,
-            contentLength: 20
-        ))
-        XCTAssertEqual(gotMultipartUploadURL, "https://tuist.dev/upload-url")
     }
 
     @Test func upload_app_bundle() async throws {
@@ -144,7 +104,8 @@ struct PreviewsUploadServiceTests {
                     generateUploadURL: .matching { callback in
                         multipartUploadCapturedGenerateUploadURLCallback = callback
                         return true
-                    }
+                    },
+                    updateProgress: .any
                 )
                 .willReturn([(etag: "etag", partNumber: 1)])
 
@@ -160,7 +121,8 @@ struct PreviewsUploadServiceTests {
                 supportedPlatforms: [.simulator(.iOS)],
                 path: temporaryDirectory,
                 fullHandle: "tuist/tuist",
-                serverURL: serverURL
+                serverURL: serverURL,
+                updateProgress: { _ in }
             )
 
             // Then
@@ -220,7 +182,8 @@ struct PreviewsUploadServiceTests {
                     generateUploadURL: .matching { callback in
                         multipartUploadCapturedGenerateUploadURLCallback = callback
                         return true
-                    }
+                    },
+                    updateProgress: .any
                 )
                 .willReturn([(etag: "etag", partNumber: 1)])
 
@@ -243,7 +206,8 @@ struct PreviewsUploadServiceTests {
                 supportedPlatforms: [.device(.iOS)],
                 path: temporaryDirectory,
                 fullHandle: "tuist/tuist",
-                serverURL: serverURL
+                serverURL: serverURL,
+                updateProgress: { _ in }
             )
 
             // Then


### PR DESCRIPTION
### Short description 📝

Updating previews upload to the latest API, so we no longer have to rely on the command event being uploaded as raised here: https://github.com/tuist/tuist/pull/7418#discussion_r2005080322

### How to test the changes locally 🧐

- Run `tuist share` in `ios_app_with_frameworks` fixture

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
