### PR TITLE
Fix generated project without `Tuist.swift` detected as an Xcode project

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -38,6 +38,7 @@ public enum TuistAcceptanceFixtures {
     case frameworkWithNativeSwiftMacro
     case frameworkWithSwiftMacro
     case frameworkWithSPMBundle
+    case generatediOSAppWithoutConfigManifest
     case invalidManifest
     case invalidWorkspaceManifestName
     case iosAppLarge
@@ -183,6 +184,8 @@ public enum TuistAcceptanceFixtures {
             return "framework_with_swift_macro"
         case .frameworkWithSPMBundle:
             return "framework_with_spm_bundle"
+        case .generatediOSAppWithoutConfigManifest:
+            return "generated_ios_app_without_config_manifest"
         case .invalidManifest:
             return "invalid_manifest"
         case .invalidWorkspaceManifestName:

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1016,6 +1016,14 @@ final class GenerateAcceptanceTestAppWithCustomScheme: TuistAcceptanceTestCase {
     }
 }
 
+final class GenerateAcceptanceTestGeneratediOSAppWithoutConfigManifest: TuistAcceptanceTestCase {
+    func test_generated_ios_app_without_config_manifest() async throws {
+        try await setUpFixture(.generatediOSAppWithoutConfigManifest)
+        try await run(InstallCommand.self)
+        try await run(BuildCommand.self)
+    }
+}
+
 final class GenerateAcceptanceTestsAppWithMetalOptions: TuistAcceptanceTestCase {
     func test_app_with_metal_options() async throws {
         try await setUpFixture(.appWithMetalOptions)

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -263,6 +263,44 @@ final class ConfigLoaderTests: TuistUnitTestCase {
         ))
     }
 
+    func test_loadConfig_whenFileIsMissing_and_generatedWorkspaceExists() async throws {
+        // Given
+        let projectPath = try temporaryPath().appending(component: "project")
+        try await fileSystem.makeDirectory(at: projectPath)
+        try await fileSystem.touch(projectPath.appending(component: "Workspace.swift"))
+        try await fileSystem.touch(projectPath.appending(component: "Test.xcworkspace"))
+        stub(rootDirectory: nil)
+
+        // When
+        let result = try await subject.loadConfig(path: projectPath)
+
+        // Then
+        XCTAssertBetterEqual(result, TuistCore.Tuist(
+            project: .defaultGeneratedProject(),
+            fullHandle: nil,
+            url: Constants.URLs.production
+        ))
+    }
+
+    func test_loadConfig_whenFileIsMissing_and_generatedProjectExists() async throws {
+        // Given
+        let projectPath = try temporaryPath().appending(component: "project")
+        try await fileSystem.makeDirectory(at: projectPath)
+        try await fileSystem.touch(projectPath.appending(component: "Project.swift"))
+        try await fileSystem.touch(projectPath.appending(component: "Project.xcodeproj"))
+        stub(rootDirectory: nil)
+
+        // When
+        let result = try await subject.loadConfig(path: projectPath)
+
+        // Then
+        XCTAssertBetterEqual(result, TuistCore.Tuist(
+            project: .defaultGeneratedProject(),
+            fullHandle: nil,
+            url: Constants.URLs.production
+        ))
+    }
+
     // MARK: - Helpers
 
     private func stub(path: AbsolutePath, exists: Bool) {

--- a/fixtures/generated_ios_app_without_config_manifest/App/Sources/AppApp.swift
+++ b/fixtures/generated_ios_app_without_config_manifest/App/Sources/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/generated_ios_app_without_config_manifest/App/Sources/ContentView.swift
+++ b/fixtures/generated_ios_app_without_config_manifest/App/Sources/ContentView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Yams
+
+struct ContentView: View {
+    init() {
+        let _ = YAMLDecoder()
+    }
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/fixtures/generated_ios_app_without_config_manifest/Package.resolved
+++ b/fixtures/generated_ios_app_without_config_manifest/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "b3b7fe8d0ba4c628a9e7f8868c8c77087586212456d60b742c15004a0a0cd175",
+  "pins" : [
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/generated_ios_app_without_config_manifest/Package.swift
+++ b/fixtures/generated_ios_app_without_config_manifest/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 5.10
+@preconcurrency import PackageDescription
+
+let package = Package(
+    name: "PackageName",
+    dependencies: [
+        .package(url: "https://github.com/jpsim/Yams", .upToNextMajor(from: "5.0.6")),
+    ]
+)

--- a/fixtures/generated_ios_app_without_config_manifest/Project.swift
+++ b/fixtures/generated_ios_app_without_config_manifest/Project.swift
@@ -1,0 +1,19 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            deploymentTargets: .iOS("16.0"),
+            infoPlist: .default,
+            sources: "App/Sources/**",
+            dependencies: [
+                .external(name: "Yams"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/generated_ios_app_without_config_manifest/README.md
+++ b/fixtures/generated_ios_app_without_config_manifest/README.md
@@ -1,0 +1,3 @@
+# Generated iOS App without a config manifest
+
+The presence of `Tuist.swift` is optional. When absent, Tuist provides a default configuration based on the type project detected in the file-system.


### PR DESCRIPTION
### Short description 📝
[This PR](https://github.com/tuist/tuist/pull/7379) introduced a regression that caused detecting generated projects without a configuration manifest as an Xcode project (not a generated one).

To fix the issue, I detect whether an Xcode project or workspace is generated or not. Since the workspace or project doesn't contain that information, I obtain it by checking if there's a workspace or manifest file.

### How to test the changes locally 🧐
You can run the following:

1. `tuist install --path ./fixtures/generated_ios_app_without_config_manifest`
2. `tuist generate --path ./fixtures/generated_ios_app_without_config_manifest`

> [!NOTE]
> I created a `.git/gitkeep` file in the fixture to simulate the root of a repository, which the config loading logic uses to determine the root.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
