### PR TITLE
Support defining `.metal` files as sources in bundle products

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,9 @@ jobs:
           experimental: true
         env:
           MISE_HTTP_TIMEOUT: 300
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check if there are releasable changes
         id: is-releasable
         working-directory: app
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run git cliff and save the output
           bumped_output=$(git cliff --include-path "app/**/*" --repository "../" --bump)
@@ -62,8 +59,6 @@ jobs:
         working-directory: app
         id: next-version
         if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEXT_VERSION=$(git cliff --include-path "app/**/*" --repository "../" --bumped-version)
 
@@ -77,8 +72,6 @@ jobs:
         id: release-notes
         if: env.should-release == 'true'
         working-directory: app
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
           git cliff --include-path "app/**/*" --repository "../" --unreleased >> "$GITHUB_OUTPUT"
@@ -92,8 +85,6 @@ jobs:
       - name: Update CHANGELOG.md
         working-directory: app
         if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git cliff --include-path "app/**/*" --repository "../" --bump -o CHANGELOG.md
       - name: Select Xcode
         if: env.should-release == 'true'

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -22,7 +22,6 @@ public enum TuistAcceptanceFixtures {
     case appWithSBTUITestTunnel
     case appWithSpmDependencies
     case appWithSpmModuleAliases
-
     case appWithSpmXcframeworkDependency
     case appWithSwiftCMark
     case appWithLocalSPMModuleWithRemoteDependencies
@@ -38,6 +37,7 @@ public enum TuistAcceptanceFixtures {
     case frameworkWithNativeSwiftMacro
     case frameworkWithSwiftMacro
     case frameworkWithSPMBundle
+    case generatedBunleWithMetalFiles
     case generatediOSAppWithoutConfigManifest
     case invalidManifest
     case invalidWorkspaceManifestName
@@ -184,6 +184,8 @@ public enum TuistAcceptanceFixtures {
             return "framework_with_swift_macro"
         case .frameworkWithSPMBundle:
             return "framework_with_spm_bundle"
+        case .generatedBunleWithMetalFiles:
+            return "generated_bundle_with_metal_files"
         case .generatediOSAppWithoutConfigManifest:
             return "generated_ios_app_without_config_manifest"
         case .invalidManifest:

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -1,27 +1,6 @@
 import XcodeGraph
 
 extension Target {
-    /// This function validates the sources against other target metadata returning which sources from the list
-    /// are valid and invalid.
-    /// - Returns: A list of valid and invalid sources.
-    var validatedSources: (valid: [SourceFile], invalid: [SourceFile]) {
-        switch product {
-        case .stickerPackExtension, .watch2App:
-            return (valid: [], invalid: sources)
-        case .bundle:
-            if isExclusiveTo(.macOS) {
-                return (valid: sources, invalid: [])
-            } else {
-                return (
-                    valid: sources.filter { $0.path.extension == "metal" },
-                    invalid: sources.filter { $0.path.extension != "metal" }
-                )
-            }
-        default:
-            return (valid: sources, invalid: [])
-        }
-    }
-
     // CoreData models are typically added to the sources build phase
     // and Xcode automatically bundles the models.
     // For static libraries / frameworks however, they don't support resources,

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -34,7 +34,7 @@ extension Target {
     //
     // - Note: Technically, CoreData models can be added a sources build phase in a `.bundle`
     // but that will result in the `.bundle` having an executable, which is not valid on iOS.
-    var shouldCoredataModelsBeSources: Bool {
+    var shouldCoreDataModelsBeSources: Bool {
         switch product {
         case .stickerPackExtension, .watch2App:
             return false

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -22,6 +22,18 @@ extension Target {
         }
     }
 
+    // CoreData models are typically added to the sources build phase
+    // and Xcode automatically bundles the models.
+    // For static libraries / frameworks however, they don't support resources,
+    // the models could be bundled in a stand alone `.bundle`
+    // as resources.
+    //
+    // e.g.
+    // MyStaticFramework (.staticFramework) -> Includes CoreData models as sources
+    // MyStaticFrameworkResources (.bundle) -> Includes CoreData models as resources
+    //
+    // - Note: Technically, CoreData models can be added a sources build phase in a `.bundle`
+    // but that will result in the `.bundle` having an executable, which is not valid on iOS.
     var shouldCoredataModelsBeSources: Bool {
         switch product {
         case .stickerPackExtension, .watch2App:

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -21,7 +21,7 @@ extension Target {
             return (valid: sources, invalid: [])
         }
     }
-    
+
     var shouldCoredataModelsBeSources: Bool {
         switch product {
         case .stickerPackExtension, .watch2App:
@@ -32,5 +32,4 @@ extension Target {
             return true
         }
     }
-    
 }

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -1,0 +1,36 @@
+import XcodeGraph
+
+extension Target {
+    /// This function validates the sources against other target metadata returning which sources from the list
+    /// are valid and invalid.
+    /// - Returns: A list of valid and invalid sources.
+    var validatedSources: (valid: [SourceFile], invalid: [SourceFile]) {
+        switch product {
+        case .stickerPackExtension, .watch2App:
+            return (valid: [], invalid: sources)
+        case .bundle:
+            if isExclusiveTo(.macOS) {
+                return (valid: sources, invalid: [])
+            } else {
+                return (
+                    valid: sources.filter { $0.path.extension == "metal" },
+                    invalid: sources.filter { $0.path.extension != "metal" }
+                )
+            }
+        default:
+            return (valid: sources, invalid: [])
+        }
+    }
+    
+    var shouldCoredataModelsBeSources: Bool {
+        switch product {
+        case .stickerPackExtension, .watch2App:
+            return false
+        case .bundle:
+            return isExclusiveTo(.macOS)
+        default:
+            return true
+        }
+    }
+    
+}

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -300,7 +300,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             }
         }
 
-        if target.shouldCoredataModelsBeSources {
+        if target.shouldCoreDataModelsBeSources {
             pbxBuildFiles.append(contentsOf: generateCoreDataModels(
                 coreDataModels: coreDataModels,
                 fileElements: fileElements,
@@ -366,7 +366,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             fileElements: fileElements
         ))
 
-        if !target.shouldCoredataModelsBeSources {
+        if !target.shouldCoreDataModelsBeSources {
             pbxBuildFiles.append(contentsOf: generateCoreDataModels(
                 coreDataModels: target.coreDataModels,
                 fileElements: fileElements,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -87,27 +87,14 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             pbxproj: pbxproj
         )
 
-        let (validSources, invalidSources) = target.validatedSources()
-
-        if !validSources.isEmpty {
-            try generateSourcesBuildPhase(
-                files: target.sources,
-                coreDataModels: target.coreDataModels,
-                target: target,
-                pbxTarget: pbxTarget,
-                fileElements: fileElements,
-                pbxproj: pbxproj
-            )
-        }
-
-        if !invalidSources.isEmpty {
-            ServiceContext.current?.alerts?
-                .warning(
-                    .alert(
-                        "The target \(target.name) contains sources that are not supported by the target: \(ListFormatter().string(from: invalidSources.map(\.path.basename)) ?? "")"
-                    )
-                )
-        }
+        try generateSourcesBuildPhase(
+            files: target.validatedSources.valid,
+            coreDataModels: target.shouldCoredataModelsBeSources ? target.coreDataModels : [],
+            target: target,
+            pbxTarget: pbxTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
 
         try generateResourcesBuildPhase(
             path: path,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -367,18 +367,6 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         ))
 
         if !target.shouldCoredataModelsBeSources {
-            // CoreData models are typically added to the sources build phase
-            // and Xcode automatically bundles the models.
-            // For static libraries / frameworks however, they don't support resources,
-            // the models could be bundled in a stand alone `.bundle`
-            // as resources.
-            //
-            // e.g.
-            // MyStaticFramework (.staticFramework) -> Includes CoreData models as sources
-            // MyStaticFrameworkResources (.bundle) -> Includes CoreData models as resources
-            //
-            // - Note: Technically, CoreData models can be added a sources build phase in a `.bundle`
-            // but that will result in the `.bundle` having an executable, which is not valid on iOS.
             pbxBuildFiles.append(contentsOf: generateCoreDataModels(
                 coreDataModels: target.coreDataModels,
                 fileElements: fileElements,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -89,7 +89,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
         try generateSourcesBuildPhase(
             files: target.validatedSources.valid,
-            coreDataModels: target.shouldCoredataModelsBeSources ? target.coreDataModels : [],
+            coreDataModels: target.coreDataModels,
             target: target,
             pbxTarget: pbxTarget,
             fileElements: fileElements,
@@ -300,11 +300,14 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             }
         }
 
-        pbxBuildFiles.append(contentsOf: generateCoreDataModels(
-            coreDataModels: coreDataModels,
-            fileElements: fileElements,
-            pbxproj: pbxproj
-        ))
+        if target.shouldCoredataModelsBeSources {
+            pbxBuildFiles.append(contentsOf: generateCoreDataModels(
+                coreDataModels: coreDataModels,
+                fileElements: fileElements,
+                pbxproj: pbxproj
+            ))
+        }
+
         pbxBuildFiles.forEach { pbxproj.add(object: $0) }
         sourcesBuildPhase.files = pbxBuildFiles
     }
@@ -363,7 +366,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             fileElements: fileElements
         ))
 
-        if !target.supportsSources {
+        if !target.shouldCoredataModelsBeSources {
             // CoreData models are typically added to the sources build phase
             // and Xcode automatically bundles the models.
             // For static libraries / frameworks however, they don't support resources,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -88,7 +88,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         )
 
         try generateSourcesBuildPhase(
-            files: target.validatedSources.valid,
+            files: target.sources,
             coreDataModels: target.coreDataModels,
             target: target,
             pbxTarget: pbxTarget,

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -76,9 +76,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
             additionalTargets.append(resourcesTarget)
         }
 
-        if target.supportsSources,
-           target.sources.containsSwiftFiles
-        {
+        if target.sources.containsSwiftFiles {
             let (filePath, data) = synthesizedSwiftFile(bundleName: bundleName, target: target, project: project)
 
             let hash = try data.map(contentHasher.hash)
@@ -89,7 +87,6 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         }
 
         if case .external = project.type,
-           target.supportsSources,
            target.sources.containsObjcFiles,
            target.resources.containsBundleAccessedResources,
            !target.supportsResources

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -74,7 +74,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
     private func mapTarget(_ target: Target, project: Project) throws -> (Target, [SideEffectDescriptor]) {
         let resourcesForSynthesizersPaths = target.resources.resources
             .map(\.path) + target.coreDataModels.map(\.path)
-        guard !resourcesForSynthesizersPaths.isEmpty, target.supportsSources else { return (target, []) }
+        guard !resourcesForSynthesizersPaths.isEmpty else { return (target, []) }
 
         var target = target
 

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -74,7 +74,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
     private func mapTarget(_ target: Target, project: Project) throws -> (Target, [SideEffectDescriptor]) {
         let resourcesForSynthesizersPaths = target.resources.resources
             .map(\.path) + target.coreDataModels.map(\.path)
-        guard !resourcesForSynthesizersPaths.isEmpty else { return (target, []) }
+        guard !resourcesForSynthesizersPaths.isEmpty, target.supportsSources else { return (target, []) }
 
         var target = target
 

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -721,6 +721,19 @@ final class GenerateAcceptanceTestCommandLineToolBase: TuistAcceptanceTestCase {
     }
 }
 
+final class GenerateAcceptanceTestGeneratedBundleWithMetalFiles: TuistAcceptanceTestCase {
+    func test_generated_bundle_with_metal_files() async throws {
+        try await setUpFixture(.generatedBunleWithMetalFiles)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "Bundle")
+        try await XCTAssertProductWithDestinationContainsResource(
+            "Bundle.bundle",
+            destination: "Debug-iphonesimulator",
+            resource: "default.metallib"
+        )
+    }
+}
+
 final class GenerateAcceptanceTestCommandLineToolWithStaticLibrary: TuistAcceptanceTestCase {
     func test_command_line_tool_with_static_library() async throws {
         try await setUpFixture(.commandLineToolWithStaticLibrary)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -154,6 +154,42 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         ])
     }
 
+    func test_generateSourcesBuildPhase_whenBundleWithMetalFiles() throws {
+        // Given
+        let pbxTarget = PBXNativeTarget(name: "Test")
+        let pbxproj = PBXProj()
+        pbxproj.add(object: pbxTarget)
+
+        let sourceFiles: [SourceFile] = [
+            SourceFile(path: "/test/resource.metal"),
+        ]
+
+        let target = Target.test(product: .bundle, sources: sourceFiles)
+
+        let fileElements = createFileElements(for: sourceFiles.map(\.path))
+
+        // When
+        try subject.generateSourcesBuildPhase(
+            files: sourceFiles,
+            coreDataModels: [],
+            target: target,
+            pbxTarget: pbxTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try pbxTarget.sourcesBuildPhase()
+        let buildFiles = buildPhase?.files ?? []
+        let buildFilesNames = buildFiles.map {
+            $0.file?.name
+        }
+
+        XCTAssertEqual(buildFilesNames, [
+            "resource.metal",
+        ])
+    }
+
     func test_generateScripts() throws {
         // Given
         let target = PBXNativeTarget(name: "Test")

--- a/fixtures/generated_bundle_with_metal_files/Bundle/Sources/Bundle.swift
+++ b/fixtures/generated_bundle_with_metal_files/Bundle/Sources/Bundle.swift
@@ -1,0 +1,3 @@
+public struct Bundle {
+    public init() {}
+}

--- a/fixtures/generated_bundle_with_metal_files/Bundle/Sources/Metal.metal
+++ b/fixtures/generated_bundle_with_metal_files/Bundle/Sources/Metal.metal
@@ -1,0 +1,11 @@
+//
+//  Metal.metal
+//  Bundle
+//
+//  Created by Pedro Piñera Buendía on 20.03.25.
+//
+
+#include <metal_stdlib>
+using namespace metal;
+
+

--- a/fixtures/generated_bundle_with_metal_files/Project.swift
+++ b/fixtures/generated_bundle_with_metal_files/Project.swift
@@ -1,0 +1,15 @@
+import ProjectDescription
+
+let project = Project(
+    name: "Bundle",
+    targets: [
+        .target(
+            name: "Bundle",
+            destinations: .iOS,
+            product: .bundle,
+            bundleId: "io.tuist.Bundle",
+            sources: ["Bundle/Sources/**"],
+            dependencies: []
+        ),
+    ]
+)

--- a/fixtures/generated_bundle_with_metal_files/Tuist.swift
+++ b/fixtures/generated_bundle_with_metal_files/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())


### PR DESCRIPTION
### Short description 📝
Our linting logic that ensures that only the products that support sources have sources didn't account for the scenario where `bundle` products can contain `.metal` files. This PR addresses that.

> [!NOTE]
> Answering whether a target supports or not sources is more complex than what we originally anticipated. Therefore, I decided to remove that responsibility from Tuist, and assume the developers know what they are doing in this front. This weakens the dependency between users and us adding support for new cases.

### How to test the changes locally 🧐

1. `tuist build --path fixtures/generated_bundle_with_metal_files`.
2. You should see `Bundle.bundle` in derived data containing the metal file inside.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
