### PR TITLE
Fix tuist init stuck on authentication

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "024689affd661c34efc6f7bf27f4ba2dce47209af5b126ce00303fbc7f7933be",
+  "originHash" : "79c8864a1db6d3371b9d0141245bd0de6ab40ca2da2c5b7b9603ae289370fde9",
   "pins" : [
     {
       "identity" : "aexml",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "revision" : "fceb977ebeba68f0653916d15e889b7f60a448fd",
-        "version" : "0.34.0"
+        "branch" : "fix/return-key",
+        "revision" : "beb54660b4c0e9da457fa2ef90e4dc57246adeff"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "79c8864a1db6d3371b9d0141245bd0de6ab40ca2da2c5b7b9603ae289370fde9",
+  "originHash" : "0572f2c9589381cfb69713da59d0b0acd9d0af39e3c1b81e79a89be6fbceb5b1",
   "pins" : [
     {
       "identity" : "aexml",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "branch" : "fix/return-key",
-        "revision" : "beb54660b4c0e9da457fa2ef90e4dc57246adeff"
+        "revision" : "049039c385630f7c25f266969f58918e91f415ab",
+        "version" : "0.34.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -536,7 +536,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-         .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.3")),
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.3")),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -536,7 +536,8 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.0")),
+        // .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.0")),
+        .package(url: "https://github.com/tuist/Noora", branch: "fix/return-key"),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -536,8 +536,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        // .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.0")),
-        .package(url: "https://github.com/tuist/Noora", branch: "fix/return-key"),
+         .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.34.3")),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),

--- a/Tests/TuistKitTests/Services/InitCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitCommandServiceTests.swift
@@ -32,6 +32,7 @@ struct InitCommandServiceTests {
     private let createOrganizationService = MockCreateOrganizationServicing()
     private let getProjectService = MockGetProjectServicing()
     private let commandRunner = MockCommandRunning()
+    private let serverURLService = MockServerURLServicing()
     private let subject: InitCommandService
 
     init() {
@@ -45,8 +46,13 @@ struct InitCommandServiceTests {
             keystrokeListener: keystrokeListener,
             createOrganizationService: createOrganizationService,
             getProjectService: getProjectService,
-            commandRunner: commandRunner
+            commandRunner: commandRunner,
+            serverURLService: serverURLService
         )
+
+        given(serverURLService)
+            .url(configServerURL: .any)
+            .willReturn(Constants.URLs.production)
     }
 
     @Test func generatesTheRightConfiguration_when_generatedAndConnectedToServer() async throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7431

### Short description 📝

- Updates `Noora` that contains the actual bug fix: https://github.com/tuist/Noora/pull/247
- Replaces hardcoded URL with a URL from `serverURLService`, so one can override the value using the `TUIST_URL`
- When searching for `.xcodeproj` or `.xcworkspace`, we only search in the current directory. Otherwise, it's very easy to get what seems like random results from projects deep inside the file hierarchy.

### How to test the changes locally 🧐

- Run `tuist init` when logged out

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
