### PR TITLE
Extract the initialization logic of ServiceContext to make it reusable

### DIFF
--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Noora
+import Path
+import ServiceContextModule
+import TSCBasic
+import TuistSupport
+
+private enum TuistServiceContextError: LocalizedError {
+    case exclusiveOptionError(String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .exclusiveOptionError(option1, option2):
+            "Cannot use --\(option1) and --\(option2) at the same time."
+        }
+    }
+}
+
+extension ServiceContext {
+    public static func tuist(_ action: (Path.AbsolutePath) async throws -> Void) async throws {
+        if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
+            throw TuistServiceContextError.exclusiveOptionError("quiet", "verbose")
+        }
+
+        if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--json") {
+            throw TuistServiceContextError.exclusiveOptionError("quiet", "json")
+        }
+
+        if CommandLine.arguments.contains("--verbose") {
+            try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true")
+        }
+
+        if CommandLine.arguments.contains("--quiet") {
+            try? ProcessEnv.setVar(Constants.EnvironmentVariables.quiet, value: "true")
+        }
+
+        try await LogsController().setup(stateDirectory: Environment.shared.stateDirectory) { loggerHandler, logFilePath in
+            /// This is the old initialization method and will eventually go away.
+            LoggingSystem.bootstrap(loggerHandler)
+
+            var context = ServiceContext.topLevel
+            context.logger = Logger(label: "dev.tuist.cli", factory: loggerHandler)
+            context.ui = Noora()
+            context.alerts = AlertController()
+            context.recentPaths = RecentPathsStore(storageDirectory: Environment.shared.stateDirectory)
+
+            try await ServiceContext.withValue(context) {
+                try await action(logFilePath)
+            }
+        }
+    }
+}

--- a/Sources/tuist/TuistCLI.swift
+++ b/Sources/tuist/TuistCLI.swift
@@ -11,53 +11,8 @@ import TuistSupport
 @_documentation(visibility: private)
 private enum TuistCLI {
     static func main() async throws {
-        if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
-            throw TuistCLIError.exclusiveOptionError("quiet", "verbose")
-        }
-
-        if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--json") {
-            throw TuistCLIError.exclusiveOptionError("quiet", "json")
-        }
-
-        if CommandLine.arguments.contains("--verbose") {
-            try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true")
-        }
-
-        if CommandLine.arguments.contains("--quiet") {
-            try? ProcessEnv.setVar(Constants.EnvironmentVariables.quiet, value: "true")
-        }
-
-        try await LogsController().setup(stateDirectory: Environment.shared.stateDirectory) { loggerHandler, logFilePath in
-            /// This is the old initialization method and will eventually go away.
-            LoggingSystem.bootstrap(loggerHandler)
-
-            var context = ServiceContext.topLevel
-            context.logger = Logger(label: "dev.tuist.cli", factory: loggerHandler)
-            context.ui = Noora()
-            context.alerts = AlertController()
-            context.recentPaths = RecentPathsStore(storageDirectory: Environment.shared.stateDirectory)
-
-            try await ServiceContext.withValue(context) {
-                try await TuistCommand.main(logFilePath: logFilePath)
-            }
-        }
-    }
-}
-
-private enum TuistCLIError: FatalError {
-    case exclusiveOptionError(String, String)
-
-    var description: String {
-        switch self {
-        case let .exclusiveOptionError(option1, option2):
-            "Cannot use --\(option1) and --\(option2) at the same time."
-        }
-    }
-
-    var type: ErrorType {
-        switch self {
-        case .exclusiveOptionError:
-            .abort
+        try await ServiceContext.tuist { logFilePath in
+            try await TuistCommand.main(logFilePath: logFilePath)
         }
     }
 }


### PR DESCRIPTION
### Short description 📝
We had a bunch of issues in the past because we had inconsistencies between the initialization logic here, and the extension that brings the cache capabilities, so I'm extracting that logic to make it reusable and avoid duplication.

### How to test the changes locally 🧐
Tests should work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
