### PR TITLE
Disable build insights unless fullHandle is defined in Tuist.swift

### DIFF
--- a/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
+++ b/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
@@ -122,7 +122,7 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
             enforceExplicitDependencies: Bool = false,
             defaultConfiguration: String? = nil,
             optionalAuthentication: Bool = false,
-            buildInsightsDisabled: Bool = false
+            buildInsightsDisabled: Bool = true
         ) -> Self {
             .init(
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,

--- a/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -25,7 +25,7 @@ extension TuistCore.TuistGeneratedProjectOptions.GenerationOptions {
             enforceExplicitDependencies: manifest.enforceExplicitDependencies,
             defaultConfiguration: manifest.defaultConfiguration,
             optionalAuthentication: manifest.optionalAuthentication,
-            buildInsightsDisabled: fullHandle != nil && manifest.buildInsightsDisabled
+            buildInsightsDisabled: fullHandle == nil || manifest.buildInsightsDisabled
         )
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -77,7 +77,7 @@ final class ConfigLoaderTests: TuistUnitTestCase {
 
         // Then
 
-        XCTAssertEqual(result, TuistCore.Tuist(
+        XCTAssertBetterEqual(result, TuistCore.Tuist(
             project: .generated(TuistGeneratedProjectOptions(
                 compatibleXcodeVersions: .all,
                 swiftVersion: nil,
@@ -189,7 +189,9 @@ final class ConfigLoaderTests: TuistUnitTestCase {
                 compatibleXcodeVersions: .all,
                 swiftVersion: nil,
                 plugins: [],
-                generationOptions: .test(),
+                generationOptions: .test(
+                    buildInsightsDisabled: false
+                ),
                 installOptions: .test()
             )),
             fullHandle: "tuist/tuist",
@@ -219,7 +221,9 @@ final class ConfigLoaderTests: TuistUnitTestCase {
                 compatibleXcodeVersions: .all,
                 swiftVersion: nil,
                 plugins: [],
-                generationOptions: .test(),
+                generationOptions: .test(
+                    buildInsightsDisabled: false
+                ),
                 installOptions: .test()
             )),
             fullHandle: "tuist/tuist",

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
@@ -1,0 +1,55 @@
+import FileSystem
+import Foundation
+import ProjectDescription
+import Testing
+import TuistCore
+
+@testable import TuistLoader
+
+struct TuistGeneratedProjectManifestMapperTests {
+    private let fileSystem = FileSystem()
+
+    @Test func buildInsightsDisabled_when_fullHandle_is_nil() async throws {
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            // When
+            let got = try TuistCore.TuistGeneratedProjectOptions.GenerationOptions.from(
+                manifest: .options(),
+                generatorPaths: GeneratorPaths(manifestDirectory: temporaryDirectory, rootDirectory: temporaryDirectory),
+                fullHandle: nil
+            )
+
+            // Then
+            #expect(got.buildInsightsDisabled == true)
+        }
+    }
+
+    @Test func buildInsightsDisabled_when_fullHandle_is_defined() async throws {
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            // When
+            let got = try TuistCore.TuistGeneratedProjectOptions.GenerationOptions.from(
+                manifest: .options(),
+                generatorPaths: GeneratorPaths(manifestDirectory: temporaryDirectory, rootDirectory: temporaryDirectory),
+                fullHandle: "tuist/tuist"
+            )
+
+            // Then
+            #expect(got.buildInsightsDisabled == false)
+        }
+    }
+
+    @Test func buildInsightsDisabled_when_fullHandle_is_defined_and_insights_disabled_in_generation_options() async throws {
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            // When
+            let got = try TuistCore.TuistGeneratedProjectOptions.GenerationOptions.from(
+                manifest: .options(
+                    buildInsightsDisabled: true
+                ),
+                generatorPaths: GeneratorPaths(manifestDirectory: temporaryDirectory, rootDirectory: temporaryDirectory),
+                fullHandle: "tuist/tuist"
+            )
+
+            // Then
+            #expect(got.buildInsightsDisabled == true)
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7432

### Short description 📝

The condition for disabling build insights was wrong and we would accidentally enable them even when `fullHandle` was not defined.

### How to test the changes locally 🧐

- `tuist generate` in `app_with_organization_name_project`
- Check the post actions do not include pushing build insights


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
