### PR TITLE
Disable pushing build insights in projects without Tuist.swift

### DIFF
--- a/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
+++ b/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
@@ -86,7 +86,7 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
                 resolveDependenciesWithSystemScm: false,
                 disablePackageVersionLocking: false,
                 staticSideEffectsWarningTargets: .all,
-                buildInsightsDisabled: false
+                buildInsightsDisabled: true
             ),
             installOptions: .init(passthroughSwiftPackageManagerArguments: [])
         )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7432

### Short description 📝

We correctly disable pushing build insights when a `Tuist.swift` is present in the project, however, the default is still false if there is _no_ `Tuist.swift`. This PR fixes the default.

### How to test the changes locally 🧐

- Run `tuist generate` in https://github.com/bc-lee/test-tuist-usage and ensure the post action is not defined.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
