### PR TITLE
Fix incorrect registry CI link

### DIFF
--- a/docs/docs/en/guides/develop/registry.md
+++ b/docs/docs/en/guides/develop/registry.md
@@ -31,7 +31,7 @@ Now you can access the registry! To resolve dependencies from the registry inste
 - <LocalizedLink href="/guides/develop/registry/xcodeproj-integration">Generated project with the XcodeProj-based package integration</LocalizedLink>
 - <LocalizedLink href="/guides/develop/registry/swift-package">Swift package</LocalizedLink>
 
-To set up the registry on the CI, follow this guide: <LocalizedLink href="/guides/develop/registry/ci">Continuous integration</LocalizedLink>.
+To set up the registry on the CI, follow this guide: <LocalizedLink href="/guides/develop/registry/continuous-integration">Continuous integration</LocalizedLink>.
 
 ### Package registry identifiers {#package-registry-identifiers}
 


### PR DESCRIPTION
### Short description 📝

Fixing a wrong URL in our docs.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
