### PR TITLE
fix: Fix `organization remove member` command

### DIFF
--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -5585,27 +5585,7 @@ internal struct Client: APIProtocol {
             deserializer: { response, responseBody in
                 switch response.status.code {
                 case 204:
-                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
-                    let body: Operations.removeOrganizationMember.Output.NoContent.Body
-                    let chosenContentType = try converter.bestContentType(
-                        received: contentType,
-                        options: [
-                            "application/json"
-                        ]
-                    )
-                    switch chosenContentType {
-                    case "application/json":
-                        body = try await converter.getResponseBodyAsJSON(
-                            OpenAPIRuntime.OpenAPIValueContainer.self,
-                            from: responseBody,
-                            transforming: { value in
-                                .json(value)
-                            }
-                        )
-                    default:
-                        preconditionFailure("bestContentType chose an invalid content type.")
-                    }
-                    return .noContent(.init(body: body))
+                    return .noContent(.init())
                 case 400:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.removeOrganizationMember.Output.BadRequest.Body

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -15745,32 +15745,8 @@ internal enum Operations {
         }
         internal enum Output: Sendable, Hashable {
             internal struct NoContent: Sendable, Hashable {
-                /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/members/{user_name}/DELETE/responses/204/content`.
-                internal enum Body: Sendable, Hashable {
-                    /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/members/{user_name}/DELETE/responses/204/content/application\/json`.
-                    case json(OpenAPIRuntime.OpenAPIValueContainer)
-                    /// The associated value of the enum case if `self` is `.json`.
-                    ///
-                    /// - Throws: An error if `self` is not `.json`.
-                    /// - SeeAlso: `.json`.
-                    internal var json: OpenAPIRuntime.OpenAPIValueContainer {
-                        get throws {
-                            switch self {
-                            case let .json(body):
-                                return body
-                            }
-                        }
-                    }
-                }
-                /// Received HTTP response body
-                internal var body: Operations.removeOrganizationMember.Output.NoContent.Body
                 /// Creates a new `NoContent`.
-                ///
-                /// - Parameters:
-                ///   - body: Received HTTP response body
-                internal init(body: Operations.removeOrganizationMember.Output.NoContent.Body) {
-                    self.body = body
-                }
+                internal init() {}
             }
             /// The member was removed
             ///

--- a/Sources/TuistServer/OpenAPI/server.yml
+++ b/Sources/TuistServer/OpenAPI/server.yml
@@ -4043,8 +4043,6 @@ paths:
             x-validate:
       responses:
         204:
-          content:
-            application/json: {}
           description: The member was removed
         400:
           content:


### PR DESCRIPTION
The API spec was incorrect, causing the CLI to expect a body for a no-content response, causing it to fail.

### Short description 📝

The API spec specified a `content-type` for the `removeOrganizationMember` operation, even though it's a 204 response. This caused the CLI to fail with

```
❯ TUIST_URL=http://localhost:8080 tuist organization remove member tuist helloo


▌ ✖ Error
▌ Client error - cause description: 'Unknown', underlying error: DecodingError: dataCorrupted - at : The given data was not valid JSON. (underlying error: The data couldn’t be read because it isn’t in the correct format.), operationID: removeOrganizationMember, operationInput: Input(path: TuistServer.Operations.removeOrganizationMember.Input.Path(organization_name: "tuist", user_name: "helloo"), headers: TuistServer.Operations.removeOrganizationMember.Input.Headers(accept: [OpenAPIRuntime.AcceptHeaderContentType<TuistServer.Operations.removeOrganizationMember.AcceptableContentType>(contentType: TuistServer.Operations.removeOrganizationMember.AcceptableContentType.json, quality: OpenAPIRuntime.QualityValue(thousands: 1000))])), request: DELETE /api/organizations/tuist/members/helloo [accept: application/json], requestBody: <nil>, baseURL: http://localhost:8080, response: 204 [cache-control: max-age=0, private, must-revalidate; content-type: application/json; charset=utf-8; date: Thu, 03 Apr 2025 11:13:37 GMT; x-request-id: 9748FFA8-D17B-4B3E-A83D-C990F73DF33C, 1BFC18D9-F971-460E-8D1A-143DFA5149D9], responseBody: OpenAPIRuntime.HTTPBody
```

The API spec fix is in https://github.com/tuist/server/pull/1625


### How to test the changes locally 🧐

Run the `organization remove member` command. It should succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
