### PR TITLE
Fix getting the executable path from the `mcp setup claude` command

### DIFF
--- a/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
+++ b/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
@@ -33,7 +33,7 @@ struct BuildInsightsActionMapper: BuildInsightsActionMapping {
         buildAction.postActions.append(
             ExecutionAction(
                 title: "Push build insights",
-                scriptText: "\(environment.currentExecutablePath.pathString) inspect build",
+                scriptText: "\(environment.currentExecutablePath().pathString) inspect build",
                 target: nil,
                 shellPath: nil
             )

--- a/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
+++ b/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
@@ -33,7 +33,7 @@ struct BuildInsightsActionMapper: BuildInsightsActionMapping {
         buildAction.postActions.append(
             ExecutionAction(
                 title: "Push build insights",
-                scriptText: "\(environment.tuistExecutablePath?.pathString ?? "tuist") inspect build",
+                scriptText: "\(environment.currentExecutablePath.pathString) inspect build",
                 target: nil,
                 shellPath: nil
             )

--- a/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
+++ b/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Mockable
 
@@ -9,11 +10,21 @@ protocol MCPServerCommandResolving {
 struct MCPServerCommandResolver: MCPServerCommandResolving {
     private let executablePath: String
 
-    init(executablePath: String = CommandLine.arguments[0]) {
+    init(executablePath: String = Self.getExecutablePath()) {
         self.executablePath = executablePath
     }
 
     func resolve() -> (String, [String]) {
+        print(executablePath)
         return (executablePath, ["mcp", "start"])
+    }
+
+    private static func getExecutablePath() -> String! {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        var pathLength = UInt32(buffer.count)
+        if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
+            return String(cString: buffer)
+        }
+        return nil
     }
 }

--- a/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
+++ b/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
@@ -11,7 +11,7 @@ protocol MCPServerCommandResolving {
 struct MCPServerCommandResolver: MCPServerCommandResolving {
     private let executablePath: String
 
-    init(executablePath: String = Environment.shared.currentExecutablePath.pathString) {
+    init(executablePath: String = Environment.shared.currentExecutablePath().pathString) {
         self.executablePath = executablePath
     }
 

--- a/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
+++ b/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import Mockable
+import TuistSupport
 
 @Mockable
 protocol MCPServerCommandResolving {
@@ -10,21 +11,11 @@ protocol MCPServerCommandResolving {
 struct MCPServerCommandResolver: MCPServerCommandResolving {
     private let executablePath: String
 
-    init(executablePath: String = Self.getExecutablePath()) {
+    init(executablePath: String = Environment.shared.currentExecutablePath.pathString) {
         self.executablePath = executablePath
     }
 
     func resolve() -> (String, [String]) {
-        print(executablePath)
         return (executablePath, ["mcp", "start"])
-    }
-
-    private static func getExecutablePath() -> String! {
-        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-        var pathLength = UInt32(buffer.count)
-        if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
-            return String(cString: buffer)
-        }
-        return nil
     }
 }

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -48,7 +48,7 @@ public protocol Environmenting: AnyObject, Sendable {
     var schemeName: String? { get }
 
     /// Returns path to the Tuist executable
-    var currentExecutablePath: AbsolutePath! { get }
+    func currentExecutablePath() -> AbsolutePath
 }
 
 /// Local environment controller.
@@ -213,13 +213,14 @@ public final class Environment: Environmenting {
         ProcessInfo.processInfo.environment["SCHEME_NAME"]
     }
 
-    public var currentExecutablePath: AbsolutePath! {
+    public func currentExecutablePath() -> AbsolutePath {
         var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
         var pathLength = UInt32(buffer.count)
         if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
             // swiftlint:disable:next force_try
             return try! AbsolutePath(validating: String(cString: buffer))
+        } else {
+            fatalError("Failed to get the executable path")
         }
-        return nil
     }
 }

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -217,6 +217,7 @@ public final class Environment: Environmenting {
         var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
         var pathLength = UInt32(buffer.count)
         if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
+            // swiftlint:disable:next force_try
             return try! AbsolutePath(validating: String(cString: buffer))
         }
         return nil

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -48,7 +48,7 @@ public protocol Environmenting: AnyObject, Sendable {
     var schemeName: String? { get }
 
     /// Returns path to the Tuist executable
-    var tuistExecutablePath: AbsolutePath? { get }
+    var currentExecutablePath: AbsolutePath! { get }
 }
 
 /// Local environment controller.
@@ -213,7 +213,12 @@ public final class Environment: Environmenting {
         ProcessInfo.processInfo.environment["SCHEME_NAME"]
     }
 
-    public var tuistExecutablePath: AbsolutePath? {
-        try? AbsolutePath(validating: ProcessInfo.processInfo.arguments[0])
+    public var currentExecutablePath: AbsolutePath! {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        var pathLength = UInt32(buffer.count)
+        if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
+            return try! AbsolutePath(validating: String(cString: buffer))
+        }
+        return nil
     }
 }

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -41,5 +41,5 @@ public final class MockEnvironment: Environmenting {
 
     public var schemeName: String? { nil }
 
-    public var tuistExecutablePath: AbsolutePath? { nil }
+    public var currentExecutablePath: AbsolutePath! { nil }
 }

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -41,5 +41,5 @@ public final class MockEnvironment: Environmenting {
 
     public var schemeName: String? { nil }
 
-    public var currentExecutablePath: AbsolutePath! { nil }
+    public func currentExecutablePath() -> AbsolutePath { directory.path.appending(component: "tuist") }
 }

--- a/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
@@ -35,7 +35,7 @@ struct BuildInsightsActionMapperTests {
         // Given
         let buildAction: BuildAction = .test()
         given(environment)
-            .tuistExecutablePath
+            .currentExecutablePath()
             .willReturn("/mise/tuist")
 
         // When


### PR DESCRIPTION
### Short description 📝
`CommandLine.arguments[0]` doesn't yield the absolute path of the executable. For example if you run it through `mise` it resolves to just `tuist`. I adjusted it to use a Darwing-specific API that returns the whole absolute path.

### How to test the changes locally 🧐

1. Build `tuist`
2. `cd` into the derived data directory containing `tuist`
3. Run `./tuist mcp setup claude`
4. You should get the absolute path in `~/Library/Application\ Support/Claude/claude_desktop_config.json`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
