### PR TITLE
Fix tuist share when the bundle version is not semantic

### DIFF
--- a/Sources/TuistAutomation/Utilities/AppBundle.swift
+++ b/Sources/TuistAutomation/Utilities/AppBundle.swift
@@ -75,7 +75,7 @@ public struct AppBundle: Equatable {
         }
 
         /// App version number (e.g. 10.3)
-        public let version: Version
+        public let version: String
 
         /// Name of the app
         public let name: String
@@ -93,7 +93,7 @@ public struct AppBundle: Equatable {
         public let bundleIcons: BundleIcons?
 
         init(
-            version: Version,
+            version: String,
             name: String,
             bundleId: String,
             minimumOSVersion: Version,
@@ -120,9 +120,7 @@ public struct AppBundle: Equatable {
         public init(from decoder: any Decoder) throws {
             let container: KeyedDecodingContainer<AppBundle.InfoPlist.CodingKeys> = try decoder
                 .container(keyedBy: AppBundle.InfoPlist.CodingKeys.self)
-            version = Version(
-                stringLiteral: try container.decode(String.self, forKey: AppBundle.InfoPlist.CodingKeys.version)
-            )
+            version = try container.decode(String.self, forKey: AppBundle.InfoPlist.CodingKeys.version)
             let name = try container.decode(String.self, forKey: AppBundle.InfoPlist.CodingKeys.name)
             self.name = name
             bundleId = try container.decode(String.self, forKey: AppBundle.InfoPlist.CodingKeys.bundleId)
@@ -166,7 +164,7 @@ public struct AppBundle: Equatable {
 
     extension AppBundle.InfoPlist {
         public static func test(
-            version: Version = Version("1.0"),
+            version: String = "1.0",
             name: String = "App",
             bundleId: String = "io.tuist.App",
             minimumOSVersion: Version = Version("17.4"),

--- a/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
+++ b/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
@@ -33,7 +33,7 @@ struct BuildInsightsActionMapper: BuildInsightsActionMapping {
         buildAction.postActions.append(
             ExecutionAction(
                 title: "Push build insights",
-                scriptText: "\(environment.currentExecutablePath().pathString) inspect build",
+                scriptText: "\(environment.currentExecutablePath()?.pathString ?? "tuist") inspect build",
                 target: nil,
                 shellPath: nil
             )

--- a/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
+++ b/Sources/TuistKit/MCP/MCPServerCommandResolver.swift
@@ -11,7 +11,7 @@ protocol MCPServerCommandResolving {
 struct MCPServerCommandResolver: MCPServerCommandResolving {
     private let executablePath: String
 
-    init(executablePath: String = Environment.shared.currentExecutablePath().pathString) {
+    init(executablePath: String = Environment.shared.currentExecutablePath()?.pathString ?? "tuist") {
         self.executablePath = executablePath
     }
 

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -48,7 +48,7 @@ public protocol Environmenting: AnyObject, Sendable {
     var schemeName: String? { get }
 
     /// Returns path to the Tuist executable
-    func currentExecutablePath() -> AbsolutePath
+    func currentExecutablePath() -> AbsolutePath?
 }
 
 /// Local environment controller.
@@ -213,14 +213,14 @@ public final class Environment: Environmenting {
         ProcessInfo.processInfo.environment["SCHEME_NAME"]
     }
 
-    public func currentExecutablePath() -> AbsolutePath {
+    public func currentExecutablePath() -> AbsolutePath? {
         var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
         var pathLength = UInt32(buffer.count)
         if _NSGetExecutablePath(&buffer, &pathLength) == 0 {
             // swiftlint:disable:next force_try
-            return try! AbsolutePath(validating: String(cString: buffer))
+            return try? AbsolutePath(validating: String(cString: buffer))
         } else {
-            fatalError("Failed to get the executable path")
+            return nil
         }
     }
 }

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -41,7 +41,5 @@ public final class MockEnvironment: Environmenting {
 
     public var schemeName: String? { nil }
 
-    public func currentExecutablePath() -> AbsolutePath {
-        try! AbsolutePath(validating: ProcessInfo.processInfo.arguments[0])
-    }
+    public func currentExecutablePath() -> AbsolutePath? { nil }
 }

--- a/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
@@ -36,7 +36,7 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
             AppBundle(
                 path: appBundlePath,
                 infoPlist: AppBundle.InfoPlist(
-                    version: Version("1.0"),
+                    version: "1.0",
                     name: "App",
                     bundleId: "io.tuist.MainApp",
                     minimumOSVersion: Version("17.0"),
@@ -67,7 +67,7 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
             AppBundle(
                 path: appBundlePath,
                 infoPlist: AppBundle.InfoPlist(
-                    version: Version("1.0"),
+                    version: "1.0",
                     name: "App",
                     bundleId: "io.tuist.App",
                     minimumOSVersion: Version("17.0"),

--- a/Tests/TuistKitTests/Services/ShareCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ShareCommandServiceTests.swift
@@ -415,7 +415,7 @@ final class ShareCommandServiceTests: TuistUnitTestCase {
                 .willReturn(
                     .test(
                         infoPlist: .test(
-                            version: Version(1, 0, 0),
+                            version: "1.0.0",
                             bundleId: "com.tuist.app",
                             supportedPlatforms: [.simulator(.iOS)]
                         )
@@ -962,7 +962,7 @@ final class ShareCommandServiceTests: TuistUnitTestCase {
                     .test(
                         path: appBundlePath,
                         infoPlist: .test(
-                            version: Version(1, 0, 0),
+                            version: "1.0.0",
                             name: "App",
                             bundleId: "com.tuist.app",
                             bundleIcons: .test(

--- a/docs/docs/en/guides/ai/mcp.md
+++ b/docs/docs/en/guides/ai/mcp.md
@@ -35,7 +35,7 @@ Alternatively, can manually edit the file at `~/Library/Application\ Support/Cla
   "mcpServers": {
     "tuist": {
       "command": "tuist",
-      "args": ["mcp"]
+      "args": ["mcp", "start"]
     }
   }
 }
@@ -46,7 +46,7 @@ Alternatively, can manually edit the file at `~/Library/Application\ Support/Cla
   "mcpServers": {
     "tuist": {
       "command": "mise",
-      "args": ["x", "tuist@latest", "--", "tuist", "mcp"] // Or tuist@x.y.z to fix the version
+      "args": ["x", "tuist@latest", "--", "tuist", "mcp", "start"] // Or tuist@x.y.z to fix the version
     }
   }
 }
@@ -66,7 +66,7 @@ Alternatively, can manually edit the file at `.cursor/mcp.json`, and add the Tui
   "mcpServers": {
     "tuist": {
       "command": "tuist",
-      "args": ["mcp"]
+      "args": ["mcp", "start"]
     }
   }
 }
@@ -77,7 +77,7 @@ Alternatively, can manually edit the file at `.cursor/mcp.json`, and add the Tui
   "mcpServers": {
     "tuist": {
       "command": "mise",
-      "args": ["x", "tuist@latest", "--", "tuist", "mcp"] // Or tuist@x.y.z to fix the version
+      "args": ["x", "tuist@latest", "--", "tuist", "mcp", "start"] // Or tuist@x.y.z to fix the version
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7452

### Short description 📝

Assuming that the bundle version short string would be a semantic version is too strict. Instead of using the `Version` struct, we should instead decode it and as a raw string.

### How to test the changes locally 🧐

- Update the `MARKETING_VERSION` of the `App` target in `xcode_app`
- Run the `test_share_xcode_app` acceptance test -> it should pass now.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
