### PR TITLE
Fix acceptnace tests due to invalid executable path in MockEnvironment

### DIFF
--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -41,5 +41,7 @@ public final class MockEnvironment: Environmenting {
 
     public var schemeName: String? { nil }
 
-    public func currentExecutablePath() -> AbsolutePath { directory.path.appending(component: "tuist") }
+    public func currentExecutablePath() -> AbsolutePath {
+        try! AbsolutePath(validating: ProcessInfo.processInfo.arguments[0])
+    }
 }


### PR DESCRIPTION
### Short description 📝

This [PR](https://github.com/tuist/tuist/pull/7456) broke `main`. The acceptance tests _did_ catch that, unfortunately, the PR got merged even with the tests failing.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
