### PR TITLE
Fix test plan container reference in a workspace

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -28,6 +28,7 @@ public enum TuistAcceptanceFixtures {
     case appWithTestPlan
     case appWithTests
     case appWithMacBundle
+    case appWorkspaceWithTestPlan
     case commandLineToolBasic
     case commandLineToolWithDynamicFramework
     case commandLineToolWithDynamicLibrary
@@ -166,6 +167,8 @@ public enum TuistAcceptanceFixtures {
             return "app_with_tests"
         case .appWithMacBundle:
             return "app_with_mac_bundle"
+        case .appWorkspaceWithTestPlan:
+            return "app_workspace_with_test_plan"
         case .commandLineToolBasic:
             return "command_line_tool_basic"
         case .commandLineToolWithDynamicFramework:

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -34,7 +34,7 @@ extension XcodeGraph.TestAction {
                 .concurrentCompactMap { index, path in
                     let resolvedPath = try generatorPaths.resolve(path: path)
                     guard try await fileSystem.exists(resolvedPath) else { return nil }
-                    return try TestPlan(path: resolvedPath, isDefault: index == 0, generatorPaths: generatorPaths)
+                    return try await TestPlan.from(path: resolvedPath, isDefault: index == 0, generatorPaths: generatorPaths)
                 }
 
             // not used when using test plans

--- a/Sources/TuistLoader/Models+ManifestMappers/TestPlan+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestPlan+ManifestMapper.swift
@@ -1,19 +1,23 @@
+import FileSystem
 import Foundation
 import Path
 import XcodeGraph
 
 extension TestPlan {
-    init(path: AbsolutePath, isDefault: Bool, generatorPaths: GeneratorPaths) throws {
-        let jsonDecoder = JSONDecoder()
-        let testPlanData = try Data(contentsOf: URL(fileURLWithPath: path.pathString))
-        let xcTestPlan = try jsonDecoder.decode(XCTestPlan.self, from: testPlanData)
+    static func from(
+        path: AbsolutePath,
+        isDefault: Bool,
+        generatorPaths: GeneratorPaths
+    ) async throws -> TestPlan {
+        let fileSystem = FileSystem()
+        let xcTestPlan: XCTestPlan = try await fileSystem.readJSONFile(at: path, decoder: JSONDecoder())
 
-        try self.init(
+        return try TestPlan(
             path: path,
             testTargets: xcTestPlan.testTargets.map { testTarget in
                 try TestableTarget(
                     target: TargetReference(
-                        projectPath: generatorPaths.resolve(path: .relativeToRoot(testTarget.target.projectPath))
+                        projectPath: generatorPaths.resolve(path: .relativeToManifest(testTarget.target.projectPath))
                             .removingLastComponent(),
                         name: testTarget.target.name
                     ),

--- a/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -32,6 +32,11 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
         try await run(TestCommand.self, "App", "--test-plan", "All")
     }
 
+    func test_with_app_workspace_with_test_plan() async throws {
+        try await setUpFixture(.appWorkspaceWithTestPlan)
+        try await run(TestCommand.self, "App", "--test-plan", "AppTestPlan")
+    }
+
     func test_with_invalid_arguments() async throws {
         try await setUpFixture(.appWithFrameworkAndTests)
         await XCTAssertThrowsSpecific(

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TestPlan+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TestPlan+ManifestMapperTests.swift
@@ -1,0 +1,61 @@
+import FileSystem
+import Foundation
+import ProjectDescription
+import Testing
+import XcodeGraph
+
+@testable import TuistLoader
+
+struct TestPlanManifestMapperTests {
+    private let fileSystem = FileSystem()
+
+    @Test func test_plan_when_manifest_directory_is_in_a_subdirectory() async throws {
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            // Given
+            let testPlanPath = temporaryDirectory.appending(component: "TestPlan.xctestplan")
+            let manifestDirectory = temporaryDirectory.appending(component: "App")
+            try await fileSystem.writeText(
+                """
+                {
+                  "testTargets" : [
+                    {
+                      "target" : {
+                        "containerPath" : "container:App.xcodeproj",
+                        "identifier" : "99DCC7BD0ABB09C467644299",
+                        "name" : "AppTests"
+                      }
+                    }
+                  ]
+                }
+                """,
+                at: testPlanPath
+            )
+
+            // When
+            let got = try await TestPlan.from(
+                path: testPlanPath,
+                isDefault: false,
+                generatorPaths: GeneratorPaths(
+                    manifestDirectory: manifestDirectory,
+                    rootDirectory: temporaryDirectory
+                )
+            )
+
+            // Then
+            #expect(
+                got == TestPlan(
+                    path: testPlanPath,
+                    testTargets: [
+                        TestableTarget(
+                            target: TargetReference(
+                                projectPath: manifestDirectory,
+                                name: "AppTests"
+                            )
+                        ),
+                    ],
+                    isDefault: false
+                )
+            )
+        }
+    }
+}

--- a/fixtures/app_workspace_with_test_plan/App/AppTestPlan.xctestplan
+++ b/fixtures/app_workspace_with_test_plan/App/AppTestPlan.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "DC1A1C37-7A0D-409D-88A8-70C61F2E8FC4",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:App.xcodeproj",
+        "identifier" : "99DCC7BD0ABB09C467644299",
+        "name" : "AppTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fixtures/app_workspace_with_test_plan/App/Project.swift
+++ b/fixtures/app_workspace_with_test_plan/App/Project.swift
@@ -1,0 +1,44 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["Sources/**"],
+            dependencies: []
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.AppTests",
+            infoPlist: .default,
+            sources: ["Tests/**"],
+            resources: [],
+            dependencies: [.target(name: "App")]
+        ),
+    ],
+    schemes: [
+        .scheme(
+            name: "App",
+            testAction: .testPlans(
+                [
+                    .relativeToManifest("AppTestPlan.xctestplan"),
+                ]
+            ),
+            runAction: .runAction(executable: "App")
+        ),
+    ]
+)

--- a/fixtures/app_workspace_with_test_plan/App/Sources/ContentView.swift
+++ b/fixtures/app_workspace_with_test_plan/App/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/app_workspace_with_test_plan/App/Sources/TuistTestExampleApp.swift
+++ b/fixtures/app_workspace_with_test_plan/App/Sources/TuistTestExampleApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TuistTestExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/app_workspace_with_test_plan/App/Tests/TuistTestExampleTests.swift
+++ b/fixtures/app_workspace_with_test_plan/App/Tests/TuistTestExampleTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class TuistTestExampleTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/fixtures/app_workspace_with_test_plan/Tuist.swift
+++ b/fixtures/app_workspace_with_test_plan/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/fixtures/app_workspace_with_test_plan/Workspace.swift
+++ b/fixtures/app_workspace_with_test_plan/Workspace.swift
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let workspace = Workspace(
+    name: "App",
+    projects: [
+        "./App",
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7451

### Short description 📝

Let's take an example test plan, such as:
```
{
  "testTargets" : [
    {
      "target" : {
        "containerPath" : "container:App.xcodeproj",
        "identifier" : "99DCC7BD0ABB09C467644299",
        "name" : "AppTests"
      }
    }
  ],
  "version" : 1
}
```

When resolving the target reference, the `container:App.xcodeproj` is a path to the xcodeproj based on the test plan's Xcode project path. Instead, we would always resolve the `container` from the root, which was incorrect. This PR fixes that.

### How to test the changes locally 🧐

- `tuist test --no-selective-testing --test-plan AppTestPlan App` in the new `app_workspace_with_test_plan` fixture should now succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
