### PR TITLE
Ignore resources inside XCFramework in the SwiftPM XcodeProj integration

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -902,6 +902,7 @@ extension ProjectDescription.ResourceFileElements {
                 ]
             )
             .collect()
+            .filter { !$0.components.contains(where: { $0.hasSuffix(".xcframework") }) }
             .filter { candidatePath in
                 try excludedPaths.allSatisfy {
                     try !AbsolutePath(validating: $0.pathString.lowercased())


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7445

### Short description 📝

This was ... a fun one to solve 😅 It took me a bit before I figured out the underlying issue as the error was somewhat confusing.

The issue happens because:
- The [Package.swift](https://github.com/salesforce-marketingcloud/MarketingCloudSDK-iOS/blob/ea47dbb124945dc32dc447f3bf1c792fde6a6c74/Package.swift#L17) links to an xcframework that's in the same path as another target's sources
- We eagerly search for any resources in a given target sources directory
- We'd end up finding resources _inside_ the `.xcframework`

The `▌ Couldn't find a reference for the file at path /Users/XXX/Developer/git/XXX/Tuist/.build/checkouts/MarketingCloudSDK-iOS/MarketingCloudSDK/MarketingCloudSDK.xcframework.` would happen as in our logic, we would create `.xcframework` as a group element if it's not a leaf – in which in this case it wouldn't, as we were including resources inside of it.

The fix is to ignore any resources inside `.xcframework`. 

### How to test the changes locally 🧐

- Run `tuist generate` in the repro project from the attached issue.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
