### PR TITLE
Remove docs for Cursor MCP integration

### DIFF
--- a/docs/docs/en/guides/ai/mcp.md
+++ b/docs/docs/en/guides/ai/mcp.md
@@ -53,37 +53,6 @@ Alternatively, can manually edit the file at `~/Library/Application\ Support/Cla
 ```
 :::
 
-### Cursor
-
-If you are using [Cursor](https://www.cursor.com), you can run the <LocalizedLink href="/cli/mcp/setup/cursor">tuist mcp setup cursor</LocalizedLink> command to configure your Claude environment.
-
-Alternatively, can manually edit the file at `.cursor/mcp.json`, and add the Tuist MCP server:
-
-:::code-group
-
-```json [Global Tuist installation (e.g. Homebrew)]
-{
-  "mcpServers": {
-    "tuist": {
-      "command": "tuist",
-      "args": ["mcp", "start"]
-    }
-  }
-}
-```
-
-```json [Mise installation]
-{
-  "mcpServers": {
-    "tuist": {
-      "command": "mise",
-      "args": ["x", "tuist@latest", "--", "tuist", "mcp", "start"] // Or tuist@x.y.z to fix the version
-    }
-  }
-}
-```
-:::
-
 ## Capabilities
 
 In the following sections you'll learn about the capabilities of the Tuist MCP server.


### PR DESCRIPTION
### Short description 📝

We got rid of the Cursor integration as it doesn't support resources, only tools – that our MCP server doesn't support currently.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
