### PR TITLE
Add support for selectively testing UI tests

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildArgumentParser.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildArgumentParser.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Mockable
+import XcodeGraph
+
+public struct XcodeBuildArguments: Equatable {
+    public struct Destination: Equatable {
+        public let name: String?
+        public let platform: String?
+        public let id: String?
+        public let os: Version?
+
+        public init(
+            name: String?,
+            platform: String?,
+            id: String?,
+            os: Version?
+        ) {
+            self.name = name
+            self.platform = platform
+            self.id = id
+            self.os = os
+        }
+    }
+
+    public let destination: Destination?
+
+    public init(
+        destination: Destination?
+    ) {
+        self.destination = destination
+    }
+}
+
+@Mockable
+public protocol XcodeBuildArgumentParsing {
+    func parse(_ arguments: [String]) -> XcodeBuildArguments
+}
+
+public struct XcodeBuildArgumentParser: XcodeBuildArgumentParsing {
+    public init() {}
+
+    public func parse(_ arguments: [String]) -> XcodeBuildArguments {
+        let destination: XcodeBuildArguments.Destination?
+        if let destinationValue = passedValue(for: "-destination", arguments: arguments) {
+            let os: Version?
+            if let osValue = value(for: "OS", optionValue: destinationValue) {
+                os = Version(string: osValue)
+            } else {
+                os = nil
+            }
+            destination = XcodeBuildArguments.Destination(
+                name: value(for: "name", optionValue: destinationValue),
+                platform: value(for: "platform", optionValue: destinationValue),
+                id: value(for: "id", optionValue: destinationValue),
+                os: os
+            )
+        } else {
+            destination = nil
+        }
+
+        return XcodeBuildArguments(
+            destination: destination
+        )
+    }
+
+    private func passedValue(
+        for option: String,
+        arguments: [String]
+    ) -> String? {
+        guard let optionIndex = arguments.firstIndex(of: option) else { return nil }
+        let valueIndex = arguments.index(after: optionIndex)
+        guard arguments.endIndex > valueIndex else { return nil }
+        return arguments[valueIndex]
+    }
+
+    private func value(
+        for parameter: String,
+        optionValue: String
+    ) -> String? {
+        let components = optionValue.components(separatedBy: ",").flatMap { $0.components(separatedBy: "=") }
+        if let nameIndex = components.firstIndex(of: parameter), nameIndex + 1 < components.endIndex {
+            return components[nameIndex + 1]
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -10,7 +10,8 @@ public protocol CacheGraphContentHashing {
         for graph: Graph,
         configuration: String?,
         defaultConfiguration: String?,
-        excludedTargets: Set<String>
+        excludedTargets: Set<String>,
+        destination: SimulatorDeviceAndRuntime?
     ) async throws -> [GraphTarget: String]
 }
 
@@ -56,7 +57,8 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
         for graph: Graph,
         configuration: String?,
         defaultConfiguration: String?,
-        excludedTargets: Set<String>
+        excludedTargets: Set<String>,
+        destination: SimulatorDeviceAndRuntime?
     ) async throws -> [GraphTarget: String] {
         let graphTraverser = GraphTraverser(graph: graph)
         let version = versionFetcher.version()
@@ -75,6 +77,7 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
                     excludedTargets: excludedTargets
                 )
             },
+            destination: destination,
             additionalStrings: [
                 configuration,
                 try swiftVersionProvider.swiftlangVersion(),

--- a/Sources/TuistHasher/GraphContentHasher.swift
+++ b/Sources/TuistHasher/GraphContentHasher.swift
@@ -16,6 +16,7 @@ public protocol GraphContentHashing {
     func contentHashes(
         for graph: Graph,
         include: @escaping (GraphTarget) -> Bool,
+        destination: SimulatorDeviceAndRuntime?,
         additionalStrings: [String]
     ) async throws -> [GraphTarget: String]
 }
@@ -56,6 +57,7 @@ public struct GraphContentHasher: GraphContentHashing {
     public func contentHashes(
         for graph: Graph,
         include: (GraphTarget) -> Bool,
+        destination: SimulatorDeviceAndRuntime?,
         additionalStrings: [String]
     ) async throws -> [GraphTarget: String] {
         let graphTraverser = GraphTraverser(graph: graph)
@@ -88,6 +90,7 @@ public struct GraphContentHasher: GraphContentHashing {
                 for: target,
                 hashedTargets: hashedTargets.value,
                 hashedPaths: hashedPaths.value,
+                destination: destination,
                 additionalStrings: additionalStrings
             )
             hashedPaths.mutate { $0 = hash.hashedPaths }

--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesService.swift
@@ -58,7 +58,8 @@ final class CachePrintHashesService {
             for: graph,
             configuration: configuration,
             defaultConfiguration: config.project.generatedProject?.generationOptions.defaultConfiguration,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
         let duration = timer.stop()
         let time = String(format: "%.3f", duration)

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -26,7 +26,8 @@ public protocol GeneratorFactorying {
         configuration: String?,
         ignoreBinaryCache: Bool,
         ignoreSelectiveTesting: Bool,
-        cacheStorage: CacheStoring
+        cacheStorage: CacheStoring,
+        destination: SimulatorDeviceAndRuntime?
     ) -> Generating
 
     /// Returns the generator for focused projects.
@@ -81,7 +82,8 @@ public class GeneratorFactory: GeneratorFactorying {
         configuration _: String?,
         ignoreBinaryCache _: Bool,
         ignoreSelectiveTesting _: Bool,
-        cacheStorage _: CacheStoring
+        cacheStorage _: CacheStoring,
+        destination _: SimulatorDeviceAndRuntime?
     ) -> Generating {
         let contentHasher = ContentHasher()
         let projectMapperFactory = ProjectMapperFactory(contentHasher: contentHasher)

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildArgumentParserTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildArgumentParserTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+import XcodeGraph
+
+@testable import TuistAutomation
+
+struct XcodeBuildArgumentParserTests {
+    private let subject = XcodeBuildArgumentParser()
+
+    @Test
+    func test_parse_with_no_destination() async throws {
+        // When
+        let got = subject.parse(["-scheme", "MyScheme"])
+
+        // Then
+        #expect(
+            got == XcodeBuildArguments(destination: nil)
+        )
+    }
+
+    @Test
+    func test_parse_with_destination_name_and_os() async throws {
+        // When
+        let got = subject.parse(["-scheme", "MyScheme", "-destination", "name=iPhone 16,OS=16.0"])
+
+        // Then
+        #expect(
+            got == XcodeBuildArguments(
+                destination: XcodeBuildArguments.Destination(
+                    name: "iPhone 16",
+                    platform: nil,
+                    id: nil,
+                    os: Version(16, 0, 0)
+                )
+            )
+        )
+    }
+
+    @Test
+    func test_parse_with_destination_id() async throws {
+        // When
+        let got = subject.parse(["-scheme", "MyScheme", "-destination", "id=some-id"])
+
+        // Then
+        #expect(
+            got == XcodeBuildArguments(
+                destination: XcodeBuildArguments.Destination(
+                    name: nil,
+                    platform: nil,
+                    id: "some-id",
+                    os: nil
+                )
+            )
+        )
+    }
+
+    @Test
+    func test_parse_with_invalid_destination() async throws {
+        // When
+        let got = subject.parse(["-scheme", "MyScheme", "-destination", "invalid_value=some-id"])
+
+        // Then
+        #expect(
+            got == XcodeBuildArguments(
+                destination: XcodeBuildArguments.Destination(
+                    name: nil,
+                    platform: nil,
+                    id: nil,
+                    os: nil
+                )
+            )
+        )
+    }
+}

--- a/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/CacheGraphContentHasherIntegrationTests.swift
@@ -114,7 +114,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -150,7 +151,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -186,7 +188,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -225,7 +228,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -261,7 +265,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -298,7 +303,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -336,7 +342,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -372,7 +379,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -412,7 +420,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         XCTAssertNotEqual(contentHash[framework1], contentHash[framework2])
@@ -449,7 +458,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
             for: graph,
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         XCTAssertNotEqual(contentHash[framework1], contentHash[framework2])

--- a/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/CacheGraphContentHasherTests.swift
@@ -56,6 +56,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             .contentHashes(
                 for: .any,
                 include: .any,
+                destination: .any,
                 additionalStrings: .any
             )
             .willReturn([:])
@@ -69,7 +70,8 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             for: Graph.test(),
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: []
+            excludedTargets: [],
+            destination: nil
         )
 
         // Then
@@ -79,6 +81,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
                 include: .matching { filter in
                     filter(includedTarget)
                 },
+                destination: .any,
                 additionalStrings: .any
             )
             .called(1)
@@ -100,6 +103,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             .contentHashes(
                 for: .any,
                 include: .any,
+                destination: .any,
                 additionalStrings: .any
             )
             .willReturn([:])
@@ -113,7 +117,8 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             for: Graph.test(),
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: ["Excluded"]
+            excludedTargets: ["Excluded"],
+            destination: nil
         )
 
         // Then
@@ -123,6 +128,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
                 include: .matching { filter in
                     filter(includedTarget) && !filter(excludedTarget)
                 },
+                destination: .any,
                 additionalStrings: .any
             )
             .called(1)
@@ -151,6 +157,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             .contentHashes(
                 for: .any,
                 include: .any,
+                destination: .any,
                 additionalStrings: .any
             )
             .willReturn([:])
@@ -164,7 +171,8 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
             for: Graph.test(),
             configuration: "Debug",
             defaultConfiguration: nil,
-            excludedTargets: ["Excluded"]
+            excludedTargets: ["Excluded"],
+            destination: nil
         )
 
         // Then
@@ -174,6 +182,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
                 include: .matching { filter in
                     filter(includedTarget) && !filter(excludedTarget) && !filter(excludedTargetResource)
                 },
+                destination: .any,
                 additionalStrings: .any
             )
             .called(1)

--- a/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
+++ b/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mockable
 import Path
+import TSCUtility
 import XCTest
 
 @testable import TuistCore
@@ -68,6 +69,18 @@ final class SimulatorControllerTests: TuistUnitTestCase {
         )
     }
 
+    func test_findAvailableDevice_by_udid_should_throwErrorWhenNoDeviceForPlatform() async throws {
+        // Given
+        _ = createSystemStubs(devices: true, runtimes: true)
+
+        // Then
+        await XCTAssertThrowsSpecific(
+            // When
+            _ = try await subject.findAvailableDevice(udid: "some-id"),
+            SimulatorControllerError.simulatorNotFound(udid: "some-id")
+        )
+    }
+
     func test_findAvailableDevice_should_throwErrorWhenNoDeviceForVersion() async throws {
         // Given
         let expectedDeviceAndRuntime = try XCTUnwrap(createSystemStubs(devices: true, runtimes: true).first)
@@ -102,6 +115,31 @@ final class SimulatorControllerTests: TuistUnitTestCase {
             _ = try await subject.findAvailableDevice(platform: .iOS, version: nil, minVersion: nil, deviceName: "iPad 100"),
             SimulatorControllerError.deviceNotFound(.iOS, nil, "iPad 100", [expectedDeviceAndRuntime])
         )
+    }
+
+    func test_findAvailableDevice_should_findDeviceWithUdid() async throws {
+        // Given
+        let expectedDeviceAndRuntime = try XCTUnwrap(createSystemStubs(devices: true, runtimes: true).first)
+
+        // When
+        let device = try await subject.findAvailableDevice(udid: "81F0475F-0A03-4742-92D7-D59ACE3A5895")
+
+        // Then
+        XCTAssertEqual(device, expectedDeviceAndRuntime)
+    }
+
+    func test_findAvailableDevice_should_findDeviceWithDeviceNameAndOSVersion() async throws {
+        // Given
+        let expectedDeviceAndRuntime = try XCTUnwrap(createSystemStubs(devices: true, runtimes: true).first)
+
+        // When
+        let device = try await subject.findAvailableDevice(
+            deviceName: "iPhone 11",
+            version: Version(14, 4, 0)
+        )
+
+        // Then
+        XCTAssertEqual(device, expectedDeviceAndRuntime)
     }
 
     func test_findAvailableDevice_should_findDeviceWithDefaults() async throws {

--- a/Tests/TuistHasherTests/GraphContentHasherTests.swift
+++ b/Tests/TuistHasherTests/GraphContentHasherTests.swift
@@ -24,7 +24,12 @@ struct GraphContentHasherTests {
         let graph = Graph.test()
 
         // When
-        let hashes = try await subject.contentHashes(for: graph, include: { _ in true }, additionalStrings: [])
+        let hashes = try await subject.contentHashes(
+            for: graph,
+            include: { _ in true },
+            destination: nil,
+            additionalStrings: []
+        )
 
         // Then
         #expect(hashes == Dictionary())
@@ -92,6 +97,7 @@ struct GraphContentHasherTests {
             include: {
                 $0.target.product == .framework
             },
+            destination: nil,
             additionalStrings: []
         )
         let hashedTargets: [GraphTarget] = hashes.keys.sorted { left, right -> Bool in
@@ -122,9 +128,10 @@ struct GraphContentHasherTests {
                     for: .any,
                     hashedTargets: .any,
                     hashedPaths: .any,
+                    destination: .any,
                     additionalStrings: .any
                 )
-                .willProduce { graphTarget, _, _, additionalStrings in
+                .willProduce { graphTarget, _, _, _, additionalStrings in
                     TargetContentHash(
                         hash: graphTarget.target.name + "-" + additionalStrings.joined(separator: "-"),
                         hashedPaths: [:]
@@ -151,6 +158,7 @@ struct GraphContentHasherTests {
                     ]
                 ),
                 include: { _ in true },
+                destination: nil,
                 additionalStrings: []
             )
 
@@ -173,9 +181,10 @@ struct GraphContentHasherTests {
                     for: .any,
                     hashedTargets: .any,
                     hashedPaths: .any,
+                    destination: .any,
                     additionalStrings: .any
                 )
-                .willProduce { graphTarget, _, _, additionalStrings in
+                .willProduce { graphTarget, _, _, _, additionalStrings in
                     TargetContentHash(
                         hash: graphTarget.target.name + "-" + additionalStrings.joined(separator: "-"),
                         hashedPaths: [:]
@@ -214,6 +223,7 @@ struct GraphContentHasherTests {
                     ]
                 ),
                 include: { _ in true },
+                destination: nil,
                 additionalStrings: []
             )
 
@@ -236,9 +246,10 @@ struct GraphContentHasherTests {
                     for: .any,
                     hashedTargets: .any,
                     hashedPaths: .any,
+                    destination: .any,
                     additionalStrings: .any
                 )
-                .willProduce { graphTarget, _, _, additionalStrings in
+                .willProduce { graphTarget, _, _, _, additionalStrings in
                     TargetContentHash(
                         hash: graphTarget.target.name + "-" + additionalStrings.joined(separator: "-"),
                         hashedPaths: [:]
@@ -276,6 +287,7 @@ struct GraphContentHasherTests {
                     ]
                 ),
                 include: { _ in true },
+                destination: nil,
                 additionalStrings: []
             )
 

--- a/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
@@ -64,7 +64,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         )
         let fullPath = FileHandler.shared.currentPath.pathString + "/full/path"
         given(cacheGraphContentHasher)
-            .contentHashes(for: .any, configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
         given(generator)
             .load(path: .any)
@@ -88,7 +94,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
             configLoader: configLoader
         )
         given(cacheGraphContentHasher)
-            .contentHashes(for: .any, configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
         given(generator)
             .load(path: .any)
@@ -112,7 +124,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
             configLoader: configLoader
         )
         given(cacheGraphContentHasher)
-            .contentHashes(for: .any, configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
         given(generator)
             .load(path: .any)
@@ -136,7 +154,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
             configLoader: configLoader
         )
         given(cacheGraphContentHasher)
-            .contentHashes(for: .any, configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
         given(generator)
             .load(path: .any)
@@ -165,7 +189,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
             .willReturn(graph)
 
         given(cacheGraphContentHasher)
-            .contentHashes(for: .value(graph), configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .value(graph),
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
 
         // When / Then
@@ -178,7 +208,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
             let target1 = GraphTarget.test(target: .test(name: "ShakiOne"))
             let target2 = GraphTarget.test(target: .test(name: "ShakiTwo"))
             given(cacheGraphContentHasher)
-                .contentHashes(for: .any, configuration: .any, defaultConfiguration: .any, excludedTargets: .any)
+                .contentHashes(
+                    for: .any,
+                    configuration: .any,
+                    defaultConfiguration: .any,
+                    excludedTargets: .any,
+                    destination: .any
+                )
                 .willReturn([target1: "hash1", target2: "hash2"])
 
             given(generator)
@@ -204,7 +240,13 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
     func test_run_gives_correct_configuration_type_to_hasher() async throws {
         // Given
         given(cacheGraphContentHasher)
-            .contentHashes(for: .any, configuration: .value("Debug"), defaultConfiguration: .any, excludedTargets: .any)
+            .contentHashes(
+                for: .any,
+                configuration: .value("Debug"),
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
             .willReturn([:])
 
         given(generator)

--- a/docs/docs/en/guides/develop/selective-testing/generated-project.md
+++ b/docs/docs/en/guides/develop/selective-testing/generated-project.md
@@ -31,3 +31,12 @@ For example, assuming the following dependency graph:
 | `tuist test` invocation | Runs the tests in `CoreTests`, `FeatureATests`, and `FeatureBTests` | The new hash of `FeatureATests` `FeatureBTests`, and `CoreTests` are persisted |
 
 `tuist test` integrates directly with binary caching to use as many binaries from your local or remote storage to improve the build time when running your test suite. The combination of selective testing with binary caching can dramatically reduce the time it takes to run tests on your CI.
+
+## UI Tests {#ui-tests}
+
+Tuist supports selective testing of UI tests. However, Tuist needs to know the destination in advance. Only if you specify the `destination` parameter, Tuist will run the UI tests selectively, such as:
+```sh
+tuist test -- -destination 'name=iPhone 14 Pro,OS=17.0'
+# or
+tuist test -- -destination 'id=SIMULATOR_ID'
+```

--- a/docs/docs/en/guides/develop/selective-testing/generated-project.md
+++ b/docs/docs/en/guides/develop/selective-testing/generated-project.md
@@ -36,7 +36,9 @@ For example, assuming the following dependency graph:
 
 Tuist supports selective testing of UI tests. However, Tuist needs to know the destination in advance. Only if you specify the `destination` parameter, Tuist will run the UI tests selectively, such as:
 ```sh
-tuist test -- -destination 'name=iPhone 14 Pro,OS=17.0'
+tuist test --device 'iPhone 14 Pro'
+# or
+tuist test -- -destination 'name=iPhone 14 Pro'
 # or
 tuist test -- -destination 'id=SIMULATOR_ID'
 ```


### PR DESCRIPTION
### Short description 📝

Adding support for selectively testing UI tests. For now, just for generated projects, but this can definitely be added to non-generated projects later on as well.

Additionally, UI tests are only run selectively when the `-destination` is passed through the passthrough arguments. This is because we need to know what device the tests will be run on advance. While we could add some heuristics to guess what `xcodebuild` would do, but I'd rather be explicit.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
