### PR TITLE
Efficiently precompute hash for registry dependencies

### DIFF
--- a/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
+++ b/Sources/TuistLoader/Models/SwiftPackageManagerWorkspaceState.swift
@@ -22,6 +22,9 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
 
             /// The revision a package has been resolved to.
             let checkoutState: CheckoutState?
+
+            /// The version a package has been resolved to.
+            let version: String?
         }
 
         /// The package reference of the dependency

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -124,12 +124,18 @@ final class DependenciesAcceptanceTestIosAppWithSPMDependenciesWithOutdatedDepen
             let packageResolvedContents = try await fileSystem.readTextFile(at: packageResolvedPath)
             try FileHandler.shared.write(packageResolvedContents + " ", path: packageResolvedPath, atomically: true)
             try await run(GenerateCommand.self)
-            XCTAssertStandardOutput(pattern: "We detected outdated dependencies. Please run \"tuist install\" to update them.")
+            XCTAssertEqual(
+                ServiceContext.current?.recordedUI()
+                    .contains("We detected outdated dependencies"), true
+            )
+            ServiceContext.current?.resetRecordedUI()
 
-            ServiceContext.current?.testingLogHandler?.flush()
             try await run(InstallCommand.self)
             try await run(GenerateCommand.self)
-            XCTAssertStandardOutputNotContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
+            XCTAssertEqual(
+                ServiceContext.current?.recordedUI()
+                    .contains("We detected outdated dependencies"), false
+            )
         }
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -1,129 +1,167 @@
+import FileSystem
+import Foundation
 import Mockable
 import ServiceContextModule
+import Testing
 import TuistCore
 import TuistSupport
 import TuistSupportTesting
-import XCTest
 
 @testable import TuistLoader
 
-final class SwiftPackageManagerGraphLoaderTests: TuistUnitTestCase {
-    private var swiftPackageManagerController: MockSwiftPackageManagerControlling!
-    private var packageInfoMapper: MockPackageInfoMapping!
-    private var manifestLoader: MockManifestLoading!
-    private var subject: SwiftPackageManagerGraphLoader!
+struct SwiftPackageManagerGraphLoaderTests {
+    private let swiftPackageManagerController = MockSwiftPackageManagerControlling()
+    private let packageInfoMapper = MockPackageInfoMapping()
+    private let manifestLoader = MockManifestLoading()
+    private let fileSystem = FileSystem()
+    private let contentHasher = MockContentHashing()
+    private let subject: SwiftPackageManagerGraphLoader
 
-    override func setUp() {
-        super.setUp()
-        swiftPackageManagerController = MockSwiftPackageManagerControlling()
-        packageInfoMapper = MockPackageInfoMapping()
-        manifestLoader = MockManifestLoading()
+    init() {
         subject = SwiftPackageManagerGraphLoader(
             swiftPackageManagerController: swiftPackageManagerController,
             packageInfoMapper: packageInfoMapper,
             manifestLoader: manifestLoader,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            contentHasher: contentHasher
         )
+
+        given(contentHasher)
+            .hash(Parameter<[String]>.any)
+            .willProduce { $0.joined(separator: "-") }
+        given(manifestLoader)
+            .loadPackage(at: .any)
+            .willReturn(.test())
+        given(packageInfoMapper)
+            .map(
+                packageInfo: .any,
+                path: .any,
+                packageType: .any,
+                packageSettings: .any,
+                packageModuleAliases: .any
+            )
+            .willReturn(.test())
     }
 
-    override func tearDown() {
-        subject = nil
-        manifestLoader = nil
-        packageInfoMapper = nil
-        swiftPackageManagerController = nil
-        super.tearDown()
-    }
-
+    @Test
     func test_load() async throws {
         try await ServiceContext.withTestingDependencies {
-            // Given
-            let temporaryPath = try temporaryPath()
-            let packageSettings = PackageSettings.test()
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+                // Given
+                let packageSettings = PackageSettings.test()
 
-            let workspacePath = temporaryPath.appending(components: [".build", "workspace-state.json"])
-            try fileHandler.createFolder(workspacePath.parentDirectory)
-            try fileHandler.write(
-                """
-                {
-                  "object" : {
-                    "artifacts" : [],
-                    "dependencies" : []
-                  }
-                }
-                """,
-                path: workspacePath,
-                atomically: true
-            )
-
-            try fileHandler.touch(temporaryPath.appending(components: [".build", "Derived", "Package.resolved"]))
-            try fileHandler.touch(temporaryPath.appending(component: "Package.resolved"))
-
-            given(packageInfoMapper)
-                .resolveExternalDependencies(
-                    path: .any,
-                    packageInfos: .any,
-                    packageToFolder: .any,
-                    packageToTargetsToArtifactPaths: .any,
-                    packageModuleAliases: .any
+                let workspacePath = temporaryDirectory.appending(components: [".build", "workspace-state.json"])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : [
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Alamofire.Alamofire",
+                              "kind" : "registry",
+                              "location" : "Alamofire.Alamofire",
+                              "name" : "Alamofire.Alamofire"
+                            },
+                            "state" : {
+                              "name" : "registryDownload",
+                              "version" : "5.10.2"
+                            },
+                            "subpath" : "Alamofire/Alamofire/5.10.2"
+                          }
+                        ],
+                      }
+                    }
+                    """,
+                    at: workspacePath
                 )
-                .willReturn([:])
 
-            // When
-            let _ = try await subject.load(
-                packagePath: temporaryPath.appending(component: "Package.swift"),
-                packageSettings: packageSettings
-            )
+                try await fileSystem.makeDirectory(at: temporaryDirectory.appending(components: [".build", "Derived"]))
+                try await fileSystem.touch(temporaryDirectory.appending(components: [".build", "Derived", "Package.resolved"]))
+                try await fileSystem.touch(temporaryDirectory.appending(component: "Package.resolved"))
 
-            // Then
-            XCTAssertPrinterOutputNotContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
+                given(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packageInfos: .any,
+                        packageToFolder: .any,
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any
+                    )
+                    .willReturn([:])
+
+                // When
+                let got = try await subject.load(
+                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                    packageSettings: packageSettings
+                )
+
+                // Then
+                #expect(
+                    got.externalProjects.values.map(\.hash) == [
+                        "Alamofire.Alamofire-5.10.2",
+                    ]
+                )
+                #expect(
+                    ServiceContext.current?.recordedUI()
+                        .contains("We detected outdated dependencies.") == false
+                )
+            }
         }
     }
 
+    @Test
     func test_load_warnOutdatedDependencies() async throws {
         try await ServiceContext.withTestingDependencies {
-            // Given
-            let temporaryPath = try temporaryPath()
-            let packageSettings = PackageSettings.test()
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+                // Given
+                let packageSettings = PackageSettings.test()
 
-            let workspacePath = temporaryPath.appending(components: [".build", "workspace-state.json"])
-            try fileHandler.createFolder(workspacePath.parentDirectory)
-            try fileHandler.write(
-                """
-                {
-                  "object" : {
-                    "artifacts" : [],
-                    "dependencies" : []
-                  }
-                }
-                """,
-                path: workspacePath,
-                atomically: true
-            )
-
-            let savedPackageResolvedPath = temporaryPath.appending(components: [".build", "Derived", "Package.resolved"])
-            let currentPackageResolvedPath = temporaryPath.appending(component: "Package.resolved")
-            try fileHandler.touch(savedPackageResolvedPath)
-            try fileHandler.write("outdated", path: savedPackageResolvedPath, atomically: true)
-            try fileHandler.touch(currentPackageResolvedPath)
-
-            given(packageInfoMapper)
-                .resolveExternalDependencies(
-                    path: .any,
-                    packageInfos: .any,
-                    packageToFolder: .any,
-                    packageToTargetsToArtifactPaths: .any,
-                    packageModuleAliases: .any
+                let workspacePath = temporaryDirectory.appending(components: [".build", "workspace-state.json"])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : []
+                      }
+                    }
+                    """,
+                    at: workspacePath
                 )
-                .willReturn([:])
 
-            // When
-            let _ = try await subject.load(
-                packagePath: temporaryPath.appending(component: "Package.swift"),
-                packageSettings: packageSettings
-            )
+                try await fileSystem.makeDirectory(at: temporaryDirectory.appending(components: [".build", "Derived"]))
+                let savedPackageResolvedPath = temporaryDirectory.appending(components: [".build", "Derived", "Package.resolved"])
+                let currentPackageResolvedPath = temporaryDirectory.appending(component: "Package.resolved")
+                try await fileSystem.writeText("outdated", at: savedPackageResolvedPath)
+                try await fileSystem.touch(currentPackageResolvedPath)
 
-            // Then
-            XCTAssertPrinterOutputContains("We detected outdated dependencies. Please run \"tuist install\" to update them.")
+                given(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packageInfos: .any,
+                        packageToFolder: .any,
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any
+                    )
+                    .willReturn([:])
+
+                // When
+                _ = try await subject.load(
+                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                    packageSettings: packageSettings
+                )
+
+                // Then
+                #expect(
+                    ServiceContext.current?.recordedUI()
+                        .contains("We detected outdated dependencies") == true
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
### Short description 📝

Applies the same optimization done in https://github.com/tuist/tuist/pull/7060 for registry dependencies. Since dependencies in a registry should be immutable, hashing the registry's `id` and version should be all we need. There's no checksum as for source control dependencies as there is no `git` checkout of registry dependencies.

### How to test the changes locally 🧐

- Run `tuist cache --print-hashes` in `app_with_registry_and_alamofire`. The hash should be different from the latest `tuist` CLI version.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
