### PR TITLE
Fix tree-shaking target references from test plans when selective testing

### DIFF
--- a/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -169,6 +169,9 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
                 scheme.testAction?.codeCoverageTargets = testAction.codeCoverageTargets.filter(
                     sourceTargets.contains
                 )
+                scheme.testAction?.testPlans = testAction.testPlans?.compactMap {
+                    treeShake(testPlan: $0, sourceTargets: sourceTargets)
+                }
             }
 
             let hasBuildTargets = !(scheme.buildAction?.targets ?? []).isEmpty
@@ -191,6 +194,22 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
             }
 
             return scheme
+        }
+    }
+
+    private func treeShake(
+        testPlan: TestPlan,
+        sourceTargets: Set<TargetReference>
+    ) -> TestPlan? {
+        let testTargets = testPlan.testTargets.filter { sourceTargets.contains($0.target) }
+        if testTargets.isEmpty {
+            return nil
+        } else {
+            return TestPlan(
+                path: testPlan.path,
+                testTargets: testTargets,
+                isDefault: testPlan.isDefault
+            )
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7472

### Short description 📝

When reproducing the issue, what I found suspicious was that on the second run, the test plan in the generated project has invalid references to the target that succeeded in the initial test run:
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/b51525dd-e9d4-4207-a2a7-21462377095d" />

How did we end up with an invalid reference that is valid when running `tuist generate`? The issue turned out to be our pruning mechanism that does not actually prune targets inside test plans. Once the target is pruned from inside the test plan, `tuist test` correctly runs the test again.

### How to test the changes locally 🧐

- See the repro steps from the attached issue

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
