### PR TITLE
Add `schemeIdentifierSchemeName` attribute to ActivityLog

### DIFF
--- a/Sources/TuistKit/Services/Inspect/Models/ActivityLog.swift
+++ b/Sources/TuistKit/Services/Inspect/Models/ActivityLog.swift
@@ -4,4 +4,12 @@ struct ActivityLog: Codable {
     let fileName: String
     let timeStartedRecording: Double
     let timeStoppedRecording: Double
+    let schemeIdentifierSchemeName: String
+
+    enum CodingKeys: String, CodingKey {
+        case fileName
+        case timeStartedRecording
+        case timeStoppedRecording
+        case schemeIdentifierSchemeName = "schemeIdentifier-schemeName"
+    }
 }

--- a/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
@@ -114,7 +114,8 @@ struct InspectBuildCommandServiceTests {
                         "id": ActivityLog(
                             fileName: "id.xcactivitylog",
                             timeStartedRecording: 10,
-                            timeStoppedRecording: 20
+                            timeStoppedRecording: 20,
+                            schemeIdentifierSchemeName: "Scheme"
                         ),
                     ]
                 ),
@@ -200,7 +201,8 @@ struct InspectBuildCommandServiceTests {
                         "id": ActivityLog(
                             fileName: "id.xcactivitylog",
                             timeStartedRecording: 10,
-                            timeStoppedRecording: 20
+                            timeStoppedRecording: 20,
+                            schemeIdentifierSchemeName: "Scheme"
                         ),
                     ]
                 ),
@@ -238,7 +240,8 @@ struct InspectBuildCommandServiceTests {
                         "id": ActivityLog(
                             fileName: "id.xcactivitylog",
                             timeStartedRecording: 10,
-                            timeStoppedRecording: 20
+                            timeStoppedRecording: 20,
+                            schemeIdentifierSchemeName: "Scheme"
                         ),
                     ]
                 ),
@@ -323,7 +326,8 @@ struct InspectBuildCommandServiceTests {
                         "id": ActivityLog(
                             fileName: "id.xcactivitylog",
                             timeStartedRecording: 10,
-                            timeStoppedRecording: 20
+                            timeStoppedRecording: 20,
+                            schemeIdentifierSchemeName: "Scheme"
                         ),
                     ]
                 ),


### PR DESCRIPTION
### Short description 📝
I need `schemeIdentifierSchemeName` to match an activity log with the scheme that originated it, so I'm including the `schemeIdentifier-schemeName` attribute of `.xcactivitylog`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
