### PR TITLE
Use Xcode 16.3 on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         run: git cliff --include-path "app/**/*" --repository "../" --bump -o CHANGELOG.md
       - name: Select Xcode
         if: env.should-release == 'true'
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_16.3.app
       - name: Install dependencies
         if: env.should-release == 'true'
         run: mise run install

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -3,7 +3,7 @@ workflows:
     name: Lint
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - github_credentials
     scripts:
@@ -32,7 +32,7 @@ workflows:
     name: SPM Build
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - github_credentials
     scripts:
@@ -51,7 +51,7 @@ workflows:
     name: Build Documentation
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -75,7 +75,7 @@ workflows:
     name: Unit tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -100,7 +100,7 @@ workflows:
     name: Cache
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -132,7 +132,7 @@ workflows:
     name: Deploy Documentation
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -167,7 +167,7 @@ workflows:
     name: Tuist automation acceptance tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -197,7 +197,7 @@ workflows:
     name: Tuist dependencies acceptance tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -236,7 +236,7 @@ workflows:
     name: Tuist generator acceptance tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -266,7 +266,7 @@ workflows:
     name: TuistKit acceptance tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials
@@ -295,7 +295,7 @@ workflows:
     name: Tuist App tests
     max_build_duration: 60
     environment:
-      xcode: 16.1
+      xcode: 16.3
       groups:
         - tuist
         - github_credentials


### PR DESCRIPTION
I want to start using [custom Swift Testing Traits](https://www.swift.org/blog/swift-6.1-released/#swift-testing) to eliminate some boilerplate from using task locals in tests, but I can't until we upgrade to Swift 6.1 so I'm updating the version of Xcode that we use in CI to 16.3, which comes with Swift 6.1, to have access to that feature.