### PR TITLE
Ignore unused symbols in synthesized resource interface files by Periphery

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -191,6 +191,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         }
 
         return """
+        // periphery:ignore:all
         // swiftlint:disable:this file_name
         // swiftlint:disable all
         // swift-format-ignore-file


### PR DESCRIPTION
### Short description 📝

> We are trying to integrate [periphery](https://github.com/peripheryapp/periphery) support into our project and getting warnings in TuistBundle+SharedComponents file

![Screenshot 2025-04-11 at 15 30 04](https://github.com/user-attachments/assets/41e12952-40d9-4641-8a79-a924afba7015)

### How to test the changes locally 🧐

> Not required, I assume

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
