### PR TITLE
Fix issue where targets with no sources generated an empty compile sources phase, leading to issues in watchOS apps

### DIFF
--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -87,14 +87,16 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             pbxproj: pbxproj
         )
 
-        try generateSourcesBuildPhase(
-            files: target.sources,
-            coreDataModels: target.coreDataModels,
-            target: target,
-            pbxTarget: pbxTarget,
-            fileElements: fileElements,
-            pbxproj: pbxproj
-        )
+        if !target.sources.isEmpty {
+            try generateSourcesBuildPhase(
+                files: target.sources,
+                coreDataModels: target.coreDataModels,
+                target: target,
+                pbxTarget: pbxTarget,
+                fileElements: fileElements,
+                pbxproj: pbxproj
+            )
+        }
 
         try generateResourcesBuildPhase(
             path: path,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -87,16 +87,14 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             pbxproj: pbxproj
         )
 
-        if !target.sources.isEmpty {
-            try generateSourcesBuildPhase(
-                files: target.sources,
-                coreDataModels: target.coreDataModels,
-                target: target,
-                pbxTarget: pbxTarget,
-                fileElements: fileElements,
-                pbxproj: pbxproj
-            )
-        }
+        try generateSourcesBuildPhase(
+            files: target.sources,
+            coreDataModels: target.coreDataModels,
+            target: target,
+            pbxTarget: pbxTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
 
         try generateResourcesBuildPhase(
             path: path,
@@ -256,8 +254,6 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         pbxproj: PBXProj
     ) throws {
         let sourcesBuildPhase = PBXSourcesBuildPhase()
-        pbxproj.add(object: sourcesBuildPhase)
-        pbxTarget.buildPhases.append(sourcesBuildPhase)
 
         var buildFilesCache = Set<AbsolutePath>()
         let sortedFiles = files
@@ -312,6 +308,11 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
         pbxBuildFiles.forEach { pbxproj.add(object: $0) }
         sourcesBuildPhase.files = pbxBuildFiles
+        
+        if !pbxBuildFiles.isEmpty {
+            pbxproj.add(object: sourcesBuildPhase)
+            pbxTarget.buildPhases.append(sourcesBuildPhase)
+        }
     }
 
     func generateHeadersBuildPhase(

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -308,7 +308,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
         pbxBuildFiles.forEach { pbxproj.add(object: $0) }
         sourcesBuildPhase.files = pbxBuildFiles
-        
+
         if !pbxBuildFiles.isEmpty {
             pbxproj.add(object: sourcesBuildPhase)
             pbxTarget.buildPhases.append(sourcesBuildPhase)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -189,6 +189,30 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "resource.metal",
         ])
     }
+    
+    func test_doesntGenerateSourcesBuildPhase_whenWatchKitTarget() throws {
+        // Given
+        let pbxTarget = PBXNativeTarget(name: "Test")
+        let pbxproj = PBXProj()
+        pbxproj.add(object: pbxTarget)
+
+        let target = Target.test(product: .watch2App)
+
+        // When
+        try subject.generateSourcesBuildPhase(
+            files: [],
+            coreDataModels: [],
+            target: target,
+            pbxTarget: pbxTarget,
+            fileElements: .init(),
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try pbxTarget.sourcesBuildPhase()
+
+        XCTAssertNil(buildPhase)
+    }
 
     func test_generateScripts() throws {
         // Given

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -189,7 +189,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "resource.metal",
         ])
     }
-    
+
     func test_doesntGenerateSourcesBuildPhase_whenWatchKitTarget() throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")


### PR DESCRIPTION
### Short description 📝

Fix issue where targets with no sources generated an empty compile sources phase, leading to issues in watchOS apps

### How to test the changes locally 🧐

Try to build a project with a watch app, the empty build sources phase causes an error:

```
Multiple commands produce 'aqkthwjckaortqcqoxxkmukrzkqm/Build/Products/Debug-watchsimulator/WatchKitApp.app/WatchKitApp'

Target 'WatchKitApp': CopyAndPreserveArchs aqkthwjckaortqcqoxxkmukrzkqm/Build/Products/Debug-watchsimulator/WatchKitApp.app/WatchKitApp

Target 'WatchKitApp' has a command with output 'aqkthwjckaortqcqoxxkmukrzkqm/Build/Products/Debug-watchsimulator/WatchKitApp.app/WatchKitApp'
```

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
