### PR TITLE
Add support for tvOS bundle icon format

### DIFF
--- a/Sources/TuistAutomation/Utilities/AppBundle.swift
+++ b/Sources/TuistAutomation/Utilities/AppBundle.swift
@@ -40,14 +40,14 @@ public struct AppBundle: Equatable {
 
             public var name: String {
                 switch self {
-                case .dictionary(let name, _), .string(let name):
+                case let .dictionary(name, _), let .string(name):
                     return name
                 }
             }
 
             public var iconFiles: [String] {
                 switch self {
-                case .dictionary(_, let iconFiles):
+                case let .dictionary(_, iconFiles):
                     return iconFiles
                 case .string:
                     return []
@@ -68,11 +68,11 @@ public struct AppBundle: Equatable {
 
             public func encode(to encoder: any Encoder) throws {
                 switch self {
-                case .dictionary(let name, let iconFiles):
+                case let .dictionary(name, iconFiles):
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     try container.encode(name, forKey: .name)
                     try container.encode(iconFiles, forKey: .iconFiles)
-                case .string(let string):
+                case let .string(string):
                     var container = encoder.singleValueContainer()
                     try container.encode(string)
                 }

--- a/Sources/TuistAutomation/Utilities/AppBundle.swift
+++ b/Sources/TuistAutomation/Utilities/AppBundle.swift
@@ -29,27 +29,53 @@ public struct AppBundle: Equatable {
     }
 
     public struct InfoPlist: Codable, Equatable {
-        public struct PrimaryBundleIcon: Codable, Equatable {
+        public enum PrimaryBundleIcon: Codable, Equatable {
             enum CodingKeys: String, CodingKey {
                 case name = "CFBundleIconName"
                 case iconFiles = "CFBundleIconFiles"
             }
 
-            public let name: String
-            public let iconFiles: [String]
+            case dictionary(name: String, iconFiles: [String])
+            case string(String)
 
-            public init(
-                name: String,
-                iconFiles: [String]
-            ) {
-                self.name = name
-                self.iconFiles = iconFiles
+            public var name: String {
+                switch self {
+                case .dictionary(let name, _), .string(let name):
+                    return name
+                }
+            }
+
+            public var iconFiles: [String] {
+                switch self {
+                case .dictionary(_, let iconFiles):
+                    return iconFiles
+                case .string:
+                    return []
+                }
             }
 
             public init(from decoder: any Decoder) throws {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                name = try container.decode(String.self, forKey: .name)
-                iconFiles = try container.decodeIfPresent([String].self, forKey: .iconFiles) ?? []
+                if let container = try? decoder.container(keyedBy: CodingKeys.self) {
+                    let name = try container.decode(String.self, forKey: .name)
+                    let iconFiles = try container.decodeIfPresent([String].self, forKey: .iconFiles) ?? []
+                    self = .dictionary(name: name, iconFiles: iconFiles)
+                } else {
+                    let container = try decoder.singleValueContainer()
+                    let name = try container.decode(String.self)
+                    self = .string(name)
+                }
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                switch self {
+                case .dictionary(let name, let iconFiles):
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode(name, forKey: .name)
+                    try container.encode(iconFiles, forKey: .iconFiles)
+                case .string(let string):
+                    var container = encoder.singleValueContainer()
+                    try container.encode(string)
+                }
             }
         }
 
@@ -197,7 +223,7 @@ public struct AppBundle: Equatable {
             name: String = "AppIcon",
             iconFiles: [String] = ["AppIcon60x60"]
         ) -> Self {
-            .init(
+            .dictionary(
                 name: name,
                 iconFiles: iconFiles
             )

--- a/Sources/TuistAutomation/Utilities/AppBundle.swift
+++ b/Sources/TuistAutomation/Utilities/AppBundle.swift
@@ -29,52 +29,43 @@ public struct AppBundle: Equatable {
     }
 
     public struct InfoPlist: Codable, Equatable {
-        public enum PrimaryBundleIcon: Codable, Equatable {
+        public struct PrimaryBundleIcon: Codable, Equatable {
             enum CodingKeys: String, CodingKey {
                 case name = "CFBundleIconName"
                 case iconFiles = "CFBundleIconFiles"
             }
 
-            case dictionary(name: String, iconFiles: [String])
-            case string(String)
+            public let name: String
+            public let iconFiles: [String]?
 
-            public var name: String {
-                switch self {
-                case let .dictionary(name, _), let .string(name):
-                    return name
-                }
-            }
-
-            public var iconFiles: [String] {
-                switch self {
-                case let .dictionary(_, iconFiles):
-                    return iconFiles
-                case .string:
-                    return []
-                }
+            public init(
+                name: String,
+                iconFiles: [String]?
+            ) {
+                self.name = name
+                self.iconFiles = iconFiles
             }
 
             public init(from decoder: any Decoder) throws {
                 if let container = try? decoder.container(keyedBy: CodingKeys.self) {
                     let name = try container.decode(String.self, forKey: .name)
                     let iconFiles = try container.decodeIfPresent([String].self, forKey: .iconFiles) ?? []
-                    self = .dictionary(name: name, iconFiles: iconFiles)
+                    self.init(name: name, iconFiles: iconFiles)
                 } else {
                     let container = try decoder.singleValueContainer()
                     let name = try container.decode(String.self)
-                    self = .string(name)
+                    self.init(name: name, iconFiles: nil)
                 }
             }
 
             public func encode(to encoder: any Encoder) throws {
-                switch self {
-                case let .dictionary(name, iconFiles):
+                if let iconFiles {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     try container.encode(name, forKey: .name)
                     try container.encode(iconFiles, forKey: .iconFiles)
-                case let .string(string):
+                } else {
                     var container = encoder.singleValueContainer()
-                    try container.encode(string)
+                    try container.encode(name)
                 }
             }
         }
@@ -223,7 +214,7 @@ public struct AppBundle: Equatable {
             name: String = "AppIcon",
             iconFiles: [String] = ["AppIcon60x60"]
         ) -> Self {
-            .dictionary(
+            .init(
                 name: name,
                 iconFiles: iconFiles
             )

--- a/Sources/TuistKit/Services/ShareCommandService.swift
+++ b/Sources/TuistKit/Services/ShareCommandService.swift
@@ -401,12 +401,12 @@ struct ShareCommandService {
     }
 
     private func iconPaths(for appBundle: AppBundle) async throws -> [AbsolutePath] {
-        try await appBundle.infoPlist.bundleIcons?.primaryIcon?.iconFiles
+        try await (appBundle.infoPlist.bundleIcons?.primaryIcon?.iconFiles ?? [])
             // This is a convention for iOS icons. We might need to adjust this for other platforms in the future.
             .map { appBundle.path.appending(component: $0 + "@2x.png") }
             .concurrentFilter {
                 try await fileSystem.exists($0)
-            } ?? []
+            }
     }
 
     private func uploadPreviews(

--- a/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
@@ -78,10 +78,35 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
         )
     }
 
-    // TODO: Ask for signed tvOS app
-    func test_load_appletv_app_bundle() async throws {
+    func test_load_appletv_info_plist() async throws {
         // Given
-        let appBundlePath = fixturePath(path: try RelativePath(validating: "tvOS-App.app"))
+        let appBundlePath = try temporaryPath()
+        let infoPlistPath = appBundlePath.appending(component: "Info.plist")
+        try fileHandler.write("""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleIcons</key>
+            <dict>
+                <key>CFBundlePrimaryIcon</key>
+                <string>App Icon</string>
+            </dict>
+            <key>CFBundleIdentifier</key>
+            <string>io.tuist.TVApp</string>
+            <key>CFBundleName</key>
+            <string>App</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundleSupportedPlatforms</key>
+            <array>
+                <string>AppleTVOS</string>
+            </array>
+            <key>MinimumOSVersion</key>
+            <string>18.2</string>
+        </dict>
+        </plist>
+        """, path: infoPlistPath, atomically: true)
 
         // When
         let appBundle = try await subject.load(appBundlePath)
@@ -94,7 +119,7 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
                 infoPlist: AppBundle.InfoPlist(
                     version: "1.0",
                     name: "App",
-                    bundleId: "io.tuist.App",
+                    bundleId: "io.tuist.TVApp",
                     minimumOSVersion: Version("18.2"),
                     supportedPlatforms: [.device(.tvOS)],
                     bundleIcons: AppBundle.InfoPlist.BundleIcons(

--- a/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
@@ -42,7 +42,7 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
                     minimumOSVersion: Version("17.0"),
                     supportedPlatforms: [.simulator(.iOS)],
                     bundleIcons: AppBundle.InfoPlist.BundleIcons(
-                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon.dictionary(
+                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon(
                             name: "AppIcon",
                             iconFiles: ["AppIcon60x60"]
                         )
@@ -123,7 +123,10 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
                     minimumOSVersion: Version("18.2"),
                     supportedPlatforms: [.device(.tvOS)],
                     bundleIcons: AppBundle.InfoPlist.BundleIcons(
-                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon.string("App Icon")
+                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon(
+                            name: "App Icon",
+                            iconFiles: nil
+                        )
                     )
                 )
             )

--- a/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/AppBundleLoaderTests.swift
@@ -42,7 +42,7 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
                     minimumOSVersion: Version("17.0"),
                     supportedPlatforms: [.simulator(.iOS)],
                     bundleIcons: AppBundle.InfoPlist.BundleIcons(
-                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon(
+                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon.dictionary(
                             name: "AppIcon",
                             iconFiles: ["AppIcon60x60"]
                         )
@@ -73,6 +73,33 @@ final class AppBundleLoaderTests: TuistUnitTestCase {
                     minimumOSVersion: Version("17.0"),
                     supportedPlatforms: [.device(.iOS)],
                     bundleIcons: nil
+                )
+            )
+        )
+    }
+
+    // TODO: Ask for signed tvOS app
+    func test_load_appletv_app_bundle() async throws {
+        // Given
+        let appBundlePath = fixturePath(path: try RelativePath(validating: "tvOS-App.app"))
+
+        // When
+        let appBundle = try await subject.load(appBundlePath)
+
+        // Then
+        XCTAssertBetterEqual(
+            appBundle,
+            AppBundle(
+                path: appBundlePath,
+                infoPlist: AppBundle.InfoPlist(
+                    version: "1.0",
+                    name: "App",
+                    bundleId: "io.tuist.App",
+                    minimumOSVersion: Version("18.2"),
+                    supportedPlatforms: [.device(.tvOS)],
+                    bundleIcons: AppBundle.InfoPlist.BundleIcons(
+                        primaryIcon: AppBundle.InfoPlist.PrimaryBundleIcon.string("App Icon")
+                    )
                 )
             )
         )


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7496>

### Short description 📝
As it turned out Apple TV provides different `CFBundleIcons` format in `Info.plist` file. Normally for iOS it contains dictionary with `name` and `iconFiles` properties. But for tvOS this key has string value which cause decoding failure.

### How to test the changes locally 🧐
I've added tests for AppBundleLoader but missing fixture for it. I will be very glad if someone can assemble it or tell me how to do it.

Also it can be checked manually:
1. Create fresh tvOS app
2. Try to distribute it as `.ipa`
3. Look for `Info.plist` inside
4. Check `CFBundleIcons` property

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
