### PR TITLE
Fix missing sources build phase for some products when no build files present

### DIFF
--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -309,7 +309,15 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         pbxBuildFiles.forEach { pbxproj.add(object: $0) }
         sourcesBuildPhase.files = pbxBuildFiles
 
-        if !pbxBuildFiles.isEmpty {
+        // Only add sources build phase if there are build files or if the product requires the sources build phase to be valid,
+        // such as `.framework`
+        switch target.product {
+        case .app, .appClip, .appExtension, .watch2App, .watch2Extension, .tvTopShelfExtension, .messagesExtension,
+             .systemExtension, .commandLineTool, .stickerPackExtension, .extensionKitExtension:
+            guard !pbxBuildFiles.isEmpty else { return }
+            pbxproj.add(object: sourcesBuildPhase)
+            pbxTarget.buildPhases.append(sourcesBuildPhase)
+        case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .xpc, .macro, .unitTests, .uiTests, .bundle:
             pbxproj.add(object: sourcesBuildPhase)
             pbxTarget.buildPhases.append(sourcesBuildPhase)
         }

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -314,7 +314,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         switch target.product {
         case .app, .appClip, .appExtension, .watch2App, .watch2Extension, .tvTopShelfExtension, .messagesExtension,
              .systemExtension, .commandLineTool, .stickerPackExtension, .extensionKitExtension:
-            guard !pbxBuildFiles.isEmpty else { return }
+            if pbxBuildFiles.isEmpty { return }
             pbxproj.add(object: sourcesBuildPhase)
             pbxTarget.buildPhases.append(sourcesBuildPhase)
         case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .xpc, .macro, .unitTests, .uiTests, .bundle:

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -214,6 +214,30 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertNil(buildPhase)
     }
 
+    func test_generatesSourcesBuildPhase_whenFramework_withNoSources() throws {
+        // Given
+        let pbxTarget = PBXNativeTarget(name: "Test")
+        let pbxproj = PBXProj()
+        pbxproj.add(object: pbxTarget)
+
+        let target = Target.test(product: .framework)
+
+        // When
+        try subject.generateSourcesBuildPhase(
+            files: [],
+            coreDataModels: [],
+            target: target,
+            pbxTarget: pbxTarget,
+            fileElements: .init(),
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try pbxTarget.sourcesBuildPhase()
+        let files = try XCTUnwrap(buildPhase?.files)
+        XCTAssertEmpty(files)
+    }
+
     func test_generateScripts() throws {
         // Given
         let target = PBXNativeTarget(name: "Test")

--- a/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/CacheAcceptanceTests.swift
@@ -8,12 +8,12 @@ final class CacheAcceptanceTestiOSAppWithFrameworks: TuistAcceptanceTestCase {
             try await setUpFixture(.iosAppWithFrameworks)
             try await run(CacheCommand.self, "--print-hashes")
             XCTAssertStandardOutput(pattern: """
-            Framework1 - f8feceb31f42a34ebcce8b80496b4933
-            Framework2-iOS - 464281b69abc95f4f2824efc01f58348
-            Framework2-macOS - 2e787be6f1ac74b7db40e9cedebbac1f
-            Framework3 - a4e947f548f5f16bd805719517eb7d47
-            Framework4 - 5fbc3d8985c9ac2104b6100119ca61db
-            Framework5 - 05a2ec5f66ed485ced57f57d6dec507a
+            Framework1 - ec51624fa9e5dc8c7b44ade54780d5aa
+            Framework2-iOS - cf1f625655179ca2e4d77b45a1786d81
+            Framework2-macOS - c06920bbd3fa5c98e5fe842ea1a594bc
+            Framework3 - 0b59f71849943925afe85184b48516c9
+            Framework4 - fab923f000d87a6f77af0ef6879edcc5
+            Framework5 - dca6e0375bf0410580e228fb15658ae2
             """)
         }
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7500

### Short description 📝

Turns out some products, like `.framework`, _require_ the sources build phase to be valid, even if they have no actual build files. Otherwise, the binary doesn't get generated and the product is invalid.

We stopped generating the sources build phase in [this PR](https://github.com/tuist/tuist/pull/7493) and we should preserve skipping that build phase for end products like `.watch2App` or `.app` cc @cooksimo 

### How to test the changes locally 🧐

- See the repro steps from the issue.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
