### PR TITLE
Update Mockable

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4ff74e4e04831a783b4937027e9e619f983aa6dbe0ee8629b5bfaa62770daff2",
+  "originHash" : "5cfdb0dd741b0671fcc535fda3d541d280ea686f33ea15df065667ca97a08d16",
   "pins" : [
     {
       "identity" : "aexml",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kolos65/Mockable.git",
       "state" : {
-        "revision" : "203336d0ccb7ff03a8a03db54a4fa18fc2b0c771",
-        "version" : "0.3.0"
+        "revision" : "68f3ed6c4b62afab27a84425494cb61421a61ac1",
+        "version" : "0.3.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "9.0.0")),
         .package(url: "https://github.com/cpisciotta/xcbeautify", .upToNextMajor(from: "2.20.0")),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
-        .package(url: "https://github.com/Kolos65/Mockable.git", .upToNextMajor(from: "0.0.11")),
+        .package(url: "https://github.com/Kolos65/Mockable.git", .upToNextMajor(from: "0.3.1")),
         .package(
             url: "https://github.com/apple/swift-openapi-runtime", .upToNextMajor(from: "1.5.0")
         ),


### PR DESCRIPTION
### Short description 📝

There seem to be some flaky CI failures due to Mockable build issues since we now use Xcode 16.3 and thus use Swift 6.1. I'm updating Mockable to get the build issue fix: https://github.com/Kolos65/Mockable/releases/tag/0.3.1

### How to test the changes locally 🧐

- CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
