### PR TITLE
Fix sending tuist xcodebuild insights

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -186,11 +186,11 @@ open class TuistAcceptanceTestCase: XCTestCase {
             .first(where: { $0.extension == "xcworkspace" })
     }
 
-    public func run(_ command: XcodeBuildCommand.Type, _ arguments: String...) async throws {
+    public func run(_ command: XcodeBuildBuildCommand.Type, _ arguments: String...) async throws {
         try await run(command, arguments)
     }
 
-    public func run(_ command: XcodeBuildCommand.Type, _ arguments: [String] = []) async throws {
+    public func run(_ command: XcodeBuildBuildCommand.Type, _ arguments: [String] = []) async throws {
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
     }

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildArchiveCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildArchiveCommand.swift
@@ -1,0 +1,31 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+import XcodeGraph
+
+public struct XcodeBuildArchiveCommand: AsyncParsableCommand, TrackableParsableCommand, RecentPathRememberableCommand {
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "archive",
+            _superCommandName: "xcodebuild",
+            abstract: "tuist xcodebuild archive extends the xcodebuild CLI archive action with insights."
+        )
+    }
+
+    var analyticsRequired: Bool { true }
+
+    public init() {}
+
+    @Argument(
+        parsing: .captureForPassthrough,
+        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+    )
+    public var passthroughXcodebuildArguments: [String] = []
+
+    public func run() async throws {
+        try await XcodeBuildBuildCommandService()
+            .run(
+                passthroughXcodebuildArguments: ["archive"] + passthroughXcodebuildArguments
+            )
+    }
+}

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildCommand.swift
@@ -1,0 +1,31 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+import XcodeGraph
+
+public struct XcodeBuildBuildCommand: AsyncParsableCommand, TrackableParsableCommand, RecentPathRememberableCommand {
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "build",
+            _superCommandName: "xcodebuild",
+            abstract: "tuist xcodebuild build extends the xcodebuild CLI build action with insights."
+        )
+    }
+
+    var analyticsRequired: Bool { true }
+
+    public init() {}
+
+    @Argument(
+        parsing: .captureForPassthrough,
+        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+    )
+    public var passthroughXcodebuildArguments: [String] = []
+
+    public func run() async throws {
+        try await XcodeBuildBuildCommandService()
+            .run(
+                passthroughXcodebuildArguments: ["build"] + passthroughXcodebuildArguments
+            )
+    }
+}

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildForTestingCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildForTestingCommand.swift
@@ -1,0 +1,31 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+import XcodeGraph
+
+public struct XcodeBuildBuildForTestingCommand: AsyncParsableCommand, TrackableParsableCommand, RecentPathRememberableCommand {
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "build-for-testing",
+            _superCommandName: "xcodebuild",
+            abstract: "tuist xcodebuild build-for-testing extends the xcodebuild CLI build-for-testing action with insights."
+        )
+    }
+
+    var analyticsRequired: Bool { true }
+
+    public init() {}
+
+    @Argument(
+        parsing: .captureForPassthrough,
+        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+    )
+    public var passthroughXcodebuildArguments: [String] = []
+
+    public func run() async throws {
+        try await XcodeBuildBuildCommandService()
+            .run(
+                passthroughXcodebuildArguments: ["build-for-testing"] + passthroughXcodebuildArguments
+            )
+    }
+}

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommand.swift
@@ -15,30 +15,20 @@ public struct XcodeBuildCommand: AsyncParsableCommand, TrackableParsableCommand,
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "xcodebuild",
-            abstract: "tuist xcodebuild extends the xcodebuild CLI with server capabilities such as selective testing or analytics."
+            abstract: "tuist xcodebuild extends the xcodebuild CLI with server capabilities such as selective testing or analytics.",
+            subcommands: [
+                XcodeBuildTestCommand.self,
+                XcodeBuildTestWithoutBuildingCommand.self,
+                XcodeBuildBuildCommand.self,
+                XcodeBuildBuildForTestingCommand.self,
+                XcodeBuildArchiveCommand.self,
+            ]
         )
     }
 
     var analyticsRequired: Bool { true }
 
     public init() {}
-
-    @Argument(
-        parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
-    )
-    public var passthroughXcodebuildArguments: [String] = []
-
-    public func run() async throws {
-        try await XcodeBuildService(
-            cacheStorageFactory: Self.cacheStorageFactory,
-            selectiveTestingGraphHasher: Self.selectiveTestingGraphHasher,
-            selectiveTestingService: Self.selectiveTestingService
-        )
-        .run(
-            passthroughXcodebuildArguments: passthroughXcodebuildArguments
-        )
-    }
 }
 
 struct EmptySelectiveTestingGraphHasher: SelectiveTestingGraphHashing {

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -1,0 +1,35 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+import XcodeGraph
+
+public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableCommand, RecentPathRememberableCommand {
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "test",
+            _superCommandName: "xcodebuild",
+            abstract: "tuist xcodebuild test extends the xcodebuild CLI test action with insights and selective testing capabilities."
+        )
+    }
+
+    var analyticsRequired: Bool { true }
+
+    public init() {}
+
+    @Argument(
+        parsing: .captureForPassthrough,
+        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+    )
+    public var passthroughXcodebuildArguments: [String] = []
+
+    public func run() async throws {
+        try await XcodeBuildTestCommandService(
+            cacheStorageFactory: XcodeBuildCommand.cacheStorageFactory,
+            selectiveTestingGraphHasher: XcodeBuildCommand.selectiveTestingGraphHasher,
+            selectiveTestingService: XcodeBuildCommand.selectiveTestingService
+        )
+        .run(
+            passthroughXcodebuildArguments: ["test"] + passthroughXcodebuildArguments
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -1,0 +1,37 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+import XcodeGraph
+
+public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, TrackableParsableCommand,
+    RecentPathRememberableCommand
+{
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "test-without-building",
+            _superCommandName: "xcodebuild",
+            abstract: "tuist xcodebuild test-without-building extends the xcodebuild CLI test action with insights and selective testing capabilities."
+        )
+    }
+
+    var analyticsRequired: Bool { true }
+
+    public init() {}
+
+    @Argument(
+        parsing: .captureForPassthrough,
+        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+    )
+    public var passthroughXcodebuildArguments: [String] = []
+
+    public func run() async throws {
+        try await XcodeBuildTestCommandService(
+            cacheStorageFactory: XcodeBuildCommand.cacheStorageFactory,
+            selectiveTestingGraphHasher: XcodeBuildCommand.selectiveTestingGraphHasher,
+            selectiveTestingService: XcodeBuildCommand.selectiveTestingService
+        )
+        .run(
+            passthroughXcodebuildArguments: ["test-without-building"] + passthroughXcodebuildArguments
+        )
+    }
+}

--- a/Sources/TuistKit/Services/XcodeBuild/XcodeBuildBuildCommandService.swift
+++ b/Sources/TuistKit/Services/XcodeBuild/XcodeBuildBuildCommandService.swift
@@ -1,0 +1,87 @@
+import FileSystem
+import Foundation
+import Path
+import ServiceContextModule
+import TuistAutomation
+import TuistCore
+import TuistLoader
+import TuistSupport
+
+struct XcodeBuildBuildCommandService {
+    private let fileSystem: FileSysteming
+    private let xcodeBuildController: XcodeBuildControlling
+    private let configLoader: ConfigLoading
+    private let cacheDirectoriesProvider: CacheDirectoriesProviding
+    private let uniqueIDGenerator: UniqueIDGenerating
+
+    init(
+        fileSystem: FileSysteming = FileSystem(),
+        xcodeBuildController: XcodeBuildControlling = XcodeBuildController(),
+        configLoader: ConfigLoading = ConfigLoader(),
+        cacheDirectoriesProvider: CacheDirectoriesProviding = CacheDirectoriesProvider(),
+        uniqueIDGenerator: UniqueIDGenerating = UniqueIDGenerator()
+    ) {
+        self.fileSystem = fileSystem
+        self.xcodeBuildController = xcodeBuildController
+        self.configLoader = configLoader
+        self.cacheDirectoriesProvider = cacheDirectoriesProvider
+        self.uniqueIDGenerator = uniqueIDGenerator
+    }
+
+    func run(
+        passthroughXcodebuildArguments: [String]
+    ) async throws {
+        var passthroughXcodebuildArguments = passthroughXcodebuildArguments
+        try await passthroughXcodebuildArguments.append(
+            contentsOf: resultBundlePathArguments(passthroughXcodebuildArguments: passthroughXcodebuildArguments)
+        )
+        try await xcodeBuildController.run(arguments: passthroughXcodebuildArguments)
+    }
+
+    private func resultBundlePathArguments(
+        passthroughXcodebuildArguments: [String]
+    ) async throws -> [String] {
+        if let resultBundlePathString = passedValue(
+            for: "-resultBundlePath",
+            arguments: passthroughXcodebuildArguments
+        ) {
+            let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+            let resultBundlePath = try AbsolutePath(validating: resultBundlePathString, relativeTo: currentWorkingDirectory)
+            await ServiceContext.current?.runMetadataStorage?.update(
+                resultBundlePath: resultBundlePath
+            )
+            return []
+        } else {
+            let resultBundlePath = try cacheDirectoriesProvider
+                .cacheDirectory(for: .runs)
+                .appending(components: uniqueIDGenerator.uniqueID())
+            await ServiceContext.current?.runMetadataStorage?.update(
+                resultBundlePath: resultBundlePath
+            )
+            return ["-resultBundlePath", resultBundlePath.pathString]
+        }
+    }
+
+    private func path(
+        passthroughXcodebuildArguments: [String]
+    ) async throws -> AbsolutePath {
+        let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+        if let workspaceOrProjectPath = passedValue(for: "-workspace", arguments: passthroughXcodebuildArguments) ??
+            passedValue(for: "-project", arguments: passthroughXcodebuildArguments)
+        {
+            return try AbsolutePath(validating: workspaceOrProjectPath, relativeTo: currentWorkingDirectory)
+        } else {
+            return currentWorkingDirectory
+        }
+    }
+
+    private func passedValue(
+        for option: String,
+        arguments: [String]
+    ) -> String? {
+        guard let optionIndex = arguments.firstIndex(of: option) else { return nil }
+        let valueIndex = arguments.index(after: optionIndex)
+        guard arguments.endIndex > valueIndex else { return nil }
+        return arguments[valueIndex]
+    }
+}

--- a/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
+++ b/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
@@ -32,13 +32,12 @@ final class InspectBuildAcceptanceTests: ServerAcceptanceTestCase {
         try await ServiceContext.withTestingDependencies {
             try await setUpFixture(.xcodeProjectWithInspectBuild)
             let arguments = [
-                "build",
                 "-scheme", "App",
                 "-destination", "generic/platform=iOS Simulator",
                 "-project", fixturePath.appending(component: "App.xcodeproj").pathString,
                 "-resultBundlePath", fixturePath.appending(component: "result-bundle").pathString,
             ]
-            try await run(XcodeBuildCommand.self, arguments)
+            try await run(XcodeBuildBuildCommand.self, arguments)
             try await run(InspectBuildCommand.self)
             let got = ServiceContext.current?.recordedUI()
             let expectedOutput = """


### PR DESCRIPTION
### Short description 📝

This PR fixes two issues related to `tuist xcodebuild test`:
- We updated the command structure, so `test` is sent as a the subcommand to the server, so we can filter runs based on that value. Note this means you can no longer run `tuist xcodebuild -project XXX test` but you need to lead with the action: `tuist xcodebuild test -project XXX`. I think that's fine. If this turns out to be annoying, we can come up with an alternative approach to pluck out the `xcodebuild` action even if it's not the first argument.
- When the underlying `xcodebuild` command fails, we should still send the run report.

### How to test the changes locally 🧐

- Run `tuist xcodebuild test-without-building -scheme App -destination "name=iPhone 16"` in the `xcode_project_with_tests`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
