### PR TITLE
Add documentation for DB-related telemetry events

### DIFF
--- a/docs/docs/en/server/on-premise/metrics.md
+++ b/docs/docs/en/server/on-premise/metrics.md
@@ -309,3 +309,25 @@ The total number of organizations.
 ### `tuist_accounts_users_total` (last_value) {#tuist_accounts_users_total-last_value}
 
 The total number of users.
+
+
+## Database metrics {#database-metrics}
+
+A set of metrics related to the database connection.
+
+### `tuist_repo_pool_checkout_queue_length` (last_value) {#tuist_repo_pool_checkout_queue_length-last_value}
+
+The number of database queries that are sitting in a queue waiting to be assigned to a database connection.
+
+### `tuist_repo_pool_ready_conn_count` (last_value) {#tuist_repo_pool_ready_conn_count-last_value}
+
+The number of database connections that are ready to be assigned to a database query.
+
+
+### `tuist_repo_pool_db_connection_connected` (last_value) {#tuist_repo_pool_db_connection_connected-last_value}
+
+The number of connections that have been established to the database.
+
+### `tuist_repo_pool_db_connection_disconnected` (last_value) {#tuist_repo_pool_db_connection_disconnected-last_value}
+
+The number of connections that have been disconnected from the database.


### PR DESCRIPTION
We added new telemetry events related to DB connections so I'm adding the documentation for on-premise customers.