### PR TITLE
Fix unstable hash when a dependency is resolved both via registry and scm

### DIFF
--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -114,6 +114,89 @@ struct SwiftPackageManagerGraphLoaderTests {
     }
 
     @Test
+    func test_load_when_dependency_via_scm_and_registry() async throws {
+        try await ServiceContext.withTestingDependencies {
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+                // Given
+                let packageSettings = PackageSettings.test()
+
+                let workspacePath = temporaryDirectory.appending(components: [".build", "workspace-state.json"])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : [
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Alamofire.Alamofire",
+                              "kind" : "registry",
+                              "location" : "Alamofire.Alamofire",
+                              "name" : "Alamofire.Alamofire"
+                            },
+                            "state" : {
+                              "name" : "registryDownload",
+                              "version" : "5.10.2"
+                            },
+                            "subpath" : "Alamofire/Alamofire/5.10.2"
+                          },
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "Alamofire",
+                              "kind" : "remoteSourceControl",
+                              "location" : "https://github.com/Alamofire/Alamofire.git",
+                              "name" : "Alamofire"
+                            },
+                            "state" : {
+                              "checkoutState" : {
+                                "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+                                "version" : "2.4.0"
+                              },
+                              "name" : "sourceControlCheckout"
+                            },
+                            "subpath" : "alamofire"
+                          },
+                        ],
+                      }
+                    }
+                    """,
+                    at: workspacePath
+                )
+
+                try await fileSystem.makeDirectory(at: temporaryDirectory.appending(components: [".build", "Derived"]))
+                try await fileSystem.touch(temporaryDirectory.appending(components: [".build", "Derived", "Package.resolved"]))
+                try await fileSystem.touch(temporaryDirectory.appending(component: "Package.resolved"))
+
+                given(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packageInfos: .any,
+                        packageToFolder: .any,
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any
+                    )
+                    .willReturn([:])
+
+                // When
+                let got = try await subject.load(
+                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                    packageSettings: packageSettings
+                )
+
+                // Then
+                #expect(
+                    got.externalProjects.values.map(\.hash) == [
+                        "Alamofire.Alamofire-5.10.2",
+                    ]
+                )
+            }
+        }
+    }
+
+    @Test
     func test_load_warnOutdatedDependencies() async throws {
         try await ServiceContext.withTestingDependencies {
             try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7515

### Short description 📝

When a transitive dependency is referenced with the registry identifier in the `Package.swift` without the `--replace-scm-with-registry` flag being used, SwiftPM ends up resolving both the scm and registry variant of the dependency. Tuist then ends up "randomly" using one or the other.

This PR fixes the issue by preferring a registry dependency if available. However, we recommend using `--replace-scm-with-registry` as a dependency resolved twice with possibly different versions is rarely what you want.

### How to test the changes locally 🧐

- See the attached issue.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
