### PR TITLE
Do not print hashes on every CI cache run

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -117,8 +117,6 @@ workflows:
           mise install
       - name: Install Tuist dependencies
         script: mise x -- tuist install
-      - name: Print hashes
-        script: mise x -- tuist cache --print-hashes
       - name: Cache
         script: mise x -- tuist cache
     triggering: &main_triggering


### PR DESCRIPTION
### Short description 📝

I've noticed we're printing hashes on every CI run – which is something no longer needed as we are surfacing the hashes in the dashboard.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
