### PR TITLE
Add Plain chat box

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-oss@tuist.io.
+contact@tuist.dev.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ The Tuist repo is scanned frequently for code and dependency vulnerabilities. No
 
 If you discover a potential security issue, do let us know as soon as possible. We'll work toward a resolution as quickly as possible, so please provide us with a reasonable amount of time before disclosure to the public or a third-party.
 
-Contact us at [security@tuist.io](mailto:security@tuist.io)
+Contact us at [contact@tuist.dev](mailto:security@tuist.dev)
 
 Thank you for helping improve Tuist security!
 

--- a/Sources/TuistKit/Commands/Organization/OrganizationUpdateSSOCommand.swift
+++ b/Sources/TuistKit/Commands/Organization/OrganizationUpdateSSOCommand.swift
@@ -29,7 +29,7 @@ struct OrganizationUpdateSSOCommand: AsyncParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "Organization ID for your SSO provider. For Google, this is your Google domain (for example, if your email is tuist@tuist.io, the domain would be tuist.io). For Okta, it's the organization domain (such as my-org.okta.com)",
+        help: "Organization ID for your SSO provider. For Google, this is your Google domain (for example, if your email is tuist@tuist.dev, the domain would be tuist.dev). For Okta, it's the organization domain (such as my-org.okta.com)",
         envKey: .organizationUpdateSSOOrganizationId
     )
     var organizationId: String

--- a/Sources/TuistServer/Models/ServerInvitation.swift
+++ b/Sources/TuistServer/Models/ServerInvitation.swift
@@ -37,7 +37,7 @@ extension ServerInvitation {
     extension ServerInvitation {
         public static func test(
             id: Int = 0,
-            inviteeEmail: String = "test@tuist.io",
+            inviteeEmail: String = "test@tuist.dev",
             inviter: ServerUser = .test(),
             organizationId: Int = 0,
             token: String = "token"

--- a/Tests/TuistKitTests/Services/LoginServiceTests.swift
+++ b/Tests/TuistKitTests/Services/LoginServiceTests.swift
@@ -84,7 +84,7 @@ final class LoginServiceTests: TuistUnitTestCase {
             // Given
             given(userInputReader)
                 .readString(asking: .value("Email:"))
-                .willReturn("email@tuist.io")
+                .willReturn("email@tuist.dev")
 
             given(serverCredentialsStore)
                 .store(
@@ -101,7 +101,7 @@ final class LoginServiceTests: TuistUnitTestCase {
 
             given(authenticateService)
                 .authenticate(
-                    email: .value("email@tuist.io"),
+                    email: .value("email@tuist.dev"),
                     password: .value("password"),
                     serverURL: .value(serverURL)
                 )
@@ -151,7 +151,7 @@ final class LoginServiceTests: TuistUnitTestCase {
 
             given(authenticateService)
                 .authenticate(
-                    email: .value("email@tuist.io"),
+                    email: .value("email@tuist.dev"),
                     password: .value("password"),
                     serverURL: .value(serverURL)
                 )
@@ -164,7 +164,7 @@ final class LoginServiceTests: TuistUnitTestCase {
 
             // When
             try await subject.run(
-                email: "email@tuist.io",
+                email: "email@tuist.dev",
                 password: nil,
                 directory: nil
             )
@@ -197,7 +197,7 @@ final class LoginServiceTests: TuistUnitTestCase {
 
             given(authenticateService)
                 .authenticate(
-                    email: .value("email@tuist.io"),
+                    email: .value("email@tuist.dev"),
                     password: .value("password"),
                     serverURL: .value(serverURL)
                 )
@@ -210,7 +210,7 @@ final class LoginServiceTests: TuistUnitTestCase {
 
             // When
             try await subject.run(
-                email: "email@tuist.io",
+                email: "email@tuist.dev",
                 password: "password",
                 directory: nil
             )

--- a/Tests/TuistKitTests/Services/WhoamiServiceTests.swift
+++ b/Tests/TuistKitTests/Services/WhoamiServiceTests.swift
@@ -43,13 +43,13 @@ final class WhoamiServiceTests: TuistUnitTestCase {
             // Given
             given(serverSessionController)
                 .authenticatedHandle(serverURL: .value(serverURL))
-                .willReturn("tuist@tuist.io")
+                .willReturn("tuist@tuist.dev")
 
             // When
             try await subject.run(directory: nil)
 
             // Then
-            XCTAssertPrinterOutputContains("tuist@tuist.io")
+            XCTAssertPrinterOutputContains("tuist@tuist.dev")
         }
     }
 

--- a/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -87,11 +87,11 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
                 .user(
                     legacyToken: nil,
                     accessToken: .test(
-                        email: "tuist@tuist.io",
+                        email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
                     ),
                     refreshToken: .test(
-                        email: "tuist@tuist.io",
+                        email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
                     )
                 )
@@ -142,11 +142,11 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
                 .user(
                     legacyToken: nil,
                     accessToken: .test(
-                        email: "tuist@tuist.io",
+                        email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
                     ),
                     refreshToken: .test(
-                        email: "tuist@tuist.io",
+                        email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
                     )
                 )

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -231,6 +231,23 @@ export default defineConfig({
       },
       "",
     ],
+    [
+      "script",
+      {},
+      `
+      (function(d, script) {
+        script = d.createElement('script');
+        script.async = false;
+        script.onload = function(){
+          Plain.init({
+            appId: 'liveChatApp_01JSH1T6AJCSB6QZ1VQ60YC2KM',
+          });
+        };
+        script.src = 'https://chat.cdn-plain.com/index.js';
+        d.getElementsByTagName('head')[0].appendChild(script);
+      }(document));
+      `,
+    ],
   ],
   sitemap: {
     hostname: "https://docs.tuist.io",

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -205,14 +205,6 @@ export default defineConfig({
       @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap');
       `,
     ],
-    [
-      "script",
-      {},
-      `
-      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-      posthog.init('phc_stva6NJi8LG6EmR6RA6uQcRdrmfTQcAVLoO3vGgWmNZ',{api_host:'https://eu.i.posthog.com'})
-    `,
-    ],
     ["meta", { property: "og:url", content: "https://docs.tuist.io" }, ""],
     ["meta", { property: "og:type", content: "website" }, ""],
     [

--- a/docs/docs/en/server/on-premise/install.md
+++ b/docs/docs/en/server/on-premise/install.md
@@ -9,7 +9,7 @@ description: Learn how to install Tuist on your infrastructure.
 We offer a self-hosted version of the Tuist server for organizations that require more control over their infrastructure. This version allows you to host Tuist on your own infrastructure, ensuring that your data remains secure and private.
 
 > [!IMPORTANT] ENTERPRISE CUSTOMERS ONLY
-> The on-premise version of Tuist is available only for organizations on the Enterprise plan. If you are interested in this version, please reach out to [contact@tuist.io](mailto:contact@tuist.io).
+> The on-premise version of Tuist is available only for organizations on the Enterprise plan. If you are interested in this version, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).
 
 ## Release cadence {#release-cadence}
 
@@ -59,7 +59,7 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 | `TUIST_LICENSE` | The license provided after signing the service level agreement | Yes | | `******` |
 
 > [!IMPORTANT] EXPIRATION DATE
-> Licenses have an expiration date. Users will receive a warning while using Tuist commands that interact with the server if the license expires in less than 30 days. If you are interested in renewing your license, please reach out to [contact@tuist.io](mailto:contact@tuist.io).
+> Licenses have an expiration date. Users will receive a warning while using Tuist commands that interact with the server if the license expires in less than 30 days. If you are interested in renewing your license, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).
 
 ### Base environment configuration {#base-environment-configuration}
 


### PR DESCRIPTION
We are giving [Plain](https://plain.com) a shot for centralising all the support in one place. Plain integrates with our incident platform, Incident.io, and will soon integrate with Discourse and GitHub making it a great candidate to help us funnel, categorise, and prioritise the support requests that come our way.

> [!NOTE]
> I took the opportunity to consolidate all the emails under contact@tuist.dev, and renamed old references to `tuist.io` in tests.