### PR TITLE
Not include --path when using 'xcodebuild test' subcommand

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -195,6 +195,15 @@ open class TuistAcceptanceTestCase: XCTestCase {
         try await parsedCommand.run()
     }
 
+    public func run(_ command: XcodeBuildTestCommand.Type, _ arguments: String...) async throws {
+        try await run(command, arguments)
+    }
+
+    public func run(_ command: XcodeBuildTestCommand.Type, _ arguments: [String] = []) async throws {
+        let parsedCommand = try command.parse(arguments)
+        try await parsedCommand.run()
+    }
+
     public func run(_ command: (some AsyncParsableCommand).Type, _ arguments: String...) async throws {
         try await run(command, Array(arguments))
     }


### PR DESCRIPTION
I just noticed with the addition of sub-commands for sub-actions of `xcodebuild` we forgot to update `TuistAcceptanceTestCase` to not pass the `--path` variable.

I think we should move away from the `TuistAcceptanceTestCase` sub-classing pattern since its ergonomics are not great, but I'd do that in a follow-up PR. I'm doing this to get a new release out the door.