### PR TITLE
Document new Prometheus HTTP metrics

### DIFF
--- a/docs/docs/en/server/on-premise/metrics.md
+++ b/docs/docs/en/server/on-premise/metrics.md
@@ -344,8 +344,7 @@ The number of outgoing HTTP requests.
 
 The sum of the duration of the outgoing requests (including the time that they spent waiting to be assigned to a connection).
 
-### `tuist_http_request_duration_nanosecond_summary` (sum) {#tuist_http_request_duration_nanosecond_summary-last_value}
-
+### `tuist_http_request_duration_nanosecond_summary` (summary) {#tuist_http_request_duration_nanosecond_summary-last_value}
 The summary of the duration of outgoing requests (including the time that they spent waiting to be assigned to a connection).
 
 ### `tuist_http_queue_count` (counter) {#tuist_http_queue_count-counter}

--- a/docs/docs/en/server/on-premise/metrics.md
+++ b/docs/docs/en/server/on-premise/metrics.md
@@ -357,8 +357,7 @@ The time it takes to retrieve a connection from the pool.
 
 ### `tuist_http_queue_idle_time_nanoseconds_sum` (sum) {#tuist_http_queue_idle_time_nanoseconds_sum-sum}
 
-The time a has been idle waiting to be retrieved.
-
+The time a connection has been idle waiting to be retrieved.
 ### `tuist_http_connection_count` (counter) {#tuist_http_connection_count-counter}
 
 The number of connections that have been established.

--- a/docs/docs/en/server/on-premise/metrics.md
+++ b/docs/docs/en/server/on-premise/metrics.md
@@ -324,10 +324,82 @@ The number of database queries that are sitting in a queue waiting to be assigne
 The number of database connections that are ready to be assigned to a database query.
 
 
-### `tuist_repo_pool_db_connection_connected` (last_value) {#tuist_repo_pool_db_connection_connected-last_value}
+### `tuist_repo_pool_db_connection_connected` (counter) {#tuist_repo_pool_db_connection_connected-counter}
 
 The number of connections that have been established to the database.
 
-### `tuist_repo_pool_db_connection_disconnected` (last_value) {#tuist_repo_pool_db_connection_disconnected-last_value}
+### `tuist_repo_pool_db_connection_disconnected` (counter) {#tuist_repo_pool_db_connection_disconnected-counter}
 
 The number of connections that have been disconnected from the database.
+
+## HTTP metrics {#http-metrics}
+
+A set of metrics related to Tuist's interactions with other services via HTTP.
+
+### `tuist_http_request_count` (counter) {#tuist_http_request_count-last_value}
+
+The number of outgoing HTTP requests.
+
+### `tuist_http_request_duration_nanosecond_sum` (sum) {#tuist_http_request_duration_nanosecond_sum-last_value}
+
+The sum of the duration of the outgoing requests (including the time that they spent waiting to be assigned to a connection).
+
+### `tuist_http_request_duration_nanosecond_summary` (sum) {#tuist_http_request_duration_nanosecond_summary-last_value}
+
+The summary of the duration of outgoing requests (including the time that they spent waiting to be assigned to a connection).
+
+### `tuist_http_queue_count` (counter) {#tuist_http_queue_count-counter}
+
+The number of requests that have been retrieved from the pool.
+
+### `tuist_http_queue_duration_nanoseconds_sum` (sum) {#tuist_http_queue_duration_nanoseconds_sum-sum}
+
+The time it takes to retrieve a connection from the pool.
+
+### `tuist_http_queue_idle_time_nanoseconds_sum` (sum) {#tuist_http_queue_idle_time_nanoseconds_sum-sum}
+
+The time a has been idle waiting to be retrieved.
+
+### `tuist_http_connection_count` (counter) {#tuist_http_connection_count-counter}
+
+The number of connections that have been established.
+
+### `tuist_http_connection_duration_nanoseconds_sum` (sum) {#tuist_http_connection_duration_nanoseconds_sum-sum}
+
+The time it takes to establish a connection against a host.
+
+### `tuist_http_connection_duration_nanoseconds_summary` (summary) {#tuist_http_connection_duration_nanoseconds_summary-summary}
+
+The summary of the time it takes to establish a connection against a host.
+
+### `tuist_http_send_count` (counter) {#tuist_http_send_count-counter}
+
+The number of requests that have been sent once assigned to a connection from the pool.
+
+### `tuist_http_send_duration_nanoseconds_sum` (sum) {#tuist_http_send_duration_nanoseconds_sum-sum}
+
+The time that it takes for requests to complete once assigned to a connection from the pool.
+
+### `tuist_http_send_duration_nanoseconds_summary` (summary) {#tuist_http_send_duration_nanoseconds_summary-summary}
+
+The summary of the time that it takes for requests to complete once assigned to a connection from the pool.
+
+### `tuist_http_receive_count` (counter) {#tuist_http_receive_count-counter}
+
+The number of responses that have been received from sent requests.
+
+### `tuist_http_receive_duration_nanoseconds_sum` (sum) {#tuist_http_receive_duration_nanoseconds_sum-sum}
+
+The time spent receiving responses.
+
+### `tuist_http_receive_duration_nanoseconds_summary` (summary) {#tuist_http_receive_duration_nanoseconds_summary-summary}
+
+The summary of the time spent receiving responses.
+
+### `tuist_http_queue_available_connections` (last_value) {#tuist_http_queue_available_connections-last_value}
+
+The number of connections available in the queue.
+
+### `tuist_http_queue_in_use_connections` (last_value) {#tuist_http_queue_in_use_connections-last_value}
+
+The number of queue connections that are in use.


### PR DESCRIPTION
We just added new HTTP-related metrics to the `/metrics` endpoint and I'm adding documentation for them.