### PR TITLE
Include available organizations in tuist init

### DIFF
--- a/Sources/TuistKit/Services/InitCommandService.swift
+++ b/Sources/TuistKit/Services/InitCommandService.swift
@@ -268,7 +268,10 @@ public struct InitCommandService {
     ) async throws -> String {
         let accountHandle = try await serverSessionController.whoami(serverURL: serverURL)!
         let organizations = (try? await listOrganizationsService.listOrganizations(serverURL: serverURL)) ?? []
-        switch answers?.accountType ?? prompter.promptAccountType(authenticatedUserHandle: accountHandle, organizations: organizations) {
+        switch answers?.accountType ?? prompter.promptAccountType(
+            authenticatedUserHandle: accountHandle,
+            organizations: organizations
+        ) {
         case .createOrganizationAccount:
             let organizationHandle = answers?.newOrganizationAccountHandle ?? prompter.promptNewOrganizationAccountHandle()
             _ = try await createOrganizationService.createOrganization(
@@ -277,7 +280,7 @@ public struct InitCommandService {
             )
             return organizationHandle
         case let .userAccount(handle),
-            let .organization(handle):
+             let .organization(handle):
             return handle
         }
     }

--- a/Sources/TuistKit/Services/InitCommandService.swift
+++ b/Sources/TuistKit/Services/InitCommandService.swift
@@ -24,6 +24,7 @@ public struct InitCommandService {
     private let loginService: LoginServicing
     private let createProjectService: CreateProjectServicing
     private let createOrganizationService: CreateOrganizationServicing
+    private let listOrganizationsService: ListOrganizationsServicing
     private let serverSessionController: ServerSessionControlling
     private let initGeneratedProjectService: InitGeneratedProjectServicing
     private let keystrokeListener: KeyStrokeListening
@@ -66,6 +67,7 @@ public struct InitCommandService {
         initGeneratedProjectService: InitGeneratedProjectServicing = InitGeneratedProjectService(),
         keystrokeListener: KeyStrokeListening = KeyStrokeListener(),
         createOrganizationService: CreateOrganizationServicing = CreateOrganizationService(),
+        listOrganizationsService: ListOrganizationsServicing = ListOrganizationsService(),
         getProjectService: GetProjectServicing = GetProjectService(),
         commandRunner: CommandRunning = CommandRunner(),
         serverURLService: ServerURLServicing = ServerURLService()
@@ -78,6 +80,7 @@ public struct InitCommandService {
         self.initGeneratedProjectService = initGeneratedProjectService
         self.keystrokeListener = keystrokeListener
         self.createOrganizationService = createOrganizationService
+        self.listOrganizationsService = listOrganizationsService
         self.getProjectService = getProjectService
         self.commandRunner = commandRunner
         self.serverURLService = serverURLService
@@ -264,7 +267,8 @@ public struct InitCommandService {
         serverURL: URL
     ) async throws -> String {
         let accountHandle = try await serverSessionController.whoami(serverURL: serverURL)!
-        switch answers?.accountType ?? prompter.promptAccountType(authenticatedUserHandle: accountHandle) {
+        let organizations = (try? await listOrganizationsService.listOrganizations(serverURL: serverURL)) ?? []
+        switch answers?.accountType ?? prompter.promptAccountType(authenticatedUserHandle: accountHandle, organizations: organizations) {
         case .createOrganizationAccount:
             let organizationHandle = answers?.newOrganizationAccountHandle ?? prompter.promptNewOrganizationAccountHandle()
             _ = try await createOrganizationService.createOrganization(
@@ -272,7 +276,8 @@ public struct InitCommandService {
                 serverURL: serverURL
             )
             return organizationHandle
-        case let .userAccount(handle):
+        case let .userAccount(handle),
+            let .organization(handle):
             return handle
         }
     }

--- a/Sources/TuistKit/Utils/InitPrompter.swift
+++ b/Sources/TuistKit/Utils/InitPrompter.swift
@@ -51,11 +51,13 @@ enum InitPromptingWorkflowType: Codable, Equatable, CustomStringConvertible {
 
 enum InitPromptingAccountType: Codable, Equatable, CustomStringConvertible {
     case userAccount(String)
+    case organization(String)
     case createOrganizationAccount
 
     var description: String {
         switch self {
         case let .userAccount(handle): "My personal account: '\(handle)'"
+        case let .organization(handle): handle
         case .createOrganizationAccount: "A new organization account"
         }
     }
@@ -65,18 +67,19 @@ enum InitPromptingAccountType: Codable, Equatable, CustomStringConvertible {
 protocol InitPrompting {
     func promptWorkflowType(xcodeProjectOrWorkspace: InitCommandService.XcodeProjectOrWorkspace?) -> InitPromptingWorkflowType
     func promptIntegrateWithServer() -> Bool
-    func promptAccountType(authenticatedUserHandle: String) -> InitPromptingAccountType
+    func promptAccountType(authenticatedUserHandle: String, organizations: [String]) -> InitPromptingAccountType
     func promptNewOrganizationAccountHandle() -> String
     func promptGeneratedProjectPlatform() -> String
     func promptGeneratedProjectName() -> String
 }
 
 struct InitPrompter: InitPrompting {
-    func promptAccountType(authenticatedUserHandle: String) -> InitPromptingAccountType {
+    func promptAccountType(authenticatedUserHandle: String, organizations: [String]) -> InitPromptingAccountType {
         var promptOptions = [
             InitPromptingAccountType.userAccount(authenticatedUserHandle),
-            InitPromptingAccountType.createOrganizationAccount,
         ]
+        promptOptions += organizations.map { InitPromptingAccountType.organization($0) }
+        promptOptions.append(InitPromptingAccountType.createOrganizationAccount)
         return (ServiceContext.current?.ui?.singleChoicePrompt(
             title: "Account",
             question: "In which account would you like to create the project?",

--- a/Sources/TuistKit/Utils/InitPrompter.swift
+++ b/Sources/TuistKit/Utils/InitPrompter.swift
@@ -57,7 +57,7 @@ enum InitPromptingAccountType: Codable, Equatable, CustomStringConvertible {
     var description: String {
         switch self {
         case let .userAccount(handle): "My personal account: '\(handle)'"
-        case let .organization(handle): handle
+        case let .organization(handle): "Organization: \(handle)"
         case .createOrganizationAccount: "A new organization account"
         }
     }

--- a/Tests/TuistKitTests/Services/InitCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitCommandServiceTests.swift
@@ -63,7 +63,8 @@ struct InitCommandServiceTests {
             given(prompter).promptGeneratedProjectName().willReturn("Test")
             given(prompter).promptIntegrateWithServer().willReturn(true)
             given(prompter).promptGeneratedProjectPlatform().willReturn("ios")
-            given(prompter).promptAccountType(authenticatedUserHandle: .value("account"), organizations: .value(["org"])).willReturn(.createOrganizationAccount)
+            given(prompter).promptAccountType(authenticatedUserHandle: .value("account"), organizations: .value(["org"]))
+                .willReturn(.createOrganizationAccount)
             given(prompter).promptNewOrganizationAccountHandle().willReturn("organization")
             given(createOrganizationService).createOrganization(
                 name: .value("organization"),
@@ -138,7 +139,8 @@ struct InitCommandServiceTests {
             given(prompter).promptWorkflowType(xcodeProjectOrWorkspace: .any)
                 .willReturn(.connectProjectOrSwiftPackage(projectName))
             given(prompter).promptIntegrateWithServer().willReturn(true)
-            given(prompter).promptAccountType(authenticatedUserHandle: .value("account"), organizations: .value(["org"])).willReturn(.userAccount("account"))
+            given(prompter).promptAccountType(authenticatedUserHandle: .value("account"), organizations: .value(["org"]))
+                .willReturn(.userAccount("account"))
             given(loginService).run(email: .value(nil), password: .value(nil), directory: .any, onEvent: .any).willReturn()
             given(serverSessionController).whoami(serverURL: .value(Constants.URLs.production)).willReturn("account")
             given(getProjectService).getProject(
@@ -207,7 +209,10 @@ struct InitCommandServiceTests {
             given(prompter).promptGeneratedProjectName().willReturn("Test")
             given(prompter).promptIntegrateWithServer().willReturn(true)
             given(prompter).promptGeneratedProjectPlatform().willReturn("ios")
-            given(prompter).promptAccountType(authenticatedUserHandle: .value("account"), organizations: .value([organizationName])).willReturn(.organization(organizationName))
+            given(prompter).promptAccountType(
+                authenticatedUserHandle: .value("account"),
+                organizations: .value([organizationName])
+            ).willReturn(.organization(organizationName))
             given(loginService).run(email: .value(nil), password: .value(nil), directory: .any, onEvent: .any).willReturn()
             given(serverSessionController).whoami(serverURL: .value(Constants.URLs.production)).willReturn("account")
             given(getProjectService).getProject(


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7466>

### Short description 📝

This PR adds list of available organizations during project initialization

### How to test the changes locally 🧐

I've managed to build tuist and then used `tuist` binary from `DerivedData`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
