### PR TITLE
Verbose-output logs to OSLog and FileLogger for Noora-migrated commands

### DIFF
--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -4,7 +4,7 @@ import Foundation
 import Path
 import ServiceContextModule
 
-public struct InitCommand: AsyncParsableCommand {
+public struct InitCommand: AsyncParsableCommand, NooraReadyCommand {
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",

--- a/Sources/TuistKit/Commands/Inspect/InspectBuildCommand.swift
+++ b/Sources/TuistKit/Commands/Inspect/InspectBuildCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-struct InspectBuildCommand: AsyncParsableCommand {
+struct InspectBuildCommand: AsyncParsableCommand, NooraReadyCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",

--- a/Sources/TuistKit/Commands/NooraReadyCommand.swift
+++ b/Sources/TuistKit/Commands/NooraReadyCommand.swift
@@ -1,0 +1,4 @@
+/// This protocol can be conformed by commands to signal that they
+/// have been migrated to Noora and therefore UI happens through Noora,
+/// and logs through "logger" can be verbose.
+protocol NooraReadyCommand {}

--- a/Sources/TuistKit/Commands/Registry/RegistryLoginCommand.swift
+++ b/Sources/TuistKit/Commands/Registry/RegistryLoginCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-struct RegistryLoginCommand: AsyncParsableCommand {
+struct RegistryLoginCommand: AsyncParsableCommand, NooraReadyCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "login",

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -123,9 +123,17 @@ public struct TuistCommand: AsyncParsableCommand {
                     command: command,
                     commandArguments: processedArguments
                 )
-                try await trackableCommand.run(
-                    backend: backend
-                )
+                if command is NooraReadyCommand {
+                    try await ServiceContext.current?.withLoggerForNoora(logFilePath: logFilePath) {
+                        try await trackableCommand.run(
+                            backend: backend
+                        )
+                    }
+                } else {
+                    try await trackableCommand.run(
+                        backend: backend
+                    )
+                }
             }
         } catch {
             parsingError = error

--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -22,6 +22,19 @@ struct IgnoreOutputPipeline: StandardPipelining {
 
 extension ServiceContext {
     public static func tuist(_ action: (Path.AbsolutePath) async throws -> Void) async throws {
+        var context = ServiceContext.topLevel
+
+        let (logger, logFilePath) = try await setupLogger()
+        context.ui = setupNoora()
+        context.alerts = AlertController()
+        context.recentPaths = RecentPathsStore(storageDirectory: Environment.shared.stateDirectory)
+
+        try await ServiceContext.withValue(context) {
+            try await action(logFilePath)
+        }
+    }
+
+    private static func setupEnv() async throws {
         if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
             throw TuistServiceContextError.exclusiveOptionError("quiet", "verbose")
         }
@@ -37,28 +50,35 @@ extension ServiceContext {
         if CommandLine.arguments.contains("--quiet") {
             try? ProcessEnv.setVar(Constants.EnvironmentVariables.quiet, value: "true")
         }
+    }
 
-        try await LogsController().setup(stateDirectory: Environment.shared.stateDirectory) { loggerHandler, logFilePath in
-            /// This is the old initialization method and will eventually go away.
-            LoggingSystem.bootstrap(loggerHandler)
+    func withLoggerForNoora(logFilePath: Path.AbsolutePath, _ action: () async throws -> Void) async throws {
+        var context = self
+        let loggerHandler = try Logger.loggerHandlerForNoora(logFilePath: logFilePath)
+        context.logger = Logger(label: "dev.tuist.cli", factory: loggerHandler)
+        try await ServiceContext.withValue(context) {
+            try await action()
+        }
+    }
 
-            var context = ServiceContext.topLevel
-            context.logger = Logger(label: "dev.tuist.cli", factory: loggerHandler)
-            if CommandLine.arguments.contains("--json") || CommandLine.arguments.contains("--quiet") {
-                context.ui = Noora(
-                    standardPipelines: StandardPipelines(
-                        output: IgnoreOutputPipeline()
-                    )
+    static func setupLogger() async throws -> (Logger, Path.AbsolutePath) {
+        let (loggerHandler, logFilePath) = try await LogsController().setup(
+            stateDirectory: Environment.shared.stateDirectory
+        )
+        /// This is the old initialization method and will eventually go away.
+        LoggingSystem.bootstrap(loggerHandler)
+        return (Logger(label: "dev.tuist.cli", factory: loggerHandler), logFilePath)
+    }
+
+    private static func setupNoora() -> Noora {
+        if CommandLine.arguments.contains("--json") || CommandLine.arguments.contains("--quiet") {
+            Noora(
+                standardPipelines: StandardPipelines(
+                    output: IgnoreOutputPipeline()
                 )
-            } else {
-                context.ui = Noora()
-            }
-            context.alerts = AlertController()
-            context.recentPaths = RecentPathsStore(storageDirectory: Environment.shared.stateDirectory)
-
-            try await ServiceContext.withValue(context) {
-                try await action(logFilePath)
-            }
+            )
+        } else {
+            Noora()
         }
     }
 }

--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -40,6 +40,17 @@ public struct LoggingConfig {
 }
 
 extension Logger {
+    public static func loggerHandlerForNoora(logFilePath: AbsolutePath) throws -> @Sendable (String) -> any LogHandler {
+        let fileLogger = try FileLogging(to: logFilePath.url)
+        return { label in
+            var fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
+            fileLogHandler.logLevel = .debug
+            var loggers: [any LogHandler] = [fileLogHandler]
+            loggers.append(OSLogHandler.verbose(label: label))
+            return MultiplexLogHandler(loggers)
+        }
+    }
+
     public static func defaultLoggerHandler(
         config: LoggingConfig = .default,
         logFilePath: AbsolutePath
@@ -62,10 +73,9 @@ extension Logger {
         let fileLogger = try FileLogging(to: logFilePath.url)
 
         let baseLoggers = { (label: String) -> [any LogHandler] in
-            var loggers: [any LogHandler] = [
-                FileLogHandler(label: label, fileLogger: fileLogger),
-            ]
+            var fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
 
+            var loggers: [any LogHandler] = [fileLogHandler]
             // OSLog is not needed in development.
             // If we include it, the Xcode console will show duplicated logs, making it harder for contributors to debug the
             // execution

--- a/Tests/TuistKitTests/Utils/LogsCleanerTests.swift
+++ b/Tests/TuistKitTests/Utils/LogsCleanerTests.swift
@@ -26,10 +26,7 @@ struct LogsControllerTests {
             )
 
             // When
-            var newLogFilePath: AbsolutePath?
-            try await subject.setup(stateDirectory: temporaryDirectory) { _, logsFilePath in
-                newLogFilePath = logsFilePath
-            }
+            let (_, newLogFilePath) = try await subject.setup(stateDirectory: temporaryDirectory)
 
             // Then
             let got = try await fileSystem.glob(directory: temporaryDirectory, include: ["logs/*"]).collect()


### PR DESCRIPTION
This is a step forward in the transition from UI and logs are the same thing, to UI and logs serve s different purpose. The former conveys progress while the latter provides a trace for debugging purposes when issues arise.

In the current state of things, if things fail, we still require developers to run the command with the `--verbose` flag. This is not ideal. To fix that, I'm introducing a new protocol `NooraReadyCommand` that commands can use to indicate at compile-time that they are already using Noora.

When a command is **noora-ready**:
- Any logs through the logger are forwarded to OSLog and a file in the file-system.
- Only the UI printed through Noora is output through `stdout``.

## How to test

Run `tuist init`, then check the most recent logs under `~/.local/state/tuist/*`.

> [!NOTE]
> We still need to figure out if we want to introduce the concept of verbosity to Noora. My hunch is that with this division, and Noora doing a good job at conveying progress, this won't be needed.