### PR TITLE
Fix alert presentations

### DIFF
--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -213,9 +213,7 @@ public struct TuistCommand: AsyncParsableCommand {
 
         if !warningAlerts.isEmpty {
             print("\n")
-            for warningAlert in warningAlerts {
-                ServiceContext.current?.ui?.warning(warningAlert)
-            }
+            ServiceContext.current?.ui?.warning(warningAlerts)
         }
         let logsNextStep: TerminalText = "Check out the logs at \(logFilePath.pathString)"
 
@@ -231,6 +229,7 @@ public struct TuistCommand: AsyncParsableCommand {
             if shouldOutputLogFilePath {
                 successAlertNextSteps.append(logsNextStep)
             }
+            print("\n")
             ServiceContext.current?.ui?.success(.alert(successAlert.message, nextSteps: successAlertNextSteps))
         }
     }


### PR DESCRIPTION
I noticed there's a bug in our logic that causes the presentation of the alerts at the end to look odd:

- [x] The extra space between lines on the left bar. This has already been fixed in Noora and will go out in the next release.
- [x] The lack of spaces between the alerts. This is something I'm fixing in this PR.
- [x] Having multiple warning alerts when they could just be one. This is also fixed in this PR.

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/9a7f3b33-16ec-4e21-8fe2-564ff869c188" />
