### PR TITLE
Fix missing logger instance in ServiceContext

### DIFF
--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -25,6 +25,7 @@ extension ServiceContext {
         var context = ServiceContext.topLevel
 
         let (logger, logFilePath) = try await setupLogger()
+        context.logger = logger
         context.ui = setupNoora()
         context.alerts = AlertController()
         context.recentPaths = RecentPathsStore(storageDirectory: Environment.shared.stateDirectory)


### PR DESCRIPTION
As part of [this PR](https://github.com/tuist/tuist/pull/7532/) I forgot to set the default logger instance passed down using `ServiceContext`. This PR fixes it.