### PR TITLE
Fix `ios_app_with_dynamic_frameworks_linking_static_frameworks` fixture not compiling

### DIFF
--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "b9ad2661b6e8fb411fef6a441c9955c3413afac0",
-        "version" : "1.5.0"
+        "revision" : "41b89b8b68d8c56c622dbb7132258f1a3e638b25",
+        "version" : "1.7.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.swift
+++ b/fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks/Tuist/Package.swift
@@ -16,6 +16,6 @@ let package = Package(
     name: "App",
     dependencies: [
         .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", exact: "11.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.4.2"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.7.0"),
     ]
 )


### PR DESCRIPTION
### Short description 📝
I fixed the fixture `ios_app_with_dynamic_frameworks_linking_static_frameworks`, which didn't compile because one of the dependencies didn't compile with the latest version of Swift. I took the opportunity to add an acceptance test to ensure we don't introduce any regression in that fixture.

### How to test the changes locally 🧐
You can either run the acceptance test or generate the project `tuist run tuist generate --path fixtures/ios_app_with_dynamic_frameworks_linking_static_frameworks` and try to build the generated project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
