### PR TITLE
Fix compilation error in synthesised code when the feature "InternalImportsByDefault" is enabled

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -197,7 +197,11 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         // swiftlint:disable all
         // swift-format-ignore-file
         // swiftformat:disable all
+        #if hasFeature(InternalImportsByDefault)
+        public import Foundation
+        #else
         import Foundation
+        #endif
         \(bundleAccessor)
         \(publicBundleAccessor)
         // swiftformat:enable all


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7541>

### Short description 📝

Adds conditional conformance for the `InternalImportsByDefault` feature into the generated resource code.

### How to test the changes locally 🧐

Add `InternalImportsByDefault` upcoming feature flag to the `SettingsDictionary` of a project:

```
let settings: SettingsDictionary = [
  "OTHER_SWIFT_FLAGS": "$(inherited) -enable-upcoming-feature InternalImportsByDefault"
]
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
