### PR TITLE
Fix wrong hash of external targets when their transitive dependencies change 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
+  MISE_EXPERIMENTAL: "1"
 
 jobs:
   release:
@@ -30,11 +31,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@v2
-        with:
-          version: 2024.11.8
-          experimental: true
-        env:
-          MISE_HTTP_TIMEOUT: 300
       - name: Check if there are releasable changes
         id: is-releasable
         working-directory: app
@@ -93,7 +89,8 @@ jobs:
         if: env.should-release == 'true'
         run: |
           mise run install
-          mise use asdf:tuist/asdf-create-dmg@latest
+      - name: Install tuist/asdf-create-dmg
+        run: mise use asdf:tuist/asdf-create-dmg@latest
       - name: Bundle Tuist App
         if: env.should-release == 'true'
         run: mise run bundle:app

--- a/Sources/TuistHasher/TargetContentHasher.swift
+++ b/Sources/TuistHasher/TargetContentHasher.swift
@@ -108,6 +108,11 @@ public final class TargetContentHasher: TargetContentHashing {
         }
 
         let destinations = graphTarget.target.destinations.map(\.rawValue).sorted()
+        let dependenciesHash = try await dependenciesContentHasher.hash(
+            graphTarget: graphTarget,
+            hashedTargets: hashedTargets,
+            hashedPaths: hashedPaths
+        )
 
         if let projectHash {
             return TargetContentHash(
@@ -116,6 +121,7 @@ public final class TargetContentHasher: TargetContentHashing {
                         projectHash,
                         graphTarget.target.product.rawValue,
                         settingsHash,
+                        dependenciesHash.hash,
                     ].compactMap { $0 } + destinations + additionalStrings
                 ),
                 hashedPaths: [:]
@@ -132,11 +138,7 @@ public final class TargetContentHasher: TargetContentHashing {
             targetScripts: graphTarget.target.scripts,
             sourceRootPath: graphTarget.project.sourceRootPath
         )
-        let dependenciesHash = try await dependenciesContentHasher.hash(
-            graphTarget: graphTarget,
-            hashedTargets: hashedTargets,
-            hashedPaths: hashedPaths
-        )
+
         hashedPaths = dependenciesHash.hashedPaths
         let environmentHash = try contentHasher.hash(graphTarget.target.environmentVariables.mapValues(\.value))
         let destinationHashes: [String] = if let destination, graphTarget.target.product == .uiTests {

--- a/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -1,13 +1,13 @@
 import Foundation
 import Mockable
+import Testing
 import TuistCore
 import TuistSupportTesting
 import XcodeGraph
-import XCTest
 
 @testable import TuistHasher
 
-final class TargetContentHasherTests: TuistUnitTestCase {
+struct TargetContentHasherTests {
     private var contentHasher: MockContentHashing!
     private var coreDataModelsContentHasher: MockCoreDataModelsContentHashing!
     private var sourceFilesContentHasher: MockSourceFilesContentHashing!
@@ -21,8 +21,7 @@ final class TargetContentHasherTests: TuistUnitTestCase {
     private var dependenciesContentHasher: MockDependenciesContentHashing!
     private var subject: TargetContentHasher!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() async throws {
         contentHasher = MockContentHashing()
         coreDataModelsContentHasher = MockCoreDataModelsContentHashing()
         sourceFilesContentHasher = MockSourceFilesContentHashing()
@@ -82,22 +81,7 @@ final class TargetContentHasherTests: TuistUnitTestCase {
             .willReturn("deployment_targets_hash")
     }
 
-    override func tearDown() async throws {
-        contentHasher = nil
-        coreDataModelsContentHasher = nil
-        sourceFilesContentHasher = nil
-        targetScriptsContentHasher = nil
-        resourcesContentHasher = nil
-        copyFilesContentHasher = nil
-        headersContentHasher = nil
-        plistContentHasher = nil
-        settingsContentHasher = nil
-        dependenciesContentHasher = nil
-        subject = nil
-        try await super.tearDown()
-    }
-
-    func test_hash_when_targetBelongsToExternalProjectWithHash() async throws {
+    @Test func test_hash_when_targetBelongsToExternalProjectWithHash() async throws {
         // Given
         let target = GraphTarget.test(project: .test(type: .external(hash: "hash")))
 
@@ -110,10 +94,10 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(got.hash, "hash-app-settings_hash-iPad-iPhone")
+        #expect(got.hash == "hash-app-settings_hash-dependencies_hash-iPad-iPhone")
     }
 
-    func test_hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
+    @Test func test_hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
         // Given
         let target = GraphTarget.test(project: .test(type: .external(hash: "hash")))
 
@@ -127,10 +111,10 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(got.hash, "hash-app-settings_hash-iPad-iPhone-additional_string_one-additional_string_two")
+        #expect(got.hash == "hash-app-settings_hash-dependencies_hash-iPad-iPhone-additional_string_one-additional_string_two")
     }
 
-    func test_hash_with_additional_strings() async throws {
+    @Test func test_hash_with_additional_strings() async throws {
         // Given
         let target = GraphTarget.test(project: .test())
 
@@ -147,13 +131,13 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(
-            got.hash,
-            "Target-app-io.tuist.Target-Target-dependencies_hash-sources_hash-resources_hash-copy_files_hash-core_data_models_hash-target_scripts_hash-dictionary_hash-iPad-iPhone-additional_string-iPad-iPhone-deployment_targets_hash-settings_hash"
+        #expect(
+            got.hash ==
+                "Target-app-io.tuist.Target-Target-dependencies_hash-sources_hash-resources_hash-copy_files_hash-core_data_models_hash-target_scripts_hash-dictionary_hash-iPad-iPhone-additional_string-iPad-iPhone-deployment_targets_hash-settings_hash"
         )
     }
 
-    func test_hash_with_destination() async throws {
+    @Test func test_hash_with_destination() async throws {
         // Given
         let target = GraphTarget.test(
             target: .test(
@@ -177,11 +161,11 @@ final class TargetContentHasherTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertTrue(
-            got.hash.contains("iPhone 16")
+        #expect(
+            got.hash.contains("iPhone 16") == true
         )
-        XCTAssertTrue(
-            got.hash.contains("iOS-16")
+        #expect(
+            got.hash.contains("iOS-16") == true
         )
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7555

### Short description 📝
[This PR](https://github.com/tuist/tuist/commit/62ac06de816937df23a4adda7f037942f9f36147) optimized the hashing of external dependencies by using the lockfile as a source of truth. However, we forgot to include in the hash the has of the dependencies, causing the hashes of some targets to not change when they should.

If the transitive dependency introduces breaking changes, like in the case of [the issue](https://github.com/tuist/tuist/issues/7555), it causes the compilation to fail.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
