### PR TITLE
Replace asdf-create-dmg with brew create-dmg in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
         if: env.should-release == 'true'
         run: |
           mise run install
-      - name: Install tuist/asdf-create-dmg
-        run: mise use asdf:tuist/asdf-create-dmg@latest
+      - name: Install create-dmg
+        run: brew install create-dmg
       - name: Bundle Tuist App
         if: env.should-release == 'true'
         run: mise run bundle:app


### PR DESCRIPTION

### Short description 📝
The release of the macOS has been failing for [some time](https://github.com/tuist/tuist/actions/runs/14859498754/job/41720610181), and I can't really understand why, so I decided to install [create-dmg](https://github.com/create-dmg/create-dmg) using Homebrew. 