### PR TITLE
Fix implicit import detection when target points to absent files

### DIFF
--- a/Sources/TuistKit/Services/TargetImportsScanner.swift
+++ b/Sources/TuistKit/Services/TargetImportsScanner.swift
@@ -48,10 +48,17 @@ final class TargetImportsScanner: TargetImportsScanning {
             return []
         }
 
-        let sourceCode = try await fileSystem.readTextFile(at: path)
-        return try importSourceCodeScanner.extractImports(
-            from: sourceCode,
-            language: language
-        )
+        /// Targets might contain references to files to absent files, either by mistake
+        /// or because those files are generated later on, like it's the case with generated
+        /// projects with synthesized files. Therefore we can't assume their existence.
+        if try await fileSystem.exists(path) {
+            let sourceCode = try await fileSystem.readTextFile(at: path)
+            return try importSourceCodeScanner.extractImports(
+                from: sourceCode,
+                language: language
+            )
+        } else {
+            return Set()
+        }
     }
 }

--- a/Sources/TuistKit/Services/TargetImportsScanner.swift
+++ b/Sources/TuistKit/Services/TargetImportsScanner.swift
@@ -48,9 +48,9 @@ final class TargetImportsScanner: TargetImportsScanning {
             return []
         }
 
-        /// Targets might contain references to files to absent files, either by mistake
-        /// or because those files are generated later on, like it's the case with generated
-        /// projects with synthesized files. Therefore we can't assume their existence.
+        /// Targets might contain references to absent files, either by mistake
+        /// or because those files are generated later on, as is the case with generated
+        /// projects with synthesized files. Therefore, we can't assume their existence.
         if try await fileSystem.exists(path) {
             let sourceCode = try await fileSystem.readTextFile(at: path)
             return try importSourceCodeScanner.extractImports(

--- a/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
+++ b/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
@@ -1,54 +1,78 @@
 import FileSystem
+import Foundation
+import Testing
 import TuistSupport
 import TuistSupportTesting
 import XcodeGraph
-import XCTest
 @testable import TuistKit
 
-final class TargetImportsScannerTests: TuistUnitTestCase {
-    func test_scannerTargetWithImports() async throws {
+struct TargetImportsScannerTests {
+    private let fileSystem = FileSystem()
+
+    @Test func imports() async throws {
         // Given
-        let fileSystem = FileSystem()
-        let path = try temporaryPath()
-        let targetPath = path.appending(components: "FirstTarget", "Sources")
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            let targetPath = temporaryDirectory.appending(components: "FirstTarget", "Sources")
 
-        let targetFirstFile = targetPath.appending(component: "FirstFile.swift")
-        let targetSecondFile = targetPath.appending(component: "SecondFile.swift")
+            let targetFirstFile = targetPath.appending(component: "FirstFile.swift")
+            let targetSecondFile = targetPath.appending(component: "SecondFile.swift")
 
-        try await fileSystem.makeDirectory(at: targetPath)
+            try await fileSystem.makeDirectory(at: targetPath)
 
-        try await fileSystem.writeText(
-            """
-            import SecondTarget
-            import A
+            try await fileSystem.writeText(
+                """
+                import SecondTarget
+                import A
 
-            let a = 5
-            """,
-            at: targetFirstFile
-        )
+                let a = 5
+                """,
+                at: targetFirstFile
+            )
 
-        try await fileSystem.writeText(
-            """
-            @testable import ThirdTarget
+            try await fileSystem.writeText(
+                """
+                @testable import ThirdTarget
 
-            func main() { }
-            """,
-            at: targetSecondFile
-        )
+                func main() { }
+                """,
+                at: targetSecondFile
+            )
 
-        let target = Target.test(
-            name: "FirstTarget",
-            sources: [
-                SourceFile(path: targetFirstFile),
-                SourceFile(path: targetSecondFile),
-            ]
-        )
+            let target = Target.test(
+                name: "FirstTarget",
+                sources: [
+                    SourceFile(path: targetFirstFile),
+                    SourceFile(path: targetSecondFile),
+                ]
+            )
 
-        // When
-        let result = try await TargetImportsScanner()
-            .imports(for: target)
+            // When
+            let result = try await TargetImportsScanner()
+                .imports(for: target)
 
-        // Then
-        XCTAssertEqual(result, ["SecondTarget", "ThirdTarget", "A"])
+            // Then
+            #expect(result == ["SecondTarget", "ThirdTarget", "A"])
+        }
+    }
+
+    @Test func imports_when_filesAreAbsent() async throws {
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            // Given
+            let sourcesPath = temporaryDirectory.appending(components: "Target", "Sources")
+            let sourcePath = sourcesPath.appending(component: "Source.swift")
+            let target = Target.test(
+                name: "Target",
+                sources: [
+                    SourceFile(path: sourcePath),
+                ]
+            )
+
+            // When
+            let result = try await TargetImportsScanner()
+                .imports(for: target)
+
+            // Then
+            #expect(result == [])
+        }
     }
 }


### PR DESCRIPTION
### Short description 📝
If a target references a file that's absent, `tuist inspect implicit-imports` fails because we assume their presence. This was a bit difficult to debug because the error manifests as "file handle closed" due to a race condition between the error propagating up the stack and structured concurrency propagating the cancellation of concurrent tasks. We should at some point explore a way to eliminate that race condition to ease debugging.

> [!NOTE]
> Absent files happen when a project uses synthesized interfaces, where we first include the reference in the graph, and we create the files as a side effect. Since those files are created by Tuist, we don't need to check those, so I think it's safe to add the existence check and skip if they are absent.

### How to test the changes locally 🧐

You can run the new test, or run the command against a generated project that has synthesized sources for resources.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
