### PR TITLE
Introduce `--warnings-as-errors` flag for all commands

### DIFF
--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -248,6 +248,6 @@ public struct TuistCommand: AsyncParsableCommand {
 
     static func processArguments(_ arguments: [String]? = nil) -> [String]? {
         let arguments = arguments ?? Array(ProcessInfo.processInfo.arguments)
-        return arguments.filter { $0 != "--verbose" && $0 != "--quiet" }
+        return arguments.filter { $0 != "--verbose" && $0 != "--quiet" && $0 != "--warnings-as-errors" }
     }
 }

--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -53,6 +53,10 @@ extension ServiceContext {
         if CommandLine.arguments.contains("--quiet") {
             try? ProcessEnv.setVar(Constants.EnvironmentVariables.quiet, value: "true")
         }
+
+        if CommandLine.arguments.contains("--warnings-as-errors") {
+            try? ProcessEnv.setVar(Constants.EnvironmentVariables.warningsAsErrors, value: "true")
+        }
     }
 
     func withLoggerForNoora(logFilePath: Path.AbsolutePath, _ action: () async throws -> Void) async throws {

--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -22,6 +22,8 @@ struct IgnoreOutputPipeline: StandardPipelining {
 
 extension ServiceContext {
     public static func tuist(_ action: (Path.AbsolutePath) async throws -> Void) async throws {
+        try setupEnv()
+
         var context = ServiceContext.topLevel
 
         let (logger, logFilePath) = try await setupLogger()
@@ -35,7 +37,7 @@ extension ServiceContext {
         }
     }
 
-    private static func setupEnv() async throws {
+    private static func setupEnv() throws {
         if CommandLine.arguments.contains("--quiet"), CommandLine.arguments.contains("--verbose") {
             throw TuistServiceContextError.exclusiveOptionError("quiet", "verbose")
         }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -77,6 +77,7 @@ public enum Constants {
         public static let deprecatedToken = "TUIST_CONFIG_CLOUD_TOKEN"
         public static let quiet = "TUIST_CONFIG_QUIET"
         public static let cirrusTuistCacheURL = "CIRRUS_TUIST_CACHE_URL"
+        public static let warningsAsErrors = "TUIST_WARNINGS_AS_ERRORS"
     }
 
     public enum URLs {


### PR DESCRIPTION
Closes: https://github.com/tuist/tuist/issues/4376

### Short description 📝

On a number of occasions our team have found ourselves mistakenly introducing often minor issues with our Tuist configuration. In most cases these issues are harmless, but it would save us time if we were able to effectively pick these up in code review in the event that the author misses it when they run `tuist generate` locally.

While we do run `tuist generate` on CI, PR reviewers don't often find themselves looking throuh the build logs and the warnings aren't spotted until the code is merged back into `main`.

Similar to how we treat warnings as errors in our Swift code so that I fails on a Pull Request, it would be great if we could do the same with warnings in our Tuist configuration.

This Pull Request tries to achieve this by introducing a ~`--strict`~ `-warnings-as-errors` flag in ~the generator command~ Tuist.

---

#### Iteration 1

<details>
<summary><b> Iteration 1 </summary></b>

This branch itself is just a proof of concept. I'm not tied to the implementation but I felt that it was better to push a PR as a starting point for discussions rather than an Issue. While implementing I did come up with a few questions that I think are worth going over:

1. Is a flag the best option for this, or should it be part of the `Tuist` configuration defined in Tuist.swift? 
2. If a flag, should it be global, or scoped specifically to the generate command? A couple of other commands also use the `printAndThrowErrorsIfNeeded()` helper so it might be beneficial to be able to control those uses as well
3. Is there a better option than just converting warnings to errors? Do we want greater control?
4. Is `strict` a good name? I copied SwiftLint for this since `--warnings-as-errors` seemed a bit lengthy, but that said it is descriptive.
5. Doc updates?

</details>

#### Iteration 2

After taking on the feedback, this change introducing a new global flag 'warnings as errors' rather than being constrained to the `tuist generate` command specifically. 

After the command has completed, before finishing i've updated `TuistCommand` itself to check the pending warnings in the `AlertController`.. If `--warnings-as-errors` is set and there are warnings, an error will be raised and the command will exit with a non-zero exit code.

It's a much simpler implementation from the previous iteration.

### How to test the changes locally 🧐

I ran this branch of `tuist` against our project with and without warnings.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
