### PR TITLE
Collect and include takeaways in success messages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1bd8ca05828419a464a795dc8a4e1df9626aec4ed460bc7705e70c2a4ee22164",
+  "originHash" : "1e881e23605a5b24aef2d311fdbe6d3ce5982807a648bb07601cb71df6a9cfc9",
   "pins" : [
     {
       "identity" : "aexml",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Noora",
       "state" : {
-        "revision" : "e695b056570bb10ea3da0d1924153ca0567b54cb",
-        "version" : "0.37.1"
+        "revision" : "53c6652a592fddd16e921408e2aba1d66a4feb73",
+        "version" : "0.38.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -538,7 +538,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.37.1")),
+        .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.38.0")),
         .package(
             url: "https://github.com/frazer-rbsn/OrderedSet.git", .upToNextMajor(from: "2.0.0")
         ),
@@ -546,7 +546,9 @@ let package = Package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",
             .upToNextMajor(from: "1.18.1")
         ),
-        .package(url: "https://github.com/loopwork-ai/mcp-swift-sdk.git", .upToNextMajor(from: "0.5.1")),
+        .package(
+            url: "https://github.com/loopwork-ai/mcp-swift-sdk.git", .upToNextMajor(from: "0.5.1")
+        ),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", .upToNextMajor(from: "5.0.2")),
     ],
     targets: targets

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -66,7 +66,7 @@ public struct CacheCommand: AsyncParsableCommand {
         if printHashes {
             ServiceContext.current?.alerts?.warning(.alert(
                 "The \(.command("tuist cache --print-hashes")) syntax is deprecated.",
-                nextStep: "Use \(.command("tuist hash cache")) instead."
+                takeaway: "Use \(.command("tuist hash cache")) instead."
             ))
             try await HashCacheCommandService(
                 generatorFactory: Self.generatorFactory

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -205,12 +205,13 @@ public struct TuistCommand: AsyncParsableCommand {
         errorAlertNextSteps: [TerminalText]? = nil
     ) {
         let errorAlert: ErrorAlert? = if let errorAlertMessage {
-            .alert(errorAlertMessage, nextSteps: errorAlertNextSteps ?? [])
+            .alert(errorAlertMessage, takeaways: errorAlertNextSteps ?? [])
         } else {
             nil
         }
         let successAlerts = ServiceContext.current?.alerts?.success() ?? []
         let warningAlerts = ServiceContext.current?.alerts?.warnings() ?? []
+        let takeaways = ServiceContext.current?.alerts?.takeaways() ?? []
 
         if !warningAlerts.isEmpty {
             print("\n")
@@ -220,18 +221,19 @@ public struct TuistCommand: AsyncParsableCommand {
 
         if let errorAlert {
             print("\n")
-            var errorAlertNextSteps = errorAlert.nextSteps
+            var errorAlertNextSteps = errorAlert.takeaways
             if shouldOutputLogFilePath {
                 errorAlertNextSteps.append(logsNextStep)
             }
-            ServiceContext.current?.ui?.error(.alert(errorAlert.message, nextSteps: errorAlertNextSteps))
+            ServiceContext.current?.ui?.error(.alert(errorAlert.message, takeaways: errorAlertNextSteps))
         } else if let successAlert = successAlerts.last {
-            var successAlertNextSteps = successAlert.nextSteps
+            var successAlertNextSteps = successAlert.takeaways
+            successAlertNextSteps.append(contentsOf: takeaways)
             if shouldOutputLogFilePath {
                 successAlertNextSteps.append(logsNextStep)
             }
             print("\n")
-            ServiceContext.current?.ui?.success(.alert(successAlert.message, nextSteps: successAlertNextSteps))
+            ServiceContext.current?.ui?.success(.alert(successAlert.message, takeaways: successAlertNextSteps))
         }
     }
 

--- a/Sources/TuistKit/Services/InitCommandService.swift
+++ b/Sources/TuistKit/Services/InitCommandService.swift
@@ -145,7 +145,7 @@ public struct InitCommandService {
             )
         }
 
-        ServiceContext.current?.alerts?.success(.alert("You are all set to explore the Tuist universe", nextSteps: nextSteps))
+        ServiceContext.current?.alerts?.success(.alert("You are all set to explore the Tuist universe", takeaways: nextSteps))
     }
 
     private func mise(path: AbsolutePath, nextSteps _: inout [TerminalText]) async throws {

--- a/Sources/TuistKit/Services/MCP/MCPSetupClaudeCommandService.swift
+++ b/Sources/TuistKit/Services/MCP/MCPSetupClaudeCommandService.swift
@@ -25,7 +25,7 @@ struct MCPSetupClaudeCommandService {
             "Claude",
             "claude_desktop_config.json",
         ]))
-        ServiceContext.current?.alerts?.success(.alert("Claude configured to point to the Tuist's MCP server.", nextSteps: [
+        ServiceContext.current?.alerts?.success(.alert("Claude configured to point to the Tuist's MCP server.", takeaways: [
             "Restart the Claude app if it was opened",
             "Check out Claude's \(.link(title: "documentation", href: "https://modelcontextprotocol.io/quickstart/user"))",
         ]))

--- a/Sources/TuistKit/Services/Registry/RegistrySetupCommandService.swift
+++ b/Sources/TuistKit/Services/Registry/RegistrySetupCommandService.swift
@@ -119,7 +119,7 @@ struct RegistrySetupCommandService {
         ServiceContext.current?.alerts?.success(
             .alert(
                 "Generated the \(accountHandle) registry configuration file at \(.accent(configurationJSONPath.relative(to: path).pathString))",
-                nextSteps: [
+                takeaways: [
                     "Commit the generated configuration file to share the configuration with the rest of your team",
                     "Ensure that your team members run \(.command("tuist registry login")) to log in to the registry",
                     "For more information about the registry, such as how to set up the registry in your CI, head to our \(.link(title: "docs", href: "https://docs.tuist.dev/en/guides/develop/registry"))",

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -254,13 +254,10 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         }
 
         if currentData != savedData {
-            ServiceContext.current?.ui?
-                .warning(
-                    .alert(
-                        "We detected outdated dependencies.",
-                        nextStep: "Run \(.command("tuist install")) to update them."
-                    )
-                )
+            ServiceContext.current?.alerts?.warning(.alert(
+                "We detected outdated dependencies.",
+                takeaway: "Run \(.command("tuist install")) to update them."
+            ))
         }
     }
 }

--- a/Sources/TuistSupport/Utils/AlertController.swift
+++ b/Sources/TuistSupport/Utils/AlertController.swift
@@ -30,6 +30,7 @@ enum Alert: Equatable, Hashable {
 public final class AlertController: @unchecked Sendable {
     private let alertQueue = DispatchQueue(label: "io.tuist.TuistSupport.AlertController")
     private var alerts: ThreadSafe<OrderedSet<Alert>> = ThreadSafe([])
+    private var _takeaways: ThreadSafe<OrderedSet<TerminalText>> = ThreadSafe([])
 
     public init() {}
 
@@ -41,13 +42,21 @@ public final class AlertController: @unchecked Sendable {
 
     public func warning(_ alert: WarningAlert) {
         alerts.mapping { alerts in
-
             return alerts.appending(.warning(alert))
+        }
+    }
+
+    public func takeaway(_ takeaway: TerminalText) {
+        _takeaways.mapping { takeaways in
+            return takeaways.appending(takeaway)
         }
     }
 
     public func reset() {
         alerts.mapping { _ in
+            return []
+        }
+        _takeaways.mapping { _ in
             return []
         }
     }
@@ -62,6 +71,10 @@ public final class AlertController: @unchecked Sendable {
         return alerts.withValue { alerts in
             alerts.compactMap(\.success)
         }
+    }
+
+    public func takeaways() -> [TerminalText] {
+        return _takeaways.withValue { $0.array }
     }
 
     public func print() {

--- a/Tests/TuistKitTests/Services/MCP/MCPSetupClaudeCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/MCP/MCPSetupClaudeCommandServiceTests.swift
@@ -38,7 +38,7 @@ struct MCPSetupClaudeCommandServiceTests {
             ✔ Success
               Claude configured to point to the Tuist's MCP server.
 
-              Recommended next steps:
+              Takeaways:
                ▸ Restart the Claude app if it was opened
                ▸ Check out Claude's <documentation: https://modelcontextprotocol.io/quickstart/user>
             """)


### PR DESCRIPTION
### Short description 📝
We'd like to be able to include takeaways throughout the execution of a command, and include them when outputting the success alert to the user. Because we already have a utility in place, `AlertController`, which collects all the information for that, I extended it to include an interface to collect "takeaways" and the logic that outputs the success alert ot make sure we include those takeaways.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
