### PR TITLE
Add missing function `buildTimesByTarget` missing in protocol `XCActivityLogControlling`

### DIFF
--- a/Sources/TuistSupport/XCActivityLog/XCActivityLogController.swift
+++ b/Sources/TuistSupport/XCActivityLog/XCActivityLogController.swift
@@ -7,6 +7,7 @@ import XCLogParser
 @Mockable
 public protocol XCActivityLogControlling {
     func mostRecentActivityLogPath(projectDerivedDataDirectory: AbsolutePath, after: Date) async throws -> AbsolutePath?
+    func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws -> [String: Double]
     func parse(_ path: AbsolutePath) throws -> XCActivityLog
 }
 


### PR DESCRIPTION
I added `XCActivityLogController.buildTimesByTarget` but I forgot to include it in `XCActivityLogControlling`, so I'm adding it.