### PR TITLE
Fix `--verbose` not working

### DIFF
--- a/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
+++ b/Sources/TuistKit/Extensions/ServiceContext+Tuist.swift
@@ -22,6 +22,8 @@ struct IgnoreOutputPipeline: StandardPipelining {
 
 extension ServiceContext {
     public static func tuist(_ action: (Path.AbsolutePath) async throws -> Void) async throws {
+        try await setupEnv()
+
         var context = ServiceContext.topLevel
 
         let (logger, logFilePath) = try await setupLogger()

--- a/Sources/TuistKit/Utils/LogsController.swift
+++ b/Sources/TuistKit/Utils/LogsController.swift
@@ -12,8 +12,7 @@ public struct LogsController {
 
     public func setup(
         stateDirectory: AbsolutePath,
-        logFilePath: AbsolutePath! = nil,
-        forceVerbose: Bool = false,
+        logFilePath: AbsolutePath! = nil
     ) async throws -> (@Sendable (String) -> any LogHandler, AbsolutePath) {
         var logFilePath = logFilePath
         if logFilePath == nil {
@@ -32,7 +31,7 @@ public struct LogsController {
                     verbose: ProcessInfo.processInfo.environment[Constants.EnvironmentVariables.verbose] != nil
                 )
             } else {
-                LoggingConfig.default
+                LoggingConfig.default()
             }
 
         try await clean(logsDirectory: logFilePath!.parentDirectory)

--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -52,7 +52,7 @@ extension Logger {
     }
 
     public static func defaultLoggerHandler(
-        config: LoggingConfig = .default,
+        config: LoggingConfig,
         logFilePath: AbsolutePath
     ) throws -> @Sendable (String) -> any LogHandler {
         let handler: VerboseLogHandler.Type
@@ -103,7 +103,7 @@ extension Logger {
 }
 
 extension LoggingConfig {
-    public static var `default`: LoggingConfig {
+    public static func `default`() -> LoggingConfig {
         let env = ProcessInfo.processInfo.environment
 
         let quiet = env[Constants.EnvironmentVariables.quiet] != nil


### PR DESCRIPTION
### Short description 📝
[This PR](https://github.com/tuist/tuist/pull/7532) introduced a regression preventing the `--verbose` flag from working.

### How to test the changes locally 🧐
You can run `tuist run tuist generate --verbose --no-generate` and check that the verbose logs are shown.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
