### PR TITLE
Fix missing bundle git metadata

### DIFF
--- a/Sources/TuistKit/Services/Inspect/InspectBundleCommandService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspectBundleCommandService.swift
@@ -70,14 +70,14 @@ struct InspectBundleCommandService {
 
         let gitCommitSHA: String?
         let gitBranch: String?
-        if gitController.isInGitRepository(workingDirectory: path.parentDirectory) {
-            if gitController.hasCurrentBranchCommits(workingDirectory: path.parentDirectory) {
-                gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path.parentDirectory)
+        if gitController.isInGitRepository(workingDirectory: path) {
+            if gitController.hasCurrentBranchCommits(workingDirectory: path) {
+                gitCommitSHA = try gitController.currentCommitSHA(workingDirectory: path)
             } else {
                 gitCommitSHA = nil
             }
 
-            gitBranch = try gitController.currentBranch(workingDirectory: path.parentDirectory)
+            gitBranch = try gitController.currentBranch(workingDirectory: path)
         } else {
             gitCommitSHA = nil
             gitBranch = nil

--- a/Tests/TuistKitTests/Services/Inspect/InspectBundleCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectBundleCommandServiceTests.swift
@@ -92,6 +92,10 @@ struct InspectBundleCommandServiceTests {
                     gitBranch: .any
                 )
                 .called(1)
+
+            verify(gitController)
+                .isInGitRepository(workingDirectory: .value(temporaryDirectory))
+                .called(1)
         }
     }
 }


### PR DESCRIPTION
### Short description 📝

I've noticed the bundles are missing git metadata – turns out the path for obtaining the metadata path is referencing `path.parentDirectory` which is wrong.

### How to test the changes locally 🧐

- Run `tuist inspect bundle` and see that the git metadata is included in the dashboard.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
