### PR TITLE
ci: move device build to GitHub Actions

### DIFF
--- a/.github/workflows/tuist-app.yml
+++ b/.github/workflows/tuist-app.yml
@@ -1,0 +1,68 @@
+name: tuist-app
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "app/**"
+      - ".github/workflows/tuist-app.yml"
+permissions:
+  contents: read
+
+env:
+  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_CONFIG_TOKEN }}
+  MISE_SOPS_AGE_KEY: ${{ secrets.MISE_SOPS_AGE_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+concurrency:
+  group: tuist-app-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  tuist-app-device-build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
+      - name: Skip Xcode Macro Fingerprint Validation
+        run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+      - name: Skip Xcode Package Validation
+        run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+
+      - name: Restore cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-tuist-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: .build
+
+      - name: Activate .env.json
+        run: cp .optional.env.json .env.json
+
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2025.1.5
+          experimental: true
+
+      - name: Generate TuistApp
+        run: mise x -- tuist generate TuistApp
+
+      - name: Bundle iOS app
+        run: mise run bundle:ios-app
+
+      - name: Inspect TuistApp
+        run: mise x -- tuist inspect bundle build/Tuist.ipa
+
+      - name: Share TuistApp
+        run: mise x -- tuist share build/Tuist.ipa
+
+      - name: Save cache
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -313,40 +313,6 @@ workflows:
         script: mise x -- tuist share TuistApp
     triggering:
       <<: *branch_triggering
-  tuist_app_device_build:
-    name: Tuist App device build
-    max_build_duration: 60
-    environment:
-      xcode: 16.3
-      groups:
-        - tuist
-    cache:
-      cache_paths:
-        - $CM_BUILD_DIR/.build
-    scripts:
-      - name: Set environment variables
-        script: |
-          echo "MISE_EXPERIMENTAL=1" >> $CM_ENV
-      - name: Install Mise
-        script: |
-          curl https://mise.run | MISE_VERSION=v2025.1.5 sh
-          mise install
-      - name: Skip Xcode Macro Fingerprint Validation
-        script: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
-      - name: Skip Xcode Package Validation
-        script: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
-      - name: Install Tuist dependencies
-        script: mise x -- tuist install
-      - name: Generate TuistApp
-        script: mise x -- tuist generate TuistApp
-      - name: Bundle iOS app
-        script: mise run bundle:ios-app
-      - name: Inspect TuistApp
-        script: mise x -- tuist inspect bundle build/Tuist.ipa
-      - name: Share TuistApp
-        script: mise x -- tuist share build/Tuist.ipa
-    triggering:
-      <<: *branch_triggering
   tuist_app_tests:
     name: Tuist App tests
     max_build_duration: 60

--- a/mise/tasks/bundle/ios-app
+++ b/mise/tasks/bundle/ios-app
@@ -17,6 +17,7 @@ if [ "${CI:-}" = "true" ]; then
 fi
 
 echo $BASE_64_CERTIFICATE | base64 --decode > $TMP_DIR/certificate.p12 && security import $TMP_DIR/certificate.p12 -P $CERTIFICATE_PASSWORD -A
+mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
 echo $BASE_64_PROVISIONING_PROFILE | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/tuist.mobileprovision"
 
 EXPORT_OPTIONS_PLIST_PATH=$TMP_DIR/ExportOptions.plist

--- a/mise/tasks/install
+++ b/mise/tasks/install
@@ -4,10 +4,4 @@
 set -euo pipefail
 
 pnpm install -C $MISE_PROJECT_ROOT/docs/
-swift package --package-path $MISE_PROJECT_ROOT resolve
-swift package --package-path $MISE_PROJECT_ROOT/app resolve
-
-if [ "${CI:-}" = "true" ]; then
-    # Mise doesn't have a way to make secrets optional, so we copy it to the file that does get loaded as part of mise install
-    cp .optional.env.json .env.json
-fi
+tuist install --path $MISE_PROJECT_ROOT


### PR DESCRIPTION
### Short description 📝

The codemagic pipelines are not well-suited for using secrets in forks. To get around that, I'm moving the app device build pipeline to GitHub Actions, so we can approve fork workflows instead of those workflows failing.

### How to test the changes locally 🧐

- CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
