### PR TITLE
Reorder enable directives so SwiftFormat runs before SwiftLint

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -283,8 +283,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No assets found
     {% endif %}
-    // swiftlint:enable all
     // swiftformat:enable all
+    // swiftlint:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -110,8 +110,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No files found
     {% endif %}
-    // swiftlint:enable all
     // swiftformat:enable all
+    // swiftlint:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -125,8 +125,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No fonts found
     {% endif %}
-    // swiftlint:enable all
     // swiftformat:enable all
+    // swiftlint:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -79,8 +79,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No files found
     {% endif %}
-    // swiftlint:enable all
     // swiftformat:enable all
+    // swiftlint:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -96,8 +96,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No string found
     {% endif %}
-    // swiftlint:enable all
     // swiftformat:enable all
+    // swiftlint:enable all
 
     """
 }


### PR DESCRIPTION
### Short description 📝

This PR swaps the order of the formatter enable directives at the end of the file so that `// swiftformat:enable all` appears before `// swiftlint:enable all`.
Without this change, some SwiftLint rules (notably `file_length`) are still applied if the SwiftLint enable comment comes first, resulting in unwanted lint failures after formatting.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
