### PR TITLE
Update documentation for transitive static dependency leaks

### DIFF
--- a/Sources/ProjectDescription/Dump.swift
+++ b/Sources/ProjectDescription/Dump.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import Foundation
+internal import Foundation
 
 func dumpIfNeeded(_ entity: some Encodable) {
     guard !ProcessInfo.processInfo.arguments.isEmpty,

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import Foundation
+internal import Foundation
 
 /// A convenience structure to read environment variables.
 @dynamicMemberLookup

--- a/docs/docs/en/guides/develop/projects/dependencies.md
+++ b/docs/docs/en/guides/develop/projects/dependencies.md
@@ -342,8 +342,8 @@ let package = Package(
 
 ### Transitive static dependencies leaking through `.swiftmodule` {#transitive-static-dependencies-leaking-through-swiftmodule}
 
-When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using [`@_implementationOnly`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly):
+When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using [`internal import`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md):
 
 ```swift
-@_implementationOnly import StaticModule
+internal import StaticModule
 ```

--- a/docs/docs/en/guides/develop/projects/dependencies.md
+++ b/docs/docs/en/guides/develop/projects/dependencies.md
@@ -342,14 +342,14 @@ let package = Package(
 
 ### Transitive static dependencies leaking through `.swiftmodule` {#transitive-static-dependencies-leaking-through-swiftmodule}
 
-When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using [`internal import`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md):
+When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially <LocalizedLink href="https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1">causing the compilation to fail</LocalizedLink>. To prevent that, you'll have to import the static dependency using <LocalizedLink href="https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md">`internal import`</LocalizedLink>:
 
 ```swift
 internal import StaticModule
 ```
 
 > [!NOTE]
-> Access level on imports was included in Swift 6. If you're using older versions of Swift, you need to use [`@_implementationOnly`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly) instead:
+> Access level on imports was included in Swift 6. If you're using older versions of Swift, you need to use <LocalizedLink href="https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly">`@_implementationOnly`</LocalizedLink> instead:
 
 ```swift
 @_implementationOnly import StaticModule

--- a/docs/docs/en/guides/develop/projects/dependencies.md
+++ b/docs/docs/en/guides/develop/projects/dependencies.md
@@ -347,3 +347,10 @@ When a dynamic framework or library depends on static ones through `import Stati
 ```swift
 internal import StaticModule
 ```
+
+> [!NOTE]
+> Access level on imports was included in Swift 6. If you're using older versions of Swift, you need to use [`@_implementationOnly`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly) instead:
+
+```swift
+@_implementationOnly import StaticModule
+```


### PR DESCRIPTION
### Short description 📝

Using @_implementationOnly started showing the following warnings in Swift 5.9:
```
Using '@_implementationOnly' without enabling library evolution for 'XXXX' may lead to instability during execution
```
In Swift 6, access level modifiers for imports [were added](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md).

This PR updates the documentation to use the new syntax following the Swift Evolution Proposal linked above:
> Current uses of @_implementationOnly import should be replaced with an internal import or lower.

### How to test the changes locally 🧐

This is just a documentation change.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
