### PR TITLE
Moving documentation generation to GH Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,9 +46,6 @@ jobs:
           version: 2025.1.3
           experimental: true
 
-      - name: Install dependencies
-        run: mise run install
-
       - name: Generate manifest docs
         run: mise run docs:generate-manifests-docs
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: docs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+      - "Sources/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "mise/tasks/docs"
+
+permissions:
+  contents: read
+
+env:
+  MISE_SOPS_AGE_KEY: ${{ secrets.MISE_SOPS_AGE_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_CONFIG_TOKEN }}
+
+concurrency:
+  group: docs-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_docs:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_16.3.app
+
+      - name: Restore cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-docs-${{ hashFiles('Package.resolved') }}
+          restore-keys: .build
+
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2025.1.3
+          experimental: true
+
+      - name: Install dependencies
+        run: mise run install
+
+      - name: Generate manifest docs
+        run: mise run docs:generate-manifests-docs
+
+      - name: Build the documentation
+        run: mise run docs:build
+
+      - name: Save cache
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -47,29 +47,6 @@ workflows:
         script: swift build --configuration debug
     triggering:
       <<: *branch_triggering
-  build_docs:
-    name: Build Documentation
-    max_build_duration: 60
-    environment:
-      xcode: 16.3
-      groups:
-        - tuist
-    scripts:
-      - name: Set environment variables
-        script: |
-          echo "MISE_EXPERIMENTAL=1" >> $CM_ENV
-      - name: Install Mise
-        script: |
-          curl https://mise.run | MISE_VERSION=v2025.1.3 sh
-          mise install
-      - name: Install dependencies
-        script: mise run install
-      - name: Generate manifest docs
-        script: mise run docs:generate-manifests-docs
-      - name: Build the documentation
-        script: mise run docs:build
-    triggering:
-      <<: *branch_triggering
   unit_tests:
     name: Unit tests
     max_build_duration: 60


### PR DESCRIPTION
### Short description 📝

I've noticed some PRs still fail due to exhausting GitHub API limits in Codemagic pipelines. While this is solvable, I'd default to using GH Actions-provided open source runners for workflows that are not as resource-heavy like acceptance tests.

### How to test the changes locally 🧐

- CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
