### PR TITLE
Remove unmatched resource glob warnings

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -40,7 +40,7 @@ extension XcodeGraph.ResourceFileElement {
                 if FileHandler.shared.isFolder(path) {
                     Logger.current
                         .warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
-                } else {
+                } else if !path.isGlobPath {
                     // FIXME: This should be done in a linter.
                     Logger.current.warning("No files found at: \(path.pathString)")
                 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -43,7 +43,7 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         }
     }
 
-    func test_from_outputs_a_warning_when_no_files_found() async throws {
+    func test_from_when_no_files_found() async throws {
         try await withMockedDependencies {
             // Given
             let temporaryPath = try temporaryPath()
@@ -65,14 +65,43 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
             )
 
             // Then
-            XCTAssertPrinterOutputContains(
+            XCTAssertPrinterOutputNotContains(
                 "No files found at: \(rootDirectory.appending(components: "Resources", "**"))"
             )
             XCTAssertEqual(model, [])
         }
     }
 
-    func test_from_outputs_a_warning_when_no_files_found_in_opaque_directory() async throws {
+    func test_from_outputs_a_warning_when_specific_file_not_found() async throws {
+        try await withMockedDependencies {
+            // Given
+            let temporaryPath = try temporaryPath()
+            let rootDirectory = temporaryPath
+            let generatorPaths = GeneratorPaths(
+                manifestDirectory: temporaryPath,
+                rootDirectory: rootDirectory
+            )
+
+            try await fileSystem.makeDirectory(at: rootDirectory.appending(component: "Resources"))
+
+            let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/Image.png")
+
+            // When
+            let model = try await XcodeGraph.ResourceFileElement.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                fileSystem: fileSystem
+            )
+
+            // Then
+            XCTAssertPrinterOutputContains(
+                "No files found at: \(rootDirectory.appending(components: "Resources", "Image.png"))"
+            )
+            XCTAssertEqual(model, [])
+        }
+    }
+
+    func test_from_when_no_files_found_in_opaque_directory() async throws {
         try await withMockedDependencies {
             // Given
             let temporaryPath = try temporaryPath()
@@ -99,7 +128,7 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
             )
 
             // Then
-            XCTAssertPrinterOutputContains(
+            XCTAssertPrinterOutputNotContains(
                 "No files found at: \(assetsDirectory.appending(components: "**"))"
             )
             XCTAssertEqual(model, [])


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5552

### Short description 📝

Removes the "No files found at:" warning for resource globs that don't match anything. Warning remains for specific files (those that don't use a glob character).

### How to test the changes locally 🧐

1. Extract [ios_app_with_unmatched_glob.zip](https://github.com/user-attachments/files/20510983/ios_app_with_unmatched_glob.zip)
2. `tuist generate` in extracted fixture

Expected: warning for specific resource file missing, no warning for glob resource missing

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
