### PR TITLE
Tuist internal test might failed depending on user system language

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -71,7 +71,10 @@ func schemes() -> [Scheme] {
                     .map { .target($0) }
             ),
             testAction: .targets(
-                Module.allCases.flatMap(\.unitTestTargets).map { .testableTarget(target: .target($0.name)) }
+                Module.allCases.flatMap(\.unitTestTargets).map { .testableTarget(target: .target($0.name)) },
+                options: .options(
+                    language: "en"
+                )
             ),
             runAction: .runAction(
                 arguments: .arguments(


### PR DESCRIPTION
~Resolves <https://github.com/tuist/tuist/issues/YYY>~

### Short description 📝

In the test `test_load_app_bundle_when_decoding_info_plist_failed`, the underlying system error is passed by string using `localizedDescription` and thus depends on user system language.

This PR does not affect end users but rather help contributors have their tests green regardless of their system language.

Alternatively, if this solution is not accepted the test should rely on error code and domain rather than description.

### How to test the changes locally 🧐

- Change your system language to anything different that "en"
- Test `test_load_app_bundle_when_decoding_info_plist_failed` should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
