### PR TITLE
Fix sandbox failure on CI

### DIFF
--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -442,6 +442,7 @@ public class ManifestLoader: ManifestLoading {
                         [
                             path,
                             try await XcodeController.current.selected().path,
+                            AbsolutePath("/Library/Preferences/com.apple.dt.Xcode.plist"),
                             searchPaths.includeSearchPath,
                             searchPaths.librarySearchPath,
                             searchPaths.frameworkSearchPath,


### PR DESCRIPTION
### Short description 📝

Fixes `sandbox-exec` error: https://github.com/tuist/tuist/actions/runs/15422265184/job/43400222944

```
Swift/ErrorType.swift:254: Fatal error: Error raised at top level: The 'sandbox-exec' command exited with error code 69 and message:
You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license' from within a Terminal window to review and agree to the Xcode and Apple SDKs license.
```

### How to test the changes locally 🧐

1. Make this change in a PR: https://github.com/tuist/tuist/pull/7631/commits/89b1315a9fb238817f3c4b1342d1c47f50c0df08
2. Check the `Test` step of the PR's lint job on GitHub

Expected: call to `swift -h` succeeds (without the `(allow file-read* (path "/Library/Preferences/com.apple.dt.Xcode.plist"))` line it does not)

Failure: https://github.com/tuist/tuist/actions/runs/15428856555/job/43422377489?pr=7631
Success: https://github.com/tuist/tuist/actions/runs/15428883495/job/43422482178?pr=7631

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
