### PR TITLE
Fix an issue where building for testing would incorrectly determine there were no tests to run when building a scheme with multiple test plans and none specified

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -305,7 +305,8 @@ final class TestService { // swiftlint:disable:this type_body_length
                     await updateTestServiceAnalytics(
                         mapperEnvironment: mapperEnvironment,
                         schemes: [scheme],
-                        testPlanConfiguration: testPlanConfiguration
+                        testPlanConfiguration: testPlanConfiguration,
+                        action: action
                     )
                     return
                 } else {
@@ -319,7 +320,8 @@ final class TestService { // swiftlint:disable:this type_body_length
             await updateTestServiceAnalytics(
                 mapperEnvironment: mapperEnvironment,
                 schemes: [scheme],
-                testPlanConfiguration: testPlanConfiguration
+                testPlanConfiguration: testPlanConfiguration,
+                action: action
             )
 
             switch (
@@ -351,7 +353,8 @@ final class TestService { // swiftlint:disable:this type_body_length
             await updateTestServiceAnalytics(
                 mapperEnvironment: mapperEnvironment,
                 schemes: schemes,
-                testPlanConfiguration: testPlanConfiguration
+                testPlanConfiguration: testPlanConfiguration,
+                action: action
             )
         }
 
@@ -419,7 +422,8 @@ final class TestService { // swiftlint:disable:this type_body_length
             schemes
                 .filter {
                     !self.testActionTargetReferences(
-                        scheme: $0, testPlanConfiguration: testPlanConfiguration
+                        scheme: $0, testPlanConfiguration: testPlanConfiguration,
+                        action: action
                     ).isEmpty
                 }
 
@@ -427,7 +431,8 @@ final class TestService { // swiftlint:disable:this type_body_length
             for: schemes,
             testPlanConfiguration: testPlanConfiguration,
             mapperEnvironment: mapperEnvironment,
-            graph: graph
+            graph: graph,
+            action: action
         )
         else { return }
 
@@ -466,7 +471,7 @@ final class TestService { // swiftlint:disable:this type_body_length
             else { throw error }
 
             let testTargets = testActionTargets(
-                for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph
+                for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
             )
 
             let passingTestTargetNames = xcResultService.successfulTestTargets(
@@ -489,7 +494,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         if action != .build {
             try await storeSuccessfulTestHashes(
                 for: testActionTargets(
-                    for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph
+                    for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action
                 ),
                 graph: graph,
                 mapperEnvironment: mapperEnvironment,
@@ -511,12 +516,14 @@ final class TestService { // swiftlint:disable:this type_body_length
     private func updateTestServiceAnalytics(
         mapperEnvironment: MapperEnvironment,
         schemes: [Scheme],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
     ) async {
         let initialTestTargets = initialTestTargets(
             mapperEnvironment: mapperEnvironment,
             schemes: schemes,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            action: action
         )
 
         await RunMetadataStorage.current.update(
@@ -560,19 +567,22 @@ final class TestService { // swiftlint:disable:this type_body_length
         for schemes: [Scheme],
         testPlanConfiguration: TestPlanConfiguration?,
         mapperEnvironment: MapperEnvironment,
-        graph: Graph
+        graph: Graph,
+        action: XcodeBuildTestAction
     ) -> Bool {
         let testActionTargets = testActionTargets(
             for: schemes,
             testPlanConfiguration: testPlanConfiguration,
-            graph: graph
+            graph: graph,
+            action: action
         )
         .map(\.target)
 
         let skippedTestTargets = initialTestTargets(
             mapperEnvironment: mapperEnvironment,
             schemes: schemes,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            action: action
         )
         .filter { target in
             !testActionTargets.contains(where: {
@@ -584,7 +594,7 @@ final class TestService { // swiftlint:disable:this type_body_length
             schemes
                 .filter {
                     !self.testActionTargetReferences(
-                        scheme: $0, testPlanConfiguration: testPlanConfiguration
+                        scheme: $0, testPlanConfiguration: testPlanConfiguration, action: action
                     ).isEmpty
                 }
 
@@ -606,7 +616,8 @@ final class TestService { // swiftlint:disable:this type_body_length
     private func initialTestTargets(
         mapperEnvironment: MapperEnvironment,
         schemes: [Scheme],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
     ) -> [GraphTarget] {
         guard let initialGraph = mapperEnvironment.initialGraph else { return [] }
         let initialSchemes = GraphTraverser(graph: initialGraph).schemes()
@@ -617,19 +628,21 @@ final class TestService { // swiftlint:disable:this type_body_length
                     schemes.contains(where: { $0.name == initialScheme.name })
                 },
             testPlanConfiguration: testPlanConfiguration,
-            graph: initialGraph
+            graph: initialGraph,
+            action: action
         )
     }
 
     private func testActionTargets(
         for schemes: [Scheme],
         testPlanConfiguration: TestPlanConfiguration?,
-        graph: Graph
+        graph: Graph,
+        action: XcodeBuildTestAction
     ) -> [GraphTarget] {
         return
             schemes
                 .flatMap {
-                    testActionTargetReferences(scheme: $0, testPlanConfiguration: testPlanConfiguration)
+                    testActionTargetReferences(scheme: $0, testPlanConfiguration: testPlanConfiguration, action: action)
                 }
                 .compactMap {
                     guard let project = graph.projects[$0.projectPath],
@@ -643,7 +656,8 @@ final class TestService { // swiftlint:disable:this type_body_length
 
     private func testActionTargetReferences(
         scheme: Scheme,
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        action: XcodeBuildTestAction
     ) -> [TargetReference] {
         let targets =
             if let testPlanConfiguration {
@@ -651,6 +665,9 @@ final class TestService { // swiftlint:disable:this type_body_length
                     .first(
                         where: { $0.name == testPlanConfiguration.testPlan }
                     )?.testTargets.map(\.target) ?? []
+            } else if action == .build, let testplans = scheme.testAction?.testPlans {
+                // If we are building a scheme that has testplans but none specified then we should return all test targets
+                testplans.flatMap(\.testTargets).map(\.target)
             } else if let defaultTestPlan = scheme.testAction?.testPlans?.first(where: {
                 $0.isDefault
             }) {


### PR DESCRIPTION
### Short description 📝

Fix an issue where building for testing would incorrectly determine there were no tests to run when building a scheme with multiple test plans and none specified

### How to test the changes locally 🧐

1. Have a project that contains a scheme with 2 test plans
2. Run the tests for both test plans so that they are cached
3. Make a change to a test target in the test plan that is not the default
4. Previously, tuist would exit early saying there are no tests to run
5. Now, it correctly builds the targets for testing

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
