### PR TITLE
Ignore missing glob directory for resources and additional files

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -21,13 +21,19 @@ extension XcodeGraph.CopyFileElement {
         func globFiles(_ path: AbsolutePath) async throws -> [AbsolutePath] {
             if try await fileSystem.exists(path), !FileHandler.shared.isFolder(path) { return [path] }
 
-            let files = try await fileSystem.throwingGlob(
-                directory: AbsolutePath.root,
-                include: [String(path.pathString.dropFirst())]
-            )
-            .collect()
-            .filter(includeFiles)
-            .sorted()
+            let files: [AbsolutePath]
+
+            do {
+                files = try await fileSystem.throwingGlob(
+                    directory: AbsolutePath.root,
+                    include: [String(path.pathString.dropFirst())]
+                )
+                .collect()
+                .filter(includeFiles)
+                .sorted()
+            } catch GlobError.nonExistentDirectory {
+                files = []
+            }
 
             if files.isEmpty {
                 if FileHandler.shared.isFolder(path) {

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -30,11 +30,17 @@ extension XcodeGraph.ResourceFileElement {
                 excluded.formUnion(globs)
             }
 
-            let files = try await fileSystem
-                .throwingGlob(directory: .root, include: [String(path.pathString.dropFirst())])
-                .collect()
-                .filter(includeFiles)
-                .filter { !excluded.contains($0) }
+            let files: [AbsolutePath]
+
+            do {
+                files = try await fileSystem
+                    .throwingGlob(directory: .root, include: [String(path.pathString.dropFirst())])
+                    .collect()
+                    .filter(includeFiles)
+                    .filter { !excluded.contains($0) }
+            } catch GlobError.nonExistentDirectory {
+                files = []
+            }
 
             if files.isEmpty {
                 if FileHandler.shared.isFolder(path) {

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/CopyFileElement+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/CopyFileElement+ManifestMapperTests.swift
@@ -97,7 +97,7 @@ final class CopyFileElementManifestMapperTests: TuistUnitTestCase {
         }
     }
 
-    func test_throws_when_the_glob_is_invalid() async throws {
+    func test_from_outputs_empty_when_the_glob_is_invalid() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         let rootDirectory = temporaryPath
@@ -106,21 +106,15 @@ final class CopyFileElementManifestMapperTests: TuistUnitTestCase {
             rootDirectory: rootDirectory
         )
         let manifest = ProjectDescription.CopyFileElement.glob(pattern: "invalid/path/**/*")
-        let invalidGlob = InvalidGlob(
-            pattern: temporaryPath.appending(try RelativePath(validating: "invalid/path/**/*"))
-                .pathString,
-            nonExistentPath: temporaryPath.appending(try RelativePath(validating: "invalid/path/"))
+
+        // When
+        let got = try await XcodeGraph.CopyFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
         )
-        let error = GlobError.nonExistentDirectory(invalidGlob)
 
         // Then
-        await XCTAssertThrowsSpecific(
-            try await XcodeGraph.CopyFileElement.from(
-                manifest: manifest,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            ),
-            error
-        )
+        XCTAssertEmpty(got)
     }
 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
@@ -123,7 +123,7 @@ final class FileElementManifestMapperTests: TuistUnitTestCase {
         }
     }
 
-    func test_throws_when_the_glob_is_invalid() async throws {
+    func test_from_outputs_empty_when_the_glob_is_invalid() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         let rootDirectory = temporaryPath
@@ -132,21 +132,15 @@ final class FileElementManifestMapperTests: TuistUnitTestCase {
             rootDirectory: rootDirectory
         )
         let manifest = ProjectDescription.FileElement.glob(pattern: "invalid/path/**/*")
-        let invalidGlob = InvalidGlob(
-            pattern: temporaryPath.appending(try RelativePath(validating: "invalid/path/**/*"))
-                .pathString,
-            nonExistentPath: temporaryPath.appending(try RelativePath(validating: "invalid/path/"))
+
+        // When
+        let got = try await XcodeGraph.FileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
         )
-        let error = GlobError.nonExistentDirectory(invalidGlob)
 
         // Then
-        await XCTAssertThrowsSpecific(
-            try await XcodeGraph.FileElement.from(
-                manifest: manifest,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            ),
-            error
-        )
+        XCTAssertEmpty(got)
     }
 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -231,7 +231,7 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         }
     }
 
-    func test_throws_when_the_glob_is_invalid() async throws {
+    func test_from_outputs_empty_when_the_glob_is_invalid() async throws {
         // Given
         let temporaryPath = try temporaryPath()
         let rootDirectory = temporaryPath
@@ -247,15 +247,15 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         )
         let error = GlobError.nonExistentDirectory(invalidGlob)
 
-        // Then
-        await XCTAssertThrowsSpecific(
-            try await XcodeGraph.ResourceFileElement.from(
-                manifest: manifest,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            ),
-            error
+        // When
+        let got = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
         )
+
+        // Then
+        XCTAssertEmpty(got)
     }
 
     func test_excluding_file() async throws {

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
@@ -10,21 +10,6 @@ import XCTest
 @testable import TuistTesting
 
 final class TargetManifestMapperErrorTests: TuistUnitTestCase {
-    func test_description_when_invalidResourcesGlob() {
-        // Given
-        let invalidGlobs: [InvalidGlob] = [.init(pattern: "/path/**/*", nonExistentPath: "/path/")]
-        let subject = TargetManifestMapperError.invalidResourcesGlob(targetName: "Target", invalidGlobs: invalidGlobs)
-
-        // When
-        let got = subject.description
-
-        // Then
-        XCTAssertEqual(
-            got,
-            "The target Target has the following invalid resource globs:\n" + invalidGlobs.invalidGlobsDescription
-        )
-    }
-
     func test_description_when_nonSpecificGeneratedResource() {
         // Given
         let path = try! AbsolutePath(validating: "/path/to/A")


### PR DESCRIPTION
### Short description 📝

Ignores missing glob directories in resources and additional files, instead of printing a warning or failing with an error.

This change is more extensive than [my previous one](https://github.com/tuist/tuist/pull/7611).

### How to test the changes locally 🧐

#### To test changes

1. Unzip [ios_app_with_invalid_globs.zip](https://github.com/user-attachments/files/20593210/ios_app_with_invalid_globs.zip)
2. Generate with new version of Tuist: `tuist generate -p ios_app_with_invalid_globs`

Expected: successful

3. Uncomment the line `"invalid/sources/**",` in the fixture and regenerate:

(desired error, we're not ignoring missing glob directories for sources)

```
✖ Error 
  The target App has the following invalid source files globs: 
  - The directory "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/sources" defined in the glob pattern "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/sources/**" does not exist. 
```

#### To repro existing problem

1. Unzip [ios_app_with_invalid_globs.zip](https://github.com/user-attachments/files/20593210/ios_app_with_invalid_globs.zip)
2. Generate with previous version of Tuist: `tuist generate -p ios_app_with_invalid_globs`

```
✖ Error
  The target App has the following invalid resource globs:
  - The directory "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/resources" defined in the glob pattern "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/resources/**" does not exist.
```

5. Comment out the line `"invalid/resources/**",` and regenerate:

```
✖ Error
  The directory "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/additional" defined in the glob pattern "/Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/invalid/additional/**" does not exist.
```

6. Add `"Additional/**"` to the resources array and create a `Additional` directory in the fixture, then regenerate:

```
! Warning

  The following items may need attention:
   ▸ No files found at: /Users/hcampbell/Developer/tuist/fixtures/ios_app_with_invalid_globs/Additional/**
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
