### PR TITLE
Fix App Device Build pipeline in forks

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -351,6 +351,7 @@ jobs:
           key: ${{ runner.os }}-tuist-${{ hashFiles('Package.resolved') }}
           restore-keys: .build
       - name: Activate .env.json
+        if: env.TUIST_CONFIG_TOKEN != ''
         run: cp .optional.env.json .env.json
       - uses: jdx/mise-action@v2
         with:


### PR DESCRIPTION
### Short description 📝

Missed one place to add the `TUIST_CONFIG_TOKEN` conditional that is still breaking the `App Device Build` workflow in forks: https://github.com/tuist/tuist/actions/runs/15455371641/job/43506523210?pr=7642

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
