### PR TITLE
Fix redundant import check for UITests with host application

### DIFF
--- a/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -100,7 +100,7 @@ final class GraphImportsLinter: GraphImportsLinting {
                 !$0.target.bundleId.hasSuffix(".generated.resources")
             }
             .filter {
-                !(target.target.product == .app && $0.target.product == .uiTests)
+                !(target.target.product == .uiTests && $0.target.product == .app)
             }
             .map { targetDependency in
                 if case .external = targetDependency.graphTarget.project.type { return graphTraverser

--- a/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
@@ -162,18 +162,18 @@ final class LintRedundantImportsServiceTests: TuistUnitTestCase {
         let config = Tuist.test()
         let uiTests = Target.test(
             name: "UITests",
-            product: .uiTests
+            product: .uiTests,
+            dependencies: [TargetDependency.target(name: "App")]
         )
 
         let app = Target.test(
             name: "App",
-            product: .app,
-            dependencies: [TargetDependency.target(name: "UITests")]
+            product: .app
         )
         let project = Project.test(path: path, targets: [uiTests, app])
         let graph = Graph.test(path: path, projects: [path: project], dependencies: [
-            .target(name: app.name, path: project.path): [
-                .target(name: uiTests.name, path: project.path),
+            .target(name: uiTests.name, path: project.path): [
+                .target(name: app.name, path: project.path),
             ],
         ])
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/pull/7628>

### Short description 📝

Accidentally, in previous PR I removed connection from UITest to App, which actually doesnt have any sense. In this PR I fixed it and remove connection from App to UITest target. 

> Describe here the purpose of your PR.

To fix redundant dependencies check and remove redundant dependencies that are not relevant

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).

### Contributor checklist ✅

- [ ✅] The code has been linted using run `mise run lint-fix`
- [ ✅] The change is tested via unit testing or acceptance testing, or both
- [ ✅] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ✅] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
