### PR TITLE
Attempt to fix token renewals

### DIFF
--- a/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -74,7 +74,7 @@ struct ServerClientAuthenticationMiddleware: ClientMiddleware {
                 Logger.current.debug("Access token expires in less than \(expiresIn) seconds. Renewing...")
                 if isExpired {
                     guard let refreshToken else { throw ServerClientAuthenticationError.notAuthenticated }
-                    tokenValue = try await cachedValueStore.getValue(key: refreshToken.token) {
+                    tokenValue = try await cachedValueStore.getValue(key: "token_refresh_\(baseURL.absoluteString)") {
                         Logger.current.debug("Refreshing access token for \(baseURL)")
                         let tokens = try await refreshTokens(baseURL: baseURL, refreshToken: refreshToken)
                         Logger.current.debug("Access token refreshed for \(baseURL)")

--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -61,7 +61,7 @@ extension Logger {
         let fileLogger = try FileLogging(to: logFilePath.url)
 
         let baseLoggers = { (label: String) -> [any LogHandler] in
-            var fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
+            let fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
 
             var loggers: [any LogHandler] = [fileLogHandler]
             // OSLog is not needed in development.


### PR DESCRIPTION
There is a bug in the CLI that causes the local environment to terminate with an invalid refresh token, most likely due to a race condition; however, I am unable to visualize the specific race condition scenario. This PR does two things:

- Adds logs to help diagnose the issue
- Attempts to fix the issue by using a more generic key. I don't think we need to be that specific using the refresh token as a key, since at the end of the day, the logic needs the latest refresh (and persisted) token, regardless of the refresh token it got renewed from.