### PR TITLE
Enforce single line comment system

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -46,3 +46,5 @@
 --wrapcollections before-first
 --wrapconditions after-first
 --wrapparameters before-first
+--enable blockComments
+--enable docComments

--- a/Package.swift
+++ b/Package.swift
@@ -491,17 +491,17 @@ let package = Package(
             name: "TuistCache",
             targets: ["TuistCache"]
         ),
-        /// TuistGenerator
-        ///
-        /// A high level Xcode generator library
-        /// responsible for generating Xcode projects & workspaces.
-        ///
-        /// This library can be used in external tools that wish to
-        /// leverage Tuist's Xcode generation features.
-        ///
-        /// Note: This library should be treated as **unstable** as
-        ///       it is still under development and may include breaking
-        ///       changes in future releases.
+        // TuistGenerator
+        //
+        // A high level Xcode generator library
+        // responsible for generating Xcode projects & workspaces.
+        //
+        // This library can be used in external tools that wish to
+        // leverage Tuist's Xcode generation features.
+        //
+        // Note: This library should be treated as **unstable** as
+        //       it is still under development and may include breaking
+        //       changes in future releases.
         .library(
             name: "TuistGenerator",
             targets: ["TuistGenerator"]

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -55,7 +55,9 @@ extension Environment.Value? {
 }
 
 extension String {
-    // Taken from https://github.com/apple/swift/blob/88b093e9d77d6201935a2c2fb13f27d961836777/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L161
+    /// Convert from "camelCaseKeys" to "snake_case_keys".
+    ///
+    /// Reference:  https://github.com/apple/swift/blob/88b093e9d77d6201935a2c2fb13f27d961836777/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L161
     fileprivate func camelCaseToSnakeCase() -> String {
         guard !isEmpty else { return self }
 

--- a/Sources/ProjectDescription/Package.swift
+++ b/Sources/ProjectDescription/Package.swift
@@ -215,7 +215,7 @@ extension Package {
     ///
     /// - Returns: A `Package` instance.
     public static func package(id: String, _ range: ClosedRange<Version>) -> Package {
-        // Increase upperbound's patch version by one.
+        // Increase upper-bound's patch version by one.
         let upper = range.upperBound
         let upperBound = Version(
             upper.major, upper.minor, upper.patch + 1,
@@ -227,6 +227,7 @@ extension Package {
 }
 
 // Mark common APIs used by mistake as unavailable to provide better error messages.
+
 extension Package {
     @available(*, unavailable, message: "use package(url:_:) with the .exact(Version) initializer instead")
     public static func package(url _: String, version _: Version) -> Package {

--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -36,10 +36,10 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// explicit.
     public var productDestinations: [String: Destinations]
 
-    // The base settings to be used for targets generated from SwiftPackageManager
+    /// The base settings to be used for targets generated from SwiftPackageManager
     public var baseSettings: Settings
 
-    // Additional settings to be added to targets generated from SwiftPackageManager.
+    /// Additional settings to be added to targets generated from SwiftPackageManager.
     public var targetSettings: [String: Settings]
 
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.

--- a/Sources/ProjectDescription/Product.swift
+++ b/Sources/ProjectDescription/Product.swift
@@ -32,10 +32,11 @@ public enum Product: String, Codable, Equatable, Sendable {
     case messagesExtension
     /// A sticker pack extension.
     case stickerPackExtension = "sticker_pack_extension"
-    //    case watchApp
-    //    case watchExtension
-    //    case tvIntentsExtension
-    //    case messagesApplication
+    // case watchApp
+    // case watchExtension
+    // case tvIntentsExtension
+    // case messagesApplication
+
     /// An XPC. (macOS platform only).
     case xpc
     /// An system extension. (macOS platform only).

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -58,7 +58,7 @@ public struct RunActionOptions: Equatable, Codable, Sendable {
     ///     - storeKitConfigurationPath: The path of the
     ///     [StoreKit configuration
     /// file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).
-    ///     Please note that this file is automatically added to the Project/Workpace. You should not add it manually.
+    ///     Please note that this file is automatically added to the Project/Workspace. You should not add it manually.
     ///     The default value is `nil`, which results in no configuration defined for the scheme
     ///
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
@@ -66,8 +66,7 @@ public struct RunActionOptions: Equatable, Codable, Sendable {
     ///
     ///     - enableGPUFrameCaptureMode: The Metal Frame Capture mode to use. e.g: .disabled
     ///     If your target links to the Metal framework, Xcode enables GPU Frame Capture.
-    ///     You can disable it to test your app in best perfomance.
-
+    ///     You can disable it to test your app in best performance.
     public static func options(
         language: SchemeLanguage? = nil,
         region: String? = nil,

--- a/Sources/ProjectDescription/SchemeLanguage.swift
+++ b/Sources/ProjectDescription/SchemeLanguage.swift
@@ -16,6 +16,7 @@ public struct SchemeLanguage: Codable, Equatable, ExpressibleByStringLiteral, Se
 }
 
 // Pre-defined languages
+
 extension SchemeLanguage {
     public static var doubleLengthPseudoLanguage: SchemeLanguage {
         SchemeLanguage(identifier: "IDELaunchSchemeLanguageDoubleLocalizedStrings")

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -84,7 +84,6 @@ public struct SourceFileGlob: Codable, Equatable, Sendable {
     ///   - compilerFlags: The compiler flags to be set to the source files in the sources build phase.
     ///   - codeGen: The source file attribute to be set in the build phase.
     ///   - compilationCondition: Condition for file compilation.
-
     public static func generated(
         _ path: Path,
         compilerFlags: String? = nil,

--- a/Sources/ProjectDescription/Workspace.swift
+++ b/Sources/ProjectDescription/Workspace.swift
@@ -19,7 +19,6 @@
 ///     projects: ["Projects/**"]
 /// )
 /// ```
-
 public struct Workspace: Codable, Equatable, Sendable {
     /// The name of the workspace. Also, the file name of the generated Xcode workspace.
     public let name: String

--- a/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
+++ b/Sources/TuistAsyncQueue/AsyncQueuePersistor.swift
@@ -72,13 +72,12 @@ final class AsyncQueuePersistor: AsyncQueuePersisting {
                   let timestamp = Double(components[0]),
                   let id = UUID(uuidString: String(components[2]))
             else {
-                /// Changing the naming convention is a breaking change. When detected
-                /// we delete the event.
+                // Changing the naming convention is a breaking change. When detected we delete the event.
                 try? await fileSystem.remove(eventPath)
                 return nil
             }
 
-            // We delete events that are older than a day to ensure the directory doesn't grow indefinitely if events continuosly
+            // We delete events that are older than a day to ensure the directory doesn't grow indefinitely if events continuously
             // fail to be uploaded.
             let date = Date(timeIntervalSince1970: timestamp)
             if dateService.now().timeIntervalSince(date) > 24 * 60 * 60 {

--- a/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -88,7 +88,7 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
         let product = target.target.product
         let name = target.target.name
 
-        /** The second condition is to exclude the resources bundle associated to the given target name */
+        // The second condition is to exclude the resources bundle associated to the given target name
         let isExcluded = excludedTargets.contains(name) || excludedTargets
             .contains(target.target.name.dropPrefix("\(target.project.name)_"))
         let dependsOnXCTest = graphTraverser.dependsOnXCTest(path: target.path, name: name)

--- a/Sources/TuistCore/Automation/XcodeBuildSettings.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildSettings.swift
@@ -77,17 +77,21 @@ extension XcodeBuildSettings: CustomStringConvertible {
 
 extension XcodeBuildSettings: Collection {
     // Required nested types, that tell Swift what our collection contains
+
     public typealias Index = DictionaryType.Index
     public typealias Element = DictionaryType.Element
 
     // The upper and lower bounds of the collection, used in iterations
+
     public var startIndex: Index { settings.startIndex }
     public var endIndex: Index { settings.endIndex }
 
     // Required subscript, based on a dictionary index
+
     public subscript(index: Index) -> Iterator.Element { settings[index] }
 
     // Method that returns the next index when iterating
+
     public func index(after i: Index) -> Index {
         settings.index(after: i)
     }

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -114,8 +114,8 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         Synthesized(dependencyReference: lhs) < Synthesized(dependencyReference: rhs)
     }
 
-    // Private helper type to auto-synthesize the hashable & comparable implementations
-    // where only the required subset of properties are used.
+    /// Private helper type to auto-synthesize the hashable & comparable implementations
+    /// where only the required subset of properties are used.
     private enum Synthesized: Comparable, Hashable {
         case macro(path: AbsolutePath)
         case sdk(path: AbsolutePath, condition: PlatformCondition?)

--- a/Sources/TuistCore/Graph/GraphLoadingError.swift
+++ b/Sources/TuistCore/Graph/GraphLoadingError.swift
@@ -33,6 +33,7 @@ enum GraphLoadingError: FatalError, Equatable {
     }
 
     // Custom equatable to ignore ordering of circular dependency
+
     public static func == (lhs: GraphLoadingError, rhs: GraphLoadingError) -> Bool {
         switch (lhs, rhs) {
         case let (.missingFile(lhsPath), .missingFile(rhsPath)):

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -318,7 +318,7 @@ public class GraphTraverser: GraphTraversing {
         }
     }
 
-    // Filter based on edges
+    /// Filter based on edges
     public func directStaticDependencies(path: Path.AbsolutePath, name: String) -> Set<
         GraphDependencyReference
     > {
@@ -350,7 +350,7 @@ public class GraphTraverser: GraphTraversing {
 
         var references = Set<GraphDependencyReference>()
 
-        /// Precompiled frameworks
+        // Precompiled frameworks
         var precompiledFrameworks = filterDependencies(
             from: .target(name: name, path: path),
             test: \.isPrecompiledDynamicAndLinkable,
@@ -375,7 +375,7 @@ public class GraphTraverser: GraphTraversing {
             }
         )
 
-        /// Other targets' frameworks.
+        // Other targets' frameworks.
         var otherTargetFrameworks = filterDependencies(
             from: .target(name: name, path: path),
             test: isEmbeddableDependencyTarget,

--- a/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
@@ -44,11 +44,11 @@ public protocol PrecompiledMetadataProviding {
     func uuids(binaryPath: AbsolutePath) throws -> Set<UUID>
 }
 
-/// PrecompiledMetadataProvider reads a framework/library metadata using the Mach-o file format.
+/// `PrecompiledMetadataProvider` reads a framework/library metadata using the Mach-o file format.
+///
 /// Useful documentation:
 /// - https://opensource.apple.com/source/cctools/cctools-809/misc/lipo.c
 /// - https://opensource.apple.com/source/xnu/xnu-4903.221.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
-
 public class PrecompiledMetadataProvider: PrecompiledMetadataProviding {
     public func architectures(binaryPath: AbsolutePath) throws -> [BinaryArchitecture] {
         let metadata = try readMetadatas(binaryPath: binaryPath)

--- a/Sources/TuistCore/Models/PackageSettings.swift
+++ b/Sources/TuistCore/Models/PackageSettings.swift
@@ -9,13 +9,13 @@ public struct PackageSettings: Equatable, Codable {
     /// Custom destinations to be used for SPM products.
     public let productDestinations: [String: Destinations]
 
-    // The base settings to be used for targets generated from SwiftPackageManager
+    /// The base settings to be used for targets generated from SwiftPackageManager.
     public let baseSettings: Settings
 
-    /// The custom `Settings` to be applied to SPM targets
+    /// The custom `Settings` to be applied to SPM targets.
     public let targetSettings: [String: Settings]
 
-    /// The custom project options for each project generated from a swift package
+    /// The custom project options for each project generated from a swift package.
     public let projectOptions: [String: XcodeGraph.Project.Options]
 
     /// Initializes a new `PackageSettings` instance.

--- a/Sources/TuistCore/Models/TestIdentifier.swift
+++ b/Sources/TuistCore/Models/TestIdentifier.swift
@@ -5,6 +5,7 @@ public struct TestIdentifier: CustomStringConvertible, Hashable {
         case invalidTestIdentifier(value: String)
 
         // Error description
+
         var description: String {
             switch self {
             case let .invalidTestIdentifier(value):
@@ -13,6 +14,7 @@ public struct TestIdentifier: CustomStringConvertible, Hashable {
         }
 
         // Error type
+
         var type: ErrorType {
             switch self {
             case .invalidTestIdentifier:

--- a/Sources/TuistCore/Models/Tuist.swift
+++ b/Sources/TuistCore/Models/Tuist.swift
@@ -20,10 +20,10 @@ public struct Tuist: Equatable, Hashable {
     /// When no project is provided, Tuist defaults to the workspace or project in the current directory.
     public let project: TuistProject
 
-    /// The full project handle such as tuist-org/tuist.
+    /// The full project handle such as "tuist-org/tuist".
     public let fullHandle: String?
 
-    /// The base URL that points to the Tuist server.
+    /// The base `URL` that points to the Tuist server.
     public let url: URL
 
     /// Returns the default Tuist configuration.
@@ -35,10 +35,12 @@ public struct Tuist: Equatable, Hashable {
         )
     }
 
-    /// Initializes the tuist cofiguration.
+    /// Initializes the tuist configuration.
     ///
     /// - Parameters:
-
+    ///   - project: The `TuistProject` instance that represents the project Tuist will interact with.
+    ///   - fullHandle: An optional string representing the full handle of the project, such as "tuist-org/tuist".
+    ///   - url: The base `URL` pointing to the Tuist server.
     public init(
         project: TuistProject,
         fullHandle: String?,

--- a/Sources/TuistCore/Simulator/SimulatorRuntime.swift
+++ b/Sources/TuistCore/Simulator/SimulatorRuntime.swift
@@ -18,13 +18,13 @@ public struct SimulatorRuntime: Equatable, Codable, Hashable, CustomStringConver
     /// Runtime identifier (e.g. com.apple.CoreSimulator.SimRuntime.iOS-13-5)
     public let identifier: String
 
-    /// Runtime version (e.g. 13.5)
+    /// Runtime version (e.g. 13.5).
     public let version: SimulatorRuntimeVersion
 
-    // True if the runtime is available.
+    /// `True` if the runtime is available.
     public let isAvailable: Bool
 
-    // Name of the runtime (e.g. iOS 13.5)
+    /// Name of the runtime (e.g. iOS 13.5).
     public let name: String
 
     public var platform: Platform? {

--- a/Sources/TuistGenerator/Extensions/Target+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Target+Extras.swift
@@ -1,18 +1,18 @@
 import XcodeGraph
 
 extension Target {
-    // CoreData models are typically added to the sources build phase
-    // and Xcode automatically bundles the models.
-    // For static libraries / frameworks however, they don't support resources,
-    // the models could be bundled in a stand alone `.bundle`
-    // as resources.
-    //
-    // e.g.
-    // MyStaticFramework (.staticFramework) -> Includes CoreData models as sources
-    // MyStaticFrameworkResources (.bundle) -> Includes CoreData models as resources
-    //
-    // - Note: Technically, CoreData models can be added a sources build phase in a `.bundle`
-    // but that will result in the `.bundle` having an executable, which is not valid on iOS.
+    /// CoreData models are typically added to the sources build phase
+    /// and Xcode automatically bundles the models.
+    /// For static libraries / frameworks however, they don't support resources,
+    /// the models could be bundled in a stand alone `.bundle`
+    /// as resources.
+    ///
+    /// e.g.
+    /// MyStaticFramework (.staticFramework) -> Includes CoreData models as sources
+    /// MyStaticFrameworkResources (.bundle) -> Includes CoreData models as resources
+    ///
+    /// - Note: Technically, CoreData models can be added a sources build phase in a `.bundle`
+    /// but that will result in the `.bundle` having an executable, which is not valid on iOS.
     var shouldCoreDataModelsBeSources: Bool {
         switch product {
         case .stickerPackExtension, .watch2App:

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -71,14 +71,14 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             )
         }
 
-        /**
-         Targets that depend on a Swift Macro have the following dependency graph:
-         - Target -> MyMacro (Static framework) -> MyMacro (Executable)
-         - or, in some cases, they directly depend on the executable: Target -> MyMacro (Executable)
-
-         The executable is compiled transitively through the static library, and we place it inside the framework to make it available to the target depending on the framework
-         to point it with the `-load-plugin-executable $(BUILD_DIR)/$(CONFIGURATION)/ExecutableName\#ExecutableName` build setting.
-         */
+        // Targets that depend on a Swift Macro have the following dependency graph:
+        // - Target -> MyMacro (Static framework) -> MyMacro (Executable)
+        // - or, in some cases, they directly depend on the executable: Target -> MyMacro (Executable)
+        //
+        // The executable is compiled transitively through the static library, and we place it inside the framework to make it
+        // available to the target depending on the framework
+        // to point it with the `-load-plugin-executable $(BUILD_DIR)/$(CONFIGURATION)/ExecutableName\#ExecutableName` build
+        // setting.
         let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
         try generateCopySwiftMacroExecutableScriptBuildPhase(
             directSwiftMacroExecutables: directSwiftMacroExecutables,
@@ -283,8 +283,8 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                 settings["COMPILER_FLAGS"] = .string(compilerFlags)
             }
 
-            /// Source file ATTRIBUTES
-            /// example: `settings = {ATTRIBUTES = (codegen, )`}
+            // Source file ATTRIBUTES
+            // example: `settings = {ATTRIBUTES = (codegen, )}`
             if let codegen = buildFile.codeGen {
                 settings["ATTRIBUTES"] = .array([codegen.rawValue])
             }
@@ -416,8 +416,8 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
                 var settings: [String: BuildFileSetting]?
 
-                /// File ATTRIBUTES
-                /// example: `settings = {ATTRIBUTES = (Codesign, )`}
+                // File ATTRIBUTES
+                // example: `settings = {ATTRIBUTES = (Codesign, )}`
                 if file.codeSignOnCopy {
                     settings = ["ATTRIBUTES": ["CodeSignOnCopy"]]
                 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -45,7 +45,7 @@ final class ConfigGenerator: ConfigGenerating {
         pbxproj: PBXProj,
         fileElements: ProjectFileElements
     ) async throws -> XCConfigurationList {
-        /// Configuration list
+        // Configuration list
         let defaultConfiguration = project.settings.defaultReleaseBuildConfiguration()
             ?? project.settings.defaultDebugBuildConfiguration()
         let configurationList = XCConfigurationList(

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -219,7 +219,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             nativeTargets[target.name] = nativeTarget
         }
 
-        /// Target dependencies
+        // Target dependencies
         try targetGenerator.generateTargetDependencies(
             path: project.path,
             targets: Array(project.targets.values),
@@ -318,17 +318,17 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         // BuildIndependentTargetsInParallel
         attributes["BuildIndependentTargetsInParallel"] = "YES"
 
-        /// Organization name
+        // Organization name
         if let organizationName = project.organizationName {
             attributes["ORGANIZATIONNAME"] = .string(organizationName)
         }
 
-        /// Class prefix
+        // Class prefix
         if let classPrefix = project.classPrefix {
             attributes["CLASSPREFIX"] = .string(classPrefix)
         }
 
-        /// Last upgrade check
+        // Last upgrade check
         if let lastUpgradeCheck = project.lastUpgradeCheck {
             attributes["LastUpgradeCheck"] = .string(lastUpgradeCheck.xcodeStringValue)
         }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -70,7 +70,7 @@ class ProjectFileElements {
             one.path < two.path
         }
 
-        /// Files
+        // Files
         try generate(
             files: sortedFiles,
             groups: groups,
@@ -98,7 +98,7 @@ class ProjectFileElements {
     func projectFiles(project: Project) -> Set<GroupFileElement> {
         var fileElements = Set<GroupFileElement>()
 
-        /// Config files
+        // Config files
         let configFiles = project.settings.configurations.values.compactMap { $0?.xcconfig }
 
         fileElements.formUnion(configFiles.map {

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -89,7 +89,7 @@ class ProjectGroups {
         project: Project,
         pbxproj: PBXProj
     ) -> ProjectGroups {
-        /// Main
+        // Main
         let projectRelativePath = project.sourceRootPath.relative(to: project.xcodeProjPath.parentDirectory).pathString
         let textSettings = project.options.textSettings
         let mainGroup = PBXGroup(
@@ -103,7 +103,7 @@ class ProjectGroups {
         )
         pbxproj.add(object: mainGroup)
 
-        /// Project & Target Groups
+        // Project & Target Groups
         let projectGroupNames = extractProjectGroupNames(from: project)
         let groupsToCreate = OrderedSet(projectGroupNames)
         var projectGroups = [(name: String, group: PBXGroup)]()
@@ -114,20 +114,20 @@ class ProjectGroups {
             projectGroups.append((item, projectGroup))
         }
 
-        /// Products
-        /// If the products group is the last non-empty group, it will not appear.
-        /// This appears to be an Xcode bug that is still there as of Xcode 15.3
-        /// https://developer.apple.com/forums/thread/77406
+        // Products
+        // If the products group is the last non-empty group, it will not appear.
+        // This appears to be an Xcode bug that is still there as of Xcode 15.3
+        // https://developer.apple.com/forums/thread/77406
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
         pbxproj.add(object: productsGroup)
         mainGroup.children.append(productsGroup)
 
-        /// SDSKs & Pre-compiled frameworks
+        // SDSKs & Pre-compiled frameworks
         let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
         pbxproj.add(object: frameworksGroup)
         mainGroup.children.append(frameworksGroup)
 
-        /// Cached frameworks
+        // Cached frameworks
         let cacheGroup = PBXGroup(children: [], sourceTree: .group, name: "Cache")
         pbxproj.add(object: cacheGroup)
         mainGroup.children.append(cacheGroup)

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -60,10 +60,10 @@ final class TargetGenerator: TargetGenerating {
         path: AbsolutePath,
         graphTraverser: GraphTraversing
     ) async throws -> PBXNativeTarget {
-        /// Products reference.
+        // Products reference.
         let productFileReference = fileElements.products[target.name]!
 
-        /// Target
+        // Target
         let pbxTarget = PBXNativeTarget(
             name: target.name,
             buildConfigurationList: nil,
@@ -78,7 +78,7 @@ final class TargetGenerator: TargetGenerating {
         pbxproj.add(object: pbxTarget)
         pbxProject.targets.append(pbxTarget)
 
-        /// Pre actions
+        // Pre actions
         try buildPhaseGenerator.generateScripts(
             target.scripts.preScripts,
             pbxTarget: pbxTarget,
@@ -86,7 +86,7 @@ final class TargetGenerator: TargetGenerating {
             sourceRootPath: project.sourceRootPath
         )
 
-        /// Build configuration
+        // Build configuration
         try await configGenerator.generateTargetConfig(
             target,
             project: project,
@@ -98,7 +98,7 @@ final class TargetGenerator: TargetGenerating {
             sourceRootPath: project.sourceRootPath
         )
 
-        /// Build phases
+        // Build phases
         try buildPhaseGenerator.generateBuildPhases(
             path: path,
             target: target,
@@ -108,7 +108,7 @@ final class TargetGenerator: TargetGenerating {
             pbxproj: pbxproj
         )
 
-        /// Links
+        // Links
         try linkGenerator.generateLinks(
             target: target,
             pbxTarget: pbxTarget,
@@ -119,7 +119,7 @@ final class TargetGenerator: TargetGenerating {
             graphTraverser: graphTraverser
         )
 
-        /// Post actions
+        // Post actions
         try buildPhaseGenerator.generateScripts(
             target.scripts.postScripts,
             pbxTarget: pbxTarget,

--- a/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -92,7 +92,7 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
 
         Logger.current.notice("Generating workspace \(workspaceName)", metadata: .section)
 
-        /// Projects
+        // Projects
         let projects = try await Array(graphTraverser.projects.values)
             .concurrentCompactMap { project -> ProjectDescriptor? in
                 try await self.projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -6,7 +6,6 @@ import XcodeGraph
 ///
 /// A linter that identifies potential issues in a graph where
 /// static products are linked multiple times.
-///
 protocol StaticProductsGraphLinting {
     func lint(graphTraverser: GraphTraversing, configGeneratedProjectOptions: TuistGeneratedProjectOptions) -> [LintingIssue]
 }
@@ -53,7 +52,6 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         return warnings
     }
 
-    ///
     /// Builds a static products map to enable performing some validation/lint checks.
     ///
     /// The map consists of all linked static products as follows:
@@ -70,7 +68,6 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
     /// - In the event a node is a static product it adds itself to the unlinked bucket
     /// - In the event a node is a node capable of linking static products, it removes all the nodes
     ///   from the unlinked bucket and places them in the linked bucket in format of _staticNode > [linkingNode]_.
-    ///
     private func buildStaticProductsMap(
         visiting dependency: GraphDependency,
         graphTraverser: GraphTraversing,
@@ -299,13 +296,13 @@ extension StaticProductsGraphLinter {
     }
 
     private struct StaticProducts {
-        // Unlinked static products
+        /// Unlinked static products
         var unlinked: Set<GraphDependency> = Set()
 
-        // Map of Static product to nodes that link it
-        // e.g.
-        //    - MyStaticFrameworkA > [MyDynamicFrameworkA, MyTestsTarget]
-        //    - MyStaticFrameworkB > [MyDynamicFrameworkA, MyTestsTarget]
+        /// Map of static product to nodes that link it
+        /// e.g.
+        ///    - MyStaticFrameworkA > [MyDynamicFrameworkA, MyTestsTarget]
+        ///    - MyStaticFrameworkB > [MyDynamicFrameworkA, MyTestsTarget]
         var linked: [GraphDependency: Set<GraphDependency>] = [:]
 
         func merged(with other: StaticProducts) -> StaticProducts {

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -72,7 +72,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         "BUNDLE_LOADER",
     ]
 
-    // These are not needed or are computed elsewhere so we exclude them
+    /// These are not needed or are computed elsewhere so we exclude them.
     private static let multiplatformExcludedSettingsKeys = Set([
         "COMBINE_HIDPI_IMAGES",
         "SDKROOT",
@@ -157,7 +157,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
             )
         }
 
-        /// This allows running the project directly withou specifying CODE_SIGN_IDENTITY
+        // This allows running the project directly without specifying `CODE_SIGN_IDENTITY`.
         if target.supportsCatalyst {
             settings.overlay(with: ["CODE_SIGN_IDENTITY": "-"], for: .macOS)
         }

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -65,11 +65,9 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
         var inputPaths: [RelativePath] = []
         var outputPaths: [String] = []
 
-        /*
-         * This is required to prevent the new build system from failing when multiple test targets cause the same
-         * output files. The symbols aren't really required to be copied for tests so this patch excludes them.
-         * For more details see the discussion on https://github.com/tuist/tuist/issues/919.
-         */
+        // This is required to prevent the new build system from failing when multiple test targets cause the same
+        // output files. The symbols aren't really required to be copied for tests so this patch excludes them.
+        // For more details see the discussion on https://github.com/tuist/tuist/issues/919.
         func addSymbolsIfRequired(inputPath: RelativePath, outputPath: String) {
             if includeSymbolsInFileLists {
                 inputPaths.append(inputPath)

--- a/Sources/TuistGenerator/Utils/SortedPBXGroup.swift
+++ b/Sources/TuistGenerator/Utils/SortedPBXGroup.swift
@@ -19,8 +19,8 @@ class SortedPBXGroup {
         value = wrappedValue
     }
 
-    // The sorting implementation was taken from https://github.com/yonaskolb/XcodeGen/blob/d64cfff8a1ca01fd8f18cbb41f72230983c4a192/Sources/XcodeGenKit/PBXProjGenerator.swift
-    // We require exactly the same sort which places groups over files while using the PBXGroup from Xcodeproj.
+    /// The sorting implementation was taken from https://github.com/yonaskolb/XcodeGen/blob/d64cfff8a1ca01fd8f18cbb41f72230983c4a192/Sources/XcodeGenKit/PBXProjGenerator.swift
+    /// We require exactly the same sort which places groups over files while using the PBXGroup from Xcodeproj.
     private func sort(with group: PBXGroup) {
         group.children.sort { child1, child2 -> Bool in
             let sortOrder1 = child1.getSortOrder()

--- a/Sources/TuistHasher/CachedContentHasher.swift
+++ b/Sources/TuistHasher/CachedContentHasher.swift
@@ -8,7 +8,7 @@ import TuistSupport
 public final class CachedContentHasher: ContentHashing {
     private let contentHasher: ContentHashing
 
-    // In memory cache for files that have already been hashed
+    /// In memory cache for files that have already been hashed.
     private var hashesCache: ThreadSafe<[AbsolutePath: String]> = ThreadSafe([:])
 
     public init(contentHasher: ContentHashing = ContentHasher()) {

--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -4,9 +4,11 @@ import TuistSupport
 
 public enum EnvKey: String, CaseIterable {
     // BUILD
+
     case buildBinaryCache = "TUIST_BUILD_BINARY_CACHE"
 
     // BUILD OPTIONS
+
     case buildOptionsScheme = "TUIST_BUILD_OPTIONS_SCHEME"
     case buildOptionsGenerate = "TUIST_BUILD_OPTIONS_GENERATE"
     case buildOptionsClean = "TUIST_BUILD_OPTIONS_CLEAN"
@@ -22,29 +24,35 @@ public enum EnvKey: String, CaseIterable {
     case buildOptionsPassthroughXcodeBuildArguments = "TUIST_BUILD_OPTIONS_PASSTHROUGH_XCODE_BUILD_ARGUMENTS"
 
     // CLEAN
+
     case cleanCleanCategories = "TUIST_CLEAN_CLEAN_CATEGORIES"
     case cleanPath = "TUIST_CLEAN_PATH"
     case cleanRemote = "TUIST_CLEAN_REMOTE"
 
     // DUMP
+
     case dumpPath = "TUIST_DUMP_PATH"
     case dumpManifest = "TUIST_DUMP_MANIFEST"
 
     // EDIT
+
     case editPath = "TUIST_EDIT_PATH"
     case editPermanent = "TUIST_EDIT_PERMANENT"
     case editOnlyCurrentDirectory = "TUIST_EDIT_ONLY_CURRENT_DIRECTORY"
 
     // INSTALL
+
     case installPath = "TUIST_INSTALL_PATH"
     case installUpdate = "TUIST_INSTALL_UPDATE"
 
     // GENERATE
+
     case generatePath = "TUIST_GENERATE_PATH"
     case generateOpen = "TUIST_GENERATE_OPEN"
     case generateBinaryCache = "TUIST_GENERATE_BINARY_CACHE"
 
     // GRAPH
+
     case graphSkipTestTargets = "TUIST_GRAPH_SKIP_TEST_TARGETS"
     case graphSkipExternalDependencies = "TUIST_GRAPH_SKIP_EXTERNAL_DEPENDENCIES"
     case graphPlatform = "TUIST_GRAPH_PLATFORM"
@@ -56,6 +64,7 @@ public enum EnvKey: String, CaseIterable {
     case graphOutputPath = "TUIST_GRAPH_OUTPUT_PATH"
 
     // INIT
+
     case initPlatform = "TUIST_INIT_PLATFORM"
     case initName = "TUIST_INIT_NAME"
     case initTemplate = "TUIST_INIT_TEMPLATE"
@@ -63,6 +72,7 @@ public enum EnvKey: String, CaseIterable {
     case initAnswers = "TUIST_INIT_ANSWERS"
 
     // MIGRATION
+
     case migrationSettingsToXcconfigXcodeprojPath = "TUIST_MIGRATION_SETTINGS_TO_XCCONFIG_XCODEPROJ_PATH"
     case migrationSettingsToXcconfigXcconfigPath = "TUIST_MIGRATION_SETTINGS_TO_XCCONFIG_XCCONFIG_PATH"
     case migrationSettingsToXcconfigTarget = "TUIST_MIGRATION_SETTINGS_TO_XCCONFIG_TARGET"
@@ -71,6 +81,7 @@ public enum EnvKey: String, CaseIterable {
     case migrationListTargetsXcodeprojPath = "TUIST_MIGRATION_LIST_TARGETS_XCODEPROJ_PATH"
 
     // PLUGIN
+
     case pluginArchivePath = "TUIST_PLUGIN_ARCHIVE_PATH"
     case pluginBuildBuildTests = "TUIST_PLUGIN_BUILD_BUILD_TESTS"
     case pluginBuildShowBinPath = "TUIST_PLUGIN_BUILD_SHOW_BIN_PATH"
@@ -84,25 +95,31 @@ public enum EnvKey: String, CaseIterable {
     case pluginTestTestProducts = "TUIST_PLUGIN_TEST_TEST_PRODUCTS"
 
     // PLUGIN OPTIONS
+
     case pluginOptionsConfiguration = "TUIST_PLUGIN_OPTIONS_CONFIGURATION"
     case pluginOptionsPath = "TUIST_PLUGIN_OPTIONS_PATH"
 
     // LINT
+
     case lintImplicitDependenciesPath = "TUIST_LINT_IMPLICIT_DEPENDENCIES_PATH"
 
     // Redundant
+
     case lintRedundantDependenciesPath = "TUIST_LINT_REDUNDANT_DEPENDENCIES_PATH"
 
     // BUILD
+
     case inspectBuildPath = "TUIST_INSPECT_BUILD_PATH"
     case inspectBuildProjectDerivedDataPath = "TUIST_INSPECT_BUILD_PROJECT_DERIVED_DATA_PATH"
 
     // BUNDLE
+
     case inspectBundle = "TUIST_INSPECT_BUNDLE"
     case inspectBundleJSON = "TUIST_INSPECT_BUNDLE_JSON"
     case inspectBundlePath = "TUIST_INSPECT_BUNDLE_PATH"
 
     // RUN
+
     case runBuildTests = "TUIST_RUN_BUILD_TESTS"
     case runSkipBuild = "TUIST_RUN_SKIP_BUILD"
     case runTask = "TUIST_RUN_TASK"
@@ -117,6 +134,7 @@ public enum EnvKey: String, CaseIterable {
     case runScheme = "TUIST_RUN_SCHEME"
 
     // SCAFFOLD
+
     case scaffoldTemplate = "TUIST_SCAFFOLD_TEMPLATE"
     case scaffoldJson = "TUIST_SCAFFOLD_JSON"
     case scaffoldPath = "TUIST_SCAFFOLD_PATH"
@@ -124,6 +142,7 @@ public enum EnvKey: String, CaseIterable {
     case scaffoldListPath = "TUIST_SCAFFOLD_LIST_PATH"
 
     // TEST
+
     case testScheme = "TUIST_TEST_SCHEME"
     case testClean = "TUIST_TEST_CLEAN"
     case testNoUpload = "TUIST_TEST_NO_UPLOAD"
@@ -149,103 +168,127 @@ public enum EnvKey: String, CaseIterable {
     case testBuildOnly = "TUIST_TEST_BUILD_ONLY"
 
     // ORGANIZATION BILLING
+
     case organizationBillingOrganizationName = "TUIST_ORGANIZATION_BILLING_ORGANIZATION_NAME"
     case organizationBillingPath = "TUIST_ORGANIZATION_BILLING_PATH"
 
     // ORGANIZATION CREATE
+
     case organizationCreateOrganizationName = "TUIST_ORGANIZATION_CREATE_ORGANIZATION_NAME"
     case organizationCreatePath = "TUIST_ORGANIZATION_CREATE_PATH"
 
     // ORGANIZATION DELETE
+
     case organizationDeleteOrganizationName = "TUIST_ORGANIZATION_DELETE_ORGANIZATION_NAME"
     case organizationDeletePath = "TUIST_ORGANIZATION_DELETE_PATH"
 
     // PROJECT TOKEN
+
     case projectTokenFullHandle = "TUIST_PROJECT_TOKEN_FULL_HANDLE"
     case projectTokenPath = "TUIST_PROJECT_TOKEN_PATH"
     case projectTokenId = "TUIST_PROJECT_TOKEN_ID"
 
     // ORGANIZATION LIST
+
     case organizationListJson = "TUIST_ORGANIZATION_LIST_JSON"
     case organizationListPath = "TUIST_ORGANIZATION_LIST_PATH"
 
     // ORGANIZATION REMOVE INVITE
+
     case organizationRemoveInviteOrganizationName = "TUIST_ORGANIZATION_REMOVE_INVITE_ORGANIZATION_NAME"
     case organizationRemoveInviteEmail = "TUIST_ORGANIZATION_REMOVE_INVITE_EMAIL"
     case organizationRemoveInvitePath = "TUIST_ORGANIZATION_REMOVE_INVITE_PATH"
 
     // ORGANIZATION REMOVE MEMBER
+
     case organizationRemoveMemberOrganizationName = "TUIST_ORGANIZATION_REMOVE_MEMBER_ORGANIZATION_NAME"
     case organizationRemoveMemberUsername = "TUIST_ORGANIZATION_REMOVE_MEMBER_USERNAME"
     case organizationRemoveMemberPath = "TUIST_ORGANIZATION_REMOVE_MEMBER_PATH"
 
     // ORGANIZATION REMOVE SSO
+
     case organizationRemoveSSOOrganizationName = "TUIST_ORGANIZATION_REMOVE_SSO_ORGANIZATION_NAME"
     case organizationRemoveSSOPath = "TUIST_ORGANIZATION_REMOVE_SSO_PATH"
 
     // ORGANIZATION UPDATE SSO
+
     case organizationUpdateSSOOrganizationName = "TUIST_ORGANIZATION_UPDATE_SSO_ORGANIZATION_NAME"
     case organizationUpdateSSOProvider = "TUIST_ORGANIZATION_UPDATE_SSO_PROVIDER"
     case organizationUpdateSSOOrganizationId = "TUIST_ORGANIZATION_UPDATE_SSO_ORGANIZATION_ID"
     case organizationUpdateSSOPath = "TUIST_ORGANIZATION_UPDATE_SSO_PATH"
 
     // PROJECT DELETE
+
     case projectDeleteFullHandle = "TUIST_PROJECT_DELETE_FULL_HANDLE"
     case projectDeletePath = "TUIST_PROJECT_DELETE_PATH"
 
     // PROJECT CREATE
+
     case projectCreateFullHandle = "TUIST_PROJECT_CREATE_FULL_HANDLE"
     case projectCreatePath = "TUIST_PROJECT_CREATE_PATH"
 
     // PROJECT SHOW
+
     case projectShowFullHandle = "TUIST_PROJECT_SHOW_FULL_HANDLE"
     case projectShowPath = "TUIST_PROJECT_SHOW_PATH"
     case projectShowWeb = "TUIST_PROJECT_SHOW_WEB"
 
     // ORGANIZATION INVITE
+
     case organizationInviteOrganizationName = "TUIST_ORGANIZATION_INVITE_ORGANIZATION_NAME"
     case organizationInviteEmail = "TUIST_ORGANIZATION_INVITE_EMAIL"
     case organizationInvitePath = "TUIST_ORGANIZATION_INVITE_PATH"
 
     // ORGANIZATION SHOW
+
     case organizationShowOrganizationName = "TUIST_ORGANIZATION_SHOW_ORGANIZATION_NAME"
     case organizationShowJson = "TUIST_ORGANIZATION_SHOW_JSON"
     case organizationShowPath = "TUIST_ORGANIZATION_SHOW_PATH"
 
     // PROJECT LIST
+
     case projectListJson = "TUIST_PROJECT_LIST_JSON"
     case projectListPath = "TUIST_PROJECT_LIST_PATH"
 
     // ORGANIZATION UPDATE MEMBER
+
     case organizationUpdateMemberOrganizationName = "TUIST_ORGANIZATION_UPDATE_MEMBER_ORGANIZATION_NAME"
     case organizationUpdateMemberUsername = "TUIST_ORGANIZATION_UPDATE_MEMBER_USERNAME"
     case organizationUpdateMemberRole = "TUIST_ORGANIZATION_UPDATE_MEMBER_ROLE"
     case organizationUpdateMemberPath = "TUIST_ORGANIZATION_UPDATE_MEMBER_PATH"
 
     // REGISTRY LOGIN
+
     case registryLoginPath = "TUIST_REGISTRY_LOGIN_PATH"
 
     // REGISTRY LOGOUT
+
     case registryLogoutPath = "TUIST_REGISTRY_LOGOUT_PATH"
 
     // REGISTRY SETUP
+
     case registrySetUpPath = "TUIST_REGISTRY_SETUP_PATH"
 
     // AUTH
+
     case authPath = "TUIST_AUTH_PATH"
     case authEmail = "TUIST_AUTH_EMAIL"
     case authPassword = "TUIST_AUTH_PASSWORD"
 
     // SESSION
+
     case whoamiPath = "TUIST_WHOAMI_PATH"
 
     // LOGOUT
+
     case logoutPath = "TUIST_LOGOUT_PATH"
 
     // ANALYTICS
+
     case analyticsPath = "TUIST_ANALYTICS_PATH"
 
     // SHARE
+
     case shareApp = "TUIST_SHARE_APP"
     case shareConfiguration = "TUIST_SHARE_CONFIGURATION"
     case sharePlatform = "TUIST_SHARE_PLATFORM"
@@ -253,6 +296,7 @@ public enum EnvKey: String, CaseIterable {
     case shareDerivedDataPath = "TUIST_SHARE_DERIVED_DATA_PATH"
 
     // CACHE
+
     case cacheExternalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
     case cacheGenerateOnly = "TUIST_CACHE_GENERATE_ONLY"
     case cachePrintHashes = "TUIST_CACHE_PRINT_HASHES"
@@ -261,10 +305,12 @@ public enum EnvKey: String, CaseIterable {
     case cacheTargets = "TUIST_CACHE_TARGETS"
 
     // HASH CACHE
+
     case hashCachePath = "TUIST_HASH_CACHE_PATH"
     case hashCacheConfiguration = "TUIST_HASH_CACHE_CONFIGURATION"
 
     // HASH TEST
+
     case hashTestPath = "TUIST_HASH_TEST_PATH"
     case hashTestConfiguration = "TUIST_HASH_TEST_CONFIGURATION"
 }

--- a/Sources/TuistKit/Commands/EnvKey/ParseableArgument+Extension.swift
+++ b/Sources/TuistKit/Commands/EnvKey/ParseableArgument+Extension.swift
@@ -138,6 +138,7 @@ extension Flag where Value == Bool {
 }
 
 // Argument Extensions
+
 extension Argument {
     init<T>(
         wrappedValue value: [T] = [],

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -57,7 +57,7 @@ public struct ScaffoldCommand: AsyncParsableCommand {
 
     public init() {}
 
-    // Custom decoding to decode dynamic options
+    /// Custom decoding to decode dynamic options.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         template = try container.decode(Argument<String>.self, forKey: .template).wrappedValue
@@ -177,6 +177,7 @@ extension ScaffoldCommand {
         }
 
         // Not used
+
         var intValue: Int? { nil }
         init?(intValue _: Int) { nil }
     }

--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -8,8 +8,7 @@ import TuistSupport
 import XcodeGraph
 
 /// `CommandEventTagger` builds a `CommandEvent` by grouping information
-/// from different sources and tells `analyticsTagger` to send the event to a provider
-
+/// from different sources and tells `analyticsTagger` to send the event to a provider.
 public final class CommandEventFactory {
     private let machineEnvironment: MachineEnvironmentRetrieving
     private let gitController: GitControlling

--- a/Sources/TuistKit/MCP/MCPCommandService.swift
+++ b/Sources/TuistKit/MCP/MCPCommandService.swift
@@ -3,6 +3,7 @@ import MCP
 import TuistSupport
 
 // Server references: https://github.com/modelcontextprotocol/servers/tree/main/src
+
 public struct MCPCommandService {
     private let resourcesRepository: MCPResourcesRepositorying
 

--- a/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
+++ b/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
@@ -27,9 +27,9 @@ public enum FocusTargetsGraphMappersError: FatalError, Equatable {
 
 /// `FocusTargetsGraphMappers` is used to filter out some targets and their dependencies and tests targets.
 public final class FocusTargetsGraphMappers: GraphMapping {
-    // When specified, if includedTargets is empty it will automatically include all targets in the test plan
+    /// When specified, if includedTargets is empty it will automatically include all targets in the test plan.
     public let testPlan: String?
-    /// The targets to be kept as non prunable with their respective dependencies and tests targets
+    /// The targets to be kept as non prunable with their respective dependencies and tests targets.
     public let includedTargets: Set<TargetQuery>
     public let excludedTargets: Set<TargetQuery>
 

--- a/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -92,10 +92,9 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
             let targetReference = TargetReference(projectPath: path, name: target.name)
             guard sourceTargets.contains(targetReference) else { continue }
 
-            /**
-             Since we have target.dependencies and graph.dependencies (duplicated), we have to apply the changes in both sides.
-             Once we refactor the code to only depend on graph.dependencies, we can get rid of these duplications.
-             */
+            // Since we have `target.dependencies` and `graph.dependencies` (duplicated), we have to apply the changes in both
+            // sides.
+            // Once we refactor the code to only depend on graph.dependencies, we can get rid of these duplications.
             target.dependencies = target.dependencies.filter { dependency in
                 switch dependency {
                 case let .target(targetDependencyName, _, _):
@@ -128,12 +127,10 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
                         .compactMap { dependency in
                             switch dependency {
                             case let .target(dependencyName, dependencyProjectPath, _):
-                                /**
-                                 If a target dependency a target depends on is tree-shaked, that dependency should be removed.
-                                 This happens in scenarios where a external target (iOS and tvOS framework) conditionally depends on
-                                 framework based on the platform. We have logic to prune unneceessary platforms from the external
-                                 part of the graph.
-                                 */
+                                // If a target dependency a target depends on is tree-shaked, that dependency should be removed.
+                                // This happens in scenarios where a external target (iOS and tvOS framework) conditionally
+                                // depends on framework based on the platform. We have logic to prune unnecessary platforms from
+                                // the external part of the graph.
                                 if sourceTargets.contains(
                                     TargetReference(
                                         projectPath: dependencyProjectPath,

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -201,7 +201,7 @@ final class ProjectEditor: ProjectEditing {
             projectDescriptionHelpersBuilder: projectDescriptionHelpersBuilder
         )
 
-        /// We error if the user tries to edit a project in a directory where there are no editable files.
+        // We error if the user tries to edit a project in a directory where there are no editable files.
         if projectManifests.isEmpty, editablePluginManifests.isEmpty, helpers.isEmpty, templateSources.isEmpty,
            resourceSynthesizers.isEmpty, stencils.isEmpty, packageManifestPath == nil
         {

--- a/Sources/TuistKit/Services/TargetImportsScanner.swift
+++ b/Sources/TuistKit/Services/TargetImportsScanner.swift
@@ -48,9 +48,9 @@ final class TargetImportsScanner: TargetImportsScanning {
             return []
         }
 
-        /// Targets might contain references to absent files, either by mistake
-        /// or because those files are generated later on, as is the case with generated
-        /// projects with synthesized files. Therefore, we can't assume their existence.
+        // Targets might contain references to absent files, either by mistake
+        // or because those files are generated later on, as is the case with generated
+        // projects with synthesized files. Therefore, we can't assume their existence.
         if try await fileSystem.exists(path) {
             let sourceCode = try await fileSystem.readTextFile(at: path)
             return try importSourceCodeScanner.extractImports(

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -20,6 +20,7 @@ enum TestServiceError: FatalError, Equatable {
     case actionInvalid
 
     // Error description
+
     var description: String {
         switch self {
         case let .schemeNotFound(scheme, existing):
@@ -59,6 +60,7 @@ enum TestServiceError: FatalError, Equatable {
     }
 
     // Error type
+
     var type: ErrorType {
         switch self {
         case .schemeNotFound, .schemeWithoutTestableTargets, .testPlanNotFound,

--- a/Sources/TuistKit/Utils/Dependencies.swift
+++ b/Sources/TuistKit/Utils/Dependencies.swift
@@ -63,7 +63,7 @@ private func initLogger() async throws -> (Logger, Path.AbsolutePath) {
     let (loggerHandler, logFilePath) = try await LogsController().setup(
         stateDirectory: Environment.current.stateDirectory
     )
-    /// This is the old initialization method and will eventually go away.
+    // This is the old initialization method and will eventually go away.
     LoggingSystem.bootstrap(loggerHandler)
     return (Logger(label: "dev.tuist.cli", factory: loggerHandler), logFilePath)
 }

--- a/Sources/TuistKit/Utils/GraphPrinter.swift
+++ b/Sources/TuistKit/Utils/GraphPrinter.swift
@@ -2,11 +2,7 @@ import Foundation
 import TuistGenerator
 import TuistSupport
 
-protocol GraphPrinting {
-    /// Outputs the graph to the standard output.
-    ///
-    /// - Parameter graph: Graph to be printed.
-}
+protocol GraphPrinting {}
 
 /// Outputs the graph to the standard output.
 class GraphPrinter: GraphPrinting {

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -322,9 +322,11 @@ private struct Hashes: Equatable, Codable {
 }
 
 private struct CachedManifest: Codable {
-    // Note: please bump the version in case the cache structure is modifed
-    // this ensures older cache versions are not loaded using this structure
+    // Note: please bump the version in case the cache structure is modified.
+    // This ensures older cache versions are not loaded using this structure.
+
     static let currentCacheVersion = 1
+
     var cacheVersion: Int = currentCacheVersion
     var tuistVersion: String
     var hashes: Hashes

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -123,8 +123,8 @@ public protocol PackageInfoMapping {
 
 // swiftlint:disable:next type_body_length
 public final class PackageInfoMapper: PackageInfoMapping {
-    // Predefined source directories, in order of preference.
-    // https://github.com/apple/swift-package-manager/blob/751f0b2a00276be2c21c074f4b21d952eaabb93b/Sources/PackageLoading/PackageBuilder.swift#L488
+    /// Predefined source directories, in order of preference.
+    /// https://github.com/apple/swift-package-manager/blob/751f0b2a00276be2c21c074f4b21d952eaabb93b/Sources/PackageLoading/PackageBuilder.swift#L488
     fileprivate static let predefinedSourceDirectories = ["Sources", "Source", "src", "srcs"]
     fileprivate static let predefinedTestDirectories = ["Tests", "Sources", "Source", "src", "srcs"]
     private let moduleMapGenerator: SwiftPackageManagerModuleMapGenerating
@@ -431,8 +431,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
         let moduleMap: ModuleMap?
         switch target.type {
         case .system:
-            /// System library targets assume the module map is located at the source directory root
-            /// https://github.com/apple/swift-package-manager/blob/main/Sources/PackageLoading/ModuleMapGenerator.swift
+            // System library targets assume the module map is located at the source directory root
+            // https://github.com/apple/swift-package-manager/blob/main/Sources/PackageLoading/ModuleMapGenerator.swift
             let packagePath = try await target.basePath(packageFolder: path)
             let moduleMapPath = packagePath.appending(component: ModuleMap.filename)
 
@@ -512,8 +512,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
 
         var dependencies: [ProjectDescription.TargetDependency] = []
 
-        /// Module aliases of used dependencies.
-        /// These need to be mapped in `OTHER_SWIFT_FLAGS` using the `-module-alias` build flag.
+        // Module aliases of used dependencies.
+        // These need to be mapped in `OTHER_SWIFT_FLAGS` using the `-module-alias` build flag.
         var dependencyModuleAliases: [String: String] = [:]
 
         if target.type.supportsDependencies {
@@ -820,11 +820,11 @@ extension ProjectDescription.ResourceFileElements {
         excluding: [String],
         fileSystem: FileSysteming
     ) async throws -> Self? {
-        /// Handles the conversion of a `.copy` resource rule of SPM
-        ///
-        /// - Parameters:
-        ///   - resourceAbsolutePath: The absolute path of that resource
-        /// - Returns: A ProjectDescription.ResourceFileElement mapped from a `.copy` resource rule of SPM
+        // Handles the conversion of a `.copy` resource rule of SPM
+        //
+        // - Parameters:
+        //   - resourceAbsolutePath: The absolute path of that resource
+        // - Returns: A ProjectDescription.ResourceFileElement mapped from a `.copy` resource rule of SPM
         @Sendable func handleCopyResource(resourceAbsolutePath: AbsolutePath) -> ProjectDescription.ResourceFileElement {
             .folderReference(path: .path(resourceAbsolutePath.pathString))
         }
@@ -833,11 +833,11 @@ extension ProjectDescription.ResourceFileElements {
             path.appending(try RelativePath(validating: $0))
         }
 
-        /// Handles the conversion of a `.process` resource rule of SPM
-        ///
-        /// - Parameters:
-        ///   - resourceAbsolutePath: The absolute path of that resource
-        /// - Returns: A ProjectDescription.ResourceFileElement mapped from a `.process` resource rule of SPM
+        // Handles the conversion of a `.process` resource rule of SPM
+        //
+        // - Parameters:
+        //   - resourceAbsolutePath: The absolute path of that resource
+        // - Returns: A ProjectDescription.ResourceFileElement mapped from a `.process` resource rule of SPM
         @Sendable func handleProcessResource(resourceAbsolutePath: AbsolutePath) async throws -> ProjectDescription
             .ResourceFileElement?
         {
@@ -934,8 +934,8 @@ extension ProjectDescription.ResourceFileElements {
         return .resources(resourceFileElements.uniqued())
     }
 
-    // These files are automatically added as resource if they are inside targets directory.
-    // Check https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package
+    /// These files are automatically added as resource if they are inside targets directory.
+    /// Check https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package
     private static let defaultSpmResourceFileExtensions = Set([
         "xib",
         "storyboard",
@@ -1389,7 +1389,7 @@ extension PackageInfo {
     }
 
     private func swiftVersion(for configuredSwiftVersion: XcodeGraph.Version?) -> String? {
-        /// Take the latest swift version compatible with the configured one
+        // Take the latest swift version compatible with the configured one
         let maxAllowedSwiftLanguageVersion = swiftLanguageVersions?
             .filter {
                 guard let configuredSwiftVersion else {

--- a/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SettingsMapper.swift
@@ -140,7 +140,7 @@ struct SettingsMapper {
         return settingsDictionary
     }
 
-    // `nil` means settings without a condition
+    /// `nil` means settings without a condition.
     private func settings(for platformName: String?) throws
         -> [PackageInfo.Target.TargetBuildSettingDescription.Setting]
     {

--- a/Sources/TuistLoader/Utils/ResourceLocator.swift
+++ b/Sources/TuistLoader/Utils/ResourceLocator.swift
@@ -54,15 +54,13 @@ public final class ResourceLocator: ResourceLocating {
         var paths: [AbsolutePath] = [
             bundlePath,
             bundlePath.parentDirectory,
-            /**
-                == Homebrew directory structure ==
-                x.y.z/
-                   bin/
-                       tuist
-                   lib/
-                       ProjectDescription.framework
-                       ProjectDescription.framework.dSYM
-                */
+            // == Homebrew directory structure ==
+            // x.y.z/
+            //   bin/
+            //       tuist
+            //   lib/
+            //       ProjectDescription.framework
+            //       ProjectDescription.framework.dSYM
             bundlePath.parentDirectory.appending(component: "lib"),
         ]
         if let frameworkSearchPaths = Environment.current.variables["TUIST_FRAMEWORK_SEARCH_PATHS"]?

--- a/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
+++ b/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
@@ -65,8 +65,8 @@ public final class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
             if acc.isEmpty { acc.formUnion(next.buildSettings.keys) } else { acc.formIntersection(next.buildSettings.keys) }
         }
 
-        /// We get the build settings that are in common to define them as SETTING_KEY=SETTING_VALUE
-        /// Otherwise, we have to define them as SETTING_KEY[config=Config]=SETTING_VALUE
+        // We get the build settings that are in common to define them as SETTING_KEY=SETTING_VALUE
+        // Otherwise, we have to define them as SETTING_KEY[config=Config]=SETTING_VALUE
         let commonBuildSettings = repeatedBuildSettingsKeys.filter { buildSetting -> Bool in
             let values = buildConfigurations.map { $0.buildSettings[buildSetting]! }
             let stringValues = values.compactMap(\.stringValue)

--- a/Sources/TuistScaffold/TemplateGenerator.swift
+++ b/Sources/TuistScaffold/TemplateGenerator.swift
@@ -26,6 +26,7 @@ public final class TemplateGenerator: TemplateGenerating {
     private let fileSystem: FileSystem
 
     // Public initializer
+
     public init(fileSystem: FileSystem = FileSystem()) {
         self.fileSystem = fileSystem
     }

--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -58,14 +58,12 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
         let paths = [
             bundlePath,
             bundlePath.parentDirectory,
-            /**
-                == Homebrew directory structure ==
-                x.y.z/
-                   bin/
-                       tuist
-                   share/
-                       Templates
-                */
+            // == Homebrew directory structure ==
+            // x.y.z/
+            //   bin/
+            //       tuist
+            //   share/
+            //       Templates
             bundlePath.parentDirectory.appending(try! RelativePath(validating: "share")),
             // swiftlint:disable:previous force_try
         ]

--- a/Sources/TuistServer/Network/URLSession+Server.swift
+++ b/Sources/TuistServer/Network/URLSession+Server.swift
@@ -2,14 +2,12 @@ import Foundation
 
 private func tuistURLSessionConfiguration() -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
-    /**
-     Our API design leads to an inefficient usage of the transport layer, which leads to Fly having to spin
-     new machines suddenly, and that causes URLSession to time out. The high timeouts here are temporary
-     until we change the server-side API to lead to a more efficient using of the transport layer.
-
-     I noticed on Fly https://fly.io/apps/tuist-cloud/metrics that the peaks can reach up to
-     100 seconds, hence why I set the limit to 120.
-     */
+    // Our API design leads to an inefficient usage of the transport layer, which leads to Fly having to spin
+    // new machines suddenly, and that causes URLSession to time out. The high timeouts here are temporary
+    // until we change the server-side API to lead to a more efficient using of the transport layer.
+    //
+    // I noticed on Fly https://fly.io/apps/tuist-cloud/metrics that the peaks can reach up to
+    // 100 seconds, hence why I set the limit to 120.
     configuration.timeoutIntervalForRequest = 120 // 2 minutes
     configuration.timeoutIntervalForResource = 300 // 5 minutes
     configuration.allowsCellularAccess = true

--- a/Sources/TuistServer/Utilities/DelayProvider.swift
+++ b/Sources/TuistServer/Utilities/DelayProvider.swift
@@ -10,7 +10,7 @@ public struct DelayProvider: DelayProviding {
     public init() {}
 
     public func delay(for retry: Int) -> UInt64 {
-        /// 0.1 seconds
+        // 0.1 seconds
         let baseInterval = TimeInterval(1_000_000)
         let randomInterval = Double.random(in: -1_000_000 ... 1_000_000)
         return UInt64(baseInterval * pow(2, Double(retry)) + randomInterval)

--- a/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
+++ b/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
@@ -109,11 +109,9 @@ public struct ServerCredentialsStore: ServerCredentialsStoring {
         guard try await fileSystem.exists(path) else { return nil }
         let data = try await fileSystem.readFile(at: path)
 
-        /**
-         This might fail if we've migrated the schema, which is very unlikely, or if someone modifies the content in it
-         and the new schema doesn't align with the one that we expect. We could add logic to handle those gracefully,
-         but since the user can recover from it by signing in again, I think it's ok not to add more complexity here.
-         */
+        // This might fail if we've migrated the schema, which is very unlikely, or if someone modifies the content in it
+        // and the new schema doesn't align with the one that we expect. We could add logic to handle those gracefully,
+        // but since the user can recover from it by signing in again, I think it's ok not to add more complexity here.
         return try? JSONDecoder().decode(ServerCredentials.self, from: data)
     }
 

--- a/Sources/TuistSupport/Extensions/Array+ExecutionContext.swift
+++ b/Sources/TuistSupport/Extensions/Array+ExecutionContext.swift
@@ -130,10 +130,9 @@ extension Array where Element: Sendable {
 
 // MARK: - Private
 
-//
 // Concurrent Map / For Each
-// based on https://talk.objc.io/episodes/S01E90-concurrent-map
-//
+// Based on https://talk.objc.io/episodes/S01E90-concurrent-map
+
 extension Array {
     private func concurrentMap<B>(_ transform: (Element) throws -> B) rethrows -> [B] {
         let result = ThreadSafe([Result<B, Error>?](repeating: nil, count: count))

--- a/Sources/TuistSupport/Extensions/String+MD5.swift
+++ b/Sources/TuistSupport/Extensions/String+MD5.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable all
+// swiftformat:disable all
 //
 //  String+MD5.swift
 //  Kingfisher

--- a/Sources/TuistSupport/Logging/DetailedLogHandler.swift
+++ b/Sources/TuistSupport/Logging/DetailedLogHandler.swift
@@ -75,7 +75,7 @@ func timestamp() -> String {
     }
 }
 
-// Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method
+/// Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method.
 protocol SuppressedWarningLogHandler {
     func log(
         level: Logging.Logger.Level,

--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -111,7 +111,7 @@ extension LoggingConfig {
     }
 }
 
-// A `VerboseLogHandler` allows for a LogHandler to be initialised with the `debug` logLevel.
+/// A `VerboseLogHandler` allows for a LogHandler to be initialised with the `debug` logLevel.
 protocol VerboseLogHandler: LogHandler {
     @Sendable static func verbose(label: String) -> LogHandler
     @Sendable init(label: String)

--- a/Sources/TuistSupport/MachineEnvironment.swift
+++ b/Sources/TuistSupport/MachineEnvironment.swift
@@ -43,7 +43,7 @@ public final class MachineEnvironment: MachineEnvironmentRetrieving {
     /// `hardwareName` is the name of the architecture of the machine running Tuist, e.g: "arm64" or "x86_64"
     public let hardwareName = ProcessInfo.processInfo.machineHardwareName
 
-    // Taken from: https://github.com/open-telemetry/opentelemetry-swift/blob/b1323295a67c7cf9b7c59a505d197432abe8a88a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift#L17
+    /// Taken from: https://github.com/open-telemetry/opentelemetry-swift/blob/b1323295a67c7cf9b7c59a505d197432abe8a88a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift#L17
     public func modelIdentifier() -> String? {
         let hwName = UnsafeMutablePointer<Int32>.allocate(capacity: 2)
         hwName[0] = CTL_HW

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -33,7 +33,7 @@ public class FileArchiver: FileArchiving {
 
     public func zip(name: String) async throws -> AbsolutePath {
         let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
-        /// ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory
+        // ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory.
         let pathsDirectoryPath = temporaryDirectory.appending(component: "\(name)-paths")
         try FileHandler.shared.createFolder(pathsDirectoryPath)
         for path in paths {

--- a/Sources/TuistTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistTesting/TestCase/TuistTestCase.swift
@@ -6,8 +6,8 @@ import XCTest
 
 @testable import TuistSupport
 
-// This mock file handler is used to override the current path to a temporary directory.
-// The temporary directory is lazily created if either the test case or subject consume the API.
+/// This mock file handler is used to override the current path to a temporary directory.
+/// The temporary directory is lazily created if either the test case or subject consume the API.
 public final class MockFileHandler: FileHandler {
     let temporaryDirectory: () throws -> (AbsolutePath)
 

--- a/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -71,9 +71,8 @@ public struct XCActivityLogController: XCActivityLogControlling {
                     ($0.signature, $0.duration)
                 })
             {
-                /**
-                 If a target supports multiple platforms, the time will persist is the time of the latest platform that we built.
-                 */
+                // If a target supports multiple platforms, the time will persist is the time of the latest platform that we
+                // built.
                 buildTimes[targetName] = targetBuildDuration
             }
         }
@@ -204,7 +203,7 @@ public struct XCActivityLogController: XCActivityLogControlling {
                     }
                 }
 
-                /// We want to ignore steps for emitting modules as we care about the compilation of the file itself.
+                // We want to ignore steps for emitting modules as we care about the compilation of the file itself.
                 guard !step.title.hasPrefix("Emit") else {
                     return nil
                 }

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -86,7 +86,7 @@ final class SettingsTests: XCTestCase {
     }
 
     func test_settingsDictionary_chainingMultipleValues() {
-        /// Given / When
+        // Given / When
         let settings = SettingsDictionary()
             .codeSignIdentityAppleDevelopment()
             .currentProjectVersion("999")
@@ -103,7 +103,7 @@ final class SettingsTests: XCTestCase {
             .otherCFlags(["$(inherited)", "-my-c-flag"])
             .otherLinkerFlags(["$(inherited)", "-my-linker-flag"])
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "CODE_SIGN_IDENTITY": "Apple Development",
             "CURRENT_PROJECT_VERSION": "999",
@@ -126,11 +126,11 @@ final class SettingsTests: XCTestCase {
     }
 
     func test_settingsDictionary_codeSignManual() {
-        /// Given/When
+        // Given/When
         let settings = SettingsDictionary()
             .manualCodeSigning(identity: "Apple Distribution", provisioningProfileSpecifier: "ABC")
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "CODE_SIGN_STYLE": "Manual",
             "CODE_SIGN_IDENTITY": "Apple Distribution",
@@ -139,14 +139,14 @@ final class SettingsTests: XCTestCase {
     }
 
     func test_settingsDictionary_otherSwiftFlags() {
-        /// Given/When
+        // Given/When
         let settingsVariadic = SettingsDictionary()
             .otherSwiftFlags("FIRST", "SECOND", "THIRD")
 
         let settingsArray = SettingsDictionary()
             .otherSwiftFlags(["FIRST", "SECOND", "THIRD"])
 
-        /// Then
+        // Then
         XCTAssertEqual(settingsVariadic, [
             "OTHER_SWIFT_FLAGS": ["FIRST", "SECOND", "THIRD"],
         ])
@@ -159,14 +159,14 @@ final class SettingsTests: XCTestCase {
     }
 
     func test_settingsDictionary_swiftActiveCompilationConditions() {
-        /// Given/When
+        // Given/When
         let settingsVariadic = SettingsDictionary()
             .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
 
         let settingsArray = SettingsDictionary()
             .swiftActiveCompilationConditions(["FIRST", "SECOND", "THIRD"])
 
-        /// Then
+        // Then
         XCTAssertEqual(settingsVariadic, [
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["FIRST", "SECOND", "THIRD"],
         ])
@@ -179,133 +179,133 @@ final class SettingsTests: XCTestCase {
     }
 
     func test_settingsDictionary_SwiftCompilationMode() {
-        /// Given/When
+        // Given/When
         let settings1 = SettingsDictionary()
             .swiftCompilationMode(.singlefile)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings1, [
             "SWIFT_COMPILATION_MODE": "singlefile",
         ])
 
-        /// Given/When
+        // Given/When
         let settings2 = SettingsDictionary()
             .swiftCompilationMode(.wholemodule)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings2, [
             "SWIFT_COMPILATION_MODE": "wholemodule",
         ])
     }
 
     func test_settingsDictionary_SwiftOptimizationLevel() {
-        /// Given/When
+        // Given/When
         let settings1 = SettingsDictionary()
             .swiftOptimizationLevel(.o)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings1, [
             "SWIFT_OPTIMIZATION_LEVEL": "-O",
         ])
 
-        /// Given/When
+        // Given/When
         let settings2 = SettingsDictionary()
             .swiftOptimizationLevel(.oNone)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings2, [
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         ])
 
-        /// Given/When
+        // Given/When
         let settings3 = SettingsDictionary()
             .swiftOptimizationLevel(.oSize)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings3, [
             "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
         ])
     }
 
     func test_settingsDictionary_swiftObjcBridgingHeaderPath() {
-        /// Given/When
+        // Given/When
         let settings = SettingsDictionary()
             .swiftObjcBridgingHeaderPath("/my/bridging/header/path.h")
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "SWIFT_OBJC_BRIDGING_HEADER": "/my/bridging/header/path.h",
         ])
     }
 
     func test_settingsDictionary_otherCFlags() {
-        /// Given/When
+        // Given/When
         let settings = SettingsDictionary()
             .otherCFlags(["$(inherited)", "-my-c-flag"])
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
         ])
     }
 
     func test_settingsDictionary_otherLinkerFlags() {
-        /// Given/When
+        // Given/When
         let settings = SettingsDictionary()
             .otherLinkerFlags(["$(inherited)", "-my-linker-flag"])
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"],
         ])
     }
 
     func test_settingsDictionary_SwiftOptimizeObjectLifetimes() {
-        /// Given/When
+        // Given/When
         let settings1 = SettingsDictionary()
             .swiftOptimizeObjectLifetimes(true)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings1, [
             "SWIFT_OPTIMIZE_OBJECT_LIFETIME": "YES",
         ])
 
-        /// Given/When
+        // Given/When
         let settings2 = SettingsDictionary()
             .swiftOptimizeObjectLifetimes(false)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings2, [
             "SWIFT_OPTIMIZE_OBJECT_LIFETIME": "NO",
         ])
     }
 
     func test_settingsDictionary_marketingVersion() {
-        /// Given/When
+        // Given/When
         let settings = SettingsDictionary()
             .marketingVersion("1.0.0")
 
-        /// Then
+        // Then
         XCTAssertEqual(settings, [
             "MARKETING_VERSION": "1.0.0",
         ])
     }
 
     func test_settingsDictionary_debugInformationFormat() {
-        /// Given/When
+        // Given/When
         let settings1 = SettingsDictionary()
             .debugInformationFormat(.dwarf)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings1, [
             "DEBUG_INFORMATION_FORMAT": "dwarf",
         ])
 
-        /// Given/When
+        // Given/When
         let settings2 = SettingsDictionary()
             .debugInformationFormat(.dwarfWithDsym)
 
-        /// Then
+        // Then
         XCTAssertEqual(settings2, [
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
         ])

--- a/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
@@ -124,7 +124,8 @@ private enum KnownGraphDependencyReference: CaseIterable {
 }
 
 extension GraphDependencyReference {
-    // This is added to enforce keeping `KnownGraphDependencyReference` and `GraphDependencyReference` in sync
+    // This is added to enforce keeping `KnownGraphDependencyReference` and `GraphDependencyReference` in sync.
+
     private var correspondingKnownType: KnownGraphDependencyReference {
         switch self {
         case .xcframework:

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1116,12 +1116,10 @@ final class GraphTraverserTests: TuistUnitTestCase {
     }
 
     func test_embeddableFrameworks_when_macroExecutableInBetween() throws {
-        /**
-         Target > Macro XCFramework > Macro Executable > Dynamic SwiftSyntax
-
-         Having a macro executable that links dynamic dependencies is an scenario that Tuist might support in the future.
-         This test ensures that our graph traverser is accounting for that already.
-         */
+        // Target > Macro XCFramework > Macro Executable > Dynamic SwiftSyntax
+        //
+        // Having a macro executable that links dynamic dependencies is an scenario that Tuist might support in the future.
+        // This test ensures that our graph traverser is accounting for that already.
         // Given
         let target = Target.test(name: "Main", product: .app)
         let precompiledMacro = GraphDependency.testXCFramework(linking: .dynamic)
@@ -3958,11 +3956,10 @@ final class GraphTraverserTests: TuistUnitTestCase {
     }
 
     func test_copyProductDependencies_when_targetHasTransitiveStaticXCFrameworks() throws {
-        /**
-         XCFrameworks are copied into the products directory to let Xcode's compilation process pick the right architecture and
-         platform at build-time. The logic that determines which xcframeworks to include should traverse the .xcframework dependencies
-         and include not only the direct but the transitive dependencies.
-         */
+        // XCFrameworks are copied into the products directory to let Xcode's compilation process pick the right architecture and
+        // platform at build-time. The logic that determines which xcframeworks to include should traverse the .xcframework
+        // dependencies
+        // and include not only the direct but the transitive dependencies.
         // Given
         let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
         let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
@@ -4213,8 +4210,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(result, .condition(.when([.ios])))
     }
 
-    // Given A -> B -> C, if A -> B has a filter of [.ios], and B -> C has a filter of `[.macos]`, A->C should return `nil` for
-    // platform filters
+    /// Given A -> B -> C, if A -> B has a filter of [.ios], and B -> C has a filter of `[.macos]`, A->C should return `nil` for
+    /// platform filters
     func test_platformFilters_transitiveDependencyHasNilPlatformFilters_whenDependencyHasDisjointFilters() throws {
         // Given
         let app = Target.test(name: "App", destinations: [.mac], product: .app)
@@ -4640,7 +4637,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(result.condition, platformCondition)
     }
 
-    // https://github.com/tuist/tuist/issues/5746
+    /// https://github.com/tuist/tuist/issues/5746
     func test_transitiveTargetDependenciesWhenIntermediateDependenciesHaveConditions() throws {
         // Given
         let app = Target.test(name: "App", destinations: [.iPhone, .mac], product: .app)

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -9,9 +9,7 @@ import XCTest
 
 @testable import TuistKit
 
-/**
- SwiftPM stores the registry configuration globally, and that prevents us from running these tests in parallel.
- */
+/// SwiftPM stores the registry configuration globally, and that prevents us from running these tests in parallel.
 @Suite(.serialized)
 struct DependenciesAcceptanceTests {
     @Test(

--- a/Tests/TuistGeneratorTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -230,15 +230,13 @@ final class MultipleConfigurationsIntegrationTests {
         #expect(staging.containsKey("C") == false) // non-existing
     }
 
-    /**
-     Exhaustive test to validate the priority of the particular settings:
-     - project .xcconfig
-     - project base
-     - project configuration settings
-     - target .xcconfig
-     - target base
-     - target configuraiton settings
-     */
+    /// Exhaustive test to validate the priority of the particular settings:
+    /// - project .xcconfig
+    /// - project base
+    /// - project configuration settings
+    /// - target .xcconfig
+    /// - target base
+    /// - target configuraiton settings
     @Test(
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -2258,13 +2258,13 @@ struct GraphLinterTests {
             // Given
             let path = try #require(FileSystem.temporaryTestDirectory)
 
-            /* extension kit target is under test */
+            // extension kit target is under test
             let sut = Target.test(name: "Extension", platform: platform, product: .extensionKitExtension)
 
-            /* app embedding the extension */
+            // app embedding the extension
             let app = Target.test(name: "App", platform: platform, product: .app)
 
-            /* extension dependencies */
+            // extension dependencies
             let dynamicFramework = Target.test(name: "DynamicFramework", platform: platform, product: .framework)
             let staticFramework = Target.test(name: "StaticFramework", platform: platform, product: .staticFramework)
             let dynamicLibrary = Target.test(name: "DynamicLibrary", platform: platform, product: .dynamicLibrary)

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 @testable import TuistGenerator
 
-// Bundle name is irrelevant if the target supports resources.
+/// Bundle name is irrelevant if the target supports resources.
 private let irrelevantBundleName = ""
 
 final class ResourcesProjectMapperTests: TuistUnitTestCase {

--- a/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
@@ -235,9 +235,9 @@ final class LintRedundantImportsServiceTests: TuistUnitTestCase {
         try await subject.run(path: path.pathString)
     }
 
-    // We need a separate app to test out Message Extensions
-    // as having both stickers pack and message extensions in one app
-    // doesn't seem to be supported.
+    /// We need a separate app to test out Message Extensions
+    /// as having both stickers pack and message extensions in one app
+    /// doesn't seem to be supported.
     func test_run_doesntThrowAnyErrorsWithAppExtensionsSetWithMessageExtension_when_thereAreNoIssues() async throws {
         // Given
         let path = try AbsolutePath(validating: "/project")

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1398,7 +1398,7 @@ struct PackageInfoMapperTests {
         )
     }
 
-    // For more context of this scenario, see: https://github.com/tuist/tuist/issues/7445
+    /// For more context of this scenario, see: https://github.com/tuist/tuist/issues/7445
     @Test(.inTemporaryDirectory, .withMockedSwiftVersionProvider) func testMap_whenResourcesInsideXCFramework() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         let sourcesPath = basePath.appending(components: "Package", "Sources", "Target1")

--- a/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/SettingsMapperTests.swift
@@ -10,9 +10,10 @@ import XCTest
 @testable import TuistTesting
 
 final class SettingsMapperTests: XCTestCase {
-    // Test that the right combintations end up in the right fields
+    // Test that the right combinations end up in the right fields
     // Test that platforms exclude correctly
     // test that platform conflicts combine correctly
+
     func test_set_defaults() throws {
         let mapper = SettingsMapper(
             headerSearchPaths: [],

--- a/Tests/TuistSupportTests/Utils/UserInputReaderTests.swift
+++ b/Tests/TuistSupportTests/Utils/UserInputReaderTests.swift
@@ -116,7 +116,7 @@ class UserInputReaderTests: TuistUnitTestCase {
     }
 }
 
-// Custom string reader to simulate user input
+/// Custom string reader to simulate user input.
 private struct StringReader {
     let input: String
     var index: String.Index

--- a/fixtures/app_with_plugins/Package.swift
+++ b/fixtures/app_with_plugins/Package.swift
@@ -7,6 +7,7 @@
     import ProjectDescription
 
     // Note: Testing importing of plugins in local helpers
+
     let localPlugin = LocalHelper(name: "local")
     let remotePlugin = RemoteHelper(name: "remote")
 

--- a/fixtures/app_with_plugins/Project.swift
+++ b/fixtures/app_with_plugins/Project.swift
@@ -5,6 +5,7 @@ import ProjectDescriptionHelpers
 import LocalPlugin
 
 // Test plugins are loaded
+
 let localHelper = LocalHelper(name: "LocalPlugin")
 let remoteHelper = RemoteHelper(name: "RemotePlugin")
 

--- a/fixtures/app_with_tasks/Project.swift
+++ b/fixtures/app_with_tasks/Project.swift
@@ -1,25 +1,22 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-/*
-                +-------------+
-                |             |
-                |     App     | Contains App App target and App unit-test target
-                |             |
-         +------+-------------+-------+
-         |         depends on         |
-         |                            |
- +----v-----+                   +-----v-----+
- |          |                   |           |
- |   Kit    |                   |     UI    |   Two independent frameworks to share code and start modularising your app
- |          |                   |           |
- +----------+                   +-----------+
-
- */
+//               +-------------+
+//               |             |
+//               |     App     | Contains App App target and App unit-test target
+//               |             |
+//        +------+-------------+-------+
+//        |         depends on         |
+//        |                            |
+// +----v-----+                   +-----v-----+
+// |          |                   |           |
+// |   Kit    |                   |     UI    |   Two independent frameworks to share code and start modularising your app
+// |          |                   |           |
+// +----------+                   +-----------+
 
 // MARK: - Project
 
-// Creates our project using a helper function defined in ProjectDescriptionHelpers
+/// Creates our project using a helper function defined in ProjectDescriptionHelpers
 let project = Project.app(
     name: "App",
     destinations: .iOS,

--- a/fixtures/app_with_tasks/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/fixtures/app_with_tasks/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -1,9 +1,9 @@
 import ProjectDescription
 
-/// Project helpers are functions that simplify the way you define your project.
-/// Share code to create targets, settings, dependencies,
-/// Create your own conventions, e.g: a func that makes sure all shared targets are "static frameworks"
-/// See https://docs.tuist.io/guides/helpers/
+// Project helpers are functions that simplify the way you define your project.
+// Share code to create targets, settings, dependencies,
+// Create your own conventions, e.g: a func that makes sure all shared targets are "static frameworks"
+// See https://docs.tuist.io/guides/helpers/
 
 extension Project {
     /// Helper function to create the Project for this ExampleApp

--- a/fixtures/ios_app_with_coredata_in_static_framework/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_coredata_in_static_framework/App/Tests/AppDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // Generated project does not set "Host Application" and "Allow testing Host Application APIs",
 // what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+
 class AppDelegateTests: XCTestCase {
 //    func testHello() {
 //        let sut = AppDelegate()

--- a/fixtures/ios_app_with_custom_scheme/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Tests/AppDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // Generated project does not set "Host Application" and "Allow testing Host Application APIs",
 // what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+
 class AppDelegateTests: XCTestCase {
 //    func testHello() {
 //        let sut = AppDelegate()

--- a/fixtures/ios_app_with_custom_workspace/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_custom_workspace/App/Tests/AppDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // Generated project does not set "Host Application" and "Allow testing Host Application APIs",
 // what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+
 class AppDelegateTests: XCTestCase {
 //    func testHello() {
 //        let sut = AppDelegate()

--- a/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 // Example of resources specified via variables instead of direct literals.
 // Often sources and resources are declared in helpers where their values
 // are computed, as such we need to support non-literal declarations.
+
 let resourcesDirectory = "Resources"
 let resources: [ResourceFileElement] = [
     "\(resourcesDirectory)/framework_resource.txt",

--- a/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 // Example of resources specified via variables instead of direct literals.
 // Often sources and resources are declared in helpers where their values
 // are computed, as such we need to support non-literal declarations.
+
 let resourcesDirectory = "Resources"
 let resources: [ResourceFileElement] = [
     "\(resourcesDirectory)/framework_resource.txt",

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Tests/AppDelegateTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // Generated project does not set "Host Application" and "Allow testing Host Application APIs",
 // what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+
 class AppDelegateTests: XCTestCase {
 //    func testHello() {
 //        let sut = AppDelegate()

--- a/fixtures/ios_app_with_local_binary_swift_package/Packages/LocalPackage/MyFramework/Project.swift
+++ b/fixtures/ios_app_with_local_binary_swift_package/Packages/LocalPackage/MyFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: .default,
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
             ],
             settings: .settings(base: [

--- a/fixtures/ios_app_with_local_swift_package/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Project.swift
@@ -14,7 +14,7 @@ let project = Project(
             infoPlist: "Support/Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [

--- a/fixtures/ios_app_with_multi_configs/Framework2/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework2/Project.swift
@@ -8,7 +8,8 @@ let settings: Settings = .settings(
     ]
 )
 
-// Targets can override select configurations if needed
+// Targets can override select configurations if needed.
+
 let targetSettings: Settings = .settings(
     base: [
         "TARGET_BASE": "TARGET_BASE",

--- a/fixtures/ios_app_with_remote_swift_package/Project.swift
+++ b/fixtures/ios_app_with_remote_swift_package/Project.swift
@@ -14,7 +14,7 @@ let project = Project(
             infoPlist: "Support/Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [

--- a/fixtures/ios_app_with_static_frameworks/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/B/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: "Sources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
             ]
         ),
         .target(

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: "Sources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
                 .project(target: "D", path: "../D"),
             ]
         ),

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/B/Project.swift
@@ -12,8 +12,8 @@ let project = Project(
             sources: "Sources/**",
             resources: "Resources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
             ]
         ),
         .target(

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/C/Project.swift
@@ -12,8 +12,8 @@ let project = Project(
             sources: "Sources/**",
             resources: "Resources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
                 .project(target: "D", path: "../D"),
             ]
         ),

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: "Sources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
             ]
         ),
         .target(

--- a/fixtures/ios_app_with_static_libraries/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/C/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: "Sources/**",
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
             ],
             settings: .settings(base: ["BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"])
         ),

--- a/fixtures/ios_app_with_static_library_and_package/Project.swift
+++ b/fixtures/ios_app_with_static_library_and_package/Project.swift
@@ -14,7 +14,7 @@ let project = Project(
             infoPlist: "Support/Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [

--- a/fixtures/ios_app_with_templates/Project.swift
+++ b/fixtures/ios_app_with_templates/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: "Support/Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ]
         ),

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -110,8 +110,8 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: .paths([.relativeToManifest("App/Sources/**")]),
             dependencies: [
-                /* Target dependencies can be defined here */
-                /* .framework(path: "framework") */
+                // Target dependencies can be defined here
+                // .framework(path: "framework")
             ],
             settings: .settings(base: [
                 "CODE_SIGN_IDENTITY": "",

--- a/fixtures/ios_app_with_watchapp2/Project.swift
+++ b/fixtures/ios_app_with_watchapp2/Project.swift
@@ -14,11 +14,11 @@ let project = Project(
             infoPlist: "Support/App-Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .target(name: "WatchApp"),
                 .package(product: "LibraryA"),

--- a/fixtures/ios_app_with_watchapp2_xcode14/Project.swift
+++ b/fixtures/ios_app_with_watchapp2_xcode14/Project.swift
@@ -14,11 +14,11 @@ let project = Project(
             infoPlist: "Support/App-Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .target(name: "WatchApp"),
                 .package(product: "LibraryA"),

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyFramework/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
             ],
             settings: .settings(base: [

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticFramework/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyStaticFramework.framework")
             ],
             settings: .settings(base: [

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticLibrary/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticLibrary/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyStaticLibrary.framework")
             ],
             settings: .settings(base: [

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FrameworkA", path: "../Frameworks/FrameworkA"),
             ]

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FrameworkB", path: "../FrameworkB"),
             ]

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FrameworkA", path: "../FrameworkA"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ]
         ),

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
@@ -12,11 +12,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "Core", path: "../CoreFramework"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
@@ -12,11 +12,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
                 .project(target: "Core", path: "../CoreFramework"),

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
@@ -12,11 +12,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "Data", path: "../DataFramework"),
                 .project(target: "Core", path: "../CoreFramework"),

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
@@ -12,11 +12,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Project.swift
@@ -12,11 +12,11 @@ let project = Project(
             infoPlist: "App/Info.plist",
             sources: ["App/Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FrameworkA", path: "Frameworks/FeatureAFramework"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/CoreFramework/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ]
         ),

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/DataFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/DataFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "Core", path: "../CoreFramework"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureAFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureAFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
                 .project(target: "Core", path: "../CoreFramework"),

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureContracts/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureContracts/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "Data", path: "../DataFramework"),
                 .project(target: "Core", path: "../CoreFramework"),

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/UIComponentsFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/UIComponentsFramework/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
             ]

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/StaticApp/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/StaticApp/Project.swift
@@ -11,11 +11,11 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ],
             dependencies: [
-                /* Target dependencies can be defined here */
+                // Target dependencies can be defined here
                 // .framework(path: "Frameworks/MyFramework.framework")
                 .project(target: "FrameworkA", path: "../Frameworks/FeatureAFramework"),
             ]

--- a/fixtures/macos_app_with_extensions/Project.swift
+++ b/fixtures/macos_app_with_extensions/Project.swift
@@ -1,8 +1,6 @@
 import ProjectDescription
 
-/**
- These are necessary for the compiler to find the Workflow's SDK and link against it.
- **/
+/// These are necessary for the compiler to find the Workflow's SDK and link against it.
 let workflowExtensionSettings: SettingsDictionary = [
     "ADDITIONAL_SDKS": "/Library/Developer/SDKs/WorkflowExtensionSDK.sdk $(inherited)",
     "OTHER_LDFLAGS": "-fapplication-extension -e _ProExtensionMain -lProExtension",

--- a/fixtures/multiplatform_app_with_swift_macros/Modules/WatchOSDynamicFramework/Sources/WatchOSDynamicFrameworkClass.swift
+++ b/fixtures/multiplatform_app_with_swift_macros/Modules/WatchOSDynamicFramework/Sources/WatchOSDynamicFrameworkClass.swift
@@ -9,6 +9,7 @@ struct Watch {
 }
 
 // @Reducer is a Swift Macro that generates other macros
+
 @Reducer
 struct Counter {
     struct State: Equatable {

--- a/fixtures/visionos_app/Project.swift
+++ b/fixtures/visionos_app/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: "Support/Info.plist",
             sources: ["Sources/**"],
             resources: [
-                /* Path to resources can be defined here */
+                // Path to resources can be defined here
                 // "Resources/**"
             ]
         ),


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7616>

### Short description 📝

Update linter to enforce `///` and `//` comment system. So that all over the project follows the same comment style.

I enabled [docComments](https://github.com/nicklockwood/SwiftFormat/blob/0.53.3/Rules.md#doccomments) and [blockComments](https://github.com/nicklockwood/SwiftFormat/blob/0.53.3/Rules.md#blockcomments) rules in `SwiftFormat` to enforce the comment style.

After applying the new rules to the full project, I rechecked all the changes manually and slightly modified some spacing and added new lines to make the comment style correct.

### How to test the changes locally 🧐

Run `mise run lint-fix` to apply and check the changes.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
