### PR TITLE
Read `currentWorkingDirectory` from Environment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let targets: [Target] = [
             pathDependency,
             swiftToolsSupportDependency,
             "FileSystem",
+            "TuistSupport",
         ]
     ),
     .executableTarget(
@@ -28,7 +29,9 @@ let targets: [Target] = [
             argumentParserDependency,
             pathDependency,
             swiftToolsSupportDependency,
+            pathDependency,
             "ProjectDescription",
+            "TuistSupport",
         ]
     ),
     .target(

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import FileSystem
 import Foundation
 import Path
+import TuistSupport
 
 public struct InitCommand: AsyncParsableCommand, NooraReadyCommand {
     public static var configuration: CommandConfiguration {
@@ -30,16 +31,10 @@ public struct InitCommand: AsyncParsableCommand, NooraReadyCommand {
     public init() {}
 
     public func run() async throws {
-        try await InitCommandService().run(from: try await directory(), answers: answers())
-    }
-
-    private func directory() async throws -> AbsolutePath {
-        let currentWorkingDirectory = try await FileSystem().currentWorkingDirectory()
-        if let pathString = path {
-            return try AbsolutePath(validating: pathString, relativeTo: currentWorkingDirectory)
-        } else {
-            return currentWorkingDirectory
-        }
+        try await InitCommandService().run(
+            from: try await Environment.current.pathRelativeToWorkingDirectory(path),
+            answers: answers()
+        )
     }
 
     private func answers() async throws -> InitPromptAnswers? {

--- a/Sources/TuistKit/Services/AccountUpdateService.swift
+++ b/Sources/TuistKit/Services/AccountUpdateService.swift
@@ -57,15 +57,7 @@ struct AccountUpdateService: AccountUpdateServicing {
         directory: String?,
         onEvent: (AccountUpdateServiceEvent) -> Void
     ) async throws {
-        let directoryPath: AbsolutePath
-        if let directory {
-            directoryPath = try AbsolutePath(
-                validating: directory, relativeTo: try await fileSystem.currentWorkingDirectory()
-            )
-        } else {
-            directoryPath = try await fileSystem.currentWorkingDirectory()
-        }
-
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(directory)
         let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverURLService.url(configServerURL: config.url)
 

--- a/Sources/TuistKit/Services/InitCommandService.swift
+++ b/Sources/TuistKit/Services/InitCommandService.swift
@@ -136,7 +136,7 @@ public struct InitCommandService {
 
         try await mise(path: projectDirectory, nextSteps: &nextSteps)
 
-        let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+        let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
         if projectDirectory != currentWorkingDirectory {
             nextSteps.insert(
                 "Choose the project directory with \(.command("cd \(projectDirectory.relative(to: currentWorkingDirectory).pathString)"))",

--- a/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -164,7 +164,7 @@ struct InspectBuildCommandService {
                 return workspacePath
             }
         } else {
-            let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+            let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
             let basePath =
                 if let path {
                     try AbsolutePath(

--- a/Sources/TuistKit/Services/Inspect/InspectBundleCommandService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspectBundleCommandService.swift
@@ -49,7 +49,7 @@ struct InspectBundleCommandService {
     ) async throws {
         let bundlePath = try AbsolutePath(
             validating: bundle,
-            relativeTo: try await fileSystem.currentWorkingDirectory()
+            relativeTo: try await Environment.current.currentWorkingDirectory()
         )
         let path = try await self.path(path)
 
@@ -100,12 +100,13 @@ struct InspectBundleCommandService {
     }
 
     private func path(_ path: String?) async throws -> AbsolutePath {
+        let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
         if let path {
-            return try await AbsolutePath(
-                validating: path, relativeTo: fileSystem.currentWorkingDirectory()
+            return try AbsolutePath(
+                validating: path, relativeTo: currentWorkingDirectory
             )
         } else {
-            return try await fileSystem.currentWorkingDirectory()
+            return currentWorkingDirectory
         }
     }
 }

--- a/Sources/TuistKit/Services/Registry/RegistryLoginCommandService.swift
+++ b/Sources/TuistKit/Services/Registry/RegistryLoginCommandService.swift
@@ -69,7 +69,7 @@ struct RegistryLoginCommandService {
     func run(
         path: String?
     ) async throws {
-        let path = try await self.path(path)
+        let path = try await Environment.current.pathRelativeToWorkingDirectory(path)
         let config = try await configLoader.loadConfig(path: path)
 
         guard let fullHandle = config.fullHandle else {
@@ -165,15 +165,5 @@ struct RegistryLoginCommandService {
             token: token,
             registryURL: registryURL
         )
-    }
-
-    private func path(_ path: String?) async throws -> AbsolutePath {
-        if let path {
-            return try await AbsolutePath(
-                validating: path, relativeTo: fileSystem.currentWorkingDirectory()
-            )
-        } else {
-            return try await fileSystem.currentWorkingDirectory()
-        }
     }
 }

--- a/Sources/TuistKit/Services/Registry/RegistryLogoutService.swift
+++ b/Sources/TuistKit/Services/Registry/RegistryLogoutService.swift
@@ -27,7 +27,7 @@ final class RegistryLogoutService {
     func run(
         path: String?
     ) async throws {
-        let path = try await self.path(path)
+        let path = try await Environment.current.pathRelativeToWorkingDirectory(path)
         let config = try await configLoader.loadConfig(path: path)
 
         Logger.current.info("Logging out of the registry...")
@@ -38,15 +38,5 @@ final class RegistryLogoutService {
         )
 
         Logger.current.info("Successfully logged out of the registry.")
-    }
-
-    private func path(_ path: String?) async throws -> AbsolutePath {
-        if let path {
-            return try await AbsolutePath(
-                validating: path, relativeTo: fileSystem.currentWorkingDirectory()
-            )
-        } else {
-            return try await fileSystem.currentWorkingDirectory()
-        }
     }
 }

--- a/Sources/TuistKit/Services/Registry/RegistrySetupCommandService.swift
+++ b/Sources/TuistKit/Services/Registry/RegistrySetupCommandService.swift
@@ -62,7 +62,7 @@ struct RegistrySetupCommandService {
     func run(
         path: String?
     ) async throws {
-        let path = try await self.path(path)
+        let path = try await Environment.current.pathRelativeToWorkingDirectory(path)
         let config = try await configLoader.loadConfig(path: path)
 
         guard let fullHandle = config.fullHandle else {
@@ -147,16 +147,6 @@ struct RegistrySetupCommandService {
                 ]
             )
         )
-    }
-
-    private func path(_ path: String?) async throws -> AbsolutePath {
-        if let path {
-            return try await AbsolutePath(
-                validating: path, relativeTo: fileSystem.currentWorkingDirectory()
-            )
-        } else {
-            return try await fileSystem.currentWorkingDirectory()
-        }
     }
 
     private func registryConfigurationJSON(

--- a/Sources/TuistKit/Services/XcodeBuild/XcodeBuildBuildCommandService.swift
+++ b/Sources/TuistKit/Services/XcodeBuild/XcodeBuildBuildCommandService.swift
@@ -44,7 +44,7 @@ struct XcodeBuildBuildCommandService {
             for: "-resultBundlePath",
             arguments: passthroughXcodebuildArguments
         ) {
-            let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+            let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
             let resultBundlePath = try AbsolutePath(validating: resultBundlePathString, relativeTo: currentWorkingDirectory)
             await RunMetadataStorage.current.update(
                 resultBundlePath: resultBundlePath
@@ -64,7 +64,7 @@ struct XcodeBuildBuildCommandService {
     private func path(
         passthroughXcodebuildArguments: [String]
     ) async throws -> AbsolutePath {
-        let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+        let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
         if let workspaceOrProjectPath = passedValue(for: "-workspace", arguments: passthroughXcodebuildArguments) ??
             passedValue(for: "-project", arguments: passthroughXcodebuildArguments)
         {

--- a/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -241,7 +241,7 @@ struct XcodeBuildTestCommandService {
             for: "-resultBundlePath",
             arguments: passthroughXcodebuildArguments
         ) {
-            let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+            let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
             let resultBundlePath = try AbsolutePath(
                 validating: resultBundlePathString, relativeTo: currentWorkingDirectory
             )
@@ -322,7 +322,7 @@ struct XcodeBuildTestCommandService {
     private func path(
         passthroughXcodebuildArguments: [String]
     ) async throws -> AbsolutePath {
-        let currentWorkingDirectory = try await fileSystem.currentWorkingDirectory()
+        let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
         if let workspaceOrProjectPath = Self.passedValue(
             for: "-workspace", arguments: passthroughXcodebuildArguments
         )

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -88,6 +88,17 @@ extension Environmenting {
             ciPlatformVariables.contains($0.key)
         }) != nil
     }
+
+    public func pathRelativeToWorkingDirectory(_ path: String?) async throws -> AbsolutePath {
+        let currentWorkingDirectory = try await currentWorkingDirectory()
+        if let path {
+            return try AbsolutePath(
+                validating: path, relativeTo: currentWorkingDirectory
+            )
+        } else {
+            return currentWorkingDirectory
+        }
+    }
 }
 
 /// Local environment controller.

--- a/Sources/tuistbenchmark/Commands/BenchmarkCommand.swift
+++ b/Sources/tuistbenchmark/Commands/BenchmarkCommand.swift
@@ -3,6 +3,7 @@ import FileSystem
 import Foundation
 import Path
 import TSCUtility
+import TuistSupport
 
 enum BenchmarkCommandError: LocalizedError {
     case missing(description: String)
@@ -84,8 +85,7 @@ struct BenchmarkCommand: AsyncParsableCommand {
         let config: BenchmarkConfig = try config.map { try parseConfig(path: $0) } ?? .default
         let fixtures = try await getFixturePaths(
             fixturesListPath: fixtureList,
-            fixturePath: fixture,
-            fileSystem: fileSystem
+            fixturePath: fixture
         )
 
         let renderer = makeRenderer(
@@ -157,8 +157,7 @@ struct BenchmarkCommand: AsyncParsableCommand {
 
     private func getFixturePaths(
         fixturesListPath: AbsolutePath?,
-        fixturePath: AbsolutePath?,
-        fileSystem: FileSysteming
+        fixturePath: AbsolutePath?
     ) async throws -> [AbsolutePath] {
         if let fixturePath {
             return [fixturePath]
@@ -167,7 +166,7 @@ struct BenchmarkCommand: AsyncParsableCommand {
         if let fixturesListPath {
             let fixtures = try parseFixtureList(path: fixturesListPath)
             return try await fixtures.paths.serialMap {
-                try AbsolutePath(validating: $0, relativeTo: try await fileSystem.currentWorkingDirectory())
+                try AbsolutePath(validating: $0, relativeTo: try await Environment.current.currentWorkingDirectory())
             }
         }
 

--- a/Sources/tuistfixturegenerator/Commands/GenerateCommand.swift
+++ b/Sources/tuistfixturegenerator/Commands/GenerateCommand.swift
@@ -2,12 +2,13 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 import TSCUtility
+import TuistSupport
 
 enum GenerateCommandError: Error {
     case invalidPath
 }
 
-struct GenerateCommand: ParsableCommand {
+struct GenerateCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "generate",
@@ -41,12 +42,8 @@ struct GenerateCommand: ParsableCommand {
     )
     var sources: Int?
 
-    func run() throws {
-        guard let currentPath = localFileSystem.currentWorkingDirectory else {
-            throw GenerateCommandError.invalidPath
-        }
-
-        let path = try AbsolutePath(validating: path ?? "Fixture", relativeTo: currentPath)
+    func run() async throws {
+        let path = try await Environment.current.pathRelativeToWorkingDirectory(path ?? "Fixture")
 
         let config = GeneratorConfig(
             projects: projects ?? GeneratorConfig.default.projects,
@@ -55,6 +52,6 @@ struct GenerateCommand: ParsableCommand {
         )
         let generator = Generator(fileSystem: localFileSystem, config: config)
 
-        try generator.generate(at: path)
+        try generator.generate(at: TSCBasic.AbsolutePath(validating: path.pathString))
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -230,6 +230,7 @@ public enum Module: String, CaseIterable {
                 ]
             case .tuistBenchmark:
                 [
+                    .target(name: Module.support.targetName),
                     .external(name: "SwiftToolsSupport"),
                     .external(name: "ArgumentParser"),
                     .external(name: "FileSystem"),
@@ -237,8 +238,10 @@ public enum Module: String, CaseIterable {
             case .tuistFixtureGenerator:
                 [
                     .target(name: Module.projectDescription.targetName),
+                    .target(name: Module.support.targetName),
                     .external(name: "SwiftToolsSupport"),
                     .external(name: "ArgumentParser"),
+                    .external(name: "Path"),
                 ]
             case .projectAutomation, .projectDescription:
                 []


### PR DESCRIPTION
`Environment.current` is our task, which allows us to mock the environment locally, the environment being the host on which the CLI is running. I noticed we were using `FileSystem().currentWorkingDirectory` in some places, so I decided to move those usages to `Environment.current.currentWorkingDirectory()` instead. 