### PR TITLE
Fix paths in the reported build insights

### DIFF
--- a/Sources/TuistSupport/Utils/GitController.swift
+++ b/Sources/TuistSupport/Utils/GitController.swift
@@ -58,6 +58,9 @@ public protocol GitControlling {
     /// - Parameter workingDirectory: The working directory of the git repository
     /// - Returns: A tuple containing git ref, branch name, and commit SHA
     func gitInfo(workingDirectory: AbsolutePath) -> (ref: String?, branch: String?, sha: String?)
+
+    /// Returns the top level `.git` directory path.
+    func topLevelGitDirectory(workingDirectory: AbsolutePath) throws -> AbsolutePath
 }
 
 /// An implementation of `GitControlling`.
@@ -72,6 +75,13 @@ public final class GitController: GitControlling {
     ) {
         self.system = system
         self.environment = environment
+    }
+
+    public func topLevelGitDirectory(workingDirectory: AbsolutePath) throws -> AbsolutePath {
+        try AbsolutePath(
+            validating: try capture(command: "git", "-C", workingDirectory.pathString, "rev-parse", "--show-toplevel")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        )
     }
 
     public func clone(url: String, into path: AbsolutePath) throws {

--- a/Tests/TuistSupportTests/Utils/GitControllerTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitControllerTests.swift
@@ -13,6 +13,16 @@ struct GitControllerTests {
         subject = GitController(system: system)
     }
 
+    @Test(.inTemporaryDirectory) func test_topLevelDirectory() throws {
+        let path = try #require(FileSystem.temporaryTestDirectory)
+
+        system.succeedCommand(["git", "-C \(path.pathString)", "rev-parse", "--show-toplevel"], output: "/path/to/root")
+
+        let gitDirectory = try subject.topLevelGitDirectory(workingDirectory: path)
+        #expect(gitDirectory == "/path/to/root")
+        #expect(system.called(["git", "-C \(path.pathString)", "rev-parse", "--show-toplevel"]) == true)
+    }
+
     @Test(.inTemporaryDirectory) func test_cloneInto() throws {
         let url = "https://some/url/to/repo.git"
         let path = try #require(FileSystem.temporaryTestDirectory)


### PR DESCRIPTION
### Short description 📝

The reported build insights uses relative paths from the root. However, the root should be derived from the `WORKSPACE_SCHEME` Xcode environment variable and we should prefer `.git` as we use the path to link to the file in git.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
