### PR TITLE
Poll for the latest activity log when it's not immediately available

### DIFF
--- a/Sources/TuistSupport/Extensions/ConcurrencyExtensions.swift
+++ b/Sources/TuistSupport/Extensions/ConcurrencyExtensions.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Inspired by: https://alejandromp.com/development/blog/the-importance-of-cooperative-cancellation/
 public func withTimeout(
     _ timeout: Duration,
-    onTimeout: @escaping () -> Void,
+    onTimeout: @escaping () throws -> Void,
     action: @escaping () async throws -> Void
 ) async throws {
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -13,7 +13,7 @@ public func withTimeout(
         }
         group.addTask {
             try await Task.sleep(for: timeout)
-            onTimeout()
+            try onTimeout()
         }
         try await group.next()
         group.cancelAll()

--- a/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
@@ -188,6 +188,72 @@ struct InspectBuildCommandServiceTests {
             .called(1)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func test_createsBuild_generated_after_initial_run() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "App.xcodeproj")
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.workspacePath = projectPath
+
+        let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
+        given(derivedDataLocator)
+            .locate(for: .any)
+            .willReturn(derivedDataPath)
+        let buildLogsPath = derivedDataPath.appending(components: "Logs", "Build")
+        let activityLogPath = buildLogsPath.appending(
+            components: "\(UUID().uuidString).xcactivitylog"
+        )
+
+        given(xcActivityLogController)
+            .parse(.value(activityLogPath))
+            .willReturn(
+                .test()
+            )
+        var numberOfAttempts = 0
+        given(xcActivityLogController).mostRecentActivityLogPath(
+            projectDerivedDataDirectory: .value(derivedDataPath),
+            after: .any
+        ).willProduce { _, _ in
+            numberOfAttempts = numberOfAttempts + 1
+            if numberOfAttempts > 2 {
+                return activityLogPath
+            } else {
+                return nil
+            }
+        }
+
+        gitController.reset()
+        given(gitController)
+            .gitInfo(workingDirectory: .any)
+            .willReturn((ref: nil, branch: "branch", sha: "sha"))
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        verify(createBuildService)
+            .createBuild(
+                fullHandle: .any,
+                serverURL: .any,
+                id: .any,
+                category: .any,
+                duration: .any,
+                files: .any,
+                gitBranch: .any,
+                gitCommitSHA: .any,
+                isCI: .any,
+                issues: .any,
+                modelIdentifier: .any,
+                macOSVersion: .any,
+                scheme: .any,
+                targets: .any,
+                xcodeVersion: .any,
+                status: .any
+            )
+            .called(1)
+    }
+
     @Test(.withMockedEnvironment())
     func test_when_should_not_wait() async throws {
         // Given


### PR DESCRIPTION
### Short description 📝

Initially reported by @vojtechvrbka.

In some cases, such as when building a scheme of a large app, Xcode doesn't _immediately_ generate the `.xcactivitylog`. Although it's still fast, the `tuist inspect build` background process invoked from the post-build action could still be too fast. To fix this, we poll whether we can find the activity log every 10 ms and for up to one second.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
