### PR TITLE
Add support for getting the build times per target given a list of activity log paths

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4da19f523679ff558e26dfef5304751d62b05f181060ebda8e5123cbfe54288f",
+  "originHash" : "ebbe622da4fe96c9ee5ab50559157b281d665635a6e6a24e94c5fc4c34053b47",
   "pins" : [
     {
       "identity" : "aexml",
@@ -463,10 +463,9 @@
     {
       "identity" : "xclogparser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XCLogParser",
+      "location" : "https://github.com/MobileNativeFoundation/XCLogParser",
       "state" : {
-        "revision" : "7cf8c50e1b84effcda573bbf8b26bdd0a6b4614f",
-        "version" : "0.2.41"
+        "revision" : "f9f32de91ee46a24620fb14921fa9d9aab6d583f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -549,7 +549,10 @@ let package = Package(
             .upToNextMajor(from: "0.2.2")
         ),
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", revision: "f9f32de91ee46a24620fb14921fa9d9aab6d583f"),
+        .package(
+            url: "https://github.com/MobileNativeFoundation/XCLogParser",
+            revision: "f9f32de91ee46a24620fb14921fa9d9aab6d583f"
+        ),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
         .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.40.1")),
         .package(

--- a/Package.swift
+++ b/Package.swift
@@ -549,7 +549,7 @@ let package = Package(
             .upToNextMajor(from: "0.2.2")
         ),
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
-        .package(url: "https://github.com/tuist/XCLogParser", .upToNextMajor(from: "0.2.41")),
+        .package(url: "https://github.com/MobileNativeFoundation/XCLogParser", revision: "f9f32de91ee46a24620fb14921fa9d9aab6d583f"),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
         .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.40.1")),
         .package(

--- a/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -15,6 +15,8 @@ public protocol XCActivityLogControlling {
     func buildTimesByTarget(projectDerivedDataDirectory: AbsolutePath) async throws -> [
         String: Double
     ]
+    func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
+        -> [String: Double]
     func parse(_ path: AbsolutePath) async throws -> XCActivityLog
 }
 
@@ -54,6 +56,12 @@ public struct XCActivityLogController: XCActivityLogControlling {
             buildLogsPath.appending(components: ["\($0).xcactivitylog"])
         }
 
+        return try await buildTimesByTarget(activityLogPaths: activityLogPaths)
+    }
+
+    public func buildTimesByTarget(activityLogPaths: [AbsolutePath]) async throws
+        -> [String: Double]
+    {
         var buildTimes: [String: Double] = [:]
         for activityLogPath in activityLogPaths {
             let activityLog = try XCLogParser.ActivityParser().parseActivityLogInURL(


### PR DESCRIPTION
I'm improving the API to get the build times per target by allowing passing a list of activity log paths. I've also updated the `XCLogParser` dependency to point to the base repository `MobileNativeFoundation/XCLogParser`