### PR TITLE
Fix inspecting build with too many issues

### DIFF
--- a/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -174,7 +174,7 @@ struct InspectBuildCommandService {
             gitBranch: gitBranch,
             gitCommitSHA: gitCommitSHA,
             isCI: Environment.current.isCI,
-            issues: xcactivityLog.issues,
+            issues: truncateIssuesIfNeeded(xcactivityLog.issues),
             modelIdentifier: machineEnvironment.modelIdentifier(),
             macOSVersion: machineEnvironment.macOSVersion,
             scheme: Environment.current.schemeName,
@@ -185,6 +185,19 @@ struct InspectBuildCommandService {
         AlertController.current.success(
             .alert("View the analyzed build at \(build.url.absoluteString)")
         )
+    }
+
+    /// This method truncates the number of warnings to 1000 and the message to 1000 characters.
+    private func truncateIssuesIfNeeded(_ issues: [XCActivityIssue]) -> [XCActivityIssue] {
+        issues
+            .prefix(1000)
+            .map {
+                var issue = $0
+                if let message = issue.message, message.count > 1000 {
+                    issue.message = message.prefix(1000) + "..."
+                }
+                return issue
+            }
     }
 
     private func projectPath(_ path: String?) async throws -> AbsolutePath {

--- a/Sources/TuistXCActivityLog/XCActivityIssue.swift
+++ b/Sources/TuistXCActivityLog/XCActivityIssue.swift
@@ -9,7 +9,7 @@ public struct XCActivityIssue: Hashable, Equatable {
     public let signature: String
     public let stepType: XCActivityStepType
     public let path: RelativePath?
-    public let message: String?
+    public var message: String?
     public let startingLine: Int
     public let endingLine: Int
     public let startingColumn: Int


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

When there are too many issues with very long messages, the POST request we make to the server to inspect the build becomes too large.

Instead of truncating the number of issues and the length of the messages, we _could_ batch the upload into multiple requests, I'd argue that if you have thousands of issues, it's unlikely to be useful to surface each individual issue in the Tuist dashboard.

We can still do batching of the requests, but I believe the new defaults won't have much of an impact on the usefulness of the build insights.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
