### PR TITLE
Merge the takeaways before printing

### DIFF
--- a/Sources/TuistSupport/Utils/AlertController.swift
+++ b/Sources/TuistSupport/Utils/AlertController.swift
@@ -82,8 +82,10 @@ public final class AlertController: @unchecked Sendable {
         for warning in warnings() {
             Noora.current.warning(warning)
         }
-        for success in success() {
-            Noora.current.success(success)
+        if let success = success().last {
+            var mergedTakeaways = success.takeaways
+            mergedTakeaways.append(contentsOf: takeaways())
+            Noora.current.success(.alert(success.message, takeaways: mergedTakeaways))
         }
     }
 }


### PR DESCRIPTION
I noticed the `print()` method, which is used in tests, did not merge the collected takeaways before printing them. This PR fixes it.