### PR TITLE
Ensure cache items are only fetched once

### DIFF
--- a/Sources/TuistServer/CacheStoring.swift
+++ b/Sources/TuistServer/CacheStoring.swift
@@ -19,8 +19,12 @@
         }
 
         public func hash(into hasher: inout Hasher) {
-            hasher.combine("cache-storable")
             hasher.combine(hash)
+            hasher.combine(name)
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            return lhs.hash == rhs.hash && lhs.name == rhs.name
         }
     }
 
@@ -36,8 +40,12 @@
         }
 
         public func hash(into hasher: inout Hasher) {
-            hasher.combine("cache-storable")
             hasher.combine(hash)
+            hasher.combine(name)
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            return lhs.hash == rhs.hash && lhs.name == rhs.name
         }
     }
 

--- a/Tests/TuistServerTests/CacheStorableItemTests.swift
+++ b/Tests/TuistServerTests/CacheStorableItemTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import TuistServer
+
+struct CacheStorableItemTests {
+    @Test
+    func cacheStorableItemsIsProperlyDeduplicatedInASet() {
+        // When
+        let got = Set(
+            [
+                CacheStorableItem(
+                    name: "name_one",
+                    hash: "hash_one",
+                    metadata: CacheStorableItemMetadata(time: 100)
+                ),
+                CacheStorableItem(
+                    name: "name_one",
+                    hash: "hash_one",
+                    metadata: CacheStorableItemMetadata(time: 200)
+                ),
+                CacheStorableItem(
+                    name: "name_two",
+                    hash: "hash_one",
+                    metadata: CacheStorableItemMetadata(time: 100)
+                ),
+            ]
+        )
+
+        // Then
+        #expect(
+            got.map(\.name).sorted() == [
+                "name_one",
+                "name_two",
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

### Short description 📝

We are depending a `Set` of `CacheStorableItem`s to deduplicate the items based on their names and hashes. However, `Set` only deduplicates items that are also _equal_. To fix this, we're also providing a custom `Equatable` implementation.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
