### PR TITLE
Fix inspecting build stuck when the activity log has too many files

### DIFF
--- a/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -210,7 +210,8 @@ public struct XCActivityLogController: XCActivityLogControlling {
     ) async throws
         -> [XCActivityBuildFile]
     {
-        try await steps
+        let derivedDataDirectory = try await Environment.current.derivedDataDirectory()
+        return try await steps
             .filter { $0.type == .detail }
             .concurrentCompactMap { step -> XCActivityBuildFile? in
                 let type: XCActivityBuildFileType
@@ -235,7 +236,7 @@ public struct XCActivityLogController: XCActivityLogControlling {
                 if let absolutePath = try? AbsolutePath(
                     validating: step.documentURL
                         .replacingOccurrences(of: "file://", with: "")
-                ), try await Environment.current.derivedDataDirectory().isAncestor(of: absolutePath) {
+                ), derivedDataDirectory.isAncestor(of: absolutePath) {
                     return nil
                 }
 


### PR DESCRIPTION
### Short description 📝

Reported by @vojtechvrbka. The `tuist inspect build` was getting stuck when we ran `Environment.current.derivedDataDirectory()` too many times from too many threads. We can precompute the value instead of calling it in each loop, which should also bring some performance benefits.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
