### PR TITLE
Don't sandbox config manifest

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -178,7 +178,7 @@ public class ManifestLoader: ManifestLoading {
     }
 
     public func loadConfig(at path: AbsolutePath) async throws -> ProjectDescription.Config {
-        try await loadManifest(.config, at: path, disableSandbox: false)
+        try await loadManifest(.config, at: path, disableSandbox: true)
     }
 
     public func loadProject(at path: AbsolutePath, disableSandbox: Bool) async throws -> ProjectDescription.Project {


### PR DESCRIPTION
### Short description 📝

This change disables sandboxing when loading the config manifest. Currently that manifest is always loaded in the sandbox. However, is for whatever reason sandboxing doesn't work, that means a dev can't disable the sandbox to work around it because that is done through the config.

### How to test the changes locally 🧐

1. Add a file I/O op to your config manifest
2. `tuist generate`

Expected: manifest build does not fail

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
