### PR TITLE
Fix build variable exposing in fileListPaths on TargetScript

### DIFF
--- a/cli/Fixtures/ios_app_with_build_variables/App/Project.swift
+++ b/cli/Fixtures/ios_app_with_build_variables/App/Project.swift
@@ -16,7 +16,7 @@ let project = Project(
                     arguments: ["\"tuist\""],
                     name: "Tuist",
                     outputPaths: ["$(DERIVED_FILE_DIR)/output.txt"],
-                    outputFileListPaths: ["$(DERIVED_FILE_DIR)/output.xcfilelist"],
+                    outputFileListPaths: ["$(DERIVED_FILE_DIR)/output.xcfilelist"]
                 ),
             ]
         ),

--- a/cli/Fixtures/ios_app_with_build_variables/App/Project.swift
+++ b/cli/Fixtures/ios_app_with_build_variables/App/Project.swift
@@ -15,7 +15,8 @@ let project = Project(
                     tool: "/bin/echo",
                     arguments: ["\"tuist\""],
                     name: "Tuist",
-                    outputPaths: ["$(DERIVED_FILE_DIR)/output.txt"]
+                    outputPaths: ["$(DERIVED_FILE_DIR)/output.txt"],
+                    outputFileListPaths: ["$(DERIVED_FILE_DIR)/output.xcfilelist"],
                 ),
             ]
         ),

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -205,8 +205,14 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                     .map {
                         (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
                     },
-                inputFileListPaths: script.inputFileListPaths,
-                outputFileListPaths: script.outputFileListPaths,
+                inputFileListPaths: script.inputFileListPaths
+                    .map {
+                        (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
+                    },
+                outputFileListPaths: script.outputFileListPaths
+                    .map {
+                        (try? AbsolutePath(validating: $0))?.relative(to: sourceRootPath).pathString ?? $0
+                    },
                 shellPath: script.shellPath,
                 shellScript: script.shellScript(sourceRootPath: sourceRootPath),
                 runOnlyForDeploymentPostprocessing: script.runForInstallBuildsOnly,

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -523,6 +523,10 @@ final class GenerateAcceptanceTestiOSAppWithBuildVariables: TuistAcceptanceTestC
             (buildPhases.first as? PBXShellScriptBuildPhase)?.outputPaths,
             ["$(DERIVED_FILE_DIR)/output.txt"]
         )
+        XCTAssertEqual(
+            (buildPhases.first as? PBXShellScriptBuildPhase)?.outputFileListPaths,
+            ["$(DERIVED_FILE_DIR)/output.xcfilelist"]
+        )
         try await run(BuildCommand.self)
     }
 }


### PR DESCRIPTION
Resolves #7693

### Short description 📝

Fixes incorrect handling of xcfilelist paths in `TargetScript` if they contain build variables (e.g. `$(DERIVED_FILE_DIR)`)

### How to test the changes locally 🧐

1. Открыть cli/Fixtures/ios_app_with_build_variables
2. tuist generate
3. Проверить что в билд фазе `Output File Lists` имеет `$(DERIVED_FILE_DIR)/output.xcfilelist`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
