### PR TITLE
Add GitHub Copilot instructions for code reviews

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,7 @@
 Resolves <https://github.com/tuist/tuist/issues/YYY>
 
-### Short description 📝
-
 > Describe here the purpose of your PR.
 
-### How to test the changes locally 🧐
+### How to test locally
 
-> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/get-started) for reference).
-
-### Contributor checklist ✅
-
-- [ ] The code has been linted using run `mise run lint-fix`
-- [ ] The change is tested via unit testing or acceptance testing, or both
-- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
-- [ ] In case the PR introduces changes that affect users, the documentation has been updated
-
-### Reviewer checklist ✅
-
-- [ ] The code architecture and patterns are consistent with the rest of the codebase
-- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
+> Document how to test your changes locally

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,73 @@
+# GitHub Copilot Instructions for Code Reviews
+
+This document provides guidelines for GitHub Copilot to assist with code reviews in the Tuist repository.
+
+## Review Checklist
+
+When reviewing pull requests, ensure the following items are addressed:
+
+### Code Quality and Testing
+- **Linting**: Verify that the code has been linted using `mise run lint-fix`. Check for any linting errors or warnings.
+- **Testing**: Ensure the change is tested via unit testing or acceptance testing, or both. Look for:
+  - New test files for new features
+  - Updated tests for modified functionality
+  - Adequate test coverage for edge cases
+  - Tests that follow the project's testing patterns
+
+### Documentation and Communication
+- **PR Title**: Verify the title is formulated in a way that is usable as a changelog entry. It should be:
+  - Clear and concise
+  - Written in present tense
+  - Descriptive of the change's impact
+- **User-Facing Changes**: For changes that affect users, confirm the documentation has been updated in the relevant places
+- **PR Description**: Check that the PR includes:
+  - A clear short description of the purpose
+  - Steps to test the changes locally
+  - A link to the related issue (if applicable)
+
+### Architecture and Patterns
+- **Consistency**: Ensure the code architecture and patterns are consistent with the rest of the codebase
+- **Code Style**: Verify adherence to Swift best practices and Tuist's coding conventions
+- **Modularity**: Check that code is properly organized within the appropriate modules
+
+### Labels and Changelog
+- **Changelog Labels**: For user-facing changes, verify the PR includes one of these labels:
+  - `changelog:added` - for new features
+  - `changelog:fixed` - for bug fixes
+  - `changelog:changed` - for changes to existing functionality
+- **Breaking Changes**: Flag any breaking changes that might require migration guides
+
+## Additional Review Guidelines
+
+### Performance Considerations
+- Look for potential performance bottlenecks
+- Check for efficient use of resources
+- Verify no unnecessary computations or allocations
+
+### Security
+- Review for potential security vulnerabilities
+- Ensure no hardcoded secrets or sensitive information
+- Check proper input validation and sanitization
+
+### Error Handling
+- Verify proper error handling and recovery
+- Check for informative error messages
+- Ensure errors are logged appropriately
+
+### Dependencies
+- Review any new dependencies for necessity and security
+- Check that dependency versions are properly specified
+- Verify compatibility with existing dependencies
+
+## Helpful Commands
+
+When reviewing, you may want to suggest running these commands:
+- `mise run build` - Build the project
+
+## Review Tone
+
+When providing feedback:
+- Be constructive and specific
+- Suggest improvements rather than just pointing out issues
+- Acknowledge good practices and clever solutions
+- Ask clarifying questions when the intent is unclear


### PR DESCRIPTION
I just noted that most of our PR template is unnecessary these days:
- GitHub Copilot & Dosu can take care of labelling things
- Linting checks are already on CI, so we don't need to have that in a checklist
- We can codify our guidelines for Copilot so that they are the ones doing the job that we were doing previously

## Summary
- Adds a comprehensive `.github/copilot-instructions.md` file to guide GitHub Copilot during code reviews
- Based on the existing PR template checklist with additional review guidelines
- Helps ensure consistent and thorough code reviews across the repository

## Test plan
- Review the created file to ensure it covers all necessary review aspects
- The instructions can be tested when GitHub Copilot performs its next code review

🤖 Generated with [Claude Code](https://claude.ai/code)