### PR TITLE
Upload icon with reverted iphone optimizations

### DIFF
--- a/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
@@ -1,3 +1,4 @@
+import Command
 import FileSystem
 import Foundation
 import Mockable
@@ -23,6 +24,7 @@ struct PreviewsUploadServiceTests {
         MockMultipartUploadCompletePreviewsServicing()
     private let uploadPreviewIconService = MockUploadPreviewIconServicing()
     private let gitController = MockGitControlling()
+    private let commandRunner = MockCommandRunning()
 
     private let serverURL: URL = .test()
     private let shareURL: URL = .test()
@@ -39,7 +41,8 @@ struct PreviewsUploadServiceTests {
             multipartUploadArtifactService: multipartUploadArtifactService,
             multipartUploadCompletePreviewsService: multipartUploadCompletePreviewsService,
             uploadPreviewIconService: uploadPreviewIconService,
-            gitController: gitController
+            gitController: gitController,
+            commandRunner: commandRunner
         )
 
         given(fileArchiverFactory)
@@ -310,6 +313,20 @@ struct PreviewsUploadServiceTests {
             given(uploadPreviewIconService)
                 .uploadPreviewIcon(.any, preview: .any, serverURL: .any, fullHandle: .any)
                 .willReturn()
+
+            given(commandRunner)
+                .run(
+                    arguments: .any,
+                    environment: .any,
+                    workingDirectory: .any
+                )
+                .willReturn(
+                    .init(
+                        unfolding: {
+                            nil
+                        }
+                    )
+                )
 
             // When
             let got = try await subject.uploadPreview(


### PR DESCRIPTION
This was a ... fun one 😄 

Turns out the png of the icon that's present in the `.ipa` bundle is "iPhone-optimized" and is no longer a fully valid PNG: https://theapplewiki.com/wiki/PNG_CgBI_Format. This custom PNG only display in some apps like Safari, but not for example in Chrome.

The fix is to use the `xcrun pngcrush -revert-iphone-optimizations` to revert those optimizations and make the PNG ... an actual PNG 🥹 

### How to test locally

- Create an `.ipa` bundle and share it with `tuist share`. The preview should display the icon in the browser.
