### PR TITLE
chore: change TuistApp product name in debug

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -96,7 +96,6 @@ jobs:
   app-device-build:
     name: Device Build
     runs-on: macos-15
-    if: env.TUIST_CONFIG_TOKEN != ''
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -122,8 +121,10 @@ jobs:
       - name: Generate TuistApp
         run: mise x -- tuist generate TuistApp
       - name: Bundle iOS app
+        if: env.TUIST_CONFIG_TOKEN != ''
         run: mise run app:bundle-ios
       - name: Inspect TuistApp
+        if: env.TUIST_CONFIG_TOKEN != ''
         run: mise x -- tuist inspect bundle build/Tuist.ipa
       - name: Share TuistApp
         if: env.TUIST_CONFIG_TOKEN != ''

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,7 @@
 
 --symlinks ignore
 --exclude cli/Tests/XCTestManifests.swift,cli/Sources/TuistSupport/Vendored,cli/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
---exclude cli/Fixtures/tuist_plugin,cli/Sources/TuistServer/OpenAPI
+--exclude cli/Fixtures/tuist_plugin,cli/Sources/TuistServer/OpenAPI,app/build
 --exclude **/Derived
 --disable conditionalAssignment
 --disable hoistAwait

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -38,6 +38,7 @@ let project = Project(
             name: "TuistApp",
             destinations: [.mac, .iPhone],
             product: .app,
+            productName: "Tuist",
             bundleId: "io.tuist.app",
             deploymentTargets: .macOS("14.0.0"),
             infoPlist: .extendingDefault(
@@ -77,14 +78,10 @@ let project = Project(
                     "CODE_SIGN_STYLE": "Automatic",
                     "CODE_SIGN_IDENTITY": "Apple Development",
                 ],
-                debug: [
-                    "PRODUCT_NAME": "TuistApp",
-                ],
                 release: [
                     // Needed for the app notarization
                     "OTHER_CODE_SIGN_FLAGS": "--timestamp --deep",
                     "ENABLE_HARDENED_RUNTIME": true,
-                    "PRODUCT_NAME": "Tuist",
                     "PROVISIONING_PROFILE_SPECIFIER[sdk=iphone*]": "Tuist Ad hoc",
                     "PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]": "Tuist macOS Distribution",
                 ]

--- a/cli/Sources/TuistKit/Services/ShareCommandService.swift
+++ b/cli/Sources/TuistKit/Services/ShareCommandService.swift
@@ -393,7 +393,7 @@ struct ShareCommandService {
         let preview = try await Noora.current.progressBarStep(
             message: "Uploading \(displayName)",
             successMessage: "\(displayName) uploaded",
-            errorMessage: "Failed to load manifests"
+            errorMessage: "Failed to upload the preview"
         ) { updateProgress in
             try await previewsUploadService.uploadPreview(
                 previewUploadType,


### PR DESCRIPTION
Aligning the product name across configurations, primarily so we end up with a single preview (we're not grouping apps with different display names), but also because the different product name per configuration no longer seems to be necessary.