### PR TITLE
Fix missing git ref when uploading preview

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -4976,6 +4976,10 @@ internal enum Operations {
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/git_commit_sha`.
                     internal var git_commit_sha: Swift.String?
+                    /// The git ref associated with the preview.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/git_ref`.
+                    internal var git_ref: Swift.String?
                     /// The supported platforms of the preview.
                     ///
                     /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/previews/start/POST/requestBody/json/supported_platforms`.
@@ -5002,6 +5006,7 @@ internal enum Operations {
                     ///   - display_name: The display name of the preview.
                     ///   - git_branch: The git branch associated with the preview.
                     ///   - git_commit_sha: The git commit SHA associated with the preview.
+                    ///   - git_ref: The git ref associated with the preview.
                     ///   - supported_platforms: The supported platforms of the preview.
                     ///   - _type: The type of the preview to upload.
                     ///   - version: The version of the preview.
@@ -5010,6 +5015,7 @@ internal enum Operations {
                         display_name: Swift.String? = nil,
                         git_branch: Swift.String? = nil,
                         git_commit_sha: Swift.String? = nil,
+                        git_ref: Swift.String? = nil,
                         supported_platforms: [Components.Schemas.PreviewSupportedPlatform]? = nil,
                         _type: Operations.startPreviewsMultipartUpload.Input.Body.jsonPayload._typePayload? = nil,
                         version: Swift.String? = nil
@@ -5018,6 +5024,7 @@ internal enum Operations {
                         self.display_name = display_name
                         self.git_branch = git_branch
                         self.git_commit_sha = git_commit_sha
+                        self.git_ref = git_ref
                         self.supported_platforms = supported_platforms
                         self._type = _type
                         self.version = version
@@ -5027,6 +5034,7 @@ internal enum Operations {
                         case display_name
                         case git_branch
                         case git_commit_sha
+                        case git_ref
                         case supported_platforms
                         case _type = "type"
                         case version

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -2365,6 +2365,11 @@ paths:
                   type: string
                   x-struct:
                   x-validate:
+                git_ref:
+                  description: The git ref associated with the preview.
+                  type: string
+                  x-struct:
+                  x-validate:
                 supported_platforms:
                   description: The supported platforms of the preview.
                   items:

--- a/cli/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadStartPreviewsService.swift
@@ -12,6 +12,7 @@ public protocol MultipartUploadStartPreviewsServicing {
         supportedPlatforms: [DestinationType],
         gitBranch: String?,
         gitCommitSHA: String?,
+        gitRef: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> AppBuildUpload
@@ -56,6 +57,7 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
         supportedPlatforms: [DestinationType],
         gitBranch: String?,
         gitCommitSHA: String?,
+        gitRef: String?,
         fullHandle: String,
         serverURL: URL
     ) async throws -> AppBuildUpload {
@@ -81,6 +83,7 @@ public final class MultipartUploadStartPreviewsService: MultipartUploadStartPrev
                         display_name: displayName,
                         git_branch: gitBranch,
                         git_commit_sha: gitCommitSHA,
+                        git_ref: gitRef,
                         supported_platforms: supportedPlatforms.map(Components.Schemas.PreviewSupportedPlatform.init),
                         _type: type,
                         version: version

--- a/cli/Sources/TuistServer/Services/PreviewsUploadService.swift
+++ b/cli/Sources/TuistServer/Services/PreviewsUploadService.swift
@@ -88,8 +88,6 @@
             updateProgress: @escaping (Double) -> Void
         ) async throws -> Preview {
             let gitInfo = try gitController.gitInfo(workingDirectory: path)
-            let gitCommitSHA = gitInfo.sha
-            let gitBranch = gitInfo.branch
 
             switch previewUploadType {
             case let .ipa(bundle):
@@ -101,8 +99,7 @@
                     bundleIdentifier: bundle.infoPlist.bundleId,
                     icon: iconPaths(for: previewUploadType).first,
                     supportedPlatforms: bundle.infoPlist.supportedPlatforms,
-                    gitBranch: gitBranch,
-                    gitCommitSHA: gitCommitSHA,
+                    gitInfo: gitInfo,
                     fullHandle: fullHandle,
                     serverURL: serverURL,
                     updateProgress: updateProgress
@@ -127,8 +124,7 @@
                         bundleIdentifier: bundle.infoPlist.bundleId,
                         icon: iconPaths(for: bundle).first,
                         supportedPlatforms: bundle.infoPlist.supportedPlatforms,
-                        gitBranch: gitBranch,
-                        gitCommitSHA: gitCommitSHA,
+                        gitInfo: gitInfo,
                         fullHandle: fullHandle,
                         serverURL: serverURL,
                         updateProgress: { progress in
@@ -149,8 +145,7 @@
             bundleIdentifier: String?,
             icon: AbsolutePath?,
             supportedPlatforms: [DestinationType],
-            gitBranch: String?,
-            gitCommitSHA: String?,
+            gitInfo: GitInfo,
             fullHandle: String,
             serverURL: URL,
             updateProgress: @escaping (Double) -> Void
@@ -165,8 +160,9 @@
                         version: version,
                         bundleIdentifier: bundleIdentifier,
                         supportedPlatforms: supportedPlatforms,
-                        gitBranch: gitBranch,
-                        gitCommitSHA: gitCommitSHA,
+                        gitBranch: gitInfo.branch,
+                        gitCommitSHA: gitInfo.sha,
+                        gitRef: gitInfo.ref,
                         fullHandle: fullHandle,
                         serverURL: serverURL
                     )

--- a/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
@@ -93,6 +93,7 @@ struct PreviewsUploadServiceTests {
                 supportedPlatforms: .any,
                 gitBranch: .any,
                 gitCommitSHA: .any,
+                gitRef: .any,
                 fullHandle: .any,
                 serverURL: .any
             )
@@ -161,6 +162,7 @@ struct PreviewsUploadServiceTests {
                     supportedPlatforms: .value([.simulator(.iOS)]),
                     gitBranch: .any,
                     gitCommitSHA: .any,
+                    gitRef: .any,
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(serverURL)
                 )
@@ -204,6 +206,7 @@ struct PreviewsUploadServiceTests {
                     supportedPlatforms: .any,
                     gitBranch: .any,
                     gitCommitSHA: .any,
+                    gitRef: .any,
                     fullHandle: .any,
                     serverURL: .any
                 )
@@ -238,6 +241,7 @@ struct PreviewsUploadServiceTests {
                     supportedPlatforms: .any,
                     gitBranch: .any,
                     gitCommitSHA: .any,
+                    gitRef: .any,
                     fullHandle: .any,
                     serverURL: .any
                 )
@@ -280,17 +284,8 @@ struct PreviewsUploadServiceTests {
 
             gitController.reset()
             given(gitController)
-                .isInGitRepository(workingDirectory: .any)
-                .willReturn(true)
-            given(gitController)
-                .hasCurrentBranchCommits(workingDirectory: .any)
-                .willReturn(true)
-            given(gitController)
-                .currentCommitSHA(workingDirectory: .any)
-                .willReturn("commit-sha")
-            given(gitController)
                 .gitInfo(workingDirectory: .any)
-                .willReturn(.test(ref: nil, branch: "main", sha: "commit-sha"))
+                .willReturn(.test(ref: "git-ref", branch: "main", sha: "commit-sha"))
 
             var multipartUploadCapturedGenerateUploadURLCallback:
                 ((MultipartUploadArtifactPart) async throws -> String)!
@@ -377,6 +372,7 @@ struct PreviewsUploadServiceTests {
                     supportedPlatforms: .value([.device(.iOS)]),
                     gitBranch: .value("main"),
                     gitCommitSHA: .value("commit-sha"),
+                    gitRef: .value("git-ref"),
                     fullHandle: .value("tuist/tuist"),
                     serverURL: .value(serverURL)
                 )


### PR DESCRIPTION
The GitHub preview comments stopped working because we (well, I 😅) forgot to include the git ref when uploading the preview.