### PR TITLE
Fix uploading .ipa icon

### DIFF
--- a/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/PreviewsUploadServiceTests.swift
@@ -380,7 +380,7 @@ struct PreviewsUploadServiceTests {
 
             verify(uploadPreviewIconService)
                 .uploadPreviewIcon(
-                    .value(iconPath),
+                    .any,
                     preview: .any,
                     serverURL: .any,
                     fullHandle: .any


### PR DESCRIPTION
In a recent PR, I added logic to revert iPhone optimizations for a given PNG image. The initial implementation was trying to do that in place but that fails with:
```
   Recompressing /var/folders/qc/zngxsyh562d1mwpsxydqg5b40000gn/T/TemporaryDirectory.55KEOu/Payload/Tuist.app/AppIcon60x60@2x.png
   Total length of data found in IDAT chunks    =    25494

   Cannot overwrite input file /var/folders/qc/zngxsyh562d1mwpsxydqg5b40000gn/T/TemporaryDirectory.55KEOu/Payload/Tuist.app/AppIcon60x60@2x.png
```

I'm pretty sure I tested the logic, but I must have missed something. Anyway, now we create a new image with the reverted optimizations.