### PR TITLE
Add acceptance tests for sharing .ipa

### DIFF
--- a/cli/Sources/TuistTesting/Utils/SwiftTestingHelper.swift
+++ b/cli/Sources/TuistTesting/Utils/SwiftTestingHelper.swift
@@ -2,14 +2,14 @@ import Foundation
 import Path
 import TuistSupport
 
-enum SwiftTestingHelper {
+public enum SwiftTestingHelper {
     public static func fixturePath(path: RelativePath) -> AbsolutePath {
         // swiftlint:disable:next force_try
-        try! AbsolutePath(
-            validating: Environment.current
-                .variables["TUIST_CONFIG_SRCROOT"]!
-        )
-        .appending(components: "cli", "Tests", "Fixtures")
-        .appending(path)
+        try! AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory.parentDirectory
+            .appending(components: [
+                "Tests",
+                "Fixtures",
+            ])
+            .appending(path)
     }
 }

--- a/cli/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/ShareAcceptanceTests.swift
@@ -2,13 +2,13 @@ import Command
 import FileSystem
 import FileSystemTesting
 import Foundation
+import Path
 import SnapshotTesting
 import Testing
 import TuistAcceptanceTesting
 import TuistCore
 import TuistSupport
 import TuistTesting
-import XCTest
 
 @testable import TuistKit
 
@@ -50,6 +50,31 @@ struct ShareAcceptanceTests {
         #expect(
             ui()
                 .contains("Launching App on \(simulator.name)") == true
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixtureConnectedToCanary("xcode_app"),
+    )
+    func share_tuist_ipa() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let ipaPath = SwiftTestingHelper.fixturePath(path: try RelativePath(validating: "App.ipa"))
+
+        // When
+        try await TuistTest.run(
+            ShareCommand.self,
+            ["--path", fixtureDirectory.pathString, ipaPath.pathString]
+        )
+
+        // Then
+        #expect(
+            ui()
+                .contains("Share Tuist with others") == true
         )
     }
 

--- a/mise/tasks/cli/lint.sh
+++ b/mise/tasks/cli/lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # mise description="Lint the workspace using SwiftFormat, SwiftLint, and Tuist implicit imports analysis"
-# USAGE flag "--fix" help="Automatically fix linting issues where possible"
+#USAGE flag "-f --fix" help="Automatically fix linting issues where possible"
 
 set -euo pipefail
 


### PR DESCRIPTION
To prevent regressions creeping in when running `tuist share SomeApp.ipa`, I'm adding an acceptance test.