### PR TITLE
fix: disable Debug executable for Manifests scheme

### DIFF
--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -317,7 +317,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         let arguments = Arguments(launchArguments: [LaunchArgument(name: "generate --path \(sourceRootPath)", isEnabled: true)])
         let runAction = RunAction(
             configurationName: "Debug",
-            attachDebugger: true,
+            attachDebugger: false,
             customLLDBInitFile: nil,
             executable: nil,
             filePath: tuistPath,


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7296>

> Describe here the purpose of your PR.

This PR disables the **Debug executable** option for the `Manifests` scheme,  
which is the default scheme used in the workspace created via the `tuist edit` command.

### How to test locally
> Document how to test your changes locally
1. Run `tuist edit`
2. In Xcode GUI:
    1. Open **Edit Scheme** for `Manifests`
    2. Select the **Run** action from the left sidebar
    3. Go to the **Info** tab
    4. Confirm that **Debug executable** is **disabled**
3. Confirm that xcode run does not fail.


### Contributor checklist ✅
- [x] The code has been linted using run mise run lint-fix
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅
- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label changelog:added, changelog:fixed, or changelog:changed, and the title is usable as a changelog entry
