### PR TITLE
fix: Add stringsdict to defaultSpmResourceFileExtensions

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -943,6 +943,7 @@ extension ProjectDescription.ResourceFileElements {
         "xcmappingmodel",
         "xcassets",
         "strings",
+        "stringsdict",
         "metal",
     ])
 


### PR DESCRIPTION
`.stringsdict` file are used describe plural forms on iOS. 

These files were not automatically added from the resources directory when imported from a Swift Package. 

### How to test locally

Add an SPM with `.stringsdict` resources for example: https://github.com/Infomaniak/ios-features/tree/feat/interapp-login

Observe that the files are now correctly referenced.
| Before  | After |
| ------------- | ------------- |
|![CleanShot 2025-06-24 at 14 33 54@2x](https://github.com/user-attachments/assets/b98a347d-5964-4e49-957d-0a4c6a5858da)|![CleanShot 2025-06-24 at 14 31 30@2x](https://github.com/user-attachments/assets/de5f9293-1523-4cf7-9f61-319a7f348473)|

I'm also wiling to add some tests but I'm not sure how 
