### PR TITLE
fix: Update documentation link to point to correct URL

### DIFF
--- a/cli/Sources/ProjectDescription/TargetDependency.swift
+++ b/cli/Sources/ProjectDescription/TargetDependency.swift
@@ -105,7 +105,7 @@ public enum TargetDependency: Codable, Hashable, Sendable {
 
     /// Dependency on a swift package manager product using Xcode native integration. It's recommended to use `external` instead.
     /// For more info, check the [external dependencies documentation
-    /// ](https://docs.tuist.io/documentation/tuist/dependencies/#External-dependencies).
+    /// ](https://docs.tuist.dev/en/guides/features/projects/dependencies#external-dependencies).
     ///
     /// - Parameters:
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.


### PR DESCRIPTION
## Summary
- Updated external dependencies documentation link from `docs.tuist.io` to `docs.tuist.dev` in TargetDependency.swift

## Details
The documentation link in the `.package` case comment was pointing to the old documentation URL. This PR updates it to point to the current documentation site.

**Changed:**
- `https://docs.tuist.io/documentation/tuist/dependencies/#External-dependencies`
- `https://docs.tuist.dev/en/guides/features/projects/dependencies#external-dependencies`

## Test plan
- [x] Verified the new URL is valid and points to the correct documentation
- [x] No functional changes, only documentation update