### PR TITLE
Add .extensionKitExtension to canEmbedBundles valid products list

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1433,6 +1433,7 @@ public class GraphTraverser: GraphTraversing {
         let validProducts: [Product] = [
             .app,
             .appExtension,
+            .extensionKitExtension,
             .watch2App,
             .appClip,
             .unitTests,


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7748>

This adds .extensionKitExtension to the canEmbedBundles validProducts list in GraphTraverser, enabling ExtensionKit extensions to embed bundles. This change allows ExtensionKit extensions, such as DeviceActivityReportExtension, to load resources like UI assets.

### How to test locally

1. Use attached project [https://github.com/softspheredev/extensionkit_extension_with_bundle](https://github.com/tuist/tuist/issues/url)
2. Run `tuist generate`
3. Observe the presence of TotalActivityFramework bundle in "Copy Bundle Resources" build phase of the ActivityReportExtension