### PR TITLE
Rename projectDerivedDataPath to derivedDataPath

### DIFF
--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -110,7 +110,7 @@ public enum EnvKey: String, CaseIterable {
     // BUILD
 
     case inspectBuildPath = "TUIST_INSPECT_BUILD_PATH"
-    case inspectBuildProjectDerivedDataPath = "TUIST_INSPECT_BUILD_PROJECT_DERIVED_DATA_PATH"
+    case inspectBuildDerivedDataPath = "TUIST_INSPECT_BUILD_DERIVED_DATA_PATH"
 
     // BUNDLE
 

--- a/cli/Sources/TuistKit/Commands/Inspect/InspectBuildCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Inspect/InspectBuildCommand.swift
@@ -21,15 +21,15 @@ struct InspectBuildCommand: AsyncParsableCommand, NooraReadyCommand {
         name: .long,
         help: "The path to the directory containing the project's derived data artifacts.",
         completion: .directory,
-        envKey: .inspectBuildProjectDerivedDataPath
+        envKey: .inspectBuildDerivedDataPath
     )
-    var projectDerivedDataPath: String?
+    var derivedDataPath: String?
 
     func run() async throws {
         try await InspectBuildCommandService()
             .run(
                 path: path,
-                projectDerivedDataPath: projectDerivedDataPath
+                derivedDataPath: derivedDataPath
             )
     }
 }

--- a/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -72,7 +72,7 @@ struct InspectBuildCommandService {
 
     func run(
         path: String?,
-        projectDerivedDataPath: String? = nil
+        derivedDataPath: String? = nil
     ) async throws {
         let referenceDate = dateService.now()
         guard let executablePath = Bundle.main.executablePath else {
@@ -98,7 +98,7 @@ struct InspectBuildCommandService {
         }
         let projectPath = try await projectPath(path)
         let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
-        var projectDerivedDataDirectory: AbsolutePath! = try projectDerivedDataPath.map { try AbsolutePath(
+        var projectDerivedDataDirectory: AbsolutePath! = try derivedDataPath.map { try AbsolutePath(
             validating: $0,
             relativeTo: currentWorkingDirectory
         ) }


### PR DESCRIPTION
For consistency with other commands.

Even if it's technically a breaking change, the parameter is considered sort of internal so we are fine changing it