### PR TITLE
Fix `tuist inspect redundant-import` check when `watchApp` depends on `watchAppExtension`

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -126,8 +126,8 @@ final class GraphImportsLinter: GraphImportsLinting {
                     case .app:
                         return false
                     case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
-                            .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
-                            .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
+                         .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
+                         .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
                         return true
                     }
                 case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .bundle,

--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -103,16 +103,36 @@ final class GraphImportsLinter: GraphImportsLinting {
                 !dependency.target.bundleId.hasSuffix(".generated.resources")
             }
             .filter { dependency in
-                !(target.target.product == .uiTests && dependency.target.product == .app)
-            }
-            .filter { dependency in
-                // App targets depending on extensions are not redundant imports
-                guard target.target.product == .app || target.target.product == .watch2App else { return true }
-                switch dependency.target.product {
-                case .appExtension, .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App:
-                    return false
-                case .app, .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
-                     .commandLineTool, .watch2Extension, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro:
+                switch target.target.product {
+                case .app:
+                    switch dependency.target.product {
+                    case .appExtension, .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App:
+                        return false
+                    case .app, .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
+                         .commandLineTool, .watch2Extension, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro:
+                        return true
+                    }
+                case .watch2App:
+                    switch dependency.target.product {
+                    case .watch2Extension:
+                        return false
+                    case .app, .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
+                         .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
+                         .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App:
+                        return true
+                    }
+                case .uiTests:
+                    switch dependency.target.product {
+                    case .app:
+                        return false
+                    case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
+                            .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
+                            .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
+                        return true
+                    }
+                case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .bundle,
+                     .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
+                     .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2Extension:
                     return true
                 }
             }

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
@@ -322,51 +322,68 @@ final class LintRedundantImportsServiceTests: TuistUnitTestCase {
         try await subject.run(path: path.pathString)
     }
 
-    func test_run_doesntThrowAnyErrorsWithAppWatchExtensionsSetWithStickerPackExtension_when_thereAreNoIssues() async throws {
+    func test_run_doesntThrowAnyErrorsWithAppWithAppWatch_when_thereAreNoIssues() async throws {
         // Given
         let path = try AbsolutePath(validating: "/project")
         let config = Tuist.test()
 
-        let appExtension = Target.test(
-            name: "AppExtension",
-            product: .appExtension
-        )
-
-        let stickerPackExtension = Target.test(
-            name: "StickerPackExtension",
-            product: .stickerPackExtension
-        )
-
-        let appIntentExtension = Target.test(
-            name: "AppIntentExtension",
-            product: .extensionKitExtension
+        let watch2App = Target.test(
+            name: "Watch2App",
+            product: .watch2App
         )
 
         let app = Target.test(
             name: "App",
-            product: .watch2App,
+            product: .app,
             dependencies: [
-                TargetDependency.target(name: "AppExtension"),
-                TargetDependency.target(name: "StickerPackExtension"),
-                TargetDependency.target(name: "AppIntentExtension"),
+                TargetDependency.target(name: "Watch2App"),
             ]
         )
-        let project = Project.test(path: path, targets: [appExtension, app])
+        let project = Project.test(path: path, targets: [watch2App, app])
         let graph = Graph.test(path: path, projects: [path: project], dependencies: [
             .target(name: app.name, path: project.path): [
-                .target(name: appExtension.name, path: project.path),
-                .target(name: stickerPackExtension.name, path: project.path),
-                .target(name: appIntentExtension.name, path: project.path),
+                .target(name: watch2App.name, path: project.path),
             ],
         ])
 
         given(configLoader).loadConfig(path: .value(path)).willReturn(config)
         given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
         given(generator).load(path: .value(path), options: .any).willReturn(graph)
-        given(targetScanner).imports(for: .value(appExtension)).willReturn(Set([]))
-        given(targetScanner).imports(for: .value(stickerPackExtension)).willReturn(Set([]))
-        given(targetScanner).imports(for: .value(appIntentExtension)).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(watch2App)).willReturn(Set([]))
         given(targetScanner).imports(for: .value(app)).willReturn(Set([]))
+
+        try await subject.run(path: path.pathString)
+    }
+
+    func test_run_doesntThrowAnyErrorsWithWatchAppWithWatchExtension_when_thereAreNoIssues() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let config = Tuist.test()
+
+        let watch2Extension = Target.test(
+            name: "Watch2Extension",
+            product: .watch2Extension
+        )
+
+        let app = Target.test(
+            name: "App",
+            product: .watch2App,
+            dependencies: [
+                TargetDependency.target(name: watch2Extension.name),
+            ]
+        )
+        let project = Project.test(path: path, targets: [app, watch2Extension])
+        let graph = Graph.test(path: path, projects: [path: project], dependencies: [
+            .target(name: app.name, path: project.path): [
+                .target(name: watch2Extension.name, path: project.path),
+            ],
+        ])
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(app)).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(watch2Extension)).willReturn(Set([]))
 
         try await subject.run(path: path.pathString)
     }


### PR DESCRIPTION
False positive as it's a legal dependency but there are no actual `import XXX` in code