### PR TITLE
ci: fix mise version when releasing app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Activate .env.json
         run: cp .optional.env.json .env.json
       - uses: jdx/mise-action@v2
+        with:
+          version: 2025.1.5
+          experimental: true
       - name: Check if there are releasable changes
         id: is-releasable
         working-directory: app


### PR DESCRIPTION
The release is failing due to auto-update of mise.