### PR TITLE
Add docs for how to set up Okta

### DIFF
--- a/docs/docs/en/guides/integrations/sso.md
+++ b/docs/docs/en/guides/integrations/sso.md
@@ -6,15 +6,42 @@ description: Learn how to set up Single Sign-On (SSO) with your organization.
 
 # SSO {#sso}
 
+## Google {#google}
+
 If you have a Google Workspace organization and you want any developer who signs in with the same Google hosted domain to be added to your Tuist organization, you can set it up with:
 ```bash
 tuist organization update sso my-organization --provider google --organization-id my-google-domain.com
 ```
 
-For on-premise customers that have Okta set up, you can get the same behavior as for Google by running:
+> [!IMPORTANT]
+> You must be authenticated with Google using an email tied to the organization whose domain you are setting up.
+
+## Okta {#okta}
+
+SSO with Okta is available only for enterprise customers. If you are interested in setting it up, please contact us at [contact@tuist.dev](mailto:contact@tuist.dev).
+
+During the process, you will be assigned a point of contact to help you set up the Okta SSO.
+
+Firstly, you will need to create an Okta application and configure it to work with Tuist:
+1. Go to Okta admin dashboard
+2. Applications > Applications > Create App Integration
+3. Select "OIDC - OpenID Connect" and "Web Application"
+4. Enter the display name for the application, for example, "Tuist". Upload a Tuist logo located at [this URL](https://tuist.dev/images/tuist_dashboard.png).
+5. Leave sign-in redirect URIs as it is for now
+6. Under "Assignments" choose the desired access control to the SSO Application and save.
+7. After saving, the general settings for the application will be available. Copy the "Client ID" and "Client Secret" – you will need to safely share this with your point of contact.
+8. The Tuist team will need to redeploy the Tuist server with the provided client ID and secret. This may take up to one business day.
+9. Once the server is deployed, click on General Settings "Edit" button.
+10. Paste the following redirect URL: `https://tuist.dev/users/auth/okta/callback`
+13. Change "Login initiated by" to "Either Okta or App".
+14. Select "Display application icon to users"
+15. Update the "Initiate login URL" with `https://tuist.dev/users/auth/okta?organization_id=1`. The `organization_id` will be supplied by your point of contact.
+16. Click "Save".
+17. Initiate Tuist login from your Okta dashboard.
+18. Give automatically access to your Tuist organization to users signed from your Okta domain by running the following command:
 ```bash
 tuist organization update sso my-organization --provider okta --organization-id my-okta-domain.com
 ```
 
 > [!IMPORTANT]
-> You must be authenticated with Google using an email tied to the organization whose domain you are setting up.
+> Users need to initially sign in via their Okta dashboard as Tuist currently doesn't support automatic provisioning and deprovisioning of users from your Okta organization. Once they sign in via their Okta dashboard, they will be automatically added to your Tuist organization.

--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -129,20 +129,16 @@ You can set up authentication with Google using [OAuth 2](https://developers.goo
 
 #### Okta {#okta}
 
-You can enable authentication with Okta through the [OAuth 2.0](https://oauth.net/2/) protocol. You'll have to [create an app](https://developer.okta.com/docs/en/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) on Okta with the following configuration:
+You can enable authentication with Okta through the [OAuth 2.0](https://oauth.net/2/) protocol. You'll have to [create an app](https://developer.okta.com/docs/en/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) on Okta following <LocalizedLink href="/guides/integrations/sso#okta">these instructions</LocalizedLink>.
 
-- **App integration name:** `Tuist`
-- **Grant type:** Enable *Authorization Code* for *Client acting on behalf of a user*
-- **Sign-in redirect URL:** `{url}/users/auth/okta/callback` where `url` is the public URL your service is accessed through.
-- **Assignments:** This configuration will depend on your security team requirements.
-
-Once the app is created you'll need to set the following environment variables:
+You will need to set the following environment variables once you obtain the client id and secret during the set up of the Okta application:
 
 | Environment variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
-| `TUIST_OKTA_SITE` | The URL of your Okta organization | Yes | | `https://your-org.okta.com` |
-| `TUIST_OKTA_CLIENT_ID` | The client ID to authenticate against Okta | Yes | | |
-| `TUIST_OKTA_CLIENT_SECRET` | The client secret to authenticate against Okta | Yes | | |
+| `TUIST_OKTA_1_CLIENT_ID` | The client ID to authenticate against Okta. The number should be your organization ID | Yes | | |
+| `TUIST_OKTA_1_CLIENT_SECRET` | The client secret to authenticate against Okta | Yes | | |
+
+The number `1` needs to be replaced with your organization ID. This will typically be 1, but check in your database.
 
 ### Storage environment configuration {#storage-environment-configuration}
 


### PR DESCRIPTION
Adding docs for setting up Okta. Steps are inspired by: https://help.letsdeel.com/hc/en-gb/articles/20957859203857-How-to-Setup-OpenID-Connect-Integration-with-Okta-for-Single-Sign-On

There are some extra steps – we expect to do rarely do this, so we skipped on some of the automation. This can be improved in the future.