### PR TITLE
Fix missing Noora output in log files

### DIFF
--- a/cli/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TuistCommand.swift
@@ -128,9 +128,11 @@ public struct TuistCommand: AsyncParsableCommand {
                 )
                 if command is NooraReadyCommand {
                     try await withLoggerForNoora(logFilePath: logFilePath) {
-                        try await trackableCommand.run(
-                            backend: backend
-                        )
+                        try await Noora.$current.withValue(initNoora()) {
+                            try await trackableCommand.run(
+                                backend: backend
+                            )
+                        }
                     }
                 } else {
                     try await trackableCommand.run(
@@ -147,14 +149,24 @@ public struct TuistCommand: AsyncParsableCommand {
 
         do {
             try await executeCommand()
-            outputCompletion(
-                logFilePath: logFilePath,
-                shouldOutputLogFilePath: logFilePathDisplayStrategy == .always
-            )
+            // We need to reinitialize Noora as by default, the logger is the legacy one until we migrate all commands to be
+            // `NooraReadyCommand` and the subsequent Noora messages would be missing from the verbose logs.
+            try await withLoggerForNoora(logFilePath: logFilePath) {
+                Noora.$current.withValue(initNoora()) {
+                    outputCompletion(
+                        logFilePath: logFilePath,
+                        shouldOutputLogFilePath: logFilePathDisplayStrategy == .always
+                    )
+                }
+            }
         } catch {
-            onError(
-                parsingError ?? error, isParsingError: parsingError != nil, logFilePath: logFilePath
-            )
+            try await withLoggerForNoora(logFilePath: logFilePath) {
+                Noora.$current.withValue(initNoora()) {
+                    onError(
+                        parsingError ?? error, isParsingError: parsingError != nil, logFilePath: logFilePath
+                    )
+                }
+            }
         }
     }
 

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -73,14 +73,17 @@ private func initLogger() async throws -> (Logger, Path.AbsolutePath) {
     return (Logger(label: "dev.tuist.cli", factory: loggerHandler), logFilePath)
 }
 
-private func initNoora() -> Noora {
+func initNoora() -> Noora {
     if CommandLine.arguments.contains("--json") || CommandLine.arguments.contains("--quiet") {
         Noora(
             standardPipelines: StandardPipelines(
                 output: IgnoreOutputPipeline()
-            )
+            ),
+            logger: Logger.current
         )
     } else {
-        Noora()
+        Noora(
+            logger: Logger.current
+        )
     }
 }


### PR DESCRIPTION
When debugging an issue, I've noticed the file logs at `~/.local/state/tuist/logs` don't include the Noora messages. This PR fixes the issue.