### PR TITLE
Fix missing logs of sending command event analytics

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -115,9 +115,15 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                             let refresh = expiresIn < 30 || forceRefresh
 
                             #if canImport(TuistSupport)
-                                Logger.current.debug(
-                                    "Access token expires in less than \(expiresIn) seconds. Renewing..."
-                                )
+                                if refresh {
+                                    Logger.current.debug(
+                                        "Access token expires in less than \(expiresIn) seconds. Renewing..."
+                                    )
+                                } else {
+                                    Logger.current.debug(
+                                        "Access token expires in \(expiresIn) seconds and it is still valid"
+                                    )
+                                }
                             #endif
                             if refresh {
                                 guard let refreshToken else {

--- a/cli/Sources/TuistSupport/Logging/Logger.swift
+++ b/cli/Sources/TuistSupport/Logging/Logger.swift
@@ -61,7 +61,8 @@ extension Logger {
         let fileLogger = try FileLogging(to: logFilePath.url)
 
         let baseLoggers = { (label: String) -> [any LogHandler] in
-            let fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
+            var fileLogHandler = FileLogHandler(label: label, fileLogger: fileLogger)
+            fileLogHandler.logLevel = .debug
 
             var loggers: [any LogHandler] = [fileLogHandler]
             // OSLog is not needed in development.


### PR DESCRIPTION
The logs for sending command events do not appear as our legacy file logger outside of Noora context doesn't have the `infoLevel` set to `.debug`.