### PR TITLE
fix: clear credentials on authentication failure

### DIFF
--- a/app/Sources/TuistMenuBar/Utilities/ErrorHandling.swift
+++ b/app/Sources/TuistMenuBar/Utilities/ErrorHandling.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import OpenAPIRuntime
+import TuistServer
 import TuistSupport
 
 final class ErrorHandling: ObservableObject, Sendable {
@@ -10,6 +11,12 @@ final class ErrorHandling: ObservableObject, Sendable {
             let alert = NSAlert()
             if let error = error as? FatalError {
                 alert.messageText = error.description
+            } else if error is ServerClientAuthenticationError {
+                // When we fail to authenticate, we sign out the user and force them to sign in again.
+                Task {
+                    try await ServerCredentialsStore.current.delete(serverURL: ServerEnvironmentService().url())
+                }
+                return
             } else if let error = error as? ClientError {
                 handle(error.underlyingError)
                 return


### PR DESCRIPTION
If your macOS app credentials are not valid, for whatever reason, we'd show an error that you should authenticate. But the error would pop up every time you would click on the menu bar, so you could actually never sign out and log in again. Instead, we clear the macOS credentials when authentication fails.