### PR TITLE
fix: don't show error when cancelling authentication

### DIFF
--- a/app/Sources/TuistAuthentication/AuthenticationService.swift
+++ b/app/Sources/TuistAuthentication/AuthenticationService.swift
@@ -210,7 +210,9 @@ public final class AuthenticationService: ObservableObject {
                 callbackURLScheme: "tuist"
             ) { callbackURL, error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    // The error often happens here when the user just cancels the authentication. Additionally, the errors coming from the callback are cryptic.
+                    // The best thing here to do UX-wise is not to show any errors.
+                    continuation.resume(returning: nil)
                     return
                 }
 


### PR DESCRIPTION
When cancelling authentication by closing the Safari window/view, we should not be showing an error as that's outright odd. Imho, it's fine to silently fail here. There doesn't seem to be an easy way to categorize the error to still show for possibly valid errors (and I don't know what errors we would even want to surface via our alert)