### PR TITLE
Remove note about menu bar app auth

### DIFF
--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -67,10 +67,8 @@ To make running Tuist Previews even easier, we developed a Tuist macOS menu bar 
 When you now click on "Run" in the Preview page, the macOS app will automatically launch it on your currently selected device.
 
 > [!IMPORTANT] REQUIREMENTS
-> To download Previews, you need to first authenticate with the `tuist auth login` command.
-> In the future, you will be able to authenticate directly in the app.
 >
-> Additionally, you need to have Xcode locally installed and be on macOS 14 or later.
+> You need to have Xcode locally installed and be on macOS 14 or later.
 
 ## Pull/merge request comments {#pullmerge-request-comments}
 


### PR DESCRIPTION
The menu bar no longer depends on the CLI session, so we can remove the note about it.