### PR TITLE
Add missing builds in preview endpoints

### DIFF
--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -1,6 +1,7 @@
 import Ecto.Query, only: [from: 2]
 
 alias Tuist.Accounts
+alias Tuist.AppBuilds.AppBuild
 alias Tuist.AppBuilds.Preview
 alias Tuist.Billing.Subscription
 alias Tuist.CommandEvents
@@ -261,7 +262,7 @@ Enum.map(1..100, fn index ->
       test_case
     end
 
-  {:ok, graph} =
+  {:ok, _graph} =
     Xcode.create_xcode_graph(%{
       command_event: command_event,
       xcode_graph: %{
@@ -355,5 +356,21 @@ test_previews =
 
 Enum.each(test_previews, fn preview_attrs ->
   changeset = Preview.create_changeset(%Preview{}, preview_attrs)
-  Repo.insert!(changeset)
+  preview = Repo.insert!(changeset)
+
+  supported_platforms = preview_attrs.supported_platforms
+
+  Enum.each(1..Enum.random(1..3), fn _ ->
+    build_platforms = Enum.take_random(supported_platforms, Enum.random(1..length(supported_platforms)))
+    build_type = Enum.random([:app_bundle, :ipa])
+
+    app_build_attrs = %{
+      preview_id: preview.id,
+      type: build_type,
+      supported_platforms: build_platforms
+    }
+
+    app_build_changeset = AppBuild.create_changeset(%AppBuild{}, app_build_attrs)
+    Repo.insert!(app_build_changeset)
+  end)
 end)

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -390,6 +390,8 @@ defmodule TuistWeb.PreviewsControllerTest do
         :ok
       end)
 
+      expect(Storage, :generate_download_url, fn _, _ -> "https://mocked-url.com" end)
+
       conn = Authentication.put_current_user(conn, user)
 
       # When
@@ -416,8 +418,16 @@ defmodule TuistWeb.PreviewsControllerTest do
                "display_name" => "App",
                "git_commit_sha" => "commit-sha",
                "git_branch" => "main",
-               "builds" => [],
-               "supported_platforms" => [],
+               "builds" => [
+                 %{
+                   "id" => app_build.id,
+                   "type" => "app_bundle",
+                   "supported_platforms" => ["ios"],
+                   "url" => "https://mocked-url.com",
+                   "inserted_at" => DateTime.to_iso8601(app_build.inserted_at)
+                 }
+               ],
+               "supported_platforms" => ["ios"],
                "inserted_at" => DateTime.to_iso8601(preview.inserted_at)
              }
     end
@@ -647,6 +657,10 @@ defmodule TuistWeb.PreviewsControllerTest do
           inserted_at: ~U[2021-01-01 01:00:00Z]
         )
 
+      app_build_two = AppBuildsFixtures.app_build_fixture(preview: preview_two)
+
+      expect(Storage, :generate_download_url, fn _, _ -> "https://mocked-url.com" end)
+
       _preview_three =
         AppBuildsFixtures.preview_fixture(
           project: project,
@@ -688,7 +702,15 @@ defmodule TuistWeb.PreviewsControllerTest do
                  "display_name" => "App",
                  "git_commit_sha" => "commit-sha-two",
                  "git_branch" => "main",
-                 "builds" => [],
+                 "builds" => [
+                   %{
+                     "id" => app_build_two.id,
+                     "type" => "app_bundle",
+                     "supported_platforms" => ["ios"],
+                     "url" => "https://mocked-url.com",
+                     "inserted_at" => DateTime.to_iso8601(app_build_two.inserted_at)
+                   }
+                 ],
                  "supported_platforms" => [],
                  "inserted_at" => DateTime.to_iso8601(preview_two.inserted_at)
                }


### PR DESCRIPTION
We are currently returning the builds array for previews in some endpoints. This PR fixes that by populating the builds array across all our endpoints (backport of PR merged after the move to monorepo)
