### PR TITLE
Add version as part of the preview server schema

### DIFF
--- a/server/lib/tuist_web/api/schemas/preview.ex
+++ b/server/lib/tuist_web/api/schemas/preview.ex
@@ -23,6 +23,10 @@ defmodule TuistWeb.API.Schemas.Preview do
         type: :string,
         description: "The URL for the icon image of the preview"
       },
+      version: %Schema{
+        type: :string,
+        description: "The app version of the preview"
+      },
       bundle_identifier: %Schema{
         type: :string,
         description: "The bundle identifier of the preview"

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -18,7 +18,7 @@ defmodule TuistWeb.API.PreviewsController do
   alias TuistWeb.API.Schemas.PreviewSupportedPlatform
   alias TuistWeb.Authentication
 
-  plug TuistWeb.Plugs.API.TransformQueryArrayParamsPlug, [:supported_platforms]
+  plug(TuistWeb.Plugs.API.TransformQueryArrayParamsPlug, [:supported_platforms])
 
   plug(OpenApiSpex.Plug.CastAndValidate,
     json_render_error_v2: true,
@@ -28,7 +28,7 @@ defmodule TuistWeb.API.PreviewsController do
   plug(TuistWeb.Plugs.LoaderPlug)
   plug(TuistWeb.API.Authorization.AuthorizationPlug, :preview)
 
-  tags ["Previews"]
+  tags(["Previews"])
 
   operation(:multipart_start,
     summary: "It initiates a multipart upload for a preview artifact.",
@@ -104,7 +104,11 @@ defmodule TuistWeb.API.PreviewsController do
                  "Data that contains preview and upload unique identifier associated with the multipart upload to use when uploading parts",
                properties: %{
                  upload_id: %Schema{type: :string, description: "The upload ID"},
-                 preview_id: %Schema{type: :string, description: "The id of the preview.", deprecated: true},
+                 preview_id: %Schema{
+                   type: :string,
+                   description: "The id of the preview.",
+                   deprecated: true
+                 },
                  app_build_id: %Schema{type: :string, description: "The id of the app build."}
                },
                required: [:upload_id, :app_build_id]
@@ -686,6 +690,7 @@ defmodule TuistWeb.API.PreviewsController do
       url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}"),
       qr_code_url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/qr-code.png"),
       icon_url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/icon.png"),
+      version: preview.version,
       bundle_identifier: preview.bundle_identifier,
       display_name: preview.display_name,
       git_commit_sha: preview.git_commit_sha,

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -48,7 +48,10 @@ defmodule TuistWeb.PreviewsControllerTest do
       assert response["status"] == "success"
       response_data = response["data"]
       assert response_data["upload_id"] == upload_id
-      {:ok, app_build} = AppBuilds.app_build_by_id(response["data"]["preview_id"], preload: [:preview])
+
+      {:ok, app_build} =
+        AppBuilds.app_build_by_id(response["data"]["preview_id"], preload: [:preview])
+
       assert app_build.preview.display_name == "name"
       assert Enum.sort(app_build.supported_platforms) == [:ios, :watchos]
       assert response_data["preview_id"] == app_build.id
@@ -188,11 +191,11 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           conn
           |> put_req_header("content-type", "application/json")
           |> post(~p"/api/projects/#{account.name}/non-existing-project/previews/start")
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{
@@ -265,7 +268,12 @@ defmodule TuistWeb.PreviewsControllerTest do
       assert response_data["url"] == "https://url.com"
     end
 
-    test "generates platform-specific multipart url", %{conn: conn, user: user, project: project, account: account} do
+    test "generates platform-specific multipart url", %{
+      conn: conn,
+      user: user,
+      project: project,
+      account: account
+    } do
       # Given
       app_build_id = "app-build-id"
       upload_id = "12344"
@@ -315,14 +323,14 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           conn
           |> put_req_header("content-type", "application/json")
           |> post(~p"/api/projects/#{account.name}/non-existing-project/previews/generate-url",
             preview_id: "preview-id",
             multipart_upload_part: %{part_number: 0, upload_id: "upload-id"}
           )
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{
@@ -370,7 +378,11 @@ defmodule TuistWeb.PreviewsControllerTest do
       upload_id = "1234"
 
       preview =
-        AppBuildsFixtures.preview_fixture(project: project, git_commit_sha: "commit-sha", git_branch: "main")
+        AppBuildsFixtures.preview_fixture(
+          project: project,
+          git_commit_sha: "commit-sha",
+          git_branch: "main"
+        )
 
       app_build =
         AppBuildsFixtures.app_build_fixture(preview: preview)
@@ -418,6 +430,7 @@ defmodule TuistWeb.PreviewsControllerTest do
                "display_name" => "App",
                "git_commit_sha" => "commit-sha",
                "git_branch" => "main",
+               "version" => "1.0.0",
                "builds" => [
                  %{
                    "id" => app_build.id,
@@ -442,7 +455,7 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           conn
           |> put_req_header("content-type", "application/json")
           |> post(~p"/api/projects/#{account.name}/non-existing-project/previews/complete",
@@ -452,7 +465,7 @@ defmodule TuistWeb.PreviewsControllerTest do
               upload_id: "upload-id"
             }
           )
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{
@@ -557,7 +570,10 @@ defmodule TuistWeb.PreviewsControllerTest do
       assert response["git_commit_sha"] == "preview-commit-sha"
       assert response["inserted_at"] == DateTime.to_iso8601(preview.inserted_at)
 
-      assert Enum.map(response["builds"], &Map.take(&1, ["id", "url", "type", "supported_platforms"])) == [
+      assert Enum.map(
+               response["builds"],
+               &Map.take(&1, ["id", "url", "type", "supported_platforms"])
+             ) == [
                %{
                  "id" => app_build.id,
                  "url" => "https://url.com",
@@ -579,9 +595,9 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           get(conn, ~p"/api/projects/#{account.name}/non-existing-project/previews/#{preview.id}")
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{
@@ -702,6 +718,7 @@ defmodule TuistWeb.PreviewsControllerTest do
                  "display_name" => "App",
                  "git_commit_sha" => "commit-sha-two",
                  "git_branch" => "main",
+                 "version" => "1.0.0",
                  "builds" => [
                    %{
                      "id" => app_build_two.id,
@@ -1090,12 +1107,12 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           get(
             conn,
             ~p"/api/projects/#{account.name}/non-existing-project/previews?specifier=latest&page_size=1"
           )
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{
@@ -1170,12 +1187,12 @@ defmodule TuistWeb.PreviewsControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           post(
             conn,
             ~p"/api/projects/#{account.name}/non-existing-project/previews/#{preview.id}/icons"
           )
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) == %{


### PR DESCRIPTION
In the iOS app, we need to access the app version of a preview.