### PR TITLE
Fix mise install in acceptance tests

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -94,6 +94,8 @@ jobs:
           key: spm-ext-v1-${{ hashFiles('cli-ext/Package.resolved') }}
           restore-keys: spm-ext-v1-${{ hashFiles('cli-ext/Package.resolved') }}
       - uses: jdx/mise-action@v2
+        with:
+          working_directory: cli-ext
       - name: Install dependencies
         working-directory: cli-ext
         run: tuist install

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/cache@v3
         name: "Cache installed dependencies folder"
         with:
-          path: .build
+          path: cli-ext/.build
           key: spm-ext-v1-${{ hashFiles('cli-ext/Package.resolved') }}
           restore-keys: spm-ext-v1-${{ hashFiles('cli-ext/Package.resolved') }}
       - uses: jdx/mise-action@v2


### PR DESCRIPTION
We weren't running `mise install` in the correct directory in the acceptance tests workflow.
`mise-action` uses `with.working_directory` instead of setting it on the action itself:
https://github.com/jdx/mise-action?tab=readme-ov-file#example-workflow