### PR TITLE
Fix server CLA

### DIFF
--- a/.github/workflows/server-cla.yml
+++ b/.github/workflows/server-cla.yml
@@ -23,7 +23,7 @@ jobs:
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
         with:
           path-to-signatures: "server/cla/signatures.json"
           path-to-document: "https://github.com/tuist/server/blob/main/server/cla/document.md"

--- a/.github/workflows/server-cla.yml
+++ b/.github/workflows/server-cla.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    environment: server-cla
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'


### PR DESCRIPTION
CLA is failing because the default token doesn't have permissions to push the signatures to `main`. This PR changes the token, which I configured scoped to the repository's `server-cla` environment.
