### PR TITLE
Fix CLA workflow branch protection issue

### DIFF
--- a/.github/workflows/server-cla.yml
+++ b/.github/workflows/server-cla.yml
@@ -24,9 +24,9 @@ jobs:
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: "server/cla/signatures.json"
           path-to-document: "https://github.com/tuist/server/blob/main/server/cla/document.md"
-          branch: "main"
+          branch: ${{ github.head_ref || github.ref_name }}
           allowlist: pepicrft,cschmatzler,asmitbm,fortmarek


### PR DESCRIPTION
## Summary
- Fixed CLA workflow failing due to branch protection on main
- Changed workflow to push signatures to source branch instead of main
- Reverted to using default GITHUB_TOKEN

## Problem
The CLA Assistant workflow was hardcoded to push CLA signatures to the `main` branch, which is protected and doesn't allow direct pushes. This caused the workflow to fail when contributors signed the CLA.

## Solution
- Use `${{ github.head_ref || github.ref_name }}` to push to the PR's source branch
- This allows the CLA signature to be included with the PR changes
- Also switched back to default `GITHUB_TOKEN` instead of custom token