### PR TITLE
fix: disable automatic zoom on activating input on mobile

### DIFF
--- a/server/assets/app/app.css
+++ b/server/assets/app/app.css
@@ -41,7 +41,7 @@ a {
 }
 
 /* This fixes an issue on iOS when an element is zoomed in when selected */
-@media screen and (-webkit-min-device-pixel-ratio:0) {
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
   select,
   textarea,
   input {


### PR DESCRIPTION
Fixes an issue when on mobile, the input field is automatically zoomed in which looks odd. See the difference between clicking on the email (fixed) vs password (not fixed in this demo):

https://github.com/user-attachments/assets/195b592a-ea15-4f07-a153-10b4f970ad1b

Taken from: https://stackoverflow.com/a/16255670 (yeah, still land on SO sometimes 😅)