### PR TITLE
fix: crash when viewing profile

### DIFF
--- a/app/Sources/TuistNoora/NooraAvatar.swift
+++ b/app/Sources/TuistNoora/NooraAvatar.swift
@@ -93,7 +93,7 @@ public struct NooraAvatar: View {
         let emailData = Data(trimmedEmail.utf8)
         let hash = Insecure.MD5.hash(data: emailData)
 
-        let colorIndex = Int(hash.hashValue) % AvatarColor.allCases.count
+        let colorIndex = abs(Int(hash.hashValue)) % AvatarColor.allCases.count
         return AvatarColor.allCases[colorIndex]
     }
 


### PR DESCRIPTION
Modulo of a negative number is ... negative. The hash value can return negative values and if that happens, the profile view crashes due to accessing the avatar color out of index.