### PR TITLE
Remove the environment from the server CLA pipeline

### DIFF
--- a/.github/workflows/server-cla.yml
+++ b/.github/workflows/server-cla.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
-    environment: server-cla
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'


### PR DESCRIPTION
With the [recent change](https://github.com/tuist/tuist/pull/7811) to push changes directly to the source branch, we don't need to set the `environment` in the job anymore.