### PR TITLE
feat: use deviceURL instead of itms scheme to install previews

### DIFF
--- a/app/Sources/TuistPreviews/PreviewRunButton.swift
+++ b/app/Sources/TuistPreviews/PreviewRunButton.swift
@@ -5,6 +5,7 @@ import TuistServer
 
 struct PreviewRunButton: View {
     @State private var isLoading = false
+    @Environment(\.openURL) private var openURL
     var isDisabled: Bool {
         !preview.appBuilds
             .contains(where: { $0.type == .ipa && $0.supportedPlatforms.contains(.device(.iOS)) })
@@ -31,10 +32,7 @@ struct PreviewRunButton: View {
     private func run() {
         guard !isDisabled else { return }
         isLoading = true
-        let url = URL(
-            string: "itms-services://?action=download-manifest&url=\(preview.url.absoluteString)/manifest.plist"
-        )!
-        UIApplication.shared.open(url)
+        openURL(preview.deviceURL)
 
         Task {
             // It takes some time for the alert to install the app to appear

--- a/cli/Sources/TuistServer/Models/ServerPreview.swift
+++ b/cli/Sources/TuistServer/Models/ServerPreview.swift
@@ -7,6 +7,7 @@ public struct ServerPreview: Sendable, Equatable, Codable, Identifiable, Hashabl
     public let url: URL
     public let qrCodeURL: URL
     public let iconURL: URL
+    public let deviceURL: URL
     public let version: Version?
     public let bundleIdentifier: String?
     public var displayName: String?
@@ -27,11 +28,13 @@ extension ServerPreview {
         guard let url = URL(string: preview.url),
               let qrCodeURL = URL(string: preview.qr_code_url),
               let iconURL = URL(string: preview.icon_url),
+              let deviceURL = URL(string: preview.device_url),
               let insertedAt = Self.dateFormatter.date(from: preview.inserted_at)
         else { return nil }
         self.url = url
         self.qrCodeURL = qrCodeURL
         self.iconURL = iconURL
+        self.deviceURL = deviceURL
         if let version = preview.version {
             self.version = Version(string: version)
         } else {
@@ -64,6 +67,7 @@ extension ServerPreview {
             // swiftlint:disable:this force_try
             iconURL: URL =
                 URL(string: "https://tuist.dev/tuist/tuist/previews/preview-id/icon.png")!,
+            deviceURL: URL = URL(string: "https://tuist.dev/tuist/tuist/previews/preview-id")!,
             version: Version = "1.0.0",
             // swiftlint:disable:this force_try
             bundleIdentifier: String? = "dev.tuist.app",
@@ -86,6 +90,7 @@ extension ServerPreview {
                 url: url,
                 qrCodeURL: qrCodeURL,
                 iconURL: iconURL,
+                deviceURL: deviceURL,
                 version: version,
                 bundleIdentifier: bundleIdentifier,
                 displayName: displayName,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -1945,6 +1945,10 @@ internal enum Components {
             ///
             /// - Remark: Generated from `#/components/schemas/Preview/created_from_ci`.
             internal var created_from_ci: Swift.Bool
+            /// The URL to download the preview on a device
+            ///
+            /// - Remark: Generated from `#/components/schemas/Preview/device_url`.
+            internal var device_url: Swift.String
             /// The display name of the preview
             ///
             /// - Remark: Generated from `#/components/schemas/Preview/display_name`.
@@ -1990,6 +1994,7 @@ internal enum Components {
             ///   - bundle_identifier: The bundle identifier of the preview
             ///   - created_by:
             ///   - created_from_ci: Whether the preview was created from CI
+            ///   - device_url: The URL to download the preview on a device
             ///   - display_name: The display name of the preview
             ///   - git_branch: The git branch associated with the preview
             ///   - git_commit_sha: The git commit SHA associated with the preview
@@ -2005,6 +2010,7 @@ internal enum Components {
                 bundle_identifier: Swift.String? = nil,
                 created_by: Components.Schemas.Account? = nil,
                 created_from_ci: Swift.Bool,
+                device_url: Swift.String,
                 display_name: Swift.String? = nil,
                 git_branch: Swift.String? = nil,
                 git_commit_sha: Swift.String? = nil,
@@ -2020,6 +2026,7 @@ internal enum Components {
                 self.bundle_identifier = bundle_identifier
                 self.created_by = created_by
                 self.created_from_ci = created_from_ci
+                self.device_url = device_url
                 self.display_name = display_name
                 self.git_branch = git_branch
                 self.git_commit_sha = git_commit_sha
@@ -2036,6 +2043,7 @@ internal enum Components {
                 case bundle_identifier
                 case created_by
                 case created_from_ci
+                case device_url
                 case display_name
                 case git_branch
                 case git_commit_sha

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -616,6 +616,11 @@ components:
           type: boolean
           x-struct:
           x-validate:
+        device_url:
+          description: The URL to download the preview on a device
+          type: string
+          x-struct:
+          x-validate:
         display_name:
           description: The display name of the preview
           type: string
@@ -677,6 +682,7 @@ components:
         - supported_platforms
         - inserted_at
         - created_from_ci
+        - device_url
       title: Preview
       type: object
       x-struct: Elixir.TuistWeb.API.Schemas.Preview

--- a/server/lib/tuist_web/api/schemas/preview.ex
+++ b/server/lib/tuist_web/api/schemas/preview.ex
@@ -17,7 +17,8 @@ defmodule TuistWeb.API.Schemas.Preview do
       :builds,
       :supported_platforms,
       :inserted_at,
-      :created_from_ci
+      :created_from_ci,
+      :device_url
     ],
     properties: %{
       id: %Schema{
@@ -25,6 +26,7 @@ defmodule TuistWeb.API.Schemas.Preview do
         description: "Unique identifier of the preview."
       },
       url: %Schema{type: :string, description: "The URL to download the preview"},
+      device_url: %Schema{type: :string, description: "The URL to download the preview on a device"},
       qr_code_url: %Schema{
         type: :string,
         description: "The URL for the QR code image to dowload the preview"

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -754,6 +754,8 @@ defmodule TuistWeb.API.PreviewsController do
     %{
       id: preview.id,
       url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}"),
+      device_url:
+        "itms-services://?action=download-manifest&url=#{url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/manifest.plist")}",
       qr_code_url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/qr-code.png"),
       icon_url: url(~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}/icon.png"),
       version: preview.version,

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -426,6 +426,8 @@ defmodule TuistWeb.PreviewsControllerTest do
                "url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}"),
                "qr_code_url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}/qr-code.png"),
                "icon_url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}/icon.png"),
+               "device_url" =>
+                 "itms-services://?action=download-manifest&url=#{url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}/manifest.plist")}",
                "bundle_identifier" => "dev.tuist.app",
                "display_name" => "App",
                "git_commit_sha" => "commit-sha",
@@ -726,6 +728,8 @@ defmodule TuistWeb.PreviewsControllerTest do
                  "url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview_two.id}"),
                  "qr_code_url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview_two.id}/qr-code.png"),
                  "icon_url" => url(~p"/#{account.name}/#{project.name}/previews/#{preview_two.id}/icon.png"),
+                 "device_url" =>
+                   "itms-services://?action=download-manifest&url=#{url(~p"/#{account.name}/#{project.name}/previews/#{preview_two.id}/manifest.plist")}",
                  "bundle_identifier" => "dev.tuist.app",
                  "display_name" => "App",
                  "git_commit_sha" => "commit-sha-two",


### PR DESCRIPTION
We can't use `itms` scheme to install the app directly from the app, so we're using a `deviceURL` instead.