### PR TITLE
docs: add note about Objective-C resource accessor limitation

### DIFF
--- a/docs/docs/en/guides/features/projects/synthesized-files.md
+++ b/docs/docs/en/guides/features/projects/synthesized-files.md
@@ -54,6 +54,9 @@ In Objective-C, you'll get an interface `{Target}Resources` to access the bundle
 NSBundle *bundle = [MyFeatureResources bundle];
 ```
 
+> [!WARNING] LIMITATION WITH INTERNAL TARGETS
+> Currently, Tuist does not generate resource bundle accessors for internal targets that contain only Objective-C sources. This is a known limitation tracked in [issue #6456](https://github.com/tuist/tuist/issues/6456).
+
 > [!TIP] SUPPORTING RESOURCES IN LIBRARIES THROUGH BUNDLES
 > If a target product, for example a library, doesn't support resources, Tuist will include the resources in a target of product type `bundle` ensuring that it ends up in the final product and that the interface points to the right bundle.
 


### PR DESCRIPTION
## Summary
- Adds a warning note to the synthesized files documentation about the current limitation with Objective-C resource accessors
- References issue #6456 for users to track the status of this limitation

## Context
Internal targets that contain only Objective-C sources don't get resource bundle accessors generated, which is a regression from previous functionality. This note helps users understand this limitation until it's fixed.

## Test plan
- [x] Documentation builds successfully
- [x] Warning is clearly visible in the Objective-C section
- [x] GitHub issue link is accessible