### PR TITLE
Do not use globbing for paths that are not look like globs

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -105,7 +105,7 @@ extension XcodeGraph.TargetScript {
             // More than that - globbing requires the path to be existing at the moment of the globbing
             // which is not always the case.
             // For example, output paths of a script that are not created yet.
-            if !isGlobPattern(path) {
+            if !isLikelyAGlobPattern(path) {
                 return [try generatorPaths.resolve(path: path)]
             }
 
@@ -115,9 +115,11 @@ extension XcodeGraph.TargetScript {
         }.reduce([], +)
     }
 
-    private static func isGlobPattern(_ path: Path) -> Bool {
+    private static let globSpecialCharacters: Set<Character> = ["*", "?", "[", "]"]
+
+    private static func isLikelyAGlobPattern(_ path: Path) -> Bool {
         let pathString = path.pathString
-        return pathString.contains("*") || pathString.contains("?") || pathString.contains("[")
+        return pathString.contains { globSpecialCharacters.contains($0) }
     }
 }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -105,7 +105,7 @@ extension XcodeGraph.TargetScript {
             // More than that - globbing requires the path to be existing at the moment of the globbing
             // which is not always the case.
             // For example, output paths of a script that are not created yet.
-            if !isLikelyAGlobPattern(path) {
+            if !fileSystem.isGlobPattern(path) {
                 return [try generatorPaths.resolve(path: path)]
             }
 
@@ -113,13 +113,6 @@ extension XcodeGraph.TargetScript {
             let base = try AbsolutePath(validating: absolutePath.dirname)
             return try await fileSystem.glob(directory: base, include: [absolutePath.basename]).collect()
         }.reduce([], +)
-    }
-
-    private static let globSpecialCharacters: Set<Character> = ["*", "?", "[", "]"]
-
-    private static func isLikelyAGlobPattern(_ path: Path) -> Bool {
-        let pathString = path.pathString
-        return pathString.contains { globSpecialCharacters.contains($0) }
     }
 }
 

--- a/cli/Sources/TuistLoader/Models/FileSysteming+Glob.swift
+++ b/cli/Sources/TuistLoader/Models/FileSysteming+Glob.swift
@@ -1,0 +1,15 @@
+import FileSystem
+import Foundation
+import ProjectDescription
+
+extension FileSysteming {
+    /// Performs a simple check to determine if the provided path is a glob pattern.
+    /// This method can be used whether to perform a glob operation, or use path as-is.
+    /// - Parameter path: The path to check.
+    func isGlobPattern(_ path: Path) -> Bool {
+        let pathString = path.pathString
+        return pathString.contains { globSpecialCharacters.contains($0) }
+    }
+}
+
+private let globSpecialCharacters: Set<Character> = ["*", "?", "[", "]", "{", "}"]


### PR DESCRIPTION
Adresses <https://github.com/tuist/tuist/issues/7725>

> Describe here the purpose of your PR.
With this PR, the script outputs, outputsLists and inputs will only be using `glob`s when patter look like a glob. 
In general, in places like scripts (inputs/outputs), because of using globbing, `tuist` de-factor tries to verify whether the files are present in the system.
In case of files that are `outputs` of the script build phases, this breaks the whole point of having file generation build phase.

This fix basically prevents checking files existance, which is fine for the most of the cases.
For the cases, where globs are used, those are still will require files to be present at the tine of the generation

### How to test locally

> Document how to test your changes locally
- Create a target with script `pre` or `post`, whihch output files pointing to the unexisting path.
- Script should be generated with the path, regardless if it was on the system at that time, or not
