### PR TITLE
fix: limit latest previews to 4 apps

### DIFF
--- a/app/Sources/TuistMenuBar/Views/AppPreviews/AppPreviews.swift
+++ b/app/Sources/TuistMenuBar/Views/AppPreviews/AppPreviews.swift
@@ -18,7 +18,7 @@ struct AppPreviews: View {
                     AppPreviewsEmptyStateView()
                 } else {
                     LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                        ForEach(viewModel.appPreviews) { appPreview in
+                        ForEach(viewModel.appPreviews.prefix(4)) { appPreview in
                             Button {
                                 errorHandling.fireAndHandleError {
                                     try await viewModel.launchAppPreview(appPreview)


### PR DESCRIPTION
This is more of a temporary fix:
- We should enable displaying more than 5 previews, but the layout currently breaks due to [this](https://github.com/tuist/tuist/blob/459ac4e2d0afc3cf791624661893c08bacff565f/app/Sources/TuistMenuBar/Views/DevicesView/DevicesView.swift#L71) line
- We should allow teams to pick which apps are in the latest section from the menu bar app settings