### PR TITLE
Make Mautic sync more robust

### DIFF
--- a/server/.credo.exs
+++ b/server/.credo.exs
@@ -12,6 +12,7 @@
       },
       requires: ["./credo/checks/**/*.ex"],
       checks: %{
+        enabled: [{Credo.Check.Refactor.Nesting, [max_nesting: 3]}],
         extra: [
           {Credo.Checks.TimestampsType, files: %{included: ["priv/repo/migrations/"]}, allowed_type: :timestamptz},
           {Credo.Checks.TimestampsType, files: %{included: ["lib/"]}, allowed_type: :utc_datetime},

--- a/server/lib/tuist/mautic.ex
+++ b/server/lib/tuist/mautic.ex
@@ -26,6 +26,7 @@ defmodule Tuist.Mautic do
            retry: retry()
          ) do
       %{status: status, body: body} when status in 200..299 -> {:ok, body}
+      %{status: status, body: body} -> {:error, %{status: status, body: body}}
     end
   end
 
@@ -37,6 +38,7 @@ defmodule Tuist.Mautic do
            retry: retry()
          ) do
       %{status: status, body: body} when status in 200..299 -> {:ok, body}
+      %{status: status, body: body} -> {:error, %{status: status, body: body}}
     end
   end
 


### PR DESCRIPTION
Resolves
https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/940.

There were some cases where `companyname` was empty, resulting in a 400 response from Mautic. That error was _also_ not handled properly and threw a `CaseClauseError`. This PR adds another fallback to set the name, and handles any non-success responses correctly.