### PR TITLE
Improve command events queries for Clickhouse

### DIFF
--- a/server/lib/tuist/command_events/clickhouse.ex
+++ b/server/lib/tuist/command_events/clickhouse.ex
@@ -12,9 +12,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
   alias Tuist.Repo
 
   def list_command_events(attrs) do
-    query = Event
-
-    {results, meta} = ClickHouseFlop.validate_and_run!(query, attrs, for: Event)
+    {results, meta} = ClickHouseFlop.validate_and_run!(Event, attrs, for: Event)
 
     results =
       results

--- a/server/lib/tuist/command_events/clickhouse.ex
+++ b/server/lib/tuist/command_events/clickhouse.ex
@@ -12,20 +12,9 @@ defmodule Tuist.CommandEvents.Clickhouse do
   alias Tuist.Repo
 
   def list_command_events(attrs) do
-    query = Event.with_hit_rate(Event)
+    query = Event
 
-    {hit_rate_filter, other_filters} = extract_hit_rate_filter(attrs)
-
-    query =
-      if hit_rate_filter do
-        apply_hit_rate_filter_to_query(query, hit_rate_filter)
-      else
-        query
-      end
-
-    {modified_attrs, query} = handle_hit_rate_sort(other_filters, query)
-
-    {results, meta} = ClickHouseFlop.validate_and_run!(query, modified_attrs, for: Event)
+    {results, meta} = ClickHouseFlop.validate_and_run!(query, attrs, for: Event)
 
     results =
       results
@@ -283,9 +272,9 @@ defmodule Tuist.CommandEvents.Clickhouse do
             e.created_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
             e.created_at < ^NaiveDateTime.new!(end_date, ~T[23:59:59]),
         select: %{
-          cacheable_targets_count: sum(fragment("length(?)", e.cacheable_targets)),
-          local_cache_target_hits_count: sum(fragment("length(?)", e.local_cache_target_hits)),
-          remote_cache_target_hits_count: sum(fragment("length(?)", e.remote_cache_target_hits))
+          cacheable_targets_count: sum(e.cacheable_targets_count),
+          local_cache_target_hits_count: sum(e.local_cache_hits_count),
+          remote_cache_target_hits_count: sum(e.remote_cache_hits_count)
         }
       )
 
@@ -309,9 +298,9 @@ defmodule Tuist.CommandEvents.Clickhouse do
             e.project_id == ^project_id,
         select: %{
           date: fragment("formatDateTime(?, ?)", e.created_at, ^date_format),
-          cacheable_targets: sum(fragment("length(?)", e.cacheable_targets)),
-          local_cache_target_hits: sum(fragment("length(?)", e.local_cache_target_hits)),
-          remote_cache_target_hits: sum(fragment("length(?)", e.remote_cache_target_hits))
+          cacheable_targets: sum(e.cacheable_targets_count),
+          local_cache_target_hits: sum(e.local_cache_hits_count),
+          remote_cache_target_hits: sum(e.remote_cache_hits_count)
         }
       )
 
@@ -328,9 +317,9 @@ defmodule Tuist.CommandEvents.Clickhouse do
             e.created_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
             e.created_at < ^NaiveDateTime.new!(end_date, ~T[23:59:59]),
         select: %{
-          test_targets_count: sum(fragment("length(?)", e.test_targets)),
-          local_test_target_hits_count: sum(fragment("length(?)", e.local_test_target_hits)),
-          remote_test_target_hits_count: sum(fragment("length(?)", e.remote_test_target_hits))
+          test_targets_count: sum(e.test_targets_count),
+          local_test_target_hits_count: sum(e.local_test_hits_count),
+          remote_test_target_hits_count: sum(e.remote_test_hits_count)
         }
       )
 
@@ -354,9 +343,9 @@ defmodule Tuist.CommandEvents.Clickhouse do
             e.project_id == ^project_id,
         select: %{
           date: fragment("formatDateTime(?, ?)", e.created_at, ^date_format),
-          test_targets: sum(fragment("length(?)", e.test_targets)),
-          local_test_target_hits: sum(fragment("length(?)", e.local_test_target_hits)),
-          remote_test_target_hits: sum(fragment("length(?)", e.remote_test_target_hits))
+          test_targets: sum(e.test_targets_count),
+          local_test_target_hits: sum(e.local_test_hits_count),
+          remote_test_target_hits: sum(e.remote_test_hits_count)
         }
       )
 
@@ -376,164 +365,6 @@ defmodule Tuist.CommandEvents.Clickhouse do
 
   def count_all_events do
     ClickHouseRepo.aggregate(from(e in Event, []), :count)
-  end
-
-  defp extract_hit_rate_filter(%{filters: filters} = attrs) when is_list(filters) do
-    {hit_rate_filters, other_filters} = Enum.split_with(filters, &(&1.field == :hit_rate))
-
-    hit_rate_filter =
-      Enum.find_value(hit_rate_filters, fn
-        %{value: value, op: op} when not is_nil(value) -> {op, value}
-        _ -> nil
-      end)
-
-    {hit_rate_filter, %{attrs | filters: other_filters}}
-  end
-
-  defp extract_hit_rate_filter(attrs), do: {nil, attrs}
-
-  defp handle_hit_rate_sort(%{order_by: order_by, order_directions: directions} = attrs, query)
-       when is_list(order_by) and is_list(directions) do
-    hit_rate_index = Enum.find_index(order_by, &(&1 == :hit_rate))
-
-    if hit_rate_index && hit_rate_index < length(directions) do
-      direction = Enum.at(directions, hit_rate_index)
-
-      {new_order_by, new_directions} =
-        remove_hit_rate_from_ordering(order_by, directions, hit_rate_index)
-
-      modified_query = apply_hit_rate_ordering(query, direction)
-
-      {%{attrs | order_by: new_order_by, order_directions: new_directions}, modified_query}
-    else
-      {attrs, query}
-    end
-  end
-
-  defp handle_hit_rate_sort(attrs, query), do: {attrs, query}
-
-  defp remove_hit_rate_from_ordering(order_by, directions, hit_rate_index) do
-    new_order_by = List.delete_at(order_by, hit_rate_index)
-    new_directions = List.delete_at(directions, hit_rate_index)
-
-    if Enum.empty?(new_order_by) do
-      {[:ran_at], [:desc]}
-    else
-      {new_order_by, new_directions}
-    end
-  end
-
-  defp apply_hit_rate_ordering(query, :desc) do
-    order_by(
-      query,
-      [e],
-      fragment(
-        "CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE NULL END DESC NULLS LAST",
-        e.cacheable_targets,
-        e.local_cache_target_hits,
-        e.remote_cache_target_hits,
-        e.cacheable_targets
-      )
-    )
-  end
-
-  defp apply_hit_rate_ordering(query, _direction) do
-    order_by(
-      query,
-      [e],
-      fragment(
-        "CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE NULL END ASC NULLS FIRST",
-        e.cacheable_targets,
-        e.local_cache_target_hits,
-        e.remote_cache_target_hits,
-        e.cacheable_targets
-      )
-    )
-  end
-
-  defp apply_hit_rate_filter_to_query(query, {op, value}) do
-    case op do
-      :> ->
-        where(
-          query,
-          [e],
-          fragment(
-            "ROUND(CAST(CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE 0 END AS Decimal(10, 1)), 1) > ROUND(CAST(? AS Decimal(10, 1)), 1)",
-            e.cacheable_targets,
-            e.local_cache_target_hits,
-            e.remote_cache_target_hits,
-            e.cacheable_targets,
-            ^value
-          )
-        )
-
-      :>= ->
-        where(
-          query,
-          [e],
-          fragment(
-            "ROUND(CAST(CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE 0 END AS Decimal(10, 1)), 1) >= ROUND(CAST(? AS Decimal(10, 1)), 1)",
-            e.cacheable_targets,
-            e.local_cache_target_hits,
-            e.remote_cache_target_hits,
-            e.cacheable_targets,
-            ^value
-          )
-        )
-
-      :< ->
-        where(
-          query,
-          [e],
-          fragment(
-            "length(?) = 0 OR ROUND(CAST(? AS Decimal(10, 1)), 1) < ROUND(CAST(? AS Decimal(10, 1)), 1)",
-            e.cacheable_targets,
-            fragment(
-              "CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE 0 END",
-              e.cacheable_targets,
-              e.local_cache_target_hits,
-              e.remote_cache_target_hits,
-              e.cacheable_targets
-            ),
-            ^value
-          )
-        )
-
-      :<= ->
-        where(
-          query,
-          [e],
-          fragment(
-            "length(?) = 0 OR ROUND(CAST(? AS Decimal(10, 1)), 1) <= ROUND(CAST(? AS Decimal(10, 1)), 1)",
-            e.cacheable_targets,
-            fragment(
-              "CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE 0 END",
-              e.cacheable_targets,
-              e.local_cache_target_hits,
-              e.remote_cache_target_hits,
-              e.cacheable_targets
-            ),
-            ^value
-          )
-        )
-
-      :== ->
-        where(
-          query,
-          [e],
-          fragment(
-            "ROUND(CAST(CASE WHEN length(?) > 0 THEN (COALESCE(length(?), 0) + COALESCE(length(?), 0))::float / length(?) * 100 ELSE 0 END AS Decimal(10, 1)), 1) = ROUND(CAST(? AS Decimal(10, 1)), 1)",
-            e.cacheable_targets,
-            e.local_cache_target_hits,
-            e.remote_cache_target_hits,
-            e.cacheable_targets,
-            ^value
-          )
-        )
-
-      _ ->
-        query
-    end
   end
 
   defp add_filters(query, opts) do

--- a/server/lib/tuist/command_events/clickhouse/event.ex
+++ b/server/lib/tuist/command_events/clickhouse/event.ex
@@ -4,8 +4,6 @@ defmodule Tuist.CommandEvents.Clickhouse.Event do
   """
   use Ecto.Schema
 
-  import Ecto.Query
-
   @derive {
     Flop.Schema,
     filterable: [
@@ -17,9 +15,10 @@ defmodule Tuist.CommandEvents.Clickhouse.Event do
       :git_branch,
       :status,
       :is_ci,
-      :user_id
+      :user_id,
+      :hit_rate
     ],
-    sortable: [:created_at, :ran_at, :duration]
+    sortable: [:created_at, :ran_at, :duration, :hit_rate]
   }
 
   @primary_key {:id, Ch, type: "UUID", autogenerate: false}
@@ -55,22 +54,16 @@ defmodule Tuist.CommandEvents.Clickhouse.Event do
     field :ran_at, Ch, type: "Nullable(DateTime64(6))"
     field :created_at, Ch, type: "DateTime64(6)"
     field :updated_at, Ch, type: "DateTime64(6)"
-    field :hit_rate, :float, virtual: true
-    field :user_account_name, :string, virtual: true
-  end
 
-  def with_hit_rate(query) do
-    from e in query,
-      select_merge: %{
-        hit_rate:
-          fragment(
-            "CASE WHEN length(?) > 0 THEN (length(?) + length(?))::float / length(?) * 100 ELSE NULL END",
-            e.cacheable_targets,
-            e.local_cache_target_hits,
-            e.remote_cache_target_hits,
-            e.cacheable_targets
-          )
-      }
+    field :cacheable_targets_count, Ch, type: "UInt32"
+    field :local_cache_hits_count, Ch, type: "UInt32"
+    field :remote_cache_hits_count, Ch, type: "UInt32"
+    field :test_targets_count, Ch, type: "UInt32"
+    field :local_test_hits_count, Ch, type: "UInt32"
+    field :remote_test_hits_count, Ch, type: "UInt32"
+    field :hit_rate, Ch, type: "Nullable(Float32)"
+
+    field :user_account_name, :string, virtual: true
   end
 
   def changeset(event_attrs) do

--- a/server/lib/tuist/command_events/postgres.ex
+++ b/server/lib/tuist/command_events/postgres.ex
@@ -249,9 +249,9 @@ defmodule Tuist.CommandEvents.Postgres do
             e.created_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
             e.created_at < ^NaiveDateTime.new!(end_date, ~T[23:59:59]),
         select: %{
-          cacheable_targets_count: sum(fragment("array_length(?, 1)", e.cacheable_targets)),
-          local_cache_target_hits_count: sum(fragment("array_length(?, 1)", e.local_cache_target_hits)),
-          remote_cache_target_hits_count: sum(fragment("array_length(?, 1)", e.remote_cache_target_hits))
+          cacheable_targets_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.cacheable_targets)),
+          local_cache_target_hits_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.local_cache_target_hits)),
+          remote_cache_target_hits_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.remote_cache_target_hits))
         }
       )
 
@@ -273,9 +273,9 @@ defmodule Tuist.CommandEvents.Postgres do
             e.project_id == ^project_id,
         select: %{
           date: selected_as(time_bucket(e.created_at, ^time_bucket), ^date_period),
-          cacheable_targets: sum(fragment("array_length(?, 1)", e.cacheable_targets)),
-          local_cache_target_hits: sum(fragment("array_length(?, 1)", e.local_cache_target_hits)),
-          remote_cache_target_hits: sum(fragment("array_length(?, 1)", e.remote_cache_target_hits))
+          cacheable_targets: sum(fragment("COALESCE(array_length(?, 1), 0)", e.cacheable_targets)),
+          local_cache_target_hits: sum(fragment("COALESCE(array_length(?, 1), 0)", e.local_cache_target_hits)),
+          remote_cache_target_hits: sum(fragment("COALESCE(array_length(?, 1), 0)", e.remote_cache_target_hits))
         }
       )
 
@@ -292,9 +292,9 @@ defmodule Tuist.CommandEvents.Postgres do
             e.created_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
             e.created_at < ^NaiveDateTime.new!(end_date, ~T[23:59:59]),
         select: %{
-          test_targets_count: sum(fragment("array_length(?, 1)", e.test_targets)),
-          local_test_target_hits_count: sum(fragment("array_length(?, 1)", e.local_test_target_hits)),
-          remote_test_target_hits_count: sum(fragment("array_length(?, 1)", e.remote_test_target_hits))
+          test_targets_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.test_targets)),
+          local_test_target_hits_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.local_test_target_hits)),
+          remote_test_target_hits_count: sum(fragment("COALESCE(array_length(?, 1), 0)", e.remote_test_target_hits))
         }
       )
 
@@ -316,9 +316,9 @@ defmodule Tuist.CommandEvents.Postgres do
             e.project_id == ^project_id,
         select: %{
           date: selected_as(time_bucket(e.created_at, ^time_bucket), ^date_period),
-          test_targets: sum(fragment("array_length(?, 1)", e.test_targets)),
-          local_test_target_hits: sum(fragment("array_length(?, 1)", e.local_test_target_hits)),
-          remote_test_target_hits: sum(fragment("array_length(?, 1)", e.remote_test_target_hits))
+          test_targets: sum(fragment("COALESCE(array_length(?, 1), 0)", e.test_targets)),
+          local_test_target_hits: sum(fragment("COALESCE(array_length(?, 1), 0)", e.local_test_target_hits)),
+          remote_test_target_hits: sum(fragment("COALESCE(array_length(?, 1), 0)", e.remote_test_target_hits))
         }
       )
 
@@ -388,30 +388,28 @@ defmodule Tuist.CommandEvents.Postgres do
   end
 
   defp apply_hit_rate_ordering(query, :desc) do
-    order_by(
-      query,
-      [e],
-      fragment(
-        "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END DESC NULLS LAST",
-        e.cacheable_targets,
-        e.local_cache_target_hits,
-        e.remote_cache_target_hits,
-        e.cacheable_targets
-      )
+    order_by(query, [e],
+      desc_nulls_last:
+        fragment(
+          "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END",
+          e.cacheable_targets,
+          e.local_cache_target_hits,
+          e.remote_cache_target_hits,
+          e.cacheable_targets
+        )
     )
   end
 
   defp apply_hit_rate_ordering(query, _direction) do
-    order_by(
-      query,
-      [e],
-      fragment(
-        "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END ASC NULLS FIRST",
-        e.cacheable_targets,
-        e.local_cache_target_hits,
-        e.remote_cache_target_hits,
-        e.cacheable_targets
-      )
+    order_by(query, [e],
+      asc_nulls_first:
+        fragment(
+          "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END",
+          e.cacheable_targets,
+          e.local_cache_target_hits,
+          e.remote_cache_target_hits,
+          e.cacheable_targets
+        )
     )
   end
 
@@ -422,7 +420,7 @@ defmodule Tuist.CommandEvents.Postgres do
           query,
           [e],
           fragment(
-            "TRUNC(CAST(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE 0 END AS NUMERIC), 1) > TRUNC(CAST(? AS NUMERIC), 1)",
+            "COALESCE(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END, 0) > ?",
             e.cacheable_targets,
             e.local_cache_target_hits,
             e.remote_cache_target_hits,
@@ -436,7 +434,7 @@ defmodule Tuist.CommandEvents.Postgres do
           query,
           [e],
           fragment(
-            "TRUNC(CAST(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE 0 END AS NUMERIC), 1) >= TRUNC(CAST(? AS NUMERIC), 1)",
+            "COALESCE(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END, 0) >= ?",
             e.cacheable_targets,
             e.local_cache_target_hits,
             e.remote_cache_target_hits,
@@ -450,15 +448,11 @@ defmodule Tuist.CommandEvents.Postgres do
           query,
           [e],
           fragment(
-            "array_length(?, 1) = 0 OR TRUNC(CAST(? AS NUMERIC), 1) < TRUNC(CAST(? AS NUMERIC), 1)",
+            "COALESCE(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END, 0) < ?",
             e.cacheable_targets,
-            fragment(
-              "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE 0 END",
-              e.cacheable_targets,
-              e.local_cache_target_hits,
-              e.remote_cache_target_hits,
-              e.cacheable_targets
-            ),
+            e.local_cache_target_hits,
+            e.remote_cache_target_hits,
+            e.cacheable_targets,
             ^value
           )
         )
@@ -468,15 +462,11 @@ defmodule Tuist.CommandEvents.Postgres do
           query,
           [e],
           fragment(
-            "array_length(?, 1) = 0 OR TRUNC(CAST(? AS NUMERIC), 1) <= TRUNC(CAST(? AS NUMERIC), 1)",
+            "COALESCE(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END, 0) <= ?",
             e.cacheable_targets,
-            fragment(
-              "CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE 0 END",
-              e.cacheable_targets,
-              e.local_cache_target_hits,
-              e.remote_cache_target_hits,
-              e.cacheable_targets
-            ),
+            e.local_cache_target_hits,
+            e.remote_cache_target_hits,
+            e.cacheable_targets,
             ^value
           )
         )
@@ -486,7 +476,7 @@ defmodule Tuist.CommandEvents.Postgres do
           query,
           [e],
           fragment(
-            "TRUNC(CAST(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE 0 END AS NUMERIC), 1) = TRUNC(CAST(? AS NUMERIC), 1)",
+            "COALESCE(CASE WHEN array_length(?, 1) > 0 THEN (COALESCE(array_length(?, 1), 0) + COALESCE(array_length(?, 1), 0))::float / array_length(?, 1) * 100 ELSE NULL END, 0) = ?",
             e.cacheable_targets,
             e.local_cache_target_hits,
             e.remote_cache_target_hits,

--- a/server/lib/tuist/command_events/postgres.ex
+++ b/server/lib/tuist/command_events/postgres.ex
@@ -11,7 +11,7 @@ defmodule Tuist.CommandEvents.Postgres do
   alias Tuist.Repo
 
   def list_command_events(attrs) do
-    query = Event.with_hit_rate(Event)
+    query = Event.with_analytics(Event)
 
     {hit_rate_filter, other_filters} = extract_hit_rate_filter(attrs)
 

--- a/server/lib/tuist/command_events/postgres/event.ex
+++ b/server/lib/tuist/command_events/postgres/event.ex
@@ -48,8 +48,15 @@ defmodule Tuist.CommandEvents.Postgres.Event do
     field :git_ref, :string
     field :git_branch, :string
     field :ran_at, :utc_datetime
-    field :hit_rate, :float, virtual: true
     field :user_account_name, :string, virtual: true
+
+    field :cacheable_targets_count, :integer, virtual: true
+    field :local_cache_hits_count, :integer, virtual: true
+    field :remote_cache_hits_count, :integer, virtual: true
+    field :test_targets_count, :integer, virtual: true
+    field :local_test_hits_count, :integer, virtual: true
+    field :remote_test_hits_count, :integer, virtual: true
+    field :hit_rate, :float, virtual: true
 
     # Binary Cache
     field :cacheable_targets, {:array, :string}, default: []
@@ -136,7 +143,7 @@ defmodule Tuist.CommandEvents.Postgres.Event do
   end
 
   def with_hit_rate(query) do
-    from e in query,
+    from(e in query,
       select_merge: %{
         hit_rate:
           fragment(
@@ -145,7 +152,14 @@ defmodule Tuist.CommandEvents.Postgres.Event do
             e.local_cache_target_hits,
             e.remote_cache_target_hits,
             e.cacheable_targets
-          )
+          ),
+        cacheable_targets_count: fragment("array_length(?, 1)", e.cacheable_targets),
+        local_cache_hits_count: fragment("array_length(?, 1)", e.local_cache_target_hits),
+        remote_cache_hits_count: fragment("array_length(?, 1)", e.remote_cache_target_hits),
+        test_targets_count: fragment("array_length(?, 1)", e.test_targets),
+        local_test_hits_count: fragment("array_length(?, 1)", e.local_test_target_hits),
+        remote_test_hits_count: fragment("array_length(?, 1)", e.remote_test_target_hits)
       }
+    )
   end
 end

--- a/server/lib/tuist/command_events/postgres/event.ex
+++ b/server/lib/tuist/command_events/postgres/event.ex
@@ -142,7 +142,7 @@ defmodule Tuist.CommandEvents.Postgres.Event do
     |> validate_inclusion(:status, [:success, :failure])
   end
 
-  def with_hit_rate(query) do
+  def with_analytics(query) do
     from(e in query,
       select_merge: %{
         hit_rate:

--- a/server/lib/tuist/runs.ex
+++ b/server/lib/tuist/runs.ex
@@ -22,11 +22,14 @@ defmodule Tuist.Runs do
          |> Build.create_changeset(attrs)
          |> Repo.insert() do
       {:ok, build} ->
-        Task.await_many([
-          Task.async(fn -> create_build_issues(build, attrs.issues) end),
-          Task.async(fn -> create_build_files(build, attrs.files) end),
-          Task.async(fn -> create_build_targets(build, attrs.targets) end)
-        ])
+        Task.await_many(
+          [
+            Task.async(fn -> create_build_issues(build, attrs.issues) end),
+            Task.async(fn -> create_build_files(build, attrs.files) end),
+            Task.async(fn -> create_build_targets(build, attrs.targets) end)
+          ],
+          30_000
+        )
 
         build = Repo.preload(build, project: :account)
 

--- a/server/priv/click_house_repo/migrations/20250715093853_add_performance_indexes_and_computed_columns.exs
+++ b/server/priv/click_house_repo/migrations/20250715093853_add_performance_indexes_and_computed_columns.exs
@@ -1,0 +1,82 @@
+defmodule Tuist.ClickHouseRepo.Migrations.AddPerformanceIndexesAndComputedColumns do
+  use Ecto.Migration
+
+  def up do
+    execute(
+      "ALTER TABLE command_events ADD COLUMN cacheable_targets_count UInt32 DEFAULT length(cacheable_targets)"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD COLUMN local_cache_hits_count UInt32 DEFAULT length(local_cache_target_hits)"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD COLUMN remote_cache_hits_count UInt32 DEFAULT length(remote_cache_target_hits)"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD COLUMN test_targets_count UInt32 DEFAULT length(test_targets)"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD COLUMN local_test_hits_count UInt32 DEFAULT length(local_test_target_hits)"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD COLUMN remote_test_hits_count UInt32 DEFAULT length(remote_test_target_hits)"
+    )
+
+    execute("""
+    ALTER TABLE command_events ADD COLUMN hit_rate Nullable(Float32) DEFAULT 
+      CASE 
+        WHEN cacheable_targets_count > 0 
+        THEN (local_cache_hits_count + remote_cache_hits_count) / cacheable_targets_count * 100
+        ELSE NULL 
+      END
+    """)
+
+    execute("ALTER TABLE command_events ADD INDEX idx_name name TYPE bloom_filter GRANULARITY 1")
+
+    execute(
+      "ALTER TABLE command_events ADD INDEX idx_git_branch git_branch TYPE bloom_filter GRANULARITY 1"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD INDEX idx_git_ref git_ref TYPE bloom_filter GRANULARITY 1"
+    )
+
+    execute(
+      "ALTER TABLE command_events ADD INDEX idx_git_commit_sha git_commit_sha TYPE bloom_filter GRANULARITY 1"
+    )
+
+    execute("ALTER TABLE command_events ADD INDEX idx_status status TYPE minmax GRANULARITY 1")
+    execute("ALTER TABLE command_events ADD INDEX idx_is_ci is_ci TYPE minmax GRANULARITY 1")
+    execute("ALTER TABLE command_events ADD INDEX idx_user_id user_id TYPE minmax GRANULARITY 1")
+
+    execute(
+      "ALTER TABLE command_events ADD INDEX idx_project_id project_id TYPE minmax GRANULARITY 1"
+    )
+
+    execute("ALTER TABLE command_events ADD INDEX idx_name_set name TYPE set(100) GRANULARITY 1")
+  end
+
+  def down do
+    execute("ALTER TABLE command_events DROP INDEX idx_name_set")
+    execute("ALTER TABLE command_events DROP INDEX idx_project_id")
+    execute("ALTER TABLE command_events DROP INDEX idx_user_id")
+    execute("ALTER TABLE command_events DROP INDEX idx_is_ci")
+    execute("ALTER TABLE command_events DROP INDEX idx_status")
+    execute("ALTER TABLE command_events DROP INDEX idx_git_commit_sha")
+    execute("ALTER TABLE command_events DROP INDEX idx_git_ref")
+    execute("ALTER TABLE command_events DROP INDEX idx_git_branch")
+    execute("ALTER TABLE command_events DROP INDEX idx_name")
+
+    execute("ALTER TABLE command_events DROP COLUMN hit_rate")
+    execute("ALTER TABLE command_events DROP COLUMN remote_test_hits_count")
+    execute("ALTER TABLE command_events DROP COLUMN local_test_hits_count")
+    execute("ALTER TABLE command_events DROP COLUMN test_targets_count")
+    execute("ALTER TABLE command_events DROP COLUMN remote_cache_hits_count")
+    execute("ALTER TABLE command_events DROP COLUMN local_cache_hits_count")
+    execute("ALTER TABLE command_events DROP COLUMN cacheable_targets_count")
+  end
+end

--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -1335,14 +1335,13 @@ defmodule Tuist.XcodeTest do
   # For querying Xcode data, we are using a materialized view in ClickHouse that can take a few milliseconds to populate.
   # In testing, where we run the assertions immediately, this can lead to flakiness if the update hasn't completed.
   # In order to be able to properly test the materialized view, we use this query helper that retries.
-  defp wait_for_clickhouse_data(query_fn, condition_fn, max_attempts \\ 10, delay_ms \\ 100) do
+  defp wait_for_clickhouse_data(query_fn, condition_fn, max_attempts \\ 10, delay_ms \\ 250) do
     Enum.reduce_while(1..max_attempts, nil, fn attempt, _acc ->
       result = query_fn.()
 
       if condition_fn.(result) do
         {:halt, result}
       else
-        # credo:disable-for-next-line
         if attempt < max_attempts do
           Process.sleep(delay_ms)
           {:cont, nil}


### PR DESCRIPTION
Bunch of performance improvements to the Clickhouse backends.

1. Adds a few indexes for often-used queries.
2. Calculates `hit_rate` on insert inside Clickhouse, meaning we can use Flop for filtering/sorting by it _and_ remove a ton of repetitive code.

It also updates the Postgres `Event` schema with a few virtual fields to keep API compatibility. Those queries are the same, just assigned differently now.