### PR TITLE
Migrate translation system from Crowdin to Weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
   <div>
     <a href="https://cal.com/team/tuist/cloud?utm_source=banner&utm_campaign=oss" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" width="150"/></a>
   </div>
-  <a title="Crowdin" target="_blank" href="https://crowdin.com/project/tuist-documentation"><img src="https://badges.crowdin.net/tuist-documentation/localized.svg"></a>
+  <a href="https://translate.tuist.dev/engage/documentation/">
+  <img src="https://translate.tuist.dev/widget/documentation/svg-badge.svg" alt="Translation status" />
+  </a>
 </div>
 
 # Tuist

--- a/docs/docs/en/contributors/translate.md
+++ b/docs/docs/en/contributors/translate.md
@@ -14,23 +14,22 @@ Since maintaining translations is a continuous effort, we add languages as we se
 - Korean
 - Japanese
 - Russian
+- Chinese
+- Spanish
+- Portuguese
 
 > [!TIP] REQUEST A NEW LANGUAGE
 > If you believe Tuist would benefit from supporting a new language, please create a new [topic in the community forum](https://community.tuist.io/c/general/4) to discuss it with the community.
 
 ## How to translate {#how-to-translate}
 
-We use [Crowdin](https://crowdin.com/) to manage the translations. First, go to the project that you want to contribute to:
+We have an instance of [Weblate](https://weblate.org/en-gb/) running at [translate.tuist.dev](https://translate.tuist.dev).
+You can head to [the documentation](https://translate.tuist.dev/engage/documentation/) project website, create an account, and start translating.
 
-- [Documentation](https://crowdin.com/project/tuist-documentation)
-- [Website](https://crowdin.com/project/tuist-documentation)
-
-You'll need an account to start translating. You can sign in with GitHub. Once you have access, you can start translating. You'll see the list of resources that are available for translation. When you click on a resource, the editor will open, and you'll see a split view with the resource in the source language on the left and the translation on the right. Translate the text on the right and save your changes.
-
-As translations are updated, Crowdin will push them automatically to the right repository opening a pull request, which the maintainers will review and merge.
+Translations are synchronized back to the source repository using GitHub pull requests which maintainers will review and merge.
 
 > [!IMPORTANT] DON'T MODIFY THE RESOURCES IN THE TARGET LANGUAGE
-> Crowdin segments the files to bind source and target languages. If you modify the source language, you'll break the binding, and the reconciliation might yield unexpected results.
+> Weblate segments the files to bind source and target languages. If you modify the source language, you'll break the binding, and the reconciliation might yield unexpected results.
 
 ## Guidelines {#guidelines}
 


### PR DESCRIPTION
## Summary

- Migrates the translation system from Crowdin to Weblate
- Updates README.md to use the new Weblate translation badge from translate.tuist.dev
- Updates contributor documentation to reflect the new Weblate workflow
- Adds support for Chinese, Spanish, and Portuguese languages

## Test plan

- [x] Translation badge updated in README.md
- [x] Documentation updated with new Weblate instructions
- [x] Additional supported languages added to the documentation
- [x] Links updated to point to translate.tuist.dev