### PR TITLE
Rework runs analytics

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -71,10 +71,11 @@ defmodule Tuist.CommandEvents do
     # However, this was a design mistake, so we are taking the last event as the valid one.
     # In a future iteration, we should delete duplicated rows, and add the unique index.
     Repo.one(
-      from c in CacheEvent,
+      from(c in CacheEvent,
         where: c.hash == ^hash and c.event_type == ^event_type,
         order_by: [desc: :created_at],
         limit: 1
+      )
     )
   end
 
@@ -839,6 +840,14 @@ defmodule Tuist.CommandEvents do
 
   def count_all_events do
     storage_module().count_all_events()
+  end
+
+  def runs_analytics_average_duration(project_id, start_date, end_date, opts) do
+    storage_module().runs_analytics_average_duration(project_id, start_date, end_date, opts)
+  end
+
+  def runs_analytics_aggregated(project_id, start_date, end_date, opts) do
+    storage_module().runs_analytics_aggregated(project_id, start_date, end_date, opts)
   end
 
   defp build_run_user_map(runs, user_map) do

--- a/server/lib/tuist/command_events/clickhouse.ex
+++ b/server/lib/tuist/command_events/clickhouse.ex
@@ -202,6 +202,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
   def runs_analytics(project_id, start_date, end_date, opts) do
     query =
       from(e in Event,
+        as: :event,
         where:
           e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
             e.ran_at < ^NaiveDateTime.new!(end_date, ~T[23:59:59]) and
@@ -290,6 +291,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
 
     query =
       from(e in Event,
+        as: :event,
         group_by: fragment("formatDateTime(?, ?)", e.ran_at, ^date_format),
         where:
           e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
@@ -309,6 +311,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
   def cache_hit_rate(project_id, start_date, end_date, opts) do
     query =
       from(e in Event,
+        as: :event,
         where:
           e.project_id == ^project_id and
             e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
@@ -333,6 +336,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
 
     query =
       from(e in Event,
+        as: :event,
         group_by: fragment("formatDateTime(?, ?)", e.ran_at, ^date_format),
         where:
           e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
@@ -354,6 +358,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
   def selective_testing_hit_rate(project_id, start_date, end_date, opts) do
     query =
       from(e in Event,
+        as: :event,
         where:
           e.project_id == ^project_id and
             e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and
@@ -378,6 +383,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
 
     query =
       from(e in Event,
+        as: :event,
         group_by: fragment("formatDateTime(?, ?)", e.ran_at, ^date_format),
         where:
           e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -256,7 +256,7 @@ defmodule TuistWeb.OverviewLive do
         Task.async(fn -> Analytics.cache_hit_rate_analytics(opts) end),
         Task.async(fn -> Analytics.selective_testing_analytics(opts) end),
         Task.async(fn -> Analytics.builds_duration_analytics(project.id, opts) end),
-        Task.async(fn -> Analytics.runs_duration_analytics("test", project_id: project.id) end)
+        Task.async(fn -> Analytics.runs_duration_analytics("test", opts) end)
       ]
 
       [


### PR DESCRIPTION
Reworks the Runs.Analytics module to not query all events and then iterate over them in memory, but instead use database aggregation functions.
Doesn't fully clean up old functionality, will do that in a follow up tomorrow.