### PR TITLE
Fix regression from #7854

### DIFF
--- a/server/lib/tuist/command_events/clickhouse.ex
+++ b/server/lib/tuist/command_events/clickhouse.ex
@@ -566,6 +566,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
     data_query =
       add_filters(
         from(e in Event,
+          as: :event,
           group_by: fragment("formatDateTime(?, ?)", e.ran_at, ^date_format),
           where:
             e.ran_at > ^NaiveDateTime.new!(start_date, ~T[00:00:00]) and


### PR DESCRIPTION
Refactoring the query caused a regression where the binding name was missing and subsequently adding filters was failing.