### PR TITLE
Send telemetry around failing token refreshes

### DIFF
--- a/docs/docs/en/guides/server/self-host/telemetry.md
+++ b/docs/docs/en/guides/server/self-host/telemetry.md
@@ -288,6 +288,23 @@ The total number of times an upload was completed to the remote storage.
 
 ---
 
+## Authentication metrics {#authentication-metrics}
+
+A set of metrics related to authentication.
+
+### `tuist_authentication_token_refresh_error_total` (counter) {#tuist_authentication_token_refresh_error_total-counter}
+
+The total number of token refresh errors.
+
+#### Tags {#tuist-authentication-token-refresh-error-total-tags}
+
+| Tag | Description |
+|--- | ---- |
+| `cli_version` | The version of the Tuist CLI that encountered the error. |
+| `reason` | The reason for the token refresh error, such as `invalid_token_type` or `invalid_token`. |
+
+---
+
 ## Projects metrics {#projects-metrics}
 
 A set of metrics related to the projects.

--- a/server/lib/tuist/analytics.ex
+++ b/server/lib/tuist/analytics.ex
@@ -14,7 +14,8 @@ defmodule Tuist.Analytics do
     [:analytics, :preview, :upload],
     [:analytics, :preview, :download],
     [:analytics, :cache_artifact, :upload],
-    [:analytics, :cache_artifact, :download]
+    [:analytics, :cache_artifact, :download],
+    [:analytics, :authentication, :token_refresh, :error]
   ]
 
   def all_events do
@@ -82,6 +83,14 @@ defmodule Tuist.Analytics do
       [:analytics, :cache_artifact, :download],
       %{size: size},
       Map.merge(%{category: category}, subject_parameters(subject))
+    )
+  end
+
+  def authentication_token_refresh_error(attrs) do
+    :telemetry.execute(
+      [:analytics, :authentication, :token_refresh, :error],
+      %{},
+      attrs
     )
   end
 

--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -66,10 +66,11 @@ defmodule Tuist.Authentication do
       Tuist.Guardian.on_revoke(old_claims, old_token)
       {:ok, {old_token, old_claims}, {new_token, new_claims}}
     else
-      {:error, :invalid_token} -> {:error, "The token is invalid"}
-      {:error, :token_not_found} -> {:error, "The token is invalid"}
-      {:error, :token_expired} -> {:error, "The token is expired"}
-      {:ok, {:user, nil}} -> {:error, "The token user doesn't exist"}
+      {:error, reason} ->
+        {:error, reason}
+
+      {:ok, {:user, nil}} ->
+        {:error, "The token user doesn't exist"}
     end
   end
 

--- a/server/lib/tuist/authentication/prom_ex_plugin.ex
+++ b/server/lib/tuist/authentication/prom_ex_plugin.ex
@@ -1,0 +1,21 @@
+defmodule Tuist.Authentication.PromExPlugin do
+  @moduledoc """
+  Defines custom Prometheus metrics for the Tuist authentication events
+  """
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(_opts) do
+    Event.build(
+      :tuist_authentication_event_metrics,
+      [
+        counter(
+          [:tuist, :authentication, :token_refresh, :error, :total],
+          event_name: [:analytics, :authentication, :token_refresh, :error],
+          description: "The number of token refresh errors.",
+          tags: [:cli_version, :reason]
+        )
+      ]
+    )
+  end
+end

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -74,6 +74,7 @@ defmodule Tuist.PromEx do
         Tuist.Registry.Swift.PromExPlugin,
         Tuist.Repo.PromExPlugin,
         Tuist.KeyValueStore.PromExPlugin,
+        Tuist.Authentication.PromExPlugin,
         Tuist.HTTP.PromExPlugin
       ]
 

--- a/server/lib/tuist_web/headers.ex
+++ b/server/lib/tuist_web/headers.ex
@@ -15,4 +15,8 @@ defmodule TuistWeb.Headers do
       _ -> nil
     end
   end
+
+  def put_cli_version(conn, version) do
+    Plug.Conn.put_req_header(conn, "x-tuist-cloud-cli-version", version)
+  end
 end

--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -1055,8 +1055,16 @@ defmodule Tuist.XcodeTest do
           }
         })
 
-      # When
-      counts = Clickhouse.selective_testing_counts(command_event)
+      # When (with retry for materialized view population)
+      counts =
+        wait_for_clickhouse_data(
+          fn ->
+            Clickhouse.selective_testing_counts(command_event)
+          end,
+          fn result ->
+            result.total_count == 3
+          end
+        )
 
       # Then
       assert counts.selective_testing_local_hits_count == 1
@@ -1101,8 +1109,16 @@ defmodule Tuist.XcodeTest do
           }
         })
 
-      # When
-      counts = Clickhouse.binary_cache_counts(command_event)
+      # When (with retry for materialized view population)
+      counts =
+        wait_for_clickhouse_data(
+          fn ->
+            Clickhouse.binary_cache_counts(command_event)
+          end,
+          fn result ->
+            result.total_count == 4
+          end
+        )
 
       # Then
       assert counts.binary_cache_local_hits_count == 1


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7865

We had a bug in the CLI that led to a race condition and the user being logged out. However, it might still happening to users that are on old version os the CLI.

This PR adds telemetry around failing toke refreshes, which could reveal a bug in the CLI, or some actor misusing the API.