### PR TITLE
fix: handle token_expired error

### DIFF
--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -68,6 +68,7 @@ defmodule Tuist.Authentication do
     else
       {:error, :invalid_token} -> {:error, "The token is invalid"}
       {:error, :token_not_found} -> {:error, "The token is invalid"}
+      {:error, :token_expired} -> {:error, "The token is expired"}
       {:ok, {:user, nil}} -> {:error, "The token user doesn't exist"}
     end
   end

--- a/server/test/tuist_web/controllers/api/auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/auth_controller_test.exs
@@ -269,6 +269,28 @@ defmodule TuistWeb.API.AuthControllerTest do
                "message" => "The refresh token is expired or invalid"
              }
     end
+
+    test "handles token_expired error", %{conn: conn} do
+      # Given
+      user = AccountsFixtures.user_fixture()
+
+      {:ok, refresh_token, _claims} =
+        Tuist.Authentication.encode_and_sign(user, %{},
+          token_type: :refresh,
+          ttl: {-1, :seconds}
+        )
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/auth/refresh_token", %{refresh_token: refresh_token})
+
+      # Then
+      assert json_response(conn, :unauthorized) == %{
+               "message" => "The refresh token is expired or invalid"
+             }
+    end
   end
 
   describe "POST /api/auth" do


### PR DESCRIPTION
Resolves: https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1001/samples/6607b64d83eb6789e61c8ba7-988861431831486482117527632602

Basically copy of: https://github.com/tuist/tuist/pull/7864