### PR TITLE
Reload command event before returning

### DIFF
--- a/server/lib/tuist/command_events/clickhouse.ex
+++ b/server/lib/tuist/command_events/clickhouse.ex
@@ -92,7 +92,7 @@ defmodule Tuist.CommandEvents.Clickhouse do
 
     event = struct(Event, event_attrs)
     {:ok, command_event} = ClickHouseRepo.insert(event)
-    Event.normalize_enums(command_event)
+    command_event |> ClickHouseRepo.reload() |> Event.normalize_enums()
   end
 
   def account_month_usage(account_id, date \\ DateTime.utc_now()) do


### PR DESCRIPTION
On deployed environments, the `legacy_id` field is generated with `DEFAULT generateSerialID('command_events_legacy_id')`. Fields that are not marked as `autogenerate: true` in Ecto might return with the field as `nil`. Since `generateSerialID` is not a default autogenerate we can set in Ecto, we need to reload the struct before returning it back to the user.