### PR TITLE
Make ClickHouse operations synchronous in testing to prevent race conditions

### DIFF
--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -59,9 +59,7 @@ defmodule Tuist.XcodeTest do
 
       # Verify data was written to ClickHouse
       [graph_ch] =
-        ClickHouseRepo.all(
-          from(g in CHXcodeGraph, where: g.command_event_id == ^command_event.id)
-        )
+        ClickHouseRepo.all(from(g in CHXcodeGraph, where: g.command_event_id == ^command_event.id))
 
       assert graph_ch.name == "TestGraph"
       assert graph_ch.command_event_id == command_event.id


### PR DESCRIPTION
## Summary
- Iterate on the `wait_for_clickhouse_data` using connection settings
- Added deterministic ClickHouse settings to test configuration to prevent race conditions  

## Changes
- **config/test.exs**: Added ClickHouse settings for synchronous mutations and single-threaded processing
- **test/tuist/xcode_test.exs**: Removed retry logic and improved query formatting