### PR TITLE
Make ClickHouse operations synchronous during testing

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -15,7 +15,16 @@ config :tuist, Oban, testing: :inline
 config :tuist, Tuist.ClickHouseRepo,
   hostname: "localhost",
   port: 8123,
-  database: "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
+  database: "tuist_test#{System.get_env("MIX_TEST_PARTITION")}",
+  settings: [
+    # These settings will be applied to all queries
+    mutations_sync: 2,
+    wait_for_async_insert: 1,
+    insert_quorum: 1,
+    # Disable parallel processing for deterministic tests
+    max_threads: 1,
+    max_insert_threads: 1
+  ]
 
 # Configures Bamboo API Client
 config :tuist, Tuist.Mailer, adapter: Bamboo.TestAdapter


### PR DESCRIPTION
I just noticed that our seeds is flaky, potentially related with the same issue that we faced in our tests where some data is asynchronously inserted in ClickHouse so we need to wait for it to be available. This PR attempts to fix it by configuring the connection to be synchronous when `MIX_ENV=test`

### Configuration Updates:
* Added query settings to `ClickHouseRepo` in `server/config/test.exs` to ensure deterministic behavior during tests, such as limiting threads and enabling synchronous mutations.

### Code Cleanup:
* Removed the unused `wait_for_clickhouse_data` helper function from `Tuist.XcodeTest`, which was previously used for retrying ClickHouse materialized view queries.
