### PR TITLE
Fix checking an account plan

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -256,9 +256,7 @@ defmodule Tuist.Billing do
     }
   end
 
-  def get_estimated_next_payment(%{
-        current_month_remote_cache_hits_count: current_month_remote_cache_hits_count
-      }) do
+  def get_estimated_next_payment(%{current_month_remote_cache_hits_count: current_month_remote_cache_hits_count}) do
     remote_cache_hits_threshold = get_payment_thresholds()[:remote_cache_hits]
 
     if current_month_remote_cache_hits_count < remote_cache_hits_threshold do

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -141,9 +141,7 @@ defmodule Tuist.BillingTest do
       assert got ==
                50
                |> Money.new(:USD)
-               |> Money.multiply(
-                 current_month_remote_cache_hits_count - remote_cache_hit_threshold
-               )
+               |> Money.multiply(current_month_remote_cache_hits_count - remote_cache_hit_threshold)
                |> Money.to_string()
     end
   end
@@ -388,8 +386,7 @@ defmodule Tuist.BillingTest do
       end)
 
       stub(Stripe.Subscription, :retrieve, fn "sub_some-id" ->
-        {:ok,
-         %Stripe.Subscription{items: %{data: [%{id: "air.usage"}, %{id: "air.flat.monthly"}]}}}
+        {:ok, %Stripe.Subscription{items: %{data: [%{id: "air.usage"}, %{id: "air.flat.monthly"}]}}}
       end)
 
       Billing.on_subscription_change(%{
@@ -426,8 +423,7 @@ defmodule Tuist.BillingTest do
       end)
 
       stub(Stripe.Subscription, :retrieve, fn "sub_some-id" ->
-        {:ok,
-         %Stripe.Subscription{items: %{data: [%{id: "pro.usage"}, %{id: "pro.flat.monthly"}]}}}
+        {:ok, %Stripe.Subscription{items: %{data: [%{id: "pro.usage"}, %{id: "pro.flat.monthly"}]}}}
       end)
 
       Billing.on_subscription_change(%{


### PR DESCRIPTION
[This PR](https://github.com/tuist/tuist/pull/7878) introduced a regression that we couldn't catch through tests because tests mocked the plans codified in the secrets. This PR fixes it by aligning the access with the new keys-as-string convention.
