### PR TITLE
Fix CLI version header handling and improve code formatting

### DIFF
--- a/server/lib/tuist_web/controllers/api/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/api/auth_controller.ex
@@ -35,7 +35,8 @@ defmodule TuistWeb.API.AuthController do
 
   operation(:device_code,
     summary: "Get a specific device code.",
-    description: "This endpoint returns a token for a given device code if the device code is authenticated.",
+    description:
+      "This endpoint returns a token for a given device code if the device code is authenticated.",
     operation_id: "getDeviceCode",
     parameters: [
       device_code: [
@@ -68,8 +69,11 @@ defmodule TuistWeb.API.AuthController do
              }
            }
          }},
-      accepted: {"The device code is not authenticated", "application/json", %Schema{type: :object}},
-      bad_request: {"The request was not accepted, e.g., when the device code is expired", "application/json", Error}
+      accepted:
+        {"The device code is not authenticated", "application/json", %Schema{type: :object}},
+      bad_request:
+        {"The request was not accepted, e.g., when the device code is expired",
+         "application/json", Error}
     }
   )
 
@@ -129,7 +133,8 @@ defmodule TuistWeb.API.AuthController do
 
   operation(:refresh_token,
     summary: "Request new tokens.",
-    description: "This endpoint returns new tokens for a given refresh token if the refresh token is valid.",
+    description:
+      "This endpoint returns new tokens for a given refresh token if the refresh token is valid.",
     operation_id: "refreshToken",
     request_body:
       {"Token params", "application/json",
@@ -149,8 +154,10 @@ defmodule TuistWeb.API.AuthController do
         "application/json",
         AuthenticationTokens
       },
-      unauthorized: {"You need to be authenticated to issue new tokens", "application/json", Error},
-      bad_request: {"The token can't be refreshed because it has invalid type", "application/json", Error}
+      unauthorized:
+        {"You need to be authenticated to issue new tokens", "application/json", Error},
+      bad_request:
+        {"The token can't be refreshed because it has invalid type", "application/json", Error}
     }
   )
 
@@ -162,7 +169,9 @@ defmodule TuistWeb.API.AuthController do
         |> json(%{message: "The refresh token is expired or invalid"})
 
       {:ok, {_old_token, _old_claims}, {new_refresh_token, _new_claims}} ->
-        case Authentication.exchange(new_refresh_token, "refresh", "access", ttl: @access_token_ttl) do
+        case Authentication.exchange(new_refresh_token, "refresh", "access",
+               ttl: @access_token_ttl
+             ) do
           {:ok, _old_token_with_claims, {new_access_token, _new_access_token_claims}} ->
             conn
             |> put_status(:ok)
@@ -174,7 +183,7 @@ defmodule TuistWeb.API.AuthController do
           {:error, reason} ->
             Tuist.Analytics.authentication_token_refresh_error(%{
               reason: if(is_binary(reason), do: reason, else: Atom.to_string(reason)),
-              cli_version: conn |> TuistWeb.Headers.get_cli_version() |> Version.to_string()
+              cli_version: conn |> TuistWeb.Headers.get_cli_version_string()
             })
 
             conn
@@ -244,7 +253,8 @@ defmodule TuistWeb.API.AuthController do
         "application/json",
         AuthenticationTokens
       },
-      unauthorized: {"Invalid Apple identity token or authorization code.", "application/json", Error},
+      unauthorized:
+        {"Invalid Apple identity token or authorization code.", "application/json", Error},
       bad_request: {"Invalid request parameters.", "application/json", Error}
     }
   )
@@ -300,7 +310,8 @@ defmodule TuistWeb.API.AuthController do
   end
 
   def authenticate_apple(
-        %{body_params: %{identity_token: identity_token, authorization_code: authorization_code}} = conn,
+        %{body_params: %{identity_token: identity_token, authorization_code: authorization_code}} =
+          conn,
         _params
       ) do
     with {:ok, user} <-

--- a/server/lib/tuist_web/headers.ex
+++ b/server/lib/tuist_web/headers.ex
@@ -6,13 +6,23 @@ defmodule TuistWeb.Headers do
 
   def cli_version_header, do: @cli_version_header
 
-  def get_cli_version(conn) do
+  def get_cli_version_string(conn) do
     with {:version_string, version_string} when not is_nil(version_string) <-
-           {:version_string, conn |> Plug.Conn.get_req_header(cli_version_header()) |> List.first()},
-         {:version, {:ok, version}} <- {:version, Version.parse(version_string)} do
-      version
+           {:version_string,
+            conn |> Plug.Conn.get_req_header(cli_version_header()) |> List.first()} do
+      version_string
     else
       _ -> nil
+    end
+  end
+
+  def get_cli_version(conn) do
+    with version_string when not is_nil(version_string) <- get_cli_version_string(conn),
+         {:ok, version} <- Version.parse(version_string) do
+      version
+    else
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
## Summary
- Extract `get_cli_version_string` function for raw version string access
- Update auth controller to use version string directly for analytics
- Fix multiline formatting in auth controller for better readability
- Improve error handling consistency across authentication endpoints

## Test plan
- [x] Verify CLI version header parsing works correctly
- [x] Confirm analytics tracking uses raw version string
- [x] Test authentication endpoints still function properly
- [x] Validate code formatting improvements