### PR TITLE
Fix PromEx ETS flush timeout

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -307,8 +307,8 @@ config :tuist, Tuist.PromEx,
   grafana: :disabled,
   # Larger numbers might lead to internal tasks timing out.
   # By keeping it small we might loose some granularity of the data, but I think it's a good tradeoff.
-  # Every second
-  ets_flush_interval: 1_000,
+  # Use default value to avoid over-compacting
+  ets_flush_interval: 7_500,
   metrics_server: [
     port: 9091,
     auth_strategy: :none

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -308,7 +308,7 @@ config :tuist, Tuist.PromEx,
   # Larger numbers might lead to internal tasks timing out.
   # By keeping it small we might loose some granularity of the data, but I think it's a good tradeoff.
   # Use default value to avoid over-compacting
-  ets_flush_interval: 7_500,
+  ets_flush_interval: 500,
   metrics_server: [
     port: 9091,
     auth_strategy: :none


### PR DESCRIPTION
[Error](https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/24)

We've had this error for a while. `prom_ex` compacts the ets table periodically to keep things performant. However, the task that it [runs](https://github.com/akoutmos/prom_ex/blob/edae7abd3e9264d665422f62cf92ce52551fff17/lib/prom_ex/ets_cron_flusher.ex#L58) timeouts because `PromEx.get_metrics(state.prom_ex_module)` takes longer than 10 seconds. My theory is that it happens because the interval is too long causing the compacting operation to take a long time. If we flush more regularly, I expect the compacting to be faster and not hit the timeout _(my theory)_.

 