### PR TITLE
Handle reserved handles

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -590,17 +590,36 @@ defmodule Tuist.Accounts do
 
       oauth2_identity
     else
-      {:ok, user} =
-        create_user(email,
-          password: generate_random_string(16),
-          oauth2_identity: %{
-            provider: provider,
-            id_in_provider: to_string(id_in_provider),
-            provider_organization_id: provider_organization_id
-          }
-        )
-
+      user = create_oauth2_user(email, provider, id_in_provider, provider_organization_id)
       find_oauth2_identity(%{user: user, provider: provider})
+    end
+  end
+
+  defp create_oauth2_user(email, provider, id_in_provider, provider_organization_id) do
+    oauth2_attrs = %{
+      provider: provider,
+      id_in_provider: to_string(id_in_provider),
+      provider_organization_id: provider_organization_id
+    }
+
+    case create_user(email, password: generate_random_string(16), oauth2_identity: oauth2_attrs) do
+      {:ok, user} ->
+        user
+
+      {:error, %{name: _name_error}} ->
+        # If name has an error (reserved, taken, etc), retry with a random suffix
+        {:ok, user} =
+          create_user(email,
+            password: generate_random_string(16),
+            suffix: "-#{:rand.uniform(9999)}",
+            oauth2_identity: oauth2_attrs
+          )
+
+        user
+
+      error ->
+        # Re-raise any other errors
+        {:ok, _} = error
     end
   end
 

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -2066,6 +2066,27 @@ defmodule Tuist.AccountsTest do
       assert user.email == got.email
       assert Accounts.find_oauth2_identity(%{user: user, provider: :okta}) != nil
     end
+
+    test "handles reserved handle names by adding a suffix" do
+      # Given
+      stub(Environment, :tuist_hosted?, fn -> true end)
+      # When
+      user =
+        Accounts.find_or_create_user_from_oauth2(%{
+          provider: :github,
+          uid: 123,
+          info: %{
+            email: "admin@example.com"
+          }
+        })
+
+      # Then
+      assert user.email == "admin@example.com"
+      account = Accounts.get_account_from_user(user)
+      # The handle should be "admin-" followed by a random number
+      assert String.starts_with?(account.name, "admin-")
+      assert account.name != "admin"
+    end
   end
 
   describe "authenticate_device_code/2" do


### PR DESCRIPTION
Resolves [AppSignal Error](https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/287/)

I noticed the OAuth2 authentication failed for a user because the handle that we tried to use fell into the list of reserved handles. This PR extends the logic to handle that scenario gracefully adding suffixes to the handle. Long-term we should give the user control over choosing the handle as part of the sign-up, but until we have that, I'd suggest that we handle it this way to not prevent those people from using the server capabilities.