### PR TITLE
Remove legacy artifact path handling

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -158,14 +158,7 @@ defmodule Tuist.CommandEvents do
     project = Repo.get!(Project, command_event.project_id)
     account = Repo.get!(Account, project.account_id)
 
-    identifier =
-      if command_event.legacy_artifact_path do
-        command_event.legacy_id
-      else
-        command_event.id
-      end
-
-    "#{account.name}/#{project.name}/runs/#{identifier}"
+    "#{account.name}/#{project.name}/runs/#{command_event.id}"
   end
 
   def list_flaky_test_cases(%Project{} = project, attrs) do

--- a/server/lib/tuist/command_events/clickhouse/event.ex
+++ b/server/lib/tuist/command_events/clickhouse/event.ex
@@ -24,7 +24,6 @@ defmodule Tuist.CommandEvents.Clickhouse.Event do
   @primary_key {:id, Ch, type: "UUID", autogenerate: false}
   schema "command_events" do
     field :legacy_id, Ch, type: "UInt64"
-    field :legacy_artifact_path, :boolean, default: false
     field :name, Ch, type: "String"
     field :subcommand, Ch, type: "Nullable(String)"
     field :command_arguments, Ch, type: "Nullable(String)"

--- a/server/lib/tuist/command_events/postgres/event.ex
+++ b/server/lib/tuist/command_events/postgres/event.ex
@@ -32,7 +32,6 @@ defmodule Tuist.CommandEvents.Postgres.Event do
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "command_events" do
     field :legacy_id, :integer
-    field :legacy_artifact_path, :boolean, default: false
     field :name, :string
     field :duration, :integer
     field :subcommand, :string
@@ -89,7 +88,6 @@ defmodule Tuist.CommandEvents.Postgres.Event do
   def create_changeset(event, attrs) do
     changeset =
       cast(event, attrs, [
-        :legacy_artifact_path,
         :project_id,
         :name,
         :subcommand,

--- a/server/priv/click_house_repo/migrations/20250721130110_drop_legacy_artifact_path_column.exs
+++ b/server/priv/click_house_repo/migrations/20250721130110_drop_legacy_artifact_path_column.exs
@@ -1,0 +1,15 @@
+defmodule Tuist.ClickHouseRepo.Migrations.DropLegacyArtifactPathColumn do
+  use Ecto.Migration
+
+  def up do
+    alter table(:command_events) do
+      remove :legacy_artifact_path
+    end
+  end
+
+  def down do
+    alter table(:command_events) do
+      add :legacy_artifact_path, :boolean, default: false
+    end
+  end
+end

--- a/server/priv/repo/migrations/20250721130110_drop_legacy_artifact_path_column.exs
+++ b/server/priv/repo/migrations/20250721130110_drop_legacy_artifact_path_column.exs
@@ -1,0 +1,15 @@
+defmodule Tuist.Repo.Migrations.DropLegacyArtifactPathColumn do
+  use Ecto.Migration
+
+  def up do
+    alter table(:command_events) do
+      remove :legacy_artifact_path
+    end
+  end
+
+  def down do
+    alter table(:command_events) do
+      add :legacy_artifact_path, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
Follow up to #7791 - it's been a long enough time now that we can drop artifact downloads for older events.