### PR TITLE
perf: improve Xcode tables and materialized view performance

### DIFF
--- a/server/lib/tuist/xcode/clickhouse.ex
+++ b/server/lib/tuist/xcode/clickhouse.ex
@@ -33,15 +33,9 @@ defmodule Tuist.Xcode.Clickhouse do
 
     Task.await_many(
       [
-        Task.async(fn ->
-          ClickHouseRepo.insert_all(XcodeGraph, xcode_graph_data)
-        end),
+        Task.async(fn -> ClickHouseRepo.insert_all(XcodeGraph, xcode_graph_data) end),
         Task.async(fn -> ClickHouseRepo.insert_all(XcodeProject, projects_data) end),
-        Task.async(fn ->
-          targets_data
-          |> Enum.chunk_every(1000)
-          |> Enum.each(&ClickHouseRepo.insert_all(XcodeTarget, &1))
-        end)
+        Task.async(fn -> ClickHouseRepo.insert_all(XcodeTarget, targets_data) end)
       ],
       30_000
     )
@@ -64,7 +58,9 @@ defmodule Tuist.Xcode.Clickhouse do
       )
 
     {targets, meta} =
-      Tuist.ClickHouseFlop.validate_and_run!(base_query, flop_params, for: XcodeTargetDenormalized)
+      Tuist.ClickHouseFlop.validate_and_run!(base_query, flop_params,
+        for: XcodeTargetDenormalized
+      )
 
     test_modules =
       Enum.map(targets, fn target ->
@@ -93,7 +89,9 @@ defmodule Tuist.Xcode.Clickhouse do
       )
 
     {targets, meta} =
-      Tuist.ClickHouseFlop.validate_and_run!(base_query, flop_params, for: XcodeTargetDenormalized)
+      Tuist.ClickHouseFlop.validate_and_run!(base_query, flop_params,
+        for: XcodeTargetDenormalized
+      )
 
     cacheable_targets =
       Enum.map(targets, fn target ->

--- a/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
+++ b/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
@@ -178,5 +178,33 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "DROP TABLE IF EXISTS xcode_graphs_new"
+
+    # Recreate the previous version of the materialized view
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW xcode_targets_denormalized
+    ENGINE = MergeTree()
+    ORDER BY (command_event_id, xcode_project_id, inserted_at)
+    AS
+    SELECT
+      xt.id as id,
+      xt.name as name,
+      xt.binary_cache_hash as binary_cache_hash,
+      xt.binary_cache_hit as binary_cache_hit,
+      xt.binary_build_duration as binary_build_duration,
+      xt.selective_testing_hash as selective_testing_hash,
+      xt.selective_testing_hit as selective_testing_hit,
+      xt.xcode_project_id as xcode_project_id,
+      xt.inserted_at as inserted_at,
+      xp.name as project_name,
+      xp.path as project_path,
+      xp.xcode_graph_id as xcode_graph_id,
+      xg.name as graph_name,
+      xg.command_event_id as command_event_id,
+      xg.binary_build_duration as graph_binary_build_duration
+    FROM xcode_targets xt
+    INNER JOIN xcode_projects xp ON xt.xcode_project_id = xp.id
+    INNER JOIN xcode_graphs xg ON xp.xcode_graph_id = xg.id
+    """
   end
 end

--- a/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
+++ b/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
@@ -136,8 +136,8 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
       xg.command_event_id as command_event_id,
       xg.binary_build_duration as graph_binary_build_duration
     FROM xcode_targets AS xt
-    INNER JOIN xcode_projects AS xp ON (xt.xcode_project_id = xp.id) AND (xt.inserted_at = xp.inserted_at)
-    INNER JOIN xcode_graphs AS xg ON (xp.xcode_graph_id = xg.id) AND (xp.inserted_at = xg.inserted_at)
+    INNER JOIN (SELECT * FROM xcode_projects WHERE inserted_at >= (now() - toIntervalMinute(10))) AS xp ON xt.xcode_project_id = xp.id
+    INNER JOIN (SELECT * FROM xcode_graphs WHERE inserted_at >= (now() - toIntervalMinute(10))) AS xg ON xp.xcode_graph_id = xg.id
     SETTINGS join_algorithm = 'partial_merge'
     """
   end

--- a/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
+++ b/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
@@ -2,18 +2,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
   use Ecto.Migration
 
   def up do
-    # Clean up any existing backup/temp tables first
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_graphs_bak"
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_projects_bak"
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_targets_bak"
-
-    # 1. Backup and recreate xcode_graphs table with new ORDER BY
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_graphs_new"
-
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     CREATE TABLE xcode_graphs_new (
@@ -23,6 +11,7 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
       binary_build_duration Nullable(UInt32),
       inserted_at DateTime
     ) ENGINE = MergeTree()
+    PARTITION BY toYYYYMMDD(inserted_at)
     ORDER BY (inserted_at, id)
     """
 
@@ -35,10 +24,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "RENAME TABLE xcode_graphs_new TO xcode_graphs"
 
-    # 2. Backup and recreate xcode_projects table with new ORDER BY
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_projects_new"
-
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     CREATE TABLE xcode_projects_new (
@@ -48,6 +33,7 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
       xcode_graph_id String,
       inserted_at DateTime
     ) ENGINE = MergeTree()
+    PARTITION BY toYYYYMMDD(inserted_at)
     ORDER BY (inserted_at, id)
     """
 
@@ -59,10 +45,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "RENAME TABLE xcode_projects_new TO xcode_projects"
-
-    # 3. Backup and recreate xcode_targets table with new ORDER BY
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_targets_new"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
@@ -77,6 +59,7 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
       xcode_project_id String,
       inserted_at DateTime
     ) ENGINE = MergeTree()
+    PARTITION BY toYYYYMMDD(inserted_at)
     ORDER BY (inserted_at, id)
     """
 
@@ -89,7 +72,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "RENAME TABLE xcode_targets_new TO xcode_targets"
 
-    # 4. Create projection for xcode_projects ordered by xcode_graph_id
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE xcode_projects
@@ -107,7 +89,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE xcode_projects MATERIALIZE PROJECTION proj_by_graph_id"
 
-    # 5. Create projection for xcode_targets ordered by xcode_project_id
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE xcode_targets
@@ -129,7 +110,6 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE xcode_targets MATERIALIZE PROJECTION proj_by_project_id"
 
-    # 6. Drop and recreate the denormalized view with prefiltering and join algorithm
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "DROP VIEW IF EXISTS xcode_targets_denormalized"
 
@@ -156,178 +136,47 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
       xg.command_event_id as command_event_id,
       xg.binary_build_duration as graph_binary_build_duration
     FROM xcode_targets AS xt
-    INNER JOIN xcode_projects AS xp ON xt.xcode_project_id = xp.id AND xt.inserted_at = xp.inserted_at
-    INNER JOIN xcode_graphs AS xg ON xp.xcode_graph_id = xg.id AND xp.inserted_at = xg.inserted_at
+    INNER JOIN xcode_projects AS xp ON (xt.xcode_project_id = xp.id) AND (xt.inserted_at = xp.inserted_at)
+    INNER JOIN xcode_graphs AS xg ON (xp.xcode_graph_id = xg.id) AND (xp.inserted_at = xg.inserted_at)
     SETTINGS join_algorithm = 'partial_merge'
-    """
-
-    # 7. Backfill the denormalized view with existing data
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    INSERT INTO xcode_targets_denormalized
-    SELECT
-      xt.id as id,
-      xt.name as name,
-      xt.binary_cache_hash as binary_cache_hash,
-      xt.binary_cache_hit as binary_cache_hit,
-      xt.binary_build_duration as binary_build_duration,
-      xt.selective_testing_hash as selective_testing_hash,
-      xt.selective_testing_hit as selective_testing_hit,
-      xt.xcode_project_id as xcode_project_id,
-      xt.inserted_at as inserted_at,
-      xp.name as project_name,
-      xp.path as project_path,
-      xp.xcode_graph_id as xcode_graph_id,
-      xg.name as graph_name,
-      xg.command_event_id as command_event_id,
-      xg.binary_build_duration as graph_binary_build_duration
-    FROM xcode_targets AS xt
-    INNER JOIN xcode_projects AS xp ON xt.xcode_project_id = xp.id AND xt.inserted_at = xp.inserted_at
-    INNER JOIN xcode_graphs AS xg ON xp.xcode_graph_id = xg.id AND xp.inserted_at = xg.inserted_at
     """
   end
 
   def down do
-    # Drop projections first
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE xcode_projects DROP PROJECTION IF EXISTS proj_by_graph_id"
+    execute "DROP VIEW IF EXISTS xcode_targets_denormalized"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE xcode_targets DROP PROJECTION IF EXISTS proj_by_project_id"
 
-    # Recreate original xcode_graphs table
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_graphs_original"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    CREATE TABLE xcode_graphs_original (
-      id String,
-      name String,
-      command_event_id UUID,
-      binary_build_duration Nullable(UInt32),
-      inserted_at DateTime DEFAULT now()
-    ) ENGINE = MergeTree()
-    ORDER BY (command_event_id, inserted_at)
-    """
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "INSERT INTO xcode_graphs_original SELECT * FROM xcode_graphs"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "RENAME TABLE xcode_graphs TO xcode_graphs_new"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "RENAME TABLE xcode_graphs_original TO xcode_graphs"
-
-    # Recreate original xcode_projects table
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_projects_original"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    CREATE TABLE xcode_projects_original (
-      id String,
-      name String,
-      path String,
-      xcode_graph_id String,
-      inserted_at DateTime DEFAULT now()
-    ) ENGINE = MergeTree()
-    ORDER BY (xcode_graph_id, name, inserted_at)
-    """
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "INSERT INTO xcode_projects_original SELECT * FROM xcode_projects"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "RENAME TABLE xcode_projects TO xcode_projects_new"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "RENAME TABLE xcode_projects_original TO xcode_projects"
-
-    # Recreate original xcode_targets table
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP TABLE IF EXISTS xcode_targets_original"
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    CREATE TABLE xcode_targets_original (
-      id String,
-      name String,
-      binary_cache_hash Nullable(String),
-      binary_cache_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
-      binary_build_duration Nullable(UInt32),
-      selective_testing_hash Nullable(String),
-      selective_testing_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
-      xcode_project_id String,
-      inserted_at DateTime DEFAULT now()
-    ) ENGINE = MergeTree()
-    ORDER BY (xcode_project_id, inserted_at)
-    """
-
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "INSERT INTO xcode_targets_original SELECT * FROM xcode_targets"
+    execute "ALTER TABLE xcode_projects DROP PROJECTION IF EXISTS proj_by_graph_id"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "RENAME TABLE xcode_targets TO xcode_targets_new"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "RENAME TABLE xcode_targets_original TO xcode_targets"
-
-    # Recreate original denormalized view
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "DROP VIEW IF EXISTS xcode_targets_denormalized"
+    execute "RENAME TABLE xcode_targets_bak TO xcode_targets"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    CREATE MATERIALIZED VIEW xcode_targets_denormalized
-    ENGINE = MergeTree()
-    ORDER BY (command_event_id, xcode_project_id, inserted_at)
-    AS
-    SELECT
-      xt.id as id,
-      xt.name as name,
-      xt.binary_cache_hash as binary_cache_hash,
-      xt.binary_cache_hit as binary_cache_hit,
-      xt.binary_build_duration as binary_build_duration,
-      xt.selective_testing_hash as selective_testing_hash,
-      xt.selective_testing_hit as selective_testing_hit,
-      xt.xcode_project_id as xcode_project_id,
-      xt.inserted_at as inserted_at,
-      xp.name as project_name,
-      xp.path as project_path,
-      xp.xcode_graph_id as xcode_graph_id,
-      xg.name as graph_name,
-      xg.command_event_id as command_event_id,
-      xg.binary_build_duration as graph_binary_build_duration
-    FROM xcode_targets xt
-    INNER JOIN xcode_projects xp ON xt.xcode_project_id = xp.id
-    INNER JOIN xcode_graphs xg ON xp.xcode_graph_id = xg.id
-    """
+    execute "DROP TABLE IF EXISTS xcode_targets_new"
 
-    # Backfill the original denormalized view
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute """
-    INSERT INTO xcode_targets_denormalized
-    SELECT
-      xt.id as id,
-      xt.name as name,
-      xt.binary_cache_hash as binary_cache_hash,
-      xt.binary_cache_hit as binary_cache_hit,
-      xt.binary_build_duration as binary_build_duration,
-      xt.selective_testing_hash as selective_testing_hash,
-      xt.selective_testing_hit as selective_testing_hit,
-      xt.xcode_project_id as xcode_project_id,
-      xt.inserted_at as inserted_at,
-      xp.name as project_name,
-      xp.path as project_path,
-      xp.xcode_graph_id as xcode_graph_id,
-      xg.name as graph_name,
-      xg.command_event_id as command_event_id,
-      xg.binary_build_duration as graph_binary_build_duration
-    FROM xcode_targets xt
-    INNER JOIN xcode_projects xp ON xt.xcode_project_id = xp.id
-    INNER JOIN xcode_graphs xg ON xp.xcode_graph_id = xg.id
-    """
+    execute "RENAME TABLE xcode_projects TO xcode_projects_new"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_projects_bak TO xcode_projects"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE IF EXISTS xcode_projects_new"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_graphs TO xcode_graphs_new"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_graphs_bak TO xcode_graphs"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE IF EXISTS xcode_graphs_new"
   end
 end

--- a/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
+++ b/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
@@ -2,23 +2,75 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
   use Ecto.Migration
 
   def up do
-    # 1. Update xcode_graphs table ORDER BY clause
+    # 1. Backup and recreate xcode_graphs table with new ORDER BY
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_graphs MODIFY ORDER BY (inserted_at, id)
+    CREATE TABLE xcode_graphs_new (
+      id String,
+      name String,
+      command_event_id UUID,
+      binary_build_duration Nullable(UInt32),
+      inserted_at DateTime
+    ) ENGINE = MergeTree()
+    ORDER BY (inserted_at, id)
     """
 
-    # 2. Update xcode_projects table ORDER BY clause
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_graphs_new SELECT id, name, command_event_id, binary_build_duration, inserted_at FROM xcode_graphs"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_graphs"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_graphs_new TO xcode_graphs"
+
+    # 2. Backup and recreate xcode_projects table with new ORDER BY
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_projects MODIFY ORDER BY (inserted_at, id)
+    CREATE TABLE xcode_projects_new (
+      id String,
+      name String,
+      path String,
+      xcode_graph_id String,
+      inserted_at DateTime
+    ) ENGINE = MergeTree()
+    ORDER BY (inserted_at, id)
     """
 
-    # 3. Update xcode_targets table ORDER BY clause
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_projects_new SELECT id, name, path, xcode_graph_id, inserted_at FROM xcode_projects"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_projects"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_projects_new TO xcode_projects"
+
+    # 3. Backup and recreate xcode_targets table with new ORDER BY
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_targets MODIFY ORDER BY (inserted_at, id)
+    CREATE TABLE xcode_targets_new (
+      id String,
+      name String,
+      binary_cache_hash Nullable(String),
+      binary_cache_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
+      binary_build_duration Nullable(UInt32),
+      selective_testing_hash Nullable(String),
+      selective_testing_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
+      xcode_project_id String,
+      inserted_at DateTime
+    ) ENGINE = MergeTree()
+    ORDER BY (inserted_at, id)
     """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_targets_new SELECT id, name, binary_cache_hash, binary_cache_hit, binary_build_duration, selective_testing_hash, selective_testing_hit, xcode_project_id, inserted_at FROM xcode_targets"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_targets"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_targets_new TO xcode_targets"
 
     # 4. Create projection for xcode_projects ordered by xcode_graph_id
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
@@ -101,31 +153,110 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     ) AS xg ON xp.xcode_graph_id = xg.id AND xp.inserted_at = xg.inserted_at
     SETTINGS join_algorithm = 'partial_merge'
     """
+
+    # 7. Backfill the denormalized view with existing data
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    INSERT INTO xcode_targets_denormalized
+    SELECT
+      xt.id as id,
+      xt.name as name,
+      xt.binary_cache_hash as binary_cache_hash,
+      xt.binary_cache_hit as binary_cache_hit,
+      xt.binary_build_duration as binary_build_duration,
+      xt.selective_testing_hash as selective_testing_hash,
+      xt.selective_testing_hit as selective_testing_hit,
+      xt.xcode_project_id as xcode_project_id,
+      xt.inserted_at as inserted_at,
+      xp.name as project_name,
+      xp.path as project_path,
+      xp.xcode_graph_id as xcode_graph_id,
+      xg.name as graph_name,
+      xg.command_event_id as command_event_id,
+      xg.binary_build_duration as graph_binary_build_duration
+    FROM default.xcode_targets AS xt
+    INNER JOIN default.xcode_projects AS xp ON xt.xcode_project_id = xp.id AND xt.inserted_at = xp.inserted_at
+    INNER JOIN default.xcode_graphs AS xg ON xp.xcode_graph_id = xg.id AND xp.inserted_at = xg.inserted_at
+    """
   end
 
   def down do
-    # Drop projections
+    # Drop projections first
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE xcode_projects DROP PROJECTION IF EXISTS proj_by_graph_id"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE xcode_targets DROP PROJECTION IF EXISTS proj_by_project_id"
 
-    # Revert ORDER BY clauses to original
+    # Recreate original xcode_graphs table
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_graphs MODIFY ORDER BY (command_event_id, inserted_at)
+    CREATE TABLE xcode_graphs_original (
+      id String,
+      name String,
+      command_event_id UInt64,
+      binary_build_duration Nullable(UInt32),
+      inserted_at DateTime DEFAULT now()
+    ) ENGINE = MergeTree()
+    ORDER BY (command_event_id, inserted_at)
     """
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_graphs_original SELECT * FROM xcode_graphs"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_graphs"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_graphs_original TO xcode_graphs"
+
+    # Recreate original xcode_projects table
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_projects MODIFY ORDER BY (xcode_graph_id, name, inserted_at)
+    CREATE TABLE xcode_projects_original (
+      id String,
+      name String,
+      path String,
+      xcode_graph_id String,
+      inserted_at DateTime DEFAULT now()
+    ) ENGINE = MergeTree()
+    ORDER BY (xcode_graph_id, name, inserted_at)
     """
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_projects_original SELECT * FROM xcode_projects"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_projects"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_projects_original TO xcode_projects"
+
+    # Recreate original xcode_targets table
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    ALTER TABLE xcode_targets MODIFY ORDER BY (xcode_project_id, inserted_at)
+    CREATE TABLE xcode_targets_original (
+      id String,
+      name String,
+      binary_cache_hash Nullable(String),
+      binary_cache_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
+      binary_build_duration Nullable(UInt32),
+      selective_testing_hash Nullable(String),
+      selective_testing_hit Enum8('miss' = 0, 'local' = 1, 'remote' = 2),
+      xcode_project_id String,
+      inserted_at DateTime DEFAULT now()
+    ) ENGINE = MergeTree()
+    ORDER BY (xcode_project_id, inserted_at)
     """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "INSERT INTO xcode_targets_original SELECT * FROM xcode_targets"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE xcode_targets"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "RENAME TABLE xcode_targets_original TO xcode_targets"
 
     # Recreate original denormalized view
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
@@ -137,6 +268,31 @@ defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjection
     ENGINE = MergeTree()
     ORDER BY (command_event_id, xcode_project_id, inserted_at)
     AS
+    SELECT
+      xt.id as id,
+      xt.name as name,
+      xt.binary_cache_hash as binary_cache_hash,
+      xt.binary_cache_hit as binary_cache_hit,
+      xt.binary_build_duration as binary_build_duration,
+      xt.selective_testing_hash as selective_testing_hash,
+      xt.selective_testing_hit as selective_testing_hit,
+      xt.xcode_project_id as xcode_project_id,
+      xt.inserted_at as inserted_at,
+      xp.name as project_name,
+      xp.path as project_path,
+      xp.xcode_graph_id as xcode_graph_id,
+      xg.name as graph_name,
+      xg.command_event_id as command_event_id,
+      xg.binary_build_duration as graph_binary_build_duration
+    FROM xcode_targets xt
+    INNER JOIN xcode_projects xp ON xt.xcode_project_id = xp.id
+    INNER JOIN xcode_graphs xg ON xp.xcode_graph_id = xg.id
+    """
+
+    # Backfill the original denormalized view
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    INSERT INTO xcode_targets_denormalized
     SELECT
       xt.id as id,
       xt.name as name,

--- a/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
+++ b/server/priv/click_house_repo/migrations/20250721104206_update_xcode_tables_ordering_and_projections.exs
@@ -1,0 +1,161 @@
+defmodule Tuist.ClickHouseRepo.Migrations.UpdateXcodeTablesOrderingAndProjections do
+  use Ecto.Migration
+
+  def up do
+    # 1. Update xcode_graphs table ORDER BY clause
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_graphs MODIFY ORDER BY (inserted_at, id)
+    """
+
+    # 2. Update xcode_projects table ORDER BY clause
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_projects MODIFY ORDER BY (inserted_at, id)
+    """
+
+    # 3. Update xcode_targets table ORDER BY clause
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_targets MODIFY ORDER BY (inserted_at, id)
+    """
+
+    # 4. Create projection for xcode_projects ordered by xcode_graph_id
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_projects
+    ADD PROJECTION proj_by_graph_id (
+      SELECT
+        id,
+        name,
+        path,
+        xcode_graph_id,
+        inserted_at
+      ORDER BY xcode_graph_id, inserted_at, id
+    )
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_projects MATERIALIZE PROJECTION proj_by_graph_id"
+
+    # 5. Create projection for xcode_targets ordered by xcode_project_id
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_targets
+    ADD PROJECTION proj_by_project_id (
+      SELECT
+        id,
+        name,
+        binary_cache_hash,
+        binary_cache_hit,
+        binary_build_duration,
+        selective_testing_hash,
+        selective_testing_hit,
+        xcode_project_id,
+        inserted_at
+      ORDER BY xcode_project_id, inserted_at, id
+    )
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_targets MATERIALIZE PROJECTION proj_by_project_id"
+
+    # 6. Drop and recreate the denormalized view with prefiltering and join algorithm
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS xcode_targets_denormalized"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW xcode_targets_denormalized
+    ENGINE = MergeTree()
+    ORDER BY (command_event_id, xcode_project_id, inserted_at)
+    AS
+    SELECT
+      xt.id as id,
+      xt.name as name,
+      xt.binary_cache_hash as binary_cache_hash,
+      xt.binary_cache_hit as binary_cache_hit,
+      xt.binary_build_duration as binary_build_duration,
+      xt.selective_testing_hash as selective_testing_hash,
+      xt.selective_testing_hit as selective_testing_hit,
+      xt.xcode_project_id as xcode_project_id,
+      xt.inserted_at as inserted_at,
+      xp.name as project_name,
+      xp.path as project_path,
+      xp.xcode_graph_id as xcode_graph_id,
+      xg.name as graph_name,
+      xg.command_event_id as command_event_id,
+      xg.binary_build_duration as graph_binary_build_duration
+    FROM default.xcode_targets AS xt
+    INNER JOIN
+    (
+        SELECT *
+        FROM default.xcode_projects
+        WHERE inserted_at >= (now() - toIntervalMinute(10))
+    ) AS xp ON xt.xcode_project_id = xp.id AND xt.inserted_at = xp.inserted_at
+    INNER JOIN
+    (
+        SELECT *
+        FROM default.xcode_graphs
+        WHERE inserted_at >= (now() - toIntervalMinute(10))
+    ) AS xg ON xp.xcode_graph_id = xg.id AND xp.inserted_at = xg.inserted_at
+    SETTINGS join_algorithm = 'partial_merge'
+    """
+  end
+
+  def down do
+    # Drop projections
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_projects DROP PROJECTION IF EXISTS proj_by_graph_id"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_targets DROP PROJECTION IF EXISTS proj_by_project_id"
+
+    # Revert ORDER BY clauses to original
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_graphs MODIFY ORDER BY (command_event_id, inserted_at)
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_projects MODIFY ORDER BY (xcode_graph_id, name, inserted_at)
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE xcode_targets MODIFY ORDER BY (xcode_project_id, inserted_at)
+    """
+
+    # Recreate original denormalized view
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS xcode_targets_denormalized"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW xcode_targets_denormalized
+    ENGINE = MergeTree()
+    ORDER BY (command_event_id, xcode_project_id, inserted_at)
+    AS
+    SELECT
+      xt.id as id,
+      xt.name as name,
+      xt.binary_cache_hash as binary_cache_hash,
+      xt.binary_cache_hit as binary_cache_hit,
+      xt.binary_build_duration as binary_build_duration,
+      xt.selective_testing_hash as selective_testing_hash,
+      xt.selective_testing_hit as selective_testing_hit,
+      xt.xcode_project_id as xcode_project_id,
+      xt.inserted_at as inserted_at,
+      xp.name as project_name,
+      xp.path as project_path,
+      xp.xcode_graph_id as xcode_graph_id,
+      xg.name as graph_name,
+      xg.command_event_id as command_event_id,
+      xg.binary_build_duration as graph_binary_build_duration
+    FROM xcode_targets xt
+    INNER JOIN xcode_projects xp ON xt.xcode_project_id = xp.id
+    INNER JOIN xcode_graphs xg ON xp.xcode_graph_id = xg.id
+    """
+  end
+end


### PR DESCRIPTION
Fixes the timeouts we've been seeing by adding partitioning, using `partial_merge` and updating a bunch of ordering keys.