### PR TITLE
Hide build time saved card from dashboard

### DIFF
--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -12,7 +12,11 @@ defmodule TuistWeb.OverviewLive do
   alias Tuist.Runs.Analytics
   alias TuistWeb.Utilities.Query
 
-  def mount(_params, _session, %{assigns: %{selected_project: project, selected_account: account}} = socket) do
+  def mount(
+        _params,
+        _session,
+        %{assigns: %{selected_project: project, selected_account: account}} = socket
+      ) do
     {:ok,
      socket
      |> assign(
@@ -265,10 +269,6 @@ defmodule TuistWeb.OverviewLive do
       ] = Task.await_many(analytics_tasks, 10_000)
 
       socket
-      |> assign(
-        :build_time_analytics,
-        Analytics.build_time_analytics(opts)
-      )
       |> assign(:binary_cache_hit_rate_analytics, binary_cache_hit_rate_analytics)
       |> assign(:selective_testing_analytics, selective_testing_analytics)
       |> assign(:build_analytics, build_analytics)

--- a/server/lib/tuist_web/live/overview_live.html.heex
+++ b/server/lib/tuist_web/live/overview_live.html.heex
@@ -230,10 +230,7 @@
         </div>
       </.card_section>
       <.card_section
-        :if={
-          @build_time_analytics.total_time_saved != 0 &&
-            @build_time_analytics.total_build_time != 0
-        }
+        :if={false}
         data-part="time-saved-card-chart-section"
       >
         <div data-part="legends">


### PR DESCRIPTION
## Summary
• Hide the build time saved card from the project overview dashboard by setting the display condition to false

## Test plan
- [ ] Verify the build time saved card no longer appears on the dashboard
- [ ] Confirm other dashboard cards still display correctly
- [ ] Test across different screen sizes to ensure layout remains intact