### PR TITLE
fix: run deeplink on continue user activity

### DIFF
--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -81,6 +81,9 @@ import TuistServer
                                 .onOpenURL { _ in
                                     activeTab = .previews
                                 }
+                                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { _ in
+                                    activeTab = .previews
+                                }
                                 .accentColor(Noora.Colors.accent)
                             } else {
                                 LogInView()

--- a/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
+++ b/app/Sources/TuistPreviews/PreviewsView/PreviewsView.swift
@@ -144,6 +144,10 @@ public struct PreviewsView: View {
             .onOpenURL { url in
                 handleOpenURL(url)
             }
+            .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
+                guard let url = userActivity.webpageURL else { return }
+                handleOpenURL(url)
+            }
         }
     }
 


### PR DESCRIPTION
The deeplinks are not activated when you open a preview by scanning a QR code. For that, we need to use the `onContinueUserActivity` method instead.