### PR TITLE
Don't clone submodules when building the server Docker image

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: false
       - name: Restore Mix Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -93,8 +94,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          context: ./server
+          file: ./server/Dockerfile
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -186,7 +186,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           submodules: false
       - name: Restore Mix Cache
         uses: actions/cache@v3

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -185,6 +185,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
       - name: Restore Mix Cache
         uses: actions/cache@v3
         id: mix-cache
@@ -205,8 +208,8 @@ jobs:
       - name: Docker build
         uses: docker/build-push-action@v6
         with:
-          context: "{{defaultContext}}:server"
-          file: Dockerfile
+          context: ./server
+          file: ./server/Dockerfile
           push: false
           tags: tuist/tuist
           cache-from: type=gha


### PR DESCRIPTION
The workflow that builds the Docker image [fails](https://github.com/tuist/tuist/actions/runs/16438579850/job/46453750944?pr=7896#step:7:246) because the remote build environment tries to clone the `TuistCacheEE` submodule. The changes in this PR disable the cloning of the submodule.