### PR TITLE
fix(cli): token refresh race condition

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "01878c6d75645566bcf9429735536546e5124d7c1326f03b287f42543e18e420",
+  "originHash" : "57ca9ad1a2fae3dcb958cd5001cc8069377467a183b14027e0df94b114f89a21",
   "pins" : [
     {
       "identity" : "aexml",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "1fa815a9fae52c8df462f80a7d19f2d72afb2a0c",
-        "version" : "0.10.15"
+        "revision" : "28c747b5ce661e8f79a4bcc3068392250d069f1c",
+        "version" : "0.11.0"
       }
     },
     {
@@ -402,8 +402,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
-        "version" : "2.84.0"
+        "revision" : "a5fea865badcb1c993c85b0f0e8d05a4bd2270fb",
+        "version" : "2.85.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let targets: [Target] = [
             "XcodeProj",
             pathDependency,
             argumentParserDependency,
+            .target(name: "TuistProcess", condition: .when(platforms: [.macOS])),
             "TuistCore",
             "TuistSupport",
             "TuistGenerator",
@@ -298,10 +299,21 @@ let targets: [Target] = [
         ]
     ),
     .target(
+        name: "TuistProcess",
+        dependencies: [
+            "Mockable"
+        ],
+        path: "cli/Sources/TuistLoader",
+        swiftSettings: [
+            .define("MOCKING", .when(configuration: .debug))
+        ]
+    ),
+    .target(
         name: "TuistAnalytics",
         dependencies: [
             .byName(name: "AnyCodable"),
             "TuistAsyncQueue",
+            "TuistServer",
             "TuistCore",
             "XcodeGraph",
             "TuistLoader",
@@ -342,6 +354,7 @@ let targets: [Target] = [
             "XcodeGraph",
             "Mockable",
             "KeychainAccess",
+            .target(name: "TuistProcess", condition: .when(platforms: [.macOS])),
             pathDependency,
             .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
             .product(name: "HTTPTypes", package: "swift-http-types"),

--- a/Package.swift
+++ b/Package.swift
@@ -303,7 +303,7 @@ let targets: [Target] = [
         dependencies: [
             "Mockable"
         ],
-        path: "cli/Sources/TuistLoader",
+        path: "cli/Sources/TuistProcess",
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug))
         ]
@@ -627,7 +627,8 @@ let package = Package(
         ),
         .package(url: "https://github.com/kean/Nuke", .upToNextMajor(from: "12.8.0")),
         .package(url: "https://github.com/leif-ibsen/SwiftECC", exact: "5.5.0"),
-        .package(url: "https://github.com/lfroms/fluid-menu-bar-extra", .upToNextMajor(from: "1.1.0")),
+        .package(
+            url: "https://github.com/lfroms/fluid-menu-bar-extra", .upToNextMajor(from: "1.1.0")),
     ],
     targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -578,7 +578,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
         .package(url: "https://github.com/tuist/XcodeGraph", .upToNextMajor(from: "1.17.0")),
-        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.8.0")),
+        .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.11.0")),
         .package(url: "https://github.com/tuist/Command.git", .upToNextMajor(from: "0.8.0")),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.4"),
         .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "1.1.4")),

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -464,6 +464,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.core.targetName),
                     .target(name: Module.loader.targetName),
                     .target(name: Module.support.targetName),
+                    .target(name: Module.server.targetName),
                     .external(name: "AnyCodable"),
                     .external(name: "XcodeGraph"),
                 ]

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -28,6 +28,7 @@ public enum Module: String, CaseIterable {
     case xcActivityLog = "TuistXCActivityLog"
     case git = "TuistGit"
     case rootDirectoryLocator = "TuistRootDirectoryLocator"
+    case process = "TuistProcess"
 
     public static func includeEE() -> Bool {
         return Environment.ee.getBoolean(default: false)
@@ -206,7 +207,7 @@ public enum Module: String, CaseIterable {
         switch self {
         case .analytics, .tuist, .tuistBenchmark, .tuistFixtureGenerator, .projectAutomation,
             .projectDescription,
-            .acceptanceTesting, .simulator, .testing:
+            .acceptanceTesting, .simulator, .testing, .process:
             return nil
         default:
             return "\(rawValue)Tests"
@@ -284,6 +285,8 @@ public enum Module: String, CaseIterable {
     public var dependencies: [TargetDependency] {
         var dependencies: [TargetDependency] =
             switch self {
+            case .process:
+                []
             case .testing:
                 [
                     .target(name: Module.projectDescription.targetName),
@@ -375,6 +378,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.cache.targetName),
                     .target(name: Module.simulator.targetName),
                     .target(name: Module.rootDirectoryLocator.targetName),
+                    .target(name: Module.process.targetName, condition: .when([.macos])),
                     .external(name: "MCP"),
                     .external(name: "FileSystem"),
                     .external(name: "SwiftToolsSupport"),
@@ -505,6 +509,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.xcActivityLog.targetName, condition: .when([.macos])),
                     .target(name: Module.simulator.targetName),
                     .target(name: Module.automation.targetName, condition: .when([.macos])),
+                    .target(name: Module.process.targetName, condition: .when([.macos])),
                     .external(name: "FileSystem"),
                     .external(name: "OpenAPIRuntime"),
                     .external(name: "OpenAPIURLSession"),
@@ -564,7 +569,7 @@ public enum Module: String, CaseIterable {
     public var unitTestDependencies: [TargetDependency] {
         var dependencies: [TargetDependency] =
             switch self {
-            case .tuist, .tuistBenchmark, .acceptanceTesting, .simulator, .testing:
+            case .tuist, .tuistBenchmark, .acceptanceTesting, .simulator, .testing, .process:
                 []
             case .tuistFixtureGenerator:
                 [
@@ -604,6 +609,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.asyncQueue.targetName),
                     .target(name: Module.plugin.targetName),
                     .target(name: Module.git.targetName),
+                    .target(name: Module.process.targetName, condition: .when([.macos])),
                     .external(name: "ArgumentParser"),
                     .external(name: "GraphViz"),
                     .external(name: "AnyCodable"),

--- a/app/Sources/TuistAuthentication/AuthenticationService.swift
+++ b/app/Sources/TuistAuthentication/AuthenticationService.swift
@@ -78,11 +78,8 @@ public final class AuthenticationService: ObservableObject {
     }
 
     private func updateAuthenticationState(with credentials: ServerCredentials?) throws {
-        if let credentials,
-           credentials.refreshToken != nil,
-           let accessToken = credentials.accessToken
-        {
-            let account = try extractAccount(from: accessToken)
+        if let credentials {
+            let account = try extractAccount(from: credentials.accessToken)
             authenticationState = .loggedIn(account: account)
         } else {
             authenticationState = .loggedOut
@@ -306,7 +303,6 @@ public final class AuthenticationService: ObservableObject {
 
         try await ServerCredentialsStore.current.store(
             credentials: ServerCredentials(
-                token: nil,
                 accessToken: accessToken,
                 refreshToken: refreshToken
             ),

--- a/cli/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
+++ b/cli/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
@@ -21,7 +21,7 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
         guard let commandEvent = event as? CommandEvent else { return }
         Task {
             // The queue dependency that we use uses Dispatch and Operations, which don't propagate the task local states.
-            // Since analytics dispatcher is somethign we run in the CLI, we can assume background refresh.
+            // Since analytics dispatcher is something we run only in the CLI, we can assume background refresh.
             try await ServerAuthenticationConfig.$current.withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
                 _ = try? await backend.send(commandEvent: commandEvent)
                 try await completion()

--- a/cli/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
+++ b/cli/Sources/TuistAnalytics/Utilities/TuistAnalyticsDispatcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TuistCore
+import TuistSupport
 
 /// `TuistAnalyticsTagger` is responsible to send analytics events that gets stored and reported to the Tuist server (if defined)
 public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
@@ -17,10 +18,16 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
 
     public func dispatch(event: AsyncQueueEvent, completion: @escaping () async throws -> Void) throws {
         guard let commandEvent = event as? CommandEvent else { return }
-
         Task {
-            _ = try? await backend.send(commandEvent: commandEvent)
-            try await completion()
+            // The queuing library that we use under the hood, [Queuer](https://github.com/FabrizioBrancati/Queuer),
+            // uses OperationQueue and Dispatch, which doesn't propagate task locals. Since this utility is only
+            // run in the context of the CLI, we can assume CLI and force the product here.
+            var environment = Environment.current
+            environment.product = .cli
+            try await Environment.$current.withValue(environment) {
+                _ = try? await backend.send(commandEvent: commandEvent)
+                try await completion()
+            }
         }
     }
 

--- a/cli/Sources/TuistKit/Commands/Auth/AuthCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/AuthCommand.swift
@@ -10,6 +10,7 @@ struct AuthCommand: ParsableCommand {
                 LoginCommand.self,
                 LogoutCommand.self,
                 WhoamiCommand.self,
+                RefreshTokenCommand.self
             ]
         )
     }

--- a/cli/Sources/TuistKit/Commands/Auth/AuthCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/AuthCommand.swift
@@ -10,7 +10,7 @@ struct AuthCommand: ParsableCommand {
                 LoginCommand.self,
                 LogoutCommand.self,
                 WhoamiCommand.self,
-                RefreshTokenCommand.self
+                RefreshTokenCommand.self,
             ]
         )
     }

--- a/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
@@ -18,15 +18,7 @@ struct RefreshTokenCommand: AsyncParsableCommand {
     )
     var serverURL: String
 
-    @Option(
-        name: .customLong("lockfile-path"),
-        help: "The path to a lockfile that's used to determine if there's a refresh happening.",
-        completion: .directory,
-        envKey: .authRefreshTokenLockfilePath
-    )
-    var lockFilePath: String
-
     func run() async throws {
-        try await AuthRefreshTokenService().run(serverURL: serverURL, lockFilePath: lockFilePath)
+        try await AuthRefreshTokenService().run(serverURL: serverURL)
     }
 }

--- a/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
@@ -11,8 +11,7 @@ struct RefreshTokenCommand: AsyncParsableCommand {
         )
     }
 
-    @Option(
-        name: .customLong("server-url"),
+    @Argument(
         help: "The URL of the server the token is being refreshed for.",
         envKey: .authRefreshTokenServerURL
     )

--- a/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
@@ -12,13 +12,14 @@ struct RefreshTokenCommand: AsyncParsableCommand {
     }
 
     @Option(
+        name: .customLong("server-url"),
         help: "The URL of the server the token is being refreshed for.",
         envKey: .authRefreshTokenServerURL
     )
     var serverURL: String
 
     @Option(
-        name: .shortAndLong,
+        name: .customLong("lockfile-path"),
         help: "The path to a lockfile that's used to determine if there's a refresh happening.",
         completion: .directory,
         envKey: .authRefreshTokenLockfilePath

--- a/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Auth/RefreshTokenCommand.swift
@@ -1,0 +1,31 @@
+import ArgumentParser
+import Foundation
+
+struct RefreshTokenCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "refresh-token",
+            _superCommandName: "auth",
+            abstract: "Refreshes the token for a particular URL",
+            shouldDisplay: false
+        )
+    }
+
+    @Option(
+        help: "The URL of the server the token is being refreshed for.",
+        envKey: .authRefreshTokenServerURL
+    )
+    var serverURL: String
+
+    @Option(
+        name: .shortAndLong,
+        help: "The path to a lockfile that's used to determine if there's a refresh happening.",
+        completion: .directory,
+        envKey: .authRefreshTokenLockfilePath
+    )
+    var lockFilePath: String
+
+    func run() async throws {
+        try await AuthRefreshTokenService().run(serverURL: serverURL, lockFilePath: lockFilePath)
+    }
+}

--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -286,7 +286,6 @@ public enum EnvKey: String, CaseIterable {
     // LOGOUT
 
     case authRefreshTokenServerURL = "TUIST_AUTH_REFRESH_TOKEN_SERVER_URL"
-    case authRefreshTokenLockfilePath = "TUIST_AUTH_REFRESH_TOKEN_LOCKFILE_PATH"
 
     // ANALYTICS
 

--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -282,6 +282,11 @@ public enum EnvKey: String, CaseIterable {
     // LOGOUT
 
     case logoutPath = "TUIST_LOGOUT_PATH"
+    
+    // LOGOUT
+
+    case authRefreshTokenServerURL = "TUIST_AUTH_REFRESH_TOKEN_SERVER_URL"
+    case authRefreshTokenLockfilePath = "TUIST_AUTH_REFRESH_TOKEN_LOCKFILE_PATH"
 
     // ANALYTICS
 

--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -282,7 +282,7 @@ public enum EnvKey: String, CaseIterable {
     // LOGOUT
 
     case logoutPath = "TUIST_LOGOUT_PATH"
-    
+
     // LOGOUT
 
     case authRefreshTokenServerURL = "TUIST_AUTH_REFRESH_TOKEN_SERVER_URL"

--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -283,7 +283,7 @@ public enum EnvKey: String, CaseIterable {
 
     case logoutPath = "TUIST_LOGOUT_PATH"
 
-    // LOGOUT
+    // AUTH REFRESH-TOKEN
 
     case authRefreshTokenServerURL = "TUIST_AUTH_REFRESH_TOKEN_SERVER_URL"
 

--- a/cli/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TuistCommand.swift
@@ -105,7 +105,7 @@ public struct TuistCommand: AsyncParsableCommand {
             let config = try await ConfigLoader().loadConfig(path: path)
             let url = try ServerEnvironmentService().url(configServerURL: config.url)
             let backend: TuistAnalyticsServerBackend?
-            if let fullHandle = config.fullHandle, processedArguments.prefix(2) != ["inspect", "build"] {
+            if let fullHandle = config.fullHandle, processedArguments.prefix(2) != ["inspect", "build"], processedArguments.prefix(2) != ["auth", "refresh-token"] {
                 let tuistAnalyticsServerBackend = TuistAnalyticsServerBackend(
                     fullHandle: fullHandle,
                     url: url

--- a/cli/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TuistCommand.swift
@@ -105,7 +105,12 @@ public struct TuistCommand: AsyncParsableCommand {
             let config = try await ConfigLoader().loadConfig(path: path)
             let url = try ServerEnvironmentService().url(configServerURL: config.url)
             let backend: TuistAnalyticsServerBackend?
-            if let fullHandle = config.fullHandle, processedArguments.prefix(2) != ["inspect", "build"], processedArguments.prefix(2) != ["auth", "refresh-token"] {
+            if let fullHandle = config.fullHandle, processedArguments.prefix(2) != ["inspect", "build"],
+               processedArguments.prefix(2) != [
+                   "auth",
+                   "refresh-token",
+               ]
+            {
                 let tuistAnalyticsServerBackend = TuistAnalyticsServerBackend(
                     fullHandle: fullHandle,
                     url: url

--- a/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
+++ b/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
@@ -37,6 +37,11 @@ struct AuthRefreshTokenService {
         guard let url = URL(string: serverURL) else {
             throw AuthRefreshTokenServiceError.invalidServerURL(serverURL)
         }
-        try await serverAuthenticationController.refreshToken(serverURL: url, inBackground: false, locking: false)
+        try await serverAuthenticationController.refreshToken(
+            serverURL: url,
+            inBackground: false,
+            locking: false,
+            forceInProcessLock: false
+        )
     }
 }

--- a/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
+++ b/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
@@ -38,7 +38,5 @@ struct AuthRefreshTokenService {
             throw AuthRefreshTokenServiceError.invalidServerURL(serverURL)
         }
         try await serverAuthenticationController.refreshToken(serverURL: url, inBackground: false, locking: false)
-        
-        try await fileSystem.writeText("token refreshed", at: "/Users/pepicrft/Downloads/progress.txt")
     }
 }

--- a/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
+++ b/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
@@ -1,0 +1,35 @@
+import Foundation
+import TuistServer
+import FileSystem
+import Path
+
+enum AuthRefreshTokenServiceError: Equatable, LocalizedError {
+    case invalidServerURL(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidServerURL(let url):
+            return "The server URL \(url) is not a valid URL."
+        }
+    }
+}
+
+struct AuthRefreshTokenService {
+    let serverAuthenticationController: ServerAuthenticationControlling
+    let fileSystem: FileSystem
+    
+    public init(serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(), fileSystem: FileSystem = FileSystem()) {
+        self.serverAuthenticationController = serverAuthenticationController
+        self.fileSystem = fileSystem
+    }
+    
+    func run(serverURL: String, lockFilePath: String) async throws {
+        guard let url = URL.init(string: serverURL) else {  throw AuthRefreshTokenServiceError.invalidServerURL(serverURL) }
+        try await serverAuthenticationController.refreshToken(serverURL: url)
+        let path = try AbsolutePath(validating: lockFilePath)
+        if try await fileSystem.exists(path) {
+            try await fileSystem.remove(path)
+        }
+    }
+    
+}

--- a/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
+++ b/cli/Sources/TuistKit/Services/Auth/AuthRefreshTokenService.swift
@@ -1,14 +1,14 @@
-import Foundation
-import TuistServer
 import FileSystem
+import Foundation
 import Path
+import TuistServer
 
 enum AuthRefreshTokenServiceError: Equatable, LocalizedError {
     case invalidServerURL(String)
-    
+
     var errorDescription: String? {
         switch self {
-        case .invalidServerURL(let url):
+        case let .invalidServerURL(url):
             return "The server URL \(url) is not a valid URL."
         }
     }
@@ -17,19 +17,21 @@ enum AuthRefreshTokenServiceError: Equatable, LocalizedError {
 struct AuthRefreshTokenService {
     let serverAuthenticationController: ServerAuthenticationControlling
     let fileSystem: FileSystem
-    
-    public init(serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(), fileSystem: FileSystem = FileSystem()) {
+
+    init(
+        serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
+        fileSystem: FileSystem = FileSystem()
+    ) {
         self.serverAuthenticationController = serverAuthenticationController
         self.fileSystem = fileSystem
     }
-    
+
     func run(serverURL: String, lockFilePath: String) async throws {
-        guard let url = URL.init(string: serverURL) else {  throw AuthRefreshTokenServiceError.invalidServerURL(serverURL) }
-        try await serverAuthenticationController.refreshToken(serverURL: url)
+        guard let url = URL(string: serverURL) else { throw AuthRefreshTokenServiceError.invalidServerURL(serverURL) }
+        try await serverAuthenticationController.refreshToken(serverURL: url, inSubprocess: false)
         let path = try AbsolutePath(validating: lockFilePath)
         if try await fileSystem.exists(path) {
             try await fileSystem.remove(path)
         }
     }
-    
 }

--- a/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -5,6 +5,7 @@ import TuistAutomation
 import TuistCore
 import TuistGit
 import TuistLoader
+import TuistProcess
 import TuistServer
 import TuistSupport
 import TuistXCActivityLog

--- a/cli/Sources/TuistKit/Services/LoginService.swift
+++ b/cli/Sources/TuistKit/Services/LoginService.swift
@@ -101,7 +101,6 @@ final class LoginService: LoginServicing {
 
         try await ServerCredentialsStore.current.store(
             credentials: ServerCredentials(
-                token: nil,
                 accessToken: authenticationTokens.accessToken,
                 refreshToken: authenticationTokens.refreshToken
             ),

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -25,14 +25,16 @@ public func initDependencies(_ action: (Path.AbsolutePath) async throws -> Void)
 
     let (logger, logFilePath) = try await initLogger()
 
-    try await Noora.$current.withValue(initNoora()) {
-        try await Logger.$current.withValue(logger) {
-            try await ServerCredentialsStore.$current.withValue(ServerCredentialsStore(backend: .fileSystem)) {
-                try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
-                    try await RecentPathsStore.$current
-                        .withValue(RecentPathsStore(storageDirectory: Environment.current.stateDirectory)) {
-                            try await action(logFilePath)
-                        }
+    try await Environment.$current.withValue(Environment(product: .cli)) {
+        try await Noora.$current.withValue(initNoora()) {
+            try await Logger.$current.withValue(logger) {
+                try await ServerCredentialsStore.$current.withValue(ServerCredentialsStore(backend: .fileSystem)) {
+                    try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
+                        try await RecentPathsStore.$current
+                            .withValue(RecentPathsStore(storageDirectory: Environment.current.stateDirectory)) {
+                                try await action(logFilePath)
+                            }
+                    }
                 }
             }
         }

--- a/cli/Sources/TuistKit/Utils/Dependencies.swift
+++ b/cli/Sources/TuistKit/Utils/Dependencies.swift
@@ -25,7 +25,7 @@ public func initDependencies(_ action: (Path.AbsolutePath) async throws -> Void)
 
     let (logger, logFilePath) = try await initLogger()
 
-    try await Environment.$current.withValue(Environment(product: .cli)) {
+    try await ServerAuthenticationConfig.$current.withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
         try await Noora.$current.withValue(initNoora()) {
             try await Logger.$current.withValue(logger) {
                 try await ServerCredentialsStore.$current.withValue(ServerCredentialsStore(backend: .fileSystem)) {

--- a/cli/Sources/TuistProcess/BackgroundProcessRunner.swift
+++ b/cli/Sources/TuistProcess/BackgroundProcessRunner.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Mockable
 
@@ -16,7 +17,7 @@ public struct BackgroundProcessRunner: BackgroundProcessRunning {
         _ arguments: [String],
         environment: [String: String]
     ) throws {
-        let process = Process()
+        let process = Foundation.Process()
         process.environment = environment
         process.launchPath = arguments.first
         process.arguments = Array(arguments.dropFirst())

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
@@ -1,0 +1,8 @@
+public struct ServerAuthenticationConfig {
+    @TaskLocal public static var current: ServerAuthenticationConfig = .init(backgroundRefresh: false)
+    public let backgroundRefresh: Bool
+
+    public init(backgroundRefresh: Bool = false) {
+        self.backgroundRefresh = backgroundRefresh
+    }
+}

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -11,7 +11,8 @@ import Path
 public enum ServerAuthenticationControllerError: LocalizedError, Equatable {
     case failToLaunchRefreshProcess(command: String, arguments: [String], serverURL: URL)
     case timedOut(seconds: Int, serverURL: URL)
-
+    case cantRefreshWithLockingAndBackground
+    
     public var errorDescription: String? {
         switch self {
         case let .failToLaunchRefreshProcess(command, arguments, serverURL):
@@ -19,6 +20,8 @@ public enum ServerAuthenticationControllerError: LocalizedError, Equatable {
             return "The refreshing of the access and refresh token pair for the URL \(serverURL.absoluteString) failed running the following command: \(command)"
         case let .timedOut(seconds, serverURL):
             return "The refreshing of the access and refresh token pair for the URL \(serverURL.absoluteString) failed after \(seconds) seconds."
+        case .cantRefreshWithLockingAndBackground:
+            return "The refreshing with background and locking configurations enabled is not a valid configuration (liley a bug)."
         }
     }
 }
@@ -28,8 +31,7 @@ public protocol ServerAuthenticationControlling: Sendable {
     func authenticationToken(serverURL: URL) async throws
         -> AuthenticationToken?
     func refreshToken(serverURL: URL) async throws
-    func refreshToken(serverURL: URL, inSubprocess: Bool) async throws
-    func lockFilePath(serverURL: URL) -> AbsolutePath
+    func refreshToken(serverURL: URL, inBackground: Bool, locking: Bool) async throws
 }
 
 public enum AuthenticationTokenStatus {
@@ -42,7 +44,7 @@ public enum AuthenticationToken: CustomStringConvertible, Equatable {
     /// The token represents a user session. User sessions are typically used in
     /// local environments where the user can be guided through an interactive
     /// authentication workflow
-    case user(legacyToken: String?, accessToken: JWT?, refreshToken: JWT?)
+    case user(accessToken: JWT, refreshToken: JWT)
 
     /// The token represents a project session. Project sessions are typically used
     /// in CI environments where limited scopes are desired for security reasons.
@@ -51,12 +53,8 @@ public enum AuthenticationToken: CustomStringConvertible, Equatable {
     /// It returns the value of the token
     public var value: String {
         switch self {
-        case let .user(legacyToken: legacyToken, accessToken: accessToken, refreshToken: _):
-            if let accessToken {
-                return accessToken.token
-            } else {
-                return legacyToken!
-            }
+        case let .user(accessToken: accessToken, refreshToken: _):
+            return accessToken.token
         case let .project(token):
             return token
         }
@@ -75,7 +73,21 @@ public enum AuthenticationToken: CustomStringConvertible, Equatable {
 public struct ServerAuthenticationController: ServerAuthenticationControlling {
     private let refreshAuthTokenService: RefreshAuthTokenServicing
     private let fileSystem: FileSysteming
-
+    #if canImport(TuistSupport)
+    private let backgroundProcessRunner: BackgroundProcessRunning
+    #endif
+    
+    #if canImport(TuistSupport)
+    public init(
+        refreshAuthTokenService: RefreshAuthTokenServicing = RefreshAuthTokenService(),
+        fileSystem: FileSysteming = FileSystem(),
+        backgroundProcessRunner: BackgroundProcessRunning = BackgroundProcessRunner()
+    ) {
+        self.refreshAuthTokenService = refreshAuthTokenService
+        self.fileSystem = fileSystem
+        self.backgroundProcessRunner = backgroundProcessRunner
+    }
+    #else
     public init(
         refreshAuthTokenService: RefreshAuthTokenServicing = RefreshAuthTokenService(),
         fileSystem: FileSysteming = FileSystem()
@@ -83,32 +95,51 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         self.refreshAuthTokenService = refreshAuthTokenService
         self.fileSystem = fileSystem
     }
-
+    #endif
+    
+    func defaultInBackground() -> Bool {
+#if canImport(TuistSupport)
+        let environment = Environment.current
+        switch environment.product {
+        case .app:
+            return false
+        case .cli:
+            return true
+        case .none:
+            return false
+        }
+#else
+        return false
+#endif
+    }
+    
     @discardableResult public func authenticationToken(serverURL: URL)
-        async throws -> AuthenticationToken?
+    async throws -> AuthenticationToken?
     {
-        #if canImport(TuistSupport)
-            if Environment.current.isCI {
-                return try await ciAuthenticationToken()
-            } else {
-                return try await authenticationTokenRefreshingIfNeeded(
-                    serverURL: serverURL,
-                    forceRefresh: false,
-                    inSubprocess: true
-                )
-            }
-        #else
+#if canImport(TuistSupport)
+        if Environment.current.isCI {
+            return try await ciAuthenticationToken()
+        } else {
             return try await authenticationTokenRefreshingIfNeeded(
-                serverURL: serverURL, forceRefresh: false
+                serverURL: serverURL,
+                forceRefresh: false,
+                inBackground: defaultInBackground(),
+                locking: true
             )
-        #endif
+        }
+#else
+        return try await authenticationTokenRefreshingIfNeeded(
+            serverURL: serverURL, forceRefresh: false, inBackground: defaultInBackground(), locking: false
+        )
+#endif
     }
 
-    public func refreshToken(serverURL: URL, inSubprocess: Bool) async throws {
+    public func refreshToken(serverURL: URL, inBackground: Bool, locking: Bool) async throws {
         try await authenticationTokenRefreshingIfNeeded(
             serverURL: serverURL,
             forceRefresh: true,
-            inSubprocess: inSubprocess
+            inBackground: inBackground,
+            locking: locking
         )
     }
 
@@ -116,14 +147,16 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         try await authenticationTokenRefreshingIfNeeded(
             serverURL: serverURL,
             forceRefresh: true,
-            inSubprocess: true
+            inBackground: defaultInBackground(),
+            locking: true
         )
     }
 
     @discardableResult private func authenticationTokenRefreshingIfNeeded(
         serverURL: URL,
         forceRefresh: Bool,
-        inSubprocess: Bool,
+        inBackground: Bool,
+        locking: Bool,
         attemptCount: Int = 0
     ) async throws
         -> AuthenticationToken?
@@ -131,65 +164,93 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         #if canImport(TuistSupport)
             Logger.current.debug("Refreshing authentication token for \(serverURL) if needed")
         #endif
+        
+        let fetchActionResult = { () async throws -> AuthenticationToken? in
+            switch try await self.tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh) {
+            case .valid(let token): return token
+            case .expired, .absent: return nil
+            }
+        }
 
-        let maxAttempts = 10
-
-        switch (try await tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh), inSubprocess) {
-        case let (.valid(token), _):
+        switch (try await tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh), inBackground, locking) {
+        case let (.valid(token), _, _):
             return token
-        case (.absent, _), (_, false):
+        case (.absent, _, _):
+            throw ServerClientAuthenticationError.notAuthenticated
+        case (.expired, false, true): // Foreground with locking
+            return try await locked(serverURL: serverURL, action: { deleteLockfile in
+                _ = try await executeRefresh(serverURL: serverURL, forceRefresh: forceRefresh)
+                try await deleteLockfile()
+            }, fetchActionResult: fetchActionResult)
+        case (.expired, false, false): // Foreground without locking
             return try await executeRefresh(serverURL: serverURL, forceRefresh: forceRefresh)?.value
-        case (.expired, true):
-            let lockfilePath = lockFilePath(serverURL: serverURL)
-
-            if !(try await fileSystem.exists(lockfilePath)) {
-                try await fileSystem.touch(lockfilePath)
-
-                let process = Foundation.Process()
-                do {
-                    process.environment = ProcessInfo.processInfo.environment
-                    process.launchPath = Environment.current.currentExecutablePath()?.pathString ?? ""
-                    process.arguments = [
-                        "auth",
-                        "refresh-token",
-                        "--server-url",
-                        serverURL.absoluteString,
-                    ]
-                    process.unbind(.isIndeterminate)
-                    try process.run()
-                } catch {
-                    try? await fileSystem.remove(lockfilePath)
-                    throw ServerAuthenticationControllerError.failToLaunchRefreshProcess(
-                        command: process.launchPath ?? "",
-                        arguments: process.arguments ?? [],
-                        serverURL: serverURL
-                    )
-                }
-            }
-
-            let retryInterval: UInt64 = 500 // Miliseconds
-
-            if attemptCount >= maxAttempts {
-                if try await fileSystem.exists(lockfilePath) {
-                    try? await fileSystem.remove(lockfilePath)
-                }
-
-                throw ServerAuthenticationControllerError.timedOut(
-                    seconds: maxAttempts * Int(retryInterval) / 1000,
-                    serverURL: serverURL
-                )
-            }
-
-            try await Task.sleep(nanoseconds: retryInterval * 1_000_000)
-
-            return try await authenticationTokenRefreshingIfNeeded(
-                serverURL: serverURL,
-                forceRefresh: forceRefresh,
-                inSubprocess: inSubprocess,
-                attemptCount: attemptCount + 1
-            )
+        case (.expired, true, true): // Background with locking
+            #if canImport(TuistSupport)
+            return try await locked(serverURL: serverURL, action: { _deleteLockfile in
+                try await spawnRefreshProcess(serverURL: serverURL)
+            }, fetchActionResult: fetchActionResult)
+            #else
+            return nil
+            #endif
+        case (.expired, true, false): // Background without locking
+            throw ServerAuthenticationControllerError.cantRefreshWithLockingAndBackground
         }
     }
+    
+    func locked<T>(serverURL: URL, attemptCount: Int = 0, action: (_ complete: () async throws -> Void) async throws -> Void,  fetchActionResult: () async throws -> T?) async throws -> T {
+//        fileSystemLocked(serverURL: serverURL, action: action, fetchActionResult: <#T##() async throws -> T?#>)
+#if canImport(TuistSupport)
+        
+        #else
+        
+        #endif
+    }
+    
+    #if canImport(TuistSupport)
+    func spawnRefreshProcess(serverURL: URL) async throws {
+        try backgroundProcessRunner.runInBackground([Environment.current.currentExecutablePath()?.pathString ?? ""] + [
+            "auth",
+            "refresh-token",
+            serverURL.absoluteString,
+        ], environment: ProcessInfo.processInfo.environment)
+    }
+    
+    func fileSystemLocked<T>(serverURL: URL, attemptCount: Int = 0, action: (_ complete: () async throws -> Void) async throws -> Void,  fetchActionResult: () async throws -> T?) async throws -> T {
+        let lockfilePath = lockFilePath(serverURL: serverURL)
+        let maxAttempts = 10
+        let retryInterval: UInt64 = 500 // Miliseconds
+        if let result = try await fetchActionResult() { return result }
+        
+        if attemptCount >= maxAttempts {
+            throw ServerAuthenticationControllerError.timedOut(
+                seconds: maxAttempts * Int(retryInterval) / 1000,
+                serverURL: serverURL
+            )
+        }
+        
+        let lockFileExists = try await fileSystem.exists(lockfilePath)
+        if !lockFileExists {
+            if !(try await fileSystem.exists(lockfilePath.parentDirectory)) { try await fileSystem.makeDirectory(at: lockfilePath.parentDirectory) }
+            try await fileSystem.touch(lockfilePath)
+            
+            try await action {
+                // When the action runs in the foreground, the action can use this closure
+                // to notify that the action has been completed and therefore the lockfile
+                // can be deleted.
+                // In the background, the lockfile is deleted by the background task.
+                try await fileSystem.remove(lockfilePath)
+            }
+        }
+        
+        // In the case of actions running in the foreground, the result
+        // will be available right after the action completion
+        if let result = try await fetchActionResult() { return result }
+       
+        try await Task.sleep(nanoseconds: retryInterval * 1_000_000)
+        
+        return try await locked(serverURL: serverURL, attemptCount: attemptCount + 1, action: action, fetchActionResult: fetchActionResult)
+    }
+#endif
 
     func tokenStatus(serverURL: URL, forceRefresh: Bool) async throws -> AuthenticationTokenStatus {
         guard let token = try await fetchTokenFromStore(serverURL: serverURL) else {
@@ -200,24 +261,18 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         case .project:
             return .valid(token)
         case let .user(
-            legacyToken: legacyToken, accessToken: accessToken, refreshToken: refreshToken
+            accessToken: accessToken, refreshToken: refreshToken
         ):
-            if legacyToken != nil {
-                return .valid(token)
-            } else if let accessToken {
-                // We consider a token to be expired if the expiration date is in the past or 30 seconds from now
-                let now = Date.now()
-                let expiresIn = accessToken.expiryDate
-                    .timeIntervalSince(now)
-                let refresh = expiresIn < 30 || forceRefresh
-                if refresh { return .expired }
-                return .valid(.user(
-                    legacyToken: nil, accessToken: accessToken,
-                    refreshToken: refreshToken
-                ))
-            } else {
-                return .absent
-            }
+            // We consider a token to be expired if the expiration date is in the past or 30 seconds from now
+            let now = Date.now()
+            let expiresIn = accessToken.expiryDate
+                .timeIntervalSince(now)
+            let refresh = expiresIn < 30 || forceRefresh
+            if refresh { return .expired }
+            return .valid(.user(
+                accessToken: accessToken,
+                refreshToken: refreshToken
+            ))
         }
     }
 
@@ -233,63 +288,53 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         case .project:
             upToDateToken = token
         case let .user(
-            legacyToken: legacyToken, accessToken: accessToken, refreshToken: refreshToken
+            accessToken: accessToken, refreshToken: refreshToken
         ):
-            if legacyToken != nil {
-                upToDateToken = token
-            } else if let accessToken {
-                // We consider a token to be expired if the expiration date is in the past or 30 seconds from now
-                let now = Date.now()
-                let expiresIn = accessToken.expiryDate
-                    .timeIntervalSince(now)
-                let refresh = expiresIn < 30 || forceRefresh
+            // We consider a token to be expired if the expiration date is in the past or 30 seconds from now
+            let now = Date.now()
+            let expiresIn = accessToken.expiryDate
+                .timeIntervalSince(now)
+            let refresh = expiresIn < 30 || forceRefresh
 
-                #if canImport(TuistSupport)
-                    if refresh {
-                        Logger.current.debug(
-                            "Access token expires in less than \(expiresIn) seconds. Renewing..."
-                        )
-                    } else {
-                        Logger.current.debug(
-                            "Access token expires in \(expiresIn) seconds and it is still valid"
-                        )
-                    }
-                #endif
+            #if canImport(TuistSupport)
                 if refresh {
-                    guard let refreshToken else {
-                        throw ServerClientAuthenticationError.notAuthenticated
-                    }
-                    #if canImport(TuistSupport)
-                        Logger.current.debug("Refreshing access token for \(serverURL)")
-                    #endif
-                    let tokens = try await refreshTokens(
-                        serverURL: serverURL, refreshToken: refreshToken
+                    Logger.current.debug(
+                        "Access token expires in less than \(expiresIn) seconds. Renewing..."
                     )
-                    #if canImport(TuistSupport)
-                        Logger.current.debug("Access token refreshed for \(serverURL)")
-                    #endif
-                    upToDateToken = .user(
-                        legacyToken: nil,
-                        accessToken: try JWT.parse(tokens.accessToken),
-                        refreshToken: try JWT.parse(tokens.refreshToken)
-                    )
-                    expiresAt = try JWT.parse(tokens.accessToken)
-                        .expiryDate
                 } else {
-                    upToDateToken = .user(
-                        legacyToken: nil, accessToken: accessToken,
-                        refreshToken: refreshToken
+                    Logger.current.debug(
+                        "Access token expires in \(expiresIn) seconds and it is still valid"
                     )
-                    expiresAt = accessToken.expiryDate
                 }
+            #endif
+            if refresh {
+                #if canImport(TuistSupport)
+                    Logger.current.debug("Refreshing access token for \(serverURL)")
+                #endif
+                let tokens = try await refreshTokens(
+                    serverURL: serverURL, refreshToken: refreshToken
+                )
+                #if canImport(TuistSupport)
+                    Logger.current.debug("Access token refreshed for \(serverURL)")
+                #endif
+                upToDateToken = .user(
+                    accessToken: try JWT.parse(tokens.accessToken),
+                    refreshToken: try JWT.parse(tokens.refreshToken)
+                )
+                expiresAt = try JWT.parse(tokens.accessToken)
+                    .expiryDate
             } else {
-                try await ServerCredentialsStore.current.delete(serverURL: serverURL)
-                throw ServerClientAuthenticationError.notAuthenticated
+                upToDateToken = .user(
+                    accessToken: accessToken,
+                    refreshToken: refreshToken
+                )
+                expiresAt = accessToken.expiryDate
             }
         }
         return (value: upToDateToken, expiresAt: expiresAt)
     }
 
+    #if canImport(TuistSupport)
     public func lockFilePath(serverURL: URL) -> AbsolutePath {
         let key = "token_\(serverURL.absoluteString)"
         // Use a sanitized version of the key for the filename
@@ -298,34 +343,20 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             .replacingOccurrences(of: " ", with: "_")
 
         return Environment.current.stateDirectory
-            .appending(component: "cached_value_store")
+            .appending(component: "auth-locks")
             .appending(component: "\(sanitizedKey).lock")
     }
+    #endif
 
     private func fetchTokenFromStore(serverURL: URL) async throws -> AuthenticationToken? {
         let credentials: ServerCredentials? = try await ServerCredentialsStore.current.read(
             serverURL: serverURL
         )
         return try credentials.map {
-            if let refreshToken = $0.refreshToken {
-                return .user(
-                    legacyToken: nil,
-                    accessToken: try $0.accessToken.map(JWT.parse),
-                    refreshToken: try JWT.parse(refreshToken)
-                )
-            } else {
-                #if canImport(TuistSupport)
-                    Logger.current
-                        .warning(
-                            "You are using a deprecated user token. Please, reauthenticate by running 'tuist auth login'."
-                        )
-                #endif
-                return .user(
-                    legacyToken: $0.token,
-                    accessToken: nil,
-                    refreshToken: nil
-                )
-            }
+            return .user(
+                accessToken: try JWT.parse($0.accessToken),
+                refreshToken: try JWT.parse($0.refreshToken)
+            )
         }
     }
 
@@ -373,7 +404,6 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             try await ServerCredentialsStore.current
                 .store(
                     credentials: ServerCredentials(
-                        token: nil,
                         accessToken: newTokens.accessToken,
                         refreshToken: newTokens.refreshToken
                     ),

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -3,6 +3,9 @@ import Foundation
 import Mockable
 import OpenAPIRuntime
 import Path
+#if canImport(TuistProcess)
+    import TuistProcess
+#endif
 
 #if canImport(TuistSupport)
     import TuistSupport
@@ -260,9 +263,11 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         #endif
 
         let fetchActionResult = { () async throws -> AuthenticationToken? in
-            switch try await tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh) {
-            case let .valid(token): return token
-            case .expired, .absent: return nil
+            switch try await tokenStatus(serverURL: serverURL, forceRefresh: false) {
+            case let .valid(token):
+                return token
+            case .expired, .absent:
+                return nil
             }
         }
 
@@ -464,7 +469,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
     }
 
     #if canImport(TuistSupport)
-        public func lockFilePath(serverURL: URL) -> AbsolutePath {
+        private func lockFilePath(serverURL: URL) -> AbsolutePath {
             let key = lockKey(serverURL: serverURL)
             // Use a sanitized version of the key for the filename
             let sanitizedKey = key.replacingOccurrences(of: "/", with: "_")

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -40,7 +40,7 @@ public enum AuthenticationTokenStatus {
     case absent
 }
 
-public enum AuthenticationToken: Equatable {
+public enum AuthenticationToken: Equatable, CustomStringConvertible {
     /// The token represents a user session. User sessions are typically used in
     /// local environments where the user can be guided through an interactive
     /// authentication workflow

--- a/cli/Sources/TuistServer/Client/ServerSessionController.swift
+++ b/cli/Sources/TuistServer/Client/ServerSessionController.swift
@@ -125,7 +125,6 @@ public final class ServerSessionController: ServerSessionControlling {
                 deviceCode: deviceCode
             )
             let credentials = ServerCredentials(
-                token: nil,
                 accessToken: tokens.accessToken,
                 refreshToken: tokens.refreshToken
             )
@@ -146,8 +145,8 @@ public final class ServerSessionController: ServerSessionControlling {
         )
         else { return nil }
         switch token {
-        case let .user(legacyToken: _, accessToken: accessToken, refreshToken: _):
-            return accessToken?.preferredUsername
+        case let .user(accessToken: accessToken, refreshToken: _):
+            return accessToken.preferredUsername
         case .project:
             return nil
         }
@@ -161,8 +160,8 @@ public final class ServerSessionController: ServerSessionControlling {
             throw ServerSessionControllerError.unauthenticated
         }
         switch token {
-        case let .user(legacyToken: _, accessToken: accessToken, refreshToken: _):
-            guard let username = accessToken?.preferredUsername else {
+        case let .user(accessToken: accessToken, refreshToken: _):
+            guard let username = accessToken.preferredUsername else {
                 throw ServerSessionControllerError.unauthenticated
             }
             return username

--- a/cli/Sources/TuistSupport/BackgroundProcessRunner.swift
+++ b/cli/Sources/TuistSupport/BackgroundProcessRunner.swift
@@ -2,15 +2,17 @@ import Foundation
 import Mockable
 
 @Mockable
-protocol BackgroundProcessRunning {
+public protocol BackgroundProcessRunning {
     func runInBackground(
         _ arguments: [String],
         environment: [String: String]
     ) throws
 }
 
-struct BackgroundProcessRunner: BackgroundProcessRunning {
-    func runInBackground(
+public struct BackgroundProcessRunner: BackgroundProcessRunning {
+    public init() {}
+    
+    public func runInBackground(
         _ arguments: [String],
         environment: [String: String]
     ) throws {

--- a/cli/Sources/TuistSupport/BackgroundProcessRunner.swift
+++ b/cli/Sources/TuistSupport/BackgroundProcessRunner.swift
@@ -11,7 +11,7 @@ public protocol BackgroundProcessRunning {
 
 public struct BackgroundProcessRunner: BackgroundProcessRunning {
     public init() {}
-    
+
     public func runInBackground(
         _ arguments: [String],
         environment: [String: String]

--- a/cli/Sources/TuistSupport/Utils/Environment.swift
+++ b/cli/Sources/TuistSupport/Utils/Environment.swift
@@ -7,19 +7,10 @@ import NIOCore
 import NIOFileSystem
 import Path
 
-/// An enum that represents the the product type the runtime logic
-/// is embedded into. This can be useful at runtime to base control
-/// flows on the product (e.g. a CLI can do things that an app can't).
-public enum EnvironmentProduct: Sendable {
-    case app
-    case cli
-}
-
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.
 @Mockable
 public protocol Environmenting: Sendable {
-    
     /// Returns the home directory.
     var homeDirectory: AbsolutePath { get }
 
@@ -77,15 +68,11 @@ public protocol Environmenting: Sendable {
 
     /// Returns path to the Tuist executable
     func currentExecutablePath() -> AbsolutePath?
-        
-    /// The product  typerunning the logic.
-    var product: EnvironmentProduct? { set get }
 }
 
 private let truthyValues = ["1", "true", "TRUE", "yes", "YES"]
 
 extension Environmenting {
-    
     public var tuistVariables: [String: String] {
         variables.filter { $0.key.hasPrefix("TUIST_") }
     }
@@ -127,17 +114,12 @@ extension Environmenting {
 /// Local environment controller.
 public struct Environment: Environmenting {
     @TaskLocal public static var current: Environmenting = Environment()
-    
+
     public var processId = UUID().uuidString
 
-    public var product: EnvironmentProduct?
     public var variables: [String: String] { ProcessInfo.processInfo.environment }
     public var arguments: [String] { ProcessInfo.processInfo.arguments }
 
-    public init(product: EnvironmentProduct? = nil) {
-        self.product = product
-    }
-    
     public var homeDirectory: AbsolutePath {
         // swiftlint:disable force_try
         try! AbsolutePath(validating: NSHomeDirectory())

--- a/cli/Sources/TuistSupport/Utils/Environment.swift
+++ b/cli/Sources/TuistSupport/Utils/Environment.swift
@@ -7,10 +7,19 @@ import NIOCore
 import NIOFileSystem
 import Path
 
+/// An enum that represents the the product type the runtime logic
+/// is embedded into. This can be useful at runtime to base control
+/// flows on the product (e.g. a CLI can do things that an app can't).
+public enum EnvironmentProduct: Sendable {
+    case app
+    case cli
+}
+
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.
 @Mockable
 public protocol Environmenting: Sendable {
+    
     /// Returns the home directory.
     var homeDirectory: AbsolutePath { get }
 
@@ -68,11 +77,15 @@ public protocol Environmenting: Sendable {
 
     /// Returns path to the Tuist executable
     func currentExecutablePath() -> AbsolutePath?
+        
+    /// The product  typerunning the logic.
+    var product: EnvironmentProduct? { set get }
 }
 
 private let truthyValues = ["1", "true", "TRUE", "yes", "YES"]
 
 extension Environmenting {
+    
     public var tuistVariables: [String: String] {
         variables.filter { $0.key.hasPrefix("TUIST_") }
     }
@@ -114,12 +127,17 @@ extension Environmenting {
 /// Local environment controller.
 public struct Environment: Environmenting {
     @TaskLocal public static var current: Environmenting = Environment()
+    
     public var processId = UUID().uuidString
 
-    /// File handler instance.
+    public var product: EnvironmentProduct?
     public var variables: [String: String] { ProcessInfo.processInfo.environment }
     public var arguments: [String] { ProcessInfo.processInfo.arguments }
 
+    public init(product: EnvironmentProduct? = nil) {
+        self.product = product
+    }
+    
     public var homeDirectory: AbsolutePath {
         // swiftlint:disable force_try
         try! AbsolutePath(validating: NSHomeDirectory())

--- a/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
+++ b/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
@@ -218,4 +218,6 @@ private class SelfSignedXCFrameworkMockFileSystem: FileSysteming {
     func writeAsJSON(_: some Encodable, at _: Path.AbsolutePath, encoder _: JSONEncoder) async throws {
         throw unexpectedCallError()
     }
+
+    func fileMetadata(at _: AbsolutePath) async throws -> FileMetadata? { throw unexpectedCallError() }
 }

--- a/cli/Tests/TuistKitAcceptanceTests/AccountAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/AccountAcceptanceTests.swift
@@ -16,19 +16,24 @@ struct AccountAcceptanceTests {
         .withFixtureConnectedToCanary("ios_app_with_frameworks")
     )
     func account_with_logged_in_user() async throws {
-        // Given
-        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        // By default, the CLI refreshes in the background spawning itself in a subprocess.
+        // This is something we can't do from accepance tests, so we configure that behaviour
+        // using the task local.
+        try await ServerAuthenticationConfig.$current.withValue(ServerAuthenticationConfig(backgroundRefresh: false)) {
+            // Given
+            let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
 
-        // When: Set up registry
-        try await TuistTest.run(
-            AccountUpdateCommand.self,
-            ["--path", fixtureDirectory.pathString, "--handle", "tuistrocks"]
-        )
+            // When: Set up registry
+            try await TuistTest.run(
+                AccountUpdateCommand.self,
+                ["--path", fixtureDirectory.pathString, "--handle", "tuistrocks"]
+            )
 
-        // Then
-        #expect(ui().contains("""
-        ✔ Success
-          The account tuistrocks was successfully updated.
-        """) == true)
+            // Then
+            #expect(ui().contains("""
+            ✔ Success
+              The account tuistrocks was successfully updated.
+            """) == true)
+        }
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
@@ -30,7 +30,8 @@ struct AuthRefreshTokenServiceTests {
         given(serverAuthenticationController).refreshToken(
             serverURL: .value(url),
             inBackground: .value(false),
-            locking: .value(false)
+            locking: .value(false),
+            forceInProcessLock: .value(false)
         ).willReturn()
 
         // When
@@ -40,9 +41,8 @@ struct AuthRefreshTokenServiceTests {
         verify(serverAuthenticationController).refreshToken(
             serverURL: .value(url),
             inBackground: .value(false),
-            locking: .value(false)
+            locking: .value(false),
+            forceInProcessLock: .value(false)
         ).called(1)
-        let lockFileExists = try await fileSystem.exists(lockFilePath)
-        #expect(lockFileExists == false)
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
@@ -1,0 +1,64 @@
+import FileSystem
+import Foundation
+import Path
+import TuistServer
+import TuistSupport
+import Testing
+import FileSystemTesting
+import Mockable
+
+@testable import TuistKit
+
+struct AuthRefreshTokenServiceTests {
+    
+    struct TestError: LocalizedError, Equatable {}
+    
+    let fileSystem = FileSystem()
+    let serverAuthenticationController = MockServerAuthenticationControlling()
+    let subject: AuthRefreshTokenService
+    
+    init() {
+        self.subject = AuthRefreshTokenService(serverAuthenticationController: serverAuthenticationController, fileSystem: fileSystem)
+    }
+    
+    @Test(.inTemporaryDirectory) func run_refreshes_the_token_and_deletes_the_lockfile() async throws {
+        // Given
+        let urlString = "https://tuist.dev"
+        let url = URL(string: urlString)!
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let lockFilePath = temporaryDirectory.appending(component: UUID().uuidString)
+        try await fileSystem.touch(lockFilePath)
+        given(serverAuthenticationController).lockFilePath(serverURL: .value(url)).willReturn(lockFilePath)
+        given(serverAuthenticationController).refreshToken(serverURL: .value(url),
+                                                           inBackground: .value(false)).willReturn()
+        
+        // When
+        try await subject.run(serverURL: urlString)
+        
+        // Then
+        verify(serverAuthenticationController).refreshToken(serverURL: .value(url),
+                                                            inBackground: .value(false)).called(1)
+        let lockFileExists = try await fileSystem.exists(lockFilePath)
+        #expect(lockFileExists == false)
+    }
+    
+    @Test(.inTemporaryDirectory) func run_deletes_the_lockfile_on_error() async throws {
+        // Given
+        let urlString = "https://tuist.dev"
+        let url = URL(string: urlString)!
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let lockFilePath = temporaryDirectory.appending(component: UUID().uuidString)
+        try await fileSystem.touch(lockFilePath)
+        let error = TestError()
+        given(serverAuthenticationController).lockFilePath(serverURL: .value(url)).willReturn(lockFilePath)
+        given(serverAuthenticationController).refreshToken(serverURL: .value(url),
+                                                           inBackground: .value(false)).willThrow(error)
+        
+        // When/Then
+        await #expect(throws: AuthRefreshTokenServiceError.tokenRefreshFailed(error.localizedDescription), performing: {
+            try await subject.run(serverURL: urlString)
+        })
+        let lockFileExists = try await fileSystem.exists(lockFilePath)
+        #expect(lockFileExists == false)
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Auth/AuthRefreshTokenServiceTests.swift
@@ -1,26 +1,25 @@
 import FileSystem
+import FileSystemTesting
 import Foundation
+import Mockable
 import Path
+import Testing
 import TuistServer
 import TuistSupport
-import Testing
-import FileSystemTesting
-import Mockable
 
 @testable import TuistKit
 
 struct AuthRefreshTokenServiceTests {
-    
     struct TestError: LocalizedError, Equatable {}
-    
+
     let fileSystem = FileSystem()
     let serverAuthenticationController = MockServerAuthenticationControlling()
     let subject: AuthRefreshTokenService
-    
+
     init() {
-        self.subject = AuthRefreshTokenService(serverAuthenticationController: serverAuthenticationController, fileSystem: fileSystem)
+        subject = AuthRefreshTokenService(serverAuthenticationController: serverAuthenticationController, fileSystem: fileSystem)
     }
-    
+
     @Test(.inTemporaryDirectory) func run_refreshes_the_token_and_deletes_the_lockfile() async throws {
         // Given
         let urlString = "https://tuist.dev"
@@ -28,36 +27,21 @@ struct AuthRefreshTokenServiceTests {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let lockFilePath = temporaryDirectory.appending(component: UUID().uuidString)
         try await fileSystem.touch(lockFilePath)
-        given(serverAuthenticationController).lockFilePath(serverURL: .value(url)).willReturn(lockFilePath)
-        given(serverAuthenticationController).refreshToken(serverURL: .value(url),
-                                                           inBackground: .value(false)).willReturn()
-        
+        given(serverAuthenticationController).refreshToken(
+            serverURL: .value(url),
+            inBackground: .value(false),
+            locking: .value(false)
+        ).willReturn()
+
         // When
         try await subject.run(serverURL: urlString)
-        
+
         // Then
-        verify(serverAuthenticationController).refreshToken(serverURL: .value(url),
-                                                            inBackground: .value(false)).called(1)
-        let lockFileExists = try await fileSystem.exists(lockFilePath)
-        #expect(lockFileExists == false)
-    }
-    
-    @Test(.inTemporaryDirectory) func run_deletes_the_lockfile_on_error() async throws {
-        // Given
-        let urlString = "https://tuist.dev"
-        let url = URL(string: urlString)!
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let lockFilePath = temporaryDirectory.appending(component: UUID().uuidString)
-        try await fileSystem.touch(lockFilePath)
-        let error = TestError()
-        given(serverAuthenticationController).lockFilePath(serverURL: .value(url)).willReturn(lockFilePath)
-        given(serverAuthenticationController).refreshToken(serverURL: .value(url),
-                                                           inBackground: .value(false)).willThrow(error)
-        
-        // When/Then
-        await #expect(throws: AuthRefreshTokenServiceError.tokenRefreshFailed(error.localizedDescription), performing: {
-            try await subject.run(serverURL: urlString)
-        })
+        verify(serverAuthenticationController).refreshToken(
+            serverURL: .value(url),
+            inBackground: .value(false),
+            locking: .value(false)
+        ).called(1)
         let lockFileExists = try await fileSystem.exists(lockFilePath)
         #expect(lockFileExists == false)
     }

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
@@ -5,6 +5,7 @@ import Testing
 import TuistCore
 import TuistGit
 import TuistLoader
+import TuistProcess
 import TuistServer
 import TuistSupport
 import TuistTesting

--- a/cli/Tests/TuistKitTests/Services/LoginServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/LoginServiceTests.swift
@@ -85,7 +85,6 @@ final class LoginServiceTests: TuistUnitTestCase {
                 .store(
                     credentials: .value(
                         ServerCredentials(
-                            token: nil,
                             accessToken: "access-token",
                             refreshToken: "refresh-token"
                         )
@@ -138,7 +137,6 @@ final class LoginServiceTests: TuistUnitTestCase {
                 .store(
                     credentials: .value(
                         ServerCredentials(
-                            token: nil,
                             accessToken: "access-token",
                             refreshToken: "refresh-token"
                         )
@@ -186,7 +184,6 @@ final class LoginServiceTests: TuistUnitTestCase {
                 .store(
                     credentials: .value(
                         ServerCredentials(
-                            token: nil,
                             accessToken: "access-token",
                             refreshToken: "refresh-token"
                         )

--- a/cli/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
@@ -227,4 +227,10 @@ public class MockFileSystem: FileSysteming {
     public func currentWorkingDirectory() async throws -> Path.AbsolutePath {
         try await currentWorkingDirectoryOverride()
     }
+
+    public var fileMetadataOverride: ((AbsolutePath) async throws -> FileMetadata?) = { _ in nil }
+
+    public func fileMetadata(at path: Path.AbsolutePath) async throws -> FileMetadata? {
+        return try await fileMetadataOverride(path)
+    }
 }

--- a/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -48,7 +48,6 @@ struct ServerClientAuthenticationMiddlewareTests {
             status: 200
         )
         let token: AuthenticationToken? = .user(
-            legacyToken: nil,
             accessToken: .test(token: "access-token"),
             refreshToken: .test(token: "refresh-token")
         )

--- a/cli/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Session/ServerSessionControllerTests.swift
@@ -59,7 +59,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             .read(serverURL: .value(serverURL))
             .willReturn(
                 ServerCredentials(
-                    token: nil, accessToken: "access-token", refreshToken: "refresh-token"
+                    accessToken: "access-token", refreshToken: "refresh-token"
                 )
             )
         given(credentialsStore)
@@ -85,7 +85,6 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
                 .user(
-                    legacyToken: nil,
                     accessToken: .test(
                         email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
@@ -109,22 +108,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
-                .user(legacyToken: nil, accessToken: nil, refreshToken: nil)
-            )
-
-        // When
-        let got = try await subject.whoami(serverURL: serverURL)
-
-        // Then
-        XCTAssertEqual(got, nil)
-    }
-
-    func test_whoami_when_logged_in_with_legacy_token() async throws {
-        // Given
-        given(serverAuthenticationController)
-            .authenticationToken(serverURL: .value(serverURL))
-            .willReturn(
-                .user(legacyToken: "legacy-token", accessToken: nil, refreshToken: nil)
+                nil
             )
 
         // When
@@ -140,7 +124,6 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
                 .user(
-                    legacyToken: nil,
                     accessToken: .test(
                         email: "tuist@tuist.dev",
                         preferredUsername: "tuist"
@@ -163,7 +146,7 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .value(serverURL))
             .willReturn(
-                .user(legacyToken: nil, accessToken: nil, refreshToken: nil)
+                nil
             )
 
         // Then
@@ -171,32 +154,6 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
             try await subject.authenticatedHandle(serverURL: serverURL),
             ServerSessionControllerError.unauthenticated
         )
-    }
-
-    func test_logout_deletesLegacyCredentials() async throws {
-        try await withMockedDependencies {
-            // Given
-            let serverCredentialsStore = try XCTUnwrap(ServerCredentialsStore.mocked)
-            given(serverCredentialsStore)
-                .delete(serverURL: .any)
-                .willReturn()
-            let credentials = ServerCredentials(
-                token: "token",
-                accessToken: nil,
-                refreshToken: nil
-            )
-            given(credentialsStore)
-                .store(credentials: .value(credentials), serverURL: .value(serverURL))
-                .willReturn()
-            try await credentialsStore.store(credentials: credentials, serverURL: serverURL)
-
-            given(credentialsStore)
-                .delete(serverURL: .value(serverURL))
-                .willReturn()
-
-            // When
-            try await subject.logout(serverURL: serverURL)
-        }
     }
 
     func test_logout_deletesCredentials() async throws {
@@ -207,7 +164,6 @@ final class ServerSessionControllerTests: TuistUnitTestCase {
                 .delete(serverURL: .any)
                 .willReturn()
             let credentials = ServerCredentials(
-                token: nil,
                 accessToken: "access-token",
                 refreshToken: "refresh-token"
             )

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -75,28 +75,6 @@ struct ServerAuthenticationControllerTests {
         #expect(got == nil)
     }
 
-    @Test(.withMockedEnvironment(), .withMockedDependencies()) func legacy_token_and_not_ci() async throws {
-        // Given
-        let serverURL: URL = .test()
-        let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
-        given(serverCredentialsStore)
-            .read(serverURL: .any)
-            .willReturn(nil)
-        let authenticationToken: AuthenticationToken? = .user(legacyToken: "legacy-token", accessToken: nil, refreshToken: nil)
-        let cachedValueStore = try #require(CachedValueStore.mocked)
-        given(cachedValueStore).getValue(key: .value("token_\(serverURL.absoluteString)"), computeIfNeeded: .matching { closure in
-            Task { try await closure() }
-            return true
-        }).willReturn(authenticationToken)
-        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(.test(token: "legacy-token"))
-
-        // When
-        let got = try await subject.authenticationToken(serverURL: .test())
-
-        // Then
-        #expect(got == authenticationToken)
-    }
-
     @Test(.withMockedEnvironment(), .withMockedDependencies()) func non_expired_access_token_and_not_ci() async throws {
         let date = Date()
         try await Date.$now.withValue({ date }) {
@@ -107,9 +85,8 @@ struct ServerAuthenticationControllerTests {
                 .read(serverURL: .any)
                 .willReturn(nil)
             let authenticationToken: AuthenticationToken? = .user(
-                legacyToken: "legacy-token",
-                accessToken: nil,
-                refreshToken: nil
+                accessToken: JWT.test(token: "access-token"),
+                refreshToken: JWT.test(token: "refresh-token")
             )
 
             let cachedValueStore = try #require(CachedValueStore.mocked)
@@ -146,9 +123,8 @@ struct ServerAuthenticationControllerTests {
                 .read(serverURL: .any)
                 .willReturn(nil)
             let authenticationToken: AuthenticationToken? = .user(
-                legacyToken: "legacy-token",
-                accessToken: nil,
-                refreshToken: nil
+                accessToken: JWT.test(token: "access-token"),
+                refreshToken: JWT.test(token: "refresh-token")
             )
 
             let cachedValueStore = try #require(CachedValueStore.mocked)
@@ -212,9 +188,8 @@ struct ServerAuthenticationControllerTests {
                 .read(serverURL: .any)
                 .willReturn(nil)
             let authenticationToken: AuthenticationToken? = .user(
-                legacyToken: "legacy-token",
-                accessToken: nil,
-                refreshToken: nil
+                accessToken: JWT.test(token: "access-token"),
+                refreshToken: JWT.test(token: "refresh-token")
             )
 
             let cachedValueStore = try #require(CachedValueStore.mocked)
@@ -281,9 +256,8 @@ struct ServerAuthenticationControllerTests {
                 .read(serverURL: .any)
                 .willReturn(nil)
             let authenticationToken: AuthenticationToken? = .user(
-                legacyToken: "legacy-token",
-                accessToken: nil,
-                refreshToken: nil
+                accessToken: JWT.test(token: "access-token"),
+                refreshToken: JWT.test(token: "refresh-token")
             )
 
             let cachedValueStore = try #require(CachedValueStore.mocked)

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -9,6 +9,7 @@ import TuistTesting
 struct ServerAuthenticationControllerTests {
     private var subject: ServerAuthenticationController!
     private let refreshAuthTokenService: MockRefreshAuthTokenServicing!
+    private let cachedValueStore: MockCachedValueStoring
 
     private let accessToken =
         "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0dWlzdF9jbG91ZCIsImV4cCI6MTcyMDQyOTgxMiwiaWF0IjoxNzIwNDI5NzUyLCJpc3MiOiJ0dWlzdF9jbG91ZCIsImp0aSI6IjlmZGEwYmRmLTE0MjMtNDhmNi1iNWRmLWM2MDVjMGMwMzBiMiIsIm5iZiI6MTcyMDQyOTc1MSwicmVzb3VyY2UiOiJ1c2VyIiwic3ViIjoiMSIsInR5cCI6ImFjY2VzcyJ9.qsxjD51lHHaQo6NWs-gUxVUhQfyWEe3v3-okM0NIV72vDY-fGgzq9JU2F8DQbdOD8POqWkseCbtO66m_4J9uFw"
@@ -16,9 +17,11 @@ struct ServerAuthenticationControllerTests {
         "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0dWlzdF9jbG91ZCIsImV4cCI6MTcyMDQyOTgxMCwiaWF0IjoxNzIwNDI5NzUyLCJpc3MiOiJ0dWlzdF9jbG91ZCIsImp0aSI6IjlmZGEwYmRmLTE0MjMtNDhmNi1iNWRmLWM2MDVjMGMwMzBiMiIsIm5iZiI6MTcyMDQyOTc1MSwicmVzb3VyY2UiOiJ1c2VyIiwic3ViIjoiMSIsInR5cCI6ImFjY2VzcyJ9.UGMOA4nysabRCO0px9ixCW3JTCA6OgYSeVA6X--Xkc8b-YA8ui2SeCL8gV9WvOYeLJA5pvzKUSulVfV1qM4LKg"
 
     init() throws {
+        cachedValueStore = MockCachedValueStoring()
         refreshAuthTokenService = MockRefreshAuthTokenServicing()
-        subject = .init(
-            refreshAuthTokenService: refreshAuthTokenService
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: refreshAuthTokenService,
+            cachedValueStore: cachedValueStore
         )
     }
 
@@ -81,29 +84,20 @@ struct ServerAuthenticationControllerTests {
             // Given
             let serverURL: URL = .test()
             let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
-            given(serverCredentialsStore)
-                .read(serverURL: .any)
-                .willReturn(nil)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(+60), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+60), typ: "refresh")
+
             let authenticationToken: AuthenticationToken? = .user(
-                accessToken: JWT.test(token: "access-token"),
-                refreshToken: JWT.test(token: "refresh-token")
+                accessToken: try JWT.parse(accessToken.token),
+                refreshToken: try JWT.parse(refreshToken.token)
             )
 
-            let cachedValueStore = try #require(CachedValueStore.mocked)
-            given(cachedValueStore).getValue(
-                key: .value("token_\(serverURL.absoluteString)"),
-                computeIfNeeded: .matching { closure in
-                    Task { try await closure() }
-                    return true
-                }
-            ).willReturn(authenticationToken)
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
+            )
 
-            let currentAccessToken = JWT.test(token: accessToken, expiryDate: date.addingTimeInterval(+60))
-            let currentRefreshToken = JWT.test(token: refreshToken, expiryDate: date.addingTimeInterval(+2000))
-            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(.test(
-                accessToken: try currentAccessToken.encode(),
-                refreshToken: try currentRefreshToken.encode()
-            ))
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
 
             // When
             let got = try await subject.authenticationToken(serverURL: .test())
@@ -113,201 +107,36 @@ struct ServerAuthenticationControllerTests {
         }
     }
 
-    @Test(.withMockedEnvironment(), .withMockedDependencies()) func expired_access_access_token_and_not_ci() async throws {
+    @Test(.withMockedEnvironment(), .withMockedDependencies()) func expired_access_token_and_not_ci_and_locking() async throws {
         let date = Date()
         try await Date.$now.withValue({ date }) {
             // Given
             let serverURL: URL = .test()
             let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
-            given(serverCredentialsStore)
-                .read(serverURL: .any)
-                .willReturn(nil)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+60), typ: "refresh")
+
             let authenticationToken: AuthenticationToken? = .user(
-                accessToken: JWT.test(token: "access-token"),
-                refreshToken: JWT.test(token: "refresh-token")
+                accessToken: try JWT.parse(accessToken.token),
+                refreshToken: try JWT.parse(refreshToken.token)
             )
 
-            let cachedValueStore = try #require(CachedValueStore.mocked)
-            given(cachedValueStore).getValue(
-                key: .value("token_\(serverURL.absoluteString)"),
-                computeIfNeeded: .matching { closure in
-                    Task { try await closure() }
-                    return true
-                }
-            ).willReturn(authenticationToken)
-
-            let currentAccessToken = try JWT.test(
-                token: "access-token",
-                expiryDate: date.addingTimeInterval(-100)
-            ).encode()
-            let currentRefreshToken = try JWT.test(
-                token: "refresh-token",
-                expiryDate: date.addingTimeInterval(+2000)
-            ).encode()
-            let refreshedAccessToken = try JWT.test(
-                token: "refreshed-access-token",
-                expiryDate: date.addingTimeInterval(+10)
-            ).encode()
-            let refreshedRefreshToken = try JWT.test(
-                token: "refreshed-refresh-token",
-                expiryDate: date.addingTimeInterval(+2010)
-            ).encode()
-            let refreshedServerCredentials = ServerCredentials.test(
-                accessToken: refreshedAccessToken,
-                refreshToken: refreshedRefreshToken
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
             )
 
-            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(.test(
-                accessToken: currentAccessToken,
-                refreshToken: currentRefreshToken
-            ))
+            given(cachedValueStore).getValue(key: .any, computeIfNeeded: .any).willReturn(authenticationToken)
 
-            given(refreshAuthTokenService).refreshTokens(serverURL: .value(serverURL), refreshToken: .value(currentRefreshToken))
-                .willReturn(.init(
-                    accessToken: refreshedAccessToken,
-                    refreshToken: refreshedRefreshToken
-                ))
-            given(serverCredentialsStore).store(credentials: .value(refreshedServerCredentials), serverURL: .value(serverURL))
-                .willReturn()
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
 
-            // When
-            let got = try await subject.authenticationToken(serverURL: .test())
-
-            // Then
-            #expect(got == authenticationToken)
-        }
-    }
-
-    @Test(.withMockedEnvironment(), .withMockedDependencies()) func close_to_expired_access_token_and_not_ci() async throws {
-        let date = Date()
-        try await Date.$now.withValue({ date }) {
-            // Given
-            let serverURL: URL = .test()
-            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
-            given(serverCredentialsStore)
-                .read(serverURL: .any)
-                .willReturn(nil)
-            let authenticationToken: AuthenticationToken? = .user(
-                accessToken: JWT.test(token: "access-token"),
-                refreshToken: JWT.test(token: "refresh-token")
+            // When/Then
+            try await subject.refreshToken(
+                serverURL: serverURL,
+                inBackground: false,
+                locking: true,
+                forceInProcessLock: true
             )
-
-            let cachedValueStore = try #require(CachedValueStore.mocked)
-            given(cachedValueStore).getValue(
-                key: .value("token_\(serverURL.absoluteString)"),
-                computeIfNeeded: .matching { closure in
-                    Task { try await closure() }
-                    return true
-                }
-            ).willReturn(authenticationToken)
-
-            let currentAccessToken = try JWT.test(
-                token: "access-token",
-                expiryDate: date.addingTimeInterval(5)
-            ).encode()
-            let currentRefreshToken = try JWT.test(
-                token: "refresh-token",
-                expiryDate: date.addingTimeInterval(+2000)
-            ).encode()
-            let refreshedAccessToken = try JWT.test(
-                token: "refreshed-access-token",
-                expiryDate: date.addingTimeInterval(+10)
-            ).encode()
-            let refreshedRefreshToken = try JWT.test(
-                token: "refreshed-refresh-token",
-                expiryDate: date.addingTimeInterval(+2010)
-            ).encode()
-            let refreshedServerCredentials = ServerCredentials.test(
-                accessToken: refreshedAccessToken,
-                refreshToken: refreshedRefreshToken
-            )
-
-            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(.test(
-                accessToken: currentAccessToken,
-                refreshToken: currentRefreshToken
-            ))
-
-            given(refreshAuthTokenService).refreshTokens(serverURL: .value(serverURL), refreshToken: .value(currentRefreshToken))
-                .willReturn(.init(
-                    accessToken: refreshedAccessToken,
-                    refreshToken: refreshedRefreshToken
-                ))
-            given(serverCredentialsStore).store(credentials: .value(refreshedServerCredentials), serverURL: .value(serverURL))
-                .willReturn()
-
-            // When
-            let got = try await subject.authenticationToken(serverURL: .test())
-
-            // Then
-            #expect(got == authenticationToken)
-        }
-    }
-
-    @Test(
-        .withMockedEnvironment(),
-        .withMockedDependencies()
-    ) func non_expired_access_token_when_forced_and_not_ci() async throws {
-        let date = Date()
-        try await Date.$now.withValue({ date }) {
-            // Given
-            let serverURL: URL = .test()
-            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
-            given(serverCredentialsStore)
-                .read(serverURL: .any)
-                .willReturn(nil)
-            let authenticationToken: AuthenticationToken? = .user(
-                accessToken: JWT.test(token: "access-token"),
-                refreshToken: JWT.test(token: "refresh-token")
-            )
-
-            let cachedValueStore = try #require(CachedValueStore.mocked)
-            given(cachedValueStore).getValue(
-                key: .value("token_\(serverURL.absoluteString)"),
-                computeIfNeeded: .matching { closure in
-                    Task { try await closure() }
-                    return true
-                }
-            ).willReturn(authenticationToken)
-
-            let currentAccessToken = try JWT.test(
-                token: "access-token",
-                expiryDate: date.addingTimeInterval(60)
-            ).encode()
-            let currentRefreshToken = try JWT.test(
-                token: "refresh-token",
-                expiryDate: date.addingTimeInterval(+2000)
-            ).encode()
-            let refreshedAccessToken = try JWT.test(
-                token: "refreshed-access-token",
-                expiryDate: date.addingTimeInterval(+10)
-            ).encode()
-            let refreshedRefreshToken = try JWT.test(
-                token: "refreshed-refresh-token",
-                expiryDate: date.addingTimeInterval(+2010)
-            ).encode()
-            let refreshedServerCredentials = ServerCredentials.test(
-                accessToken: refreshedAccessToken,
-                refreshToken: refreshedRefreshToken
-            )
-
-            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(.test(
-                accessToken: currentAccessToken,
-                refreshToken: currentRefreshToken
-            ))
-
-            given(refreshAuthTokenService).refreshTokens(serverURL: .value(serverURL), refreshToken: .value(currentRefreshToken))
-                .willReturn(.init(
-                    accessToken: refreshedAccessToken,
-                    refreshToken: refreshedRefreshToken
-                ))
-            given(serverCredentialsStore).store(credentials: .value(refreshedServerCredentials), serverURL: .value(serverURL))
-                .willReturn()
-
-            // When
-            let got = try await subject.authenticationToken(serverURL: .test())
-
-            // Then
-            #expect(got == authenticationToken)
         }
     }
 }

--- a/cli/Tests/TuistServerTests/Utilities/ServerCredentialsStoreTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerCredentialsStoreTests.swift
@@ -17,28 +17,6 @@ final class ServerCredentialsStoreTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_crud_with_legacy_token() async throws {
-        // Given
-        let temporaryDirectory = try temporaryPath()
-        let subject = ServerCredentialsStore(
-            backend: .fileSystem,
-            fileSystem: fileSystem,
-            configDirectory: temporaryDirectory
-        )
-        let credentials = ServerCredentials(token: "token", accessToken: nil, refreshToken: nil)
-        let serverURL = URL(string: "https://tuist.io")!
-
-        // When
-        try await subject.store(credentials: credentials, serverURL: serverURL)
-
-        // Then
-        let gotRead = try await subject.read(serverURL: serverURL)
-        XCTAssertEqual(gotRead, credentials)
-        try await subject.delete(serverURL: serverURL)
-        let gotReadAfterDelete = try await subject.read(serverURL: serverURL)
-        XCTAssertEqual(gotReadAfterDelete, nil)
-    }
-
     func test_crud() async throws {
         // Given
         let temporaryDirectory = try temporaryPath()
@@ -48,7 +26,7 @@ final class ServerCredentialsStoreTests: TuistUnitTestCase {
             configDirectory: temporaryDirectory
         )
         let credentials = ServerCredentials(
-            token: nil, accessToken: "access-token", refreshToken: "refresh-token"
+            accessToken: "access-token", refreshToken: "refresh-token"
         )
         let serverURL = URL(string: "https://tuist.io")!
 


### PR DESCRIPTION
We think we might have found what causes the sporadic logouts. If the CLI process exits while a token refresh is happening server-side, the new token doesn't get persisted locally, and the local one becomes invalidated by the server.

To solve the issue, I'm refreshing the token spawning the `tuist` CLI in a new independent process running a hidden refresh command:

```bash
tuist auth refresh-token https://tuist.dev
```

If a refresh is required because the token is expired, we spawn the process and loop until it completes. 