### PR TITLE
chore(server): fix Zed Elixir LSP

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,9 @@
+{
+  "lsp": {
+    "elixir-ls": {
+      "settings": {
+        "projectDir": "server"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Zed Elixir LSP was not working since the mix project is no longer in the root.