### PR TITLE
Fix the compilation with the caching logic

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -91,6 +91,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.core.targetName),
                     .target(name: Module.server.targetName),
                     .target(name: Module.support.targetName),
+                    .target(name: Module.testing.targetName),
                     .target(name: "TuistCacheEE"),
                     .external(name: "XcodeGraph"),
                     .external(name: "Path"),


### PR DESCRIPTION
I noticed the compilation with the ee module [started failing](https://github.com/tuist/tuist/actions/runs/16515987153/job/46706831612). It turns out the removal of the legacy token broke the contract, and there was also a dependency missing in the definition.