### PR TITLE
chore(cli): change submodule to a non-SSH url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/fortmarek/ExampleTuistPlugin/
 [submodule "cli/TuistCacheEE"]
 	path = cli/TuistCacheEE
-	url = git@github.com:tuist/TuistCacheEE.git
+	url = https://github.com/tuist/TuistCacheEE/


### PR DESCRIPTION
We've been mostly using cloning via the URL, not SSH. Is there a reason we should keep the current path? It feels odd to combine the two inside a single `.gitmodules` file.