### PR TITLE
ci(app): fix CD of the iOS app

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -92,7 +92,8 @@ jobs:
         if: env.should-release == 'true'
         run: |
           sed -i '' -e "s/CFBundleShortVersionString.*/CFBundleShortVersionString\": \"${{ steps.next-version.outputs.NEXT_VERSION_NUMBER }}\",/g" "Project.swift"
-          sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"${{ steps.next-version.outputs.NEXT_VERSION_NUMBER }}\",/g" "Project.swift"
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"$COMMIT_COUNT\",/g" "Project.swift"
       - name: Update CHANGELOG.md
         working-directory: app
         if: env.should-release == 'true'


### PR DESCRIPTION
We currently set both `CFBundleVersion` and `CFBundleShortVersionString` to be the version computed by `git-cliff`.

But when uploading the iOS to the app store connect, we:
- Update the versions
- Build and upload to the App Store Connect
- Simultaneously, we build the macOS
- Commit updated versions to `main`

However, when build and upload to the App Store Connect succeeds, but then for example the macOS build fails, we don't commit the version to `main`. That means we get to a state where the next time the app release runs, we try to upload the same version to the App Store Connect – which won't succeed due to:
```
NSUnderlyingError = "Error Domain=IrisAPI Code=-19241 \"The provided entity includes an attribute with a value that has already been used\" UserInfo={status=409, detail=The bundle version must be higher than the previously uploaded version., source={\n    pointer = \"/data/attributes/cfBundleVersion\";\n}, id=a87c40eb-23c0-405b-8fcb-1a57999e771a, code=ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE, title=The provided entity includes an attribute with a value that has already been used, meta={\n    previousBundleVersion = \"0.20.3\";\n}, NSLocalizedDescription=The provided entity includes an attribute with a value that has already been used, NSLocalizedFailureReason=The bundle version must be higher than the previously uploaded version.}";
```

The fix here is to use the number of commits for `CFBundleVersion`, so it's unique per commit on `main`. The `CFBundleShortVersionString`, which is the user-facing value, continues to be the value computed by `git-cliff`.