### PR TITLE
feat(server): Support running the web and the worker independently

### DIFF
--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -80,6 +80,15 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 | `TUIST_LOG_LEVEL` | The log level to use for the app | No | `info` | [Log levels](https://hexdocs.pm/logger/1.12.3/Logger.html#module-levels) |
 | `TUIST_GITHUB_APP_PRIVATE_KEY` | The private key used for the GitHub app to unlock extra functionality such as posting automatic PR comments | No | `-----BEGIN RSA...` | |
 | `TUIST_OPS_USER_HANDLES` | A comma-separated list of user handles that have access to the operations URLs | No | | `user1,user2` |
+| `TUIST_WEB` | Whether to run the web server component | No | `1` | `1` or `0` |
+| `TUIST_WORKER` | Whether to run the background job processing component | No | `1` | `1` or `0` |
+
+> [!NOTE] WEB SERVER AND BACKGROUND WORKER SEPARATION
+> By default, both the web server and background job processing run in the same process for simplicity. However, you can separate them by running multiple instances of the Docker image with different configurations:
+> - **Web server only:** Set `TUIST_WEB=1` and `TUIST_WORKER=0`
+> - **Background workers only:** Set `TUIST_WEB=0` and `TUIST_WORKER=1`
+> 
+> This separation allows you to scale web servers and background workers independently based on your workload requirements.
 
 ### Database configuration {#database-configuration}
 

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -10,13 +10,13 @@ import Config
 # ## Using releases
 #
 # If you use `mix release`, you need to explicitly enable the server
-# by passing the PHX_SERVER=true when you start it:
+# by passing the TUIST_WEB=true when you start it:
 #
-#     PHX_SERVER=true bin/tuist start
+#     TUIST_WEB=true bin/tuist start
 #
 # Alternatively, you can use `mix phx.gen.release` to generate a `bin/server`
 # script that automatically sets the env var above.
-if System.get_env("PHX_SERVER") do
+if Tuist.Environment.web?() do
   config :tuist, TuistWeb.Endpoint, server: true
 end
 

--- a/server/fly.canary.toml
+++ b/server/fly.canary.toml
@@ -4,62 +4,65 @@ kill_signal = "SIGINT"
 kill_timeout = "5s"
 console_command = "/app/bin/tuist remote"
 
+[[vm]]
+size = "shared-cpu-2x"
+memory = "2gb"
+
 [experimental]
-  auto_rollback = true
-  cmd = ["sh", "-C", "/app/bin/server"]
+auto_rollback = true
+cmd = ["sh", "-C", "/app/bin/server"]
 
 [deploy]
-  release_command = '/app/bin/migrate'
+release_command = '/app/bin/migrate'
 
 [env]
-  PORT = "8080"
-  MIX_ENV="can"
-  TUIST_APP_URL="https://canary.tuist.dev"
-  TUIST_HOSTED="1"
-  TUIST_USE_IPV6="1"
-  TUIST_USE_SSL_FOR_DATABASE="1"
-  TUIST_DATABASE_POOL_SIZE="6"
+PORT = "8080"
+MIX_ENV = "can"
+TUIST_APP_URL = "https://canary.tuist.dev"
+TUIST_HOSTED = "1"
+TUIST_USE_IPV6 = "1"
+TUIST_USE_SSL_FOR_DATABASE = "1"
+TUIST_DATABASE_POOL_SIZE = "6"
 
 [[vm]]
-  cpu_kind = 'shared'
-  memory = "2048mb"
-  cpus = 2
+cpu_kind = 'shared'
+memory = "2048mb"
+cpus = 2
 
 [[services]]
-  protocol = "tcp"
-  internal_port = 8080
-  auto_stop_machines = false
-  auto_start_machines = false
-  min_machines_running = 1
-  processes = ["app"]
+protocol = "tcp"
+internal_port = 8080
+auto_stop_machines = "suspend"
+auto_start_machines = true
+processes = ["app"]
 
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-    force_https = true
-    http_options = { h2_backend = true }
+[[services.ports]]
+port = 80
+handlers = ["http"]
+force_https = true
+http_options = { h2_backend = true }
 
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
-  [services.concurrency]
-    type = "connections"
-    soft_limit = 20
+[[services.ports]]
+port = 443
+handlers = ["tls", "http"]
+[services.concurrency]
+type = "connections"
+soft_limit = 20
 
-  [[services.http_checks]]
-    interval = 10000
-    grace_period = "10s"
-    method = "get"
-    path = "/ready"
-    protocol = "http"
-    timeout = 2000
-    tls_skip_verify = false
-    [services.http_checks.headers]
+[[services.http_checks]]
+interval = 10000
+grace_period = "10s"
+method = "get"
+path = "/ready"
+protocol = "http"
+timeout = 2000
+tls_skip_verify = false
+[services.http_checks.headers]
 
 [[statics]]
-  guest_path = "/app/public"
-  url_prefix = "/"
+guest_path = "/app/public"
+url_prefix = "/"
 
 [[metrics]]
-  port = 9091
-  path = "/metrics"
+port = 9091
+path = "/metrics"

--- a/server/fly.prod.toml
+++ b/server/fly.prod.toml
@@ -4,64 +4,77 @@ kill_signal = "SIGINT"
 kill_timeout = "5s"
 console_command = "/app/bin/tuist remote"
 
-[experimental]
-  auto_rollback = true
-  cmd = ["sh", "-C", "/app/bin/server"]
-
-[deploy]
-  release_command = '/app/bin/migrate'
-
-[env]
-  PORT = "8080"
-  MIX_ENV="prod"
-  TUIST_APP_URL="https://tuist.dev"
-  TUIST_HOSTED="1"
-  TUIST_USE_IPV6="1"
-  TUIST_USE_SSL_FOR_DATABASE="1"
-  TUIST_DATABASE_POOL_SIZE="10"
-  TUIST_S3_POOL_COUNT="1"
-  TUIST_S3_POOL_SIZE="50"
+[processes]
+web = "sh -C /app/bin/web"
+worker = "sh -C /app/bin/worker"
 
 [[vm]]
-  cpu_kind = 'performance'
-  memory = "4096mb"
-  cpus = 2
+size = "performance-1x"
+memory = "2gb"
+
+[[vm.processes]]
+app = "worker"
+size = "shared-cpu-4x "
+memory = "8gb"
+
+[experimental]
+auto_rollback = true
+cmd = ["sh", "-C", "/app/bin/server"]
+
+[deploy]
+release_command = '/app/bin/migrate'
+
+[env]
+PORT = "8080"
+MIX_ENV = "prod"
+TUIST_APP_URL = "https://tuist.dev"
+TUIST_HOSTED = "1"
+TUIST_USE_IPV6 = "1"
+TUIST_USE_SSL_FOR_DATABASE = "1"
+TUIST_DATABASE_POOL_SIZE = "10"
+TUIST_S3_POOL_COUNT = "1"
+TUIST_S3_POOL_SIZE = "50"
+
+[[vm]]
+cpu_kind = 'performance'
+memory = "4096mb"
+cpus = 2
 
 [[services]]
-  protocol = "tcp"
-  internal_port = 8080
-  auto_stop_machines = false
-  auto_start_machines = false
-  min_machines_running = 2
-  processes = ["app"]
-  http_options = { h2_backend = true }
+protocol = "tcp"
+internal_port = 8080
+auto_stop_machines = false
+auto_start_machines = false
+min_machines_running = 2
+processes = ["app"]
+http_options = { h2_backend = true }
 
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-    force_https = true
+[[services.ports]]
+port = 80
+handlers = ["http"]
+force_https = true
 
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
-  [services.concurrency]
-    type = "connections"
-    soft_limit = 80
+[[services.ports]]
+port = 443
+handlers = ["tls", "http"]
+[services.concurrency]
+type = "connections"
+soft_limit = 80
 
-  [[services.http_checks]]
-    interval = 10000
-    grace_period = "10s"
-    method = "get"
-    path = "/ready"
-    protocol = "http"
-    timeout = 2000
-    tls_skip_verify = false
-    [services.http_checks.headers]
+[[services.http_checks]]
+interval = 10000
+grace_period = "10s"
+method = "get"
+path = "/ready"
+protocol = "http"
+timeout = 2000
+tls_skip_verify = false
+[services.http_checks.headers]
 
 [[statics]]
-  guest_path = "/app/public"
-  url_prefix = "/"
+guest_path = "/app/public"
+url_prefix = "/"
 
 [[metrics]]
-  port = 9091
-  path = "/metrics"
+port = 9091
+path = "/metrics"

--- a/server/fly.staging.toml
+++ b/server/fly.staging.toml
@@ -4,62 +4,65 @@ kill_signal = "SIGINT"
 kill_timeout = "5s"
 console_command = "/app/bin/tuist remote"
 
+[[vm]]
+size = "shared-cpu-2x"
+memory = "2gb"
+
 [experimental]
-  auto_rollback = true
-  cmd = ["sh", "-C", "/app/bin/server"]
+auto_rollback = true
+cmd = ["sh", "-C", "/app/bin/server"]
 
 [deploy]
-  release_command = '/app/bin/migrate'
+release_command = '/app/bin/migrate'
 
 [env]
-  PORT = "8080"
-  MIX_ENV="stag"
-  TUIST_APP_URL="https://staging.tuist.dev"
-  TUIST_HOSTED="1"
-  TUIST_USE_IPV6="1"
-  TUIST_USE_SSL_FOR_DATABASE="1"
-  TUIST_DATABASE_POOL_SIZE="15"
+PORT = "8080"
+MIX_ENV = "stag"
+TUIST_APP_URL = "https://staging.tuist.dev"
+TUIST_HOSTED = "1"
+TUIST_USE_IPV6 = "1"
+TUIST_USE_SSL_FOR_DATABASE = "1"
+TUIST_DATABASE_POOL_SIZE = "15"
 
 [[vm]]
-  cpu_kind = 'shared'
-  memory = "2048mb"
-  cpus = 2
+cpu_kind = 'shared'
+memory = "2048mb"
+cpus = 2
 
 [[services]]
-  protocol = "tcp"
-  internal_port = 8080
-  auto_stop_machines = false
-  auto_start_machines = false
-  min_machines_running = 1
-  processes = ["app"]
-  http_options = { h2_backend = true }
+protocol = "tcp"
+internal_port = 8080
+auto_stop_machines = "suspend"
+auto_start_machines = true
+processes = ["app"]
+http_options = { h2_backend = true }
 
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-    force_https = true
+[[services.ports]]
+port = 80
+handlers = ["http"]
+force_https = true
 
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
-  [services.concurrency]
-    type = "connections"
-    soft_limit = 20
+[[services.ports]]
+port = 443
+handlers = ["tls", "http"]
+[services.concurrency]
+type = "connections"
+soft_limit = 20
 
-  [[services.http_checks]]
-    interval = 10000
-    grace_period = "10s"
-    method = "get"
-    path = "/ready"
-    protocol = "http"
-    timeout = 2000
-    tls_skip_verify = false
-    [services.http_checks.headers]
+[[services.http_checks]]
+interval = 10000
+grace_period = "10s"
+method = "get"
+path = "/ready"
+protocol = "http"
+timeout = 2000
+tls_skip_verify = false
+[services.http_checks.headers]
 
 [[statics]]
-  guest_path = "/app/public"
-  url_prefix = "/"
+guest_path = "/app/public"
+url_prefix = "/"
 
 [[metrics]]
-  port = 9091
-  path = "/metrics"
+port = 9091
+path = "/metrics"

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -52,21 +52,27 @@ defmodule Tuist.Application do
         {Tuist.Repo, connection_listeners: [TelemetryListener]},
         {Tuist.ClickHouseRepo, []},
         {Cachex, [:tuist, cachex_opts()]},
-        {Oban, Application.fetch_env!(:tuist, Oban)},
-        {Phoenix.PubSub, name: Tuist.PubSub},
         {Finch, name: Tuist.Finch, pools: finch_pools()},
-        {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]},
-        {Tuist.API.Pipeline, []},
-        # Rate limit
-        {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
-        TuistWeb.Telemetry,
-        # Start a worker by calling: Tuist.Worker.start_link(arg)
-        # {Tuist.Worker, arg},
-        # Start to serve requests, typically the last entry
-        TuistWeb.Endpoint
+        TuistWeb.Telemetry
       ]
 
     children
+    |> Kernel.++(
+      if Environment.web?(),
+        do: [
+          {Phoenix.PubSub, name: Tuist.PubSub},
+          {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
+          {Tuist.API.Pipeline, []},
+          {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]},
+          TuistWeb.Endpoint
+        ],
+        else: []
+    )
+    |> Kernel.++(
+      if Environment.worker?(),
+        do: [{Oban, Application.fetch_env!(:tuist, Oban)}],
+        else: []
+    )
     |> Kernel.++(if Environment.analytics_enabled?(), do: [Tuist.Analytics.Posthog], else: [])
     |> Kernel.++(
       if Environment.tuist_hosted?(),

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -67,6 +67,14 @@ defmodule Tuist.Environment do
     Enum.member?(["1", "true", "TRUE", "yes", "YES"], value)
   end
 
+  def worker?() do
+    System.get_env("TUIST_WORKER", "1") |> truthy?()
+  end
+
+  def web?() do
+    System.get_env("TUIST_WEB", "1") |> truthy?()
+  end
+
   def database_url(secrets \\ secrets()) do
     System.get_env("DATABASE_URL") || get([:database_url], secrets)
   end

--- a/server/rel/overlays/bin/server
+++ b/server/rel/overlays/bin/server
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-PHX_SERVER=true exec ./tuist start
+TUIST_WEB=true TUIST_WORKER=true exec ./tuist start

--- a/server/rel/overlays/bin/server.bat
+++ b/server/rel/overlays/bin/server.bat
@@ -1,2 +1,2 @@
-set PHX_SERVER=true
+set TUIST_WEB=true
 call "%~dp0\tuist" start

--- a/server/rel/overlays/bin/start
+++ b/server/rel/overlays/bin/start
@@ -25,4 +25,4 @@ echo "Migration completed successfully."
 
 # Starting the server
 echo "Starting the server..."
-PHX_SERVER=true exec ./tuist start
+TUIST_WEB=true TUIST_WORKER=true exec ./tuist start

--- a/server/rel/overlays/bin/web
+++ b/server/rel/overlays/bin/web
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+TUIST_WEB=true TUIST_WORKER=false exec ./tuist start

--- a/server/rel/overlays/bin/web.bat
+++ b/server/rel/overlays/bin/web.bat
@@ -1,0 +1,2 @@
+set TUIST_WEB=true TUIST_WORKER=false
+call "%~dp0\tuist" start

--- a/server/rel/overlays/bin/worker
+++ b/server/rel/overlays/bin/worker
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+TUIST_WEB=false TUIST_WORKER=true exec ./tuist start

--- a/server/rel/overlays/bin/worker.bat
+++ b/server/rel/overlays/bin/worker.bat
@@ -1,0 +1,2 @@
+set TUIST_WEB=false TUIST_WORKER=true
+call "%~dp0\tuist" start


### PR DESCRIPTION
Our production instance has workloads with different needs:
- **HTTP server:** Mostly IO-bound with memory under 1 Gb.
- **Worker:** Memory-intense with peaks of 4Gb when syncing the Swift registry.

Because we currently run them together, increasing the memory comes with adding CPU power and cost, which we don't really need, therefore I think we should have the option to separate the processes and assign different machine specs to each.

This PR introduces the `TUIST_WEB` and `TUIST_WEB` environment variables to activate the server and the worker (by default they are both enabled) so the change is non-breaking. In our canary and staging environments we want to continue running the two together.

Moreover, I've adjusted our production app accordingly based on the above patterns observed in our production system.
- The web server runs in a dedicated machine with dedicated resources. A single (but fast) CPU is enough for our needs. I assigned it 2Gb of memory because we are currently at 900 Mb on average.
- The worker runs in a shared machine with 8gb of memory. Our registry syncing logic is peaking at 4gb, so there's enough room there. It's fine if we don't have a dedicated machine in this case since this is running in the background and it's completely fine if we share resources with other apps running in Fly's infra.