### PR TITLE
fix(server): fix server not launching after embracing semver versioning

### DIFF
--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -8,17 +8,38 @@ description: Learn how to install Tuist on your infrastructure.
 
 We offer a self-hosted version of the Tuist server for organizations that require more control over their infrastructure. This version allows you to host Tuist on your own infrastructure, ensuring that your data remains secure and private.
 
-> [!IMPORTANT] ENTERPRISE CUSTOMERS ONLY
-> The on-premise version of Tuist is available only for organizations on the Enterprise plan. If you are interested in this version, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).
+> [!IMPORTANT] LICENSE REQUIRED
+> Self-hosting Tuist requires a legally valid paid license. The on-premise version of Tuist is available only for organizations on the Enterprise plan. If you are interested in this version, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).
 
 ## Release cadence {#release-cadence}
 
-The Tuist server is **released every Monday** and the version name follows the convention name `{MAJOR}.YY.MM.DD`. The date component is used to warn the CLI user if their hosted version is 60 days older than the release date of the CLI. It's crucial that on-premise organizations keep up with Tuist updates to ensure their developers benefit from the most recent improvements and that we can drop deprecated features with the confidence that we are not breaking any of the on-premise setups.
+We release new versions of Tuist continuously as new releasable changes land on main. We follow [semantic versioning](https://semver.org/) to ensure predictable versioning and compatibility.
 
-The major component of the CLI is used to flag breaking changes in the Tuist server that will require coordination with the on-premise users. You should not expect us to use it, and in case we needed, rest asure we'll work with you in making the transition smooth.
+The major component is used to flag breaking changes in the Tuist server that will require coordination with the on-premise users. You should not expect us to use it, and in case we needed, rest assured we'll work with you in making the transition smooth.
 
-> [!NOTE] RELEASE NOTES
-> You'll be given access to a `tuist/registry` repository associated with the registry where images are published. Every new released will be published in that repository as a GitHub release and will contain release notes to inform you about what changes come with it.
+## Continuous deployment {#continuous-deployment}
+
+We strongly recommend setting up a continuous deployment pipeline that automatically deploys the latest version of Tuist every day. This ensures you always have access to the latest features, improvements, and security updates.
+
+Here's an example GitHub Actions workflow that checks for and deploys new versions daily:
+
+```yaml
+name: Update Tuist Server
+on:
+  schedule:
+    - cron: '0 3 * * *' # Run daily at 3 AM UTC
+  workflow_dispatch: # Allow manual runs
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and deploy latest version
+        run: |
+          # Your deployment commands here
+          # Example: docker pull ghcr.io/tuist/tuist:latest
+          # Deploy to your infrastructure
+```
 
 ## Runtime requirements {#runtime-requirements}
 
@@ -183,25 +204,27 @@ On top of the `TUIST_GITHUB_APP_CLIENT_ID` and `TUIST_GITHUB_APP_CLIENT_SECRET`,
 
 ## Deployment {#deployment}
 
-On-premise users are granted access to the repository located at [tuist/registry](https://github.com/cloud/registry) which has a linked container registry for pulling images. Currently, the container registry allows authentication only as an individual user. Therefore, users with repository access must generate a **personal access token** within the Tuist organization, ensuring they have the necessary permissions to read packages. After submission, we will promptly approve this token.
-
-> [!IMPORTANT] USER VS ORGANIZATION-SCOPED TOKENS
-> Using a personal access token presents a challenge because it's associated with an individual who might eventually depart from the enterprise organization. GitHub recognizes this limitation and is actively developing a solution to allow GitHub apps to authenticate with app-generated tokens.
+The official Tuist Docker image is available at:
+```
+ghcr.io/tuist/tuist
+```
 
 ### Pulling the Docker image {#pulling-the-docker-image}
 
-After generating the token, you can retrieve the image by executing the following command:
+You can retrieve the image by executing the following command:
 
 ```bash
-echo $TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 docker pull ghcr.io/tuist/tuist:latest
+```
+
+Or pull a specific version:
+```bash
+docker pull ghcr.io/tuist/tuist:0.1.0
 ```
 
 ### Deploying the Docker image {#deploying-the-docker-image}
 
 The deployment process for the Docker image will differ based on your chosen cloud provider and your organization's continuous deployment approach. Since most cloud solutions and tools, like [Kubernetes](https://kubernetes.io/), utilize Docker images as fundamental units, the examples in this section should align well with your existing setup.
-
-We recommend establishing a deployment pipeline that that runs **every Tuesday**, pulling and deploying fresh images. This ensures you consistently benefit from the latest improvements.
 
 > [!IMPORTANT]
 > If your deployment pipeline needs to validate that the server is up and running, you can send a `GET` HTTP request to `/ready` and assert a `200` status code in the response.

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -2,26 +2,6 @@ defmodule Tuist.Environment do
   @moduledoc false
   @env Mix.env()
 
-  defmodule Version do
-    @moduledoc ~S"""
-    A module that represents a Tuist version.
-    Tuist versions follow the convention MAJOR.YY.MM.DD.
-    """
-    @type t :: %{
-            major: integer(),
-            date: Date.t()
-          }
-    @enforce_keys [:major, :date]
-
-    defstruct [:major, :date]
-  end
-
-  defimpl String.Chars, for: Version do
-    def to_string(version) do
-      "#{version.major}.#{Timex.format!(version.date, "{YY}.{0M}.{0D}")}"
-    end
-  end
-
   def env do
     @env
   end
@@ -140,28 +120,9 @@ defmodule Tuist.Environment do
   end
 
   def version do
-    version = get([:version])
-
-    case version do
-      nil ->
-        %Version{major: "1", date: Date.utc_today()}
-
-      "" ->
-        %Version{major: "1", date: Date.utc_today()}
-
-      version ->
-        [major, yy, mm, dd] = String.split(version, ".")
-
-        date =
-          "#{yy}-#{mm}-#{dd}"
-          |> Timex.parse("%y-%m-%d", :strftime)
-          |> case do
-            {:ok, date} -> date
-            # Fallback in case of error
-            {:error, _} -> Date.utc_today()
-          end
-
-        %Version{major: major, date: date}
+    case (get([:version]) || "0.1.0") |> Version.parse() do
+      :error -> nil
+      {:ok, version} -> version
     end
   end
 

--- a/server/lib/tuist_web/live/ops_configuration_live.ex
+++ b/server/lib/tuist_web/live/ops_configuration_live.ex
@@ -31,7 +31,7 @@ defmodule TuistWeb.OpsConfigurationLive do
 
     rows = [
       # Displaying the version helps identify the running application version for debugging and operational purposes.
-      %{name: "Version", value: "#{version} (released #{Timex.from_now(version.date)})"},
+      %{name: "Version", value: "#{version}"},
       %{name: "S3 region", value: Tuist.Environment.s3_region()},
       %{
         name: "S3 request timeout",

--- a/server/lib/tuist_web/plugs/on_premise_plug.ex
+++ b/server/lib/tuist_web/plugs/on_premise_plug.ex
@@ -10,10 +10,8 @@ defmodule TuistWeb.OnPremisePlug do
   alias Tuist.License
   alias Tuist.Time
   alias TuistWeb.Authentication
-  alias TuistWeb.WarningsHeaderPlug
 
   def init(:api_license_validation), do: :api_license_validation
-  def init(:warn_on_outdated_cli), do: :warn_on_outdated_cli
   def init(:forward_marketing_to_dashboard), do: :forward_marketing_to_dashboard
 
   def call(conn, opts) do
@@ -46,57 +44,6 @@ defmodule TuistWeb.OnPremisePlug do
           message: "The license has expired. Please, contact contact@tuist.dev to renovate it."
         })
         |> halt()
-    end
-  end
-
-  def call_on_premise(conn, :warn_on_outdated_cli) do
-    cli_release_date_string =
-      conn |> get_req_header("x-tuist-cli-release-date") |> List.first()
-
-    cli_release_date_string =
-      if is_nil(cli_release_date_string) do
-        conn |> get_req_header("x-tuist-cloud-cli-release-date") |> List.first()
-      else
-        cli_release_date_string
-      end
-
-    cli_version = conn |> get_req_header("x-tuist-cli-version") |> List.first()
-
-    cli_version =
-      if is_nil(cli_version) do
-        conn |> get_req_header("x-tuist-cloud-cli-version") |> List.first()
-      else
-        cli_version
-      end
-
-    if cli_release_date_string != nil and not Environment.tuist_hosted?() do
-      cli_release_date =
-        cli_release_date_string |> String.replace(".", "-") |> Date.from_iso8601!()
-
-      tuist_cloud_release_date = Environment.version().date
-
-      diff = Date.diff(cli_release_date, tuist_cloud_release_date)
-
-      cond do
-        # Tuist is 15 days behind (warning)
-        diff > 15 ->
-          WarningsHeaderPlug.put_warning(
-            conn,
-            "Your version of the Tuist server is 15 days behind the version of the CLI that you are using, #{cli_version}. Please update it to the latest version."
-          )
-
-        # Tuist is 4 months behind (warning)
-        diff < -(30 * 4) ->
-          WarningsHeaderPlug.put_warning(
-            conn,
-            "Your version of the Tuist CLI is 4 months behind the version of the Tuist server that you are using. We recommend updating the CLI to the latest version."
-          )
-
-        true ->
-          conn
-      end
-    else
-      conn
     end
   end
 

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -31,8 +31,10 @@ defmodule TuistWeb.Router do
       script_src_elem:
         "'self' 'nonce' https://cdn.jsdelivr.net https://esm.sh https://chat.cdn-plain.com https://*.posthog.com https://marketing.tuist.dev",
       font_src: "'self' https://fonts.gstatic.com data: https://fonts.scalar.com https://rsms.me",
-      frame_src: "'self' https://chat.cdn-plain.com https://*.tuist.dev https://newassets.hcaptcha.com",
-      connect_src: "'self' https://chat.cdn-plain.com  https://chat.uk.plain.com https://*.posthog.com"
+      frame_src:
+        "'self' https://chat.cdn-plain.com https://*.tuist.dev https://newassets.hcaptcha.com",
+      connect_src:
+        "'self' https://chat.cdn-plain.com  https://chat.uk.plain.com https://*.posthog.com"
   end
 
   pipeline :browser_app do
@@ -116,7 +118,6 @@ defmodule TuistWeb.Router do
 
   pipeline :on_premise_api do
     plug TuistWeb.OnPremisePlug, :api_license_validation
-    plug TuistWeb.OnPremisePlug, :warn_on_outdated_cli
   end
 
   pipeline :analytics do
@@ -140,7 +141,8 @@ defmodule TuistWeb.Router do
 
     get "/newsletter/rss.xml", MarketingController, :newsletter_rss, metadata: %{type: :marketing}
 
-    get "/newsletter/atom.xml", MarketingController, :newsletter_atom, metadata: %{type: :marketing}
+    get "/newsletter/atom.xml", MarketingController, :newsletter_atom,
+      metadata: %{type: :marketing}
 
     get "/sitemap.xml", MarketingController, :sitemap, metadata: %{type: :marketing}
   end
@@ -222,7 +224,10 @@ defmodule TuistWeb.Router do
 
     get "/ready", TuistWeb.PageController, :ready
     get "/api/docs", TuistWeb.APIController, :docs
-    get "/.well-known/apple-app-site-association", TuistWeb.AppleAppSiteAssociationController, :show
+
+    get "/.well-known/apple-app-site-association",
+        TuistWeb.AppleAppSiteAssociationController,
+        :show
   end
 
   scope path: "/api",
@@ -316,7 +321,8 @@ defmodule TuistWeb.Router do
 
     get "/organizations/:organization_name/usage", OrganizationsController, :usage
 
-    resources "/organizations/:organization_name/invitations", InvitationsController, only: [:create]
+    resources "/organizations/:organization_name/invitations", InvitationsController,
+      only: [:create]
 
     delete "/organizations/:organization_name/invitations", InvitationsController, :delete
 

--- a/server/test/tuist_web/plugs/on_premise_plug_test.exs
+++ b/server/test/tuist_web/plugs/on_premise_plug_test.exs
@@ -41,7 +41,8 @@ defmodule TuistWeb.OnPremisePlugTest do
       assert got.halted == true
 
       assert json_response(got, 422) == %{
-               "message" => "The license has expired. Please, contact contact@tuist.dev to renovate it."
+               "message" =>
+                 "The license has expired. Please, contact contact@tuist.dev to renovate it."
              }
     end
 
@@ -88,117 +89,6 @@ defmodule TuistWeb.OnPremisePlugTest do
 
       # Then
       assert got == conn
-    end
-  end
-
-  describe "warn_on_outdated_cli" do
-    test "returns the same connection if the environment is not on premise", %{conn: conn} do
-      # Given
-      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-      opts = OnPremisePlug.init(:warn_on_outdated_cli)
-
-      conn =
-        conn
-        |> put_req_header("x-tuist-cli-release-date", "2024.04.11")
-        |> put_req_header("x-tuist-cli-version", "1.2.3")
-
-      # When
-      got = OnPremisePlug.call(conn, opts)
-
-      # Then
-      assert got == conn
-    end
-
-    test "returns the same connection if the environment is on premise but the release date header is missing",
-         %{conn: conn} do
-      # Given
-      stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
-      opts = OnPremisePlug.init(:warn_on_outdated_cli)
-      conn = put_req_header(conn, "x-tuist-cli-version", "1.2.3")
-
-      # When
-      got = OnPremisePlug.call(conn, opts)
-
-      # Then
-      assert got == conn
-    end
-
-    test "returns the same connection with a warning if the environment is on premise, the deprecated headers are used, and Tuist is more than 15 days behind",
-         %{conn: conn} do
-      # Given
-      Tuist.Environment
-      |> stub(:tuist_hosted?, fn -> false end)
-      |> stub(:version, fn ->
-        %Tuist.Environment.Version{major: 1, date: Date.from_iso8601!("2024-01-01")}
-      end)
-
-      opts = OnPremisePlug.init(:warn_on_outdated_cli)
-
-      conn =
-        conn
-        |> put_req_header("x-tuist-cloud-cli-release-date", "2024.02.01")
-        |> put_req_header("x-tuist-cloud-cli-version", "1.2.3")
-
-      # When
-      got = OnPremisePlug.call(conn, opts)
-
-      # Then
-      [warning] = TuistWeb.WarningsHeaderPlug.get_warnings(got)
-
-      assert warning ==
-               "Your version of the Tuist server is 15 days behind the version of the CLI that you are using, 1.2.3. Please update it to the latest version."
-    end
-
-    test "returns the connection with a warning when it's on premise and Tuist is more than 15 days behind",
-         %{conn: conn} do
-      # Given
-      Tuist.Environment
-      |> stub(:tuist_hosted?, fn -> false end)
-      |> stub(:version, fn ->
-        %Tuist.Environment.Version{major: 1, date: Date.from_iso8601!("2024-01-01")}
-      end)
-
-      opts = OnPremisePlug.init(:warn_on_outdated_cli)
-
-      conn =
-        conn
-        |> put_req_header("x-tuist-cli-release-date", "2024.02.01")
-        |> put_req_header("x-tuist-cli-version", "1.2.3")
-
-      # When
-      got = OnPremisePlug.call(conn, opts)
-
-      # Then
-      [warning] = TuistWeb.WarningsHeaderPlug.get_warnings(got)
-
-      assert warning ==
-               "Your version of the Tuist server is 15 days behind the version of the CLI that you are using, 1.2.3. Please update it to the latest version."
-    end
-
-    test "returns the connection with a warning when it's on premise and the CLI is more than one month behind",
-         %{conn: conn} do
-      # Given
-      Tuist.Environment
-      |> stub(:tuist_hosted?, fn -> false end)
-      |> stub(:version, fn ->
-        %Tuist.Environment.Version{major: 1, date: Date.from_iso8601!("2024-06-01")}
-      end)
-
-      opts = OnPremisePlug.init(:warn_on_outdated_cli)
-
-      conn =
-        conn
-        |> put_req_header("x-tuist-cli-release-date", "2024.01.01")
-        |> put_req_header("x-tuist-cli-version", "1.2.3")
-
-      # When
-      got = OnPremisePlug.call(conn, opts)
-
-      # Then
-      [warning] = TuistWeb.WarningsHeaderPlug.get_warnings(got)
-
-      assert warning ==
-               "Your version of the Tuist CLI is 4 months behind the version of the Tuist server that you are using. We recommend updating the CLI to the latest version."
     end
   end
 


### PR DESCRIPTION
I noticed the interactions with canary resulted in a 5xx error, and led me to discover that the app was not launching. It turns out that with continuous releasing, which changes the versioning schema of the server, we have some startup logic that tries to parse the version and fails to do so.

This PR adjusts that logic to use semver. Moreover, it removes the warning that we had in a plug to tell on-premise users when the CLI was ahead or behind the server and that could cause issues. I first thought about pulling the date information from the GitHub API (and cache it to prevent rate limits), but I think it's better if we require on-premise to continuously deploy our updates. In other words, discourage that scenario by encouraging continuous deployment on their end too. I've updated the docs reflecting that, and took the opportunity to add a mention that self-hosting Tuist requires a paid license.