### PR TITLE
feat(cli): Ignore internal server errors when interating with the cache

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     paths:
+      - "cli/TuistCacheEE"
+      - "cli/TuistCacheEE/**"
       - "cli/Sources/**"
       - "cli/Tests/**"
       - "*.swift"

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+      - uses: amannn/action-semantic-pull-request@v5
         with:
-          ignoreCommits: "true"
-          commitTitleMatch: "false"
+          requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Tuist CLI uses pre-signed URLs to interact with S3 storages. Those can have outages, causing internal server errors. In those cases, we don't want the Tuist workflows to fail. This PR points to the latest `TuistCacheEE` version that handles those gracefully printing a warning instead of failing.

> [!NOTE]
> I've updated the GitHub Actions workflow that checks the conventional title of the PR to ensure that it also checks that we are including a scope.