### PR TITLE
feat(server): Include the fediverse creator tag in the marketing pages' posts

### DIFF
--- a/server/lib/tuist/marketing/blog.ex
+++ b/server/lib/tuist/marketing/blog.ex
@@ -45,7 +45,8 @@ defmodule Tuist.Marketing.Blog do
         "name" => "Pedro Piñera",
         "x_handle" => "pepicrft",
         "mastodon_url" => "https://mastodon.social/@pepicrft",
-        "github_handle" => "pepicrft"
+        "github_handle" => "pepicrft",
+        "fediverse_username" => "@pepicrft@mastodon.social"
       },
       "ollieatkinson" => %{
         "role" => "Senior software engineer at Monzo",
@@ -70,7 +71,8 @@ defmodule Tuist.Marketing.Blog do
         "name" => "Marek Fořt",
         "x_handle" => "marekfort",
         "mastodon_url" => "https://mastodon.social/@marekfort@mastodon.online",
-        "github_handle" => "fortmarek"
+        "github_handle" => "fortmarek",
+        "fediverse_username" => "@marekfort@mastodon.online"
       },
       "cpisciotta" => %{
         "role" => "Software engineer at Audible",
@@ -96,13 +98,15 @@ defmodule Tuist.Marketing.Blog do
         "role" => "Designer at Tuist",
         "name" => " Asmit Malakannawar ",
         "mastodon_url" => "https://mastodon.social/@asmitbm",
-        "github_handle" => "asmitbm"
+        "github_handle" => "asmitbm",
+        "fediverse_username" => "@asmitbm@mastodon.online"
       },
       "cschmatzler" => %{
         "role" => "Software Engineer at Tuist",
         "name" => "Christoph Schmatzler",
         "x_handle" => "cschmatzler",
-        "github_handle" => "cschmatzler"
+        "github_handle" => "cschmatzler",
+        "fediverse_username" => "@cschmatzler@fosstodon.org"
       }
     }
   end

--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -59,6 +59,7 @@ defmodule TuistWeb.LayoutComponents do
     <meta property="og:type" content="website" />
     <meta property="og:title" content={assigns[:head_title] || "Tuist"} />
     <meta property="og:description" content={assigns[:head_description] || default_description} />
+    <meta :if={not is_nil(assigns[:head_fediverse_creator])} name="fediverse:creator" content={assigns[:head_fediverse_creator]} />
 
     <%= if is_nil(assigns[:head_image]) do %>
       <meta

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -234,6 +234,7 @@ defmodule TuistWeb.Marketing.MarketingController do
       |> assign(:head_title, post.title)
       |> assign(:head_description, post.excerpt)
       |> assign(:head_keywords, post.tags)
+      |> assign(:head_fediverse_creator, author["fediverse_username"])
       |> assign(
         :head_image,
         if post.og_image_path do
@@ -266,20 +267,25 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   def pricing(conn, _params) do
     faqs = [
-      {gettext("Why is your pricing model more accessible compared to traditional enterprise models?"),
+      {gettext(
+         "Why is your pricing model more accessible compared to traditional enterprise models?"
+       ),
        gettext(
          ~S"""
          <p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with "contact sales" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>
          <p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>
          """,
-         read_more: "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
+         read_more:
+           "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
        )},
       {gettext("How can I estimate the cost of my project?"),
        gettext(
          "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
        )},
       {gettext("Is there a free trial on paid plans?"),
-       gettext("We have a generous free tier on every paid plan so you can try out the features before paying any money.")},
+       gettext(
+         "We have a generous free tier on every paid plan so you can try out the features before paying any money."
+       )},
       {gettext("Do you offer discounts for non-profits and open-source?"),
        gettext("Yes, we do. Please reach out to oss@tuist.io for more information.")}
     ]
@@ -323,7 +329,8 @@ defmodule TuistWeb.Marketing.MarketingController do
     |> assign(
       :head_image,
       Tuist.Environment.app_url(
-        path: "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
+        path:
+          "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
       )
     )
     |> assign(:head_twitter_card, "summary_large_image")


### PR DESCRIPTION
Mastodon added support for a new `<meta>` tag for publishers, so I'm adding support for it. When present, Mastodon mentions the author of the page under the preview. Example:

<img width="598" height="639" alt="image" src="https://github.com/user-attachments/assets/773549ea-9a30-430c-9a57-5e494a112f3e" />
