### PR TITLE
refactor: implement streaming read parallelism

### DIFF
--- a/server/lib/tuist/tasks.ex
+++ b/server/lib/tuist/tasks.ex
@@ -1,0 +1,16 @@
+defmodule Tuist.Tasks do
+  @moduledoc false
+  @task_timeout 60_000
+
+  def parallel_tasks(queries, opts \\ []) do
+    max_concurrency = Keyword.get(opts, :max_concurrency, 3)
+
+    queries
+    |> Task.async_stream(fn fun -> fun.() end,
+      max_concurrency: max_concurrency,
+      timeout: @task_timeout
+    )
+    |> Enum.to_list()
+    |> Enum.map(fn {:ok, result} -> result end)
+  end
+end

--- a/server/lib/tuist_web/live/builds_live.ex
+++ b/server/lib/tuist_web/live/builds_live.ex
@@ -82,18 +82,6 @@ defmodule TuistWeb.BuildsLive do
         _ -> opts
       end
 
-    analytics_tasks = [
-      Task.async(fn -> Analytics.build_duration_analytics(project.id, opts) end),
-      Task.async(fn -> Analytics.build_percentile_durations(project.id, 0.99, opts) end),
-      Task.async(fn -> Analytics.build_percentile_durations(project.id, 0.9, opts) end),
-      Task.async(fn -> Analytics.build_percentile_durations(project.id, 0.5, opts) end),
-      Task.async(fn -> Analytics.build_analytics(project.id, opts) end),
-      Task.async(fn ->
-        Analytics.build_analytics(project.id, Keyword.put(opts, :status, :failure))
-      end),
-      Task.async(fn -> Analytics.build_success_rate_analytics(project.id, opts) end)
-    ]
-
     [
       builds_duration_analytics,
       builds_p99_durations,
@@ -102,7 +90,7 @@ defmodule TuistWeb.BuildsLive do
       total_builds_analytics,
       failed_builds_analytics,
       build_success_rate_analytics
-    ] = Task.await_many(analytics_tasks, 10_000)
+    ] = Analytics.combined_builds_analytics(project.id, opts)
 
     socket
     |> assign(:builds_duration_analytics, builds_duration_analytics)

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -250,19 +250,12 @@ defmodule TuistWeb.OverviewLive do
       environment_label(analytics_environment)
     )
     |> then(fn socket ->
-      analytics_tasks = [
-        Task.async(fn -> Analytics.cache_hit_rate_analytics(opts) end),
-        Task.async(fn -> Analytics.selective_testing_analytics(opts) end),
-        Task.async(fn -> Analytics.build_duration_analytics(project.id, opts) end),
-        Task.async(fn -> Analytics.runs_duration_analytics("test", opts) end)
-      ]
-
       [
         binary_cache_hit_rate_analytics,
         selective_testing_analytics,
         build_analytics,
         test_analytics
-      ] = Task.await_many(analytics_tasks, 10_000)
+      ] = Analytics.combined_overview_analytics(project.id, opts)
 
       socket
       |> assign(:binary_cache_hit_rate_analytics, binary_cache_hit_rate_analytics)

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -161,16 +161,8 @@ defmodule TuistWeb.TestRunsLive do
 
     uri = URI.new!("?" <> URI.encode_query(params))
 
-    analytics_tasks = [
-      Task.async(fn -> Analytics.runs_analytics(project.id, "test", opts) end),
-      Task.async(fn ->
-        Analytics.runs_analytics(project.id, "test", Keyword.put(opts, :status, :failure))
-      end),
-      Task.async(fn -> Analytics.runs_duration_analytics("test", opts) end)
-    ]
-
     [test_runs_analytics, failed_test_runs_analytics, test_runs_duration_analytics] =
-      Task.await_many(analytics_tasks, 10_000)
+      Analytics.combined_test_runs_analytics(project.id, opts)
 
     analytics_selected_widget = analytics_selected_widget(params)
 


### PR DESCRIPTION
Creates a helper for asynchronously streaming multiple analytics result, and refactors existing usages from `Task.await_many/1` to use it.