### PR TITLE
feat(server): Show build time saved only for CI environments

### DIFF
--- a/server/assets/app/css/pages/overview.css
+++ b/server/assets/app/css/pages/overview.css
@@ -69,34 +69,6 @@
       display: flex;
       flex: 1;
       flex-direction: column;
-
-      & [data-part="footer"] {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        align-items: center;
-        gap: 6px;
-        margin-top: auto;
-
-        & [data-part="indicator"] {
-          align-self: stretch;
-          border-radius: var(--noora-radius-xsmall);
-          background-color: var(--noora-chart-legend-primary);
-          width: 6px;
-        }
-
-        & [data-part="title"] {
-          color: var(--noora-surface-label-secondary);
-          font: var(--noora-font-weight-medium) var(--noora-font-body-small);
-        }
-
-        & [data-part="value"] {
-          flex: 1;
-          color: var(--noora-surface-label-primary);
-          font: var(--noora-font-weight-medium) var(--noora-font-body-xsmall);
-          text-align: end;
-        }
-      }
     }
   }
 

--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -59,7 +59,11 @@ defmodule TuistWeb.LayoutComponents do
     <meta property="og:type" content="website" />
     <meta property="og:title" content={assigns[:head_title] || "Tuist"} />
     <meta property="og:description" content={assigns[:head_description] || default_description} />
-    <meta :if={not is_nil(assigns[:head_fediverse_creator])} name="fediverse:creator" content={assigns[:head_fediverse_creator]} />
+    <meta
+      :if={not is_nil(assigns[:head_fediverse_creator])}
+      name="fediverse:creator"
+      content={assigns[:head_fediverse_creator]}
+    />
 
     <%= if is_nil(assigns[:head_image]) do %>
       <meta

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -265,6 +265,10 @@ defmodule TuistWeb.OverviewLive do
       ] = Task.await_many(analytics_tasks, 10_000)
 
       socket
+      |> assign(
+        :build_time_analytics,
+        Analytics.build_time_analytics(opts)
+      )
       |> assign(:binary_cache_hit_rate_analytics, binary_cache_hit_rate_analytics)
       |> assign(:selective_testing_analytics, selective_testing_analytics)
       |> assign(:build_analytics, build_analytics)

--- a/server/lib/tuist_web/live/overview_live.html.heex
+++ b/server/lib/tuist_web/live/overview_live.html.heex
@@ -231,14 +231,15 @@
       </.card_section>
       <.card_section
         :if={
-          @build_time_analytics.total_time_saved != 0 &&
+          @analytics_environment == "ci" &&
+            @build_time_analytics.total_time_saved != 0 &&
             @build_time_analytics.total_build_time != 0
         }
         data-part="time-saved-card-chart-section"
       >
         <div data-part="legends">
           <.legend
-            title={gettext("Build time saved on CI")}
+            title={gettext("Build time saved")}
             value={
               Tuist.Utilities.DateFormatter.format_duration_from_milliseconds(
                 @build_time_analytics.total_time_saved,

--- a/server/lib/tuist_web/live/overview_live.html.heex
+++ b/server/lib/tuist_web/live/overview_live.html.heex
@@ -238,14 +238,14 @@
       >
         <div data-part="legends">
           <.legend
-            title={gettext("Build time saved")}
+            title={gettext("Build time saved on CI")}
             value={
               Tuist.Utilities.DateFormatter.format_duration_from_milliseconds(
                 @build_time_analytics.total_time_saved,
                 include_seconds: false
               )
             }
-            style="primary-translucent"
+            style="primary"
           />
         </div>
         <.chart
@@ -301,34 +301,11 @@
           }
           series={[
             %{
-              name: gettext("Actual build time"),
+              name: gettext("Saved"),
               type: "bar",
               stack: "total",
               itemStyle: %{
                 color: "var:noora-chart-legend-primary",
-                borderRadius: [4, 0, 0, 4]
-              },
-              data: [
-                if(@build_time_analytics.total_build_time < 3_600_000,
-                  do:
-                    ((@build_time_analytics.total_build_time -
-                        @build_time_analytics.total_time_saved) / 1000)
-                    |> Decimal.from_float()
-                    |> Decimal.round(1),
-                  else:
-                    ((@build_time_analytics.total_build_time -
-                        @build_time_analytics.total_time_saved) / 3_600_000)
-                    |> Decimal.from_float()
-                    |> Decimal.round(2)
-                )
-              ]
-            },
-            %{
-              name: gettext("Build time saved"),
-              type: "bar",
-              stack: "total",
-              itemStyle: %{
-                color: "var:noora-chart-legend-primary-translucent",
                 borderRadius: [0, 4, 4, 0]
               },
               data: [
@@ -347,17 +324,6 @@
           ]}
           x_axis_min={0}
         />
-        <div data-part="footer">
-          <div data-part="indicator" />
-          <span data-part="title">{gettext("Actual build time")}</span>
-          <span data-part="value">
-            {Tuist.Utilities.DateFormatter.format_duration_from_milliseconds(
-              @build_time_analytics.total_build_time -
-                @build_time_analytics.total_time_saved,
-              include_seconds: false
-            )}
-          </span>
-        </div>
       </.card_section>
     </div>
     <.empty_card_section

--- a/server/lib/tuist_web/live/overview_live.html.heex
+++ b/server/lib/tuist_web/live/overview_live.html.heex
@@ -229,7 +229,13 @@
           />
         </div>
       </.card_section>
-      <.card_section :if={false} data-part="time-saved-card-chart-section">
+      <.card_section
+        :if={
+          @build_time_analytics.total_time_saved != 0 &&
+            @build_time_analytics.total_build_time != 0
+        }
+        data-part="time-saved-card-chart-section"
+      >
         <div data-part="legends">
           <.legend
             title={gettext("Build time saved")}

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -267,25 +267,20 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   def pricing(conn, _params) do
     faqs = [
-      {gettext(
-         "Why is your pricing model more accessible compared to traditional enterprise models?"
-       ),
+      {gettext("Why is your pricing model more accessible compared to traditional enterprise models?"),
        gettext(
          ~S"""
          <p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with "contact sales" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>
          <p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>
          """,
-         read_more:
-           "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
+         read_more: "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
        )},
       {gettext("How can I estimate the cost of my project?"),
        gettext(
          "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
        )},
       {gettext("Is there a free trial on paid plans?"),
-       gettext(
-         "We have a generous free tier on every paid plan so you can try out the features before paying any money."
-       )},
+       gettext("We have a generous free tier on every paid plan so you can try out the features before paying any money.")},
       {gettext("Do you offer discounts for non-profits and open-source?"),
        gettext("Yes, we do. Please reach out to oss@tuist.io for more information.")}
     ]
@@ -329,8 +324,7 @@ defmodule TuistWeb.Marketing.MarketingController do
     |> assign(
       :head_image,
       Tuist.Environment.app_url(
-        path:
-          "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
+        path: "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
       )
     )
     |> assign(:head_twitter_card, "summary_large_image")


### PR DESCRIPTION
I'm bringing back the build time saved as a graph in the project overview page, but I'm only showing it in the case of CI environments. 

Why only for CI? In CI we can assume an action will follow the generation from which we've obtain the time that would be saved. The same is not true for local environments, where a generation can be followed by a handful of compilations (clean or not) that we can't trace. 

Since the page has an environment filter, I show/hide the graph based on the value of the filter as shown in the screenshot below:

<img width="593" height="541" alt="image" src="https://github.com/user-attachments/assets/250bfe51-4da3-4c2d-a81a-f86660f1add2" />
