### PR TITLE
fix(server): Fix empty release notes in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,15 +401,16 @@ jobs:
 
       - name: Get release notes
         id: release-notes
+        working-directory: server
         run: |
           # Get the latest server version tag
           LATEST_VERSION=$(git tag -l | grep -E "^server@[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
 
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
           if [ -n "$LATEST_VERSION" ]; then
-            git cliff --include-path "server/**/*" --config cliff.toml --repository "." 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "server/**/*" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           else
-            git cliff --include-path "server/**/*" --config cliff.toml --repository "." 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "server/**/*" --config cliff.toml --repository "../" 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           fi
           echo "EOF" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
I noticed our release notes for the server were empty. It turns out that the pipeline had an issue, which this PR addresses.

## Summary (Claude)
- Fixed the server release notes generation in the GitHub Actions workflow
- Server releases were showing empty release notes due to incorrect working directory

## Details
The issue was that the git cliff command for server releases was running from the root directory instead of the server directory. This caused it to not find the correct `cliff.toml` configuration file and fail to generate release notes properly.

### Changes made:
- Added `working-directory: server` to the release notes generation step
- Changed repository path from `"."` to `"../"` to match the CLI release pattern
- This ensures git cliff finds the correct configuration and generates proper release notes

## Test plan
- [x] Verified the same pattern is used in CLI releases which work correctly
- [ ] The next server release will validate that release notes are properly generated