### PR TITLE
chore(server): Fix fly.prod.toml configuration for multiple processes

### DIFF
--- a/server/fly.prod.toml
+++ b/server/fly.prod.toml
@@ -11,11 +11,7 @@ console_command = "/app/bin/tuist remote"
 [[vm]]
   size = "performance-1x"
   memory = "2gb"
-
-  [[vm.processes]]
-    app = "worker"
-    size = "shared-cpu-4x "
-    memory = "8gb"
+  processes = ["web"]
 
 [experimental]
   auto_rollback = true
@@ -36,9 +32,9 @@ console_command = "/app/bin/tuist remote"
   TUIST_S3_POOL_SIZE = "50"
 
 [[vm]]
-  cpu_kind = 'performance'
-  memory = "4096mb"
-  cpus = 2
+  size = "shared-cpu-4x"
+  memory = "8gb"
+  processes = ["worker"]
 
 [[services]]
   protocol = "tcp"
@@ -46,7 +42,7 @@ console_command = "/app/bin/tuist remote"
   auto_stop_machines = false
   auto_start_machines = false
   min_machines_running = 2
-  processes = ["app"]
+  processes = ["web"]
   http_options = { h2_backend = true }
 
   [[services.ports]]


### PR DESCRIPTION
Production deployments [are failing](https://github.com/tuist/tuist/actions/runs/16592983184/job/46933366424) because the fly.toml configuration introduced to separate the `web` and `worker` processes is invalid:

```
Run flyctl deploy -c fly.prod.toml --build-arg TUIST_HOSTED=1 --build-arg MIX_ENV=prod --build-arg TUIST_VERSION=0.1.0 --build-arg APP_REVISION=$GITHUB_SHA --wait-timeout 3600
WARN WARNING the config file at 'fly.prod.toml' is not valid: json: cannot unmarshal object into Go struct field Compute.vm.processes of type string
==> Verifying app config
Validating fly.prod.toml

   ✘json: cannot unmarshal object into Go struct field Compute.vm.processes of type string
Error: App configuration is not valid
```

This PR fixes the configuration file.

# Claude-generated summary

## Summary
- Fixed invalid fly.prod.toml configuration that was causing deployment failures
- Corrected the VM configuration syntax for multiple process groups

## Changes
- Removed invalid nested `[[vm.processes]]` structure that was causing JSON unmarshaling errors
- Created separate `[[vm]]` sections for web and worker processes as per Fly.io documentation
- Fixed service configuration to reference the correct process name ("web" instead of "app")
- Consolidated duplicate VM configurations

## Process Configuration
- **Web process**: performance-1x VM with 2GB memory
- **Worker process**: shared-cpu-4x VM with 8GB memory