### PR TITLE
Fix server releases being created without server-scoped commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,23 +138,22 @@ jobs:
             # Use git cliff to determine next version from the latest tag
             NEXT_VERSION=$(git cliff --include-path "server/**/*" --config cliff.toml --repository "." --bumped-version 2>/dev/null -- ${LATEST_VERSION}..HEAD)
 
-            # If git cliff returns empty or starts with a number (CLI version), check for changes
+            # If git cliff returns empty or starts with a number (CLI version), no server-scoped commits
             if [ -z "$NEXT_VERSION" ] || [[ "$NEXT_VERSION" =~ ^[0-9] ]]; then
-              # Check if there are any changes in server directory since last tag
-              if git diff --quiet ${LATEST_VERSION}..HEAD -- server/; then
-                # No changes, keep current version
-                NEXT_VERSION="${LATEST_VERSION#server@}"
-              else
-                # There are changes, extract version and bump patch
-                VERSION_NUM="${LATEST_VERSION#server@}"
-                IFS='.' read -r major minor patch <<< "$VERSION_NUM"
-                NEXT_VERSION="$major.$minor.$((patch + 1))"
-              fi
+              # No server-scoped conventional commits, keep current version
+              NEXT_VERSION="${LATEST_VERSION#server@}"
             fi
           else
-            # No server tags exist, default to 0.1.0
-            echo "No server tags found, defaulting to initial version"
-            NEXT_VERSION="0.1.0"
+            # No server tags exist, check if there are any server-scoped commits
+            COMMITS_OUTPUT=$(git cliff --include-path "server/**/*" --config cliff.toml --repository "." 2>/dev/null)
+            if [ -n "$COMMITS_OUTPUT" ]; then
+              # There are server-scoped commits, use git cliff to determine version
+              NEXT_VERSION=$(git cliff --include-path "server/**/*" --config cliff.toml --repository "." --bumped-version 2>/dev/null)
+            else
+              # No server-scoped commits found, use initial version
+              echo "No server tags or server-scoped commits found, defaulting to initial version"
+              NEXT_VERSION="0.1.0"
+            fi
           fi
 
           # Add server@ prefix if not present and remove any duplicate prefixes


### PR DESCRIPTION
## Summary

This PR fixes an issue where the server release automation was creating new releases even when there were no server-scoped conventional commits.

## Problem

The server release check in `.github/workflows/release.yml` had fallback logic that would:
1. First check for server-scoped commits using `git cliff`
2. If none were found, it would check if there were ANY changes in the `server/` directory
3. If any changes existed (even non-conventional commits), it would bump the patch version

This caused unnecessary server releases when changes were made to the server directory that didn't warrant a release (e.g., documentation updates, refactoring without conventional commit messages, etc.).

## Solution

The fix removes the generic change detection fallback and relies solely on `git cliff` to determine if there are releasable server-scoped commits. The server will only release when there are commits following the pattern:
- `feat(server): ...`
- `fix(server): ...`
- `perf(server): ...`
- etc.

This aligns with how the CLI and App releases work and ensures we only create releases for meaningful, properly scoped changes.

## Test plan

- [x] The workflow will only trigger server releases when there are server-scoped conventional commits
- [x] Non-conventional commits or commits without the `(server)` scope will not trigger a release
- [x] The initial version logic (when no tags exist) is preserved