### PR TITLE
feat(cli): support hashing transitive `.xcconfig` files

### DIFF
--- a/cli/Sources/TuistHasher/SettingsContentHasher.swift
+++ b/cli/Sources/TuistHasher/SettingsContentHasher.swift
@@ -12,11 +12,13 @@ public protocol SettingsContentHashing {
 /// is responsible for computing a hash that uniquely identifies some `Settings`
 public final class SettingsContentHasher: SettingsContentHashing {
     private let contentHasher: ContentHashing
+    private let xcconfigHasher: XCConfigContentHashing
 
     // MARK: - Init
 
-    public init(contentHasher: ContentHashing) {
+    public init(contentHasher: ContentHashing, xcconfigHasher: XCConfigContentHashing) {
         self.contentHasher = contentHasher
+        self.xcconfigHasher = xcconfigHasher
     }
 
     // MARK: - SettingsContentHashing
@@ -52,7 +54,7 @@ public final class SettingsContentHasher: SettingsContentHashing {
     private func hash(_ configuration: Configuration) async throws -> String {
         var configurationHash = try hash(configuration.settings)
         if let xcconfigPath = configuration.xcconfig {
-            let xcconfigHash = try await contentHasher.hash(path: xcconfigPath)
+            let xcconfigHash = try await xcconfigHasher.hash(path: xcconfigPath)
             configurationHash += xcconfigHash
         }
         return configurationHash

--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -40,6 +40,7 @@ public final class TargetContentHasher: TargetContentHashing {
 
     public convenience init(contentHasher: ContentHashing) {
         let platformConditionContentHasher = PlatformConditionContentHasher(contentHasher: contentHasher)
+        let xcconfigHasher = XCConfigContentHasher(contentHasher: contentHasher)
         self.init(
             contentHasher: contentHasher,
             sourceFilesContentHasher: SourceFilesContentHasher(
@@ -56,7 +57,7 @@ public final class TargetContentHasher: TargetContentHashing {
             headersContentHasher: HeadersContentHasher(contentHasher: contentHasher),
             deploymentTargetContentHasher: DeploymentTargetsContentHasher(contentHasher: contentHasher),
             plistContentHasher: PlistContentHasher(contentHasher: contentHasher),
-            settingsContentHasher: SettingsContentHasher(contentHasher: contentHasher),
+            settingsContentHasher: SettingsContentHasher(contentHasher: contentHasher, xcconfigHasher: xcconfigHasher),
             dependenciesContentHasher: DependenciesContentHasher(contentHasher: contentHasher)
         )
     }

--- a/cli/Sources/TuistHasher/XCConfigContentHasher.swift
+++ b/cli/Sources/TuistHasher/XCConfigContentHasher.swift
@@ -12,7 +12,7 @@ public protocol XCConfigContentHashing {
 
 /// `XCConfigContentHasher`
 /// is responsible for computing a hash that uniquely identifies some `xcconfig` file
-public final class XCConfigContentHasher: XCConfigContentHashing {
+public struct XCConfigContentHasher: XCConfigContentHashing {
     private let contentHasher: ContentHashing
     private let fileSystem: FileSysteming
 

--- a/cli/Sources/TuistHasher/XCConfigContentHasher.swift
+++ b/cli/Sources/TuistHasher/XCConfigContentHasher.swift
@@ -1,0 +1,44 @@
+import FileSystem
+import Foundation
+import Mockable
+import Path
+import TSCBasic
+import TuistCore
+
+@Mockable
+public protocol XCConfigContentHashing {
+    func hash(path: Path.AbsolutePath) async throws -> String
+}
+
+/// `XCConfigContentHasher`
+/// is responsible for computing a hash that uniquely identifies some `xcconfig` file
+public final class XCConfigContentHasher: XCConfigContentHashing {
+    private let contentHasher: ContentHashing
+    private let fileSystem: FileSysteming
+
+    // MARK: - Init
+
+    public init(contentHasher: ContentHashing, fileSystem: FileSysteming = FileSystem()) {
+        self.contentHasher = contentHasher
+        self.fileSystem = fileSystem
+    }
+
+    // MARK: - XCConfigContentHashing
+
+    public func hash(path: Path.AbsolutePath) async throws -> String {
+        let source = try await fileSystem.readTextFile(at: path)
+
+        let pattern = "#include\\s*\"([^'\"]+)\""
+        let includes = ((try? RegEx(pattern: pattern).matchGroups(in: source)) ?? []).joined()
+
+        var xcconfigHash = try contentHasher.hash(source)
+
+        for include in includes {
+            let includePath = try Path.AbsolutePath(validating: include, relativeTo: path.parentDirectory)
+            let hash = try await hash(path: includePath)
+            xcconfigHash += hash
+        }
+
+        return xcconfigHash
+    }
+}

--- a/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/SettingsContentHasherTests.swift
@@ -12,12 +12,14 @@ import XCTest
 final class SettingsContentHasherTests: TuistUnitTestCase {
     private var subject: SettingsContentHasher!
     private var contentHasher: MockContentHashing!
+    private var xcconfigHasher: MockXCConfigContentHashing!
     private let filePath1 = try! AbsolutePath(validating: "/file1")
 
     override func setUp() {
         super.setUp()
         contentHasher = .init()
-        subject = SettingsContentHasher(contentHasher: contentHasher)
+        xcconfigHasher = .init()
+        subject = SettingsContentHasher(contentHasher: contentHasher, xcconfigHasher: xcconfigHasher)
 
         given(contentHasher)
             .hash(Parameter<[String]>.any)
@@ -36,7 +38,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
     // MARK: - Tests
 
     func test_hash_whenRecommended_withXCConfig_callsContentHasherWithExpectedStrings() async throws {
-        given(contentHasher)
+        given(xcconfigHasher)
             .hash(path: .value(filePath1))
             .willReturn("xconfigHash")
 
@@ -61,7 +63,7 @@ final class SettingsContentHasherTests: TuistUnitTestCase {
     }
 
     func test_hash_whenEssential_withoutXCConfig_callsContentHasherWithExpectedStrings() async throws {
-        given(contentHasher)
+        given(xcconfigHasher)
             .hash(path: .value(filePath1))
             .willReturn("xconfigHash")
 

--- a/cli/Tests/TuistHasherTests/XCConfigContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/XCConfigContentHasherTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Mockable
+import Path
+import TuistCore
+import TuistTesting
+import XCTest
+
+@testable import TuistHasher
+
+final class XCConfigContentHasherTests: TuistUnitTestCase {
+    private var subject: XCConfigContentHasher!
+    private var contentHasher: MockContentHashing!
+
+    private var sourceFile1Path: AbsolutePath!
+    private var sourceFile2Path: AbsolutePath!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        contentHasher = .init()
+        subject = XCConfigContentHasher(contentHasher: contentHasher)
+
+        let temporaryDir = try temporaryPath()
+        sourceFile1Path = temporaryDir.appending(component: "xcconfigFile1")
+        sourceFile2Path = temporaryDir.appending(component: "xcconfigFile2")
+
+        given(contentHasher)
+            .hash(Parameter<String>.any)
+            .willProduce { $0 + "-hash" }
+    }
+
+    override func tearDown() {
+        sourceFile1Path = nil
+        sourceFile2Path = nil
+        subject = nil
+        contentHasher = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_hash_when_xcconfigHasNoIncludes() async throws {
+        // Given
+        try await fileSystem.writeText("xcconfigFile1", at: sourceFile1Path)
+
+        // When
+        let hash = try await subject.hash(path: sourceFile1Path)
+
+        // Then
+        XCTAssertEqual(
+            hash,
+            "xcconfigFile1-hash"
+        )
+    }
+
+    func test_hash_when_xcconfigHasRelativeInclude() async throws {
+        // Given
+        try await fileSystem.writeText(
+            """
+            #include "xcconfigFile2"
+            xcconfigFile1
+            """,
+            at: sourceFile1Path
+        )
+        try await fileSystem.writeText("xcconfigFile2", at: sourceFile2Path)
+
+        // When
+        let hash = try await subject.hash(path: sourceFile1Path)
+
+        // Then
+        XCTAssertEqual(
+            hash,
+            """
+            #include "xcconfigFile2"
+            xcconfigFile1-hashxcconfigFile2-hash
+            """
+        )
+    }
+
+    func test_hash_when_xcconfigHasAbsoluteInclude() async throws {
+        // Given
+        try await fileSystem.writeText(
+            """
+            #include "\(sourceFile2Path.pathString)"
+            xcconfigFile1
+            """,
+            at: sourceFile1Path
+        )
+        try await fileSystem.writeText("xcconfigFile2", at: sourceFile2Path)
+
+        // When
+        let hash = try await subject.hash(path: sourceFile1Path)
+
+        // Then
+        XCTAssertEqual(
+            hash,
+            """
+            #include "\(sourceFile2Path.pathString)"
+            xcconfigFile1-hashxcconfigFile2-hash
+            """
+        )
+    }
+}


### PR DESCRIPTION
### Short description

> XCConfigContentHasher adds support to parse includes in xcconfig files and calculate its hashes properly. Currently when file included in xcconfig is changed it's target hash do not change, because original xcconfig not modified. To fix this issue XConfigHasher recursively calculates hash for all included files.

### How to test locally

> Add xcconfig to any target settings in fixtures. Add include of another config to first config. Check that changing second (included) xcconfig changes target hash respectively by running `tuist hash cache`.
