### PR TITLE
fix(cli): include project settings hash in target hash

### DIFF
--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -107,6 +107,8 @@ public final class TargetContentHasher: TargetContentHashing {
             settingsHash = nil
         }
 
+        let projectSettingsHash = try await settingsContentHasher.hash(settings: graphTarget.project.settings)
+
         let destinations = graphTarget.target.destinations.map(\.rawValue).sorted()
         let dependenciesHash = try await dependenciesContentHasher.hash(
             graphTarget: graphTarget,
@@ -120,6 +122,7 @@ public final class TargetContentHasher: TargetContentHashing {
                     [
                         projectHash,
                         graphTarget.target.product.rawValue,
+                        projectSettingsHash,
                         settingsHash,
                         dependenciesHash.hash,
                     ].compactMap { $0 } + destinations + additionalStrings
@@ -181,6 +184,8 @@ public final class TargetContentHasher: TargetContentHashing {
             let entitlementsHash = try await plistContentHasher.hash(plist: .entitlements(entitlements))
             stringsToHash.append(entitlementsHash)
         }
+
+        stringsToHash.append(projectSettingsHash)
 
         if let settingsHash {
             stringsToHash.append(settingsHash)

--- a/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheGraphContentHasherIntegrationTests.swift
@@ -193,8 +193,8 @@ struct ContentHashingIntegrationTests {
         )
 
         // Then
-        #expect(contentHash[framework1] == "73294b8f7af85fb40f2b33f6e8cab8f2")
-        #expect(contentHash[framework2] == "801057d42dff92e23a86de21c9e71eff")
+        #expect(contentHash[framework1] == "95f6c14ea2410a34fcc83b1845e15762")
+        #expect(contentHash[framework2] == "ebdaa10588d6f2553873df53b7e34d55")
     }
 
     // MARK: - Resources

--- a/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -94,7 +94,7 @@ struct TargetContentHasherTests {
         )
 
         // Then
-        #expect(got.hash == "hash-app-settings_hash-dependencies_hash-iPad-iPhone")
+        #expect(got.hash == "hash-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone")
     }
 
     @Test func hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
@@ -111,7 +111,10 @@ struct TargetContentHasherTests {
         )
 
         // Then
-        #expect(got.hash == "hash-app-settings_hash-dependencies_hash-iPad-iPhone-additional_string_one-additional_string_two")
+        #expect(
+            got.hash ==
+                "hash-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone-additional_string_one-additional_string_two"
+        )
     }
 
     @Test func hash_with_additional_strings() async throws {
@@ -133,7 +136,11 @@ struct TargetContentHasherTests {
         // Then
         #expect(
             got.hash ==
-                "Target-app-io.tuist.Target-Target-dependencies_hash-sources_hash-resources_hash-copy_files_hash-core_data_models_hash-target_scripts_hash-dictionary_hash-iPad-iPhone-additional_string-iPad-iPhone-deployment_targets_hash-settings_hash"
+                """
+                Target-app-io.tuist.Target-Target-dependencies_hash-sources_hash-resources_hash-copy_files_hash\
+                -core_data_models_hash-target_scripts_hash-dictionary_hash-iPad-iPhone-additional_string-iPad\
+                -iPhone-deployment_targets_hash-settings_hash-settings_hash
+                """
         )
     }
 


### PR DESCRIPTION
### Description 

Currently target hash does not include project settings hash. This leads to bug that changing project settings or project xcconfig do not change target hash. This PR adds project settings hash to target hash calculation.

### How to test locally

Change project settings in any fixture. Check that changing project settings also modifies target hash by running `tuist hash cache`

