### PR TITLE
fix(server): do not set charset for png preview responses

### DIFF
--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -65,7 +65,7 @@ defmodule TuistWeb.PreviewController do
       |> QRCode.render(:png)
 
     conn
-    |> put_resp_content_type("image/png")
+    |> put_resp_content_type("image/png", nil)
     |> send_resp(200, qr_code_image)
   end
 
@@ -82,7 +82,7 @@ defmodule TuistWeb.PreviewController do
 
     if Storage.object_exists?(object_key) do
       conn
-      |> put_resp_content_type("image/png")
+      |> put_resp_content_type("image/png", nil)
       |> send_chunked(:ok)
       |> stream_object(object_key)
     else

--- a/server/test/tuist_web/controllers/preview_controller_test.exs
+++ b/server/test/tuist_web/controllers/preview_controller_test.exs
@@ -232,7 +232,7 @@ defmodule TuistWeb.PreviewControllerTest do
 
       # Then
       assert response(conn, 200) =~ icon_content
-      assert get_resp_header(conn, "content-type") == ["image/png; charset=utf-8"]
+      assert get_resp_header(conn, "content-type") == ["image/png"]
     end
 
     test "returns 404 when the icon does not exist", %{conn: conn} do


### PR DESCRIPTION
We're sending extra `charset=utf8` as part of the content-type header when served dynamically. This is different from how we serve static images.

I'm trying to see if this can fix loading images on GitLab: https://github.com/tuist/tuist/issues/7963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image downloads to ensure correct response content type for PNG files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->