### PR TITLE
fix(cli): treat the new .icon asset as an opaque directory

### DIFF
--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -68,6 +68,7 @@ extension AbsolutePath {
             "bundle",
             "mlmodelc",
             "xcmappingmodel",
+            "icon",
         ]
         .contains(self.extension ?? "")
     }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/7923

The new `.icon` directory should be treated as a file (opaque directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of directories with the "icon" extension, ensuring they are treated as opaque and their contents are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->