### PR TITLE
feat(server): write xcode rows through ingestion buffer

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -10,6 +10,9 @@ defmodule Tuist.Application do
   alias Tuist.CommandEvents
   alias Tuist.DBConnection.TelemetryListener
   alias Tuist.Environment
+  alias Tuist.Xcode.XcodeGraph
+  alias Tuist.Xcode.XcodeProject
+  alias Tuist.Xcode.XcodeTarget
 
   require Logger
 
@@ -59,6 +62,9 @@ defmodule Tuist.Application do
         {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Phoenix.PubSub, name: Tuist.PubSub},
         Supervisor.child_spec(CommandEvents.Buffer, id: CommandEvents.Buffer),
+        Supervisor.child_spec(XcodeGraph.Buffer, id: XcodeGraph.Buffer),
+        Supervisor.child_spec(XcodeProject.Buffer, id: XcodeProject.Buffer),
+        Supervisor.child_spec(XcodeTarget.Buffer, id: XcodeTarget.Buffer),
         TuistWeb.Telemetry
       ]
 

--- a/server/lib/tuist/xcode/buffer/xcode_graph.ex
+++ b/server/lib/tuist/xcode/buffer/xcode_graph.ex
@@ -1,0 +1,39 @@
+defmodule Tuist.Xcode.XcodeGraph.Buffer do
+  @moduledoc false
+
+  alias Tuist.Ingestion.Buffer
+
+  %{
+    header: header,
+    insert_sql: insert_sql,
+    insert_opts: insert_opts,
+    fields: fields,
+    encoding_types: encoding_types
+  } = Tuist.Xcode.Clickhouse.XcodeGraph.buffer_opts()
+
+  def child_spec(opts) do
+    opts =
+      Keyword.merge(opts,
+        name: __MODULE__,
+        header: unquote(header),
+        insert_sql: unquote(insert_sql),
+        insert_opts: unquote(insert_opts)
+      )
+
+    Buffer.child_spec(opts)
+  end
+
+  def insert(xcode_graph) do
+    row_binary =
+      [Enum.map(unquote(fields), fn field -> Map.fetch!(xcode_graph, field) end)]
+      |> Ch.RowBinary._encode_rows(unquote(encoding_types))
+      |> IO.iodata_to_binary()
+
+    :ok = Buffer.insert(__MODULE__, row_binary)
+    {:ok, xcode_graph}
+  end
+
+  def flush do
+    Buffer.flush(__MODULE__)
+  end
+end

--- a/server/lib/tuist/xcode/buffer/xcode_project.ex
+++ b/server/lib/tuist/xcode/buffer/xcode_project.ex
@@ -1,0 +1,47 @@
+defmodule Tuist.Xcode.XcodeProject.Buffer do
+  @moduledoc false
+
+  alias Tuist.Ingestion.Buffer
+
+  %{
+    header: header,
+    insert_sql: insert_sql,
+    insert_opts: insert_opts,
+    fields: fields,
+    encoding_types: encoding_types
+  } = Tuist.Xcode.Clickhouse.XcodeProject.buffer_opts()
+
+  def child_spec(opts) do
+    opts =
+      Keyword.merge(opts,
+        name: __MODULE__,
+        header: unquote(header),
+        insert_sql: unquote(insert_sql),
+        insert_opts: unquote(insert_opts)
+      )
+
+    Buffer.child_spec(opts)
+  end
+
+  def insert(xcode_project_or_projects) do
+    :ok = Buffer.insert(__MODULE__, encode(xcode_project_or_projects))
+    {:ok, xcode_project_or_projects}
+  end
+
+  def flush do
+    Buffer.flush(__MODULE__)
+  end
+
+  defp encode(xcode_projects) when is_list(xcode_projects) do
+    xcode_projects
+    |> Enum.map(fn xcode_project ->
+      Enum.map(unquote(fields), fn field -> Map.fetch!(xcode_project, field) end)
+    end)
+    |> Ch.RowBinary._encode_rows(unquote(encoding_types))
+    |> IO.iodata_to_binary()
+  end
+
+  defp encode(xcode_project) do
+    encode([xcode_project])
+  end
+end

--- a/server/lib/tuist/xcode/buffer/xcode_target.ex
+++ b/server/lib/tuist/xcode/buffer/xcode_target.ex
@@ -1,0 +1,47 @@
+defmodule Tuist.Xcode.XcodeTarget.Buffer do
+  @moduledoc false
+
+  alias Tuist.Ingestion.Buffer
+
+  %{
+    header: header,
+    insert_sql: insert_sql,
+    insert_opts: insert_opts,
+    fields: fields,
+    encoding_types: encoding_types
+  } = Tuist.Xcode.Clickhouse.XcodeTarget.buffer_opts()
+
+  def child_spec(opts) do
+    opts =
+      Keyword.merge(opts,
+        name: __MODULE__,
+        header: unquote(header),
+        insert_sql: unquote(insert_sql),
+        insert_opts: unquote(insert_opts)
+      )
+
+    Buffer.child_spec(opts)
+  end
+
+  def insert(xcode_target_or_targets) do
+    :ok = Buffer.insert(__MODULE__, encode(xcode_target_or_targets))
+    {:ok, xcode_target_or_targets}
+  end
+
+  def flush do
+    Buffer.flush(__MODULE__)
+  end
+
+  defp encode(xcode_targets) when is_list(xcode_targets) do
+    xcode_targets
+    |> Enum.map(fn xcode_target ->
+      Enum.map(unquote(fields), fn field -> Map.fetch!(xcode_target, field) end)
+    end)
+    |> Ch.RowBinary._encode_rows(unquote(Macro.escape(encoding_types)))
+    |> IO.iodata_to_binary()
+  end
+
+  defp encode(xcode_target) do
+    encode([xcode_target])
+  end
+end

--- a/server/lib/tuist/xcode/clickhouse/xcode_graph.ex
+++ b/server/lib/tuist/xcode/clickhouse/xcode_graph.ex
@@ -1,6 +1,7 @@
 defmodule Tuist.Xcode.Clickhouse.XcodeGraph do
   @moduledoc false
   use Ecto.Schema
+  use Tuist.Ingestion.Bufferable
 
   @primary_key false
   schema "xcode_graphs" do

--- a/server/lib/tuist/xcode/clickhouse/xcode_project.ex
+++ b/server/lib/tuist/xcode/clickhouse/xcode_project.ex
@@ -1,6 +1,7 @@
 defmodule Tuist.Xcode.Clickhouse.XcodeProject do
   @moduledoc false
   use Ecto.Schema
+  use Tuist.Ingestion.Bufferable
 
   @primary_key false
   schema "xcode_projects" do

--- a/server/lib/tuist/xcode/clickhouse/xcode_target.ex
+++ b/server/lib/tuist/xcode/clickhouse/xcode_target.ex
@@ -1,6 +1,7 @@
 defmodule Tuist.Xcode.Clickhouse.XcodeTarget do
   @moduledoc false
   use Ecto.Schema
+  use Tuist.Ingestion.Bufferable
 
   @primary_key false
 

--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -1,10 +1,7 @@
-import Ecto.Query, only: [from: 2]
-
 alias Tuist.Accounts
 alias Tuist.AppBuilds.AppBuild
 alias Tuist.AppBuilds.Preview
 alias Tuist.Billing.Subscription
-alias Tuist.ClickHouseRepo
 alias Tuist.CommandEvents
 alias Tuist.CommandEvents.Clickhouse.Event
 alias Tuist.IngestRepo
@@ -239,7 +236,7 @@ command_events
 end)
 
 test_command_events =
-  ClickHouseRepo.all(from(c in Event, where: c.name == "test"))
+  Enum.filter(command_events, &(&1.name == "test"))
 
 test_command_events
 |> Enum.shuffle()
@@ -292,6 +289,10 @@ test_command_events
         ]
       }
     })
+
+  Tuist.Xcode.XcodeGraph.Buffer.flush()
+  Tuist.Xcode.XcodeProject.Buffer.flush()
+  Tuist.Xcode.XcodeTarget.Buffer.flush()
 
   xcode_targets =
     command_event.id

--- a/server/test/support/tuist_test_support/cases/data_case.ex
+++ b/server/test/support/tuist_test_support/cases/data_case.ex
@@ -36,6 +36,7 @@ defmodule TuistTestSupport.Cases.DataCase do
 
   setup tags do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
+
     :ok
   end
 

--- a/server/test/support/tuist_test_support/utilities.ex
+++ b/server/test/support/tuist_test_support/utilities.ex
@@ -7,11 +7,14 @@ defmodule TuistTestSupport.Utilities do
   end
 
   @doc """
-  Flushes the command events ingestion buffer after running the callback function.
+  Flushes the ingestion buffers after running the callback function.
   """
-  def with_flushed_command_events(fun) when is_function(fun, 0) do
+  def with_flushed_ingestion_buffers(fun) when is_function(fun, 0) do
     result = fun.()
     Tuist.CommandEvents.Buffer.flush()
+    Tuist.Xcode.XcodeGraph.Buffer.flush()
+    Tuist.Xcode.XcodeProject.Buffer.flush()
+    Tuist.Xcode.XcodeTarget.Buffer.flush()
     result
   end
 end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -143,7 +143,7 @@ defmodule Tuist.AccountsTest do
       _user = %{account: %{id: account_id}} = AccountsFixtures.user_fixture()
       _project = %{id: project_id} = ProjectsFixtures.project_fixture(account_id: account_id)
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project_id,
           remote_test_target_hits: ["Core"],
@@ -226,7 +226,7 @@ defmodule Tuist.AccountsTest do
       today = ~U[2025-01-02 23:00:00Z]
       stub(DateTime, :utc_now, fn -> today end)
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           name: "generate",
           project_id: first_user_project.id,
@@ -265,7 +265,7 @@ defmodule Tuist.AccountsTest do
       today = ~U[2025-01-02 23:00:00Z]
       stub(DateTime, :utc_now, fn -> today end)
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           name: "generate",
           project_id: first_user_project.id,
@@ -1413,7 +1413,7 @@ defmodule Tuist.AccountsTest do
       Accounts.add_user_to_organization(user, organization)
 
       command_event =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             name: "generate",
             project_id: project.id,

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -130,7 +130,7 @@ defmodule Tuist.CommandEventsTest do
     test "computes remote_cache_hits_count and remote_test_hits_count on insertion" do
       # When
       command_event =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             remote_cache_target_hits: ["A"],
             remote_test_target_hits: ["ATests"]
@@ -287,7 +287,7 @@ defmodule Tuist.CommandEventsTest do
       user = AccountsFixtures.user_fixture()
 
       command_event =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(name: "generate", user_id: user.id)
         end)
 
@@ -499,7 +499,7 @@ defmodule Tuist.CommandEventsTest do
       project_two = ProjectsFixtures.project_fixture()
 
       command_event_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "one",
@@ -508,7 +508,7 @@ defmodule Tuist.CommandEventsTest do
           )
         end)
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project_two.id,
           name: "xxx",
@@ -518,7 +518,7 @@ defmodule Tuist.CommandEventsTest do
       end)
 
       command_event_two =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "two",
@@ -528,7 +528,7 @@ defmodule Tuist.CommandEventsTest do
         end)
 
       command_event_three =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "three",
@@ -538,7 +538,7 @@ defmodule Tuist.CommandEventsTest do
         end)
 
       command_event_four =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "four",
@@ -548,7 +548,7 @@ defmodule Tuist.CommandEventsTest do
         end)
 
       command_event_five =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "five",
@@ -680,7 +680,7 @@ defmodule Tuist.CommandEventsTest do
       project = ProjectsFixtures.project_fixture()
       _project_two = ProjectsFixtures.project_fixture()
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         _command_event_one =
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
@@ -700,7 +700,7 @@ defmodule Tuist.CommandEventsTest do
       end)
 
       command_event_two =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "xcodebuild",
@@ -711,7 +711,7 @@ defmodule Tuist.CommandEventsTest do
         end)
 
       command_event_three =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "xcodebuild",
@@ -722,7 +722,7 @@ defmodule Tuist.CommandEventsTest do
         end)
 
       command_event_five =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             name: "test",
@@ -2073,7 +2073,7 @@ defmodule Tuist.CommandEventsTest do
       # Given
       project = ProjectsFixtures.project_fixture()
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           name: "test",
@@ -2160,7 +2160,7 @@ defmodule Tuist.CommandEventsTest do
       # Given
       project = ProjectsFixtures.project_fixture()
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           name: "test",
@@ -2208,7 +2208,7 @@ defmodule Tuist.CommandEventsTest do
       # Given
       project = ProjectsFixtures.project_fixture()
 
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           name: "test",

--- a/server/test/tuist/qa/agent_test.exs
+++ b/server/test/tuist/qa/agent_test.exs
@@ -203,7 +203,7 @@ defmodule Tuist.QA.AgentTest do
                  %{
                    role: :tool,
                    tool_results: [
-                     %LangChain.Message.ToolResult{
+                     %ToolResult{
                        content: ["Screenshot data"],
                        name: "screenshot"
                      }

--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -51,7 +51,10 @@ defmodule Tuist.XcodeTest do
       }
 
       # When
-      {:ok, xcode_graph} = Clickhouse.create_xcode_graph(xcode_data)
+      {:ok, xcode_graph} =
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(xcode_data)
+        end)
 
       # Then
       assert xcode_graph.name == "TestGraph"
@@ -157,24 +160,26 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       result = Clickhouse.has_selective_testing_data?(command_event)
@@ -188,24 +193,26 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       result = Clickhouse.has_selective_testing_data?(command_event)
@@ -219,24 +226,26 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       result = Clickhouse.has_binary_cache_data?(command_event)
@@ -250,24 +259,26 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       result = Clickhouse.has_binary_cache_data?(command_event)
@@ -281,32 +292,34 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  },
-                  %{
-                    "name" => "TestTarget2",
-                    "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
-                  },
-                  %{
-                    "name" => "TestTarget3",
-                    "selective_testing_metadata" => %{"hash" => "hash-3", "hit" => "miss"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    },
+                    %{
+                      "name" => "TestTarget2",
+                      "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
+                    },
+                    %{
+                      "name" => "TestTarget3",
+                      "selective_testing_metadata" => %{"hash" => "hash-3", "hit" => "miss"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When (with retry for materialized view population)
       {analytics, _meta} = Clickhouse.selective_testing_analytics(command_event)
@@ -329,36 +342,38 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "CacheGraph",
-            projects: [
-              %{
-                "name" => "CacheProject",
-                "path" => "CacheApp",
-                "targets" => [
-                  %{
-                    "name" => "CacheTarget1",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-1", "hit" => "local"}
-                  },
-                  %{
-                    "name" => "CacheTarget2",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-2", "hit" => "remote"}
-                  },
-                  %{
-                    "name" => "CacheTarget3",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-3", "hit" => "miss"}
-                  },
-                  %{
-                    "name" => "CacheTarget4",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-4", "hit" => "local"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "CacheGraph",
+              projects: [
+                %{
+                  "name" => "CacheProject",
+                  "path" => "CacheApp",
+                  "targets" => [
+                    %{
+                      "name" => "CacheTarget1",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-1", "hit" => "local"}
+                    },
+                    %{
+                      "name" => "CacheTarget2",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-2", "hit" => "remote"}
+                    },
+                    %{
+                      "name" => "CacheTarget3",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-3", "hit" => "miss"}
+                    },
+                    %{
+                      "name" => "CacheTarget4",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-4", "hit" => "local"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       {analytics, _meta} = Clickhouse.binary_cache_analytics(command_event)
@@ -834,19 +849,21 @@ defmodule Tuist.XcodeTest do
         end
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => targets
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => targets
+                }
+              ]
+            }
+          })
+        end)
 
       # When - First page (with retry for materialized view population)
       {result, meta} = Clickhouse.selective_testing_analytics(command_event, %{page_size: 10})
@@ -875,19 +892,21 @@ defmodule Tuist.XcodeTest do
         end
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "CacheGraph",
-            projects: [
-              %{
-                "name" => "CacheProject",
-                "path" => "CacheApp",
-                "targets" => targets
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "CacheGraph",
+              projects: [
+                %{
+                  "name" => "CacheProject",
+                  "path" => "CacheApp",
+                  "targets" => targets
+                }
+              ]
+            }
+          })
+        end)
 
       # When - First page (with retry for materialized view population)
       {result, meta} = Clickhouse.binary_cache_analytics(command_event, %{page_size: 10})
@@ -1007,32 +1026,34 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  },
-                  %{
-                    "name" => "TestTarget2",
-                    "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
-                  },
-                  %{
-                    "name" => "TestTarget3",
-                    "selective_testing_metadata" => %{"hash" => "hash-3", "hit" => "miss"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    },
+                    %{
+                      "name" => "TestTarget2",
+                      "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
+                    },
+                    %{
+                      "name" => "TestTarget3",
+                      "selective_testing_metadata" => %{"hash" => "hash-3", "hit" => "miss"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When (with retry for materialized view population)
       counts = Clickhouse.selective_testing_counts(command_event)
@@ -1049,36 +1070,38 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "CacheGraph",
-            projects: [
-              %{
-                "name" => "CacheProject",
-                "path" => "CacheApp",
-                "targets" => [
-                  %{
-                    "name" => "CacheTarget1",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-1", "hit" => "local"}
-                  },
-                  %{
-                    "name" => "CacheTarget2",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-2", "hit" => "remote"}
-                  },
-                  %{
-                    "name" => "CacheTarget3",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-3", "hit" => "miss"}
-                  },
-                  %{
-                    "name" => "CacheTarget4",
-                    "binary_cache_metadata" => %{"hash" => "cache-hash-4", "hit" => "miss"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "CacheGraph",
+              projects: [
+                %{
+                  "name" => "CacheProject",
+                  "path" => "CacheApp",
+                  "targets" => [
+                    %{
+                      "name" => "CacheTarget1",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-1", "hit" => "local"}
+                    },
+                    %{
+                      "name" => "CacheTarget2",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-2", "hit" => "remote"}
+                    },
+                    %{
+                      "name" => "CacheTarget3",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-3", "hit" => "miss"}
+                    },
+                    %{
+                      "name" => "CacheTarget4",
+                      "binary_cache_metadata" => %{"hash" => "cache-hash-4", "hit" => "miss"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When (with retry for materialized view population)
       counts = Clickhouse.binary_cache_counts(command_event)
@@ -1126,19 +1149,21 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "EmptyGraph",
-            projects: [
-              %{
-                "name" => "EmptyProject",
-                "path" => "EmptyApp",
-                "targets" => []
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "EmptyGraph",
+              projects: [
+                %{
+                  "name" => "EmptyProject",
+                  "path" => "EmptyApp",
+                  "targets" => []
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       counts = Clickhouse.selective_testing_counts(command_event)
@@ -1191,28 +1216,30 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
-                  },
-                  %{
-                    "name" => "TestTarget2",
-                    "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "selective_testing_metadata" => %{"hash" => "hash-1", "hit" => "local"}
+                    },
+                    %{
+                      "name" => "TestTarget2",
+                      "selective_testing_metadata" => %{"hash" => "hash-2", "hit" => "remote"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When - Call without flop params (with retry for materialized view population)
       {result, meta} = Clickhouse.selective_testing_analytics(command_event)
@@ -1269,28 +1296,30 @@ defmodule Tuist.XcodeTest do
       command_event = CommandEventsFixtures.command_event_fixture()
 
       {:ok, _xcode_graph} =
-        Clickhouse.create_xcode_graph(%{
-          command_event: command_event,
-          xcode_graph: %{
-            name: "TestGraph",
-            projects: [
-              %{
-                "name" => "TestProject",
-                "path" => "TestApp",
-                "targets" => [
-                  %{
-                    "name" => "TestTarget1",
-                    "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "miss"}
-                  },
-                  %{
-                    "name" => "TestTarget2",
-                    "binary_cache_metadata" => %{"hash" => "hash-2", "hit" => "miss"}
-                  }
-                ]
-              }
-            ]
-          }
-        })
+        with_flushed_ingestion_buffers(fn ->
+          Clickhouse.create_xcode_graph(%{
+            command_event: command_event,
+            xcode_graph: %{
+              name: "TestGraph",
+              projects: [
+                %{
+                  "name" => "TestProject",
+                  "path" => "TestApp",
+                  "targets" => [
+                    %{
+                      "name" => "TestTarget1",
+                      "binary_cache_metadata" => %{"hash" => "hash-1", "hit" => "miss"}
+                    },
+                    %{
+                      "name" => "TestTarget2",
+                      "binary_cache_metadata" => %{"hash" => "hash-2", "hit" => "miss"}
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        end)
 
       # When
       counts = Clickhouse.binary_cache_counts(command_event)

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -507,6 +507,9 @@ defmodule TuistWeb.AnalyticsControllerTest do
       response = json_response(conn, :ok)
 
       Tuist.CommandEvents.Buffer.flush()
+      Tuist.Xcode.XcodeGraph.Buffer.flush()
+      Tuist.Xcode.XcodeProject.Buffer.flush()
+      Tuist.Xcode.XcodeTarget.Buffer.flush()
       {:ok, command_event} = CommandEvents.get_command_event_by_id(response["id"])
 
       assert response == %{
@@ -920,7 +923,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       account = Accounts.get_account_by_id(project.account_id)
 
       command_event =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(project_id: project.id)
         end)
 

--- a/server/test/tuist_web/live/cache_runs_live_test.exs
+++ b/server/test/tuist_web/live/cache_runs_live_test.exs
@@ -23,7 +23,7 @@ defmodule TuistWeb.CacheRunsLiveTest do
       project: project
     } do
       # Given
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           user_id: user.id,
@@ -70,7 +70,7 @@ defmodule TuistWeb.CacheRunsLiveTest do
       project: project
     } do
       # Given
-      with_flushed_command_events(fn ->
+      with_flushed_ingestion_buffers(fn ->
         CommandEventsFixtures.command_event_fixture(
           project_id: project.id,
           user_id: user.id,

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -24,7 +24,7 @@ defmodule TuistWeb.GenerateRunsLiveTest do
     } do
       # Given
       _generate_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -41,7 +41,7 @@ defmodule TuistWeb.GenerateRunsLiveTest do
         end)
 
       _generate_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -88,7 +88,7 @@ defmodule TuistWeb.GenerateRunsLiveTest do
     } do
       # Given
       _generate_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -105,7 +105,7 @@ defmodule TuistWeb.GenerateRunsLiveTest do
         end)
 
       _generate_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,

--- a/server/test/tuist_web/live/run_detail_live_test.exs
+++ b/server/test/tuist_web/live/run_detail_live_test.exs
@@ -30,7 +30,7 @@ defmodule TuistWeb.RunDetailLiveTest do
     } do
       # Given
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "cache",
@@ -61,7 +61,7 @@ defmodule TuistWeb.RunDetailLiveTest do
       stub(CommandEvents, :has_result_bundle?, fn _ -> true end)
 
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "test",
@@ -88,7 +88,7 @@ defmodule TuistWeb.RunDetailLiveTest do
       stub(CommandEvents, :has_result_bundle?, fn _ -> false end)
 
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "test",
@@ -121,7 +121,7 @@ defmodule TuistWeb.RunDetailLiveTest do
     } do
       # Given
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "test",
@@ -160,7 +160,7 @@ defmodule TuistWeb.RunDetailLiveTest do
     } do
       # Given
       cache_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "cache",
@@ -202,7 +202,7 @@ defmodule TuistWeb.RunDetailLiveTest do
     } do
       # Given
       ci_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "cache",
@@ -233,7 +233,7 @@ defmodule TuistWeb.RunDetailLiveTest do
       stub(CommandEvents, :has_result_bundle?, fn _ -> true end)
 
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "test",
@@ -260,7 +260,7 @@ defmodule TuistWeb.RunDetailLiveTest do
       stub(CommandEvents, :has_result_bundle?, fn _ -> false end)
 
       test_run =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project: project,
             name: "test",

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -24,7 +24,7 @@ defmodule TuistWeb.TestRunsLiveTest do
     } do
       # Given
       _test_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -41,7 +41,7 @@ defmodule TuistWeb.TestRunsLiveTest do
         end)
 
       _test_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -91,7 +91,7 @@ defmodule TuistWeb.TestRunsLiveTest do
     } do
       # Given
       _test_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,
@@ -108,7 +108,7 @@ defmodule TuistWeb.TestRunsLiveTest do
         end)
 
       _test_run_one =
-        with_flushed_command_events(fn ->
+        with_flushed_ingestion_buffers(fn ->
           CommandEventsFixtures.command_event_fixture(
             project_id: project.id,
             user_id: user.id,


### PR DESCRIPTION
Adds buffers to efficiently insert xcode graphs, projects and targets in bulk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added buffered ingestion for Xcode graph, project, and target data, enabling more efficient batch processing and data handling.

* **Bug Fixes**
  * Improved buffer flushing in tests to ensure all relevant ingestion buffers are cleared, enhancing test reliability.

* **Tests**
  * Updated test helpers and test suites to use the new buffer flushing mechanism for Xcode ingestion buffers.
  * Enhanced test coverage by wrapping Xcode graph creation calls with buffer flushing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->