### PR TITLE
fix(server): handle xcresult upload with asynchronously inserted command events

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -143,22 +143,37 @@ defmodule Tuist.CommandEvents do
   end
 
   def get_result_bundle_key(command_event) do
-    "#{get_command_event_artifact_base_path_key(command_event)}/result_bundle.zip"
+    project = Repo.get!(Project, command_event.project_id)
+    account = Repo.get!(Account, project.account_id)
+    "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
   end
 
   def get_result_bundle_invocation_record_key(command_event) do
-    "#{get_command_event_artifact_base_path_key(command_event)}/invocation_record.json"
+    project = Repo.get!(Project, command_event.project_id)
+    account = Repo.get!(Account, project.account_id)
+    "#{account.name}/#{project.name}/runs/#{command_event.id}/invocation_record.json"
   end
 
   def get_result_bundle_object_key(command_event, result_bundle_object_id) do
-    "#{get_command_event_artifact_base_path_key(command_event)}/#{result_bundle_object_id}.json"
-  end
-
-  defp get_command_event_artifact_base_path_key(command_event) do
     project = Repo.get!(Project, command_event.project_id)
     account = Repo.get!(Account, project.account_id)
+    "#{account.name}/#{project.name}/runs/#{command_event.id}/#{result_bundle_object_id}.json"
+  end
 
-    "#{account.name}/#{project.name}/runs/#{command_event.id}"
+  def get_result_bundle_key(run_id, project) do
+    "#{get_command_event_artifact_base_path_key(run_id, project)}/result_bundle.zip"
+  end
+
+  def get_result_bundle_invocation_record_key(run_id, project) do
+    "#{get_command_event_artifact_base_path_key(run_id, project)}/invocation_record.json"
+  end
+
+  def get_result_bundle_object_key(run_id, project, result_bundle_object_id) do
+    "#{get_command_event_artifact_base_path_key(run_id, project)}/#{result_bundle_object_id}.json"
+  end
+
+  def get_command_event_artifact_base_path_key(run_id, project) do
+    "#{project.account.name}/#{project.name}/runs/#{run_id}"
   end
 
   def list_flaky_test_cases(%Project{} = project, attrs) do

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -768,7 +768,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       upload_id = "12344"
 
       object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
+        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/result_bundle.zip"
 
       expect(Storage, :multipart_start, fn ^object_key ->
         upload_id
@@ -801,7 +801,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       upload_id = "12344"
 
       object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.id}/some-id.json"
+        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/some-id.json"
 
       expect(Storage, :multipart_start, fn ^object_key ->
         upload_id
@@ -839,7 +839,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       upload_url = "https://url.com"
 
       object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
+        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/result_bundle.zip"
 
       expect(Storage, :multipart_generate_url, fn ^object_key,
                                                   ^upload_id,
@@ -882,7 +882,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       upload_id = "1234"
 
       object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
+        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/result_bundle.zip"
 
       parts = [
         %{part_number: 1, etag: "etag1"},
@@ -930,7 +930,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       upload_id = "1234"
 
       object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.id}/result_bundle.zip"
+        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/result_bundle.zip"
 
       parts = [
         %{part_number: 1, etag: "etag1"},


### PR DESCRIPTION
resolves #7970 

In CI, the CLI tries to immediately upload the `xcresult` file after uploading the command event metadata. For that, it requests an upload URL from the server; to generate that URL, the controller queries the event from the database. After #7942, that might lead to a race condition where the event hasn't materialised to the database yet, returning a 404.

This PR solves this by making the upload of the result bundle independent of the database state and just generating the URL based on the event identifier in the request.
1. For Postgres, the behavior stays the same. Events are still inserted synchronously and can be queried for their ID.
2. For Clickhouse, we _need_ to use the legacy integer identifier, since that is now derivable from the UUID. For older CLI versions, we just take the integer from the request, for newer versions, we derive it from the UUID in the request. We cannot derive the UUID from the integer, so the other direction wouldn't work.
3. I've removed test case handling from the controller completely for now, since we're reworking that _right now_ and also are making it asynchronous.