### PR TITLE
feat(cli): print the full sandbox command when a system command fails

### DIFF
--- a/cli/Sources/TuistSupport/System/System.swift
+++ b/cli/Sources/TuistSupport/System/System.swift
@@ -23,11 +23,14 @@ extension ProcessResult {
     /// If the command is executed through xcrun, then the name of the tool is returned instead.
     /// - Returns: Returns the command that the process executed.
     func command() -> String {
-        let command = arguments.first!
-        if command == "/usr/bin/xcrun" {
-            return arguments[1]
-        }
-        return command
+        let arguments: [String] = { [arguments] in
+            if arguments.first == "/usr/bin/xcrun" {
+                return Array(arguments.dropFirst())
+            } else {
+                return arguments
+            }
+        }()
+        return arguments.map { $0.spm_shellEscaped() }.joined(separator: " ")
     }
 }
 
@@ -40,15 +43,15 @@ public enum SystemError: FatalError, Equatable {
         switch self {
         case let .signalled(command, code, data):
             if data.count > 0, let string = String(data: data, encoding: .utf8) {
-                return "The '\(command)' was interrupted with a signal \(code) and message:\n\(string)"
+                return "The command `\(command)` was interrupted with a signal \(code) and message:\n\(string)"
             } else {
-                return "The '\(command)' was interrupted with a signal \(code)"
+                return "The command `\(command)` was interrupted with a signal \(code)"
             }
         case let .terminated(command, code, data):
             if data.count > 0, let string = String(data: data, encoding: .utf8) {
-                return "The '\(command)' command exited with error code \(code) and message:\n\(string)"
+                return "The command `\(command)` exited with error code \(code) and message:\n\(string)"
             } else {
-                return "The '\(command)' command exited with error code \(code)"
+                return "The command `\(command)` exited with error code \(code)"
             }
         case let .parseSwiftVersion(output):
             return "Couldn't obtain the Swift version from the output: \(output)."


### PR DESCRIPTION
Resolves https://tuist-community.slack.com/archives/C018QG7U7SN/p1750835310975249?thread_ts=1750667666.337849&cid=C018QG7U7SN

This logs the full command, which includes the sandbox profile, when a system command fails in the Tuist CLI. The intent is to provide a little more detail so that users can more easily notice sandbox violations.

### How to test locally

`TUIST_DISABLE_SANDBOX=NO tuig -p cli/Fixtures/ios_app_with_sandbox_disabled` with these changes to see log:

```
Loading and constructing the graph
It might take a while if the cache is empty


✖ Error
  The command `sandbox-exec -p '(version 1) 
  ; Deny all operations by default unless explicitly allowed 
  (deny default) 
  ; Import base system rules 
  (import "system.sb") 
  ; Allow process operations (fork, exec, etc.) 
  (allow process*) 
  ; Allow querying information about the current process 
  (allow process-info* (target self)) 
  ; Allow reading file metadata (permissions, size, etc.) 
  (allow file-read-metadata) 
  ; Allow reading and writing temporary and intermediate build files and caches 
  (allow file-read* file-write* (subpath "/private/tmp/")) 
  (allow file-read* file-write* (subpath "/private/var/")) 
  ; Allow reading from specified paths 
  (allow file-read* (subpath "/Applications/Xcode-16.4.0.app")) 
  (allow file-read* (subpath "/Users/hcampbell/Developer/tuist/cli/Fixtures/ios_app_with_sandbox_disabled/Project.swift")) 
  (allow file-read* (subpath "/Library/Preferences/com.apple.dt.Xcode.plist")) 
  (allow file-read* (subpath "/Users/hcampbell/Library/Developer/Xcode/DerivedData/Tuist-evqhqhjgivxrgbevvohdgopyjcvs/Build/Products/Debug"))' /usr/bin/xcrun swift -suppress-warnings -I /Users/hcampbell/Library/Developer/Xcode/DerivedData/Tuist-evqhqhjgivxrgbevvohdgopyjcvs/Build/Products/Debug -L /Users/hcampbell/Library/Developer/Xcode/DerivedData/Tuist-evqhqhjgivxrgbevvohdgopyjcvs/Build/Products/Debug -F /Users/hcampbell/Library/Developer/Xcode/DerivedData/Tuist-evqhqhjgivxrgbevvohdgopyjcvs/Build/Products/Debug -lProjectDescription -framework ProjectDescription /Users/hcampbell/Developer/tuist/cli/Fixtures/ios_app_with_sandbox_disabled/Project.swift --tuist-dump` was interrupted with a signal 5 and message: 
  Project/Project.swift:6: Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSCocoaErrorDomain Code=257 "The file “hosts” couldn’t be opened because you don’t have permission to view it." UserInfo={NSFilePath=/etc/hosts, NSURL=file:///etc/hosts, NSUnderlyingError=0x600000135350 {Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted"}} 
  Stack dump: 
  0.	Program arguments: /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -interpret /Users/hcampbell/Developer/tuist/cli/Fixtures/ios_app_with_sandbox_disabled/Project.swift -Xllvm -aarch64-use-tbi -enable-objc-interop -stack-check -sdk /Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk -I /Users/hcampbell/.local/share/mise/installs/tuist/4.57.1/bin -F /Users/hcampbell/.local/share/mise/installs/tuist/4.57.1/bin -suppress-warnings -new-driver-path /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-driver -empty-abi-descriptor -resource-dir /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift -module-name Project -disable-clang-spi -target-sdk-version 15.5 -target-sdk-name macosx15.5 -external-plugin-path /Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins#/Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/local/lib/swift/host/plugins#/Applications/Xcode-16.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -in-process-plugin-server-path /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode-16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -lProjectDescription -framework ProjectDescription -- --tuist-dump
  1.	Apple Swift version 6.1.2 (swiftlang-6.1.2.1.2 clang-1700.0.13.5)
  2.	Compiling with effective version 5.10
  3.	While running user code "/Users/hcampbell/Developer/tuist/cli/Fixtures/ios_app_with_sandbox_disabled/Project.swift"
  Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
  0  swift-frontend           0x000000010af0ae24 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
  1  swift-frontend           0x000000010af08c5c llvm::sys::RunSignalHandlers() + 112
  2  swift-frontend           0x000000010af0b460 SignalHandler(int) + 360
  3  libsystem_platform.dylib 0x000000018f92d6a4 _sigtramp + 56
  4  libswiftCore.dylib       0x00000001a10c41f8 $ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_SSAHSus6UInt32VtF + 176
  5  libswiftCore.dylib       0x00000001a1132378 swift_unexpectedError + 656
  6  libswiftCore.dylib       0x0000000116aec8ac swift_unexpectedError + 18446744071387719620
  7  libswiftCore.dylib       0x0000000116aec03c swift_unexpectedError + 18446744071387717460
  8  swift-frontend           0x0000000104eb14c4 llvm::orc::runAsMain(int (*)(int, char**), llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::optional<llvm::StringRef>) + 908
  9  swift-frontend           0x0000000104dc7870 swift::SwiftJIT::runMain(llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>) + 628
  10 swift-frontend           0x0000000104dd4c5c swift::RunImmediately(swift::CompilerInstance&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, swift::IRGenOptions const&, swift::SILOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>&&) + 1052
  11 swift-frontend           0x0000000104d61840 processCommandLineAndRunImmediately(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>&&, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::FrontendObserver*, int&) + 504
  12 swift-frontend           0x0000000104d5cffc performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 1980
  13 swift-frontend           0x0000000104d5c71c swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 2688
  14 swift-frontend           0x0000000104d5fe44 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 3796
  15 swift-frontend           0x0000000104d5dfd8 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3716
  16 swift-frontend           0x0000000104ce20bc swift::mainEntry(int, char const**) + 5428
  17 dyld                     0x000000018f552b98 start + 6076

  Sorry this didn’t work. Here’s what to try next:
   ▸ If the error is actionable, address it
   ▸ If the error is not actionable, let's discuss it in the Troubleshooting & how to
   ▸ If you are very certain it's a bug, file an issue
   ▸ Check out the logs at /Users/hcampbell/.local/state/tuist/logs/F2C389D6-E744-45D6-9E3E-66FA24419339.log
```
