### PR TITLE
fix(server): fix crash on unknown sorting parameters

### DIFF
--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -472,6 +472,8 @@ defmodule TuistWeb.BundleLive do
     Enum.sort_by(artifacts, & &1.size, :desc)
   end
 
+  defp sort_file_breakdown_artifacts(artifacts, _, _), do: artifacts
+
   defp sort_module_breakdown_artifacts(artifacts, "name", "asc") do
     Enum.sort_by(artifacts, & &1.name, :desc)
   end
@@ -487,6 +489,8 @@ defmodule TuistWeb.BundleLive do
   defp sort_module_breakdown_artifacts(artifacts, "size", "desc") do
     Enum.sort_by(artifacts, & &1.size, :desc)
   end
+
+  defp sort_module_breakdown_artifacts(artifacts, _, _), do: artifacts
 
   defp find_duplicates(artifacts) do
     all_artifacts = flatten_artifacts(artifacts)


### PR DESCRIPTION
resolves https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1036

only triggered by weird AI crawler behavior on `tuist/tuist` since that's public, but polluting our error reporting.