### PR TITLE
feat(cli): cache binaries by default for arm64 only, add --architectures option to specify architectures

### DIFF
--- a/cli/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/cli/Sources/TuistKit/Commands/CacheCommand.swift
@@ -28,6 +28,13 @@ public struct CacheCommand: AsyncParsableCommand {
     )
     var configuration: String?
 
+    @Option(
+        name: .long,
+        help: "Architectures to build for. If not specified, the binaries are built for arm64.",
+        envKey: .cacheArchitectures
+    )
+    var architectures: [MacArchitecture] = []
+
     @Argument(
         help: """
         A list of targets to cache. \
@@ -76,9 +83,12 @@ public struct CacheCommand: AsyncParsableCommand {
         try await Extension.cacheService.run(
             path: path,
             configuration: configuration,
+            architectures: architectures,
             targetsToBinaryCache: Set(targets),
             externalOnly: externalOnly,
             generateOnly: generateOnly
         )
     }
 }
+
+extension MacArchitecture: @retroactive ExpressibleByArgument {}

--- a/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/cli/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -307,6 +307,7 @@ public enum EnvKey: String, CaseIterable {
     case cacheConfiguration = "TUIST_CACHE_CONFIGURATION"
     case cachePath = "TUIST_CACHE_PATH"
     case cacheTargets = "TUIST_CACHE_TARGETS"
+    case cacheArchitectures = "TUIST_CACHE_ARCHITECTURES"
 
     // HASH CACHE
 


### PR DESCRIPTION
Implements: https://community.tuist.dev/t/cache-skip-building-in-x86-per-default/705/2

Right now, we're building for both `arm64` and `x86_64`. However, the majority of CI machines as well as engineering laptops are running on arm64 and building additionally for `x86_64` increases the build time, unnecessarily so.

We still allow teams to build for `x86_64`, but only as a fallback. The current macOS release is probably the last one supporting Intel chips, so we think this is the right time to change the default.