### PR TITLE
feat(cli): Add support for buildable folders

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "57ca9ad1a2fae3dcb958cd5001cc8069377467a183b14027e0df94b114f89a21",
+  "originHash" : "eb16746856ee92a2a4cb1b46b263734a23f9f0c47d5436b03c51652a8fc1c2db",
   "pins" : [
     {
       "identity" : "aexml",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "28c747b5ce661e8f79a4bcc3068392250d069f1c",
-        "version" : "0.11.0"
+        "revision" : "23bcf23ce85edb653817a34c42c5140b16a6132c",
+        "version" : "0.11.5"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit",
       "state" : {
-        "revision" : "d0b543aa795d83539691b80959b0adb152b072e7",
-        "version" : "0.35.1"
+        "revision" : "5a09d8ad1be010bcd58d8a39554480b19e0a45e1",
+        "version" : "0.37.0"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-fileio.git",
       "state" : {
-        "revision" : "23349fe1eb23c6ca2876d461a46ff60c0fa92f9c",
-        "version" : "0.9.0"
+        "revision" : "63daf8e8402789339ccc5a19d198ff0fcafd29d9",
+        "version" : "0.11.0"
       }
     },
     {
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {
@@ -402,8 +402,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "a5fea865badcb1c993c85b0f0e8d05a4bd2270fb",
-        "version" : "2.85.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {
@@ -537,8 +537,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeGraph",
       "state" : {
-        "revision" : "d65980cf291174ad007e8b265eab84590d0ea7e5",
-        "version" : "1.17.0"
+        "branch" : "buildable-folders",
+        "revision" : "8b129fe7994fcbdf2021f9731202834683227f09"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -590,7 +590,7 @@ let package = Package(
             url: "https://github.com/apple/swift-openapi-urlsession", .upToNextMajor(from: "1.0.2")
         ),
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.0")),
-        .package(url: "https://github.com/tuist/XcodeGraph", .upToNextMajor(from: "1.17.0")),
+        .package(url: "https://github.com/tuist/XcodeGraph", branch: "buildable-folders"),
         .package(url: "https://github.com/tuist/FileSystem.git", .upToNextMajor(from: "0.11.0")),
         .package(url: "https://github.com/tuist/Command.git", .upToNextMajor(from: "0.8.0")),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.4"),

--- a/cli/Fixtures/app_with_buildable_folders/.gitignore
+++ b/cli/Fixtures/app_with_buildable_folders/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/cli/Fixtures/app_with_buildable_folders/Project.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             infoPlist: .default,
             dependencies: [],
             buildableFolders: [
-                .folder(path: "Sources"),
                 .folder(path: "Resources"),
+                .folder(path: "Sources"),
             ]
         ),
     ]

--- a/cli/Fixtures/app_with_buildable_folders/Project.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Project.swift
@@ -1,0 +1,19 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .macOS,
+            product: .app,
+            bundleId: "dev.tuist.app-with-buildable-folders",
+            infoPlist: .default,
+            dependencies: [],
+            buildableFolders: [
+                .folder(path: "Sources"),
+                .folder(path: "Resources"),
+            ]
+        ),
+    ]
+)

--- a/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/Contents.json
+++ b/cli/Fixtures/app_with_buildable_folders/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/cli/Fixtures/app_with_buildable_folders/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Sources/AppWithBuildableFoldersApp.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Sources/AppWithBuildableFoldersApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppWithBuildableFoldersApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Sources/ContentView.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/cli/Fixtures/app_with_buildable_folders/Tuist.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/cli/Fixtures/app_with_buildable_folders/Tuist/Package.swift
+++ b/cli/Fixtures/app_with_buildable_folders/Tuist/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+#if TUIST
+    import struct ProjectDescription.PackageSettings
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,]
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "app_with_buildable_folders",
+    dependencies: [
+        // Add your own dependencies here:
+        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
+        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
+    ]
+)

--- a/cli/Sources/ProjectDescription/BuildableFolder.swift
+++ b/cli/Sources/ProjectDescription/BuildableFolder.swift
@@ -1,0 +1,14 @@
+/// A buildable folder (known as synchronized root group in pbxproj's lingo), it's
+/// a reference to a folder whose content will be resolved/synced by Xcode. It was
+/// introduced by Xcode in the version 16 to reduce frequent git conflicts caused
+/// by frequent file reference updates across branches.
+public struct BuildableFolder: Sendable, Codable, Equatable {
+    public var path: Path
+
+    /// Creates an instance of a buildable folder.
+    /// - Parameter path: Path to the buildable folder.
+    /// - Returns: An instance of buildable folder.
+    public static func folder(path: Path) -> Self {
+        Self(path: path)
+    }
+}

--- a/cli/Sources/ProjectDescription/Target.swift
+++ b/cli/Sources/ProjectDescription/Target.swift
@@ -103,6 +103,9 @@ public struct Target: Codable, Equatable, Sendable {
     /// The target's metadata.
     public var metadata: TargetMetadata
 
+    /// The target's buildable folders.
+    public var buildableFolders: [BuildableFolder]
+
     public static func target(
         name: String,
         destinations: Destinations,
@@ -127,7 +130,8 @@ public struct Target: Codable, Equatable, Sendable {
         mergedBinaryType: MergedBinaryType = .disabled,
         mergeable: Bool = false,
         onDemandResourcesTags: OnDemandResourcesTags? = nil,
-        metadata: TargetMetadata = .default
+        metadata: TargetMetadata = .default,
+        buildableFolders: [BuildableFolder] = []
     ) -> Self {
         self.init(
             name: name,
@@ -153,7 +157,8 @@ public struct Target: Codable, Equatable, Sendable {
             mergedBinaryType: mergedBinaryType,
             mergeable: mergeable,
             onDemandResourcesTags: onDemandResourcesTags,
-            metadata: metadata
+            metadata: metadata,
+            buildableFolders: buildableFolders
         )
     }
 }

--- a/cli/Sources/TuistGenerator/Descriptors/ProjectDescriptor.swift
+++ b/cli/Sources/TuistGenerator/Descriptors/ProjectDescriptor.swift
@@ -61,7 +61,7 @@ public struct ProjectDescriptor {
                 mainGroup: mainGroup
             )
             let pbxproj = PBXProj(
-                objectVersion: 50,
+                objectVersion: 70,
                 archiveVersion: 10
             )
             pbxproj.add(object: mainGroup)

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -308,6 +308,12 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         pbxBuildFiles.forEach { pbxproj.add(object: $0) }
         sourcesBuildPhase.files = pbxBuildFiles
 
+        if !target.buildableFolders.isEmpty {
+            pbxproj.add(object: sourcesBuildPhase)
+            pbxTarget.buildPhases.append(sourcesBuildPhase)
+            return
+        }
+
         // Only add sources build phase if there are build files or if the product requires the sources build phase to be valid,
         // such as `.framework`
         switch target.product {

--- a/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -40,6 +40,13 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
                 archiveVersion: Xcode.LastKnown.archiveVersion
             )
         }
+
+        static var xcode16: ProjectConstants {
+            ProjectConstants(
+                objectVersion: 70,
+                archiveVersion: Xcode.LastKnown.archiveVersion
+            )
+        }
     }
 
     // MARK: - Attributes
@@ -337,6 +344,6 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
 
     private func determineProjectConstants() throws -> ProjectConstants {
         // TODO: Determine if this can be inferred by the set Xcode version
-        .xcode13
+        .xcode16
     }
 }

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -78,6 +78,9 @@ final class TargetGenerator: TargetGenerating {
         pbxproj.add(object: pbxTarget)
         pbxProject.targets.append(pbxTarget)
 
+        // Buildable folders
+        generateSynchronizedGroups(target: target, fileElements: fileElements, pbxTarget: pbxTarget)
+
         // Pre actions
         try buildPhaseGenerator.generateScripts(
             target.scripts.preScripts,
@@ -134,6 +137,17 @@ final class TargetGenerator: TargetGenerating {
         )
 
         return pbxTarget
+    }
+
+    private func generateSynchronizedGroups(target: Target, fileElements: ProjectFileElements, pbxTarget: PBXNativeTarget) {
+        for buildableFolder in target.buildableFolders {
+            guard let fileElement = fileElements.elements[buildableFolder.path],
+                  let synchronizedGroup = fileElement as? PBXFileSystemSynchronizedRootGroup else { continue }
+            if pbxTarget.fileSystemSynchronizedGroups == nil {
+                pbxTarget.fileSystemSynchronizedGroups = []
+            }
+            pbxTarget.fileSystemSynchronizedGroups?.append(synchronizedGroup)
+        }
     }
 
     func generateTargetDependencies(

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -1,0 +1,13 @@
+import Foundation
+import ProjectDescription
+import TuistCore
+import XcodeGraph
+
+extension XcodeGraph.BuildableFolder {
+    static func from(
+        manifest: ProjectDescription.BuildableFolder,
+        generatorPaths: GeneratorPaths
+    ) throws -> XcodeGraph.BuildableFolder {
+        return XcodeGraph.BuildableFolder(path: try generatorPaths.resolve(path: manifest.path))
+    }
+}

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -135,6 +135,10 @@ extension XcodeGraph.Target {
         }
 
         let metadata = XcodeGraph.TargetMetadata(tags: Set(manifest.metadata.tags))
+        let buildableFolders = try manifest.buildableFolders.map { try XcodeGraph.BuildableFolder.from(
+            manifest: $0,
+            generatorPaths: generatorPaths
+        ) }
 
         return XcodeGraph.Target(
             name: name,
@@ -163,7 +167,8 @@ extension XcodeGraph.Target {
             mergeable: manifest.mergeable,
             onDemandResourcesTags: onDemandResourcesTags,
             metadata: metadata,
-            type: type
+            type: type,
+            buildableFolders: buildableFolders
         )
     }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -579,7 +579,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
             resources: resources,
             headers: headers,
             dependencies: dependencies,
-            settings: settings
+            settings: settings,
+            buildableFolders: []
         )
     }
 

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -85,7 +85,8 @@ import TuistSupport
             settings: Settings? = nil,
             coreDataModels: [CoreDataModel] = [],
             environment: [String: String] = [:],
-            metadata: TargetMetadata = .default
+            metadata: TargetMetadata = .default,
+            buildableFolders: [BuildableFolder] = []
         ) -> Target {
             .target(
                 name: name,
@@ -103,7 +104,8 @@ import TuistSupport
                 settings: settings,
                 coreDataModels: coreDataModels,
                 environmentVariables: environment.mapValues { .init(stringLiteral: $0) },
-                metadata: metadata
+                metadata: metadata,
+                buildableFolders: buildableFolders
             )
         }
     }

--- a/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -32,6 +32,29 @@ struct BuildAcceptanceTests {
             ]
         )
     }
+
+    @Test(
+        .withFixture("app_with_buildable_folders"),
+        .inTemporaryDirectory,
+        .withMockedEnvironment()
+    ) func app_with_buildable_folders() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        // When/Then
+        try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
+        try await TuistTest.run(
+            BuildCommand.self,
+            [
+                "App",
+                "--path",
+                fixtureDirectory.pathString,
+                "--derived-data-path",
+                temporaryDirectory.pathString,
+            ]
+        )
+    }
 }
 
 /// Build projects using Tuist build

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -651,10 +651,9 @@ struct BuildPhaseGeneratorTests {
         )
         for file in files {
             try fileElements.generate(
-                fileElement: GroupFileElement(
+                fileElement: GroupFileElement.folder(
                     path: file,
-                    group: .group(name: "Project"),
-                    isReference: true
+                    group: .group(name: "Project")
                 ),
                 groups: groups,
                 pbxproj: pbxproj,
@@ -703,10 +702,9 @@ struct BuildPhaseGeneratorTests {
         )
         for file in files {
             try fileElements.generate(
-                fileElement: GroupFileElement(
+                fileElement: GroupFileElement.folder(
                     path: file,
-                    group: .group(name: "Project"),
-                    isReference: true
+                    group: .group(name: "Project")
                 ),
                 groups: groups,
                 pbxproj: pbxproj,

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -69,17 +69,17 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         // Then
         XCTAssertTrue(files.isSuperset(of: [
-            GroupFileElement(path: "/project/debug.xcconfig", group: project.filesGroup),
-            GroupFileElement(path: "/project/release.xcconfig", group: project.filesGroup),
-            GroupFileElement(path: "/path/to/file", group: project.filesGroup),
-            GroupFileElement(path: "/path/to/folder", group: project.filesGroup, isReference: true),
-            GroupFileElement(path: "/path/to/configuration.storekit", group: project.filesGroup),
+            GroupFileElement.file(path: "/project/debug.xcconfig", group: project.filesGroup),
+            GroupFileElement.file(path: "/project/release.xcconfig", group: project.filesGroup),
+            GroupFileElement.file(path: "/path/to/file", group: project.filesGroup),
+            GroupFileElement.folder(path: "/path/to/folder", group: project.filesGroup),
+            GroupFileElement.file(path: "/path/to/configuration.storekit", group: project.filesGroup),
         ]))
     }
 
     func test_addElement() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/myfolder/resources/a.png",
             group: .group(name: "Project")
         )
@@ -101,7 +101,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_withDotFolders() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/my.folder/resources/a.png",
             group: .group(name: "Project")
         )
@@ -123,10 +123,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_fileReference() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.folder(
             path: "/path/myfolder/resources/generated_images",
-            group: .group(name: "Project"),
-            isReference: true
+            group: .group(name: "Project")
         )
 
         // When
@@ -146,7 +145,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_parentDirectories() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/another/path/resources/a.png",
             group: .group(name: "Project")
         )
@@ -168,7 +167,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_xcassets() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/myfolder/resources/assets.xcassets",
             group: .group(name: "Project")
         )
@@ -190,7 +189,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_docc() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/myfolder/resources/ImportantDocumentation.docc",
             group: .group(name: "Project")
         )
@@ -212,7 +211,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
     func test_addElement_scnassets() throws {
         // Given
-        let element = GroupFileElement(
+        let element = GroupFileElement.file(
             path: "/path/myfolder/resources/assets.scnassets",
             group: .group(name: "Project")
         )
@@ -245,10 +244,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
 
         let elements = resources.map {
-            GroupFileElement(
+            GroupFileElement.folder(
                 path: $0,
-                group: .group(name: "Project"),
-                isReference: true
+                group: .group(name: "Project")
             )
         }
 
@@ -296,10 +294,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
 
         let elements = resources.map {
-            GroupFileElement(
+            GroupFileElement.folder(
                 path: $0,
-                group: .group(name: "Project"),
-                isReference: true
+                group: .group(name: "Project")
             )
         }
 
@@ -347,10 +344,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
 
         let elements = resources.map {
-            GroupFileElement(
+            GroupFileElement.file(
                 path: $0,
-                group: .group(name: "Project"),
-                isReference: true
+                group: .group(name: "Project")
             )
         }
 
@@ -425,28 +421,32 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             ),
             dependencies: [],
             playgrounds: ["/project/MyPlayground.playground"],
-            additionalFiles: [.file(path: try AbsolutePath(validating: "/project/README.md"))]
+            additionalFiles: [.file(path: try AbsolutePath(validating: "/project/README.md"))],
+            buildableFolders: [
+                BuildableFolder(path: "/project/buildable"),
+            ]
         )
 
         // When
-        let files = try subject.targetFiles(target: target)
+        let files = try subject.targetFiles(target: target, project: Project.test())
 
         // Then
         XCTAssertTrue(files.isSuperset(of: [
-            GroupFileElement(path: "/project/debug.xcconfig", group: target.filesGroup),
-            GroupFileElement(path: "/project/release.xcconfig", group: target.filesGroup),
-            GroupFileElement(path: "/project/file.swift", group: target.filesGroup),
-            GroupFileElement(path: "/project/MyPlayground.playground", group: target.filesGroup),
-            GroupFileElement(path: "/project/image.png", group: target.filesGroup),
-            GroupFileElement(path: "/project/reference", group: target.filesGroup, isReference: true),
-            GroupFileElement(path: "/project/public.h", group: target.filesGroup),
-            GroupFileElement(path: "/project/project.h", group: target.filesGroup),
-            GroupFileElement(path: "/project/private.h", group: target.filesGroup),
-            GroupFileElement(path: "/project/model.xcdatamodeld/1.xcdatamodel", group: target.filesGroup),
-            GroupFileElement(path: "/project/model.xcdatamodeld", group: target.filesGroup),
-            GroupFileElement(path: "/project/tuist.rtfd", group: target.filesGroup),
-            GroupFileElement(path: "/project/tuist.rtfd/TXT.rtf", group: target.filesGroup),
-            GroupFileElement(path: "/project/README.md", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/debug.xcconfig", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/release.xcconfig", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/file.swift", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/MyPlayground.playground", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/image.png", group: target.filesGroup),
+            GroupFileElement.folder(path: "/project/reference", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/public.h", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/project.h", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/private.h", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/model.xcdatamodeld/1.xcdatamodel", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/model.xcdatamodeld", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/tuist.rtfd", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/tuist.rtfd/TXT.rtf", group: target.filesGroup),
+            GroupFileElement.file(path: "/project/README.md", group: target.filesGroup),
+            GroupFileElement.synchronizedFolder(path: "/project/buildable", group: target.filesGroup),
         ]))
     }
 
@@ -590,7 +590,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         // Given
         let pbxproj = PBXProj()
         let path = try AbsolutePath(validating: "/a/b/c/file.swift")
-        let fileElement = GroupFileElement(path: path, group: .group(name: "SomeGroup"))
+        let fileElement = GroupFileElement.file(path: path, group: .group(name: "SomeGroup"))
         let project = Project.test(
             path: .root,
             sourceRootPath: .root,
@@ -995,9 +995,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(gpxFiles, [
-            GroupFileElement(path: "/gpx/A", group: filesGroup),
-            GroupFileElement(path: "/gpx/B", group: filesGroup),
-            GroupFileElement(path: "/gpx/C", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/A", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/B", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/C", group: filesGroup),
         ])
     }
 
@@ -1024,10 +1024,10 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(gpxFiles, [
-            GroupFileElement(path: "/gpx/A", group: filesGroup),
-            GroupFileElement(path: "/gpx/B", group: filesGroup),
-            GroupFileElement(path: "/gpx/C", group: filesGroup),
-            GroupFileElement(path: "/gpx/D", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/A", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/B", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/C", group: filesGroup),
+            GroupFileElement.file(path: "/gpx/D", group: filesGroup),
         ])
     }
 

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -1,39 +1,76 @@
 import Foundation
 import Path
+import Testing
 import TuistCore
 import XcodeGraph
 import XcodeProj
-import XCTest
 @testable import TuistGenerator
 
-final class TargetGeneratorTests: XCTestCase {
+struct TargetGeneratorTests {
     var path: AbsolutePath!
     var subject: TargetGenerator!
     var pbxproj: PBXProj!
     var pbxProject: PBXProject!
     var fileElements: ProjectFileElements!
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         path = try! AbsolutePath(validating: "/test")
         pbxproj = PBXProj()
         pbxProject = createPbxProject(pbxproj: pbxproj)
         fileElements = ProjectFileElements([:])
-
         subject = TargetGenerator()
     }
 
-    override func tearDown() {
-        subject = nil
-        fileElements = nil
-        pbxProject = nil
-        pbxproj = nil
-        path = nil
-        super.tearDown()
+    @Test func generateTarget_synchronizedGroups() async throws {
+        // Given
+        let buildableFolderPath = path.appending(component: "Sources")
+        let target = Target.test(
+            name: "MyFramework",
+            product: .framework,
+            scripts: [],
+            buildableFolders: [
+                BuildableFolder(path: buildableFolderPath),
+            ]
+        )
+        let project = Project.test(
+            path: path,
+            sourceRootPath: path,
+            xcodeProjPath: path.appending(component: "Test.xcodeproj"),
+            targets: [target]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(
+            project: project,
+            pbxproj: pbxproj
+        )
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // When
+        let generatedTarget = try await subject.generateTarget(
+            target: target,
+            project: project,
+            pbxproj: pbxproj,
+            pbxProject: pbxProject,
+            projectSettings: Settings.test(),
+            fileElements: fileElements,
+            path: path,
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        #expect(generatedTarget.fileSystemSynchronizedGroups?.count != 0)
+        let group = try #require(generatedTarget.fileSystemSynchronizedGroups?.first)
+        let groupAbsolutePath = try group.fullPath(sourceRoot: project.xcodeProjPath.pathString)
+        #expect(group.nameOrPath == "xxx")
     }
 
-    func test_generateTarget_productName() async throws {
+    @Test func generateTarget_productName() async throws {
         // Given
         let target = Target.test(
             name: "MyFramework",
@@ -85,25 +122,20 @@ final class TargetGeneratorTests: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(generatedTarget.productName, "MyFramework")
-        XCTAssertEqual(generatedTarget.productNameWithExtension(), "MyFramework.framework")
-        XCTAssertEqual(generatedTarget.productType, .framework)
+        #expect(generatedTarget.productName == "MyFramework")
+        #expect(generatedTarget.productNameWithExtension() == "MyFramework.framework")
+        #expect(generatedTarget.productType == .framework)
+        let preBuildPhase = try #require(generatedTarget.buildPhases.first(where: { $0.name() == "pre" }))
+        let postBuildPhase = try #require(generatedTarget.buildPhases.first(where: { $0.name() == "post" }))
 
-        guard let preBuildPhase = generatedTarget.buildPhases.first(where: { $0.name() == "pre" }),
-              let postBuildPhase = generatedTarget.buildPhases.first(where: { $0.name() == "post" })
-        else {
-            XCTFail("Failed to generate target with build phases pre and post")
-            return
-        }
+        #expect(preBuildPhase.inputFileListPaths == [])
+        #expect(preBuildPhase.outputFileListPaths == [])
 
-        XCTAssertEqual(preBuildPhase.inputFileListPaths, [])
-        XCTAssertEqual(preBuildPhase.outputFileListPaths, [])
-
-        XCTAssertEqual(postBuildPhase.inputFileListPaths, ["/tmp/b"])
-        XCTAssertEqual(postBuildPhase.outputFileListPaths, ["/tmp/d"])
+        #expect(postBuildPhase.inputFileListPaths == ["/tmp/b"])
+        #expect(postBuildPhase.outputFileListPaths == ["/tmp/d"])
     }
 
-    func test_generateTargetDependencies() async throws {
+    @Test func test_generateTargetDependencies() async throws {
         // Given
         let targetA = Target.test(
             name: "TargetA",
@@ -131,7 +163,7 @@ final class TargetGeneratorTests: XCTestCase {
                     from: .target(name: targetA.name, path: path),
                     to: .target(name: targetC.name, path: path)
                 ):
-                    try XCTUnwrap(.when([.ios])),
+                    .when([.ios])!,
             ]
         )
         let graphTraverser = GraphTraverser(graph: graph)
@@ -155,13 +187,13 @@ final class TargetGeneratorTests: XCTestCase {
         ]
 
         for (index, dependency) in nativeTargetA.dependencies.enumerated() {
-            XCTAssertEqual(dependency.name, expected[index].name)
-            XCTAssertEqual(dependency.platformFilter, expected[index].platformFilter)
-            XCTAssertEqual(dependency.platformFilters, expected[index].platformFilters)
+            #expect(dependency.name == expected[index].name)
+            #expect(dependency.platformFilter == expected[index].platformFilter)
+            #expect(dependency.platformFilters == expected[index].platformFilters)
         }
     }
 
-    func test_generateTarget_actions() async throws {
+    @Test func generateTarget_actions() async throws {
         // Given
         let graph = Graph.test()
         let graphTraverser = GraphTraverser(graph: graph)
@@ -212,14 +244,14 @@ final class TargetGeneratorTests: XCTestCase {
 
         // Then
         let preBuildPhase = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase
-        XCTAssertEqual(preBuildPhase?.name, "pre")
-        XCTAssertEqual(preBuildPhase?.shellPath, "/bin/sh")
-        XCTAssertEqual(preBuildPhase?.shellScript, "\"$SRCROOT\"/script.sh arg")
+        #expect(preBuildPhase?.name == "pre")
+        #expect(preBuildPhase?.shellPath == "/bin/sh")
+        #expect(preBuildPhase?.shellScript == "\"$SRCROOT\"/script.sh arg")
 
         let postBuildPhase = pbxTarget.buildPhases.last as? PBXShellScriptBuildPhase
-        XCTAssertEqual(postBuildPhase?.name, "post")
-        XCTAssertEqual(postBuildPhase?.shellPath, "/bin/sh")
-        XCTAssertEqual(postBuildPhase?.shellScript, "\"$SRCROOT\"/script.sh arg")
+        #expect(postBuildPhase?.name == "post")
+        #expect(postBuildPhase?.shellPath == "/bin/sh")
+        #expect(postBuildPhase?.shellScript == "\"$SRCROOT\"/script.sh arg")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Related: https://github.com/tuist/XcodeGraph/pull/266

Buildable folders (internally referred to as synchronized groups by Xcode projects) have been out since Xcode 16 as an official solution to frequent git conflicts. In the context of generated projects, which still play a role in helping with the complexities of modularization, not supporting them can worsen developer experiences such as adding/removing files without going through Xcode's UI (e.g. while using an agent).

This PR adds basic support for it:

```swift
let target = Target(
  name: "MyApp"
  buildableFolders: [
   .folder("Sources"),
   .folder("Resources")
  ] 
```

> [!NOTE]
> I leaned on aligning the naming with the term the community and Apple has used publicly because it should help make the feature more discoverable.