### PR TITLE
chore(cli): fix running CI from forks

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Generate TuistApp
         run: mise x -- tuist generate TuistApp
       - name: Build TuistApp
-        run: mise x -- tuist xcodebuild build -scheme TuistApp -destination "generic/platform=iOS Simulator" -workspace Tuist.xcworkspace CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        run: mise x -- tuist xcodebuild build -scheme TuistApp -destination "generic/platform=iOS Simulator" -workspace Tuist.xcworkspace CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCHS="arm64"
       - name: Share TuistApp
         if: |
           github.event_name == 'push' ||

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           github-token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           script: |
+            if (context.payload.pull_request.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo) {
+              core.setOutput('is-member', 'false');
+              return;
+            }
+
             try {
               const { data: membership } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'tuist',

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           github-token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           script: |
+            if (context.payload.pull_request.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo) {
+              core.setOutput('is-member', 'false');
+              return;
+            }
+
             try {
               const { data: membership } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'tuist',


### PR DESCRIPTION
CI workflows depending on the membership check are failing because the `GITHUB_TOKEN` is not available in forks (example: https://github.com/tuist/tuist/actions/runs/16798470803/job/47581058779?pr=7976).

If we recognize we're in a fork, we return early and set that the actor is not a member.