### PR TITLE
fix(cli): unexpected behaviours when renaming resources in cached targets

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -37,8 +37,16 @@ jobs:
         id: check
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TUIST_GITHUB_TOKEN }}
+          github-token: ${{ secrets.TUIST_GITHUB_TOKEN || github.token }}
           script: |
+            // If TUIST_GITHUB_TOKEN is not available (e.g., from a fork), treat as non-member
+            const token = '${{ secrets.TUIST_GITHUB_TOKEN }}';
+            if (!token || token === '') {
+              console.log(`Running from fork - treating ${context.payload.pull_request.user.login} as non-member`);
+              core.setOutput('is-member', 'false');
+              return;
+            }
+            
             try {
               const { data: membership } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'tuist',

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -59,8 +59,16 @@ jobs:
         id: check
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TUIST_GITHUB_TOKEN }}
+          github-token: ${{ secrets.TUIST_GITHUB_TOKEN || github.token }}
           script: |
+            // If TUIST_GITHUB_TOKEN is not available (e.g., from a fork), treat as non-member
+            const token = '${{ secrets.TUIST_GITHUB_TOKEN }}';
+            if (!token || token === '') {
+              console.log(`Running from fork - treating ${context.payload.pull_request.user.login} as non-member`);
+              core.setOutput('is-member', 'false');
+              return;
+            }
+            
             try {
               const { data: membership } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'tuist',

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,6 +1,7 @@
 name: conventional-pr
 on:
-  pull_request: {}
+  pull_request:
+    types: [opened, edited, synchronize]
 
 jobs:
   lint-pr:

--- a/cli/Sources/TuistHasher/ResourcesContentHasher.swift
+++ b/cli/Sources/TuistHasher/ResourcesContentHasher.swift
@@ -58,6 +58,7 @@ public struct ResourcesContentHasher: ResourcesContentHashing {
 
     private func hashResourceFileElement(element: ResourceFileElement) async throws -> MerkleNode {
         var children: [MerkleNode] = [
+            MerkleNode(hash: try contentHasher.hash(element.path.basename), identifier: "name"),
             MerkleNode(hash: try await contentHasher.hash(path: element.path), identifier: "content"),
             MerkleNode(hash: try contentHasher.hash(element.isReference), identifier: "isReference"),
             MerkleNode(hash: try contentHasher.hash(element.tags), identifier: "tags"),


### PR DESCRIPTION
### Short description 

> Currently resource name is not counted when calculating hash for target. So renaming resource, but leaving its content unchanged, don't update target hash. It can lead to unexpected behavior in runtime, missing images and even crashes. To fix it I've added resource name hash to resource hash.

### How to test locally

> Check target hash by print hashes command. Change resource name. Check that target hash has changed after rename.
