### PR TITLE
fix(cli): `tuist run` fails to run a scheme even though it has runnable targets

### DIFF
--- a/cli/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/cli/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -196,16 +196,12 @@ public final class BuildGraphInspector: BuildGraphInspecting {
     }
 
     public func runnableTarget(scheme: Scheme, graphTraverser: GraphTraversing) -> GraphTarget? {
-        guard let runTarget = scheme.runAction?.executable else { return nil }
-        return graphTraverser.target(
-            path: runTarget.projectPath,
-            name: runTarget.name
-        )
+        return graphTraverser.schemeRunnableTarget(scheme: scheme)
     }
 
     public func runnableSchemes(graphTraverser: GraphTraversing) -> [Scheme] {
         graphTraverser.schemes()
-            .filter { $0.runAction?.executable != nil }
+            .filter { graphTraverser.schemeRunnableTarget(scheme: $0) != nil }
             .sorted(by: { $0.name < $1.name })
     }
 

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -618,6 +618,14 @@ public class GraphTraverser: GraphTraversing {
         )
     }
 
+    public func schemeRunnableTarget(scheme: Scheme) -> GraphTarget? {
+        let specifiedExecutableTarget = scheme.runAction?.executable
+        let defaultTarget = scheme.buildAction?.targets.first
+        guard let target = specifiedExecutableTarget ?? defaultTarget else { return nil }
+        guard let graphTarget = self.target(path: target.projectPath, name: target.name) else { return nil }
+        return graphTarget.target.product.runnable ? graphTarget : nil
+    }
+
     public func copyProductDependencies(path: Path.AbsolutePath, name: String) -> Set<GraphDependencyReference> {
         guard let target = target(path: path, name: name) else { return Set() }
 

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -290,6 +290,11 @@ public protocol GraphTraversing {
         path: AbsolutePath,
         name: String
     ) -> Set<GraphDependency>
+
+    /// Given a scheme, it returns the runnable target.
+    /// - Parameter scheme: Scheme to check against.
+    /// - Returns: The runnable target if any.
+    func schemeRunnableTarget(scheme: Scheme) -> GraphTarget?
 }
 
 extension GraphTraversing {

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -442,28 +442,26 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         rootPath: AbsolutePath,
         generatedProjects: [AbsolutePath: GeneratedProject]
     ) throws -> XCScheme.LaunchAction? {
-        let specifiedExecutableTarget = scheme.runAction?.executable
-        let defaultTarget = defaultTargetReference(scheme: scheme)
-        guard let target = specifiedExecutableTarget ?? defaultTarget else { return nil }
-
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
         var pathRunnable: XCScheme.PathRunnable?
         var defaultBuildConfiguration = BuildConfiguration.debug.name
+        var graphTarget: GraphTarget?
 
         if let filePath = scheme.runAction?.filePath {
             pathRunnable = XCScheme.PathRunnable(filePath: filePath.pathString)
         } else {
-            guard let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
-            defaultBuildConfiguration = graphTarget.project.defaultDebugBuildConfigurationName
+            guard let graphRunnableTarget = graphTraverser.schemeRunnableTarget(scheme: scheme) else { return nil }
+            graphTarget = graphRunnableTarget
+            defaultBuildConfiguration = graphRunnableTarget.project.defaultDebugBuildConfigurationName
             guard let buildableReference = try createBuildableReference(
-                graphTarget: graphTarget,
+                graphTarget: graphRunnableTarget,
                 graphTraverser: graphTraverser,
                 rootPath: rootPath,
                 generatedProjects: generatedProjects
             ) else { return nil }
 
-            if graphTarget.target.product.runnable {
+            if graphRunnableTarget.target.product.runnable {
                 buildableProductRunnable = XCScheme.BuildableProductRunnable(
                     buildableReference: buildableReference,
                     runnableDebuggingMode: "0"
@@ -543,8 +541,6 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 launcherIdentifier = launchActionConstants.launcher
             }
         }
-
-        let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name)
 
         let customLLDBInitFilePath: RelativePath?
         if let customLLDBInitFile = scheme.runAction?.customLLDBInitFile,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7983

`tuist run` fails to run if the scheme doesn't explicitly specify the runnable targets. However, at generation time, we set as runnable the first runnable target from the build list, so schemes are indeed runnable. I've fixed that by aligning the generation and the run logic.

### How to test locally

You can use the reproducible project [in this isssue](https://github.com/tuist/tuist/issues/7983) and run `tuist run TuistRunExample-Debug`
