### PR TITLE
fix(cli): XCFramework signature

### DIFF
--- a/cli/Sources/TuistCore/MetadataProviders/XCFrameworkSignatureProvider.swift
+++ b/cli/Sources/TuistCore/MetadataProviders/XCFrameworkSignatureProvider.swift
@@ -52,7 +52,14 @@ public struct XCFrameworkSignatureProvider {
     }
 
     private static let signedWithAppleCertificateString = "Authority=Apple Root CA"
-    private static let teamNameRegExPattern = #"Authority=[^:]+?:\s*([^()]+)\s*\(([A-Z0-9]+)\)"#
+
+    /// Regex to find team name in signature description. Examples:
+    /// 1. Authority=iPhone Distribution: Tuist GmbH
+    /// 2. Authority=Developer ID Application: Tuist GmbH (U6LC622NKF)
+    private static let teamNameRegExPattern = #"Authority=[^:]+?:\s*([^()|^\n]+)\s*(\(([A-Z0-9]+)\))?"#
+
+    /// Regex to find team id in signature description. Example
+    /// TeamIdentifier=U6LC622NKF
     private static let teamIdentifierRegExPattern = #"TeamIdentifier=([A-Z0-9]+)"#
 
     /// Returns the signature of the XCFramework at the given `xcframeworkPath`.

--- a/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
+++ b/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
@@ -66,6 +66,27 @@ final class XCFrameworkSignatureProviderIntegrationTests: TuistUnitTestCase {
         XCTAssertEqual(result, .signedWithAppleCertificate(teamIdentifier: "U6LC622NKF", teamName: "Tuist GmbH"))
     }
 
+    func test_signature_appleSignedNoTeamIdInAuthority() async throws {
+        // Given
+        let codesignOutput = """
+        Identifier=SignedXCFramework
+        Authority=iPhone Distribution: Tuist GmbH
+        Authority=Developer ID Certification Authority
+        Authority=Apple Root CA
+        TeamIdentifier=U6LC622NKF
+        """
+
+        given(codesignController)
+            .signature(of: .value(path))
+            .willReturn(codesignOutput)
+
+        // When
+        let result = try await subject.signature(of: path)
+
+        // Then
+        XCTAssertEqual(result, .signedWithAppleCertificate(teamIdentifier: "U6LC622NKF", teamName: "Tuist GmbH"))
+    }
+
     func test_signature_selfSigned() async throws {
         // Given
         let codesign0FixturePath = fixturePath(


### PR DESCRIPTION
### Description 

1) This PR fixes regex for finding team name in codesign description which don't have team id in round brackets. Example of such description can be seen in Vungle SDK for iOS. 
```
Authority=iPhone Distribution: Vungle, Inc.
Authority=Apple Worldwide Developer Relations Certification Authority
Authority=Apple Root CA
Timestamp=16 Jul 2025 at 00:39:09
Info.plist entries=3
TeamIdentifier=GTA9LK7P23
```
Currently XCFrameworkSignatureProvider fails to get info for such description. PR makes team id in curly brackets optional in regex, so it properly works in both cases when it exists or not.

2) Also this PR updates Xcode project version to version 60 when expected signature is specified. It is default behavior for Xcode 16 when adding expected signature for xcframework. Xcode updates project version even when opening project with already specified expected signature.

### How to test locally

1. Download Vungle SDK from here https://support.vungle.com/hc/en-us/articles/15718672681883-Download-Vungle-SDK-for-iOS. Add it as xcframework dependency to any target and specify expected signature.  Run `tuist generate` to check that projects properly generate without error.
2. Add xcframework with expected signature to any target. Check that generated project has version 60. 
