### PR TITLE
fix(cli): use Xcode default for which architectures are built

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
@@ -846,10 +846,8 @@ final class EmptyCacheService: CacheServicing {
 
         private func xcargs(for architectures: [MacArchitecture]) -> [XcodeBuildArgument] {
             if architectures.isEmpty {
-                return [
-                    // We're building for arm64 by default
-                    .xcarg("ARCHS", "arm64"),
-                ]
+                // Defaulting to Xcode's default.
+                return []
             } else {
                 return [
                     .xcarg("ARCHS", architectures.map(\.rawValue).joined(separator: " ")),


### PR DESCRIPTION
In https://github.com/tuist/tuist/pull/7977, we've forced the set of architectures that are built as part of `tuist cache` to be only `arm64`. However, in some cases, such as when you run `xcodebuild` with the `generic/platform=iOS Simulator` as destination, `xcodebuild` annoyingly still tries to build for both architectures.

We retain the option for folks to pick the architecture as part of `tuist cache`, but we'll revert to whatever Xcode default is.