### PR TITLE
fix(cli,app): fetching devices when running previews

### DIFF
--- a/cli/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
+++ b/cli/Tests/TuistAutomationTests/Device/DeviceControllerTests.swift
@@ -241,6 +241,38 @@ final class DeviceControllerTests: TuistUnitTestCase {
           {
             "capabilities" : [
               {
+                "featureIdentifier" : "com.apple.coredevice.feature.tags",
+                "name" : "Modify Tags"
+              },
+              {
+                "featureIdentifier" : "com.apple.coredevice.feature.default.user.credentials",
+                "name" : "Modify credentials for default users for a device"
+              }
+            ],
+            "connectionProperties" : {
+              "isMobileDeviceOnly" : false,
+              "pairingState" : "unsupported",
+              "potentialHostnames" : [
+                "67946E7A-2A5D-5B91-9E34-ECD8AC0E4D09.coredevice.local"
+              ],
+              "tunnelState" : "unavailable"
+            },
+            "deviceProperties" : {
+              "bootState" : "booted",
+              "ddiServicesAvailable" : false
+            },
+            "hardwareProperties" : {
+
+            },
+            "identifier" : "67946E7A-2A5D-5B91-9E34-ECD8AC0E4D09",
+            "tags" : [
+
+            ],
+            "visibilityClass" : "default"
+          },
+          {
+            "capabilities" : [
+              {
                 "featureIdentifier" : "com.apple.coredevice.feature.connectdevice",
                 "name" : "Connect to Device"
               },


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/8001

Fetching devices when running previews (either using the macOS app or the `tuist run` command) currently fails when the `devicectl` output contains devices with no hardware or device properties. Since we can't do much with these devices, we filter these devices out, but no longer fail when decoding such a JSON.

Example of such a device:
```
{
            "capabilities" : [
              {
                "featureIdentifier" : "com.apple.coredevice.feature.tags",
                "name" : "Modify Tags"
              },
              {
                "featureIdentifier" : "com.apple.coredevice.feature.default.user.credentials",
                "name" : "Modify credentials for default users for a device"
              }
            ],
            "connectionProperties" : {
              "isMobileDeviceOnly" : false,
              "pairingState" : "unsupported",
              "potentialHostnames" : [
                "67946E7A-2A5D-5B91-9E34-ECD8AC0E4D09.coredevice.local"
              ],
              "tunnelState" : "unavailable"
            },
            "deviceProperties" : {
              "bootState" : "booted",
              "ddiServicesAvailable" : false
            },
            "hardwareProperties" : {

            },
            "identifier" : "67946E7A-2A5D-5B91-9E34-ECD8AC0E4D09",
            "tags" : [

            ],
            "visibilityClass" : "default"
          },
```

I've added this device in our unit tests to prevent regressions here.