### PR TITLE
fix(server): fix rendering preview QR code images in GitLab

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -36,7 +36,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app do
-    plug :accepts, ["html"]
+    plug :accepts, ["html", "svg", "png"]
     plug :disable_robot_indexing
     plug :fetch_session
     plug :fetch_live_flash
@@ -539,9 +539,18 @@ defmodule TuistWeb.Router do
 
     get "/manifest.plist", PreviewController, :manifest
     get "/app.ipa", PreviewController, :download_archive
+    get "/download", PreviewController, :download_preview
+  end
+
+  scope "/:account_handle/:project_handle/previews/:id", TuistWeb do
+    pipe_through [
+      :open_api,
+      :browser_app,
+      :analytics
+    ]
+
     get "/qr-code.svg", PreviewController, :download_qr_code_svg
     get "/qr-code.png", PreviewController, :download_qr_code_png
-    get "/download", PreviewController, :download_preview
   end
 
   scope "/:account_handle/:project_handle/previews/:id", TuistWeb do


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/7963

This one took me a bit to figure out 😅 

There were two issues connected with our QR code images:
- GitLab sends headers for the type of content it accepts based on the URL (in our case, SVG or PNG). But our current routes actually accept only requests asking for `html` content. Now, this is all fine if the client doesn't specify the type of content it accepts ... but if it does, like GitLab, we return a [406 error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/406)
- Additionally, we were requiring the user to be authenticated for non-ipa previews – that's really not needed as the QR images are basically just a link that _then_ runs the appropriate authorization logic if needed

I updated the plugs to remedy both of these issues.