### PR TITLE
chore(cli,app): fix caching pipelines due to archs incompatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -470,7 +470,7 @@ let targets: [Target] = [
             "ArgumentParser": .staticFramework,
             "Mockable": .staticFramework,
         ],
-        baseSettings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES"])
+        baseSettings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES", "ARCHS": "arm64"])
     )
 
 #endif

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -67,6 +67,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "SwiftECC"),
                 ],
                 settings: .settings(
+                    base: ["ARCHS": "arm64"],
                     configurations: [
                         .debug(
                             name: "Debug",
@@ -807,7 +808,8 @@ public enum Module: String, CaseIterable {
 
         var baseSettings = settings.base
         baseSettings["MACOSX_DEPLOYMENT_TARGET"] = "14.0"
-
+        baseSettings["ARCHS"] = "arm64"
+        
         let settings = Settings.settings(
             base: baseSettings,
             configurations: [
@@ -854,7 +856,8 @@ public enum Module: String, CaseIterable {
         case .tuist:
             return .settings(
                 base: [
-                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)"
+                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
+                    "ARCHS": "arm64"
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),
@@ -879,6 +882,7 @@ public enum Module: String, CaseIterable {
             )
         default:
             return .settings(
+                base: ["ARCHS": "arm64"],
                 configurations: [
                     .debug(
                         name: "Debug",

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -53,6 +53,7 @@ let bundleId =
 let project = Project(
     name: "TuistApp",
     settings: .settings(
+        base: ["ARCHS": "arm64"],
         debug: [
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
         ]


### PR DESCRIPTION
I noticed our caching pipeline failed to warm the cache because the build graph tried to build and like sources for x86_64 when the binaries were compiled for arm64. I'm configuring all the targets to only build for `arm64`.