### PR TITLE
chore(cli): fix homebrew release

### DIFF
--- a/.github/workflows/handbook-deploy.yml
+++ b/.github/workflows/handbook-deploy.yml
@@ -33,8 +33,6 @@ jobs:
             ~/.pnpm/store
           key: pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
       - uses: jdx/mise-action@v2
-        with:
-          experimental: true
       - name: Deploy handbook
         env:
           NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -39,6 +39,4 @@ jobs:
             ~/.pnpm/store
           key: pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
       - uses: jdx/mise-action@v2
-        with:
-          experimental: true
       - run: mise run handbook:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
 
+      - uses: jdx/mise-action@v2
+
       - name: Download CLI artifacts
         if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli.result == 'success'
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The publishing of the formulas and casks on release is still not working because the release pipeline is missing the step that installs Mise. I'm fixing it and hopefully 🤞🏼 the next one will go through.

> [!NOTE]
> For 4.62.0 I triggered the workflow manually.