### PR TITLE
fix(server): remove :commands tag from Redis pipeline metric

### DIFF
--- a/server/lib/tuist/key_value_store/prom_ex_plugin.ex
+++ b/server/lib/tuist/key_value_store/prom_ex_plugin.ex
@@ -32,7 +32,7 @@ defmodule Tuist.KeyValueStore.PromExPlugin do
           counter(
             [:tuist, :key_value_store, :redis, :pipeline_completed],
             event_name: [:redix, :pipeline, :stop],
-            tags: [:connection_name, :commands, :kind, :reason],
+            tags: [:connection_name, :kind, :reason],
             description: "A pipeline has been completed.",
             measurement: fn _ -> 1 end
           )


### PR DESCRIPTION
[AppSignal Error](https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/329)

## Summary
- Fixes ArgumentError when Redis EVAL commands are executed
- Removes problematic `:commands` tag from Redis pipeline telemetry metric
- Preserves other important telemetry data (connection_name, kind, reason)

## Problem
The `:commands` tag in the Redis pipeline telemetry metric was causing `ArgumentError: cannot convert the given list to a string` when complex Redis commands (like EVAL with Lua scripts from rate limiting) were executed. The Prometheus label formatting in `Peep.Prometheus.escape/1` couldn't convert the nested command arrays to strings.

## Solution
Remove the `:commands` tag from the `pipeline_completed` counter metric in `Tuist.KeyValueStore.PromExPlugin`. This maintains observability for Redis operations while avoiding the conversion error.