### PR TITLE
fix(cli): `bundle show` failing due to wrong data passed by the cli

### DIFF
--- a/cli/Sources/TuistServer/Services/GetBundleService.swift
+++ b/cli/Sources/TuistServer/Services/GetBundleService.swift
@@ -53,9 +53,9 @@ public final class GetBundleService: GetBundleServicing {
         let response = try await client.getBundle(
             .init(
                 path: .init(
-                    account_handle: bundleId,
-                    project_handle: handles.accountHandle,
-                    bundle_id: handles.projectHandle,
+                    account_handle: handles.accountHandle,
+                    project_handle: handles.projectHandle,
+                    bundle_id: bundleId,
                 )
             )
         )


### PR DESCRIPTION
I just noticed our new `tuist bundle show` command was failing with an error that indicated that the full handle that we were using was wrong. It turns out we were using the wrong values.