### PR TITLE
feat(cli): improve passthrough argument documentation with usage examples

### DIFF
--- a/cli/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/cli/Sources/TuistKit/Commands/BuildCommand.swift
@@ -116,7 +116,7 @@ public struct BuildOptions: ParsableArguments {
 
     @Argument(
         parsing: .postTerminator,
-        help: "Arguments that will be passed through to xcodebuild",
+        help: "Arguments that will be passed through to xcodebuild. Use -- followed by xcodebuild arguments. Example: tuist build -- -destination 'platform=iOS Simulator,name=iPhone 15' -sdk iphonesimulator",
         envKey: .buildOptionsPassthroughXcodeBuildArguments
     )
     var passthroughXcodeBuildArguments: [String] = []

--- a/cli/Sources/TuistKit/Commands/RunCommand.swift
+++ b/cli/Sources/TuistKit/Commands/RunCommand.swift
@@ -91,7 +91,7 @@ public struct RunCommand: AsyncParsableCommand {
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "The arguments to pass to the runnable target during execution.",
+        help: "Arguments to pass to the application during execution. All arguments after the scheme name are forwarded to the app. Example: tuist run MyApp --verbose --config debug",
         envKey: .runArguments
     )
     var arguments: [String] = []

--- a/cli/Sources/TuistKit/Commands/TestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TestCommand.swift
@@ -196,7 +196,7 @@ public struct TestCommand: AsyncParsableCommand, LogConfigurableCommand,
 
     @Argument(
         parsing: .postTerminator,
-        help: "xcodebuild arguments that will be passthrough"
+        help: "Arguments that will be passed through to xcodebuild. Use -- followed by xcodebuild arguments. Example: tuist test -- -destination 'platform=iOS Simulator,name=iPhone 15' -parallel-testing-enabled YES"
     )
     var passthroughXcodeBuildArguments: [String] = []
 

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildArchiveCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildArchiveCommand.swift
@@ -18,7 +18,7 @@ public struct XcodeBuildArchiveCommand: AsyncParsableCommand, TrackableParsableC
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+        help: "Arguments that will be passed through to the xcodebuild CLI. All arguments are forwarded to xcodebuild. Example: tuist xcodebuild archive -scheme MyApp -archivePath ./build/MyApp.xcarchive"
     )
     public var passthroughXcodebuildArguments: [String] = []
 

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildCommand.swift
@@ -18,7 +18,7 @@ public struct XcodeBuildBuildCommand: AsyncParsableCommand, TrackableParsableCom
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+        help: "Arguments that will be passed through to the xcodebuild CLI. All arguments are forwarded to xcodebuild. Example: tuist xcodebuild build -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'"
     )
     public var passthroughXcodebuildArguments: [String] = []
 

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildForTestingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildBuildForTestingCommand.swift
@@ -18,7 +18,7 @@ public struct XcodeBuildBuildForTestingCommand: AsyncParsableCommand, TrackableP
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+        help: "Arguments that will be passed through to the xcodebuild CLI. All arguments are forwarded to xcodebuild. Example: tuist xcodebuild build-for-testing -scheme MyAppTests -destination 'platform=iOS Simulator,name=iPhone 15'"
     )
     public var passthroughXcodebuildArguments: [String] = []
 

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -18,7 +18,7 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+        help: "Arguments that will be passed through to the xcodebuild CLI. All arguments are forwarded to xcodebuild. Example: tuist xcodebuild test -scheme MyAppTests -destination 'platform=iOS Simulator,name=iPhone 15' -parallel-testing-enabled YES"
     )
     public var passthroughXcodebuildArguments: [String] = []
 

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -20,7 +20,7 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "xcodebuild arguments that will be passed through to the xcodebuild CLI."
+        help: "Arguments that will be passed through to the xcodebuild CLI. All arguments are forwarded to xcodebuild. Example: tuist xcodebuild test-without-building -scheme MyAppTests -destination 'platform=iOS Simulator,name=iPhone 15' -testConfiguration Debug"
     )
     public var passthroughXcodebuildArguments: [String] = []
 


### PR DESCRIPTION
## Summary
• Enhanced help text for CLI commands with passthrough arguments to include clear usage examples
• Added concrete examples showing common xcodebuild argument patterns
• Improved syntax guidance for different argument parsing strategies

## Changes
- **build command**: Added example showing `--` usage with destination and SDK arguments
- **test command**: Added example with destination and parallel testing flags
- **run command**: Added example showing application argument forwarding
- **xcodebuild subcommands**: Added command-specific examples for build, test, archive, build-for-testing, and test-without-building

## Test plan
- [x] Verify help text displays correctly: `tuist build --help`
- [x] Verify help text displays correctly: `tuist test --help`  
- [x] Verify help text displays correctly: `tuist run --help`
- [x] Verify help text displays correctly: `tuist xcodebuild build --help`
- [x] Test that passthrough arguments still work as expected
- [x] Run linting to ensure code quality maintained