### PR TITLE
fix(cli): revert caching only the default architecture

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -104,7 +104,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Cache
-        run: mise x -- tuist cache
+        run: tuist cache --architectures arm64
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -29,7 +29,7 @@ public enum Module: String, CaseIterable {
     case git = "TuistGit"
     case rootDirectoryLocator = "TuistRootDirectoryLocator"
     case process = "TuistProcess"
-    
+
     func forceStaticLinking() -> Bool {
         return Environment.forceStaticLinking.getBoolean(default: false)
     }
@@ -67,7 +67,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "SwiftECC"),
                 ],
                 settings: .settings(
-                    base: ["ARCHS": "arm64"],
+                    base: ["ARCHS": "arm64 x86_64"],
                     configurations: [
                         .debug(
                             name: "Debug",
@@ -102,7 +102,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "XcodeGraph"),
                     .external(name: "Path"),
                     .external(name: "FileSystem"),
-                    .external(name: "Mockable")
+                    .external(name: "Mockable"),
                 ]
             ),
             .target(
@@ -123,9 +123,9 @@ public enum Module: String, CaseIterable {
                     .external(name: "Path"),
                     .external(name: "FileSystem"),
                     .external(name: "Mockable"),
-                    .external(name: "TSCTestSupport")
+                    .external(name: "TSCTestSupport"),
                 ]
-            )
+            ),
         ]
     }
 
@@ -230,7 +230,7 @@ public enum Module: String, CaseIterable {
         case .tuist, .tuistBenchmark, .tuistFixtureGenerator:
             return .commandLineTool
         case .projectAutomation, .projectDescription:
-            return  forceStaticLinking() ? .staticFramework : .framework
+            return forceStaticLinking() ? .staticFramework : .framework
         default:
             return .staticFramework
         }
@@ -809,7 +809,7 @@ public enum Module: String, CaseIterable {
         var baseSettings = settings.base
         baseSettings["MACOSX_DEPLOYMENT_TARGET"] = "14.0"
         baseSettings["ARCHS"] = "arm64"
-        
+
         let settings = Settings.settings(
             base: baseSettings,
             configurations: [
@@ -857,7 +857,7 @@ public enum Module: String, CaseIterable {
             return .settings(
                 base: [
                     "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
-                    "ARCHS": "arm64"
+                    "ARCHS": "arm64",
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),
@@ -882,7 +882,7 @@ public enum Module: String, CaseIterable {
             )
         default:
             return .settings(
-                base: ["ARCHS": "arm64"],
+                base: ["ARCHS": "arm64 x86_64"],
                 configurations: [
                     .debug(
                         name: "Debug",

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -857,7 +857,7 @@ public enum Module: String, CaseIterable {
             return .settings(
                 base: [
                     "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
-                    "ARCHS": "arm64",
+                    "ARCHS": "arm64 x86_64",
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -23,10 +23,10 @@ func tuistMenuBarDependencies() -> [TargetDependency] {
 let inspectBuildPostAction: ExecutionAction = .executionAction(
     title: "Inspect build",
     scriptText: """
-        eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
+    eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
 
-        tuist inspect build
-        """
+    tuist inspect build
+    """
 )
 
 let oauthClientIdEnvironmentVariable: EnvironmentVariable =
@@ -55,7 +55,7 @@ let project = Project(
     settings: .settings(
         base: ["ARCHS": "arm64 x86_64"],
         debug: [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
         ]
     ),
     targets: [
@@ -76,7 +76,7 @@ let project = Project(
                                 "CFBundleURLName": .string(bundleId),
                                 "CFBundleURLSchemes": ["tuist"],
                             ]
-                        )
+                        ),
                     ],
                     "LSUIElement": true,
                     "LSApplicationCategoryType": "public.app-category.developer-tools",
@@ -87,7 +87,7 @@ let project = Project(
                     "CFBundleVersion": "0.20.2",
                     "UILaunchStoryboardName": "LaunchScreen.storyboard",
                     "UISupportedInterfaceOrientations": [
-                        "UIInterfaceOrientationPortrait"
+                        "UIInterfaceOrientationPortrait",
                     ],
                 ]
             ),
@@ -149,7 +149,7 @@ let project = Project(
             sources: ["Sources/TuistNoora/**"],
             resources: ["Resources/TuistNoora/**"],
             dependencies: [
-                .external(name: "NukeUI")
+                .external(name: "NukeUI"),
             ]
         ),
         .target(
@@ -200,7 +200,7 @@ let project = Project(
             deploymentTargets: .multiplatform(iOS: "18.0", macOS: "14.0.0"),
             sources: ["Sources/TuistAppStorage/**"],
             dependencies: [
-                .external(name: "Mockable")
+                .external(name: "Mockable"),
             ]
         ),
         .target(
@@ -245,16 +245,16 @@ let project = Project(
             name: "TuistApp",
             buildAction: .buildAction(
                 targets: [
-                    .target("TuistApp")
+                    .target("TuistApp"),
                 ],
                 postActions: [
-                    inspectBuildPostAction
+                    inspectBuildPostAction,
                 ],
                 runPostActionsOnFailure: true
             ),
             testAction: .targets(
                 [
-                    .testableTarget(target: "TuistMenuBarTests")
+                    .testableTarget(target: "TuistMenuBarTests"),
                 ],
                 options: .options(
                     language: "en"
@@ -270,6 +270,6 @@ let project = Project(
                     ]
                 )
             )
-        )
+        ),
     ]
 )

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -23,10 +23,10 @@ func tuistMenuBarDependencies() -> [TargetDependency] {
 let inspectBuildPostAction: ExecutionAction = .executionAction(
     title: "Inspect build",
     scriptText: """
-    eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
+        eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
 
-    tuist inspect build
-    """
+        tuist inspect build
+        """
 )
 
 let oauthClientIdEnvironmentVariable: EnvironmentVariable =
@@ -53,9 +53,9 @@ let bundleId =
 let project = Project(
     name: "TuistApp",
     settings: .settings(
-        base: ["ARCHS": "arm64"],
+        base: ["ARCHS": "arm64 x86_64"],
         debug: [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING"
         ]
     ),
     targets: [
@@ -76,7 +76,7 @@ let project = Project(
                                 "CFBundleURLName": .string(bundleId),
                                 "CFBundleURLSchemes": ["tuist"],
                             ]
-                        ),
+                        )
                     ],
                     "LSUIElement": true,
                     "LSApplicationCategoryType": "public.app-category.developer-tools",
@@ -87,7 +87,7 @@ let project = Project(
                     "CFBundleVersion": "0.20.2",
                     "UILaunchStoryboardName": "LaunchScreen.storyboard",
                     "UISupportedInterfaceOrientations": [
-                        "UIInterfaceOrientationPortrait",
+                        "UIInterfaceOrientationPortrait"
                     ],
                 ]
             ),
@@ -112,7 +112,8 @@ let project = Project(
                     "DEVELOPMENT_TEAM": "U6LC622NKF",
                     "CODE_SIGN_STYLE": "Automatic",
                     "CODE_SIGN_IDENTITY": "Apple Development",
-                    "CODE_SIGN_ENTITLEMENTS[sdk=iphone*]": "Resources/TuistApp/TuistApp.entitlements",
+                    "CODE_SIGN_ENTITLEMENTS[sdk=iphone*]":
+                        "Resources/TuistApp/TuistApp.entitlements",
                 ],
                 release: [
                     // Needed for the app notarization
@@ -148,7 +149,7 @@ let project = Project(
             sources: ["Sources/TuistNoora/**"],
             resources: ["Resources/TuistNoora/**"],
             dependencies: [
-                .external(name: "NukeUI"),
+                .external(name: "NukeUI")
             ]
         ),
         .target(
@@ -199,7 +200,7 @@ let project = Project(
             deploymentTargets: .multiplatform(iOS: "18.0", macOS: "14.0.0"),
             sources: ["Sources/TuistAppStorage/**"],
             dependencies: [
-                .external(name: "Mockable"),
+                .external(name: "Mockable")
             ]
         ),
         .target(
@@ -244,16 +245,16 @@ let project = Project(
             name: "TuistApp",
             buildAction: .buildAction(
                 targets: [
-                    .target("TuistApp"),
+                    .target("TuistApp")
                 ],
                 postActions: [
-                    inspectBuildPostAction,
+                    inspectBuildPostAction
                 ],
                 runPostActionsOnFailure: true
             ),
             testAction: .targets(
                 [
-                    .testableTarget(target: "TuistMenuBarTests"),
+                    .testableTarget(target: "TuistMenuBarTests")
                 ],
                 options: .options(
                     language: "en"
@@ -269,6 +270,6 @@ let project = Project(
                     ]
                 )
             )
-        ),
+        )
     ]
 )

--- a/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
@@ -846,8 +846,10 @@ final class EmptyCacheService: CacheServicing {
 
         private func xcargs(for architectures: [MacArchitecture]) -> [XcodeBuildArgument] {
             if architectures.isEmpty {
-                // Defaulting to Xcode's default.
-                return []
+                return [
+                    // We're building for arm64 by default
+                    .xcarg("ARCHS", "arm64"),
+                ]
             } else {
                 return [
                     .xcarg("ARCHS", architectures.map(\.rawValue).joined(separator: " ")),


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/8043

We [changed the caching logic](https://github.com/tuist/tuist/pull/8007) to only cache the default architecture to improve caching times. However, this came with some side issues so I'm going to revert it.