### PR TITLE
chore(server): correct server cliff config path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,9 +414,9 @@ jobs:
 
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
           if [ -n "$LATEST_VERSION" ]; then
-            git cliff --include-path "server/**/*" --config server/cliff.toml --repository "." 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "server/**/*" --config cliff.toml --repository "../" 2>/dev/null -- ${LATEST_VERSION}..HEAD | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           else
-            git cliff --include-path "server/**/*" --config server/cliff.toml --repository "." 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
+            git cliff --include-path "server/**/*" --config cliff.toml --repository "../" 2>/dev/null | sed -n '/<!-- RELEASE NOTES START -->/,$p' | tail -n +2 >> "$GITHUB_OUTPUT"
           fi
           echo "EOF" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
[Server releases](https://github.com/tuist/tuist/releases/tag/server%400.5.0) are working now, but they lack release notes. I aligned the logic to get the release notes with the logic that we use for the CLI, which is working.

## Summary (Claude)

* Fix server release notes generation by correcting git-cliff configuration paths
* The server release workflow was using incorrect paths that resulted in empty release notes

## Problem
The server releases on GitHub have been missing their release notes content. When comparing with the CLI releases (which work correctly), I found the server workflow was using:
- `--config server/cliff.toml --repository "."`

But since the step runs with `working-directory: server`, it should use:
- `--config cliff.toml --repository "../"`

## Solution
Updated the git-cliff command paths in `.github/workflows/release.yml` lines 417 and 419 to match the working directory context and align with the successful CLI workflow pattern.

## Test plan
- [x] Verify the CLI workflow uses the correct pattern (`--config cliff.toml --repository "../"`)
- [x] Confirm recent server releases have empty release notes
- [x] Confirm recent CLI releases have proper release notes  
- [ ] Test with next server release to verify fix works