### PR TITLE
fix(cli): CocoaPods unable to install dependencies due to project's `objectVersion`

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -344,6 +344,6 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
 
     private func determineProjectConstants() throws -> ProjectConstants {
         // TODO: Determine if this can be inferred by the set Xcode version
-        .xcode16
+        .xcode13
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -129,7 +129,7 @@ struct ProjectDescriptorGeneratorTests {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        #expect(pbxproj.objectVersion == 70)
+        #expect(pbxproj.objectVersion == 55)
         #expect(pbxproj.archiveVersion == Xcode.LastKnown.archiveVersion)
     }
 
@@ -160,7 +160,7 @@ struct ProjectDescriptorGeneratorTests {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        #expect(pbxproj.objectVersion == 70)
+        #expect(pbxproj.objectVersion == 55)
         #expect(pbxproj.archiveVersion == Xcode.LastKnown.archiveVersion)
     }
 
@@ -191,7 +191,7 @@ struct ProjectDescriptorGeneratorTests {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        #expect(pbxproj.objectVersion == 70)
+        #expect(pbxproj.objectVersion == 55)
         #expect(pbxproj.archiveVersion == Xcode.LastKnown.archiveVersion)
     }
 


### PR DESCRIPTION
Fixes: https://github.com/tuist/tuist/issues/8030

When I added support for buildable folders I bumped the object version of the project to 70 (Xcode 16). However, that makes `pod install` fail as reported [here](https://github.com/tuist/tuist/issues/8030). This PR downgrades it since it should have no effect in the feature working or not.