### PR TITLE
fix(server): add default minio port value

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -305,7 +305,7 @@ defmodule Tuist.Environment do
   end
 
   def minio_console_port(secrets \\ secrets()) do
-    get([:minio, :console_port], secrets)
+    get([:minio, :console_port], secrets, default_value: 9098)
   end
 
   def mautic_username(secrets \\ secrets()) do


### PR DESCRIPTION
#8055 added a regression where minio wouldn't start because it doesn't automatically set a default value.