### PR TITLE
fix(server): showing billing page when an account has payment method without a card

### DIFF
--- a/server/lib/tuist_web/live/billing_live.html.heex
+++ b/server/lib/tuist_web/live/billing_live.html.heex
@@ -236,7 +236,10 @@
             <.external_link />
           </:icon_right>
         </.button>
-        <div :if={not is_nil(@payment_method)} data-part="payment-card-details">
+        <div
+          :if={not is_nil(@payment_method) and not is_nil(@payment_method.card)}
+          data-part="payment-card-details"
+        >
           <span data-part="name">
             {@payment_method.card.cardholder_name}
           </span>

--- a/server/test/tuist_web/live/billing_live_test.exs
+++ b/server/test/tuist_web/live/billing_live_test.exs
@@ -166,4 +166,34 @@ defmodule TuistWeb.BillingLiveTest do
       assert has_element?(lv, "[data-part='current-plan-card-section']", "Enterprise")
     end
   end
+
+  describe "when payment method card is nil" do
+    @tag account_without_customer: true
+    test "does not crash when payment method has nil card", %{conn: conn, account: account} do
+      # Given
+      stub(Billing, :get_current_active_subscription, fn _ ->
+        %{
+          plan: :pro,
+          status: "active",
+          default_payment_method: "payment_method_id",
+          trial_end: nil,
+          subscription_id: "subscription_id"
+        }
+      end)
+
+      stub(Billing, :get_payment_method_id_from_subscription_id, fn _ ->
+        "payment_method_id"
+      end)
+
+      stub(Billing, :get_payment_method_by_id, fn _ ->
+        %{
+          id: "payment_method_id",
+          card: nil
+        }
+      end)
+
+      # When/Then
+      assert {:ok, _lv, _html} = live(conn, ~p"/#{account.name}/billing")
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/837

When an account has a payment method but _no_ card, we currently end up 500'ing. This can happen for example when an account has a Link payment method which not always has to be associated with a card.

In the future, we should also add support for showing non-card payment methods in the billing page.
