### PR TITLE
feat(cli): add filePath and customWorkingDirectory support to RunAction

### DIFF
--- a/cli/Sources/ProjectDescription/RunAction.swift
+++ b/cli/Sources/ProjectDescription/RunAction.swift
@@ -20,6 +20,14 @@ public struct RunAction: Equatable, Codable, Sendable {
     /// The name of the executable or target to run.
     public var executable: TargetReference?
 
+    /// Custom working directory path for the run action. When set, the executable
+    /// will be launched from this directory instead of the default location.
+    public var customWorkingDirectory: Path?
+
+    /// Path to an executable file to run instead of the built product. This allows
+    /// running arbitrary executables or scripts as part of the run action.
+    public var filePath: Path?
+
     /// Command line arguments passed on launch and environment variables.
     public var arguments: Arguments?
 
@@ -48,6 +56,8 @@ public struct RunAction: Equatable, Codable, Sendable {
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         executable: TargetReference? = nil,
+        customWorkingDirectory: Path? = nil,
+        filePath: Path? = nil,
         arguments: Arguments? = nil,
         options: RunActionOptions = .options(),
         diagnosticsOptions: SchemeDiagnosticsOptions = .options(),
@@ -62,6 +72,8 @@ public struct RunAction: Equatable, Codable, Sendable {
         self.preActions = preActions
         self.postActions = postActions
         self.executable = executable
+        self.customWorkingDirectory = customWorkingDirectory
+        self.filePath = filePath
         self.arguments = arguments
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
@@ -78,6 +90,10 @@ public struct RunAction: Equatable, Codable, Sendable {
     ///   - preActions: A list of actions that are executed before starting the run process.
     ///   - postActions: A list of actions that are executed after the run process.
     ///   - executable: The name of the executable or target to run.
+    ///   - customWorkingDirectory: Custom working directory path for the run action. When set, the executable will be
+    /// launched from this directory instead of the default location.
+    ///   - filePath: Path to an executable file to run instead of the built product. This allows running arbitrary
+    /// executables or scripts as part of the run action.
     ///   - arguments: Command line arguments passed on launch and environment variables.
     ///   - options: List of options to set to the action.
     ///   - diagnosticsOptions: List of diagnostics options to set to the action.
@@ -94,6 +110,8 @@ public struct RunAction: Equatable, Codable, Sendable {
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         executable: TargetReference? = nil,
+        customWorkingDirectory: Path? = nil,
+        filePath: Path? = nil,
         arguments: Arguments? = nil,
         options: RunActionOptions = .options(),
         diagnosticsOptions: SchemeDiagnosticsOptions = .options(),
@@ -109,6 +127,8 @@ public struct RunAction: Equatable, Codable, Sendable {
             preActions: preActions,
             postActions: postActions,
             executable: executable,
+            customWorkingDirectory: customWorkingDirectory,
+            filePath: filePath,
             arguments: arguments,
             options: options,
             diagnosticsOptions: diagnosticsOptions,

--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -60,6 +60,7 @@ public class GraphLinter: GraphLinting {
         issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintSchemesUnknownTargets(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintSchemesRunAction(graphTraverser: graphTraverser))
         return issues
     }
 
@@ -89,6 +90,21 @@ public class GraphLinter: GraphLinting {
                 reason: "Cannot find targets \(targetsDescriptionStrings.joined(separator: ", "))  defined in \(scheme.name)",
                 severity: .warning
             )
+        }
+    }
+
+    private func lintSchemesRunAction(graphTraverser: GraphTraversing) -> [LintingIssue] {
+        return graphTraverser.schemes().compactMap { scheme in
+            guard let runAction = scheme.runAction else { return nil }
+
+            if let filePath = runAction.filePath, let executable = runAction.executable {
+                return LintingIssue(
+                    reason: "On scheme '\(scheme.name)', filePath ('\(filePath.pathString)') takes precedence over executable ('\(executable.name)').",
+                    severity: .warning
+                )
+            }
+
+            return nil
         }
     }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Path
 import ProjectDescription
 import TuistCore
 import XcodeGraph
@@ -58,6 +59,18 @@ extension XcodeGraph.RunAction {
             )
         }
 
+        var filePathResolved: AbsolutePath?
+        if let filePath = manifest.filePath {
+            filePathResolved = try generatorPaths.resolve(path: filePath)
+        }
+
+        var useCustomWorkingDirectory = false
+        var customWorkingDirectoryResolved: AbsolutePath?
+        if let customWorkingDirectory = manifest.customWorkingDirectory {
+            customWorkingDirectoryResolved = try generatorPaths.resolve(path: customWorkingDirectory)
+            useCustomWorkingDirectory = true
+        }
+
         let options = try XcodeGraph.RunActionOptions.from(manifest: manifest.options, generatorPaths: generatorPaths)
 
         let diagnosticsOptions = XcodeGraph.SchemeDiagnosticsOptions.from(manifest: manifest.diagnosticsOptions)
@@ -90,14 +103,16 @@ extension XcodeGraph.RunAction {
             preActions: preActions,
             postActions: postActions,
             executable: executableResolved,
-            filePath: nil,
+            filePath: filePathResolved,
             arguments: arguments,
             options: options,
             diagnosticsOptions: diagnosticsOptions,
             metalOptions: metalOptions,
             expandVariableFromTarget: expandVariablesFromTarget,
             launchStyle: launchStyle,
-            appClipInvocationURL: appClipInvocationURL
+            appClipInvocationURL: appClipInvocationURL,
+            customWorkingDirectory: customWorkingDirectoryResolved,
+            useCustomWorkingDirectory: useCustomWorkingDirectory
         )
     }
 }

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -189,6 +189,8 @@ import TuistSupport
         public static func test(
             configuration: ConfigurationName = .debug,
             executable: TargetReference? = nil,
+            customWorkingDirectory: Path? = nil,
+            filePath: Path? = nil,
             arguments: Arguments? = nil,
             options: RunActionOptions = .options(),
             appClipInvocationURLString: String? = nil
@@ -196,6 +198,8 @@ import TuistSupport
             RunAction(
                 configuration: configuration,
                 executable: executable,
+                customWorkingDirectory: customWorkingDirectory,
+                filePath: filePath,
                 arguments: arguments,
                 options: options,
                 appClipInvocationURLString: appClipInvocationURLString

--- a/cli/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
+++ b/cli/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
@@ -200,7 +200,7 @@ extension TuistTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
-        XCTAssertEqual(runAction.executable?.name, manifest.executable?.targetName)
+        XCTAssertEqual(runAction.executable?.name, manifest.executable?.targetName, file: file, line: line)
         XCTAssertEqual(
             runAction.executable?.projectPath,
             try generatorPaths.resolveSchemeActionProjectPath(manifest.executable?.projectPath),

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Scheme+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Scheme+ManifestMapperTests.swift
@@ -98,4 +98,31 @@ final class SchemeManifestMapperTests: TuistUnitTestCase {
         // Then
         try assert(scheme: model, matches: manifest, path: projectPath, generatorPaths: generatorPaths)
     }
+
+    func test_from_when_the_scheme_uses_custom_executable_and_working_directory() async throws {
+        // Given
+        let projectPath = try AbsolutePath(validating: "/somepath/Project")
+        let runAction = ProjectDescription.RunAction.test(
+            customWorkingDirectory: "/home/user/dev/project",
+            filePath: "/usr/bin/my-script"
+        )
+        let manifest = ProjectDescription.Scheme.test(
+            name: "Scheme",
+            shared: false,
+            runAction: runAction
+        )
+        let rootDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: projectPath,
+            rootDirectory: rootDirectory
+        )
+
+        // When
+        let model = try await XcodeGraph.Scheme.from(manifest: manifest, generatorPaths: generatorPaths)
+
+        // Then
+        XCTAssertNil(model.runAction?.executable)
+        XCTAssertEqual(model.runAction?.customWorkingDirectory, "/home/user/dev/project")
+        XCTAssertEqual(model.runAction?.filePath, "/usr/bin/my-script")
+    }
 }


### PR DESCRIPTION
- Add filePath property to allow running arbitrary executables instead of built products
- Add customWorkingDirectory property to specify custom working directory for run actions
- Add linting to warn when filePath overrides executable setting

Resolves <https://github.com/tuist/tuist/issues/YYY>

> Describe here the purpose of your PR.

### How to test locally

> Document how to test your changes locally
