### PR TITLE
fix(server): make migrations reversible

### DIFF
--- a/server/priv/ingest_repo/migrations/20250715093853_add_performance_indexes_and_computed_columns.exs
+++ b/server/priv/ingest_repo/migrations/20250715093853_add_performance_indexes_and_computed_columns.exs
@@ -61,15 +61,15 @@ defmodule Tuist.ClickHouseRepo.Migrations.AddPerformanceIndexesAndComputedColumn
   end
 
   def down do
-    execute("ALTER TABLE command_events DROP INDEX idx_name_set")
-    execute("ALTER TABLE command_events DROP INDEX idx_project_id")
-    execute("ALTER TABLE command_events DROP INDEX idx_user_id")
-    execute("ALTER TABLE command_events DROP INDEX idx_is_ci")
-    execute("ALTER TABLE command_events DROP INDEX idx_status")
-    execute("ALTER TABLE command_events DROP INDEX idx_git_commit_sha")
-    execute("ALTER TABLE command_events DROP INDEX idx_git_ref")
-    execute("ALTER TABLE command_events DROP INDEX idx_git_branch")
-    execute("ALTER TABLE command_events DROP INDEX idx_name")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_name_set")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_project_id")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_user_id")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_is_ci")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_status")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_git_commit_sha")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_git_ref")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_git_branch")
+    execute("ALTER TABLE command_events DROP INDEX IF EXISTS idx_name")
 
     execute("ALTER TABLE command_events DROP COLUMN hit_rate")
     execute("ALTER TABLE command_events DROP COLUMN remote_test_hits_count")

--- a/server/priv/repo/migrations/20241119161955_add_index_previews_project_id.exs
+++ b/server/priv/repo/migrations/20241119161955_add_index_previews_project_id.exs
@@ -4,7 +4,12 @@ defmodule Tuist.Repo.Migrations.AddIndexPreviewsProjectId do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  def change do
+  def up do
     create index(:previews, [:project_id], concurrently: true)
+  end
+
+  def down do
+    # Table was renamed to app_builds and recreated, nothing to rollback
+    :ok
   end
 end

--- a/server/priv/repo/migrations/20241119161955_add_index_previews_project_id.exs
+++ b/server/priv/repo/migrations/20241119161955_add_index_previews_project_id.exs
@@ -9,7 +9,6 @@ defmodule Tuist.Repo.Migrations.AddIndexPreviewsProjectId do
   end
 
   def down do
-    # Table was renamed to app_builds and recreated, nothing to rollback
-    :ok
+    drop_if_exists index(:previews, [:project_id])
   end
 end

--- a/server/priv/repo/migrations/20250128153554_add_path_to_xcode_projects.exs
+++ b/server/priv/repo/migrations/20250128153554_add_path_to_xcode_projects.exs
@@ -1,9 +1,22 @@
 defmodule Tuist.Repo.Migrations.AddPathToXcodeProjects do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:xcode_projects) do
       add :path, :string, null: false
+    end
+  end
+
+  def down do
+    secrets = Tuist.Environment.decrypt_secrets()
+
+    if !Tuist.Environment.clickhouse_configured?(secrets) || Tuist.Environment.test?() do
+      alter table(:xcode_projects) do
+        remove :path, :string
+      end
+    else
+      # Table was dropped by later migration, nothing to rollback
+      :ok
     end
   end
 end

--- a/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
+++ b/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
@@ -13,7 +13,11 @@ defmodule Tuist.Repo.Migrations.AddMetadataToPreview do
   end
 
   def down do
-    # Table was renamed to app_builds and recreated, nothing to rollback
-    :ok
+    drop_if_exists index(:previews, [:project_id, :git_branch])
+    alter table(:previews) do
+      remove_if_exists :ran_by_account_id, references(:accounts, on_delete: :nilify_all)
+      remove_if_exists :git_commit_sha, :string
+      remove_if_exists :git_branch, :string
+    end
   end
 end

--- a/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
+++ b/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
@@ -1,7 +1,7 @@
 defmodule Tuist.Repo.Migrations.AddMetadataToPreview do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:previews) do
       add :git_branch, :string
       add :git_commit_sha, :string
@@ -10,5 +10,10 @@ defmodule Tuist.Repo.Migrations.AddMetadataToPreview do
 
     # excellent_migrations:safety-assured-for-next-line index_not_concurrently
     create index(:previews, [:project_id, :git_branch])
+  end
+
+  def down do
+    # Table was renamed to app_builds and recreated, nothing to rollback
+    :ok
   end
 end

--- a/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
+++ b/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
@@ -14,6 +14,7 @@ defmodule Tuist.Repo.Migrations.AddMetadataToPreview do
 
   def down do
     drop_if_exists index(:previews, [:project_id, :git_branch])
+
     alter table(:previews) do
       remove_if_exists :ran_by_account_id, references(:accounts, on_delete: :nilify_all)
       remove_if_exists :git_commit_sha, :string

--- a/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
+++ b/server/priv/repo/migrations/20250320095026_add_metadata_to_preview.exs
@@ -13,12 +13,12 @@ defmodule Tuist.Repo.Migrations.AddMetadataToPreview do
   end
 
   def down do
-    drop_if_exists index(:previews, [:project_id, :git_branch])
+    drop index(:previews, [:project_id, :git_branch])
 
     alter table(:previews) do
-      remove_if_exists :ran_by_account_id, references(:accounts, on_delete: :nilify_all)
-      remove_if_exists :git_commit_sha, :string
-      remove_if_exists :git_branch, :string
+      remove :ran_by_account_id, references(:accounts, on_delete: :nilify_all)
+      remove :git_commit_sha, :string
+      remove :git_branch, :string
     end
   end
 end

--- a/server/priv/repo/migrations/20250528140917_drop_artifacts_foreign_key.exs
+++ b/server/priv/repo/migrations/20250528140917_drop_artifacts_foreign_key.exs
@@ -1,7 +1,13 @@
 defmodule Tuist.Repo.Migrations.DropArtifactsForeignKey do
   use Ecto.Migration
 
-  def change do
+  def up do
     drop constraint(:artifacts, "artifacts_artifact_id_fkey")
+  end
+
+  def down do
+    alter table(:artifacts) do
+      modify :artifact_id, references(:artifacts, type: :uuid, on_delete: :delete_all)
+    end
   end
 end

--- a/server/priv/repo/migrations/20250612115646_remove_xcode_target_fk_from_test_case_runs.exs
+++ b/server/priv/repo/migrations/20250612115646_remove_xcode_target_fk_from_test_case_runs.exs
@@ -1,7 +1,7 @@
 defmodule Tuist.Repo.Migrations.RemoveXcodeTargetFkFromTestCaseRuns do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:test_case_runs) do
       add :xcode_target_id_temp, :string
     end
@@ -20,5 +20,25 @@ defmodule Tuist.Repo.Migrations.RemoveXcodeTargetFkFromTestCaseRuns do
 
     # excellent_migrations:safety-assured-for-next-line column_renamed
     rename table(:test_case_runs), :xcode_target_id_temp, to: :xcode_target_id
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line column_renamed
+    rename table(:test_case_runs), :xcode_target_id, to: :xcode_target_id_temp
+
+    alter table(:test_case_runs) do
+      add :xcode_target_id, references(:xcode_targets, type: :uuid, on_delete: :nothing)
+    end
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    UPDATE test_case_runs
+    SET xcode_target_id = CAST(xcode_target_id_temp AS UUID)
+    WHERE xcode_target_id_temp IS NOT NULL
+    """
+
+    alter table(:test_case_runs) do
+      remove :xcode_target_id_temp
+    end
   end
 end

--- a/server/priv/repo/migrations/20250613140005_add_binary_build_duration_to_xcode_targets.exs
+++ b/server/priv/repo/migrations/20250613140005_add_binary_build_duration_to_xcode_targets.exs
@@ -1,9 +1,22 @@
 defmodule Tuist.Repo.Migrations.AddBinaryBuildDurationToXcodeTargets do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:xcode_targets) do
       add :binary_build_duration, :integer, null: true
+    end
+  end
+
+  def down do
+    secrets = Tuist.Environment.decrypt_secrets()
+
+    if !Tuist.Environment.clickhouse_configured?(secrets) || Tuist.Environment.test?() do
+      alter table(:xcode_targets) do
+        remove :binary_build_duration, :integer
+      end
+    else
+      # Table was dropped by later migration, nothing to rollback
+      :ok
     end
   end
 end

--- a/server/priv/repo/migrations/20250613144635_add_binary_build_duration_to_xcode_graphs.exs
+++ b/server/priv/repo/migrations/20250613144635_add_binary_build_duration_to_xcode_graphs.exs
@@ -1,9 +1,22 @@
 defmodule Tuist.Repo.Migrations.AddBinaryBuildDurationToXcodeGraphs do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:xcode_graphs) do
       add :binary_build_duration, :integer, null: true
+    end
+  end
+
+  def down do
+    secrets = Tuist.Environment.decrypt_secrets()
+
+    if !Tuist.Environment.clickhouse_configured?(secrets) || Tuist.Environment.test?() do
+      alter table(:xcode_graphs) do
+        remove :binary_build_duration, :integer
+      end
+    else
+      # Table was dropped by later migration, nothing to rollback
+      :ok
     end
   end
 end

--- a/server/priv/repo/migrations/20250615093614_rename_previews_to_app_builds.exs
+++ b/server/priv/repo/migrations/20250615093614_rename_previews_to_app_builds.exs
@@ -1,8 +1,13 @@
 defmodule Tuist.Repo.Migrations.RenamePreviewsToAppBuilds do
   use Ecto.Migration
 
-  def change do
+  def up do
     # excellent_migrations:safety-assured-for-next-line table_renamed
     rename table(:previews), to: table(:app_builds)
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line table_renamed
+    rename table(:app_builds), to: table(:previews)
   end
 end

--- a/server/priv/repo/migrations/20250623090458_drop_xcode_tables.exs
+++ b/server/priv/repo/migrations/20250623090458_drop_xcode_tables.exs
@@ -35,8 +35,10 @@ defmodule Tuist.Repo.Migrations.DropXcodeTables do
       create table(:xcode_projects, primary_key: false) do
         add :id, :uuid, primary_key: true, null: false
         add :name, :string, null: false
+
         add :xcode_graph_id, references(:xcode_graphs, type: :uuid, on_delete: :delete_all),
           null: false
+
         timestamps(type: :timestamptz)
       end
 
@@ -49,9 +51,11 @@ defmodule Tuist.Repo.Migrations.DropXcodeTables do
         add :binary_cache_hit, :integer
         add :selective_testing_hash, :string
         add :selective_testing_hit, :integer
+
         add :xcode_project_id,
             references(:xcode_projects, type: :uuid, on_delete: :delete_all),
             null: false
+
         timestamps(type: :timestamptz)
       end
 

--- a/server/priv/repo/migrations/20250623090458_drop_xcode_tables.exs
+++ b/server/priv/repo/migrations/20250623090458_drop_xcode_tables.exs
@@ -1,7 +1,7 @@
 defmodule Tuist.Repo.Migrations.DropXcodeTables do
   use Ecto.Migration
 
-  def change do
+  def up do
     secrets = Tuist.Environment.decrypt_secrets()
 
     if !Tuist.Environment.clickhouse_configured?(secrets) || Tuist.Environment.test?() do
@@ -13,6 +13,49 @@ defmodule Tuist.Repo.Migrations.DropXcodeTables do
       drop table(:xcode_projects)
       # excellent_migrations:safety-assured-for-next-line table_dropped
       drop table(:xcode_graphs)
+    end
+  end
+
+  def down do
+    secrets = Tuist.Environment.decrypt_secrets()
+
+    if !Tuist.Environment.clickhouse_configured?(secrets) || Tuist.Environment.test?() do
+      :ok
+    else
+      # Recreate tables in reverse order to satisfy foreign key constraints
+      create table(:xcode_graphs, primary_key: false) do
+        add :id, :uuid, primary_key: true, null: false
+        add :name, :string, null: false
+        add :command_event_id, :id, null: false
+        timestamps(type: :timestamptz)
+      end
+
+      create unique_index(:xcode_graphs, [:command_event_id])
+
+      create table(:xcode_projects, primary_key: false) do
+        add :id, :uuid, primary_key: true, null: false
+        add :name, :string, null: false
+        add :xcode_graph_id, references(:xcode_graphs, type: :uuid, on_delete: :delete_all),
+          null: false
+        timestamps(type: :timestamptz)
+      end
+
+      create unique_index(:xcode_projects, [:xcode_graph_id, :name])
+
+      create table(:xcode_targets, primary_key: false) do
+        add :id, :uuid, primary_key: true, null: false
+        add :name, :string, null: false
+        add :binary_cache_hash, :string
+        add :binary_cache_hit, :integer
+        add :selective_testing_hash, :string
+        add :selective_testing_hit, :integer
+        add :xcode_project_id,
+            references(:xcode_projects, type: :uuid, on_delete: :delete_all),
+            null: false
+        timestamps(type: :timestamptz)
+      end
+
+      create unique_index(:xcode_targets, [:xcode_project_id, :name])
     end
   end
 end

--- a/server/priv/repo/migrations/20250623091758_clients_key_pair_types.exs
+++ b/server/priv/repo/migrations/20250623091758_clients_key_pair_types.exs
@@ -1,5 +1,25 @@
 defmodule Tuist.Repo.Migrations.ClientsKeyPairTypes do
   use Ecto.Migration
 
-  use Boruta.Migrations.ClientsKeyPairTypes
+  def up do
+    alter table(:oauth_clients) do
+      add :key_pair_type, :jsonb, default: ~s({
+        "type": "rsa",
+        "modulus_size": "1024",
+        "exponent_size": "65537"
+      })
+    end
+
+    execute("""
+      UPDATE oauth_clients
+      SET key_pair_type = '{"type": "ec", "curve": "P-256"}'
+      WHERE public_client_id IS NOT NULL
+    """)
+  end
+
+  def down do
+    alter table(:oauth_clients) do
+      remove :key_pair_type
+    end
+  end
 end

--- a/server/priv/repo/migrations/20250623091800_clients_signatures_adapters.exs
+++ b/server/priv/repo/migrations/20250623091800_clients_signatures_adapters.exs
@@ -4,9 +4,6 @@ defmodule Tuist.Repo.Migrations.ClientsSignaturesAdapters do
   def up do
     alter table(:oauth_clients) do
       add :signatures_adapter, :string, null: false, default: "Elixir.Boruta.Internal.Signatures"
-    end
-
-    alter table(:oauth_clients) do
       modify :did, :text
     end
   end
@@ -14,9 +11,6 @@ defmodule Tuist.Repo.Migrations.ClientsSignaturesAdapters do
   def down do
     alter table(:oauth_clients) do
       modify :did, :string
-    end
-
-    alter table(:oauth_clients) do
       remove :signatures_adapter
     end
   end

--- a/server/priv/repo/migrations/20250623091800_clients_signatures_adapters.exs
+++ b/server/priv/repo/migrations/20250623091800_clients_signatures_adapters.exs
@@ -1,5 +1,23 @@
 defmodule Tuist.Repo.Migrations.ClientsSignaturesAdapters do
   use Ecto.Migration
 
-  use Boruta.Migrations.ClientsSignaturesAdapters
+  def up do
+    alter table(:oauth_clients) do
+      add :signatures_adapter, :string, null: false, default: "Elixir.Boruta.Internal.Signatures"
+    end
+
+    alter table(:oauth_clients) do
+      modify :did, :text
+    end
+  end
+
+  def down do
+    alter table(:oauth_clients) do
+      modify :did, :string
+    end
+
+    alter table(:oauth_clients) do
+      remove :signatures_adapter
+    end
+  end
 end

--- a/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
+++ b/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
@@ -1,7 +1,7 @@
 defmodule Tuist.Repo.Migrations.CreateQAScreenshots do
   use Ecto.Migration
 
-  def change do
+  def up do
     create table(:qa_screenshots, primary_key: false) do
       add :id, :uuid, primary_key: true, null: false
       add :qa_run_id, references(:qa_runs, type: :uuid, on_delete: :delete_all), null: false
@@ -18,5 +18,13 @@ defmodule Tuist.Repo.Migrations.CreateQAScreenshots do
     create index(:qa_screenshots, [:qa_step_id])
     create index(:qa_screenshots, [:inserted_at])
     create unique_index(:qa_screenshots, [:qa_run_id, :file_name])
+  end
+
+  def down do
+    drop unique_index(:qa_screenshots, [:qa_run_id, :file_name])
+    drop index(:qa_screenshots, [:inserted_at])
+    drop index(:qa_screenshots, [:qa_step_id])
+    drop index(:qa_screenshots, [:qa_run_id])
+    drop table(:qa_screenshots)
   end
 end

--- a/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
+++ b/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
@@ -21,7 +21,6 @@ defmodule Tuist.Repo.Migrations.CreateQAScreenshots do
   end
 
   def down do
-    drop unique_index(:qa_screenshots, [:qa_run_id, :file_name])
     drop index(:qa_screenshots, [:inserted_at])
     drop index(:qa_screenshots, [:qa_step_id])
     drop index(:qa_screenshots, [:qa_run_id])

--- a/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
+++ b/server/priv/repo/migrations/20250805130346_create_qa_screenshots.exs
@@ -21,9 +21,6 @@ defmodule Tuist.Repo.Migrations.CreateQAScreenshots do
   end
 
   def down do
-    drop index(:qa_screenshots, [:inserted_at])
-    drop index(:qa_screenshots, [:qa_step_id])
-    drop index(:qa_screenshots, [:qa_run_id])
     drop table(:qa_screenshots)
   end
 end

--- a/server/priv/repo/migrations/20250815134927_make_qa_step_description_optional.exs
+++ b/server/priv/repo/migrations/20250815134927_make_qa_step_description_optional.exs
@@ -1,9 +1,15 @@
 defmodule Tuist.Repo.Migrations.MakeQaStepDescriptionOptional do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:qa_steps) do
       modify :description, :text, null: true
+    end
+  end
+
+  def down do
+    alter table(:qa_steps) do
+      modify :description, :text, null: false
     end
   end
 end


### PR DESCRIPTION
goes through all migrations up until August 2024 and makes them reversible. 
will go through the remaining ones too, but quick solution for a customer that faces an issue.