### PR TITLE
chore(server): disable distributed cache

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -59,7 +59,7 @@ defmodule Tuist.Application do
         Tuist.IngestRepo,
         Tuist.Vault,
         {Oban, Application.fetch_env!(:tuist, Oban)},
-        {Cachex, [:tuist, cachex_opts()]},
+        {Cachex, [:tuist, []]},
         {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Phoenix.PubSub, name: Tuist.PubSub},
         Supervisor.child_spec(CommandEvents.Buffer, id: CommandEvents.Buffer),
@@ -126,24 +126,6 @@ defmodule Tuist.Application do
         ],
         else: []
     )
-  end
-
-  def cachex_opts do
-    if Environment.tuist_hosted?() do
-      # Tuist-managed instances are configured to support a multi-node cluster.
-      [
-        router:
-          router(
-            module: Cachex.Router.Ring,
-            options: [
-              monitor: true
-            ]
-          )
-      ]
-    else
-      # In on-premise environments we assume a single Node.
-      []
-    end
   end
 
   defp finch_pools do


### PR DESCRIPTION
While debugging [this error](https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/714/samples/6607b64d83eb6789e61c8ba7-489575373660731413217557942203):

```
** (Cachex.Error) Specified cache not running
```

I realized that our current "distributed" setup might be the culprit of it, and in fact not something that we want. My assumption is that the issue happens because there's a data race. The distributed cache relies on notifications when nodes are up and down, so it's possible that when a node tries to look up a value in another down, the down is down (e.g. because a new one has been deployed). We could add some logic to handle this gracefully but then I realized that we might not need a distributed cache.

The reason why we have a cache is two fold:
1. Reduce the DB throughput for highly concurrent requests (i.e. cache endpoints)
2. Reduce the latency of responses by not having to go to another region to do things like authentication or authorization

1 is solved with a distributed and local cache, but 2 is something we don't get if we distribute the cache because a Node might need to go to anothe region to lookup a key.

Therefore I decided to make the cache local, which means we can achieve 2 and 1 (with a slighly higher throughput that we should be able to handle).