### PR TITLE
Simplify SwiftUI previews using #Preview macro

### DIFF
--- a/cli/Fixtures/app_with_composable_architecture/App/Sources/ContentView.swift
+++ b/cli/Fixtures/app_with_composable_architecture/App/Sources/ContentView.swift
@@ -9,8 +9,7 @@ public struct ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
+@available(*, introduced: iOS 17, macOS 14, tvOS 17, watchOS 10)
+#Preview {
+    ContentView()
 }


### PR DESCRIPTION
This PR updates SwiftUI previews to use the modern #Preview macro introduced in Xcode 15 / Swift 5.9.
It removes the need for PreviewProvider boilerplate and simplifies preview declarations.

### How to test locally

1. Open the project in Xcode 15 or newer
2. Navigate to a SwiftUI view file
3. Open the Canvas (⌥⌘↵)
4. Verify that the preview renders correctly without warnings
5. Run on multiple schemes (iOS, macOS, watchOS, tvOS) to confirm availability attributes work