### PR TITLE
feat(cli): implement support for xcbeautify parameters

### DIFF
--- a/cli/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/cli/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Mockable
 import Path
 import XcodeGraph
@@ -118,7 +119,8 @@ public protocol XcodeBuildControlling {
 
     /// Runs `xcodebuild` with passed `arguments` and formats the output
     /// - arguments: Arguments to pass to `xcodebuild`
-    func run(arguments: [String]) async throws
+    @discardableResult
+    func run(arguments: [String]) async throws -> Data
 
     /// - Returns: `xcodebuild` version. This version is aligned with the Xcode version.
     func version() async throws -> Version?

--- a/cli/Sources/TuistKit/Utils/XCBeautifyArgumentsParser.swift
+++ b/cli/Sources/TuistKit/Utils/XCBeautifyArgumentsParser.swift
@@ -1,0 +1,49 @@
+/// Represents parsed arguments split between xcodebuild and xcbeautify
+struct XCBeautifyParsedArguments {
+    /// Arguments that remain for xcodebuild
+    let remaining: [String]
+    /// Arguments that should be passed through to xcbeautify
+    let xcbeautify: [String]
+}
+
+/// Protocol defining an arguments parser for xcbeautify
+protocol XCBeautifyArgumentsParsing {
+    /// Parses the provided arguments into xcodebuild and xcbeautify subsets
+    /// - Parameter arguments: The full list of CLI arguments
+    /// - Returns: A struct containing separated arguments
+    func parse(_ arguments: [String]) -> XCBeautifyParsedArguments
+}
+
+final class XCBeautifyArgumentsParser: XCBeautifyArgumentsParsing {
+    func parse(_ arguments: [String]) -> XCBeautifyParsedArguments {
+        var passthroughArgs: [String] = []
+        var remainingArgs: [String] = []
+        var skipNext = false
+
+        for (index, arg) in arguments.enumerated() {
+            if skipNext {
+                skipNext = false
+                continue
+            }
+
+            if arg.starts(with: "--xcbeautify-") {
+                let beautifyArg = "--" + arg.dropFirst("--xcbeautify-".count)
+                if index + 1 < arguments.count {
+                    let next = arguments[index + 1]
+                    if !next.starts(with: "-") {
+                        passthroughArgs.append(contentsOf: [beautifyArg, next])
+                        skipNext = true
+                    } else {
+                        passthroughArgs.append(beautifyArg)
+                    }
+                } else {
+                    passthroughArgs.append(beautifyArg)
+                }
+            } else {
+                remainingArgs.append(arg)
+            }
+        }
+
+        return XCBeautifyParsedArguments(remaining: remainingArgs, xcbeautify: passthroughArgs)
+    }
+}

--- a/cli/Sources/TuistKit/Utils/XCBeautifyController.swift
+++ b/cli/Sources/TuistKit/Utils/XCBeautifyController.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Defines a protocol for controlling xcbeautify execution
+protocol XCBeautifyControlling {
+    /// Runs xcbeautify with the given arguments and build output
+    ///
+    /// - Parameters:
+    ///   - arguments: The arguments to pass to xcbeautify
+    ///   - buildOutput: The raw build output data to be piped into xcbeautify
+    func run(arguments: [String], buildOutput: Data) async throws
+}
+
+final class XCBeautifyController: XCBeautifyControlling {
+    func run(arguments: [String], buildOutput: Data) async throws {
+        let xcbeautify = Process()
+        xcbeautify.executableURL = URL(fileURLWithPath: "/usr/local/bin/xcbeautify")
+        xcbeautify.arguments = arguments
+
+        let inputPipe = Pipe()
+        xcbeautify.standardInput = inputPipe
+
+        try xcbeautify.run()
+
+        try inputPipe.fileHandleForWriting.write(contentsOf: buildOutput)
+
+        inputPipe.fileHandleForWriting.closeFile()
+
+        xcbeautify.waitUntilExit()
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildBuildCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildBuildCommandServiceTests.swift
@@ -70,7 +70,7 @@ struct XcodeBuildBuildCommandServiceTests {
 
         given(xcodeBuildController)
             .run(arguments: .any)
-            .willReturn()
+            .willReturn(Data())
 
         // When
         try await subject.run(passthroughXcodebuildArguments: arguments)

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -39,7 +39,7 @@ struct XcodeBuildTestCommandServiceTests {
             .willReturn(.test())
         given(xcodeBuildController)
             .run(arguments: .any)
-            .willReturn()
+            .willReturn(Data())
         given(cacheStorage)
             .store(.any, cacheCategory: .any)
             .willReturn()

--- a/cli/Tests/TuistKitTests/Utils/XCBeautifyArgumentsParserTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/XCBeautifyArgumentsParserTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import TuistKit
+
+struct XCBeautifyArgumentsParserTests {
+    let parser = XCBeautifyArgumentsParser()
+
+    @Test
+    func noBeautifyArgs() {
+        // Given
+        let args = ["build", "-scheme", "App"]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining == args)
+        #expect(result.xcbeautify.isEmpty)
+    }
+
+    @Test
+    func singleBeautifyFlagWithValue() {
+        // Given
+        let args = ["build", "--xcbeautify-color", "always"]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining == ["build"])
+        #expect(result.xcbeautify == ["--color", "always"])
+    }
+
+    @Test
+    func singleBeautifyFlagWithoutValue() {
+        // Given
+        let args = ["--xcbeautify-quiet"]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining.isEmpty)
+        #expect(result.xcbeautify == ["--quiet"])
+    }
+
+    @Test
+    func beautifyFlagFollowedByFlag() {
+        // Given
+        let args = ["--xcbeautify-color", "--other-flag"]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining == ["--other-flag"])
+        #expect(result.xcbeautify == ["--color"])
+    }
+
+    @Test
+    func mixedArgs() {
+        // Given
+        let args = [
+            "test",
+            "--xcbeautify-color", "always",
+            "--xcbeautify-quiet",
+            "-scheme", "App",
+        ]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining == ["test", "-scheme", "App"])
+        #expect(result.xcbeautify == ["--color", "always", "--quiet"])
+    }
+
+    @Test
+    func beautifyFlagAtEnd() {
+        // Given
+        let args = ["build", "--xcbeautify-verbose"]
+
+        // When
+        let result = parser.parse(args)
+
+        // Then
+        #expect(result.remaining == ["build"])
+        #expect(result.xcbeautify == ["--verbose"])
+    }
+}


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7605>

This PR adds support for `xcbeautify` parameters.
Now the parser collects output parameters from `xcodebuild` and passes them through to `xcbeautify`.

### How to test locally

> Document how to test your changes locally
