### PR TITLE
chore(server): keep ClickHouse connections alive, and use IPv6 if available

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -51,6 +51,11 @@ if Enum.member?([:prod, :stag, :can], env) do
         # Specifies the join algorithms to use in order of preference: direct (fastest for small tables),
         # parallel_hash (good for medium tables), and hash (fallback for large tables)
         join_algorithm: "direct,parallel_hash,hash"
+      ],
+      transport_opts: [
+        keepalive: true,
+        show_econnreset: true,
+        inet6: Tuist.Environment.use_ipv6?(secrets)
       ]
 
     config :tuist, Tuist.IngestRepo,
@@ -60,7 +65,12 @@ if Enum.member?([:prod, :stag, :can], env) do
       queue_interval: Tuist.Environment.clickhouse_queue_interval(secrets),
       flush_interval_ms: Tuist.Environment.clickhouse_flush_interval_ms(secrets),
       max_buffer_size: Tuist.Environment.clickhouse_max_buffer_size(secrets),
-      pool_size: Tuist.Environment.clickhouse_buffer_pool_size(secrets)
+      pool_size: Tuist.Environment.clickhouse_buffer_pool_size(secrets),
+      transport_opts: [
+        keepalive: true,
+        show_econnreset: true,
+        inet6: Tuist.Environment.use_ipv6?(secrets)
+      ]
   end
 
   database_url =

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -4,7 +4,6 @@ defmodule Tuist.Application do
   use Application
   use Boundary, top_level?: true, deps: [Tuist, TuistWeb]
 
-  import Cachex.Spec
   import Tuist.Environment, only: [run_if_error_tracking_enabled: 1]
 
   alias Tuist.CommandEvents


### PR DESCRIPTION
I noticed some ClickHouse queries being dropped from the queue and I think it might be caused by connections from the pool dropping, causing the establishing of the connection (with TLS handshake included), which can take longer than the time queries can wait in the queue.

Like we did with Postgres, I'm configuring the connections to remain alive and use IPv6 if available.