### PR TITLE
fix(server): launch errors related to ClickHouse and Cachex

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -55,22 +55,30 @@ defmodule Tuist.Application do
       [
         {DBConnection.TelemetryListener, name: TelemetryListener},
         {Tuist.Repo, connection_listeners: [TelemetryListener]},
-        Tuist.ClickHouseRepo,
-        Tuist.IngestRepo,
         Tuist.Vault,
         {Oban, Application.fetch_env!(:tuist, Oban)},
         {Cachex, [:tuist, []]},
         {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Phoenix.PubSub, name: Tuist.PubSub},
-        Supervisor.child_spec(CommandEvents.Buffer, id: CommandEvents.Buffer),
-        Supervisor.child_spec(Logs.Buffer, id: Logs.Buffer),
-        Supervisor.child_spec(XcodeGraph.Buffer, id: XcodeGraph.Buffer),
-        Supervisor.child_spec(XcodeProject.Buffer, id: XcodeProject.Buffer),
-        Supervisor.child_spec(XcodeTarget.Buffer, id: XcodeTarget.Buffer),
         TuistWeb.Telemetry
       ]
 
     children
+    |> Kernel.++(
+      if Environment.clickhouse_configured?() do
+        [
+          Tuist.ClickHouseRepo,
+          Tuist.IngestRepo,
+          Supervisor.child_spec(CommandEvents.Buffer, id: CommandEvents.Buffer),
+          Supervisor.child_spec(Logs.Buffer, id: Logs.Buffer),
+          Supervisor.child_spec(XcodeGraph.Buffer, id: XcodeGraph.Buffer),
+          Supervisor.child_spec(XcodeProject.Buffer, id: XcodeProject.Buffer),
+          Supervisor.child_spec(XcodeTarget.Buffer, id: XcodeTarget.Buffer)
+        ]
+      else
+        []
+      end
+    )
     |> Kernel.++(
       if Environment.dev_use_remote_storage?() do
         []

--- a/server/lib/tuist/key_value_store.ex
+++ b/server/lib/tuist/key_value_store.ex
@@ -93,7 +93,11 @@ defmodule Tuist.KeyValueStore do
     end
 
     if Keyword.get(opts, :locking, true) do
-      Cachex.transaction!(cachex_cache(opts), [cache_key(cache_key)], read_or_update)
+      case Cachex.transaction(cachex_cache(opts), [cache_key(cache_key)], read_or_update) do
+        {:ok, value} -> value
+        # If the cache is unavailable, we handle it gracefully by obtaining the value without caching it.
+        {:error, reason} -> func.()
+      end
     else
       read_or_update.(cachex_cache(opts))
     end


### PR DESCRIPTION
It's been reported that in some environment scenario, the Tuist server fails to launch with the following errors:

## `[error] Ch.Connection (#PID<0.5291.0>) failed to connect: ** (Mint.TransportError) connection refused`

This happens because we are initializing some ClickHouse processes even when ClickHouse is not configured in the instance. I've adjusted the application's children list to not include those if ClickHouse is absent.

## `** (Cachex.Error) Specified cache not running`

I believe this is caused due to a race condition at launch time where the license checker, which caches the validation result, might try to use the cache while it's being initialized. I adjusted the cache implementation to handle those scenarios gracefully and fallback to returning the value directly skipping the cache.
