### PR TITLE
fix(server): runs metadata failing to upload

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -731,6 +731,151 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// It completes a multi-part upload
+    ///
+    /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)`.
+    public func completeAnalyticsArtifactMultipartUploadProject(_ input: Operations.completeAnalyticsArtifactMultipartUploadProject.Input) async throws -> Operations.completeAnalyticsArtifactMultipartUploadProject.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.completeAnalyticsArtifactMultipartUploadProject.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/runs/{}/complete",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.run_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .post
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case .none:
+                    body = nil
+                case let .json(value):
+                    body = try converter.setOptionalRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 204:
+                    return .noContent(.init())
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                case 500:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.InternalServerError.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .internalServerError(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// List bundles for a project
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles`.
@@ -763,15 +908,15 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
+                    name: "page_size",
+                    value: input.query.page_size
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "page_size",
-                    value: input.query.page_size
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,
@@ -1107,12 +1252,13 @@ public struct Client: APIProtocol {
             }
         )
     }
-    /// It initiates a multipart upload for a command event artifact.
+    /// It initiates a multipart upload for a run artifact
     ///
     /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/start`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     public func startAnalyticsArtifactMultipartUpload(_ input: Operations.startAnalyticsArtifactMultipartUpload.Input) async throws -> Operations.startAnalyticsArtifactMultipartUpload.Output {
         try await client.send(
             input: input,
@@ -2191,6 +2337,129 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Completes artifacts uploads for a given run
+    ///
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)`.
+    public func completeAnalyticsArtifactsUploadsProject(_ input: Operations.completeAnalyticsArtifactsUploadsProject.Input) async throws -> Operations.completeAnalyticsArtifactsUploadsProject.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.completeAnalyticsArtifactsUploadsProject.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/runs/{}/complete_artifacts_uploads",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.run_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .put
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case .none:
+                    body = nil
+                case let .json(value):
+                    body = try converter.setOptionalRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 204:
+                    return .noContent(.init())
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.completeAnalyticsArtifactsUploadsProject.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// It generates a signed URL for uploading a part.
     ///
     /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
@@ -2359,6 +2628,292 @@ public struct Client: APIProtocol {
                 case 404:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.generateCacheArtifactMultipartUploadURL.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// It generates a signed URL for uploading a part
+    ///
+    /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)`.
+    public func generateAnalyticsArtifactMultipartUploadURLProject(_ input: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input) async throws -> Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.generateAnalyticsArtifactMultipartUploadURLProject.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/runs/{}/generate-url",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.run_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .post
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case .none:
+                    body = nil
+                case let .json(value):
+                    body = try converter.setOptionalRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ArtifactMultipartUploadURL.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
+    /// It initiates a multipart upload for a run artifact
+    ///
+    /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/start`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)`.
+    public func startAnalyticsArtifactMultipartUploadProject(_ input: Operations.startAnalyticsArtifactMultipartUploadProject.Input) async throws -> Operations.startAnalyticsArtifactMultipartUploadProject.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.startAnalyticsArtifactMultipartUploadProject.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/runs/{}/start",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.run_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .post
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case .none:
+                    body = nil
+                case let .json(value):
+                    body = try converter.setOptionalRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas.ArtifactUploadID.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 401:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .unauthorized(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body
                     let chosenContentType = try converter.bestContentType(
                         received: contentType,
                         options: [
@@ -3701,6 +4256,7 @@ public struct Client: APIProtocol {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/generate-url`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURL)`.
+    @available(*, deprecated)
     public func generateAnalyticsArtifactMultipartUploadURL(_ input: Operations.generateAnalyticsArtifactMultipartUploadURL.Input) async throws -> Operations.generateAnalyticsArtifactMultipartUploadURL.Output {
         try await client.send(
             input: input,
@@ -4564,6 +5120,7 @@ public struct Client: APIProtocol {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/complete`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     public func completeAnalyticsArtifactMultipartUpload(_ input: Operations.completeAnalyticsArtifactMultipartUpload.Input) async throws -> Operations.completeAnalyticsArtifactMultipartUpload.Output {
         try await client.send(
             input: input,
@@ -7035,12 +7592,13 @@ public struct Client: APIProtocol {
             }
         )
     }
-    /// Completes artifacts uploads for a given command event
+    /// Completes artifacts uploads for a given run
     ///
-    /// Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
     ///
     /// - Remark: HTTP `PUT /api/runs/{run_id}/complete_artifacts_uploads`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)`.
+    @available(*, deprecated)
     public func completeAnalyticsArtifactsUploads(_ input: Operations.completeAnalyticsArtifactsUploads.Input) async throws -> Operations.completeAnalyticsArtifactsUploads.Output {
         try await client.send(
             input: input,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -44,6 +44,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /api/auth/refresh_token`.
     /// - Remark: Generated from `#/paths//api/auth/refresh_token/post(refreshToken)`.
     func refreshToken(_ input: Operations.refreshToken.Input) async throws -> Operations.refreshToken.Output
+    /// It completes a multi-part upload
+    ///
+    /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)`.
+    func completeAnalyticsArtifactMultipartUploadProject(_ input: Operations.completeAnalyticsArtifactMultipartUploadProject.Input) async throws -> Operations.completeAnalyticsArtifactMultipartUploadProject.Output
     /// List bundles for a project
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles`.
@@ -61,12 +68,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/auth/device_code/{device_code}`.
     /// - Remark: Generated from `#/paths//api/auth/device_code/{device_code}/get(getDeviceCode)`.
     func getDeviceCode(_ input: Operations.getDeviceCode.Input) async throws -> Operations.getDeviceCode.Output
-    /// It initiates a multipart upload for a command event artifact.
+    /// It initiates a multipart upload for a run artifact
     ///
     /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/start`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     func startAnalyticsArtifactMultipartUpload(_ input: Operations.startAnalyticsArtifactMultipartUpload.Input) async throws -> Operations.startAnalyticsArtifactMultipartUpload.Output
     /// List projects the authenticated user has access to.
     ///
@@ -113,6 +121,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/cache/ac/{hash}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/cache/ac/{hash}/get(getCacheActionItem)`.
     func getCacheActionItem(_ input: Operations.getCacheActionItem.Input) async throws -> Operations.getCacheActionItem.Output
+    /// Completes artifacts uploads for a given run
+    ///
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)`.
+    func completeAnalyticsArtifactsUploadsProject(_ input: Operations.completeAnalyticsArtifactsUploadsProject.Input) async throws -> Operations.completeAnalyticsArtifactsUploadsProject.Output
     /// It generates a signed URL for uploading a part.
     ///
     /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
@@ -120,6 +135,20 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /api/cache/multipart/generate-url`.
     /// - Remark: Generated from `#/paths//api/cache/multipart/generate-url/post(generateCacheArtifactMultipartUploadURL)`.
     func generateCacheArtifactMultipartUploadURL(_ input: Operations.generateCacheArtifactMultipartUploadURL.Input) async throws -> Operations.generateCacheArtifactMultipartUploadURL.Output
+    /// It generates a signed URL for uploading a part
+    ///
+    /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)`.
+    func generateAnalyticsArtifactMultipartUploadURLProject(_ input: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input) async throws -> Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output
+    /// It initiates a multipart upload for a run artifact
+    ///
+    /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/start`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)`.
+    func startAnalyticsArtifactMultipartUploadProject(_ input: Operations.startAnalyticsArtifactMultipartUploadProject.Input) async throws -> Operations.startAnalyticsArtifactMultipartUploadProject.Output
     /// Authenticate with Apple identity token.
     ///
     /// This endpoint returns API tokens for a given Apple identity token and authorization code from the first-party Tuist iOS app.
@@ -188,6 +217,7 @@ public protocol APIProtocol: Sendable {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/generate-url`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURL)`.
+    @available(*, deprecated)
     func generateAnalyticsArtifactMultipartUploadURL(_ input: Operations.generateAnalyticsArtifactMultipartUploadURL.Input) async throws -> Operations.generateAnalyticsArtifactMultipartUploadURL.Output
     /// Cleans cache for a given project
     ///
@@ -228,6 +258,7 @@ public protocol APIProtocol: Sendable {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/complete`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     func completeAnalyticsArtifactMultipartUpload(_ input: Operations.completeAnalyticsArtifactMultipartUpload.Input) async throws -> Operations.completeAnalyticsArtifactMultipartUpload.Output
     /// Lists the organizations
     ///
@@ -339,12 +370,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `DELETE /api/accounts/{account_handle}`.
     /// - Remark: Generated from `#/paths//api/accounts/{account_handle}/delete(deleteAccount)`.
     func deleteAccount(_ input: Operations.deleteAccount.Input) async throws -> Operations.deleteAccount.Output
-    /// Completes artifacts uploads for a given command event
+    /// Completes artifacts uploads for a given run
     ///
-    /// Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
     ///
     /// - Remark: HTTP `PUT /api/runs/{run_id}/complete_artifacts_uploads`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)`.
+    @available(*, deprecated)
     func completeAnalyticsArtifactsUploads(_ input: Operations.completeAnalyticsArtifactsUploads.Input) async throws -> Operations.completeAnalyticsArtifactsUploads.Output
 }
 
@@ -429,6 +461,23 @@ extension APIProtocol {
             body: body
         ))
     }
+    /// It completes a multi-part upload
+    ///
+    /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)`.
+    public func completeAnalyticsArtifactMultipartUploadProject(
+        path: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Path,
+        headers: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Headers = .init(),
+        body: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Body? = nil
+    ) async throws -> Operations.completeAnalyticsArtifactMultipartUploadProject.Output {
+        try await completeAnalyticsArtifactMultipartUploadProject(Operations.completeAnalyticsArtifactMultipartUploadProject.Input(
+            path: path,
+            headers: headers,
+            body: body
+        ))
+    }
     /// List bundles for a project
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles`.
@@ -474,12 +523,13 @@ extension APIProtocol {
             headers: headers
         ))
     }
-    /// It initiates a multipart upload for a command event artifact.
+    /// It initiates a multipart upload for a run artifact
     ///
     /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/start`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     public func startAnalyticsArtifactMultipartUpload(
         path: Operations.startAnalyticsArtifactMultipartUpload.Input.Path,
         headers: Operations.startAnalyticsArtifactMultipartUpload.Input.Headers = .init(),
@@ -586,6 +636,23 @@ extension APIProtocol {
             headers: headers
         ))
     }
+    /// Completes artifacts uploads for a given run
+    ///
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)`.
+    public func completeAnalyticsArtifactsUploadsProject(
+        path: Operations.completeAnalyticsArtifactsUploadsProject.Input.Path,
+        headers: Operations.completeAnalyticsArtifactsUploadsProject.Input.Headers = .init(),
+        body: Operations.completeAnalyticsArtifactsUploadsProject.Input.Body? = nil
+    ) async throws -> Operations.completeAnalyticsArtifactsUploadsProject.Output {
+        try await completeAnalyticsArtifactsUploadsProject(Operations.completeAnalyticsArtifactsUploadsProject.Input(
+            path: path,
+            headers: headers,
+            body: body
+        ))
+    }
     /// It generates a signed URL for uploading a part.
     ///
     /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
@@ -599,6 +666,40 @@ extension APIProtocol {
         try await generateCacheArtifactMultipartUploadURL(Operations.generateCacheArtifactMultipartUploadURL.Input(
             query: query,
             headers: headers
+        ))
+    }
+    /// It generates a signed URL for uploading a part
+    ///
+    /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)`.
+    public func generateAnalyticsArtifactMultipartUploadURLProject(
+        path: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Path,
+        headers: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Headers = .init(),
+        body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Body? = nil
+    ) async throws -> Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output {
+        try await generateAnalyticsArtifactMultipartUploadURLProject(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input(
+            path: path,
+            headers: headers,
+            body: body
+        ))
+    }
+    /// It initiates a multipart upload for a run artifact
+    ///
+    /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/start`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)`.
+    public func startAnalyticsArtifactMultipartUploadProject(
+        path: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Path,
+        headers: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Headers = .init(),
+        body: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Body? = nil
+    ) async throws -> Operations.startAnalyticsArtifactMultipartUploadProject.Output {
+        try await startAnalyticsArtifactMultipartUploadProject(Operations.startAnalyticsArtifactMultipartUploadProject.Input(
+            path: path,
+            headers: headers,
+            body: body
         ))
     }
     /// Authenticate with Apple identity token.
@@ -751,6 +852,7 @@ extension APIProtocol {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/generate-url`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURL)`.
+    @available(*, deprecated)
     public func generateAnalyticsArtifactMultipartUploadURL(
         path: Operations.generateAnalyticsArtifactMultipartUploadURL.Input.Path,
         headers: Operations.generateAnalyticsArtifactMultipartUploadURL.Input.Headers = .init(),
@@ -847,6 +949,7 @@ extension APIProtocol {
     ///
     /// - Remark: HTTP `POST /api/runs/{run_id}/complete`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUpload)`.
+    @available(*, deprecated)
     public func completeAnalyticsArtifactMultipartUpload(
         path: Operations.completeAnalyticsArtifactMultipartUpload.Input.Path,
         headers: Operations.completeAnalyticsArtifactMultipartUpload.Input.Headers = .init(),
@@ -1110,12 +1213,13 @@ extension APIProtocol {
             headers: headers
         ))
     }
-    /// Completes artifacts uploads for a given command event
+    /// Completes artifacts uploads for a given run
     ///
-    /// Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
     ///
     /// - Remark: HTTP `PUT /api/runs/{run_id}/complete_artifacts_uploads`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)`.
+    @available(*, deprecated)
     public func completeAnalyticsArtifactsUploads(
         path: Operations.completeAnalyticsArtifactsUploads.Input.Path,
         headers: Operations.completeAnalyticsArtifactsUploads.Input.Headers = .init(),
@@ -5121,7 +5225,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The command event was created
+            /// The run was created
             ///
             /// - Remark: Generated from `#/paths//api/analytics/post(createCommandEvent)/responses/200`.
             ///
@@ -5223,7 +5327,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// You don't have permission to create command events for the project.
+            /// You don't have permission to create runs for the project.
             ///
             /// - Remark: Generated from `#/paths//api/analytics/post(createCommandEvent)/responses/403`.
             ///
@@ -6225,6 +6329,366 @@ public enum Operations {
             }
         }
     }
+    /// It completes a multi-part upload
+    ///
+    /// Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)`.
+    public enum completeAnalyticsArtifactMultipartUploadProject {
+        public static let id: Swift.String = "completeAnalyticsArtifactMultipartUploadProject"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/path/project_handle`.
+                public var project_handle: Swift.String
+                /// The id of the run.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/path/run_id`.
+                public var run_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - run_id: The id of the run.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    run_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.run_id = run_id
+                }
+            }
+            public var path: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.completeAnalyticsArtifactMultipartUploadProject.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.completeAnalyticsArtifactMultipartUploadProject.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Headers
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/requestBody/json`.
+                public struct jsonPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/requestBody/json/command_event_artifact`.
+                    public var command_event_artifact: Components.Schemas.CommandEventArtifact
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/requestBody/json/multipart_upload_parts`.
+                    public var multipart_upload_parts: Components.Schemas.ArtifactMultipartUploadParts
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - command_event_artifact:
+                    ///   - multipart_upload_parts:
+                    public init(
+                        command_event_artifact: Components.Schemas.CommandEventArtifact,
+                        multipart_upload_parts: Components.Schemas.ArtifactMultipartUploadParts
+                    ) {
+                        self.command_event_artifact = command_event_artifact
+                        self.multipart_upload_parts = multipart_upload_parts
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case command_event_artifact
+                        case multipart_upload_parts
+                    }
+                }
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/requestBody/content/application\/json`.
+                case json(Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Body.jsonPayload)
+            }
+            public var body: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Path,
+                headers: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Headers = .init(),
+                body: Operations.completeAnalyticsArtifactMultipartUploadProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
+                /// Creates a new `NoContent`.
+                public init() {}
+            }
+            /// The upload has been completed
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NoContent)
+            /// The associated value of the enum case if `self` is `.noContent`.
+            ///
+            /// - Throws: An error if `self` is not `.noContent`.
+            /// - SeeAlso: `.noContent`.
+            public var noContent: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NoContent {
+                get throws {
+                    switch self {
+                    case let .noContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "noContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/401/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// The project doesn't exist
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct InternalServerError: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/500/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/POST/responses/500/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.InternalServerError.Body
+                /// Creates a new `InternalServerError`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.InternalServerError.Body) {
+                    self.body = body
+                }
+            }
+            /// An internal server error occurred
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete/post(completeAnalyticsArtifactMultipartUploadProject)/responses/500`.
+            ///
+            /// HTTP response code: `500 internalServerError`.
+            case internalServerError(Operations.completeAnalyticsArtifactMultipartUploadProject.Output.InternalServerError)
+            /// The associated value of the enum case if `self` is `.internalServerError`.
+            ///
+            /// - Throws: An error if `self` is not `.internalServerError`.
+            /// - SeeAlso: `.internalServerError`.
+            public var internalServerError: Operations.completeAnalyticsArtifactMultipartUploadProject.Output.InternalServerError {
+                get throws {
+                    switch self {
+                    case let .internalServerError(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "internalServerError",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// List bundles for a project
     ///
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/bundles`.
@@ -6262,28 +6726,28 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
                 public var page: Swift.Int?
-                /// Filter bundles by git branch.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
-                public var git_branch: Swift.String?
                 /// Number of items per page.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
                 public var page_size: Swift.Int?
+                /// Filter bundles by git branch.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
+                public var git_branch: Swift.String?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
                 ///   - page: Page number for pagination.
-                ///   - git_branch: Filter bundles by git branch.
                 ///   - page_size: Number of items per page.
+                ///   - git_branch: Filter bundles by git branch.
                 public init(
                     page: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil,
-                    page_size: Swift.Int? = nil
+                    page_size: Swift.Int? = nil,
+                    git_branch: Swift.String? = nil
                 ) {
                     self.page = page
-                    self.git_branch = git_branch
                     self.page_size = page_size
+                    self.git_branch = git_branch
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -7204,7 +7668,7 @@ public enum Operations {
             }
         }
     }
-    /// It initiates a multipart upload for a command event artifact.
+    /// It initiates a multipart upload for a run artifact
     ///
     /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
     ///
@@ -7215,14 +7679,14 @@ public enum Operations {
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/api/runs/{run_id}/start/POST/path`.
             public struct Path: Sendable, Hashable {
-                /// The id of the command event UUID.
+                /// The id of the run UUID.
                 ///
                 /// - Remark: Generated from `#/paths/api/runs/{run_id}/start/POST/path/run_id`.
                 public var run_id: Swift.String
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
-                ///   - run_id: The id of the command event UUID.
+                ///   - run_id: The id of the run UUID.
                 public init(run_id: Swift.String) {
                     self.run_id = run_id
                 }
@@ -7444,7 +7908,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The command event doesn't exist
+            /// The run doesn't exist
             ///
             /// - Remark: Generated from `#/paths//api/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUpload)/responses/404`.
             ///
@@ -9605,6 +10069,292 @@ public enum Operations {
             }
         }
     }
+    /// Completes artifacts uploads for a given run
+    ///
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)`.
+    public enum completeAnalyticsArtifactsUploadsProject {
+        public static let id: Swift.String = "completeAnalyticsArtifactsUploadsProject"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/path/project_handle`.
+                public var project_handle: Swift.String
+                /// The id of the run.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/path/run_id`.
+                public var run_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - run_id: The id of the run.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    run_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.run_id = run_id
+                }
+            }
+            public var path: Operations.completeAnalyticsArtifactsUploadsProject.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.completeAnalyticsArtifactsUploadsProject.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.completeAnalyticsArtifactsUploadsProject.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.completeAnalyticsArtifactsUploadsProject.Input.Headers
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/requestBody/content/application\/json`.
+                case json(OpenAPIRuntime.OpenAPIObjectContainer)
+            }
+            public var body: Operations.completeAnalyticsArtifactsUploadsProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.completeAnalyticsArtifactsUploadsProject.Input.Path,
+                headers: Operations.completeAnalyticsArtifactsUploadsProject.Input.Headers = .init(),
+                body: Operations.completeAnalyticsArtifactsUploadsProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct NoContent: Sendable, Hashable {
+                /// Creates a new `NoContent`.
+                public init() {}
+            }
+            /// The run artifact uploads were successfully finished
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.completeAnalyticsArtifactsUploadsProject.Output.NoContent)
+            /// The associated value of the enum case if `self` is `.noContent`.
+            ///
+            /// - Throws: An error if `self` is not `.noContent`.
+            /// - SeeAlso: `.noContent`.
+            public var noContent: Operations.completeAnalyticsArtifactsUploadsProject.Output.NoContent {
+                get throws {
+                    switch self {
+                    case let .noContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "noContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/401/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.completeAnalyticsArtifactsUploadsProject.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.completeAnalyticsArtifactsUploadsProject.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactsUploadsProject.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.completeAnalyticsArtifactsUploadsProject.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.completeAnalyticsArtifactsUploadsProject.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/PUT/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.completeAnalyticsArtifactsUploadsProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.completeAnalyticsArtifactsUploadsProject.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// The run doesn't exist
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploadsProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.completeAnalyticsArtifactsUploadsProject.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.completeAnalyticsArtifactsUploadsProject.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
     /// It generates a signed URL for uploading a part.
     ///
     /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
@@ -9942,6 +10692,649 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.notFound`.
             /// - SeeAlso: `.notFound`.
             public var notFound: Operations.generateCacheArtifactMultipartUploadURL.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// It generates a signed URL for uploading a part
+    ///
+    /// Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)`.
+    public enum generateAnalyticsArtifactMultipartUploadURLProject {
+        public static let id: Swift.String = "generateAnalyticsArtifactMultipartUploadURLProject"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/path/project_handle`.
+                public var project_handle: Swift.String
+                /// The id of the run.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/path/run_id`.
+                public var run_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - run_id: The id of the run.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    run_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.run_id = run_id
+                }
+            }
+            public var path: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.generateAnalyticsArtifactMultipartUploadURLProject.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.generateAnalyticsArtifactMultipartUploadURLProject.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Headers
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/requestBody/json`.
+                public struct jsonPayload: Codable, Hashable, Sendable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/requestBody/json/command_event_artifact`.
+                    public var command_event_artifact: Components.Schemas.CommandEventArtifact
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/requestBody/json/multipart_upload_part`.
+                    public var multipart_upload_part: Components.Schemas.ArtifactMultipartUploadPart
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - command_event_artifact:
+                    ///   - multipart_upload_part:
+                    public init(
+                        command_event_artifact: Components.Schemas.CommandEventArtifact,
+                        multipart_upload_part: Components.Schemas.ArtifactMultipartUploadPart
+                    ) {
+                        self.command_event_artifact = command_event_artifact
+                        self.multipart_upload_part = multipart_upload_part
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case command_event_artifact
+                        case multipart_upload_part
+                    }
+                }
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/requestBody/content/application\/json`.
+                case json(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Body.jsonPayload)
+            }
+            public var body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Path,
+                headers: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Headers = .init(),
+                body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/200/content/application\/json`.
+                    case json(Components.Schemas.ArtifactMultipartUploadURL)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ArtifactMultipartUploadURL {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// The URL has been generated
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/401/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/POST/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// The project doesn't exist
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url/post(generateAnalyticsArtifactMultipartUploadURLProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.generateAnalyticsArtifactMultipartUploadURLProject.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// It initiates a multipart upload for a run artifact
+    ///
+    /// The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
+    ///
+    /// - Remark: HTTP `POST /api/projects/{account_handle}/{project_handle}/runs/{run_id}/start`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)`.
+    public enum startAnalyticsArtifactMultipartUploadProject {
+        public static let id: Swift.String = "startAnalyticsArtifactMultipartUploadProject"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/path/project_handle`.
+                public var project_handle: Swift.String
+                /// The id of the run.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/path/run_id`.
+                public var run_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - run_id: The id of the run.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    run_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.run_id = run_id
+                }
+            }
+            public var path: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.startAnalyticsArtifactMultipartUploadProject.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.startAnalyticsArtifactMultipartUploadProject.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Headers
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/requestBody/content/application\/json`.
+                case json(Components.Schemas.CommandEventArtifact)
+            }
+            public var body: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Path,
+                headers: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Headers = .init(),
+                body: Operations.startAnalyticsArtifactMultipartUploadProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/200/content/application\/json`.
+                    case json(Components.Schemas.ArtifactUploadID)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas.ArtifactUploadID {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// The upload has been started
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.startAnalyticsArtifactMultipartUploadProject.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/401/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/401/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Unauthorized.Body) {
+                    self.body = body
+                }
+            }
+            /// You need to be authenticated to access this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.startAnalyticsArtifactMultipartUploadProject.Output.Unauthorized)
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.startAnalyticsArtifactMultipartUploadProject.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.startAnalyticsArtifactMultipartUploadProject.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/POST/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.startAnalyticsArtifactMultipartUploadProject.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// The run doesn't exist
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/runs/{run_id}/start/post(startAnalyticsArtifactMultipartUploadProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.startAnalyticsArtifactMultipartUploadProject.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.startAnalyticsArtifactMultipartUploadProject.Output.NotFound {
                 get throws {
                     switch self {
                     case let .notFound(response):
@@ -13005,14 +14398,14 @@ public enum Operations {
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/api/runs/{run_id}/generate-url/POST/path`.
             public struct Path: Sendable, Hashable {
-                /// The id of the command event.
+                /// The id of the run.
                 ///
                 /// - Remark: Generated from `#/paths/api/runs/{run_id}/generate-url/POST/path/run_id`.
                 public var run_id: Swift.String
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
-                ///   - run_id: The id of the command event.
+                ///   - run_id: The id of the run.
                 public init(run_id: Swift.String) {
                     self.run_id = run_id
                 }
@@ -14925,14 +16318,14 @@ public enum Operations {
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/api/runs/{run_id}/complete/POST/path`.
             public struct Path: Sendable, Hashable {
-                /// The id of the command event.
+                /// The id of the run.
                 ///
                 /// - Remark: Generated from `#/paths/api/runs/{run_id}/complete/POST/path/run_id`.
                 public var run_id: Swift.String
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
-                ///   - run_id: The id of the command event.
+                ///   - run_id: The id of the run.
                 public init(run_id: Swift.String) {
                     self.run_id = run_id
                 }
@@ -21119,9 +22512,9 @@ public enum Operations {
             }
         }
     }
-    /// Completes artifacts uploads for a given command event
+    /// Completes artifacts uploads for a given run
     ///
-    /// Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+    /// Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
     ///
     /// - Remark: HTTP `PUT /api/runs/{run_id}/complete_artifacts_uploads`.
     /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)`.
@@ -21130,14 +22523,14 @@ public enum Operations {
         public struct Input: Sendable, Hashable {
             /// - Remark: Generated from `#/paths/api/runs/{run_id}/complete_artifacts_uploads/PUT/path`.
             public struct Path: Sendable, Hashable {
-                /// The id of the command event.
+                /// The id of the run.
                 ///
                 /// - Remark: Generated from `#/paths/api/runs/{run_id}/complete_artifacts_uploads/PUT/path/run_id`.
                 public var run_id: Swift.String
                 /// Creates a new `Path`.
                 ///
                 /// - Parameters:
-                ///   - run_id: The id of the command event.
+                ///   - run_id: The id of the run.
                 public init(run_id: Swift.String) {
                     self.run_id = run_id
                 }
@@ -21182,7 +22575,7 @@ public enum Operations {
                 /// Creates a new `NoContent`.
                 public init() {}
             }
-            /// The command event artifact uploads were successfully finished
+            /// The run artifact uploads were successfully finished
             ///
             /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)/responses/204`.
             ///
@@ -21335,7 +22728,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The command event doesn't exist
+            /// The run doesn't exist
             ///
             /// - Remark: Generated from `#/paths//api/runs/{run_id}/complete_artifacts_uploads/put(completeAnalyticsArtifactsUploads)/responses/404`.
             ///

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -2486,7 +2486,7 @@ paths:
               type: object
               x-struct:
               x-validate:
-        description: Command event params
+        description: Run params
         required: false
       responses:
         '200':
@@ -2494,7 +2494,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CommandEvent'
-          description: The command event was created
+          description: The run was created
         '401':
           content:
             application/json:
@@ -2506,7 +2506,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: You don't have permission to create command events for the project.
+          description: You don't have permission to create runs for the project.
       summary: Create a a new command analytics event
       tags:
         - Analytics
@@ -2752,6 +2752,83 @@ paths:
       summary: Request new tokens.
       tags:
         - Authentication
+  /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete:
+    post:
+      callbacks: {}
+      description: Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
+      operationId: completeAnalyticsArtifactMultipartUploadProject
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The id of the run.
+          in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                command_event_artifact:
+                  $ref: '#/components/schemas/CommandEventArtifact'
+                multipart_upload_parts:
+                  $ref: '#/components/schemas/ArtifactMultipartUploadParts'
+              required:
+                - command_event_artifact
+                - multipart_upload_parts
+              type: object
+              x-struct:
+              x-validate:
+        description: Run artifact multipart upload completion
+        required: false
+      responses:
+        '204':
+          description: The upload has been completed
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The project doesn't exist
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: An internal server error occurred
+      summary: It completes a multi-part upload
+      tags:
+        - Analytics
   /api/projects/{account_handle}/{project_handle}/bundles:
     get:
       callbacks: {}
@@ -2765,20 +2842,20 @@ paths:
             type: integer
             x-struct:
             x-validate:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
-            x-struct:
-            x-validate:
         - description: Number of items per page.
           in: query
           name: page_size
           required: false
           schema:
             type: integer
+            x-struct:
+            x-validate:
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
+          schema:
+            type: string
             x-struct:
             x-validate:
         - description: The handle of the account.
@@ -3023,10 +3100,11 @@ paths:
   /api/runs/{run_id}/start:
     post:
       callbacks: {}
+      deprecated: true
       description: The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
       operationId: startAnalyticsArtifactMultipartUpload
       parameters:
-        - description: The id of the command event UUID.
+        - description: The id of the run UUID.
           in: path
           name: run_id
           required: true
@@ -3065,8 +3143,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: The command event doesn't exist
-      summary: It initiates a multipart upload for a command event artifact.
+          description: The run doesn't exist
+      summary: It initiates a multipart upload for a run artifact
       tags:
         - Analytics
   /api/projects:
@@ -3461,6 +3539,70 @@ paths:
       summary: Get a cache action item.
       tags:
         - Cache
+  /api/projects/{account_handle}/{project_handle}/runs/{run_id}/complete_artifacts_uploads:
+    put:
+      callbacks: {}
+      description: Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+      operationId: completeAnalyticsArtifactsUploadsProject
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The id of the run.
+          in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties: {}
+              type: object
+              x-struct:
+              x-validate:
+        description: Extra metadata for the post-processing of a command event.
+        required: false
+      responses:
+        '204':
+          description: The run artifact uploads were successfully finished
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The run doesn't exist
+      summary: Completes artifacts uploads for a given run
+      tags:
+        - Analytics
   /api/cache/multipart/generate-url:
     post:
       callbacks: {}
@@ -3555,6 +3697,146 @@ paths:
       summary: It generates a signed URL for uploading a part.
       tags:
         - Cache
+  /api/projects/{account_handle}/{project_handle}/runs/{run_id}/generate-url:
+    post:
+      callbacks: {}
+      description: Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
+      operationId: generateAnalyticsArtifactMultipartUploadURLProject
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The id of the run.
+          in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                command_event_artifact:
+                  $ref: '#/components/schemas/CommandEventArtifact'
+                multipart_upload_part:
+                  $ref: '#/components/schemas/ArtifactMultipartUploadPart'
+              required:
+                - command_event_artifact
+                - multipart_upload_part
+              type: object
+              x-struct:
+              x-validate:
+        description: Artifact to generate a signed URL for
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactMultipartUploadURL'
+          description: The URL has been generated
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The project doesn't exist
+      summary: It generates a signed URL for uploading a part
+      tags:
+        - Analytics
+  /api/projects/{account_handle}/{project_handle}/runs/{run_id}/start:
+    post:
+      callbacks: {}
+      description: The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.
+      operationId: startAnalyticsArtifactMultipartUploadProject
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The id of the run.
+          in: path
+          name: run_id
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommandEventArtifact'
+        description: Artifact to upload
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactUploadID'
+          description: The upload has been started
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You need to be authenticated to access this resource
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The run doesn't exist
+      summary: It initiates a multipart upload for a run artifact
+      tags:
+        - Analytics
   /api/auth/apple:
     post:
       callbacks: {}
@@ -4131,10 +4413,11 @@ paths:
   /api/runs/{run_id}/generate-url:
     post:
       callbacks: {}
+      deprecated: true
       description: Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.
       operationId: generateAnalyticsArtifactMultipartUploadURL
       parameters:
-        - description: The id of the command event.
+        - description: The id of the run.
           in: path
           name: run_id
           required: true
@@ -4546,10 +4829,11 @@ paths:
   /api/runs/{run_id}/complete:
     post:
       callbacks: {}
+      deprecated: true
       description: Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.
       operationId: completeAnalyticsArtifactMultipartUpload
       parameters:
-        - description: The id of the command event.
+        - description: The id of the run.
           in: path
           name: run_id
           required: true
@@ -4572,7 +4856,7 @@ paths:
               type: object
               x-struct:
               x-validate:
-        description: Command event artifact multipart upload completion
+        description: Run artifact multipart upload completion
         required: false
       responses:
         '204':
@@ -5960,10 +6244,11 @@ paths:
   /api/runs/{run_id}/complete_artifacts_uploads:
     put:
       callbacks: {}
-      description: Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
+      deprecated: true
+      description: Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.
       operationId: completeAnalyticsArtifactsUploads
       parameters:
-        - description: The id of the command event.
+        - description: The id of the run.
           in: path
           name: run_id
           required: true
@@ -5980,11 +6265,11 @@ paths:
               type: object
               x-struct:
               x-validate:
-        description: Extra metadata for the post-processing of a command event.
+        description: Extra metadata for the post-processing of a run.
         required: false
       responses:
         '204':
-          description: The command event artifact uploads were successfully finished
+          description: The run artifact uploads were successfully finished
         '401':
           content:
             application/json:
@@ -6002,8 +6287,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: The command event doesn't exist
-      summary: Completes artifacts uploads for a given command event
+          description: The run doesn't exist
+      summary: Completes artifacts uploads for a given run
       tags:
         - Analytics
 security:

--- a/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -10,6 +10,8 @@
     public protocol AnalyticsArtifactUploadServicing {
         func uploadResultBundle(
             _ resultBundle: AbsolutePath,
+            accountHandle: String,
+            projectHandle: String,
             commandEventId: String,
             serverURL: URL
         ) async throws
@@ -67,6 +69,8 @@
 
         public func uploadResultBundle(
             _ resultBundle: AbsolutePath,
+            accountHandle: String,
+            projectHandle: String,
             commandEventId: String,
             serverURL: URL
         ) async throws {
@@ -75,6 +79,8 @@
                     type: .resultBundle
                 ),
                 artifactPath: resultBundle,
+                accountHandle: accountHandle,
+                projectHandle: projectHandle,
                 commandEventId: commandEventId,
                 serverURL: serverURL
             )
@@ -107,6 +113,8 @@
                             name: id
                         ),
                         artifactPath: resultBundleObjectPath,
+                        accountHandle: accountHandle,
+                        projectHandle: projectHandle,
                         commandEventId: commandEventId,
                         serverURL: serverURL
                     )
@@ -117,11 +125,15 @@
                         type: .invocationRecord
                     ),
                     artifactPath: invocationRecordPath,
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
                     commandEventId: commandEventId,
                     serverURL: serverURL
                 )
 
                 try await completeAnalyticsArtifactsUploadsService.completeAnalyticsArtifactsUploads(
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
                     commandEventId: commandEventId,
                     serverURL: serverURL
                 )
@@ -132,6 +144,8 @@
             _ artifact: ServerCommandEvent.Artifact,
             artifactPath: AbsolutePath,
             name _: String? = nil,
+            accountHandle: String,
+            projectHandle: String,
             commandEventId: String,
             serverURL: URL
         ) async throws {
@@ -149,6 +163,8 @@
             try await retryProvider.runWithRetries { [self] in
                 let uploadId = try await multipartUploadStartAnalyticsService.uploadAnalyticsArtifact(
                     artifact,
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
                     commandEventId: commandEventId,
                     serverURL: serverURL
                 )
@@ -158,6 +174,8 @@
                     generateUploadURL: { part in
                         try await self.multipartUploadGenerateURLAnalyticsService.uploadAnalytics(
                             artifact,
+                            accountHandle: accountHandle,
+                            projectHandle: projectHandle,
                             commandEventId: commandEventId,
                             partNumber: part.number,
                             uploadId: uploadId,
@@ -170,6 +188,8 @@
 
                 try await multipartUploadCompleteAnalyticsService.uploadAnalyticsArtifact(
                     artifact,
+                    accountHandle: accountHandle,
+                    projectHandle: projectHandle,
                     commandEventId: commandEventId,
                     uploadId: uploadId,
                     parts: parts,

--- a/cli/Sources/TuistServer/Services/CompleteAnalyticsArtifactsUploads.swift
+++ b/cli/Sources/TuistServer/Services/CompleteAnalyticsArtifactsUploads.swift
@@ -5,6 +5,8 @@ import OpenAPIRuntime
 @Mockable
 public protocol CompleteAnalyticsArtifactsUploadsServicing {
     func completeAnalyticsArtifactsUploads(
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         serverURL: URL
     ) async throws
@@ -30,13 +32,15 @@ public final class CompleteAnalyticsArtifactsUploadsService: CompleteAnalyticsAr
     public init() {}
 
     public func completeAnalyticsArtifactsUploads(
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         serverURL: URL
     ) async throws {
         let client = Client.authenticated(serverURL: serverURL)
-        let response = try await client.completeAnalyticsArtifactsUploads(
+        let response = try await client.completeAnalyticsArtifactsUploadsProject(
             .init(
-                path: .init(run_id: commandEventId)
+                path: .init(account_handle: accountHandle, project_handle: projectHandle, run_id: commandEventId)
             )
         )
         switch response {

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,8 +63,7 @@ public final class ListBundlesService: ListBundlesServicing {
                 ),
                 query: .init(
                     page: page,
-                    git_branch: gitBranch,
-                    page_size: pageSize
+                    page_size: pageSize, git_branch: gitBranch
                 )
             )
         )

--- a/cli/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
@@ -6,6 +6,8 @@ import OpenAPIRuntime
 public protocol MultipartUploadCompleteAnalyticsServicing {
     func uploadAnalyticsArtifact(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)],
@@ -35,27 +37,28 @@ public final class MultipartUploadCompleteAnalyticsService: MultipartUploadCompl
 
     public func uploadAnalyticsArtifact(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)],
         serverURL: URL
     ) async throws {
         let client = Client.authenticated(serverURL: serverURL)
-        let response = try await client.completeAnalyticsArtifactMultipartUpload(
-            .init(
-                path: .init(run_id: commandEventId),
-                body: .json(
-                    .init(
-                        command_event_artifact: .init(artifact),
-                        multipart_upload_parts: .init(
-                            parts: parts
-                                .map { .init(etag: $0.etag, part_number: $0.partNumber) },
-                            upload_id: uploadId
-                        )
+        let response = try await client.completeAnalyticsArtifactMultipartUploadProject(
+            path: .init(account_handle: accountHandle, project_handle: projectHandle, run_id: commandEventId),
+            body: .json(
+                .init(
+                    command_event_artifact: .init(artifact),
+                    multipart_upload_parts: .init(
+                        parts: parts
+                            .map { .init(etag: $0.etag, part_number: $0.partNumber) },
+                        upload_id: uploadId
                     )
                 )
             )
         )
+
         switch response {
         case .noContent:
             return

--- a/cli/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
@@ -5,6 +5,8 @@ import Mockable
 public protocol MultipartUploadGenerateURLAnalyticsServicing {
     func uploadAnalytics(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         partNumber: Int,
         uploadId: String,
@@ -34,6 +36,8 @@ public final class MultipartUploadGenerateURLAnalyticsService: MultipartUploadGe
 
     public func uploadAnalytics(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         partNumber: Int,
         uploadId: String,
@@ -41,17 +45,15 @@ public final class MultipartUploadGenerateURLAnalyticsService: MultipartUploadGe
         contentLength: Int
     ) async throws -> String {
         let client = Client.authenticated(serverURL: serverURL)
-        let response = try await client.generateAnalyticsArtifactMultipartUploadURL(
-            .init(
-                path: .init(run_id: commandEventId),
-                body: .json(
-                    .init(
-                        command_event_artifact: .init(artifact),
-                        multipart_upload_part: .init(
-                            content_length: contentLength,
-                            part_number: partNumber,
-                            upload_id: uploadId
-                        )
+        let response = try await client.generateAnalyticsArtifactMultipartUploadURLProject(
+            path: .init(account_handle: accountHandle, project_handle: projectHandle, run_id: commandEventId),
+            body: .json(
+                .init(
+                    command_event_artifact: .init(artifact),
+                    multipart_upload_part: .init(
+                        content_length: contentLength,
+                        part_number: partNumber,
+                        upload_id: uploadId
                     )
                 )
             )

--- a/cli/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
@@ -5,6 +5,8 @@ import Mockable
 public protocol MultipartUploadStartAnalyticsServicing {
     func uploadAnalyticsArtifact(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         serverURL: URL
     ) async throws -> String
@@ -32,13 +34,15 @@ public final class MultipartUploadStartAnalyticsService: MultipartUploadStartAna
 
     public func uploadAnalyticsArtifact(
         _ artifact: ServerCommandEvent.Artifact,
+        accountHandle: String,
+        projectHandle: String,
         commandEventId: String,
         serverURL: URL
     ) async throws -> String {
         let client = Client.authenticated(serverURL: serverURL)
-        let response = try await client.startAnalyticsArtifactMultipartUpload(
+        let response = try await client.startAnalyticsArtifactMultipartUploadProject(
             .init(
-                path: .init(run_id: commandEventId),
+                path: .init(account_handle: accountHandle, project_handle: projectHandle, run_id: commandEventId),
                 body: .json(.init(artifact))
             )
         )

--- a/cli/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -25,7 +25,7 @@ struct TuistAnalyticsDispatcherTests {
 
     @Test(.withMockedEnvironment(), .inTemporaryDirectory) mutating func dispatch_sendsToServer() async throws {
         // Given
-        let fullHandle = "project"
+        let fullHandle = "account/project"
         let commandEventID = UUID().uuidString
         let url = URL.test()
         let backend = TuistAnalyticsServerBackend(
@@ -55,6 +55,8 @@ struct TuistAnalyticsDispatcherTests {
         given(analyticsArtifactUploadService)
             .uploadResultBundle(
                 .any,
+                accountHandle: .value("account"),
+                projectHandle: .value("project"),
                 commandEventId: .value(commandEventID),
                 serverURL: .value(url)
             )

--- a/cli/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/TuistAnalyticsServerBackendTests.swift
@@ -121,6 +121,8 @@ struct TuistAnalyticsServerBackendTests {
             given(analyticsArtifactUploadService)
                 .uploadResultBundle(
                     .value(resultBundle),
+                    accountHandle: .any,
+                    projectHandle: .any,
                     commandEventId: .value(eventID),
                     serverURL: .value(Constants.URLs.production)
                 )

--- a/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
@@ -63,6 +63,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         let temporaryDirectory = try temporaryPath()
         let resultBundle = temporaryDirectory.appending(component: "artifact.bundle")
         try FileHandler.shared.touch(resultBundle)
+        let accountHandle = "account-\(UUID().uuidString)"
+        let projectHandle = "project-\(UUID().uuidString)"
 
         let serverURL: URL = .test()
         let commandEventID = UUID().uuidString
@@ -81,6 +83,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadStartAnalyticsService)
             .uploadAnalyticsArtifact(
                 .value(.init(type: .resultBundle)),
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .value(commandEventID),
                 serverURL: .value(serverURL)
             )
@@ -101,6 +105,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadCompleteAnalyticsService)
             .uploadAnalyticsArtifact(
                 .any,
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .value(commandEventID),
                 uploadId: .value("upload-id"),
                 parts: .matching { parts in
@@ -113,6 +119,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadStartAnalyticsService)
             .uploadAnalyticsArtifact(
                 .value(.init(type: .invocationRecord)),
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .value(commandEventID),
                 serverURL: .value(serverURL)
             )
@@ -140,6 +148,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         given(multipartUploadStartAnalyticsService)
             .uploadAnalyticsArtifact(
                 .value(.init(type: .resultBundleObject, name: testResultBundleObjectId)),
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .value(commandEventID),
                 serverURL: .value(serverURL)
             )
@@ -147,6 +157,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
 
         given(completeAnalyticsArtifactsUploadsService)
             .completeAnalyticsArtifactsUploads(
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .any,
                 serverURL: .value(serverURL)
             )
@@ -167,6 +179,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
                         type: .resultBundle
                     )
                 ),
+                accountHandle: .value(accountHandle),
+                projectHandle: .value(projectHandle),
                 commandEventId: .value(commandEventID),
                 partNumber: .value(1),
                 uploadId: .value("upload-id"),
@@ -178,6 +192,8 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         // When / Then
         try await subject.uploadResultBundle(
             resultBundle,
+            accountHandle: accountHandle,
+            projectHandle: projectHandle,
             commandEventId: commandEventID,
             serverURL: serverURL
         )

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -39,7 +39,7 @@ defmodule TuistWeb.API.AnalyticsController do
       ]
     ],
     request_body:
-      {"Command event params", "application/json",
+      {"Run params", "application/json",
        %Schema{
          type: :object,
          properties: %{
@@ -265,7 +265,7 @@ defmodule TuistWeb.API.AnalyticsController do
          ]
        }},
     responses: %{
-      ok: {"The command event was created", "application/json", CommandEvent},
+      ok: {"The run was created", "application/json", CommandEvent},
       unauthorized:
         {"You need to be authenticated to access this resource", "application/json", Error},
       forbidden:
@@ -557,11 +557,11 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
-      {"Command event artifact multipart upload completion", "application/json",
+      {"Run artifact multipart upload completion", "application/json",
        %Schema{
          type: :object,
          properties: %{
@@ -613,9 +613,9 @@ defmodule TuistWeb.API.AnalyticsController do
   end
 
   operation(:complete_artifacts_uploads,
-    summary: "Completes artifacts uploads for a given command event",
+    summary: "Completes artifacts uploads for a given run",
     description:
-      "Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
+      "Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
     deprecated: true,
     operation_id: "completeAnalyticsArtifactsUploads",
     parameters: [
@@ -623,11 +623,11 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
-      {"Extra metadata for the post-processing of a command event.", "application/json",
+      {"Extra metadata for the post-processing of a run.", "application/json",
        %Schema{
          deprecated: true,
          type: :object,
@@ -635,13 +635,13 @@ defmodule TuistWeb.API.AnalyticsController do
          required: []
        }},
     responses: %{
-      no_content: "The command event artifact uploads were successfully finished",
+      no_content: "The run artifact uploads were successfully finished",
       unauthorized:
         {"You need to be authenticated to access this resource", "application/json", Error},
       forbidden:
         {"The authenticated subject is not authorized to perform this action", "application/json",
          Error},
-      not_found: {"The command event doesn't exist", "application/json", Error}
+      not_found: {"The run doesn't exist", "application/json", Error}
     }
   )
 
@@ -654,7 +654,7 @@ defmodule TuistWeb.API.AnalyticsController do
   # New operations for project-scoped routes (not deprecated)
 
   operation(:multipart_start_project,
-    summary: "It initiates a multipart upload for a command event artifact.",
+    summary: "It initiates a multipart upload for a run artifact",
     description:
       "The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.",
     operation_id: "startAnalyticsArtifactMultipartUploadProject",
@@ -675,7 +675,7 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event UUID."
+        description: "The id of the run."
       ]
     ],
     request_body: {"Artifact to upload", "application/json", CommandEventArtifact},
@@ -686,14 +686,14 @@ defmodule TuistWeb.API.AnalyticsController do
       forbidden:
         {"The authenticated subject is not authorized to perform this action", "application/json",
          Error},
-      not_found: {"The command event doesn't exist", "application/json", Error}
+      not_found: {"The run doesn't exist", "application/json", Error}
     }
   )
 
   def multipart_start_project(conn, params), do: multipart_start(conn, params)
 
   operation(:multipart_generate_url_project,
-    summary: "It generates a signed URL for uploading a part.",
+    summary: "It generates a signed URL for uploading a part",
     description:
       "Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.",
     operation_id: "generateAnalyticsArtifactMultipartUploadURLProject",
@@ -714,7 +714,7 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
@@ -741,7 +741,7 @@ defmodule TuistWeb.API.AnalyticsController do
   def multipart_generate_url_project(conn, params), do: multipart_generate_url(conn, params)
 
   operation(:multipart_complete_project,
-    summary: "It completes a multi-part upload.",
+    summary: "It completes a multi-part upload",
     description:
       "Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.",
     operation_id: "completeAnalyticsArtifactMultipartUploadProject",
@@ -762,11 +762,11 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
-      {"Command event artifact multipart upload completion", "application/json",
+      {"Run artifact multipart upload completion", "application/json",
        %Schema{
          type: :object,
          properties: %{
@@ -790,9 +790,9 @@ defmodule TuistWeb.API.AnalyticsController do
   def multipart_complete_project(conn, params), do: multipart_complete(conn, params)
 
   operation(:complete_artifacts_uploads_project,
-    summary: "Completes artifacts uploads for a given command event",
+    summary: "Completes artifacts uploads for a given run",
     description:
-      "Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
+      "Given a run, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
     operation_id: "completeAnalyticsArtifactsUploadsProject",
     parameters: [
       account_handle: [
@@ -811,7 +811,7 @@ defmodule TuistWeb.API.AnalyticsController do
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
@@ -822,13 +822,13 @@ defmodule TuistWeb.API.AnalyticsController do
          required: []
        }},
     responses: %{
-      no_content: "The command event artifact uploads were successfully finished",
+      no_content: "The run artifact uploads were successfully finished",
       unauthorized:
         {"You need to be authenticated to access this resource", "application/json", Error},
       forbidden:
         {"The authenticated subject is not authorized to perform this action", "application/json",
          Error},
-      not_found: {"The command event doesn't exist", "application/json", Error}
+      not_found: {"The run doesn't exist", "application/json", Error}
     }
   )
 

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -651,7 +651,6 @@ defmodule TuistWeb.API.AnalyticsController do
     |> json(%{})
   end
 
-  # New operations for project-scoped routes (not deprecated)
 
   operation(:multipart_start_project,
     summary: "It initiates a multipart upload for a run artifact",

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -266,12 +266,17 @@ defmodule TuistWeb.API.AnalyticsController do
        }},
     responses: %{
       ok: {"The command event was created", "application/json", CommandEvent},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"You don't have permission to create command events for the project.", "application/json", Error}
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"You don't have permission to create runs for the project.", "application/json", Error}
     }
   )
 
-  def create(%{body_params: body_params, assigns: %{selected_project: selected_project}} = conn, _params) do
+  def create(
+        %{body_params: body_params, assigns: %{selected_project: selected_project}} = conn,
+        _params
+      ) do
     current_user = Authentication.current_user(conn)
 
     user_id =
@@ -334,8 +339,10 @@ defmodule TuistWeb.API.AnalyticsController do
         git_remote_url_origin: git_remote_url_origin,
         project_id: selected_project.id,
         preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-        preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-        command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
+        preview_qr_code_url_template:
+          "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
+        command_run_url_template:
+          "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
         bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
         build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
       })
@@ -343,7 +350,9 @@ defmodule TuistWeb.API.AnalyticsController do
 
     url =
       if is_nil(build_run_id) do
-        url(~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{command_event.id}")
+        url(
+          ~p"/#{selected_project.account.name}/#{selected_project.name}/runs/#{command_event.id}"
+        )
       else
         url(
           ~p"/#{selected_project.account.name}/#{selected_project.name}/builds/build-runs/#{String.downcase(build_run_id)}"
@@ -423,24 +432,28 @@ defmodule TuistWeb.API.AnalyticsController do
   end
 
   operation(:multipart_start,
-    summary: "It initiates a multipart upload for a command event artifact.",
+    summary: "It initiates a multipart upload for a run artifact",
     description:
       "The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.",
+    deprecated: true,
     operation_id: "startAnalyticsArtifactMultipartUpload",
     parameters: [
       run_id: [
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event UUID."
+        description: "The id of the run UUID."
       ]
     ],
     request_body: {"Artifact to upload", "application/json", CommandEventArtifact},
     responses: %{
       ok: {"The upload has been started", "application/json", ArtifactUploadId},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
-      not_found: {"The command event doesn't exist", "application/json", Error}
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
+      not_found: {"The run doesn't exist", "application/json", Error}
     }
   )
 
@@ -458,7 +471,8 @@ defmodule TuistWeb.API.AnalyticsController do
   end
 
   def multipart_start(
-        %{path_params: %{"run_id" => run_id}, body_params: %{type: type} = command_event_artifact} = conn,
+        %{path_params: %{"run_id" => run_id}, body_params: %{type: type} = command_event_artifact} =
+          conn,
         _params
       ) do
     with {:ok, object_key} <-
@@ -472,13 +486,14 @@ defmodule TuistWeb.API.AnalyticsController do
     summary: "It generates a signed URL for uploading a part.",
     description:
       "Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.",
+    deprecated: true,
     operation_id: "generateAnalyticsArtifactMultipartUploadURL",
     parameters: [
       run_id: [
         in: :path,
         type: :string,
         required: true,
-        description: "The id of the command event."
+        description: "The id of the run."
       ]
     ],
     request_body:
@@ -493,8 +508,11 @@ defmodule TuistWeb.API.AnalyticsController do
        }},
     responses: %{
       ok: {"The URL has been generated", "application/json", ArtifactMultipartUploadUrl},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error}
     }
   )
@@ -504,7 +522,8 @@ defmodule TuistWeb.API.AnalyticsController do
           path_params: %{"run_id" => run_id},
           body_params: %{
             command_event_artifact: %{type: type} = command_event_artifact,
-            multipart_upload_part: %{part_number: part_number, upload_id: upload_id} = multipart_upload_part
+            multipart_upload_part:
+              %{part_number: part_number, upload_id: upload_id} = multipart_upload_part
           }
         } = conn,
         _params
@@ -529,7 +548,9 @@ defmodule TuistWeb.API.AnalyticsController do
 
   operation(:multipart_complete,
     summary: "It completes a multi-part upload.",
-    description: "Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.",
+    description:
+      "Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.",
+    deprecated: true,
     operation_id: "completeAnalyticsArtifactMultipartUpload",
     parameters: [
       run_id: [
@@ -551,8 +572,11 @@ defmodule TuistWeb.API.AnalyticsController do
        }},
     responses: %{
       no_content: "The upload has been completed",
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       internal_server_error: {"An internal server error occurred", "application/json", Error}
     }
@@ -563,7 +587,10 @@ defmodule TuistWeb.API.AnalyticsController do
           path_params: %{"run_id" => run_id},
           body_params: %{
             command_event_artifact: %{type: type} = command_event_artifact,
-            multipart_upload_parts: %ArtifactMultipartUploadParts{parts: parts, upload_id: upload_id}
+            multipart_upload_parts: %ArtifactMultipartUploadParts{
+              parts: parts,
+              upload_id: upload_id
+            }
           }
         } = conn,
         _params
@@ -589,6 +616,7 @@ defmodule TuistWeb.API.AnalyticsController do
     summary: "Completes artifacts uploads for a given command event",
     description:
       "Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
+    deprecated: true,
     operation_id: "completeAnalyticsArtifactsUploads",
     parameters: [
       run_id: [
@@ -608,8 +636,11 @@ defmodule TuistWeb.API.AnalyticsController do
        }},
     responses: %{
       no_content: "The command event artifact uploads were successfully finished",
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The command event doesn't exist", "application/json", Error}
     }
   )
@@ -620,8 +651,193 @@ defmodule TuistWeb.API.AnalyticsController do
     |> json(%{})
   end
 
+  # New operations for project-scoped routes (not deprecated)
+
+  operation(:multipart_start_project,
+    summary: "It initiates a multipart upload for a command event artifact.",
+    description:
+      "The endpoint returns an upload ID that can be used to generate URLs for the individual parts and complete the upload.",
+    operation_id: "startAnalyticsArtifactMultipartUploadProject",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the account."
+      ],
+      project_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the project."
+      ],
+      run_id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The id of the command event UUID."
+      ]
+    ],
+    request_body: {"Artifact to upload", "application/json", CommandEventArtifact},
+    responses: %{
+      ok: {"The upload has been started", "application/json", ArtifactUploadId},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
+      not_found: {"The command event doesn't exist", "application/json", Error}
+    }
+  )
+
+  def multipart_start_project(conn, params), do: multipart_start(conn, params)
+
+  operation(:multipart_generate_url_project,
+    summary: "It generates a signed URL for uploading a part.",
+    description:
+      "Given an upload ID and a part number, this endpoint returns a signed URL that can be used to upload a part of a multipart upload. The URL is short-lived and expires in 120 seconds.",
+    operation_id: "generateAnalyticsArtifactMultipartUploadURLProject",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the account."
+      ],
+      project_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the project."
+      ],
+      run_id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The id of the command event."
+      ]
+    ],
+    request_body:
+      {"Artifact to generate a signed URL for", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{
+           command_event_artifact: CommandEventArtifact,
+           multipart_upload_part: ArtifactMultipartUploadPart
+         },
+         required: [:command_event_artifact, :multipart_upload_part]
+       }},
+    responses: %{
+      ok: {"The URL has been generated", "application/json", ArtifactMultipartUploadUrl},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
+      not_found: {"The project doesn't exist", "application/json", Error}
+    }
+  )
+
+  def multipart_generate_url_project(conn, params), do: multipart_generate_url(conn, params)
+
+  operation(:multipart_complete_project,
+    summary: "It completes a multi-part upload.",
+    description:
+      "Given the upload ID and all the parts with their ETags, this endpoint completes the multipart upload.",
+    operation_id: "completeAnalyticsArtifactMultipartUploadProject",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the account."
+      ],
+      project_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the project."
+      ],
+      run_id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The id of the command event."
+      ]
+    ],
+    request_body:
+      {"Command event artifact multipart upload completion", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{
+           command_event_artifact: CommandEventArtifact,
+           multipart_upload_parts: ArtifactMultipartUploadParts
+         },
+         required: [:command_event_artifact, :multipart_upload_parts]
+       }},
+    responses: %{
+      no_content: "The upload has been completed",
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
+      not_found: {"The project doesn't exist", "application/json", Error},
+      internal_server_error: {"An internal server error occurred", "application/json", Error}
+    }
+  )
+
+  def multipart_complete_project(conn, params), do: multipart_complete(conn, params)
+
+  operation(:complete_artifacts_uploads_project,
+    summary: "Completes artifacts uploads for a given command event",
+    description:
+      "Given a command event, it marks all artifact uploads as finished and does extra processing of a given command run, such as test flakiness detection.",
+    operation_id: "completeAnalyticsArtifactsUploadsProject",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the account."
+      ],
+      project_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the project."
+      ],
+      run_id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The id of the command event."
+      ]
+    ],
+    request_body:
+      {"Extra metadata for the post-processing of a command event.", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{},
+         required: []
+       }},
+    responses: %{
+      no_content: "The command event artifact uploads were successfully finished",
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
+      not_found: {"The command event doesn't exist", "application/json", Error}
+    }
+  )
+
+  def complete_artifacts_uploads_project(conn, params),
+    do: complete_artifacts_uploads(conn, params)
+
   defp get_object_key(%{type: type, run_id: run_id, name: name}, conn) do
-    project = Authentication.current_project(conn)
+    # Use selected_project from URL if available (new routes), otherwise fall back to authenticated project (old routes)
+    project = Map.get(conn.assigns, :selected_project) || Authentication.current_project(conn)
 
     with {:ok, run_id} <- normalize_run_id(run_id) do
       object_key =
@@ -682,7 +898,10 @@ defmodule TuistWeb.API.AnalyticsController do
     end
   end
 
-  defp bad_request_when_project_authenticated_from_non_ci_environment(%{body_params: body_params} = conn, _opts) do
+  defp bad_request_when_project_authenticated_from_non_ci_environment(
+         %{body_params: body_params} = conn,
+         _opts
+       ) do
     if is_nil(Authentication.current_project(conn)) or
          body_params.is_ci do
       conn

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -277,10 +277,10 @@ defmodule TuistWeb.Router do
         scope "/runs" do
           get "/", RunsController, :index
           post "/", RunsController, :create
-          post "/:run_id/start", AnalyticsController, :multipart_start
-          post "/:run_id/generate-url", AnalyticsController, :multipart_generate_url
-          post "/:run_id/complete", AnalyticsController, :multipart_complete
-          put "/:run_id/complete_artifacts_uploads", AnalyticsController, :complete_artifacts_uploads
+          post "/:run_id/start", AnalyticsController, :multipart_start_project
+          post "/:run_id/generate-url", AnalyticsController, :multipart_generate_url_project
+          post "/:run_id/complete", AnalyticsController, :multipart_complete_project
+          put "/:run_id/complete_artifacts_uploads", AnalyticsController, :complete_artifacts_uploads_project
         end
 
         scope "/previews" do

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -277,6 +277,10 @@ defmodule TuistWeb.Router do
         scope "/runs" do
           get "/", RunsController, :index
           post "/", RunsController, :create
+          post "/:run_id/start", AnalyticsController, :multipart_start
+          post "/:run_id/generate-url", AnalyticsController, :multipart_generate_url
+          post "/:run_id/complete", AnalyticsController, :multipart_complete
+          put "/:run_id/complete_artifacts_uploads", AnalyticsController, :complete_artifacts_uploads
         end
 
         scope "/previews" do

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -457,9 +457,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
       conn: conn,
       user: user
     } do
-      stub(Environment, :clickhouse_configured?, fn -> true end)
-      stub(FunWithFlags, :enabled?, fn :clickhouse_events -> true end)
-
+      # Given
       conn = Authentication.put_current_user(conn, user)
 
       account = Accounts.get_account_from_user(user)
@@ -959,9 +957,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
     end
 
     test "completes a multipart upload returns a raw error - clickhouse", %{conn: conn} do
-      stub(Environment, :clickhouse_configured?, fn -> true end)
-      stub(FunWithFlags, :enabled?, fn :clickhouse_events -> true end)
-
+      # Given
       project = ProjectsFixtures.project_fixture()
       account = Accounts.get_account_by_id(project.account_id)
 
@@ -972,18 +968,17 @@ defmodule TuistWeb.AnalyticsControllerTest do
 
       upload_id = "1234"
 
-      object_key =
-        "#{account.name}/#{project.name}/runs/#{command_event.legacy_id}/result_bundle.zip"
-
       parts = [
         %{part_number: 1, etag: "etag1"},
         %{part_number: 2, etag: "etag2"},
         %{part_number: 3, etag: "etag3"}
       ]
 
-      expect(Storage, :multipart_complete_upload, fn ^object_key,
+      expect(Storage, :multipart_complete_upload, fn object_key,
                                                      ^upload_id,
                                                      [{1, "etag1"}, {2, "etag2"}, {3, "etag3"}] ->
+        assert String.contains?(object_key, "#{account.name}/#{project.name}/runs/")
+        assert String.ends_with?(object_key, "/result_bundle.zip")
         :ok
       end)
 


### PR DESCRIPTION
With the adoption of ClickHouse, which meant runs wouldn't get inserted synchronously, we adjusted the routes to upload runs metadata to take the authenticated project as the project the run is associated with. While this works when the authenticated entity is a project, it doesn't if the authenticated subject is a user.

To fix that, I'm deprecating the current routes in favor of `/api/projects/{account}/{project}/runs/...` such that the project is codified in the route.