### PR TITLE
chore(server): Disable Prometheus temporarily in our production server

### DIFF
--- a/server/fly.prod.toml
+++ b/server/fly.prod.toml
@@ -30,6 +30,7 @@ console_command = "/app/bin/tuist remote"
   TUIST_DATABASE_POOL_SIZE = "10"
   TUIST_S3_POOL_COUNT = "1"
   TUIST_S3_POOL_SIZE = "50"
+  TUIST_PROMETHEUS_ENABLED = "0"
 
 [[vm]]
   size = "shared-cpu-4x"


### PR DESCRIPTION
I think our Prometheus setup might still be causing CPU and memory clogging, which manifests as timeouts elsewhere in the app since the CPU is busy and can't pick up new work. Since we are not using the data at the moment because there's a bug in Fly.io's `/metrics` feature causing data gaps, I suggest that we disable it and observe the CPU and memory profiles and errors for the following days.