### PR TITLE
feat(cli): Add additionalPackageResolutionArguments for xcodebuild

### DIFF
--- a/cli/Sources/ProjectDescription/ConfigGenerationOptions.swift
+++ b/cli/Sources/ProjectDescription/ConfigGenerationOptions.swift
@@ -11,6 +11,7 @@ extension Tuist {
 
         /// When passed, Xcode will resolve its Package Manager dependencies using the system-defined
         /// accounts (for example, git) instead of the Xcode-defined accounts
+        @available(*, deprecated, message: "Use `additionalPackageResolutionArguments` instead.")
         public var resolveDependenciesWithSystemScm: Bool
 
         /// Disables locking Swift packages. This can speed up generation but does increase risk if packages are not locked
@@ -19,7 +20,11 @@ extension Tuist {
 
         /// Allows setting a custom directory to be used when resolving package dependencies
         /// This path is passed to `xcodebuild` via the `-clonedSourcePackagesDirPath` argument
+        @available(*, deprecated, message: "Use `additionalPackageResolutionArguments` instead.")
         public var clonedSourcePackagesDirPath: Path?
+
+        /// A list of arguments to be passed to `xcodebuild` when resolving package dependencies.
+        public var additionalPackageResolutionArguments: [String]
 
         /// Allows configuring which targets Tuist checks for potential side effects due multiple branches of the graph
         /// including the same static library of framework as a transitive dependency.
@@ -54,6 +59,36 @@ extension Tuist {
         public var includeGenerateScheme: Bool
 
         public static func options(
+            disablePackageVersionLocking: Bool = false,
+            staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all,
+            defaultConfiguration: String? = nil,
+            optionalAuthentication: Bool = false,
+            buildInsightsDisabled: Bool = false,
+            disableSandbox: Bool = false,
+            includeGenerateScheme: Bool = true,
+            additionalPackageResolutionArguments: [String] = []
+        ) -> Self {
+            self.init(
+                resolveDependenciesWithSystemScm: false,
+                disablePackageVersionLocking: disablePackageVersionLocking,
+                clonedSourcePackagesDirPath: nil,
+                additionalPackageResolutionArguments: additionalPackageResolutionArguments,
+                staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
+                enforceExplicitDependencies: false,
+                defaultConfiguration: defaultConfiguration,
+                optionalAuthentication: optionalAuthentication,
+                buildInsightsDisabled: buildInsightsDisabled,
+                disableSandbox: disableSandbox,
+                includeGenerateScheme: includeGenerateScheme
+            )
+        }
+
+        @available(
+            *,
+            deprecated,
+            message: "Use `options(disablePackageVersionLocking:staticSideEffectsWarningTargets:defaultConfiguration:optionalAuthentication:buildInsightsDisabled:disableSandbox:includeGenerateScheme:additionalPackageResolutionArguments)` instead."
+        )
+        public static func options(
             resolveDependenciesWithSystemScm: Bool = false,
             disablePackageVersionLocking: Bool = false,
             clonedSourcePackagesDirPath: Path? = nil,
@@ -64,10 +99,19 @@ extension Tuist {
             disableSandbox: Bool = false,
             includeGenerateScheme: Bool = true
         ) -> Self {
-            self.init(
+            var additionalPackageResolutionArguments: [String] = []
+            if resolveDependenciesWithSystemScm {
+                additionalPackageResolutionArguments.append("-resolvePackageDependenciesWithSystemScm")
+            }
+            if let clonedSourcePackagesDirPath {
+                additionalPackageResolutionArguments.append("-clonedSourcePackagesDirPath")
+                additionalPackageResolutionArguments.append(clonedSourcePackagesDirPath.pathString)
+            }
+            return self.init(
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
                 disablePackageVersionLocking: disablePackageVersionLocking,
                 clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+                additionalPackageResolutionArguments: additionalPackageResolutionArguments,
                 staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
                 enforceExplicitDependencies: false,
                 defaultConfiguration: defaultConfiguration,
@@ -96,6 +140,7 @@ extension Tuist {
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
                 disablePackageVersionLocking: disablePackageVersionLocking,
                 clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+                additionalPackageResolutionArguments: [],
                 staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
                 enforceExplicitDependencies: enforceExplicitDependencies,
                 defaultConfiguration: defaultConfiguration,

--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -22,7 +22,7 @@
 /// ```swift
 /// import ProjectDescription
 ///
-/// let tuist = Config(project: .tuist(generationOptions: .options(resolveDependenciesWithSystemScm: false)))
+/// let tuist = Config(project: .tuist(generationOptions: .options(additionalPackageResolutionArguments: ["--some-argument"])))
 ///
 /// ```
 public typealias Config = Tuist

--- a/cli/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistCore/Models/TuistGeneratedProjectOptions.swift
@@ -61,9 +61,12 @@ extension TuistGeneratedProjectOptions {
             case excluding([String])
         }
 
+        @available(*, deprecated, message: "Use `additionalPackageResolutionArguments` instead.")
         public let resolveDependenciesWithSystemScm: Bool
         public let disablePackageVersionLocking: Bool
+        @available(*, deprecated, message: "Use `additionalPackageResolutionArguments` instead.")
         public let clonedSourcePackagesDirPath: AbsolutePath?
+        public let additionalPackageResolutionArguments: [String]
         public let staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets
         public let enforceExplicitDependencies: Bool
         public let defaultConfiguration: String?
@@ -76,6 +79,7 @@ extension TuistGeneratedProjectOptions {
             resolveDependenciesWithSystemScm: Bool,
             disablePackageVersionLocking: Bool,
             clonedSourcePackagesDirPath: AbsolutePath? = nil,
+            additionalPackageResolutionArguments: [String] = [],
             staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all,
             enforceExplicitDependencies: Bool = false,
             defaultConfiguration: String? = nil,
@@ -87,6 +91,7 @@ extension TuistGeneratedProjectOptions {
             self.resolveDependenciesWithSystemScm = resolveDependenciesWithSystemScm
             self.disablePackageVersionLocking = disablePackageVersionLocking
             self.clonedSourcePackagesDirPath = clonedSourcePackagesDirPath
+            self.additionalPackageResolutionArguments = additionalPackageResolutionArguments
             self.staticSideEffectsWarningTargets = staticSideEffectsWarningTargets
             self.enforceExplicitDependencies = enforceExplicitDependencies
             self.defaultConfiguration = defaultConfiguration
@@ -144,6 +149,7 @@ extension TuistGeneratedProjectOptions {
             resolveDependenciesWithSystemScm: Bool = false,
             disablePackageVersionLocking: Bool = false,
             clonedSourcePackagesDirPath: AbsolutePath? = nil,
+            additionalPackageResolutionArguments: [String] = [],
             staticSideEffectsWarningTargets: TuistGeneratedProjectOptions.GenerationOptions
                 .StaticSideEffectsWarningTargets = .all,
             enforceExplicitDependencies: Bool = false,
@@ -157,6 +163,7 @@ extension TuistGeneratedProjectOptions {
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
                 disablePackageVersionLocking: disablePackageVersionLocking,
                 clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+                additionalPackageResolutionArguments: additionalPackageResolutionArguments,
                 staticSideEffectsWarningTargets: staticSideEffectsWarningTargets,
                 enforceExplicitDependencies: enforceExplicitDependencies,
                 defaultConfiguration: defaultConfiguration,

--- a/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -64,18 +64,8 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
         Logger.current.notice("Resolving package dependencies using xcodebuild")
         // -list parameter is a workaround to resolve package dependencies for given workspace without specifying scheme
         var arguments = ["xcodebuild", "-resolvePackageDependencies"]
-
-        // This allows using the system-defined git credentials instead of using Xcode's accounts permissions
-        if configGeneratedProjectOptions.generationOptions.resolveDependenciesWithSystemScm {
-            arguments.append(contentsOf: ["-scmProvider", "system"])
-        }
-
-        // Set specific clone directory for Xcode managed SPM dependencies
-        if let clonedSourcePackagesDirPath = configGeneratedProjectOptions.generationOptions.clonedSourcePackagesDirPath {
-            let workspace = (workspaceName as NSString).deletingPathExtension
-            let path = "\(clonedSourcePackagesDirPath.pathString)/\(workspace)"
-            arguments.append(contentsOf: ["-clonedSourcePackagesDirPath", path])
-        }
+        
+        arguments.append(contentsOf: configGeneratedProjectOptions.generationOptions.additionalPackageResolutionArguments)
 
         arguments.append(contentsOf: ["-workspace", workspacePath.pathString, "-list"])
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -15,10 +15,19 @@ extension TuistCore.TuistGeneratedProjectOptions.GenerationOptions {
                 return nil
             }
         }()
+        var additionalPackageResolutionArguments = manifest.additionalPackageResolutionArguments
+        if manifest.resolveDependenciesWithSystemScm {
+            additionalPackageResolutionArguments.append("-resolvePackageDependenciesWithSystemScm")
+        }
+        if let clonedSourcePackagesDirPath {
+            additionalPackageResolutionArguments.append("-clonedSourcePackagesDirPath")
+            additionalPackageResolutionArguments.append(clonedSourcePackagesDirPath.pathString)
+        }
         return .init(
             resolveDependenciesWithSystemScm: manifest.resolveDependenciesWithSystemScm,
             disablePackageVersionLocking: manifest.disablePackageVersionLocking,
             clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+            additionalPackageResolutionArguments: additionalPackageResolutionArguments,
             staticSideEffectsWarningTargets: TuistCore.TuistGeneratedProjectOptions.GenerationOptions
                 .StaticSideEffectsWarningTargets
                 .from(manifest: manifest.staticSideEffectsWarningTargets),

--- a/cli/Tests/ProjectDescriptionTests/ConfigTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/ConfigTests.swift
@@ -7,7 +7,18 @@ final class ConfigTests: XCTestCase {
         let config = Config(
             cloud: Cloud(url: "https://cloud.tuist.io", projectId: "123", options: []),
             generationOptions: .options(
-                resolveDependenciesWithSystemScm: false,
+                additionalPackageResolutionArguments: ["--some-test-flag"]
+            )
+        )
+
+        XCTAssertCodable(config)
+    }
+
+    func test_config_toJSON_backwardsCompatibility() throws {
+        let config = Config(
+            cloud: Cloud(url: "https://cloud.tuist.io", projectId: "123", options: []),
+            generationOptions: .options(
+                resolveDependenciesWithSystemScm: true,
                 disablePackageVersionLocking: true,
                 clonedSourcePackagesDirPath: .relativeToRoot("SourcePackages")
             )

--- a/cli/Tests/TuistGeneratorTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -99,7 +99,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         XCTAssertTrue(exists)
     }
 
-    func test_generate_usesSystemGitCredentials() async throws {
+    func test_install_forwards_additional_arguments() async throws {
         // Given
         let temporaryPath = try temporaryPath()
 
@@ -126,8 +126,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
             .succeedCommand([
                 "xcodebuild",
                 "-resolvePackageDependencies",
-                "-scmProvider",
-                "system",
+                "--some-extra-argument",
                 "-workspace",
                 workspacePath.pathString,
                 "-list",
@@ -140,7 +139,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
             workspaceName: workspacePath.basename,
             configGeneratedProjectOptions: .test(
                 compatibleXcodeVersions: .all,
-                generationOptions: .test(resolveDependenciesWithSystemScm: true)
+                generationOptions: .test(additionalPackageResolutionArguments: ["--some-extra-argument"])
             )
         )
 
@@ -221,55 +220,6 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         // Then
         let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
         XCTAssertFalse(exists)
-    }
-
-    func test_generate_sets_cloned_source_packages_dir_path() async throws {
-        // Given
-        let temporaryPath = try temporaryPath()
-        let spmPath = temporaryPath.appending(component: "spm")
-        let target = anyTarget(dependencies: [
-            .package(product: "Example", type: .runtime),
-        ])
-        let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
-        let project = Project.test(
-            path: temporaryPath,
-            name: "Test",
-            settings: .default,
-            targets: [target],
-            packages: [package]
-        )
-        let graph = Graph.test(
-            path: project.path,
-            packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
-        )
-        let graphTraverser = GraphTraverser(graph: graph)
-
-        let workspacePath = temporaryPath.appending(component: "\(project.name).xcworkspace")
-        system.succeedCommand([
-            "xcodebuild",
-            "-resolvePackageDependencies",
-            "-clonedSourcePackagesDirPath",
-            "\(spmPath.pathString)/\(project.name)",
-            "-workspace",
-            workspacePath.pathString,
-            "-list",
-        ])
-        try await createFiles(["\(workspacePath.basename)/xcshareddata/swiftpm/Package.resolved"])
-
-        // When
-        try await subject.install(
-            graphTraverser: graphTraverser,
-            workspaceName: workspacePath.basename,
-            configGeneratedProjectOptions: .test(generationOptions: .test(
-                clonedSourcePackagesDirPath: temporaryPath
-                    .appending(component: "spm")
-            ))
-        )
-
-        // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
-        XCTAssertTrue(exists)
     }
 
     // MARK: - Helpers

--- a/docs/docs/en/guides/features/registry/continuous-integration.md
+++ b/docs/docs/en/guides/features/registry/continuous-integration.md
@@ -54,9 +54,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
+
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/es/guides/features/registry/continuous-integration.md
+++ b/docs/docs/es/guides/features/registry/continuous-integration.md
@@ -56,10 +56,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
 
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/ja/guides/features/registry/continuous-integration.md
+++ b/docs/docs/ja/guides/features/registry/continuous-integration.md
@@ -56,10 +56,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
 
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/ko/guides/features/registry/continuous-integration.md
+++ b/docs/docs/ko/guides/features/registry/continuous-integration.md
@@ -56,10 +56,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
 
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/pt/guides/features/registry/continuous-integration.md
+++ b/docs/docs/pt/guides/features/registry/continuous-integration.md
@@ -56,10 +56,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
 
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/ru/guides/features/registry/continuous-integration.md
+++ b/docs/docs/ru/guides/features/registry/continuous-integration.md
@@ -56,10 +56,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
 
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.

--- a/docs/docs/zh/guides/features/registry/continuous-integration.md
+++ b/docs/docs/zh/guides/features/registry/continuous-integration.md
@@ -54,9 +54,16 @@ jobs:
 ### Incremental resolution across environments {#incremental-resolution-across-environments}
 
 Clean/cold resolutions are slightly faster with our registry, and you can experience even greater improvements if you persist the resolved dependencies across CI builds. Note that thanks to the registry, the size of the directory that you need to store and restore is much smaller than without the registry, taking significantly less time.
-To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `-clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`, such as:
-```sh
-xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build
+To cache dependencies when using the default Xcode package integration, the best way is to specify a custom `clonedSourcePackagesDirPath` when resolving dependencies via `xcodebuild`. This can be done by adding the following to your `Config.swift` file:
+
+```swift
+import ProjectDescription
+
+let config = Config(
+    generationOptions: .options(
+        additionalPackageResolutionArguments: ["-clonedSourcePackagesDirPath", ".build"]
+    )
+)
 ```
 
 Additionally, you will need to find a path of the `Package.resolved`. You can grab the path by running `ls **/Package.resolved`. The path should look something like `App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.


### PR DESCRIPTION
Resolves https://community.tuist.dev/t/add-support-of-packageauthorizationprovider-in-tuist-generate/731/4

> Describe here the purpose of your PR.

We discussed on the forum that it would be ideal to deprecate old flags and provide more flexibility in passing xcodebuild arguments directly as strings - `additionalPackageResolutionArguments`

### How to test locally

> Document how to test your changes locally

Do new generate project structure and run project
