### PR TITLE
fix(server): memory leak with Prometheus metrics

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -339,10 +339,9 @@ config :tuist, Tuist.PromEx,
   manual_metrics_start_delay: :no_delay,
   drop_metrics_groups: [],
   grafana: :disabled,
-  # Larger numbers might lead to internal tasks timing out.
-  # By keeping it small we might loose some granularity of the data, but I think it's a good tradeoff.
-  # Use default value to avoid over-compacting
-  ets_flush_interval: 7_500,
+  # Fly.io polls every 15 seconds, so I'm setting the interval to 20 seconds to avoid
+  # missing data.
+  ets_flush_interval: 20_000,
   metrics_server: [
     port: 9091,
     auth_strategy: :none

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -64,7 +64,7 @@ defmodule Tuist.PromEx do
         # Plugins.PhoenixLiveView,
         # Plugins.Absinthe,
         # Plugins.Broadway,
-
+        PromEx.Plugins.Beam,
         Tuist.Storage.PromExPlugin,
         Tuist.CommandEvents.PromExPlugin,
         Tuist.Accounts.PromExPlugin,

--- a/server/lib/tuist/prom_ex/striped_peep.ex
+++ b/server/lib/tuist/prom_ex/striped_peep.ex
@@ -7,10 +7,32 @@ defmodule Tuist.PromEx.StripedPeep do
 
   @impl true
   def scrape(name) do
-    name
-    |> Peep.get_all_metrics()
+    metrics =
+      name
+      |> Peep.get_all_metrics()
+      |> case do
+        # Handle case when Peep instance doesn't exist
+        nil -> %{}
+        metrics -> metrics
+      end
+
+    flush_storage(name)
+
+    metrics
     |> Peep.Prometheus.export()
     |> IO.iodata_to_binary()
+  end
+
+  defp flush_storage(name) do
+    case Peep.Persistent.fetch(name) do
+      %Peep.Persistent{storage: {Peep.Storage.Striped, tids}} ->
+        tids
+        |> Tuple.to_list()
+        |> Enum.each(&:ets.delete_all_objects/1)
+
+      _ ->
+        :ok
+    end
   end
 
   @impl true

--- a/server/test/tuist/prom_ex/striped_peep_test.exs
+++ b/server/test/tuist/prom_ex/striped_peep_test.exs
@@ -1,0 +1,155 @@
+defmodule Tuist.PromEx.StripedPeepTest do
+  use ExUnit.Case, async: false
+
+  alias Tuist.PromEx.StripedPeep
+
+  defp unique_id(), do: String.replace(UUIDv7.generate(), "-", "_")
+
+  describe "scrape/1" do
+    test "clears striped ETS tables after scraping metrics" do
+      test_id = unique_id()
+      name = :"test_peep_#{test_id}"
+      event_name = ["test", test_id, "counter"]
+
+      metrics = [Telemetry.Metrics.counter(Enum.join(event_name, "."))]
+      opts = [name: name, metrics: metrics, storage: :striped]
+
+      {:ok, _pid} = Peep.start_link(opts)
+      Process.sleep(50)
+
+      :telemetry.execute(event_name, %{}, %{test: "value1"})
+      :telemetry.execute(event_name, %{}, %{test: "value2"})
+
+      # Wait for Peep to process metrics
+      Process.sleep(50)
+
+      metrics_before = Peep.get_all_metrics(name) || %{}
+
+      result = StripedPeep.scrape(name)
+      assert is_binary(result)
+
+      if map_size(metrics_before) > 0 do
+        metrics_after = Peep.get_all_metrics(name) || %{}
+        assert map_size(metrics_after) == 0
+      end
+
+      GenServer.stop(name)
+    end
+
+    test "handles different metric types" do
+      test_id = unique_id()
+      name = :"test_peep_mixed_#{test_id}"
+
+      events = %{
+        counter: ["test", test_id, "counter"],
+        last_value: ["test", test_id, "last_value"],
+        sum: ["test", test_id, "sum"]
+      }
+
+      metrics = [
+        Telemetry.Metrics.counter(Enum.join(events.counter, ".")),
+        Telemetry.Metrics.last_value(Enum.join(events.last_value, ".")),
+        Telemetry.Metrics.sum(Enum.join(events.sum, "."))
+      ]
+
+      opts = [name: name, metrics: metrics, storage: :striped]
+      {:ok, _pid} = Peep.start_link(opts)
+      Process.sleep(50)
+
+      :telemetry.execute(events.counter, %{}, %{type: "request"})
+      :telemetry.execute(events.last_value, %{value: 42}, %{resource: "cpu"})
+      :telemetry.execute(events.sum, %{bytes: 1024}, %{endpoint: "api"})
+      Process.sleep(10)
+
+      result = StripedPeep.scrape(name)
+      assert is_binary(result)
+      assert String.contains?(result, "# EOF")
+
+      GenServer.stop(name)
+    end
+
+    test "handles non-striped storage without clearing" do
+      test_id = unique_id()
+      name = :"test_peep_default_#{test_id}"
+      event_name = ["test", test_id, "counter"]
+
+      metrics = [Telemetry.Metrics.counter(Enum.join(event_name, "."))]
+      opts = [name: name, metrics: metrics, storage: :default]
+
+      {:ok, _pid} = Peep.start_link(opts)
+      Process.sleep(50)
+
+      :telemetry.execute(event_name, %{}, %{test: "value"})
+      Process.sleep(50)
+
+      metrics_before = Peep.get_all_metrics(name) || %{}
+      result = StripedPeep.scrape(name)
+      assert is_binary(result)
+
+      if map_size(metrics_before) > 0 do
+        metrics_after = Peep.get_all_metrics(name) || %{}
+        assert map_size(metrics_after) > 0
+      end
+
+      GenServer.stop(name)
+    end
+
+    test "handles non-existent Peep instance gracefully" do
+      fake_name = :"non_existent_#{unique_id()}"
+
+      result = StripedPeep.scrape(fake_name)
+      assert is_binary(result)
+      assert String.contains?(result, "# EOF")
+    end
+
+    test "memory leak prevention through multiple scrape cycles" do
+      test_id = unique_id()
+      name = :"test_peep_memory_#{test_id}"
+      event_name = ["test", test_id, "leak_test"]
+
+      metrics = [Telemetry.Metrics.counter(Enum.join(event_name, "."))]
+      opts = [name: name, metrics: metrics, storage: :striped]
+
+      {:ok, _pid} = Peep.start_link(opts)
+      Process.sleep(50)
+
+      for cycle <- 1..3 do
+        for i <- 1..5 do
+          :telemetry.execute(event_name, %{}, %{cycle: cycle, iteration: i})
+        end
+
+        Process.sleep(10)
+
+        result = StripedPeep.scrape(name)
+        assert is_binary(result)
+
+        Process.sleep(10)
+      end
+
+      GenServer.stop(name)
+    end
+  end
+
+  describe "child_spec/2" do
+    test "returns valid Peep child spec with striped storage" do
+      test_id = unique_id()
+      name = :"test_child_spec_#{test_id}"
+
+      metrics = [
+        Telemetry.Metrics.counter("test.child_spec.#{test_id}")
+      ]
+
+      result = StripedPeep.child_spec(name, metrics)
+
+      assert is_map(result)
+      assert Map.has_key?(result, :id)
+      assert Map.has_key?(result, :start)
+      assert result.id == name
+
+      assert {Peep, :start_link, [opts]} = result.start
+      assert opts[:name] == name
+      assert opts[:metrics] == metrics
+      assert opts[:storage] == :striped
+    end
+  end
+end

--- a/server/test/tuist/prom_ex/striped_peep_test.exs
+++ b/server/test/tuist/prom_ex/striped_peep_test.exs
@@ -3,7 +3,7 @@ defmodule Tuist.PromEx.StripedPeepTest do
 
   alias Tuist.PromEx.StripedPeep
 
-  defp unique_id(), do: String.replace(UUIDv7.generate(), "-", "_")
+  defp unique_id, do: String.replace(UUIDv7.generate(), "-", "_")
 
   describe "scrape/1" do
     test "clears striped ETS tables after scraping metrics" do


### PR DESCRIPTION
We migrated to [peep](https://github.com/rkallos/peep) as a tool used by `:prom_ex` to turn telemetry metrics into Prometheus telemetry data. This solution provides a better less CPU contention than `:prom_ex`'s default. However, I noticed our memory was still leaking and our telemetry gaps still present in our Grafana dashboards.

It turns out our wrapper of Peep, which I copied from [Plausible's codebase](https://github.com/plausible/analytics/pull/5130), doesn't delete the metrics after scraping them, causing the memory to grow endlessly. This is fine if you are continuously deploying the service, but since this is not the case for us, the memory will grow indefinitively. Once it reaches a certain size (above 16Mb), Fly stops pulling those metrics, and that's why we have the gaps in the dashboard. Those get resetted when we do new deployments.

With the help of Claude (😬), I adjusted the `scrape` function, and confirmed locally that metrics are now deleted periodically. Now we need to make sure the polling interval of Fly is faster than our periodic cleanup. If so, we should have our metrics back in Grafana, and also the memory leak gone.

> [!NOTE]
> I recommend holding this a bit until we can confirm the leak is connected with this, and then merge it.