### PR TITLE
chore(server): fix mise task to open a console against remote environments

### DIFF
--- a/server/mise/tasks/fly/console/canary.sh
+++ b/server/mise/tasks/fly/console/canary.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # mise description="Opens an Elixir console with the remote canary server"
 
-(cd server && flyctl ssh console --app tuist-cloud-canary --pty -C "/app/bin/tuist remote")
+flyctl ssh console --app tuist-cloud-canary --pty -C "/app/bin/tuist remote"

--- a/server/mise/tasks/fly/console/production.sh
+++ b/server/mise/tasks/fly/console/production.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # mise description="Opens an Elixir console with the remote production server"
 
-(cd server && flyctl ssh console --app tuist-cloud --pty -C "/app/bin/tuist remote")
+flyctl ssh console --app tuist-cloud --pty -C "/app/bin/tuist remote"

--- a/server/mise/tasks/fly/console/staging.sh
+++ b/server/mise/tasks/fly/console/staging.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # mise description="Opens an Elixir console with the remote staging server"
 
-(cd server && flyctl ssh console --app tuist-cloud-staging --pty -C "/app/bin/tuist remote")
+flyctl ssh console --app tuist-cloud-staging --pty -C "/app/bin/tuist remote"


### PR DESCRIPTION
I noticed our Mise tasks to open server consoles did not reflect the recent change in the Mise set up where we extracted the server tasks into its own Mise scope. This PR fixes it.