### PR TITLE
fix(server): cascade the deletion of invitations

### DIFF
--- a/server/priv/repo/migrations/20250828065245_add_foreign_key_constraints_to_invitations.exs
+++ b/server/priv/repo/migrations/20250828065245_add_foreign_key_constraints_to_invitations.exs
@@ -1,0 +1,49 @@
+defmodule Tuist.Repo.Migrations.AddForeignKeyConstraintsToInvitations do
+  use Ecto.Migration
+
+  def up do
+    # Clean up any orphaned invitation records before adding constraints
+    # Delete invitations where inviter_id references non-existent users
+    execute """
+    DELETE FROM invitations 
+    WHERE inviter_id IS NOT NULL 
+    AND NOT EXISTS (
+      SELECT 1 FROM users WHERE id = invitations.inviter_id
+    )
+    """
+
+    # Delete invitations where organization_id references non-existent organizations
+    execute """
+    DELETE FROM invitations 
+    WHERE organization_id IS NOT NULL 
+    AND NOT EXISTS (
+      SELECT 1 FROM organizations WHERE id = invitations.organization_id
+    )
+    """
+
+    # Add foreign key constraint for inviter_id -> users.id with cascade delete
+    alter table(:invitations) do
+      modify :inviter_id, references(:users, on_delete: :delete_all), 
+             null: false, 
+             from: {:bigint, null: false}
+    end
+
+    # Add foreign key constraint for organization_id -> organizations.id with cascade delete  
+    alter table(:invitations) do
+      modify :organization_id, references(:organizations, on_delete: :delete_all), 
+             null: false, 
+             from: {:bigint, null: false}
+    end
+  end
+
+  def down do
+    # Remove foreign key constraints
+    alter table(:invitations) do
+      modify :inviter_id, :bigint, null: false
+    end
+
+    alter table(:invitations) do
+      modify :organization_id, :bigint, null: false
+    end
+  end
+end


### PR DESCRIPTION
If an organization or user associated with an invitation through the relationship organization and inviter respectively are deleted, we end up with invalid invitations that we fail to render because we assume the inviter is there.
This PR adds a new foreign key to ensure the deletion of organizations and users also cascades to invitations.