### PR TITLE
fix(server): retry on :closed_for_writing 

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -151,8 +151,8 @@ defmodule Tuist.Application do
               verify: :verify_peer
             ]
           ],
-          size: 10,
-          count: 1,
+          size: 2,
+          count: 10,
           protocols: [:http2, :http1],
           start_pool_metrics?: true
         ],

--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -10,6 +10,25 @@ defmodule Tuist.GitHub.Client do
   alias Tuist.VCS.Repositories.Content
   alias Tuist.VCS.Repositories.Tag
 
+  defp retry_on_closed_for_writing(_request, %Req.HTTPError{protocol: :http2, reason: :closed_for_writing}) do
+    {:delay, 100}
+  end
+
+  defp retry_on_closed_for_writing(request, response_or_exception) do
+    # Fall back to default retry logic for other errors
+    case request.method do
+      method when method in [:get, :head] ->
+        case response_or_exception do
+          %Req.Response{status: status} when status in [408, 429, 500, 502, 503, 504] -> true
+          %Req.TransportError{reason: reason} when reason in [:timeout, :econnrefused, :closed] -> true
+          %Req.HTTPError{protocol: :http2, reason: :unprocessed} -> true
+          _ -> false
+        end
+      _ ->
+        false
+    end
+  end
+
   @doc """
   `repository_full_handle` is necessary as to interact with the user endpoint,
   we need to be authenticated with the GitHub app installation token associated with a specific repository.
@@ -111,7 +130,8 @@ defmodule Tuist.GitHub.Client do
            headers: default_headers(token),
            decode_body: false,
            finch: Tuist.Finch,
-           into: File.stream!(path, [:write])
+           into: File.stream!(path, [:write]),
+           retry: &retry_on_closed_for_writing/2
          ) do
       {:ok, %{status: 200}} ->
         {:ok, path}
@@ -141,7 +161,8 @@ defmodule Tuist.GitHub.Client do
     case Req.get(
            url: url,
            headers: default_headers(token),
-           finch: Tuist.Finch
+           finch: Tuist.Finch,
+           retry: &retry_on_closed_for_writing/2
          ) do
       {:ok, %{status: 200, body: %{"content" => content, "path" => path}}} ->
         {:ok, %Content{path: path, content: Base64.decode(content)}}
@@ -172,6 +193,7 @@ defmodule Tuist.GitHub.Client do
             {"Authorization", "token #{token}"}
           ])
           |> Keyword.put(:finch, Tuist.Finch)
+          |> Keyword.put(:retry, &retry_on_closed_for_writing/2)
           |> Keyword.delete(:repository_full_handle)
 
         attrs_with_headers |> method.() |> handle_github_response(method, attrs)
@@ -222,7 +244,7 @@ defmodule Tuist.GitHub.Client do
   end
 
   defp get_all_tags_recursively(%{url: url, token: token, tags: tags}) do
-    case Req.get(url: url, headers: default_headers(token), finch: Tuist.Finch) do
+    case Req.get(url: url, headers: default_headers(token), finch: Tuist.Finch, retry: &retry_on_closed_for_writing/2) do
       {:ok, %Req.Response{status: 200, body: page_tags, headers: response_headers}} ->
         page_tags = Enum.map(page_tags, &%Tag{name: &1["name"]})
 

--- a/server/test/tuist/github/client_test.exs
+++ b/server/test/tuist/github/client_test.exs
@@ -35,7 +35,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:finch] == Tuist.Finch
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-        
+
         {:ok,
          %Req.Response{
            status: 200,
@@ -143,7 +143,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:headers] == @default_headers
         assert opts[:json] == %{body: "comment"}
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-        
+
         {:ok, %Req.Response{status: 201}}
       end)
 
@@ -168,7 +168,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:headers] == @default_headers
         assert opts[:json] == %{body: "comment"}
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/comments/1"
-        
+
         {:ok, %Req.Response{status: 201}}
       end)
 
@@ -192,7 +192,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:finch] == Tuist.Finch
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/user/123"
-        
+
         {:ok, %Req.Response{status: 200, body: %{"login" => "tuist"}}}
       end)
 
@@ -209,7 +209,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:finch] == Tuist.Finch
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/user/123"
-        
+
         {:ok, %Req.Response{status: 404, body: "Not found"}}
       end)
 
@@ -228,6 +228,7 @@ defmodule Tuist.GitHub.ClientTest do
         case opts[:url] do
           "https://api.github.com/user/123" ->
             {:ok, %Req.Response{status: 200, body: %{"login" => "tuist"}}}
+
           "https://api.github.com/repos/tuist/tuist/collaborators/tuist/permission" ->
             {:ok, %Req.Response{status: 200, body: %{"permission" => "admin"}}}
         end
@@ -249,7 +250,7 @@ defmodule Tuist.GitHub.ClientTest do
         assert opts[:finch] == Tuist.Finch
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist"
-        
+
         {:ok,
          %Req.Response{
            status: 200,

--- a/server/test/tuist/github/client_test.exs
+++ b/server/test/tuist/github/client_test.exs
@@ -31,11 +31,11 @@ defmodule Tuist.GitHub.ClientTest do
   describe "get_comments/1" do
     test "returns comments" do
       # Given
-      expect(Req, :get, fn [
-                             finch: Tuist.Finch,
-                             headers: @default_headers,
-                             url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                           ] ->
+      expect(Req, :get, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        
         {:ok,
          %Req.Response{
            status: 200,
@@ -138,12 +138,12 @@ defmodule Tuist.GitHub.ClientTest do
   describe "create_comment/1" do
     test "creates a new comment" do
       # Given
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: "comment"}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:json] == %{body: "comment"}
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        
         {:ok, %Req.Response{status: 201}}
       end)
 
@@ -163,12 +163,12 @@ defmodule Tuist.GitHub.ClientTest do
   describe "update_comment/1" do
     test "updates comment" do
       # Given
-      expect(Req, :patch, fn [
-                               finch: Tuist.Finch,
-                               headers: @default_headers,
-                               url: "https://api.github.com/repos/tuist/tuist/issues/comments/1",
-                               json: %{body: "comment"}
-                             ] ->
+      expect(Req, :patch, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:json] == %{body: "comment"}
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/comments/1"
+        
         {:ok, %Req.Response{status: 201}}
       end)
 
@@ -188,11 +188,11 @@ defmodule Tuist.GitHub.ClientTest do
   describe "get_user_by_id/1" do
     test "returns user" do
       # Given
-      expect(Req, :get, fn [
-                             finch: Tuist.Finch,
-                             headers: @default_headers,
-                             url: "https://api.github.com/user/123"
-                           ] ->
+      expect(Req, :get, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/user/123"
+        
         {:ok, %Req.Response{status: 200, body: %{"login" => "tuist"}}}
       end)
 
@@ -205,44 +205,33 @@ defmodule Tuist.GitHub.ClientTest do
 
     test "returns ok with 404 error" do
       # Given
-      expect(Req, :get, fn [
-                             finch: Tuist.Finch,
-                             headers: @default_headers,
-                             url: "https://api.github.com/user/123"
-                           ] ->
-        {:ok, %Req.Response{status: 404}}
+      expect(Req, :get, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/user/123"
+        
+        {:ok, %Req.Response{status: 404, body: "Not found"}}
       end)
 
       # When
       user = Client.get_user_by_id(%{id: "123", repository_full_handle: "tuist/tuist"})
 
       # Then
-      assert user == {:error, "Unexpected status code: 404. Body: \"\""}
+      assert user == {:error, "Unexpected status code: 404. Body: \"Not found\""}
     end
   end
 
   describe "get_user_permission/1" do
     test "returns user permission" do
       # Given
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/user/123"
-                         ] ->
-        {:ok, %Req.Response{status: 200, body: %{"login" => "tuist"}}}
-      end)
-
-      stub(
-        Req,
-        :get,
-        fn [
-             finch: Tuist.Finch,
-             headers: @default_headers,
-             url: "https://api.github.com/repos/tuist/tuist/collaborators/tuist/permission"
-           ] ->
-          {:ok, %Req.Response{status: 200, body: %{"permission" => "admin"}}}
+      stub(Req, :get, fn opts ->
+        case opts[:url] do
+          "https://api.github.com/user/123" ->
+            {:ok, %Req.Response{status: 200, body: %{"login" => "tuist"}}}
+          "https://api.github.com/repos/tuist/tuist/collaborators/tuist/permission" ->
+            {:ok, %Req.Response{status: 200, body: %{"permission" => "admin"}}}
         end
-      )
+      end)
 
       # When
       permission =
@@ -256,11 +245,11 @@ defmodule Tuist.GitHub.ClientTest do
   describe "get_repository/1" do
     test "returns repository" do
       # Given
-      expect(Req, :get, fn [
-                             finch: Tuist.Finch,
-                             headers: @default_headers,
-                             url: "https://api.github.com/repos/tuist/tuist"
-                           ] ->
+      expect(Req, :get, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist"
+        
         {:ok,
          %Req.Response{
            status: 200,
@@ -292,7 +281,8 @@ defmodule Tuist.GitHub.ClientTest do
           [
             url: "https://api.github.com/repos/tuist/tuist/tags?page_size=100",
             headers: @default_api_headers,
-            finch: Tuist.Finch
+            finch: Tuist.Finch,
+            retry: _
           ] ->
             {:ok,
              %Req.Response{
@@ -311,7 +301,8 @@ defmodule Tuist.GitHub.ClientTest do
           [
             url: "https://api.github.com/repos/tuist/tuist/tags?page=2&page_size=100",
             headers: @default_api_headers,
-            finch: Tuist.Finch
+            finch: Tuist.Finch,
+            retry: _
           ] ->
             {:ok,
              %Req.Response{
@@ -344,7 +335,8 @@ defmodule Tuist.GitHub.ClientTest do
           [
             url: "https://api.github.com/repos/tuist/tuist/tags?page_size=100",
             headers: @default_api_headers,
-            finch: Tuist.Finch
+            finch: Tuist.Finch,
+            retry: _
           ] ->
             {:ok,
              %Req.Response{

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -360,11 +360,7 @@ defmodule Tuist.VCSTest do
           status: :failure
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -391,12 +387,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      stub(Req, :post, fn [
-                            finch: Tuist.Finch,
-                            headers: @default_headers,
-                            url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                            json: %{body: ^expected_body}
-                          ] ->
+      stub(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -460,11 +456,7 @@ defmodule Tuist.VCSTest do
           display_name: "WatchApp"
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -483,12 +475,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: ^expected_body}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -651,15 +643,15 @@ defmodule Tuist.VCSTest do
         {:ok, %{token: "github_token", expires_at: ~U[2024-04-30 10:30:31Z]}}
       end)
 
-      stub(Req, :patch, fn [
-                             finch: Tuist.Finch,
-                             headers: [
-                               {"Accept", "application/vnd.github.v3+json"},
-                               {"Authorization", "token github_token"}
-                             ],
-                             url: "https://api.github.com/repos/tuist/tuist/issues/comments/1",
-                             json: %{body: _}
-                           ] ->
+      stub(Req, :patch, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == [
+          {"Accept", "application/vnd.github.v3+json"},
+          {"Authorization", "token github_token"}
+        ]
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/comments/1"
+        assert Map.has_key?(opts[:json], :body)
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -888,11 +880,7 @@ defmodule Tuist.VCSTest do
           inserted_at: ~U[2024-01-01 05:00:00Z]
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -910,12 +898,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: ^expected_body}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -954,11 +942,7 @@ defmodule Tuist.VCSTest do
           git_ref: @git_ref
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -976,12 +960,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: ^expected_body}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -1017,11 +1001,7 @@ defmodule Tuist.VCSTest do
           inserted_at: ~U[2024-01-01 04:00:00Z]
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -1039,12 +1019,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: ^expected_body}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -1080,11 +1060,7 @@ defmodule Tuist.VCSTest do
           inserted_at: ~U[2024-01-01 04:00:00Z]
         )
 
-      stub(Req, :get, fn [
-                           finch: Tuist.Finch,
-                           headers: @default_headers,
-                           url: "https://api.github.com/repos/tuist/tuist/issues/1/comments"
-                         ] ->
+      stub(Req, :get, fn _opts ->
         {:ok, %Req.Response{status: 200, body: []}}
       end)
 
@@ -1102,12 +1078,12 @@ defmodule Tuist.VCSTest do
 
         """
 
-      expect(Req, :post, fn [
-                              finch: Tuist.Finch,
-                              headers: @default_headers,
-                              url: "https://api.github.com/repos/tuist/tuist/issues/1/comments",
-                              json: %{body: ^expected_body}
-                            ] ->
+      expect(Req, :post, fn opts ->
+        assert opts[:finch] == Tuist.Finch
+        assert opts[:headers] == @default_headers
+        assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
+        assert opts[:json] == %{body: expected_body}
+        
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -392,7 +392,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -480,7 +480,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -645,13 +645,15 @@ defmodule Tuist.VCSTest do
 
       stub(Req, :patch, fn opts ->
         assert opts[:finch] == Tuist.Finch
+
         assert opts[:headers] == [
-          {"Accept", "application/vnd.github.v3+json"},
-          {"Authorization", "token github_token"}
-        ]
+                 {"Accept", "application/vnd.github.v3+json"},
+                 {"Authorization", "token github_token"}
+               ]
+
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/comments/1"
         assert Map.has_key?(opts[:json], :body)
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -903,7 +905,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -965,7 +967,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -1024,7 +1026,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 
@@ -1083,7 +1085,7 @@ defmodule Tuist.VCSTest do
         assert opts[:headers] == @default_headers
         assert opts[:url] == "https://api.github.com/repos/tuist/tuist/issues/1/comments"
         assert opts[:json] == %{body: expected_body}
-        
+
         {:ok, %Req.Response{status: 200, body: %{}}}
       end)
 


### PR DESCRIPTION
GitHub sometimes closes the HTTP connection unexpectedly.
This PR 
1. adjusts pool settings so it happens less often
2. adds the `closed_for_writing` reason to Req retries as its not included in the defaults

Closes #8104 