### PR TITLE
feat(server): skip dev releases in registry

### DIFF
--- a/server/lib/tuist/registry/swift/packages.ex
+++ b/server/lib/tuist/registry/swift/packages.ex
@@ -104,7 +104,9 @@ defmodule Tuist.Registry.Swift.Packages do
     |> Enum.filter(fn version ->
       # Matches semantic version as per: https://semver.org/
       # Examples: 1.0.0, 1.0.0-alpha, 1.0.0-alpha.1, 1.1
+      # Skip dev versions like 0.9.3-dev1985
       Regex.match?(~r/^v?\d+\.\d+(\.\d+)?[0-9A-Za-z-]*(\.[0-9A-Za-z]*)?$/, version) and
+        not Regex.match?(~r/-dev/, version) and
         not Enum.any?(package.package_releases, &(&1.version == semantic_version(version)))
     end)
     |> Enum.uniq_by(&semantic_version(&1))


### PR DESCRIPTION
Some packages such as [duckdb-swift](https://github.com/duckdb/duckdb-swift) are adding tags on every commit, which is... a lot. This PR adds another filter for `-dev` tags.