### PR TITLE
fix(server): prevent scientific notation in trend badge display

### DIFF
--- a/server/lib/tuist_web/components/trend_badge.ex
+++ b/server/lib/tuist_web/components/trend_badge.ex
@@ -8,14 +8,23 @@ defmodule TuistWeb.Components.TrendBadge do
   attr :trend_value, :integer, required: true
   attr :trend_inverse, :boolean, default: false
 
+  defp format_trend_value(value) do
+    rounded = Float.round(value, 1)
+    if abs(rounded) < 0.1 and rounded != 0.0 do
+      "0.0"
+    else
+      :erlang.float_to_binary(rounded, decimals: if(abs(rounded) >= 1000, do: 0, else: 1))
+    end
+  end
+
   def trend_badge(assigns) do
     ~H"""
     <.badge
       size="large"
       label={
         if @trend_value > 0,
-          do: "+#{@trend_value |> Float.round(1)}%",
-          else: "#{@trend_value |> Float.round(1)}%"
+          do: "+#{format_trend_value(@trend_value)}%",
+          else: "#{format_trend_value(@trend_value)}%"
       }
       color={
         cond do

--- a/server/lib/tuist_web/components/trend_badge.ex
+++ b/server/lib/tuist_web/components/trend_badge.ex
@@ -8,23 +8,23 @@ defmodule TuistWeb.Components.TrendBadge do
   attr :trend_value, :integer, required: true
   attr :trend_inverse, :boolean, default: false
 
-  defp format_trend_value(value) do
-    rounded = Float.round(value, 1)
-    if abs(rounded) < 0.1 and rounded != 0.0 do
-      "0.0"
-    else
-      :erlang.float_to_binary(rounded, decimals: if(abs(rounded) >= 1000, do: 0, else: 1))
-    end
-  end
-
   def trend_badge(assigns) do
+    rounded = Float.round(assigns.trend_value, 1)
+
+    formatted_value =
+      if abs(rounded) < 0.1 and rounded != 0.0 do
+        "0.0"
+      else
+        :erlang.float_to_binary(rounded, decimals: if(abs(rounded) >= 1000, do: 0, else: 1))
+      end
+
     ~H"""
     <.badge
       size="large"
       label={
         if @trend_value > 0,
-          do: "+#{format_trend_value(@trend_value)}%",
-          else: "#{format_trend_value(@trend_value)}%"
+          do: "+#{formatted_value}%",
+          else: "#{formatted_value}%"
       }
       color={
         cond do


### PR DESCRIPTION
- Add format_trend_value helper function to handle large and small trend values
- Large values (>= 1000) display as integers to avoid 4.12e4% format
- Small values (< 0.1) display as 0.0 instead of scientific notation

Solves #7958
