### PR TITLE
fix(cli): default to caching the manifests

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
@@ -4,7 +4,12 @@ import TuistSupport
 public final class ManifestLoaderFactory {
     private let useCache: Bool
     public convenience init() {
-        self.init(useCache: Environment.current.isVariableTruthy(Constants.EnvironmentVariables.cacheManifests))
+        let useCache = if Environment.current.variables[Constants.EnvironmentVariables.cacheManifests] != nil {
+            Environment.current.isVariableTruthy(Constants.EnvironmentVariables.cacheManifests)
+        } else {
+            true
+        }
+        self.init(useCache: useCache)
     }
 
     public init(useCache: Bool) {


### PR DESCRIPTION
I've been noticing for quite a while that the generation was slower than usual. It turns out that I introduced a regression [in this PR](https://github.com/tuist/tuist/pull/7595/files#diff-c82d21c825ce98ed0ccd18b949ca8211f18b308cc5d0287fd2b40a47f21b48e1) making the new default `false` instead of `true`.

### How to test locally

You can run `tuist run tuist generate --no-open --path ./cli/Fixtures/ios_app_with_frameworks`. The first generation should take a bit longer, but the consecutive ones should be faster. You can also delete `~/.cache/tuist/Manifests` pre generation, and check the content after the project has been generated. You should see the manifests cached there.
