### PR TITLE
chore(server): use new mise script syntax

### DIFF
--- a/docs/mise/tasks/build.sh
+++ b/docs/mise/tasks/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Builds the documentation website."
+#MISE description="Builds the documentation website."
 
 set -euo pipefail
 

--- a/docs/mise/tasks/deploy.sh
+++ b/docs/mise/tasks/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Deploys the documentation website."
+#MISE description="Deploys the documentation website."
 
 set -euo pipefail
 

--- a/docs/mise/tasks/dev.sh
+++ b/docs/mise/tasks/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Dev the documentation website."
+#MISE description="Dev the documentation website."
 
 set -euo pipefail
 

--- a/docs/mise/tasks/generate-cli-docs.sh
+++ b/docs/mise/tasks/generate-cli-docs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Generates the markdown documentation for the cli files"
+#MISE description="Generates the markdown documentation for the cli files"
 
 set -euo pipefail
 

--- a/docs/mise/tasks/generate-manifests-docs.sh
+++ b/docs/mise/tasks/generate-manifests-docs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Generates the markdown documentation for the manifest files"
+#MISE description="Generates the markdown documentation for the manifest files"
 
 set -euo pipefail
 

--- a/docs/mise/tasks/install.sh
+++ b/docs/mise/tasks/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Install the documentation dependencies"
+#MISE description="Install the documentation dependencies"
 
 pnpm install

--- a/handbook/mise/tasks/build.sh
+++ b/handbook/mise/tasks/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Build the handbook"
+#MISE description="Build the handbook"
 
 pnpm run build

--- a/handbook/mise/tasks/deploy.sh
+++ b/handbook/mise/tasks/deploy.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Deploy the handbook"
+#MISE description="Deploy the handbook"
 
 pnpm run deploy

--- a/handbook/mise/tasks/dev.sh
+++ b/handbook/mise/tasks/dev.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Dev the handbook"
+#MISE description="Dev the handbook"
 
 pnpm run dev

--- a/handbook/mise/tasks/install.sh
+++ b/handbook/mise/tasks/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Install the handbook dependencies"
+#MISE description="Install the handbook dependencies"
 
 pnpm install

--- a/mise/tasks/app/bundle-ios.sh
+++ b/mise/tasks/app/bundle-ios.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Creates Tuist iOS app .ipa archive."
+#MISE description="Creates Tuist iOS app .ipa archive."
 
 set -eo pipefail
 

--- a/mise/tasks/app/bundle.sh
+++ b/mise/tasks/app/bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Bundles the Tuist macOS app for distribution"
+#MISE description="Bundles the Tuist macOS app for distribution"
 
 set -euo pipefail
 

--- a/mise/tasks/app/upload-ios.sh
+++ b/mise/tasks/app/upload-ios.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Creates Tuist iOS app .ipa archive and uploads it to App Store Connect."
+#MISE description="Creates Tuist iOS app .ipa archive and uploads it to App Store Connect."
 
 set -eo pipefail
 

--- a/mise/tasks/cli/benchmark/build.sh
+++ b/mise/tasks/cli/benchmark/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Build the 'tuistbenchmark' tool"
+#MISE description="Build the 'tuistbenchmark' tool"
 set -euo pipefail
 
 swift build --target tuistbenchmark $@

--- a/mise/tasks/cli/benchmark/run.sh
+++ b/mise/tasks/cli/benchmark/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Run the 'tuistbenchmark' tool"
+#MISE description="Run the 'tuistbenchmark' tool"
 set -euo pipefail
 
 FIXTURES_DIRECTORY=cli/Fixtures

--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Bundles the CLI"
+#MISE description="Bundles the CLI"
 
 set -e
 

--- a/mise/tasks/cli/clean.sh
+++ b/mise/tasks/cli/clean.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Cleans SPM's .build directory and Tuist-** derived data directories"
+#MISE description="Cleans SPM's .build directory and Tuist-** derived data directories"
 set -euo pipefail
 
 DERIVED_DATA_PATH=$($MISE_PROJECT_ROOT/mise/utilities/derived_data_path.sh)

--- a/mise/tasks/cli/ee.sh
+++ b/mise/tasks/cli/ee.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Updates the TuistCacheEE submodule to ensure it's up to date"
+#MISE description="Updates the TuistCacheEE submodule to ensure it's up to date"
 
 set -euo pipefail
 

--- a/mise/tasks/cli/fixturegenerator/build.sh
+++ b/mise/tasks/cli/fixturegenerator/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Build the 'tuistfixturegenerator' tool"
+#MISE description="Build the 'tuistfixturegenerator' tool"
 set -euo pipefail
 
 swift build --package-path $MISE_PROJECT_ROOT --target tuistfixturegenerator $@

--- a/mise/tasks/cli/fixturegenerator/run.sh
+++ b/mise/tasks/cli/fixturegenerator/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Run the 'tuistfixturegenerator' tool"
+#MISE description="Run the 'tuistfixturegenerator' tool"
 set -euo pipefail
 
 source $MISE_PROJECT_ROOT/mise/utilities/setup.sh

--- a/mise/tasks/cli/release/homebrew-cask.sh
+++ b/mise/tasks/cli/release/homebrew-cask.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Triggers the GitHub Actions workflow to release a new version of the Homebrew cask."
+#MISE description="Triggers the GitHub Actions workflow to release a new version of the Homebrew cask."
 set -eo pipefail
 
 # Parse command line arguments

--- a/mise/tasks/cli/release/homebrew-formula.sh
+++ b/mise/tasks/cli/release/homebrew-formula.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Triggers the GitHub Actions workflow to release a new version of the Homebrew formula."
+#MISE description="Triggers the GitHub Actions workflow to release a new version of the Homebrew formula."
 set -eo pipefail
 
 # Parse command line arguments

--- a/mise/tasks/cli/spm/tuist/build.sh
+++ b/mise/tasks/cli/spm/tuist/build.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# mise description="Build the project using Tuist"
+#MISE description="Build the project using Tuist"
 
 set -euo pipefail
 
 swift build --package-path $MISE_PROJECT_ROOT
 $MISE_PROJECT_ROOT/.build/debug/tuist install --path $MISE_PROJECT_ROOT
 $MISE_PROJECT_ROOT/.build/debug/tuist build --path $MISE_PROJECT_ROOT --generate $@
-

--- a/mise/tasks/cli/spm/tuist/edit.sh
+++ b/mise/tasks/cli/spm/tuist/edit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Edit the project using Tuist"
+#MISE description="Edit the project using Tuist"
 
 set -euo pipefail
 

--- a/mise/tasks/cli/spm/tuist/generate.sh
+++ b/mise/tasks/cli/spm/tuist/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Generate the project using Tuist"
+#MISE description="Generate the project using Tuist"
 
 set -euo pipefail
 

--- a/mise/tasks/cli/spm/tuist/run.sh
+++ b/mise/tasks/cli/spm/tuist/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Run the project using Tuist"
+#MISE description="Run the project using Tuist"
 
 set -euo pipefail
 

--- a/mise/tasks/cli/spm/tuist/test.sh
+++ b/mise/tasks/cli/spm/tuist/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Test the project using Tuist"
+#MISE description="Test the project using Tuist"
 
 set -euo pipefail
 

--- a/mise/tasks/env/edit.sh
+++ b/mise/tasks/env/edit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Edit the .env file"
+#MISE description="Edit the .env file"
 
 set -eo pipefail
 

--- a/mise/tasks/env/encrypt.sh
+++ b/mise/tasks/env/encrypt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Encrypts the .env file"
+#MISE description="Encrypts the .env file"
 
 set -eo pipefail
 

--- a/mise/tasks/install.sh
+++ b/mise/tasks/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Install all necessary dependencies"
+#MISE description="Install all necessary dependencies"
 
 set -eo pipefail
 

--- a/server/mise/tasks/clickhouse/start.sh
+++ b/server/mise/tasks/clickhouse/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Start ClickHouse server as daemon"
+#MISE description="Start ClickHouse server as daemon"
 
 set -euo pipefail
 

--- a/server/mise/tasks/clickhouse/stop.sh
+++ b/server/mise/tasks/clickhouse/stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Start ClickHouse server as daemon"
+#MISE description="Start ClickHouse server as daemon"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/create.sh
+++ b/server/mise/tasks/db/create.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Creates the database"
+#MISE description="Creates the database"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/drop.sh
+++ b/server/mise/tasks/db/drop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Drops the database"
+#MISE description="Drops the database"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/load.sh
+++ b/server/mise/tasks/db/load.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Loads the dumped database schema into the database"
+#MISE description="Loads the dumped database schema into the database"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/migrate.sh
+++ b/server/mise/tasks/db/migrate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Migrates the database"
+#MISE description="Migrates the database"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/reset.sh
+++ b/server/mise/tasks/db/reset.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Re-creates and migrates the database and seeds it with data"
+#MISE description="Re-creates and migrates the database and seeds it with data"
 
 set -eo pipefail
 

--- a/server/mise/tasks/db/seed.sh
+++ b/server/mise/tasks/db/seed.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Seeds data into the database for local development"
+#MISE description="Seeds data into the database for local development"
 
 set -euo pipefail
 

--- a/server/mise/tasks/db/setup.sh
+++ b/server/mise/tasks/db/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Sets up the database"
+#MISE description="Sets up the database"
 
 set -euo pipefail
 

--- a/server/mise/tasks/deploy/canary.sh
+++ b/server/mise/tasks/deploy/canary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Deploys the app to canary"
+#MISE description="Deploys the app to canary"
 
 set -euo pipefail
 

--- a/server/mise/tasks/deploy/production.sh
+++ b/server/mise/tasks/deploy/production.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Deploys the app to production"
+#MISE description="Deploys the app to production"
 
 set -euo pipefail
 

--- a/server/mise/tasks/deploy/staging.sh
+++ b/server/mise/tasks/deploy/staging.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Deploys the app to staging"
+#MISE description="Deploys the app to staging"
 
 set -euo pipefail
 

--- a/server/mise/tasks/dev.sh
+++ b/server/mise/tasks/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Devs the application"
+#MISE description="Devs the application"
 
 set -euo pipefail
 

--- a/server/mise/tasks/docker/clean.sh
+++ b/server/mise/tasks/docker/clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Clean the Docker images"
+#MISE description="Clean the Docker images"
 
 # Remove all Docker images
 docker_images=$(docker images -aq)

--- a/server/mise/tasks/docker/release-macos-image.sh
+++ b/server/mise/tasks/docker/release-macos-image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Releases the macOS image"
+#MISE description="Releases the macOS image"
 
 echo "Make sure you are authenticated against the GitHub registry: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry"
 

--- a/server/mise/tasks/fly/console/canary.sh
+++ b/server/mise/tasks/fly/console/canary.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Opens an Elixir console with the remote canary server"
+#MISE description="Opens an Elixir console with the remote canary server"
 
 flyctl ssh console --app tuist-cloud-canary --pty -C "/app/bin/tuist remote"

--- a/server/mise/tasks/fly/console/production.sh
+++ b/server/mise/tasks/fly/console/production.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Opens an Elixir console with the remote production server"
+#MISE description="Opens an Elixir console with the remote production server"
 
 flyctl ssh console --app tuist-cloud --pty -C "/app/bin/tuist remote"

--- a/server/mise/tasks/fly/console/staging.sh
+++ b/server/mise/tasks/fly/console/staging.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# mise description="Opens an Elixir console with the remote staging server"
+#MISE description="Opens an Elixir console with the remote staging server"
 
 flyctl ssh console --app tuist-cloud-staging --pty -C "/app/bin/tuist remote"

--- a/server/mise/tasks/fly/observe.sh
+++ b/server/mise/tasks/fly/observe.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Run Erlang's observer tool on a remote Fly.io instance"
+#MISE description="Run Erlang's observer tool on a remote Fly.io instance"
 
 # After opening a Wireguard connection to your Fly network, run this script to
 # open a BEAM Observer from your local machine to the remote server. This creates

--- a/server/mise/tasks/generate-api-cli-code.sh
+++ b/server/mise/tasks/generate-api-cli-code.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Generates the Swift code off the Open API specification."
+#MISE description="Generates the Swift code off the Open API specification."
 
 set -euo pipefail
 

--- a/server/mise/tasks/generate-version.sh
+++ b/server/mise/tasks/generate-version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Generate version for server deployments"
+#MISE description="Generate version for server deployments"
 
 # Get the latest server@x.y.z tag
 latest_tag=$(git tag -l "server@*" | sort -V | tail -n 1)

--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mise description="Install all necessary dependencies"
+#MISE description="Install all necessary dependencies"
 
 set -eo pipefail
 

--- a/server/mise/tasks/security.sh
+++ b/server/mise/tasks/security.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise description="Run security static checks"
+#MISE description="Run security static checks"
 #USAGE flag "-l --update-lockfile" help="Update the lockfile .sobelow-skips with new findings that have been verified."
 
 if [ "$usage_update_lockfile" = "true" ]; then


### PR DESCRIPTION
I've updated my local mise and it complains about the following:
```
mise WARN  deprecated [file_task_headers_old_syntax]: The `# mise ...` syntax for task headers is deprecated and will be removed in mise 2026.3.0. Use the new `#MISE ...` syntax instead.
```

I'm updating all our mise scripts to the new syntax.