### PR TITLE
fix(server): uploading run analytics when run has not been inserted yet

### DIFF
--- a/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
+++ b/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
@@ -62,18 +62,14 @@ defmodule TuistWeb.API.AccountTokensController do
           required: [:token]
         }
       },
-      unauthorized:
-        {"You need to be authenticated to issue new tokens", "application/json", Error},
+      unauthorized: {"You need to be authenticated to issue new tokens", "application/json", Error},
       forbidden: {"You need to be authorized to issue new tokens", "application/json", Error},
       not_found: {"The account was not found", "application/json", Error},
       bad_request: {"The request is invalid", "application/json", Error}
     }
   )
 
-  def create(
-        %{params: %{"scopes" => scopes}, assigns: %{selected_account: selected_account}} = conn,
-        _opts
-      ) do
+  def create(%{params: %{"scopes" => scopes}, assigns: %{selected_account: selected_account}} = conn, _opts) do
     current_user = Authentication.current_user(conn)
 
     with :ok <- Authorization.authorize(:account_token_create, current_user, selected_account),

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -15,13 +15,16 @@ defmodule TuistWeb.API.AnalyticsController do
   alias TuistWeb.API.Schemas.CommandEventArtifact
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.Authentication
+  alias TuistWeb.Plugs.LoaderPlug
 
   plug(OpenApiSpex.Plug.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
   )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
+  # We don't want to try and load the run when generating the mulitpart URL as the run might not exist, yet, at this point
+  plug(LoaderPlug, [:project, :account] when action in [:multipart_generate_url_project])
+  plug(LoaderPlug when action not in [:multipart_generate_url_project])
   plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
   plug :bad_request_when_project_authenticated_from_non_ci_environment when action in [:create]
 
@@ -651,7 +654,6 @@ defmodule TuistWeb.API.AnalyticsController do
     |> json(%{})
   end
 
-
   operation(:multipart_start_project,
     summary: "It initiates a multipart upload for a run artifact",
     description:
@@ -875,7 +877,14 @@ defmodule TuistWeb.API.AnalyticsController do
           {:ok, command_event.legacy_id}
 
         _ ->
-          {:error, :not_found}
+          # For multipart upload operations, we can work with the run_id even if the run doesn't exist yet
+          # since these operations are used during async run insertion
+          if Tuist.UUIDv7.valid?(run_id) do
+            {:ok, Tuist.UUIDv7.to_int64(run_id)}
+          else
+            # If it's already an integer ID (string), use it as-is
+            {:ok, run_id}
+          end
       end
     end
   end

--- a/server/lib/tuist_web/live/ops_qa_logs_live.html.heex
+++ b/server/lib/tuist_web/live/ops_qa_logs_live.html.heex
@@ -47,7 +47,10 @@
                 <span data-part="tool-name">{format_log_message(log)}</span>
               </div>
               <div :if={expanded?(log, @expanded_tools)} data-part="tool-call-details">
-                <div :if={is_tool_result_log?(log) and log.screenshot_metadata} data-part="screenshot-content">
+                <div
+                  :if={is_tool_result_log?(log) and log.screenshot_metadata}
+                  data-part="screenshot-content"
+                >
                   <img
                     :if={log.screenshot_metadata[:screenshot_id]}
                     src={
@@ -56,14 +59,19 @@
                     alt="Screenshot"
                     style="max-width: 100%; max-height: 400px; height: auto; border-radius: 6px; margin-bottom: 12px;"
                   />
-                  <p :if={!log.screenshot_metadata[:screenshot_id]} style="color: #666; font-style: italic;">
+                  <p
+                    :if={!log.screenshot_metadata[:screenshot_id]}
+                    style="color: #666; font-style: italic;"
+                  >
                     Screenshot captured (metadata unavailable)
                   </p>
                 </div>
                 <pre data-part="json-content">{prettify_json(log.data)}</pre>
               </div>
             </div>
-            <div :if={!is_tool_log?(log)} data-part="log-message" data-type={log.type}>{format_log_message(log)}</div>
+            <div :if={!is_tool_log?(log)} data-part="log-message" data-type={log.type}>
+              {format_log_message(log)}
+            </div>
           </div>
         </div>
       </.card_section>

--- a/server/runner/lib/runner/qa/tools.ex
+++ b/server/runner/lib/runner/qa/tools.ex
@@ -738,16 +738,17 @@ defmodule Runner.QA.Tools do
         })
       ],
       function: fn %{"step_id" => step_id, "result" => result, "issues" => issues} = _params, _context ->
-        {:ok, :async} = Client.start_update_step(%{
-          step_id: step_id,
-          result: result,
-          issues: issues,
-          server_url: server_url,
-          run_id: run_id,
-          auth_token: auth_token,
-          account_handle: account_handle,
-          project_handle: project_handle
-        })
+        {:ok, :async} =
+          Client.start_update_step(%{
+            step_id: step_id,
+            result: result,
+            issues: issues,
+            server_url: server_url,
+            run_id: run_id,
+            auth_token: auth_token,
+            account_handle: account_handle,
+            project_handle: project_handle
+          })
 
         {:ok, "Step report submitted asynchronously."}
       end

--- a/server/runner/test/qa/tools_test.exs
+++ b/server/runner/test/qa/tools_test.exs
@@ -557,15 +557,15 @@ defmodule Runner.QA.ToolsTest do
       issues = ["Minor UI alignment issue in login button"]
 
       expect(Client, :start_update_step, fn %{
-                                        step_id: ^step_id,
-                                        result: ^result,
-                                        issues: ^issues,
-                                        server_url: "http://test.com",
-                                        run_id: "test-run-id",
-                                        auth_token: "test-token",
-                                        account_handle: "test-account",
-                                        project_handle: "test-project"
-                                      } ->
+                                              step_id: ^step_id,
+                                              result: ^result,
+                                              issues: ^issues,
+                                              server_url: "http://test.com",
+                                              run_id: "test-run-id",
+                                              auth_token: "test-token",
+                                              account_handle: "test-account",
+                                              project_handle: "test-project"
+                                            } ->
         {:ok, :async}
       end)
 
@@ -593,15 +593,15 @@ defmodule Runner.QA.ToolsTest do
       issues = ["Timeout error", "Server unresponsive"]
 
       expect(Client, :start_update_step, fn %{
-                                        step_id: ^step_id,
-                                        result: ^result,
-                                        issues: ^issues,
-                                        server_url: "http://test.com",
-                                        run_id: "test-run-id",
-                                        auth_token: "test-token",
-                                        account_handle: "test-account",
-                                        project_handle: "test-project"
-                                      } ->
+                                              step_id: ^step_id,
+                                              result: ^result,
+                                              issues: ^issues,
+                                              server_url: "http://test.com",
+                                              run_id: "test-run-id",
+                                              auth_token: "test-token",
+                                              account_handle: "test-account",
+                                              project_handle: "test-project"
+                                            } ->
         {:ok, :async}
       end)
 

--- a/server/test/tuist/registry/swift/packages_test.exs
+++ b/server/test/tuist/registry/swift/packages_test.exs
@@ -364,7 +364,7 @@ defmodule Tuist.Registry.Swift.PackagesTest do
                "5.10.2-beta+1",
                "5.10.2-beta+2",
                "5.10.2-beta-3"
-              ]
+             ]
     end
 
     test "skips dev versions like 0.9.3-dev1985" do


### PR DESCRIPTION
Follow-up to: https://github.com/tuist/tuist/pull/7971

I don't think that PR actually fully worked since `LoaderPlug`, ran as part of all analytics endpoints, was still assuming the run would be existing in the db.

I updated the `LoaderPlug` to accept what entities should be loaded, so we can skip loading the run for the generate upload url endpoint where we can operate with just the run id.