### PR TITLE
fix(server): running Oban cron jobs

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -326,7 +326,8 @@ oban_plugins =
 
 config :tuist, Oban,
   queues: oban_queues,
-  plugins: oban_plugins
+  plugins: oban_plugins,
+  peer: !Tuist.Environment.web?()
 
 # Guardian
 config :tuist, Tuist.Guardian,


### PR DESCRIPTION
Currently, no Oban cron jobs are being run. Based on [this](https://hexdocs.pm/oban/troubleshooting.html#jobs-or-plugins-aren-t-running), we should set `peer: false` in the web node to fix the issue.