### PR TITLE
fix(server): Add oban_met as dependency to enable Oban analytics in the split worker setup

### DIFF
--- a/server/mix.exs
+++ b/server/mix.exs
@@ -145,7 +145,8 @@ defmodule Tuist.MixProject do
       # causing runime errors when processing the telemetry events. We opened
       # a PR (https://github.com/rkallos/peep/pull/54) but it's still pending to
       # be merged.
-      {:peep, git: "https://github.com/pepicrft/peep", ref: "cae2ddd2349ae0766352d106c4ebebc29949f110", override: true}
+      {:peep, git: "https://github.com/pepicrft/peep", ref: "cae2ddd2349ae0766352d106c4ebebc29949f110", override: true},
+      {:oban_met, "~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
Follow-up to: https://github.com/tuist/tuist/pull/8128

To get Oban analytics working in the dual node setup, we must include `oban_met` as an explicit dependency as per: https://hexdocs.pm/oban_web/installation.html#split-web-and-worker-nodes