### PR TITLE
fix(server): don't suspend canary machine

### DIFF
--- a/server/fly.canary.toml
+++ b/server/fly.canary.toml
@@ -32,8 +32,8 @@ console_command = "/app/bin/tuist remote"
 [[services]]
   protocol = "tcp"
   internal_port = 8080
-  auto_stop_machines = "suspend"
-  auto_start_machines = true
+  auto_stop_machines = false
+  auto_start_machines = false
   processes = ["app"]
 
   [[services.ports]]


### PR DESCRIPTION
Keep the canary machine running at all times to speed up acceptance tests and solve connection errors on startup.