### PR TITLE
refactor(server): move web and worker into one process

### DIFF
--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -104,15 +104,7 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 | `TUIST_GITHUB_APP_PRIVATE_KEY_BASE64` | The base64-encoded private key used for the GitHub app to unlock extra functionality such as posting automatic PR comments | No | `LS0tLS1CRUdJTiBSU0EgUFJJVkFUR...` | |
 | `TUIST_GITHUB_APP_PRIVATE_KEY` | The private key used for the GitHub app to unlock extra functionality such as posting automatic PR comments. **We recommend using the base64-encoded version instead to avoid issues with special characters** | No | `-----BEGIN RSA...` | |
 | `TUIST_OPS_USER_HANDLES` | A comma-separated list of user handles that have access to the operations URLs | No | | `user1,user2` |
-| `TUIST_WEB` | Whether to run the web server component | No | `1` | `1` or `0` |
-| `TUIST_WORKER` | Whether to run the background job processing component | No | `1` | `1` or `0` |
-
-> [!NOTE] WEB SERVER AND BACKGROUND WORKER SEPARATION
-> By default, both the web server and background job processing run in the same process for simplicity. However, you can separate them by running multiple instances of the Docker image with different configurations:
-> - **Web server only:** Set `TUIST_WEB=1` and `TUIST_WORKER=0`
-> - **Background workers only:** Set `TUIST_WEB=0` and `TUIST_WORKER=1`
->
-> This separation allows you to scale web servers and background workers independently based on your workload requirements.
+| `TUIST_WEB` | Enable the web server endpoint | No | `1` | `1` or `0` |
 
 ### Database configuration {#database-configuration}
 

--- a/server/fly.prod.toml
+++ b/server/fly.prod.toml
@@ -4,15 +4,6 @@ kill_signal = "SIGINT"
 kill_timeout = "5s"
 console_command = "/app/bin/tuist remote"
 
-[processes]
-  web = "sh -C /app/bin/web"
-  worker = "sh -C /app/bin/worker"
-
-[[vm]]
-  size = "performance-1x"
-  memory = "2gb"
-  processes = ["web"]
-
 [experimental]
   auto_rollback = true
   cmd = ["sh", "-C", "/app/bin/server"]
@@ -33,17 +24,17 @@ console_command = "/app/bin/tuist remote"
   TUIST_PROMETHEUS_ENABLED = "1"
 
 [[vm]]
-  size = "shared-cpu-4x"
-  memory = "8gb"
-  processes = ["worker"]
+  cpu_kind = "shared"
+  memory = "4096mb"
+  cpus = 8
 
 [[services]]
   protocol = "tcp"
   internal_port = 8080
   auto_stop_machines = false
   auto_start_machines = false
-  min_machines_running = 2
-  processes = ["web"]
+  min_machines_running = 1
+  processes = ["app"]
   http_options = { h2_backend = true }
 
   [[services.ports]]
@@ -75,4 +66,4 @@ console_command = "/app/bin/tuist remote"
 [[metrics]]
   port = 9091
   path = "/metrics"
-  processes = ["web"]
+  processes = ["app"]

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -59,7 +59,11 @@ defmodule Tuist.Application do
         {Cachex, [:tuist, []]},
         {Finch, name: Tuist.Finch, pools: finch_pools()},
         {Phoenix.PubSub, name: Tuist.PubSub},
-        TuistWeb.Telemetry
+        {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
+        {Tuist.API.Pipeline, []},
+        {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]},
+        TuistWeb.Telemetry,
+        TuistWeb.Endpoint
       ]
 
     children
@@ -103,22 +107,6 @@ defmodule Tuist.Application do
           Tuist.MinioBucketCreator
         ]
       end
-    )
-    |> Kernel.++(
-      if Environment.web?(),
-        do: [
-          {TuistWeb.RateLimit.InMemory, [clean_period: to_timeout(hour: 1)]},
-          {Tuist.API.Pipeline, []},
-          TuistWeb.Endpoint
-        ],
-        else: []
-    )
-    |> Kernel.++(
-      if Environment.worker?(),
-        do: [
-          {Guardian.DB.Sweeper, [interval: 60 * 60 * 1000]}
-        ],
-        else: []
     )
     |> Kernel.++(
       if Environment.tuist_hosted?(),

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -47,10 +47,6 @@ defmodule Tuist.Environment do
     Enum.member?(["1", "true", "TRUE", "yes", "YES"], value)
   end
 
-  def worker? do
-    "TUIST_WORKER" |> System.get_env("1") |> truthy?()
-  end
-
   def web? do
     "TUIST_WEB" |> System.get_env("1") |> truthy?()
   end

--- a/server/lib/tuist/registry/swift/workers/create_package_release_worker.ex
+++ b/server/lib/tuist/registry/swift/workers/create_package_release_worker.ex
@@ -3,6 +3,7 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorker do
   A worker that creates a single Swift package release.
   """
   use Oban.Worker,
+    queue: :registry,
     unique: [
       period: 60,
       states: [:available, :scheduled, :executing, :retryable],

--- a/server/lib/tuist/registry/swift/workers/sync_packages_worker.ex
+++ b/server/lib/tuist/registry/swift/workers/sync_packages_worker.ex
@@ -7,6 +7,7 @@ defmodule Tuist.Registry.Swift.Workers.SyncPackagesWorker do
   4. Spawning individual workers to create missing releases
   """
   use Oban.Worker,
+    queue: :registry,
     unique: [
       period: :infinity,
       states: [:available, :scheduled, :executing, :retryable]

--- a/server/rel/overlays/bin/server
+++ b/server/rel/overlays/bin/server
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-TUIST_WEB=true TUIST_WORKER=true exec ./tuist start
+TUIST_WEB=true exec ./tuist start

--- a/server/rel/overlays/bin/start
+++ b/server/rel/overlays/bin/start
@@ -25,4 +25,4 @@ echo "Migration completed successfully."
 
 # Starting the server
 echo "Starting the server..."
-TUIST_WEB=true TUIST_WORKER=true exec ./tuist start
+TUIST_WEB=true exec ./tuist start

--- a/server/rel/overlays/bin/web
+++ b/server/rel/overlays/bin/web
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd -P -- "$(dirname -- "$0")"
-TUIST_WEB=true TUIST_WORKER=false exec ./tuist start

--- a/server/rel/overlays/bin/worker
+++ b/server/rel/overlays/bin/worker
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd -P -- "$(dirname -- "$0")"
-TUIST_WEB=false TUIST_WORKER=true exec ./tuist start


### PR DESCRIPTION
Reverts #7921


After refactoring the package release workers in #8112, we should have much smaller worker processes running concurrently rather than one big resource hungry worker. This means that we can reduce infrastructure complexity and move back to one process.