### PR TITLE
fix(server): don't configure Finch pools for endpoints that aren't configured

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -202,6 +202,8 @@ defmodule Tuist.Application do
           start_pool_metrics?: true
         ]
       }
+      |> Enum.reject(fn {key, _value} -> is_nil(key) end)
+      |> Map.new()
     end
   end
 


### PR DESCRIPTION
#8134 introduced a Finch pool for Tigris - this is not configured on self-hosted infrastructure.
As such, it sets a finch pool with
```
nil => [
...
]
```
which prevents Finch from starting with

```
  ** (EXIT) an exception was raised:
        ** (ArgumentError) invalid destination: nil
            (finch 0.20.0) lib/finch.ex:209: anonymous fn/1 in Finch.pool_options!/1
            (stdlib 6.2.2) maps.erl:860: :maps.fold_1/4
            (finch 0.20.0) lib/finch.ex:164: Finch.start_link/1
            (stdlib 6.2.2) supervisor.erl:959: :supervisor.do_start_child_i/3
```