### PR TITLE
fix(server): use port from `DATABASE_URL`

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -96,6 +96,7 @@ if Enum.member?([:prod, :stag, :can], env) do
     username: username,
     password: password,
     hostname: parsed_url.host,
+    port: parsed_url.port || 5432,
     socket_options: socket_opts,
     parameters: [
       tcp_keepalives_idle: "60",


### PR DESCRIPTION
**Problem**

DATABASE_URL environment variable port was being ignored in the database configuration. When users provided a DATABASE_URL with a custom port (e.g., postgres://user:pass@localhost:5433/db), the application would fall back to the default PostgreSQL port (5432) instead of using the specified port.

**Root Cause**
In server/config/runtime.exs, the database_options configuration was missing the port parameter while parsing the DATABASE_URL. Only hostname, username, password, and database were being extracted from the parsed URL.


**Notes**
I'm not familiar with Elixir and I'm using Cursor to solve this problem, so please let me know if there's an issue.