### PR TITLE
feat(cli): optimize dependency conditions calculation

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -25,6 +25,7 @@ public class GraphTraverser: GraphTraversing {
 
     private let graph: Graph
     private let conditionCache = ConditionCache()
+    private let conditionalTargets: ThreadSafe<Set<GraphDependency>> = ThreadSafe([])
     private let swiftPluginExecutablesCache = GraphCache<GraphDependency, Set<String>>()
     private let systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding =
         SystemFrameworkMetadataProvider()
@@ -1144,10 +1145,25 @@ public class GraphTraverser: GraphTraversing {
         -> PlatformCondition
         .CombinationResult
     {
+        if graph.dependencyConditions.isEmpty {
+            return .condition(nil)
+        }
+
+        // Skip targets which are not in conditional part of the graph
+        let shouldSkip = conditionalTargets.mutate {
+            if $0.isEmpty {
+                let conditionalTargets = Set(graph.dependencyConditions.keys.map { [$0.from, $0.to] }.joined())
+                $0 = filterDependencies(from: conditionalTargets).union(conditionalTargets)
+            }
+            return !$0.contains(rootDependency) && !$0.contains(transitiveDependency)
+        }
+
+        if shouldSkip {
+            return .condition(nil)
+        }
+
         if let cached = conditionCache[(rootDependency, transitiveDependency)] {
             return cached
-        } else if graph.dependencyConditions.isEmpty {
-            return .condition(nil)
         }
 
         // if we're at a leaf dependency, there is nothing else to traverse.


### PR DESCRIPTION
### Description

This PR intended to improve calculation of targets conditions in graphs. It is common that in large projects with highly populated graph most of the targets don't have conditions. Currently even if only few targets have conditions `GraphTraverser` calculates conditions for all edges of graph which takes significant time and uses large cache size. In tested project with around 700 modules `GraphTraverser`'s `conditionCache` contains about 170k entries at the end of all calculations.

In this PR I've added logic to skip calculations for part of the graph which is unconditional. Conditional part of graph calculated from all targets which has conditions and their direct and transitive dependencies. Unconditional part of graph is all other targets. Usually it is bigger part of the graph, because conditions commonly used for low level multi platform targets. In same tested project with around 700 modules and around 50 conditional targets `GraphTraverser`'s `conditionCache` size at the end of all calculations reduced to 15k entries. Generation time improved for about 2 seconds.

Additionally when generating tested project I have encountered the bug relevant to NSCache. In rare cases `conditionCache` `NSCache` stopped to accept added elements and always returned nil for already cached elements which led to extreme increasing of generation time. From perspective of common user it looks like freezing. Reducing `conditionCache` size seems to fixes this problem for large projects or at least makes it almost unreproducible. I have not been able to repeat it after implementing this fix.
