### PR TITLE
fix(server): disable preview pages being public by default

### DIFF
--- a/server/lib/tuist/app_builds.ex
+++ b/server/lib/tuist/app_builds.ex
@@ -29,14 +29,24 @@ defmodule Tuist.AppBuilds do
       from(p in Preview)
       |> where([p], p.project_id == ^project_id)
       |> then(&if(is_nil(display_name), do: &1, else: where(&1, [p], p.display_name == ^display_name)))
-      |> then(&if(is_nil(bundle_identifier), do: &1, else: where(&1, [p], p.bundle_identifier == ^bundle_identifier)))
+      |> then(
+        &if(is_nil(bundle_identifier),
+          do: &1,
+          else: where(&1, [p], p.bundle_identifier == ^bundle_identifier)
+        )
+      )
       |> then(
         &if(is_nil(created_by_account_id),
           do: &1,
           else: where(&1, [p], p.created_by_account_id == ^created_by_account_id)
         )
       )
-      |> then(&if(is_nil(git_commit_sha), do: &1, else: where(&1, [p], p.git_commit_sha == ^git_commit_sha)))
+      |> then(
+        &if(is_nil(git_commit_sha),
+          do: &1,
+          else: where(&1, [p], p.git_commit_sha == ^git_commit_sha)
+        )
+      )
       |> then(&if(is_nil(version), do: &1, else: where(&1, [p], p.version == ^version)))
       |> limit(1)
       |> Repo.one()
@@ -71,12 +81,9 @@ defmodule Tuist.AppBuilds do
   def update_preview_with_app_build(preview_id, app_build) do
     preview = Repo.get!(Preview, preview_id)
 
-    visibility = if app_build.type == :ipa, do: :public, else: preview.visibility
-
     preview
     |> Preview.create_changeset(%{
-      supported_platforms: Enum.uniq(preview.supported_platforms ++ app_build.supported_platforms),
-      visibility: visibility
+      supported_platforms: Enum.uniq(preview.supported_platforms ++ app_build.supported_platforms)
     })
     |> Repo.update!()
   end
@@ -132,7 +139,10 @@ defmodule Tuist.AppBuilds do
 
     order_direction = attrs |> Map.get(:order_directions, [:desc]) |> hd()
 
-    filters = attrs |> Map.get(:filters, []) |> Enum.map(&%Flop.Filter{field: &1.field, op: &1.op, value: &1.value})
+    filters =
+      attrs
+      |> Map.get(:filters, [])
+      |> Enum.map(&%Flop.Filter{field: &1.field, op: &1.op, value: &1.value})
 
     if distinct_bundle_identifier do
       preview_ids =
@@ -253,7 +263,11 @@ defmodule Tuist.AppBuilds do
         where:
           ab.preview_id == parent_as(:p).id and
             (is_nil(type(^supported_platform, ^enum_el_type)) or
-               fragment("? = ANY(?)", type(^supported_platform, ^enum_el_type), ab.supported_platforms)),
+               fragment(
+                 "? = ANY(?)",
+                 type(^supported_platform, ^enum_el_type),
+                 ab.supported_platforms
+               )),
         order_by: [desc: ab.inserted_at],
         limit: 1
 

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -280,7 +280,10 @@ defmodule TuistWeb.Router do
           post "/:run_id/start", AnalyticsController, :multipart_start_project
           post "/:run_id/generate-url", AnalyticsController, :multipart_generate_url_project
           post "/:run_id/complete", AnalyticsController, :multipart_complete_project
-          put "/:run_id/complete_artifacts_uploads", AnalyticsController, :complete_artifacts_uploads_project
+
+          put "/:run_id/complete_artifacts_uploads",
+              AnalyticsController,
+              :complete_artifacts_uploads_project
         end
 
         scope "/previews" do
@@ -541,22 +544,11 @@ defmodule TuistWeb.Router do
     pipe_through [
       :open_api,
       :browser_app,
-      :require_authenticated_user_for_previews,
       :analytics
     ]
 
     get "/manifest.plist", PreviewController, :manifest
     get "/app.ipa", PreviewController, :download_archive
-    get "/download", PreviewController, :download_preview
-  end
-
-  scope "/:account_handle/:project_handle/previews/:id", TuistWeb do
-    pipe_through [
-      :open_api,
-      :browser_app,
-      :analytics
-    ]
-
     get "/qr-code.svg", PreviewController, :download_qr_code_svg
     get "/qr-code.png", PreviewController, :download_qr_code_png
   end
@@ -568,6 +560,8 @@ defmodule TuistWeb.Router do
       :require_authenticated_user_for_previews,
       :analytics
     ]
+
+    get "/download", PreviewController, :download_preview
 
     live_session :preview_detail,
       layout: {TuistWeb.Layouts, :project},

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -6,7 +6,7 @@
   "ubi:aquasecurity/trivy" = "0.63.0"
   "clickhouse" = "25.5.1"
   "npm:prettier" = "3.4.2"
-  "elixir" = "1.18.4"
+  "elixir" = "1.18.4-otp-28"
   "flyctl" = "0.3.172"
   "erlang" = "27.3.2"
   "asdf:aeons/asdf-minio" = "latest"

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -6,7 +6,7 @@
   "ubi:aquasecurity/trivy" = "0.63.0"
   "clickhouse" = "25.5.1"
   "npm:prettier" = "3.4.2"
-  "elixir" = "1.18.4-otp-28"
+  "elixir" = "1.18.4-otp-27"
   "flyctl" = "0.3.172"
   "erlang" = "27.3.2"
   "asdf:aeons/asdf-minio" = "latest"

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -6,7 +6,7 @@
   "ubi:aquasecurity/trivy" = "0.63.0"
   "clickhouse" = "25.5.1"
   "npm:prettier" = "3.4.2"
-  "elixir" = "1.18.3"
+  "elixir" = "1.18.4"
   "flyctl" = "0.3.172"
   "erlang" = "27.3.2"
   "asdf:aeons/asdf-minio" = "latest"

--- a/server/test/tuist/app_builds_test.exs
+++ b/server/test/tuist/app_builds_test.exs
@@ -942,7 +942,7 @@ defmodule Tuist.AppBuildsTest do
       assert updated_preview.visibility == :private
     end
 
-    test "sets visibility to public for ipa type and merges platforms" do
+    test "keeps visibility to private for ipa type and merges platforms" do
       # Given
       project = ProjectsFixtures.project_fixture()
 
@@ -966,7 +966,7 @@ defmodule Tuist.AppBuildsTest do
 
       # Then
       assert Enum.sort(updated_preview.supported_platforms) == [:ios, :watchos]
-      assert updated_preview.visibility == :public
+      assert updated_preview.visibility == :private
     end
 
     test "removes duplicate platforms when merging" do

--- a/server/test/tuist/registry/swift/create_package_release_worker_test.exs
+++ b/server/test/tuist/registry/swift/create_package_release_worker_test.exs
@@ -5,6 +5,7 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
   import Ecto.Query
 
   alias Tuist.Registry.Swift.Packages
+  alias Tuist.Registry.Swift.Packages.PackageRelease
   alias Tuist.Registry.Swift.Workers.CreatePackageReleaseWorker
   alias Tuist.Repo
   alias Tuist.Storage
@@ -770,11 +771,12 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
       # Given
       package = PackagesFixtures.package_fixture()
 
-      existing_package_release = PackagesFixtures.package_release_fixture(
-        package_id: package.id,
-        version: "1.0.0",
-        checksum: "existing_checksum"
-      )
+      existing_package_release =
+        PackagesFixtures.package_release_fixture(
+          package_id: package.id,
+          version: "1.0.0",
+          checksum: "existing_checksum"
+        )
 
       setup_standard_stubs("TestPackage", "TestPackage", "1.0.0", "TestPackage-1.0.0")
 
@@ -796,7 +798,7 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
       assert package_release.id == existing_package_release.id
       assert package_release.checksum == "existing_checksum"
 
-      all_releases = Repo.all(from pr in Tuist.Registry.Swift.Packages.PackageRelease, where: pr.package_id == ^package.id and pr.version == "1.0.0")
+      all_releases = Repo.all(from pr in PackageRelease, where: pr.package_id == ^package.id and pr.version == "1.0.0")
       assert length(all_releases) == 1
     end
 
@@ -804,11 +806,12 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
       # Given
       package = PackagesFixtures.package_fixture()
 
-      existing_package_release = PackagesFixtures.package_release_fixture(
-        package_id: package.id,
-        version: "1.0.0",
-        checksum: "existing_checksum"
-      )
+      existing_package_release =
+        PackagesFixtures.package_release_fixture(
+          package_id: package.id,
+          version: "1.0.0",
+          checksum: "existing_checksum"
+        )
 
       setup_standard_stubs("TestPackage", "TestPackage", "1.0", "TestPackage-1.0")
 
@@ -816,7 +819,8 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
         args: %{
           "scope" => package.scope,
           "name" => package.name,
-          "version" => "1.0"  # This will be normalized to "1.0.0"
+          # This will be normalized to "1.0.0"
+          "version" => "1.0"
         }
       }
 
@@ -829,7 +833,7 @@ defmodule Tuist.Registry.Swift.Workers.CreatePackageReleaseWorkerTest do
       package_release = Packages.get_package_release_by_version(%{package: package, version: "1.0.0"})
       assert package_release.id == existing_package_release.id
       assert package_release.checksum == "existing_checksum"
-      all_releases = Repo.all(from pr in Tuist.Registry.Swift.Packages.PackageRelease, where: pr.package_id == ^package.id and pr.version == "1.0.0")
+      all_releases = Repo.all(from pr in PackageRelease, where: pr.package_id == ^package.id and pr.version == "1.0.0")
       assert length(all_releases) == 1
     end
   end


### PR DESCRIPTION
We've made preview pages that include an app build of `:ipa` public by default to ease the access by the QA team. However, making these pages public without the consent of the team makes the feature feel less secure.

Instead, all new previews will be `:private`.

Flagged an issue to make it possible again to make preview pages public: https://github.com/tuist/tuist/issues/8152