### PR TITLE
fix(server): respect Tigris feature flag for registry

### DIFF
--- a/server/lib/tuist/storage.ex
+++ b/server/lib/tuist/storage.ex
@@ -256,7 +256,7 @@ defmodule Tuist.Storage do
 
   defp use_tigris?(actor) do
     case actor do
-      :registry -> false
+      :registry -> FunWithFlags.enabled?(:tigris)
       _ -> FunWithFlags.enabled?(:tigris, for: actor)
     end
   end

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -6,7 +6,7 @@
   "ubi:aquasecurity/trivy" = "0.63.0"
   "clickhouse" = "25.5.1"
   "npm:prettier" = "3.4.2"
-  "elixir" = "1.18.3"
+  "elixir" = "1.18.4-otp-27"
   "flyctl" = "0.3.172"
   "erlang" = "27.3.2"
   "asdf:aeons/asdf-minio" = "latest"


### PR DESCRIPTION
For `:registry`, we hardcoded the value for `use_tigris` instead of using the feature flag, so when we turned on the Tigris feature flag, the registry stayed on AWS.

This PR will move the registry to Tigris. Once deployed, I'll delete all package releases that were added while we were on AWS as those releases will not be present in Tigris (or the Cloudflare shadow bucket). Additionally, we should clone the package releases from Cloudflare to Tigris, so we can completely remove Cloudflare as a shadow bucket.