### PR TITLE
fix(cli): generate bundle accessor when a module has only buildable folders

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -35,7 +35,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
     // swiftlint:disable:next function_body_length
     public func mapTarget(_ target: Target, project: Project) throws -> ([Target], [SideEffectDescriptor]) {
         if target.resources.resources.isEmpty, target.coreDataModels.isEmpty,
-           !target.sources.contains(where: { $0.path.extension == "metal" })
+           !target.sources.contains(where: { $0.path.extension == "metal" }), target.buildableFolders.isEmpty
         { return (
             [target],
             []


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/8148

When a module contains _only_ buildable folders (no direct sources/resources), we'd return early from the `ResourcesProjectMapper`. To fix the issue, we should always generate the accessor when buildable folders are not empty.
