### PR TITLE
fix(cli): not generate bundle accessors in when buildable folders don't resolve to any resources

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/BuildableFolderChecker.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildableFolderChecker.swift
@@ -1,0 +1,39 @@
+import FileSystem
+import Mockable
+import XcodeGraph
+
+@Mockable
+public protocol BuildableFolderChecking {
+    func containsResources(_ folders: [XcodeGraph.BuildableFolder]) async throws -> Bool
+    func containsSources(_ folders: [XcodeGraph.BuildableFolder]) async throws -> Bool
+}
+
+public struct BuildableFolderChecker: BuildableFolderChecking {
+    private let fileSystem: FileSysteming
+
+    public init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    public func containsSources(_ folders: [XcodeGraph.BuildableFolder]) async throws -> Bool {
+        for folder in folders {
+            if !(try await fileSystem.glob(directory: folder.path, include: Target.validSourceExtensions.map { "**/*.\($0)" })
+                .collect().isEmpty
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    public func containsResources(_ folders: [XcodeGraph.BuildableFolder]) async throws -> Bool {
+        for folder in folders {
+            if !(try await fileSystem.glob(directory: folder.path, include: Target.validResourceExtensions.map { "**/*.\($0)" })
+                .collect().isEmpty
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -102,7 +102,7 @@ final class TargetGenerator: TargetGenerating {
         )
 
         // Build phases
-        try buildPhaseGenerator.generateBuildPhases(
+        try await buildPhaseGenerator.generateBuildPhases(
             path: path,
             target: target,
             graphTraverser: graphTraverser,

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -49,7 +49,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func test_generateSourcesBuildPhase() throws {
+    ) func test_generateSourcesBuildPhase() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -69,7 +69,7 @@ struct BuildPhaseGeneratorTests {
         let fileElements = createFileElements(for: sources.map(\.path))
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: sources,
             coreDataModels: [],
             target: target,
@@ -110,7 +110,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_whenMultiPlatformSourceFiles() throws {
+    ) func generateSourcesBuildPhase_whenMultiPlatformSourceFiles() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -130,7 +130,7 @@ struct BuildPhaseGeneratorTests {
         let fileElements = createFileElements(for: sourceFiles.map(\.path))
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: sourceFiles,
             coreDataModels: [],
             target: target,
@@ -171,7 +171,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_whenBundleWithMetalFiles() throws {
+    ) func generateSourcesBuildPhase_whenBundleWithMetalFiles() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -186,7 +186,7 @@ struct BuildPhaseGeneratorTests {
         let fileElements = createFileElements(for: sourceFiles.map(\.path))
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: sourceFiles,
             coreDataModels: [],
             target: target,
@@ -211,7 +211,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func doesntGenerateSourcesBuildPhase_whenWatchKitTarget() throws {
+    ) func doesntGenerateSourcesBuildPhase_whenWatchKitTarget() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -220,7 +220,7 @@ struct BuildPhaseGeneratorTests {
         let target = Target.test(product: .watch2App)
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: [],
             coreDataModels: [],
             target: target,
@@ -239,7 +239,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generatesSourcesBuildPhase_whenFramework_withNoSources() throws {
+    ) func generatesSourcesBuildPhase_whenFramework_withNoSources() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -248,7 +248,7 @@ struct BuildPhaseGeneratorTests {
         let target = Target.test(product: .framework)
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: [],
             coreDataModels: [],
             target: target,
@@ -321,7 +321,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_throws_when_theFileReferenceIsMissing() {
+    ) func generateSourcesBuildPhase_throws_when_theFileReferenceIsMissing() async throws {
         let path = try! AbsolutePath(validating: "/test/file.swift")
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -330,8 +330,8 @@ struct BuildPhaseGeneratorTests {
         let target = Target.test()
         let fileElements = ProjectFileElements()
 
-        #expect(throws: BuildPhaseGenerationError.missingFileReference(path), performing: {
-            try subject.generateSourcesBuildPhase(
+        await #expect(throws: BuildPhaseGenerationError.missingFileReference(path), performing: {
+            try await subject.generateSourcesBuildPhase(
                 files: [SourceFile(path: path, compilerFlags: nil)],
                 coreDataModels: [],
                 target: target,
@@ -346,7 +346,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_withDocCArchive() throws {
+    ) func generateSourcesBuildPhase_withDocCArchive() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -361,7 +361,7 @@ struct BuildPhaseGeneratorTests {
         let fileElements = createFileElements(for: sources.map(\.path))
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: sources,
             coreDataModels: [],
             target: target,
@@ -384,7 +384,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_whenLocalizedFile() throws {
+    ) func generateSourcesBuildPhase_whenLocalizedFile() async throws {
         // Given
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -401,7 +401,7 @@ struct BuildPhaseGeneratorTests {
         ])
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: sources,
             coreDataModels: [],
             target: target,
@@ -423,7 +423,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_throws_whenLocalizedFileAndFileReferenceIsMissing() {
+    ) func generateSourcesBuildPhase_throws_whenLocalizedFileAndFileReferenceIsMissing() async throws {
         let path = try! AbsolutePath(validating: "/test/Base.lproj/file.intentdefinition")
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -432,8 +432,8 @@ struct BuildPhaseGeneratorTests {
         let target = Target.test()
         let fileElements = ProjectFileElements()
 
-        #expect(throws: BuildPhaseGenerationError.missingFileReference(path), performing: {
-            try subject.generateSourcesBuildPhase(
+        await #expect(throws: BuildPhaseGenerationError.missingFileReference(path), performing: {
+            try await subject.generateSourcesBuildPhase(
                 files: [SourceFile(path: path, compilerFlags: nil)],
                 coreDataModels: [],
                 target: target,
@@ -497,7 +497,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateHeadersBuildPhase_empty_when_iOSAppTarget() throws {
+    ) func generateHeadersBuildPhase_empty_when_iOSAppTarget() async throws {
         let tmpDir = try #require(FileSystem.temporaryTestDirectory)
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -524,7 +524,7 @@ struct BuildPhaseGeneratorTests {
         let graph = Graph.test(path: tmpDir)
         let graphTraverser = GraphTraverser(graph: graph)
 
-        try subject.generateBuildPhases(
+        try await subject.generateBuildPhases(
             path: tmpDir,
             target: target,
             graphTraverser: graphTraverser,
@@ -540,7 +540,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateHeadersBuildPhase_before_generateSourceBuildPhase() throws {
+    ) func generateHeadersBuildPhase_before_generateSourceBuildPhase() async throws {
         let tmpDir = try #require(FileSystem.temporaryTestDirectory)
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
@@ -567,7 +567,7 @@ struct BuildPhaseGeneratorTests {
         let graph = Graph.test(path: tmpDir)
         let graphTraverser = GraphTraverser(graph: graph)
 
-        try subject.generateBuildPhases(
+        try await subject.generateBuildPhases(
             path: tmpDir,
             target: target,
             graphTraverser: graphTraverser,
@@ -731,7 +731,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateSourcesBuildPhase_whenCoreDataModel() throws {
+    ) func generateSourcesBuildPhase_whenCoreDataModel() async throws {
         // Given
         let coreDataModel = CoreDataModel(
             path: try AbsolutePath(validating: "/Model.xcdatamodeld"),
@@ -754,7 +754,7 @@ struct BuildPhaseGeneratorTests {
         let nativeTarget = PBXNativeTarget(name: "Test")
 
         // When
-        try subject.generateSourcesBuildPhase(
+        try await subject.generateSourcesBuildPhase(
             files: target.sources,
             coreDataModels: target.coreDataModels,
             target: target,
@@ -1809,7 +1809,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateBuildPhases_whenStaticFrameworkWithCoreDataModels() throws {
+    ) func generateBuildPhases_whenStaticFrameworkWithCoreDataModels() async throws {
         // Given
         let path = try AbsolutePath(validating: "/path/to/project")
         let coreDataModel = CoreDataModel(
@@ -1827,7 +1827,7 @@ struct BuildPhaseGeneratorTests {
         let pbxTarget = PBXNativeTarget(name: target.name)
 
         // When
-        try subject.generateBuildPhases(
+        try await subject.generateBuildPhases(
             path: "/path/to/target",
             target: target,
             graphTraverser: graphTraverser,
@@ -1855,7 +1855,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateBuildPhases_whenBundleWithCoreDataModels() throws {
+    ) func generateBuildPhases_whenBundleWithCoreDataModels() async throws {
         // Given
         let path = try AbsolutePath(validating: "/path/to/project")
         let coreDataModel = CoreDataModel(
@@ -1873,7 +1873,7 @@ struct BuildPhaseGeneratorTests {
         let pbxTarget = PBXNativeTarget(name: target.name)
 
         // When
-        try subject.generateBuildPhases(
+        try await subject.generateBuildPhases(
             path: "/path/to/target",
             target: target,
             graphTraverser: graphTraverser,
@@ -1902,7 +1902,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesAShellScriptBuildPhase_when_targetIsAMacroFramework() throws {
+    ) func generateLinks_generatesAShellScriptBuildPhase_when_targetIsAMacroFramework() async throws {
         // Given
         let app = Target.test(name: "app", platform: .iOS, product: .app)
         let macroFramework = Target.test(name: "framework", platform: .iOS, product: .staticFramework)
@@ -1923,7 +1923,7 @@ struct BuildPhaseGeneratorTests {
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        try subject.generateBuildPhases(
+        try await subject.generateBuildPhases(
             path: "/Project",
             target: macroFramework,
             graphTraverser: graphTraverser,

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildableFolderCheckerTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildableFolderCheckerTests.swift
@@ -1,0 +1,45 @@
+import FileSystem
+import Testing
+import TuistGenerator
+import XcodeGraph
+
+struct BuildableFolderCheckerTests {
+    let subject = BuildableFolderChecker()
+    let fileSystem = FileSystem()
+
+    @Test(.inTemporaryDirectory) func containsSources_when_containsSources() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.touch(temporaryDirectory.appending(component: "File.swift"))
+
+        let got = try await subject.containsSources([BuildableFolder(path: temporaryDirectory)])
+
+        #expect(got == true)
+    }
+
+    @Test(.inTemporaryDirectory) func containsSources_when_doesntContainSources() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.touch(temporaryDirectory.appending(component: "File.xcstrings"))
+
+        let got = try await subject.containsSources([BuildableFolder(path: temporaryDirectory)])
+
+        #expect(got == false)
+    }
+
+    @Test(.inTemporaryDirectory) func containsResources_when_containsResources() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.touch(temporaryDirectory.appending(component: "File.xcstrings"))
+
+        let got = try await subject.containsResources([BuildableFolder(path: temporaryDirectory)])
+
+        #expect(got == true)
+    }
+
+    @Test(.inTemporaryDirectory) func containsResources_when_doesntContainResources() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.touch(temporaryDirectory.appending(component: "File.swift"))
+
+        let got = try await subject.containsResources([BuildableFolder(path: temporaryDirectory)])
+
+        #expect(got == false)
+    }
+}

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -14,13 +14,15 @@ private let irrelevantBundleName = ""
 
 final class ResourcesProjectMapperTests: TuistUnitTestCase {
     var project: Project!
+    var buildableFolderChecker: MockBuildableFolderChecking!
     var subject: ResourcesProjectMapper!
     var contentHasher: MockContentHashing!
 
     override func setUp() {
         super.setUp()
         contentHasher = .init()
-        subject = ResourcesProjectMapper(contentHasher: contentHasher)
+        buildableFolderChecker = MockBuildableFolderChecking()
+        subject = ResourcesProjectMapper(contentHasher: contentHasher, buildableFolderChecker: buildableFolderChecker)
 
         given(contentHasher)
             .hash(Parameter<Data>.any)
@@ -33,14 +35,16 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_map_when_a_target_that_has_resources_and_doesnt_supports_them() throws {
+    func test_map_when_a_target_that_has_resources_and_doesnt_supports_them() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: .init(resources))
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -89,21 +93,23 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         ])
     }
 
-    func test_map_when_an_external_objc_target_that_has_resources_and_supports_them() throws {
+    func test_map_when_an_external_objc_target_that_has_resources_and_supports_them() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .framework, sources: ["/Absolute/File.m"], resources: .init(resources))
         project = Project.test(targets: [target], type: .external(hash: nil))
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         XCTAssertEmpty(gotSideEffects)
         XCTAssertEqual(project, gotProject)
     }
 
-    func testMap_whenDisableBundleAccessorsIsTrue_doesNotGenerateAccessors() throws {
+    func testMap_whenDisableBundleAccessorsIsTrue_doesNotGenerateAccessors() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .staticLibrary, resources: .init(resources))
@@ -113,25 +119,29 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             ),
             targets: [target]
         )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(project, gotProject)
         XCTAssertEqual(gotSideEffects, [])
     }
 
-    func test_map_when_no_sources() throws {
+    func test_map_when_no_sources() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .staticLibrary, sources: [], resources: .init(resources))
         project = Project.test(
             targets: [target]
         )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects, [])
@@ -158,21 +168,24 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.resources.resources, resources)
     }
 
-    func test_map_when_no_sources_but_buildable_folders() throws {
+    func test_map_when_no_sources_but_buildable_folders() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let buildableFolders = [BuildableFolder(path: try AbsolutePath(validating: "/sources"))]
         let target = Target.test(
             product: .staticLibrary,
             sources: [],
             resources: .init(resources),
-            buildableFolders: [BuildableFolder(path: try AbsolutePath(validating: "/sources"))]
+            buildableFolders: buildableFolders
         )
         project = Project.test(
             targets: [target]
         )
+        given(buildableFolderChecker).containsResources(.value(buildableFolders)).willReturn(true)
+        given(buildableFolderChecker).containsSources(.value(buildableFolders)).willReturn(true)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -211,23 +224,26 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.resources.resources, resources)
     }
 
-    func test_map_when_no_sources_and_resources_but_buildable_folders() throws {
+    func test_map_when_no_sources_and_resources_but_buildable_folders() async throws {
         // Given
+        let buildableFolders = [
+            BuildableFolder(path: try AbsolutePath(validating: "/sources")),
+            BuildableFolder(path: try AbsolutePath(validating: "/resources")),
+        ]
         let target = Target.test(
             product: .staticLibrary,
             sources: [],
             resources: ResourceFileElements([]),
-            buildableFolders: [
-                BuildableFolder(path: try AbsolutePath(validating: "/sources")),
-                BuildableFolder(path: try AbsolutePath(validating: "/resources")),
-            ]
+            buildableFolders: buildableFolders
         )
         project = Project.test(
             targets: [target]
         )
+        given(buildableFolderChecker).containsResources(.value(buildableFolders)).willReturn(true)
+        given(buildableFolderChecker).containsSources(.value(buildableFolders)).willReturn(true)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -265,16 +281,18 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.filesGroup, target.filesGroup)
     }
 
-    func test_map_when_a_target_that_has_core_data_models_and_doesnt_supports_them() throws {
+    func test_map_when_a_target_that_has_core_data_models_and_doesnt_supports_them() async throws {
         // Given
 
         let coreDataModels: [CoreDataModel] =
             [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
         let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -317,14 +335,16 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.coreDataModels, coreDataModels)
     }
 
-    func test_map_when_a_target_that_has_resources_and_supports_them() throws {
+    func test_map_when_a_target_that_has_resources_and_supports_them() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], resources: .init(resources))
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -354,7 +374,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
-    func test_map_when_a_target_that_has_no_resources_but_has_metal_source_files_and_supports_them() throws {
+    func test_map_when_a_target_that_has_no_resources_but_has_metal_source_files_and_supports_them() async throws {
         // Given
         let target = Target.test(
             product: .framework,
@@ -362,9 +382,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             resources: .init([])
         )
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -393,15 +415,17 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
-    func test_map_when_a_target_that_has_core_data_models_and_supports_them() throws {
+    func test_map_when_a_target_that_has_core_data_models_and_supports_them() async throws {
         // Given
         let coreDataModels: [CoreDataModel] =
             [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
         let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -431,21 +455,23 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
-    func test_map_when_a_target_has_no_resources() throws {
+    func test_map_when_a_target_has_no_resources() async throws {
         // Given
         let resources: [ResourceFileElement] = []
         let target = Target.test(product: .framework, resources: .init(resources))
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         XCTAssertEqual(Array(gotProject.targets.values), [target])
         XCTAssertEmpty(gotSideEffects)
     }
 
-    func test_map_when_a_target_does_not_support_sources() throws {
+    func test_map_when_a_target_does_not_support_sources() async throws {
         // Given
         let resources: [ResourceFileElement] = [
             .file(path: "/Some/ResourceA"),
@@ -453,16 +479,18 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         ]
         let target = Target.test(product: .bundle, resources: .init(resources))
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         XCTAssertEqual(Array(gotProject.targets.values), [target])
         XCTAssertEmpty(gotSideEffects)
     }
 
-    func test_map_when_a_target_that_has_name_with_hyphen() throws {
+    func test_map_when_a_target_that_has_name_with_hyphen() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
         let target = Target.test(
@@ -472,9 +500,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             resources: .init(resources)
         )
         project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (_, gotSideEffects) = try subject.map(project: project)
+        let (_, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         XCTAssertEqual(gotSideEffects.count, 1)
@@ -493,7 +523,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
     }
 
-    func test_map_when_a_project_is_external_target_has_swift_source_but_no_resource_files() throws {
+    func test_map_when_a_project_is_external_target_has_swift_source_but_no_resource_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = []
@@ -503,31 +533,35 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             targets: [target],
             type: .external(hash: nil)
         )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         XCTAssertEqual(Array(gotProject.targets.values), [target])
         XCTAssertEmpty(gotSideEffects)
     }
 
-    func test_map_when_a_project_is_not_external_target_has_swift_source_but_no_resource_files() throws {
+    func test_map_when_a_project_is_not_external_target_has_swift_source_but_no_resource_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = []
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
         project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         XCTAssertEqual(Array(gotProject.targets.values), [target])
         XCTAssertEmpty(gotSideEffects)
     }
 
-    func test_map_when_a_project_is_external_target_has_swift_source_and_resource_files() throws {
+    func test_map_when_a_project_is_external_target_has_swift_source_and_resource_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
@@ -537,29 +571,33 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             targets: [target],
             type: .external(hash: nil)
         )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (_, gotSideEffects) = try subject.map(project: project)
+        let (_, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         try verify(gotSideEffects, for: target, in: project, by: "\(project.name)_\(target.name)")
     }
 
-    func test_map_when_a_project_is_not_external_target_has_swift_source_and_resource_files() throws {
+    func test_map_when_a_project_is_not_external_target_has_swift_source_and_resource_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.swift"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
         project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (_, gotSideEffects) = try subject.map(project: project)
+        let (_, gotSideEffects) = try await subject.map(project: project)
 
         // Then: Side effects
         try verify(gotSideEffects, for: target, in: project, by: "\(project.name)_\(target.name)")
     }
 
-    func test_map_when_a_project_is_external_target_has_objc_source_files() throws {
+    func test_map_when_a_project_is_external_target_has_objc_source_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
@@ -569,9 +607,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             targets: [target],
             type: .external(hash: nil)
         )
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().last)
@@ -582,15 +622,17 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         )
     }
 
-    func test_map_when_a_project_is_not_external_target_has_objc_source_files() throws {
+    func test_map_when_a_project_is_not_external_target_has_objc_source_files() async throws {
         // Given
         let sources: [SourceFile] = ["/ViewController.m"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(product: .staticLibrary, sources: sources, resources: .init(resources))
         project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), targets: [target], type: .local)
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, gotSideEffects) = try subject.map(project: project)
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
 
         // Then
         let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().last)
@@ -603,7 +645,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     }
 
     func test_map_when_project_name_has_dashes_in_it_bundle_name_include_dash_for_project_name_and_underscore_for_target_name(
-    ) throws {
+    ) async throws {
         // Given
         let projectName = "sdk-with-dash"
         let targetName = "target-with-dash"
@@ -612,9 +654,11 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(name: targetName, product: .staticLibrary, sources: sources, resources: .init(resources))
         project = Project.test(path: try AbsolutePath(validating: "/AbsolutePath/Project"), name: projectName, targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
 
         // Got
-        let (gotProject, _) = try subject.map(project: project)
+        let (gotProject, _) = try await subject.map(project: project)
         let bundleTarget = try XCTUnwrap(gotProject.targets.values.sorted().first(where: { $0.product == .bundle }))
 
         // Then


### PR DESCRIPTION
[This PR](https://github.com/tuist/tuist/pull/8156) introduced a regression for targets that have buildable folders that don't resolve to any resource. In some scenarios we ended up generating bundle targets containing no resources and causing the graph validation to fail. This PR fixes it by resolving the buildable folders at generation time and checking if they actually contain any resources.