### PR TITLE
fix(server): disable HTTP2 for S3

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -204,7 +204,7 @@ defmodule Tuist.Environment do
   def s3_protocols(secrets \\ secrets()) do
     case get([:s3, :protocol], secrets) do
       protocol when is_binary(protocol) -> [String.to_atom(protocol)]
-      _ -> [:http2, :http1]
+      _ -> [:http1]
     end
   end
 


### PR DESCRIPTION
Since moving to Tigris, a bunch of our requests to S3 are failing in the registry pool:

```
** (Oban.PerformError) Tuist.Registry.Swift.Workers.CreatePackageReleaseWorker failed with {:error, %ExAws.Error{message: "ExAws Request Error!\n\n{:error, %Req.HTTPError{protocol: :http2, reason: {:exceeds_window_size, :request, 1048576}}}\n"}}
```
https://tuist.dev/ops/oban/jobs/476622

Basically, our reused connections run out of space and Tigris does not refill it - so we should use HTTP1 and a new connection for each upload.
https://hexdocs.pm/mint/Mint.HTTP2.html#get_window_size/2-http-2-flow-control
