### PR TITLE
chore(server): rename marketing CTA to talk to us

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
@@ -12,7 +12,7 @@
 
     <div class="marketing__home__section__hero__ctas">
       <.primary_button size="big" href="https://cal.tuist.dev/team/tuist/tuist" target="_blank">
-        {gettext("Explore solutions together")}
+        {gettext("Talk to us")}
       </.primary_button>
       <.marketing_link
         class="marketing__component__link font-l-strong"

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
@@ -12,7 +12,7 @@
 
     <div class="marketing__home__section__hero__ctas">
       <.primary_button size="big" href="https://cal.tuist.dev/team/tuist/tuist" target="_blank">
-        {gettext("Talk to the founders")}
+        {gettext("Explore solutions together")}
       </.primary_button>
       <.marketing_link
         class="marketing__component__link font-l-strong"


### PR DESCRIPTION
Someone gave us as feedback that "Talk to founders" can also mean talking to founder about topics other than just exploring solutions. Therefore, I'm iterating o the copy. I leaned on Claude for this, and here are some ideas that I got suggested:

```
Story-focused:

"Share your story"
"Tell us your needs"
"Share your challenges"
"Tell us about your team"

Consultation-focused:

"Get personalized advice"
"Discuss your workflow"
"Explore solutions together"
"Get expert guidance"

Connection-focused:

"Connect with founders"
"Chat with the team"
"Let's discuss your goals"
"Book a consultation"

Action-oriented:

"Discover your solution"
"Find your fit"
"Get tailored advice"
"Learn how we can help"
```
