### PR TITLE
feat(server): add initial support for default previews visibility

### DIFF
--- a/server/lib/tuist/projects.ex
+++ b/server/lib/tuist/projects.ex
@@ -192,7 +192,8 @@ defmodule Tuist.Projects do
       created_at: created_at,
       visibility: visibility,
       vcs_repository_full_handle: Keyword.get(opts, :vcs_repository_full_handle),
-      vcs_provider: Keyword.get(opts, :vcs_provider)
+      vcs_provider: Keyword.get(opts, :vcs_provider),
+      default_previews_visibility: Keyword.get(opts, :default_previews_visibility, :private)
     })
     |> Repo.insert!()
     |> Repo.preload(preload)

--- a/server/lib/tuist/projects/project.ex
+++ b/server/lib/tuist/projects/project.ex
@@ -24,6 +24,7 @@ defmodule Tuist.Projects.Project do
     field :vcs_repository_full_handle, :string
     field :vcs_provider, Ecto.Enum, values: [github: 0]
     field :last_interacted_at, :naive_datetime, virtual: true
+    field :default_previews_visibility, Ecto.Enum, values: [private: 0, public: 1], default: :private
 
     belongs_to :account, Account
 
@@ -49,7 +50,8 @@ defmodule Tuist.Projects.Project do
       :created_at,
       :visibility,
       :vcs_repository_full_handle,
-      :vcs_provider
+      :vcs_provider,
+      :default_previews_visibility
     ])
     |> validate_allowed_handle()
     |> validate_inclusion(:visibility, [:private, :public])
@@ -71,6 +73,7 @@ defmodule Tuist.Projects.Project do
     end)
     |> update_change(:name, &String.downcase/1)
     |> unique_constraint([:name, :account_id], name: "index_projects_on_name_and_account_id")
+    |> validate_inclusion(:default_previews_visibility, [:private, :public])
   end
 
   def validate_allowed_handle(changeset) do
@@ -79,8 +82,15 @@ defmodule Tuist.Projects.Project do
 
   def update_changeset(project, attrs) do
     project
-    |> cast(attrs, [:default_branch, :vcs_repository_full_handle, :vcs_provider, :visibility])
+    |> cast(attrs, [
+      :default_branch,
+      :vcs_repository_full_handle,
+      :vcs_provider,
+      :visibility,
+      :default_previews_visibility
+    ])
     |> validate_inclusion(:vcs_provider, [:github])
     |> validate_inclusion(:visibility, [:private, :public])
+    |> validate_inclusion(:default_previews_visibility, [:private, :public])
   end
 end

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -151,7 +151,7 @@ defmodule TuistWeb.API.PreviewsController do
         display_name: Map.get(body_params, :display_name),
         git_branch: Map.get(body_params, :git_branch),
         git_ref: Map.get(body_params, :git_ref),
-        visibility: :private,
+        visibility: selected_project.default_previews_visibility,
         supported_platforms: []
       })
 

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -151,7 +151,6 @@ defmodule TuistWeb.API.PreviewsController do
         display_name: Map.get(body_params, :display_name),
         git_branch: Map.get(body_params, :git_branch),
         git_ref: Map.get(body_params, :git_ref),
-        visibility: selected_project.default_previews_visibility,
         supported_platforms: []
       })
 

--- a/server/priv/repo/migrations/20250910084708_add_default_previews_visibility_to_projects.exs
+++ b/server/priv/repo/migrations/20250910084708_add_default_previews_visibility_to_projects.exs
@@ -1,0 +1,9 @@
+defmodule Tuist.Repo.Migrations.AddDefaultPreviewsVisibilityToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :default_previews_visibility, :integer, default: 0, null: false
+    end
+  end
+end

--- a/server/priv/repo/migrations/20250910095538_make_preview_visibility_nullable.exs
+++ b/server/priv/repo/migrations/20250910095538_make_preview_visibility_nullable.exs
@@ -1,0 +1,12 @@
+defmodule Tuist.Repo.Migrations.MakePreviewVisibilityNullable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:previews) do
+      modify :visibility, :integer,
+        null: true,
+        default: nil,
+        from: {:integer, null: false, default: 1}
+    end
+  end
+end

--- a/server/test/support/tuist_test_support/fixtures/app_builds_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/app_builds_fixtures.ex
@@ -24,7 +24,7 @@ defmodule TuistTestSupport.Fixtures.AppBuildsFixtures do
       git_commit_sha: Keyword.get(opts, :git_commit_sha, "7c184b7"),
       git_ref: Keyword.get(opts, :git_ref, "refs/heads/main"),
       created_by_account_id: Keyword.get(opts, :created_by_account_id, project.account.id),
-      visibility: Keyword.get(opts, :visibility, :private),
+      visibility: Keyword.get(opts, :visibility),
       supported_platforms: Keyword.get(opts, :supported_platforms, []),
       inserted_at: Keyword.get(opts, :inserted_at)
     })

--- a/server/test/support/tuist_test_support/fixtures/projects_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/projects_fixtures.ex
@@ -27,6 +27,7 @@ defmodule TuistTestSupport.Fixtures.ProjectsFixtures do
       visibility: Keyword.get(opts, :visibility, :private),
       vcs_provider: Keyword.get(opts, :vcs_provider),
       vcs_repository_full_handle: Keyword.get(opts, :vcs_repository_full_handle),
+      default_previews_visibility: Keyword.get(opts, :default_previews_visibility, :private),
       preload: preload
     )
     |> Repo.preload(Keyword.get(opts, :preload, []))

--- a/server/test/tuist/projects/project_test.exs
+++ b/server/test/tuist/projects/project_test.exs
@@ -213,5 +213,42 @@ defmodule Tuist.ProjectTest do
       assert changeset.valid? == false
       assert "is invalid" in errors_on(changeset).visibility
     end
+
+    test "update changeset is valid when default_previews_visibility is :private" do
+      # When
+      changeset =
+        Project.update_changeset(
+          %Project{},
+          %{default_previews_visibility: :private}
+        )
+
+      # Then
+      assert changeset.valid? == true
+    end
+
+    test "update changeset is valid when default_previews_visibility is :public" do
+      # When
+      changeset =
+        Project.update_changeset(
+          %Project{},
+          %{default_previews_visibility: :public}
+        )
+
+      # Then
+      assert changeset.valid? == true
+    end
+
+    test "update changeset is invalid when default_previews_visibility is not a valid value" do
+      # When
+      changeset =
+        Project.update_changeset(
+          %Project{},
+          %{default_previews_visibility: :invalid_visibility}
+        )
+
+      # Then
+      assert changeset.valid? == false
+      assert "is invalid" in errors_on(changeset).default_previews_visibility
+    end
   end
 end

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -74,47 +74,8 @@ defmodule TuistWeb.PreviewsControllerTest do
                git_commit_sha: "commit-sha",
                git_ref: "git-ref",
                created_by_account_id: account.id,
-               visibility: :private
+               visibility: nil
              }
-    end
-
-    test "starts multipart upload when project's default preview visibility is public", %{
-      conn: conn,
-      user: user,
-      account: account
-    } do
-      # Given
-      project_with_public_default =
-        ProjectsFixtures.project_fixture(
-          account_id: account.id,
-          default_previews_visibility: :public
-        )
-
-      upload_id = "upload-id"
-
-      expect(Storage, :multipart_start, fn _object_key, _actor ->
-        upload_id
-      end)
-
-      # When
-      conn =
-        conn
-        |> Authentication.put_current_user(user)
-        |> put_req_header("content-type", "application/json")
-        |> post(~p"/api/projects/#{account.name}/#{project_with_public_default.name}/previews/start",
-          display_name: "name",
-          version: "1.0.0",
-          bundle_identifier: "dev.tuist.app"
-        )
-
-      # Then
-      response = json_response(conn, :ok)
-      assert response["status"] == "success"
-
-      {:ok, app_build} =
-        AppBuilds.app_build_by_id(response["data"]["preview_id"], preload: [:preview])
-
-      assert app_build.preview.visibility == :public
     end
 
     test "starts multipart upload of a bundle app build", %{


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/8152

This PR adds support for setting the default preview visibility – albeit without the UI, for now, so we can unblock teams who were relying on this.

New previews will have a `visibility` set to `NULL` – in which case the `project.default_previews_visibility` will take precedence. We're keeping the `preview.visibility`, so that the visibility can be overridden for individual previews.