### PR TITLE
fix(server): set inserted_at for streamed logs

### DIFF
--- a/server/lib/tuist/qa.ex
+++ b/server/lib/tuist/qa.ex
@@ -964,7 +964,10 @@ defmodule Tuist.QA do
     "#{pad_number(h)}:#{pad_number(m)}:#{pad_number(s)}"
   end
 
-  defp format_timestamp(_), do: "??:??:??"
+  defp format_timestamp(%DateTime{} = dt) do
+    %{hour: h, minute: m, second: s} = DateTime.to_time(dt)
+    "#{pad_number(h)}:#{pad_number(m)}:#{pad_number(s)}"
+  end
 
   defp pad_number(n), do: String.pad_leading(to_string(n), 2, "0")
 

--- a/server/lib/tuist_web/live/ops_qa_logs_live.ex
+++ b/server/lib/tuist_web/live/ops_qa_logs_live.ex
@@ -33,6 +33,7 @@ defmodule TuistWeb.OpsQALogsLive do
   @impl true
   def handle_info({:qa_log_created, log}, socket) do
     current_logs = socket.assigns.logs
+    log = %{log | inserted_at: NaiveDateTime.utc_now()}
     updated_logs = current_logs ++ [log]
     updated_formatted_logs = QA.prepare_and_format_logs(updated_logs)
 

--- a/server/lib/tuist_web/live/qa_run_live.ex
+++ b/server/lib/tuist_web/live/qa_run_live.ex
@@ -51,6 +51,7 @@ defmodule TuistWeb.QARunLive do
   def handle_info({:qa_log_created, log}, socket) do
     if socket.assigns.live_action == :logs do
       current_logs = socket.assigns[:logs] || []
+      log = %{log | inserted_at: NaiveDateTime.utc_now()}
       updated_logs = current_logs ++ [log]
       updated_formatted_logs = QA.prepare_and_format_logs(updated_logs, hide_usage_logs: true)
 

--- a/server/test/tuist/qa_test.exs
+++ b/server/test/tuist/qa_test.exs
@@ -1722,28 +1722,7 @@ defmodule Tuist.QATest do
              ] = result
     end
 
-    test "handles malformed timestamp gracefully" do
-      # Given
-      qa_run = QAFixtures.qa_run_fixture()
-
-      logs = [
-        %{
-          id: Ecto.UUID.generate(),
-          qa_run_id: qa_run.id,
-          type: :message,
-          data: Jason.encode!(%{"message" => "Test message"}),
-          timestamp: nil,
-          screenshot_metadata: nil
-        }
-      ]
-
-      # When
-      result = QA.format_logs_for_display(logs)
-
-      # Then
-      assert [formatted_log] = result
-      assert formatted_log.timestamp == "??:??:??"
-    end
+    
   end
 
   describe "prepare_log_with_metadata/1" do


### PR DESCRIPTION
Properly formats incoming logs with timestamps before `inserted_at` is set by the database.