### PR TITLE
fix(cli): Passing the wrong package resolution args when `resolveDependenciesWithSystemScm` is set

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TuistGeneratedProject+ManifestMapper.swift
@@ -10,7 +10,7 @@ extension TuistCore.TuistGeneratedProjectOptions.GenerationOptions {
     ) throws -> Self {
         var additionalPackageResolutionArguments = manifest.additionalPackageResolutionArguments
         if manifest.resolveDependenciesWithSystemScm {
-            additionalPackageResolutionArguments.append("-resolvePackageDependenciesWithSystemScm")
+            additionalPackageResolutionArguments.append(contentsOf: ["-scmProvider", "system"])
         }
 
         let clonedSourcePackagesDirPath: AbsolutePath? = try {

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TuistGeneratedProject+ManifestMapperTests.swift
@@ -77,7 +77,7 @@ struct TuistGeneratedProjectManifestMapperTests {
             )
 
             // Then
-            #expect(got.additionalPackageResolutionArguments.contains("-resolvePackageDependenciesWithSystemScm"))
+            #expect(got.additionalPackageResolutionArguments == ["-scmProvider", "system"])
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/8178

## Summary

[This PR](https://github.com/tuist/tuist/pull/8099) introduced a regression because we tried to pass  the `-resolveDependenciesWithSystemScm` argument to resolve packages when the option `resolveDependenciesWithSystemScm` is set to true. This is likely an agent smart idea to guess that the name of the argument is the same 🤦🏼 

## Test plan
- [x] Updated unit tests pass with new argument format
- [x] Verified Swift package resolution functionality works with new arguments