### PR TITLE
feat(server): include the link to the QA session in GitHub comments

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,9 +1,0 @@
-{
-  "lsp": {
-    "elixir-ls": {
-      "settings": {
-        "projectDir": "server"
-      }
-    }
-  }
-}

--- a/server/lib/tuist/qa.ex
+++ b/server/lib/tuist/qa.ex
@@ -36,30 +36,21 @@ defmodule Tuist.QA do
   EEx.function_from_file(:defp, :render_qa_summary, @qa_summary_template_path, [:assigns])
 
   @doc """
-  Run a QA test run for the given app build.
+  Run a QA test run for the given QA run.
   """
-  def test(%{app_build: %AppBuild{id: app_build_id} = app_build, prompt: prompt} = params) do
-    app_build = Repo.preload(app_build, preview: [project: :account])
-    issue_comment_id = Map.get(params, :issue_comment_id)
+  def test(%Run{} = qa_run) do
+    qa_run = Repo.preload(qa_run, app_build: [preview: [project: :account]])
+    app_build = qa_run.app_build
 
-    launch_argument_groups = select_launch_argument_groups(prompt, app_build.preview.project)
+    launch_argument_groups = select_launch_argument_groups(qa_run.prompt, app_build.preview.project)
 
-    with {:ok, qa_run} <-
-           create_qa_run(%{
-             app_build_id: app_build_id,
-             prompt: prompt,
-             status: "pending",
-             issue_comment_id: issue_comment_id,
-             git_ref: app_build.preview.git_ref,
-             vcs_provider: app_build.preview.project.vcs_provider,
-             vcs_repository_full_handle: app_build.preview.project.vcs_repository_full_handle
-           }),
-         app_build_url = generate_app_build_download_url(app_build),
-         {:ok, auth_token} <- create_qa_auth_token(app_build) do
+    app_build_url = generate_app_build_download_url(app_build)
+
+    with {:ok, auth_token} <- create_qa_auth_token(app_build) do
       attrs = %{
         preview_url: app_build_url,
         bundle_identifier: app_build.preview.bundle_identifier,
-        prompt: prompt,
+        prompt: qa_run.prompt,
         launch_arguments: Enum.map_join(launch_argument_groups, " ", & &1.value),
         server_url: Environment.app_url(),
         run_id: qa_run.id,

--- a/server/lib/tuist/qa/qa_test_summary.eex
+++ b/server/lib/tuist/qa/qa_test_summary.eex
@@ -3,6 +3,7 @@
 **Issues:** <%= if @issue_count > 0 do %>⚠️ <%= @issue_count %><% else %>✅ 0<% end %>
 **Preview:** [<%= @preview_display_name %>](<%= @preview_url %>)
 **Commit:** [<%= String.slice(@commit_sha, 0, 9) %>](<%= @git_remote_url_origin %>/commit/<%= @commit_sha %>)
+**QA Session:** [View detailed results](<%= @app_url %>/<%= @account_handle %>/<%= @project_handle %>/qa/<%= @qa_run_id %>)
 
 <%= if not Enum.empty?(@run_steps) do %>
 

--- a/server/lib/tuist/qa/workers/test_worker.ex
+++ b/server/lib/tuist/qa/workers/test_worker.ex
@@ -9,19 +9,13 @@ defmodule Tuist.QA.Workers.TestWorker do
     ],
     max_attempts: 1
 
-  alias Tuist.AppBuilds
   alias Tuist.QA
 
   @impl Oban.Worker
-  def perform(
-        %Oban.Job{args: %{"app_build_id" => app_build_id, "prompt" => prompt, "issue_comment_id" => issue_comment_id}} =
-          _job
-      ) do
-    {:ok, app_build} =
-      AppBuilds.app_build_by_id(app_build_id, preload: [preview: [project: :account]])
+  def perform(%Oban.Job{args: %{"qa_run_id" => qa_run_id}} = _job) do
+    {:ok, qa_run} = QA.qa_run(qa_run_id, preload: [app_build: [preview: [project: :account]]])
 
-    {:ok, qa_run} =
-      QA.test(%{app_build: app_build, prompt: prompt, issue_comment_id: issue_comment_id})
+    {:ok, qa_run} = QA.test(qa_run)
 
     QA.post_vcs_test_summary(qa_run)
   end

--- a/server/lib/tuist_web/controllers/webhooks/github_controller.ex
+++ b/server/lib/tuist_web/controllers/webhooks/github_controller.ex
@@ -71,41 +71,56 @@ defmodule TuistWeb.Webhooks.GitHubController do
   end
 
   defp start_or_enqueue_qa_run(project, prompt, git_ref) do
-    simulator_app_build = AppBuilds.latest_app_build(git_ref, project, supported_platform: :ios_simulator)
+    simulator_app_build =
+      AppBuilds.latest_app_build(git_ref, project, supported_platform: :ios_simulator)
 
-    {:ok, %{"id" => comment_id}} =
-      post_initial_comment(simulator_app_build, project.vcs_repository_full_handle, git_ref, project)
-
-    if simulator_app_build do
-      %{
-        "app_build_id" => simulator_app_build.id,
-        "prompt" => prompt,
-        "issue_comment_id" => comment_id
-      }
-      |> QA.Workers.TestWorker.new()
-      |> Oban.insert()
-    else
+    {:ok, qa_run} =
       QA.create_qa_run(%{
-        app_build_id: nil,
+        app_build_id: simulator_app_build && simulator_app_build.id,
         prompt: prompt,
         status: "pending",
         vcs_provider: project.vcs_provider,
         vcs_repository_full_handle: project.vcs_repository_full_handle,
         git_ref: git_ref,
-        issue_comment_id: comment_id
+        issue_comment_id: nil
       })
+
+    {:ok, %{"id" => comment_id}} =
+      post_initial_comment(
+        simulator_app_build,
+        project.vcs_repository_full_handle,
+        git_ref,
+        project,
+        qa_run
+      )
+
+    {:ok, qa_run} = QA.update_qa_run(qa_run, %{issue_comment_id: comment_id})
+
+    if simulator_app_build do
+      %{
+        "app_build_id" => simulator_app_build.id,
+        "prompt" => prompt,
+        "issue_comment_id" => comment_id,
+        "qa_run_id" => qa_run.id
+      }
+      |> QA.Workers.TestWorker.new()
+      |> Oban.insert()
     end
   end
 
-  defp post_initial_comment(simulator_app_build, repository_full_handle, git_ref, project) do
+  defp post_initial_comment(simulator_app_build, repository_full_handle, git_ref, project, qa_run) do
+    qa_run_url =
+      "#{Environment.app_url()}/#{project.account.name}/#{project.name}/qa/#{qa_run.id}"
+
     body =
       if simulator_app_build do
         simulator_app_build = Repo.preload(simulator_app_build, :preview)
         preview = simulator_app_build.preview
 
-        preview_url = "#{Environment.app_url()}/#{project.account.name}/#{project.name}/previews/#{preview.id}"
+        preview_url =
+          "#{Environment.app_url()}/#{project.account.name}/#{project.name}/previews/#{preview.id}"
 
-        "Running QA for [#{preview.display_name}](#{preview_url}). The QA report is coming soon."
+        "Running QA for [#{preview.display_name}](#{preview_url}). [See the live QA session](#{qa_run_url})."
       else
         "No preview found for your PR. Tuist QA will be triggered as soon as a Tuist Preview is available. Make sure to include `tuist share` as part of your CI pipeline. For more details on how to set up Previews, head over to our [documentation](https://docs.tuist.dev/en/guides/features/previews)."
       end

--- a/server/test/tuist_web/controllers/webhooks/github_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/github_controller_test.exs
@@ -5,7 +5,6 @@ defmodule TuistWeb.Webhooks.GitHubControllerTest do
   alias Tuist.Accounts.Account
   alias Tuist.AppBuilds
   alias Tuist.Projects
-  alias Tuist.QA
   alias Tuist.VCS
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.AppBuildsFixtures
@@ -163,11 +162,11 @@ defmodule TuistWeb.Webhooks.GitHubControllerTest do
       end)
 
       expect(Oban, :insert, fn job_changeset ->
-        assert job_changeset.changes.args == %{
-                 "app_build_id" => app_build.id,
-                 "prompt" => "test login flow",
-                 "issue_comment_id" => "comment_123"
-               }
+        args = job_changeset.changes.args
+        assert args["app_build_id"] == app_build.id
+        assert args["prompt"] == "test login flow"
+        assert args["issue_comment_id"] == "comment_123"
+        assert Map.has_key?(args, "qa_run_id")
 
         {:ok, job_changeset}
       end)
@@ -213,10 +212,6 @@ defmodule TuistWeb.Webhooks.GitHubControllerTest do
 
       expect(VCS, :create_comment, fn _comment_params ->
         {:ok, %{"id" => "comment_789"}}
-      end)
-
-      expect(QA, :create_qa_run, fn _run_params ->
-        {:ok, %{id: 1}}
       end)
 
       # When


### PR DESCRIPTION
This PR adds a link to the QA session from the GitHub comment: https://github.com/tuist/tuist/pull/7829#issuecomment-3284434254

To be able to link to the live QA session, we need to eagerly create the QA run in the database instead of creating once the testing starts in the worker.