### PR TITLE
fix(server): handle 0 bundle download size

### DIFF
--- a/server/lib/tuist_web/live/bundles_live.ex
+++ b/server/lib/tuist_web/live/bundles_live.ex
@@ -204,7 +204,8 @@ defmodule TuistWeb.BundlesLive do
   defp bundle_size_trend_label(_), do: gettext("since last month")
 
   defp bundle_size_trend_value(last_bundle, previous_bundle) do
-    if last_bundle && last_bundle.download_size > 0 && previous_bundle && previous_bundle.download_size do
+    if last_bundle && last_bundle.download_size && last_bundle.download_size > 0 &&
+         previous_bundle && previous_bundle.download_size do
       (1 - previous_bundle.download_size / last_bundle.download_size) * 100
     else
       0.0

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -356,25 +356,20 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   def pricing(conn, _params) do
     faqs = [
-      {gettext(
-         "Why is your pricing model more accessible compared to traditional enterprise models?"
-       ),
+      {gettext("Why is your pricing model more accessible compared to traditional enterprise models?"),
        gettext(
          ~S"""
          <p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with "contact sales" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>
          <p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>
          """,
-         read_more:
-           "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
+         read_more: "<a href=\"#{~p"/blog/2024/11/05/our-pricing-philosophy"}\">#{gettext("read more")}</a>"
        )},
       {gettext("How can I estimate the cost of my project?"),
        gettext(
          "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
        )},
       {gettext("Is there a free trial on paid plans?"),
-       gettext(
-         "We have a generous free tier on every paid plan so you can try out the features before paying any money."
-       )},
+       gettext("We have a generous free tier on every paid plan so you can try out the features before paying any money.")},
       {gettext("Do you offer discounts for non-profits and open-source?"),
        gettext("Yes, we do. Please reach out to oss@tuist.io for more information.")}
     ]
@@ -418,8 +413,7 @@ defmodule TuistWeb.Marketing.MarketingController do
     |> assign(
       :head_image,
       Tuist.Environment.app_url(
-        path:
-          "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
+        path: "/marketing/images/og/generated/#{page.slug |> String.split("/") |> List.last()}.jpg"
       )
     )
     |> assign(:head_twitter_card, "summary_large_image")

--- a/server/test/tuist_web/live/bundles_live_test.exs
+++ b/server/test/tuist_web/live/bundles_live_test.exs
@@ -214,4 +214,66 @@ defmodule TuistWeb.BundlesLiveTest do
     # Then
     assert has_element?(lv, "#widget-download-size span", "0.0%")
   end
+
+  test "download size is 0.0% when last bundle download_size is 0", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    # Given
+    _previous_bundle =
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        name: "TestApp",
+        install_size: 1000,
+        download_size: 500,
+        inserted_at: DateTime.add(DateTime.utc_now(), -31, :day)
+      )
+
+    _last_bundle =
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        name: "TestApp",
+        install_size: 1500,
+        download_size: 0,
+        inserted_at: DateTime.utc_now()
+      )
+
+    # When
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/bundles")
+
+    # Then
+    assert has_element?(lv, "#widget-download-size span", "0.0%")
+  end
+
+  test "download is 0.0% when previous bundle download_size is 0", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    # Given
+    _previous_bundle =
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        name: "TestApp",
+        install_size: 1000,
+        download_size: 0,
+        inserted_at: DateTime.add(DateTime.utc_now(), -31, :day)
+      )
+
+    _last_bundle =
+      BundlesFixtures.bundle_fixture(
+        project: project,
+        name: "TestApp",
+        install_size: 1500,
+        download_size: 1000,
+        inserted_at: DateTime.utc_now()
+      )
+
+    # When
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/bundles")
+
+    # Then
+    assert has_element?(lv, "#widget-download-size span", "0.0%")
+  end
 end


### PR DESCRIPTION
Resolves https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/919

When the bundle download size is 0, in the bundles page, we would divide by zero ... which is not a valid operation.
