### PR TITLE
fix(server): Lean on multiplexing requests in a single connection over having many HTTP2 connections against GitHub

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -152,7 +152,8 @@ defmodule Tuist.Application do
             transport_opts: [
               inet6: Environment.use_ipv6?() in ~w(true 1),
               cacertfile: CAStore.file_path(),
-              verify: :verify_peer
+              verify: :verify_peer,
+              debug: true
             ]
           ],
           size: 10,

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -148,16 +148,16 @@ defmodule Tuist.Application do
         "https://api.github.com" => [
           conn_opts: [
             log: true,
-            protocols: [:http1],
+            protocols: [:http2, :http1],
             transport_opts: [
               inet6: Environment.use_ipv6?() in ~w(true 1),
               cacertfile: CAStore.file_path(),
               verify: :verify_peer
             ]
           ],
-          size: 2,
-          count: 10,
-          protocols: [:http1],
+          size: 10,
+          count: 2,
+          protocols: [:http2, :http1],
           start_pool_metrics?: true
         ],
         Environment.s3_endpoint() => [

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -148,7 +148,7 @@ defmodule Tuist.Application do
         "https://api.github.com" => [
           conn_opts: [
             log: true,
-            protocols: [:http2, :http1],
+            protocols: [:http1],
             transport_opts: [
               inet6: Environment.use_ipv6?() in ~w(true 1),
               cacertfile: CAStore.file_path(),
@@ -157,7 +157,7 @@ defmodule Tuist.Application do
           ],
           size: 2,
           count: 10,
-          protocols: [:http2, :http1],
+          protocols: [:http1],
           start_pool_metrics?: true
         ],
         Environment.s3_endpoint() => [

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -152,8 +152,7 @@ defmodule Tuist.Application do
             transport_opts: [
               inet6: Environment.use_ipv6?() in ~w(true 1),
               cacertfile: CAStore.file_path(),
-              verify: :verify_peer,
-              debug: true
+              verify: :verify_peer
             ]
           ],
           size: 10,

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -64,6 +64,7 @@ defmodule Tuist.PromEx do
         # Plugins.PhoenixLiveView,
         # Plugins.Absinthe,
         # Plugins.Broadway,
+        PromEx.Plugins.Finch,
         PromEx.Plugins.Beam,
         Tuist.Storage.PromExPlugin,
         Tuist.CommandEvents.PromExPlugin,

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -64,7 +64,6 @@ defmodule Tuist.PromEx do
         # Plugins.PhoenixLiveView,
         # Plugins.Absinthe,
         # Plugins.Broadway,
-        PromEx.Plugins.Finch,
         PromEx.Plugins.Beam,
         Tuist.Storage.PromExPlugin,
         Tuist.CommandEvents.PromExPlugin,


### PR DESCRIPTION
[AppSignal Error](https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1108/samples/6607b64d83eb6789e61c8ba7-406887120491509987117577756001)

I noticed we have a few `:server_closed_request, :refused_stream}` errors when interacting against GitHub so I'm making a few changes to minimize them and handle them more gracefully when they happen.

- Establish fewer HTTP2 connections, and do more multiplexing in the existing ones. 
- Extend our retry logic to retry those scenarios.

