### PR TITLE
feat(cli): add macro executable to file group

### DIFF
--- a/cli/Fixtures/command_line_tool_with_macro_dependency/CommandLineTool/Sources/main.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/CommandLineTool/Sources/main.swift
@@ -1,0 +1,4 @@
+import SampleMacro
+
+print(#SampleMacro)
+print("hello world")

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Modules/SampleMacro/Sources/SampleMacro/SampleMacro.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Modules/SampleMacro/Sources/SampleMacro/SampleMacro.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro SampleMacro() -> String = #externalMacro(module: "SampleMacroPlugin", type: "SampleMacro")

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Modules/SampleMacro/Sources/SampleMacroPlugin/SampleMacroPlugin.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Modules/SampleMacro/Sources/SampleMacroPlugin/SampleMacroPlugin.swift
@@ -1,0 +1,19 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftCompilerPlugin
+
+@main
+struct SampleMacroPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+      SampleMacro.self,
+    ]
+}
+
+public struct SampleMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        return "\"Hello from macro!\""
+    }
+}

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Project.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Project.swift
@@ -1,0 +1,54 @@
+import ProjectDescription
+
+let project = Project(
+    name: "SampleMacro",
+    packages: [
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0")
+    ],
+    targets: [
+        .target(
+            name: "CommandLineTool",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "com.example.cli",
+            sources: ["CommandLineTool/Sources/**"],
+            dependencies: [
+              .macro(name: "SampleMacro")
+            ]
+        ),
+//        .target(
+//          name: "ExtenalSampleMacro",
+//          destinations: .macOS,
+//          product: .framework,
+//          bundleId: "com.example.samplemacro",
+//          sources: ["Modules/SampleMacro/Sources/SampleMacro/**"],
+//          dependencies: [
+//            .external(name: "SwiftSyntaxMacros"),
+//            .external(name: "SwiftCompilerPlugin"),
+//          ]
+//        )
+        .target(
+            name: "SampleMacro",
+            destinations: .macOS,
+            product: .framework,
+            bundleId: "com.example.samplemacro",
+            sources: ["Modules/SampleMacro/Sources/SampleMacro/**"],
+            dependencies: [
+                .macro(name: "SampleMacroPlugin")
+            ]
+        ),
+        .target(
+            name: "SampleMacroPlugin",
+            destinations: .macOS,
+            product: .macro,
+            bundleId: "com.example.samplemacroplugin",
+            sources: ["Modules/SampleMacro/Sources/SampleMacroPlugin/**"],
+            dependencies: [
+//                .external(name: "SwiftSyntaxMacros"),
+//                .external(name: "SwiftCompilerPlugin"),
+                .package(product: "SwiftSyntaxMacros", type: .runtime),
+                .package(product: "SwiftCompilerPlugin", type: .runtime)
+            ]
+        )
+    ]
+)

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist.swift
@@ -1,0 +1,5 @@
+import ProjectDescription
+
+let tuist = Tuist(
+    project: .tuist()
+)

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist/Config.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist/Config.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let config = Config()

--- a/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist/Config.swift
+++ b/cli/Fixtures/command_line_tool_with_macro_dependency/Tuist/Config.swift
@@ -1,3 +1,0 @@
-import ProjectDescription
-
-let config = Config()

--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -34,6 +34,7 @@ public enum TuistAcceptanceFixtures {
     case commandLineToolWithDynamicFramework
     case commandLineToolWithDynamicLibrary
     case commandLineToolWithStaticLibrary
+    case commandLineToolWithMacroDependency
     case frameworkWithEnvironmentVariables
     case frameworkWithMacroAndPluginPackages
     case frameworkWithNativeSwiftMacro
@@ -184,6 +185,8 @@ public enum TuistAcceptanceFixtures {
             return "command_line_tool_with_dynamic_library"
         case .commandLineToolWithStaticLibrary:
             return "command_line_tool_with_static_library"
+        case .commandLineToolWithMacroDependency:
+            return "command_line_tool_with_macro_dependency"
         case .frameworkWithEnvironmentVariables:
             return "framework_with_environment_variables"
         case .frameworkWithMacroAndPluginPackages:

--- a/cli/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/cli/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -86,6 +86,8 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 status: xcframework.status,
                 condition: condition
             )
+        case let .macro(path):
+            self = .macro(path: path)
         default:
             preconditionFailure("unsupported dependencies")
         }

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -199,7 +199,7 @@ public protocol GraphTraversing {
     /// be referenced from the project. This method is intended to be used when generating
     /// the groups.
     /// - Parameter path: Path to the directory where the project is defined.
-    func allProjectDependencies(path: AbsolutePath) throws -> Set<GraphDependencyReference>
+    func allProjectDependencies(path: AbsolutePath) async throws -> Set<GraphDependencyReference>
 
     /// Determines whether ENABLE_TESTING_SEARCH_PATHS needs to be enabled
     ///
@@ -295,6 +295,14 @@ public protocol GraphTraversing {
     /// - Parameter scheme: Scheme to check against.
     /// - Returns: The runnable target if any.
     func schemeRunnableTarget(scheme: Scheme) -> GraphTarget?
+        
+    /// Given a project directory, .xcodeproj filename, and a target name, it returns a list of macro executable dependencies
+    ///
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - xcodeProjectName: Xcode project filename without extension
+    ///   - name: Target name
+    func macroExecutableDependencies(path: AbsolutePath, xcodeProjectName: String, name: String) async -> Set<GraphDependencyReference>
 }
 
 extension GraphTraversing {

--- a/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -105,7 +105,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         )
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
         let fileElements = ProjectFileElements()
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,

--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -88,7 +88,7 @@ class ProjectFileElements {
         graphTraverser: GraphTraversing,
         groups: ProjectGroups,
         pbxproj: PBXProj
-    ) throws {
+    ) async throws {
         var files = Set<GroupFileElement>()
 
         for target in project.targets.values.sorted() {
@@ -117,7 +117,7 @@ class ProjectFileElements {
         }
 
         // Dependencies
-        let dependencies = try graphTraverser.allProjectDependencies(path: project.path).sorted()
+        let dependencies = try await graphTraverser.allProjectDependencies(path: project.path).sorted()
 
         try generate(
             dependencyReferences: Set(directProducts + dependencies),

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -296,8 +296,7 @@ final class TestService { // swiftlint:disable:this type_body_length
         if let schemeName {
             guard let scheme = graphTraverser.schemes().first(where: { $0.name == schemeName })
             else {
-                let schemes =
-                    mapperEnvironment.initialGraph.map(GraphTraverser.init)?.schemes()
+                let schemes = mapperEnvironment.initialGraph.map { GraphTraverser(graph: $0) }?.schemes()
                         ?? graphTraverser.schemes()
                 if let scheme = schemes.first(where: { $0.name == schemeName }) {
                     Logger.current.log(

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -838,7 +838,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(got?.target, app)
     }
 
-    func test_allDependencies() throws {
+    func test_allDependencies() async throws {
         // Given
         // App -> StaticLibrary -> Bundle
         let app = Target.test(name: "App", product: .app)
@@ -861,7 +861,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let subject = GraphTraverser(graph: graph)
 
         // When
-        let got = try subject.allProjectDependencies(path: project.path).sorted()
+        let got = try await subject.allProjectDependencies(path: project.path).sorted()
 
         // Then
         XCTAssertEqual(Set(got), Set([

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -773,6 +773,14 @@ final class GenerateAcceptanceTestCommandLineToolWithDynamicFramework: TuistAcce
     }
 }
 
+final class GenerateAcceptanceTestCommandLineToolWithMacroDependency: TuistAcceptanceTestCase {
+    func test_command_line_tool_with_macro_dependency() async throws {
+        try await setUpFixture(.commandLineToolWithMacroDependency)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "CommandLineTool")
+    }
+}
+
 final class GenerateAcceptanceTestmacOSAppWithCopyFiles: TuistAcceptanceTestCase {
     func test_macos_app_with_copy_files() async throws {
         try await setUpFixture(.macosAppWithCopyFiles)

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1570,7 +1570,7 @@ struct BuildPhaseGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -1654,7 +1654,7 @@ struct BuildPhaseGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -1727,7 +1727,7 @@ struct BuildPhaseGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -1465,7 +1465,7 @@ struct ConfigGeneratorTests {
 
         let fileElements = ProjectFileElements()
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -526,7 +526,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         }
     }
 
-    func test_generateProduct_fileReferencesProperties() throws {
+    func test_generateProduct_fileReferencesProperties() async throws {
         // Given
         let pbxproj = PBXProj()
         let project = Project.test(
@@ -542,7 +542,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
-        try subject.generateProjectFiles(
+        try await subject.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -924,7 +924,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         XCTAssertEqual(sdkElement?.name, sdkPath.basename)
     }
 
-    func test_generateDependencies_remoteSwiftPackage_doNotGenerateElements() throws {
+    func test_generateDependencies_remoteSwiftPackage_doNotGenerateElements() async throws {
         // Given
         let pbxproj = PBXProj()
         let target = Target.empty(name: "TargetA")
@@ -959,7 +959,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        try subject.generateProjectFiles(
+        try await subject.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -1031,7 +1031,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
-    func test_generateDependencies_localSwiftPackageEmbedded_doNotGenerateElements() throws {
+    func test_generateDependencies_localSwiftPackageEmbedded_doNotGenerateElements() async throws {
         // Given
         let pbxproj = PBXProj()
         let localPackagePath = try AbsolutePath(validating: "/LocalPackages/LocalPackageA")
@@ -1067,7 +1067,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        try subject.generateProjectFiles(
+        try await subject.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -450,7 +450,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ]))
     }
 
-    func test_generateProduct() throws {
+    func test_generateProduct() async throws {
         // Given
         let pbxproj = PBXProj()
         let project = Project.test(
@@ -468,7 +468,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
-        try subject.generateProjectFiles(
+        try await subject.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -483,7 +483,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
-    func test_generateProducts_stableOrder() throws {
+    func test_generateProducts_stableOrder() async throws {
         for _ in 0 ..< 5 {
             let pbxproj = PBXProj()
             let subject = ProjectFileElements()
@@ -507,7 +507,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
             // When
-            try subject.generateProjectFiles(
+            try await subject.generateProjectFiles(
                 project: project,
                 graphTraverser: graphTraverser,
                 groups: groups,

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -44,7 +44,7 @@ struct TargetGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -101,7 +101,7 @@ struct TargetGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,
@@ -222,7 +222,7 @@ struct TargetGeneratorTests {
             project: project,
             pbxproj: pbxproj
         )
-        try fileElements.generateProjectFiles(
+        try await fileElements.generateProjectFiles(
             project: project,
             graphTraverser: graphTraverser,
             groups: groups,


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/5898>

> Describe here the purpose of your PR.
- Add macro executable reference to file group on tuist generate.

### How to test locally
> Document how to test your changes locally
1. Edit `tuist` scheme so that working directory is set to `/tuist/cli/Fixtures/command_line_tool_with_macro_dependency`.
2. Run `tuist generate` following the [contribution documentation](https://docs.tuist.dev/en/contributors/get-started#run-tuist).
3. Confirm that the project generation succeeds and that the macro executable is added to the file group as shown in the screenshot below. (Note: The link will be highlighted in red before the generated project is built, as the macro executable is not yet present at the specified path.)
<img width="500" alt="Screenshot 2025-09-15 at 20 31 05" src="https://github.com/user-attachments/assets/1d16024f-7b7f-4670-aded-af5cf64c257c" />

### Contributor checklist ✅
- [x] The code has been linted using run mise run lint-fix
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅
- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label changelog:added, changelog:fixed, or changelog:changed, and the title is usable as a changelog entry