### PR TITLE
fix(cli): tuist cache failing due to the new BuildOperationMetrics attachment type

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -528,8 +528,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MobileNativeFoundation/XCLogParser",
       "state" : {
-        "branch" : "fix/build-operation-metrics",
-        "revision" : "e2b640186612919724fe8c435687c5040ece55a8"
+        "branch" : "master",
+        "revision" : "d37cc78024c5411e1bd9b2b73092b9e35b7cf1bb"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -605,7 +605,7 @@ let package = Package(
         .package(url: "https://github.com/crspybits/swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(
             url: "https://github.com/MobileNativeFoundation/XCLogParser",
-            branch: "fix/build-operation-metrics"
+            branch: "master"
         ),
         .package(url: "https://github.com/davidahouse/XCResultKit", .upToNextMajor(from: "1.2.2")),
         .package(url: "https://github.com/tuist/Noora", .upToNextMajor(from: "0.45.0")),


### PR DESCRIPTION
For more context, see: https://github.com/MobileNativeFoundation/XCLogParser/pull/237