### PR TITLE
chore(cli): Increase the flexibility to select the targets replaced by binaries

### DIFF
--- a/cli/Sources/TuistCache/TargetReplacementDecider.swift
+++ b/cli/Sources/TuistCache/TargetReplacementDecider.swift
@@ -1,9 +1,8 @@
-import Foundation
 import TuistCore
 import XcodeGraph
 
 /// A decider that determines whether a target should be replaced with a cached binary.
-protocol TargetReplacementDeciding {
+public protocol TargetReplacementDeciding {
     /// Determines whether a target should be replaced with a cached binary.
     /// - Parameters:
     ///   - project: The project containing the target.
@@ -13,18 +12,25 @@ protocol TargetReplacementDeciding {
 }
 
 /// A decider that chooses to replace only external targets.
-struct ExternalOnlyTargetReplacementDecider: TargetReplacementDeciding {
-    func shouldReplace(project: Project, target _: Target) -> Bool {
-        project.isExternal
+public struct ExternalOnlyTargetReplacementDecider: TargetReplacementDeciding {
+    public init() {}
+
+    public func shouldReplace(project: Project, target _: Target) -> Bool {
+        switch project.type {
+        case .external:
+            true
+        case .local:
+            false
+        }
     }
 }
 
 /// A decider that chooses to replace all targets, except for those that are explicitly excluded.
-struct AllPossibleTargetReplacementDecider: TargetReplacementDeciding {
+public struct AllPossibleTargetReplacementDecider: TargetReplacementDeciding {
     private let exceptionNames: Set<String>
     private let exceptionTags: Set<String>
 
-    init(exceptions: Set<TargetQuery>) {
+    public init(exceptions: Set<TargetQuery>) {
         var names = Set<String>()
         var tags = Set<String>()
         for exception in exceptions {
@@ -39,7 +45,7 @@ struct AllPossibleTargetReplacementDecider: TargetReplacementDeciding {
         exceptionTags = tags
     }
 
-    func shouldReplace(project _: Project, target: Target) -> Bool {
+    public func shouldReplace(project _: Project, target: Target) -> Bool {
         if exceptionNames.contains(target.name) {
             return false
         }
@@ -47,16 +53,5 @@ struct AllPossibleTargetReplacementDecider: TargetReplacementDeciding {
             return false
         }
         return true
-    }
-}
-
-extension Project {
-    fileprivate var isExternal: Bool {
-        switch type {
-        case .external:
-            return true
-        case .local:
-            return false
-        }
     }
 }

--- a/cli/Sources/TuistKit/Deciders/TargetReplacementDecider.swift
+++ b/cli/Sources/TuistKit/Deciders/TargetReplacementDecider.swift
@@ -1,0 +1,62 @@
+import Foundation
+import TuistCore
+import XcodeGraph
+
+/// A decider that determines whether a target should be replaced with a cached binary.
+protocol TargetReplacementDeciding {
+    /// Determines whether a target should be replaced with a cached binary.
+    /// - Parameters:
+    ///   - project: The project containing the target.
+    ///   - target: The target to check.
+    /// - Returns: `true` if the target should be replaced.
+    func shouldReplace(project: Project, target: Target) -> Bool
+}
+
+/// A decider that chooses to replace only external targets.
+struct ExternalOnlyTargetReplacementDecider: TargetReplacementDeciding {
+    func shouldReplace(project: Project, target _: Target) -> Bool {
+        project.isExternal
+    }
+}
+
+/// A decider that chooses to replace all targets, except for those that are explicitly excluded.
+struct AllPossibleTargetReplacementDecider: TargetReplacementDeciding {
+    private let exceptionNames: Set<String>
+    private let exceptionTags: Set<String>
+
+    init(exceptions: Set<TargetQuery>) {
+        var names = Set<String>()
+        var tags = Set<String>()
+        for exception in exceptions {
+            switch exception {
+            case let .named(name):
+                names.insert(name)
+            case let .tagged(tag):
+                tags.insert(tag)
+            }
+        }
+        exceptionNames = names
+        exceptionTags = tags
+    }
+
+    func shouldReplace(project _: Project, target: Target) -> Bool {
+        if exceptionNames.contains(target.name) {
+            return false
+        }
+        if !exceptionTags.isEmpty, !target.metadata.tags.isDisjoint(with: exceptionTags) {
+            return false
+        }
+        return true
+    }
+}
+
+extension Project {
+    fileprivate var isExternal: Bool {
+        switch type {
+        case .external:
+            return true
+        case .local:
+            return false
+        }
+    }
+}

--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -7,6 +7,7 @@ import TuistGenerator
 #if canImport(TuistCacheEE)
     import TuistCacheEE
 #endif
+import TuistCache
 import TuistServer
 import XcodeGraph
 

--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -147,7 +147,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
             if !ignoreBinaryCache {
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
-                    sources: includedTargets.isEmpty ? .tests : .explicit(includedTargets),
+                    decider: AllPossibleTargetReplacementDecider(exceptions: includedTargets),
                     configuration: configuration,
                     cacheStorage: cacheStorage
                 )
@@ -176,7 +176,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
             if !ignoreBinaryCache {
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
-                    sources: .build,
+                    decider: ExternalOnlyTargetReplacementDecider(),
                     configuration: configuration,
                     cacheStorage: cacheStorage
                 )
@@ -211,7 +211,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
             if !ignoreBinaryCache {
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
-                    sources: cacheSources,
+                    decider: AllPossibleTargetReplacementDecider(exceptions: cacheSources),
                     configuration: configuration,
                     cacheStorage: cacheStorage
                 )
@@ -252,7 +252,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
 
             let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                 config: config,
-                sources: cacheSources,
+                decider: AllPossibleTargetReplacementDecider(exceptions: cacheSources),
                 configuration: configuration,
                 cacheStorage: cacheStorage
             )

--- a/cli/Tests/TuistCacheTests/TargetReplacementDeciderTests.swift
+++ b/cli/Tests/TuistCacheTests/TargetReplacementDeciderTests.swift
@@ -1,6 +1,6 @@
 import Testing
 import XcodeGraph
-@testable import TuistKit
+@testable import TuistCache
 
 struct TargetReplacementDeciderTests {
     @Test func externalOnly_replaces_external_only() {

--- a/cli/Tests/TuistKitTests/Deciders/TargetReplacementDeciderTests.swift
+++ b/cli/Tests/TuistKitTests/Deciders/TargetReplacementDeciderTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import XcodeGraph
+@testable import TuistKit
+
+struct TargetReplacementDeciderTests {
+    @Test func externalOnly_replaces_external_only() {
+        let decider = ExternalOnlyTargetReplacementDecider()
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .external()),
+            target: Target.test()
+        ))
+        #expect(!decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test()
+        ))
+    }
+
+    @Test func allPossible_no_exceptions_replaces_everything() {
+        let decider = AllPossibleTargetReplacementDecider(exceptions: [])
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test()
+        ))
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .external()),
+            target: Target.test()
+        ))
+    }
+
+    @Test func allPossible_with_name_exception_does_not_replace_that_name() {
+        let decider = AllPossibleTargetReplacementDecider(exceptions: [.named("DoNotReplace")])
+        #expect(!decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test(name: "DoNotReplace")
+        ))
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test()
+        ))
+    }
+
+    @Test func allPossible_with_tag_exception_does_not_replace_matching_tag() {
+        let decider = AllPossibleTargetReplacementDecider(exceptions: [.tagged("DoNotReplace")])
+        #expect(!decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test(metadata: .test(tags: ["DoNotReplace"]))
+        ))
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test(metadata: .test(tags: ["Other"]))
+        ))
+        #expect(decider.shouldReplace(
+            project: Project.test(type: .local),
+            target: Target.test()
+        ))
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/tuist/tuist/pull/7987

I took over [this PR](https://github.com/tuist/tuist/pull/7987) from @hiltonc to add the flexibility required for [this other PR](https://github.com/tuist/tuist/pull/8122). The goal is to add support for "caching profiles" such that the user can define which targets should be replaced by binaries.

### How to test locally

You should be able to run `tuist generate` using binaries and have the same behaviour that we had before:
- Default to using binaries for external dependencies in `tuist generate`
- Default to as many as possible when running automation command such as `tuist build`.
