### PR TITLE
feat(cli): Increase the security of the cache surface

### DIFF
--- a/cli/Sources/TuistServer/Client/Client+Server.swift
+++ b/cli/Sources/TuistServer/Client/Client+Server.swift
@@ -3,24 +3,20 @@ import OpenAPIRuntime
 import OpenAPIURLSession
 
 extension Client {
-    private static let commonMiddlewares: [any ClientMiddleware] = [
-        ServerClientRequestIdMiddleware(),
-        ServerClientVerboseLoggingMiddleware(),
-        ServerClientOutputWarningsMiddleware(),
-    ]
+    @TaskLocal public static var additionalMiddlewares: [any ClientMiddleware] = []
 
     /// Tuist client for authenticated sessions
     public static func authenticated(serverURL: URL) -> Client {
         .init(
             serverURL: serverURL,
             transport: URLSessionTransport(configuration: .init(session: .tuistShared)),
-            middlewares: commonMiddlewares + [
+            middlewares: [
                 ServerClientRequestIdMiddleware(),
                 ServerClientCLIMetadataHeadersMiddleware(),
                 ServerClientAuthenticationMiddleware(),
                 ServerClientVerboseLoggingMiddleware(),
                 ServerClientOutputWarningsMiddleware(),
-            ]
+            ] + additionalMiddlewares
         )
     }
 
@@ -29,7 +25,11 @@ extension Client {
         .init(
             serverURL: serverURL,
             transport: URLSessionTransport(configuration: .init(session: .tuistShared)),
-            middlewares: commonMiddlewares
+            middlewares: [
+                ServerClientRequestIdMiddleware(),
+                ServerClientVerboseLoggingMiddleware(),
+                ServerClientOutputWarningsMiddleware(),
+            ]
         )
     }
 }

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -16,14 +16,13 @@ defmodule Tuist.License do
     @validation_url
   end
 
-  def sign(item) do
+  def sign(value) when is_binary(value) do
     if Tuist.Environment.dev?() or Tuist.Environment.test?() do
       nil
     else
       {:ok, %{signing_key: key_base64}} = get_license()
       key = Base.decode64!(key_base64)
-      data = Jason.encode!(item)
-      signature = :crypto.mac(:hmac, :sha256, data, key)
+      signature = :crypto.mac(:hmac, :sha256, key, value)
       Base.encode64(signature)
     end
   end

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -29,9 +29,9 @@ defmodule TuistWeb.API.CacheController do
 
   plug(TuistWeb.API.Authorization.BillingPlug)
 
-  plug :sign
+  plug(:sign)
 
-  tags ["Cache"]
+  tags(["Cache"])
 
   operation(:get_cache_action_item,
     summary: "Get a cache action item.",
@@ -60,19 +60,13 @@ defmodule TuistWeb.API.CacheController do
     responses: %{
       ok: {"The item exists in the action cache", "application/json", Schemas.CacheActionItem},
       not_found: {"The item doesn't exist in the actino cache", "application/json", Error},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
   )
 
-  def get_cache_action_item(
-        %{assigns: %{selected_project: selected_project}} = conn,
-        %{hash: hash} = _params
-      ) do
+  def get_cache_action_item(%{assigns: %{selected_project: selected_project}} = conn, %{hash: hash} = _params) do
     cache_action_item =
       Tuist.KeyValueStore.get_or_update(
         [
@@ -109,16 +103,14 @@ defmodule TuistWeb.API.CacheController do
 
   operation(:download,
     summary: "Downloads an artifact from the cache.",
-    description:
-      "This endpoint returns a signed URL that can be used to download an artifact from the cache.",
+    description: "This endpoint returns a signed URL that can be used to download an artifact from the cache.",
     operation_id: "downloadCacheArtifact",
     parameters: [
       cache_category: [
         in: :query,
         type: CacheCategory,
         required: false,
-        description:
-          "The category of the cache. It's used to differentiate between different types of caches."
+        description: "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -135,13 +127,9 @@ defmodule TuistWeb.API.CacheController do
       name: [in: :query, type: :string, required: true, description: "The name of the artifact."]
     ],
     responses: %{
-      ok:
-        {"The artifact exists and is downloadable", "application/json", CacheArtifactDownloadURL},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      ok: {"The artifact exists and is downloadable", "application/json", CacheArtifactDownloadURL},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project or the cache artifact doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -205,8 +193,7 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description:
-          "The category of the cache. It's used to differentiate between different types of caches."
+        description: "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -237,11 +224,8 @@ defmodule TuistWeb.API.CacheController do
              }
            }
          }},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found:
         {"The artifact doesn't exist", "application/json",
          %Schema{
@@ -330,15 +314,10 @@ defmodule TuistWeb.API.CacheController do
        }},
     responses: %{
       created: {"The action item was cached", "application/json", Schemas.CacheActionItem},
-      ok:
-        {"The request is valid but the cache action item already exists", "application/json",
-         Schemas.CacheActionItem},
+      ok: {"The request is valid but the cache action item already exists", "application/json", Schemas.CacheActionItem},
       bad_request: {"The request has missing or invalid parameters", "application/json", Error},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -412,8 +391,7 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description:
-          "The category of the cache. It's used to differentiate between different types of caches."
+        description: "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -431,11 +409,8 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       ok: {"The upload has been started", "application/json", ArtifactUploadId},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -484,15 +459,13 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description:
-          "The category of the cache. It's used to differentiate between different types of caches."
+        description: "The category of the cache. It's used to differentiate between different types of caches."
       ],
       content_length: [
         in: :query,
         type: :integer,
         required: false,
-        description:
-          "The size in bytes of the part that will be uploaded. It's used to generate the signed URL."
+        description: "The size in bytes of the part that will be uploaded. It's used to generate the signed URL."
       ],
       project_id: [
         in: :query,
@@ -522,11 +495,8 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       ok: {"The URL has been generated", "application/json", ArtifactMultipartUploadUrl},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -562,8 +532,7 @@ defmodule TuistWeb.API.CacheController do
         part_number,
         selected_project.account,
         expires_in: expires_in,
-        content_length:
-          if(is_nil(content_length), do: nil, else: String.to_integer(content_length))
+        content_length: if(is_nil(content_length), do: nil, else: String.to_integer(content_length))
       )
 
     json(conn, %{status: "success", data: %{url: url}})
@@ -600,8 +569,7 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description:
-          "The category of the cache. It's used to differentiate between different types of caches."
+        description: "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -639,11 +607,8 @@ defmodule TuistWeb.API.CacheController do
              }
            }
          }},
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -713,11 +678,8 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       no_content: "The cache has been successfully cleaned",
-      unauthorized:
-        {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden:
-        {"The authenticated subject is not authorized to perform this action", "application/json",
-         Error},
+      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
       not_found: {"The project was not found", "application/json", Error}
     }
   )
@@ -732,12 +694,7 @@ defmodule TuistWeb.API.CacheController do
     send_resp(conn, :no_content, "")
   end
 
-  defp get_object_key(%{
-         hash: hash,
-         cache_category: cache_category,
-         name: name,
-         project_slug: project_slug
-       }) do
+  defp get_object_key(%{hash: hash, cache_category: cache_category, name: name, project_slug: project_slug}) do
     if cache_category == nil do
       "#{String.downcase(project_slug)}/#{hash}/#{name}"
     else
@@ -746,14 +703,22 @@ defmodule TuistWeb.API.CacheController do
   end
 
   defp sign(%{query_params: %{"hash" => hash}} = conn, _opts) do
-    if Tuist.Environment.test?() or Tuist.Environment.dev?() do
-      conn |> put_resp_header("x-tuist-signature", "tuist")
-    else
-      conn |> put_resp_header("x-tuist-signature", Tuist.License.sign([hash]))
-    end
+    sign_conn(conn, hash)
+  end
+
+  defp sign(%{path_params: %{"hash" => hash}} = conn, _opts) do
+    sign_conn(conn, hash)
   end
 
   defp sign(conn, _opts) do
     conn
+  end
+
+  defp sign_conn(conn, hash) do
+    if Tuist.Environment.test?() or Tuist.Environment.dev?() do
+      put_resp_header(conn, "x-tuist-signature", "tuist")
+    else
+      put_resp_header(conn, "x-tuist-signature", Tuist.License.sign([hash]))
+    end
   end
 end

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -60,13 +60,19 @@ defmodule TuistWeb.API.CacheController do
     responses: %{
       ok: {"The item exists in the action cache", "application/json", Schemas.CacheActionItem},
       not_found: {"The item doesn't exist in the actino cache", "application/json", Error},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
   )
 
-  def get_cache_action_item(%{assigns: %{selected_project: selected_project}} = conn, %{hash: hash} = _params) do
+  def get_cache_action_item(
+        %{assigns: %{selected_project: selected_project}} = conn,
+        %{hash: hash} = _params
+      ) do
     cache_action_item =
       Tuist.KeyValueStore.get_or_update(
         [
@@ -103,14 +109,16 @@ defmodule TuistWeb.API.CacheController do
 
   operation(:download,
     summary: "Downloads an artifact from the cache.",
-    description: "This endpoint returns a signed URL that can be used to download an artifact from the cache.",
+    description:
+      "This endpoint returns a signed URL that can be used to download an artifact from the cache.",
     operation_id: "downloadCacheArtifact",
     parameters: [
       cache_category: [
         in: :query,
         type: CacheCategory,
         required: false,
-        description: "The category of the cache. It's used to differentiate between different types of caches."
+        description:
+          "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -127,9 +135,13 @@ defmodule TuistWeb.API.CacheController do
       name: [in: :query, type: :string, required: true, description: "The name of the artifact."]
     ],
     responses: %{
-      ok: {"The artifact exists and is downloadable", "application/json", CacheArtifactDownloadURL},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      ok:
+        {"The artifact exists and is downloadable", "application/json", CacheArtifactDownloadURL},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project or the cache artifact doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -193,7 +205,8 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description: "The category of the cache. It's used to differentiate between different types of caches."
+        description:
+          "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -224,8 +237,11 @@ defmodule TuistWeb.API.CacheController do
              }
            }
          }},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found:
         {"The artifact doesn't exist", "application/json",
          %Schema{
@@ -314,10 +330,15 @@ defmodule TuistWeb.API.CacheController do
        }},
     responses: %{
       created: {"The action item was cached", "application/json", Schemas.CacheActionItem},
-      ok: {"The request is valid but the cache action item already exists", "application/json", Schemas.CacheActionItem},
+      ok:
+        {"The request is valid but the cache action item already exists", "application/json",
+         Schemas.CacheActionItem},
       bad_request: {"The request has missing or invalid parameters", "application/json", Error},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -391,7 +412,8 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description: "The category of the cache. It's used to differentiate between different types of caches."
+        description:
+          "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -409,8 +431,11 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       ok: {"The upload has been started", "application/json", ArtifactUploadId},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -459,13 +484,15 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description: "The category of the cache. It's used to differentiate between different types of caches."
+        description:
+          "The category of the cache. It's used to differentiate between different types of caches."
       ],
       content_length: [
         in: :query,
         type: :integer,
         required: false,
-        description: "The size in bytes of the part that will be uploaded. It's used to generate the signed URL."
+        description:
+          "The size in bytes of the part that will be uploaded. It's used to generate the signed URL."
       ],
       project_id: [
         in: :query,
@@ -495,8 +522,11 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       ok: {"The URL has been generated", "application/json", ArtifactMultipartUploadUrl},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -532,7 +562,8 @@ defmodule TuistWeb.API.CacheController do
         part_number,
         selected_project.account,
         expires_in: expires_in,
-        content_length: if(is_nil(content_length), do: nil, else: String.to_integer(content_length))
+        content_length:
+          if(is_nil(content_length), do: nil, else: String.to_integer(content_length))
       )
 
     json(conn, %{status: "success", data: %{url: url}})
@@ -569,7 +600,8 @@ defmodule TuistWeb.API.CacheController do
         in: :query,
         type: CacheCategory,
         required: false,
-        description: "The category of the cache. It's used to differentiate between different types of caches."
+        description:
+          "The category of the cache. It's used to differentiate between different types of caches."
       ],
       project_id: [
         in: :query,
@@ -607,8 +639,11 @@ defmodule TuistWeb.API.CacheController do
              }
            }
          }},
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project doesn't exist", "application/json", Error},
       payment_required: {"The account has an invalid plan", "application/json", Error}
     }
@@ -678,8 +713,11 @@ defmodule TuistWeb.API.CacheController do
     ],
     responses: %{
       no_content: "The cache has been successfully cleaned",
-      unauthorized: {"You need to be authenticated to access this resource", "application/json", Error},
-      forbidden: {"The authenticated subject is not authorized to perform this action", "application/json", Error},
+      unauthorized:
+        {"You need to be authenticated to access this resource", "application/json", Error},
+      forbidden:
+        {"The authenticated subject is not authorized to perform this action", "application/json",
+         Error},
       not_found: {"The project was not found", "application/json", Error}
     }
   )
@@ -694,7 +732,12 @@ defmodule TuistWeb.API.CacheController do
     send_resp(conn, :no_content, "")
   end
 
-  defp get_object_key(%{hash: hash, cache_category: cache_category, name: name, project_slug: project_slug}) do
+  defp get_object_key(%{
+         hash: hash,
+         cache_category: cache_category,
+         name: name,
+         project_slug: project_slug
+       }) do
     if cache_category == nil do
       "#{String.downcase(project_slug)}/#{hash}/#{name}"
     else
@@ -702,12 +745,15 @@ defmodule TuistWeb.API.CacheController do
     end
   end
 
-  defp sign(conn, _opts) do
-    with hash when not is_nil(hash) <- conn.params[:hash],
-         signature when not is_nil(signature) <- Tuist.License.sign([hash]) do
-      put_resp_header(conn, "x-tuist-signature", signature)
+  defp sign(%{query_params: %{"hash" => hash}} = conn, _opts) do
+    if Tuist.Environment.test?() or Tuist.Environment.dev?() do
+      conn |> put_resp_header("x-tuist-signature", "tuist")
     else
-      _ -> conn
+      conn |> put_resp_header("x-tuist-signature", Tuist.License.sign([hash]))
     end
+  end
+
+  defp sign(conn, _opts) do
+    conn
   end
 end

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -718,7 +718,7 @@ defmodule TuistWeb.API.CacheController do
     if Tuist.Environment.test?() or Tuist.Environment.dev?() do
       put_resp_header(conn, "x-tuist-signature", "tuist")
     else
-      put_resp_header(conn, "x-tuist-signature", Tuist.License.sign([hash]))
+      put_resp_header(conn, "x-tuist-signature", Tuist.License.sign(hash))
     end
   end
 end

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -34,6 +34,8 @@ defmodule TuistWeb.API.CacheControllerTest do
       date = ~N[2024-04-30 10:20:30Z]
 
       signed_fields = [hash]
+      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :dev?, fn -> false end)
       stub(Tuist.License, :sign, fn ^signed_fields -> "signature" end)
       stub(NaiveDateTime, :utc_now, fn :second -> date end)
 
@@ -160,6 +162,8 @@ defmodule TuistWeb.API.CacheControllerTest do
       account = Accounts.get_account_by_id(project.account_id)
       hash = "hash"
       signed_fields = [hash]
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
       stub(Tuist.License, :sign, fn ^signed_fields -> "signature" end)
 
       CacheActionItems.create_cache_action_item(%{
@@ -784,11 +788,11 @@ defmodule TuistWeb.API.CacheControllerTest do
 
       # When
       {_, _, payload} =
-        assert_error_sent :not_found, fn ->
+        assert_error_sent(:not_found, fn ->
           conn
           |> assign(:cache, cache)
           |> put(~p"/api/projects/#{account.name}/non-existing-project/cache/clean")
-        end
+        end)
 
       # Then
       assert JSON.decode!(payload) ==


### PR DESCRIPTION
Cache endpoints now validate requests with signatures. Makes it harder for anyone to tamper with or spoof cache operations. The builds stay fast and now they're harder to mess with.