### PR TITLE
fix(server): registry scope

### DIFF
--- a/server/lib/tuist/accounts/account_token.ex
+++ b/server/lib/tuist/accounts/account_token.ex
@@ -19,6 +19,16 @@ defmodule Tuist.Accounts.AccountToken do
   end
 
   def create_changeset(account, attrs) do
+    attrs =
+      Map.update(attrs, :scopes, nil, fn scopes ->
+        scopes
+        |> Enum.map(fn
+          :account_registry_read -> :registry_read
+          scope -> scope
+        end)
+        |> Enum.uniq()
+      end)
+
     account
     |> cast(attrs, [:account_id, :encrypted_token_hash, :scopes])
     |> validate_required([:account_id, :encrypted_token_hash, :scopes])

--- a/server/test/tuist/accounts/account_token_test.exs
+++ b/server/test/tuist/accounts/account_token_test.exs
@@ -1,6 +1,8 @@
 defmodule Tuist.Accounts.AccountTokenTest do
   use TuistTestSupport.Cases.DataCase
 
+  import Ecto.Changeset
+
   alias Tuist.Accounts.AccountToken
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
@@ -63,6 +65,40 @@ defmodule Tuist.Accounts.AccountTokenTest do
 
       # Then
       assert got.valid?
+    end
+
+    test "maps account_registry_read scope to registry_read" do
+      # Given
+      token = %AccountToken{}
+
+      # When
+      got =
+        AccountToken.create_changeset(token, %{
+          account_id: 1,
+          encrypted_token_hash: "hash",
+          scopes: [:account_registry_read]
+        })
+
+      # Then
+      assert got.valid?
+      assert get_change(got, :scopes) == [:registry_read]
+    end
+
+    test "maps account_registry_read scope to registry_read while preserving other scopes, deduplicating" do
+      # Given
+      token = %AccountToken{}
+
+      # When
+      got =
+        AccountToken.create_changeset(token, %{
+          account_id: 1,
+          encrypted_token_hash: "hash",
+          scopes: [:account_registry_read, :registry_read]
+        })
+
+      # Then
+      assert got.valid?
+      assert get_change(got, :scopes) == [:registry_read]
     end
 
     test "ensures account_id and encrypted_token_hash are unique" do


### PR DESCRIPTION
Fixes registry token creation for CLI versions prior to [4.65.5](https://github.com/tuist/tuist/releases/tag/4.65.5).
Should be removed once we drop support for that CLI.