### PR TITLE
fix(server): Change modal title from 'Create project' to 'Invite member'

### DIFF
--- a/server/lib/tuist_web/live/members_live.ex
+++ b/server/lib/tuist_web/live/members_live.ex
@@ -147,7 +147,7 @@ defmodule TuistWeb.MembersLive do
   defp invite_member_form(assigns) do
     ~H"""
     <.form id={@id} for={@form} phx-submit="invite-members">
-      <.modal id={"#{@id}-modal"} title={gettext("Create project")} on_dismiss="close-invite-members">
+      <.modal id={"#{@id}-modal"} title={gettext("Invite member")} on_dismiss="close-invite-members">
         <:trigger :let={attrs}>
           <.button variant="primary" label={gettext("Invite members")} {attrs} />
         </:trigger>


### PR DESCRIPTION
I'm fixing a typo that I noticed in the dashboard.
