### PR TITLE
fix(server): upload QA recording

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -117,8 +117,6 @@ if Enum.member?([:prod, :stag, :can], env) do
       database_options
     end
 
-  config :tuist, Tuist.Repo, database_options
-
   dns_name = System.get_env("RENDER_DISCOVERY_SERVICE")
   app_name = System.get_env("RENDER_SERVICE_NAME")
 
@@ -165,6 +163,8 @@ if Enum.member?([:prod, :stag, :can], env) do
   #
   # Check `Plug.SSL` for all available options in `force_ssl`.
   config :logger, level: Tuist.Environment.log_level()
+
+  config :tuist, Tuist.Repo, database_options
 end
 
 if Enum.member?([:prod, :stag, :can, :dev], env) do

--- a/server/runner/lib/runner/qa/agent.ex
+++ b/server/runner/lib/runner/qa/agent.ex
@@ -12,6 +12,7 @@ defmodule Runner.QA.Agent do
   alias Runner.QA.AppiumClient
   alias Runner.QA.Client
   alias Runner.QA.Simulators
+  alias Runner.QA.Sleeper
   alias Runner.QA.Tools
   alias Runner.Zip
 
@@ -255,7 +256,10 @@ defmodule Runner.QA.Agent do
          account_handle: account_handle,
          project_handle: project_handle
        }) do
-    Simulators.stop_recording(recording_port)
+    :ok = Simulators.stop_recording(recording_port)
+
+    # After stopping the recording, the command takes some time to fully store the video, so we're adding some timeout for that to finish
+    Sleeper.sleep(1000)
 
     {:ok, fixed_recording_path} = Briefly.create(extname: ".mp4")
 

--- a/server/runner/test/qa/agent_test.exs
+++ b/server/runner/test/qa/agent_test.exs
@@ -12,6 +12,7 @@ defmodule Runner.QA.AgentTest do
   alias Runner.QA.Client
   alias Runner.QA.Simulators
   alias Runner.QA.Simulators.SimulatorDevice
+  alias Runner.QA.Sleeper
   alias Runner.QA.Tools
 
   setup do
@@ -95,6 +96,8 @@ defmodule Runner.QA.AgentTest do
     end)
 
     stub(Client, :stream_log, fn :fake_log_streamer_pid, _log_params -> :ok end)
+
+    stub(Sleeper, :sleep, fn _milliseconds -> :ok end)
 
     {:ok, device: device, preview_path: preview_path, extract_dir: extract_dir, app_path: app_path}
   end


### PR DESCRIPTION
Turns out after we stop the recording, the video is not immediately saved on disk, so putting some timeouts ⌛ 