### PR TITLE
chore(server): don't run cron oban jobs in dev

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -342,7 +342,7 @@ config :tuist, Oban,
     {Oban.Plugins.Lifeline, rescue_after: to_timeout(minute: 30)},
     {Oban.Plugins.Cron,
      crontab:
-       if(Tuist.Environment.tuist_hosted?(),
+       if(Tuist.Environment.tuist_hosted?() and env in [:prod, :stag, :can],
          do: [
            {"0 10 * * 1-5", Tuist.Ops.DailySlackReportWorker},
            {"0 * * * 1-5", Tuist.Ops.HourlySlackReportWorker},


### PR DESCRIPTION
If you currently run our server locally, we start syncing the packages ... which is probably not what we want 😅 

We can keep running just in non-dev envs.