### PR TITLE
feat(server): update icon radius to liquid glass

### DIFF
--- a/server/assets/app/app.css
+++ b/server/assets/app/app.css
@@ -5,6 +5,10 @@
 
 @import "noora/noora.css";
 
+:root * {
+  --tuist-app-icon-radius: calc(var(--size) / 2 * 0.4453125);
+}
+
 body {
   margin: 0;
 }

--- a/server/assets/app/css/components/previews/app_preview.css
+++ b/server/assets/app/css/components/previews/app_preview.css
@@ -33,9 +33,10 @@
   }
 
   & > [data-part="icon"] {
-    border-radius: 8.42px;
-    width: 48px;
-    height: 48px;
+    --size: 48px;
+    border-radius: var(--tuist-app-icon-radius);
+    width: var(--size);
+    height: var(--size);
   }
 
   & > [data-part="metadata"] {

--- a/server/assets/app/css/pages/preview.css
+++ b/server/assets/app/css/pages/preview.css
@@ -46,9 +46,10 @@
           0px 7px 4px 0px oklch(0% 0 0 / 0.05),
           0px 3px 3px 0px oklch(0% 0 0 / 0.09),
           0px 1px 2px 0px oklch(0% 0 0 / 0.1);
-        border-radius: 9.82px;
-        width: 56px;
-        height: 56px;
+        --size: 56px;
+        border-radius: var(--tuist-app-icon-radius);
+        width: var(--size);
+        height: var(--size);
       }
 
       & [data-part="dots"] {

--- a/server/assets/app/css/pages/qa_run.css
+++ b/server/assets/app/css/pages/qa_run.css
@@ -46,9 +46,10 @@
           0px 7px 4px 0px oklch(0% 0 0 / 0.05),
           0px 3px 3px 0px oklch(0% 0 0 / 0.09),
           0px 1px 2px 0px oklch(0% 0 0 / 0.1);
-        border-radius: 9.82px;
-        width: 56px;
-        height: 56px;
+        --size: 56px;
+        border-radius: var(--tuist-app-icon-radius);
+        width: var(--size);
+        height: var(--size);
       }
 
       & [data-part="dots"] {


### PR DESCRIPTION
<img width="618" height="323" alt="image" src="https://github.com/user-attachments/assets/3bac049f-169a-4e4d-83bd-e16f0b80d220" />

The corner radius for liquid glass icons is slightly different. @asmitbm came up with an equation that I'm storing as a CSS variable.

This does mean older icons will have a slightly bigger corner radius, but I expect most apps to update to the new style soon. 