### PR TITLE
fix(server): incorrect Sort by label for Build duration

### DIFF
--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -232,6 +232,7 @@
             label={
               case @module_breakdown_sort_by do
                 "name" -> gettext("Module")
+                "build-duration" -> gettext("Build duration")
                 _ -> gettext("Compilation duration")
               end
             }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8258

The Sort by label was incorrect because we were defaulting to `Compilation duration` even when the valid option of `Build duration` was selected.