### PR TITLE
fix(server): Check for the truthiness of TUIST_HOSTED

### DIFF
--- a/server/rel/env.sh.eex
+++ b/server/rel/env.sh.eex
@@ -6,7 +6,21 @@ if [ ! -z "$TUIST_USE_IPV6" ]; then
   export ECTO_IPV6="true"
 fi
 
-if [ ! -z "$TUIST_HOSTED" ]; then
+# interpret common truthy values the same way our Elixir helpers do
+is_truthy() {
+  case "$1" in
+    1|true|TRUE|yes|YES)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+HOSTED_FLAG="${TUIST_CLOUD_HOSTED:-${TUIST_HOSTED:-0}}"
+
+if is_truthy "$HOSTED_FLAG"; then
   export DNS_CLUSTER_QUERY="${RENDER_DISCOVERY_SERVICE}"
   export RELEASE_DISTRIBUTION="name"
   export RELEASE_NODE="${RENDER_SERVICE_NAME}@${RENDER_INTERNAL_IP}"


### PR DESCRIPTION
The script that's run before starting the Erlang runtime, `rel/env.sh.eex`, only checked for the presence of TUIST_HOSTED or TUIST_CLOUD_HOSTED but not its truthiness, leading to configuring a DNS cluster in cases where `TUIST_HOSTED=0`. This PR fixes it by checking for truthiness instead of presence.