### PR TITLE
chore(server): add alamofire to allowlist in can and stag

### DIFF
--- a/server/config/can.exs
+++ b/server/config/can.exs
@@ -13,4 +13,4 @@ config :tuist, Tuist.Mailer, adapter: Bamboo.MailgunAdapter
 # before starting your production server.
 config :tuist,
   cache_static_manifest: "priv/static/cache_manifest.json",
-  package_sync_allowlist: ["tuist/*"]
+  package_sync_allowlist: ["tuist/*", "Alamofire/*"]

--- a/server/config/stag.exs
+++ b/server/config/stag.exs
@@ -13,4 +13,4 @@ config :tuist, Tuist.Mailer, adapter: Bamboo.MailgunAdapter
 # before starting your production server.
 config :tuist,
   cache_static_manifest: "priv/static/cache_manifest.json",
-  package_sync_allowlist: ["tuist/*"]
+  package_sync_allowlist: ["tuist/*", "Alamofire/*"]


### PR DESCRIPTION
Our acceptance tests depend on the Alamofire being in the registry in canary, but we only populated `tuist/*` packages. Adding `Alamofire/*` to the list.