### PR TITLE
feat(server): improve the UI when the environment is being prepared

### DIFF
--- a/server/lib/tuist_web/live/qa_run_live.html.heex
+++ b/server/lib/tuist_web/live/qa_run_live.html.heex
@@ -87,7 +87,7 @@
   </.tab_menu_horizontal>
 
   <div :if={@live_action in [:overview]} data-part="overview">
-    <div :if={@qa_run.status == "running"} data-part="running-state">
+    <div :if={@qa_run.status in ["running", "pending"]} data-part="running-state">
       <img src="/images/qa_running_state_light.png" data-theme="light" />
       <img src="/images/qa_running_state_dark.png" data-theme="dark" />
       <div data-part="labels">
@@ -678,7 +678,7 @@
     <.live_component
       module={TuistWeb.Components.Logs}
       logs={@formatted_logs || []}
-      empty_message={gettext("No logs found")}
+      empty_message={if @qa_run.status in ["running", "pending"], do: gettext("Preparing the agent environment..."), else: gettext("No logs found")}
       id="qa-run-logs"
     />
   </div>


### PR DESCRIPTION
When the environment is pending/running and we don't have any logs, we should show `Preparing the agent environment...` instead of `No logs found`, so that it's obvious the logs will still come.

The UI for "Running tests" should also be shown when the qa run state is `pending`. We could probably have a dedicated illustration for that, but let's roll with what we have for now.