### PR TITLE
fix(app): iOS app release

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -90,7 +90,6 @@ jobs:
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
           restore-keys: .build
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Generate TuistApp
         run: mise x -- tuist generate TuistApp
       - name: Build TuistApp
@@ -132,7 +131,6 @@ jobs:
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
           restore-keys: .build
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Test TuistApp
         run: mise x -- tuist test TuistApp -- CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
       - name: Save cache
@@ -166,7 +164,6 @@ jobs:
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
           restore-keys: .build
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Generate TuistApp
         run: mise x -- tuist generate TuistApp
       - name: Bundle iOS app

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -119,7 +119,6 @@ jobs:
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Initialize TuistCacheEE submodule
         run: mise run cli:ee
       - name: Run tests
@@ -163,7 +162,6 @@ jobs:
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Initialize TuistCacheEE submodule
         run: mise run cli:ee
       - name: Run tests
@@ -207,7 +205,6 @@ jobs:
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Initialize TuistCacheEE submodule
         run: mise run cli:ee
       - name: Run tests

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -58,7 +58,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Lint
         run: mise run cli:lint
       - name: Save cache
@@ -83,7 +82,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Build
         run: swift build --configuration debug
       - name: Save cache
@@ -109,7 +107,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Cache
         run: tuist cache
       - name: Save cache
@@ -134,7 +131,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Run tests
         run: mise x -- tuist test TuistUnitTests
       - name: Save cache
@@ -160,7 +156,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -192,7 +187,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -231,7 +225,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
@@ -263,7 +256,6 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
-      - run: tuist install
       - name: Skip Xcode Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,6 +388,50 @@ jobs:
             build/Tuist.dmg
           retention-days: 1
 
+  release-ios:
+    name: Release iOS App
+    needs: check-releases
+    if: needs.check-releases.outputs.app-should-release == 'true'
+    runs-on: namespace-profile-default-macos
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TUIST_GITHUB_TOKEN }}
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
+      - name: Skip Xcode Macro Fingerprint Validation
+        run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+      - name: Skip Xcode Package Validation
+        run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
+      - uses: jdx/mise-action@v2
+      - name: Restore cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
+          restore-keys: .build
+      - name: Update version
+        working-directory: app
+        run: |
+          VERSION_NUMBER="${{ needs.check-releases.outputs.app-next-version }}"
+          VERSION_NUMBER="${VERSION_NUMBER#app@}"
+          sed -i '' -e "s/CFBundleShortVersionString.*/CFBundleShortVersionString\": \"$VERSION_NUMBER\",/g" "Project.swift"
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"$COMMIT_COUNT\",/g" "Project.swift"
+      - name: Generate TuistApp
+        run: mise x -- tuist generate TuistApp
+      - name: Upload iOS App to App Store Connect
+        run: mise run app:upload-ios
+        env:
+          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          BASE_64_CERTIFICATE: ${{ secrets.BASE_64_CERTIFICATE }}
+          BASE_64_PROVISIONING_PROFILE: ${{ secrets.BASE_64_PROVISIONING_PROFILE }}
+
   release-server:
     name: Release Server
     needs: check-releases
@@ -477,7 +521,8 @@ jobs:
 
   commit-and-release:
     name: Commit and Release
-    needs: [check-releases, release-cli, release-app, release-server]
+    needs:
+      [check-releases, release-cli, release-app, release-ios, release-server]
     if: always() && needs.check-releases.outputs.should-release-any == 'true'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -85,7 +85,6 @@ jobs:
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install dependencies
-        run: tuist install
       - name: Initialize TuistCacheEE submodule
         env:
           TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,9 @@
     sops = "3.9.3"
     age = "1.2.1"
 
+[hooks]
+    postinstall = "mise/tasks/install.sh"
+
 [env]
     _.file = { path = ".env.json", redact = true }
     TUIST_CACHE_CONCURRENCY_LIMIT="none"


### PR DESCRIPTION
The iOS app release got removed at some point for whatever reason ... I'm bringing it back.

Also, fixing the postinstall hook and removing the now-redundant `tuist install` steps in our workflows.