### PR TITLE
feat(server): move back to installing axe via brew

### DIFF
--- a/server/lib/tuist/qa.ex
+++ b/server/lib/tuist/qa.ex
@@ -145,18 +145,7 @@ defmodule Tuist.QA do
     """
     set -e
 
-    # We're using a fork of AXe for streaming capabilities.
-    # This can be removed once this PR is merged: https://github.com/cameroncooke/AXe/pull/4
-    if [ ! -f "/usr/local/bin/axe" ]; then
-      git clone -b feature/stream-video-complete https://github.com/pepicrft/AXe.git /tmp/axe
-      cd /tmp/axe
-      export CLANG_MODULE_CACHE_PATH=/tmp/my-clang-cache
-      mkdir -p /tmp/my-clang-cache
-      swift build -c release --product axe
-      # Symlink instead of copy to maintain dynamic framework dependencies
-      sudo ln -sf /tmp/axe/.build/release/axe /usr/local/bin/axe
-      cd -
-    fi
+    brew install cameroncooke/axe/axe --quiet || true
     brew install ffmpeg
     npm i --location=global appium
     appium driver install xcuitest

--- a/server/runner/lib/runner/qa/agent.ex
+++ b/server/runner/lib/runner/qa/agent.ex
@@ -12,6 +12,7 @@ defmodule Runner.QA.Agent do
   alias Runner.QA.AppiumClient
   alias Runner.QA.Client
   alias Runner.QA.Simulators
+  alias Runner.QA.Sleeper
   alias Runner.QA.Tools
   alias Runner.Zip
 
@@ -247,6 +248,8 @@ defmodule Runner.QA.Agent do
 
   defp upload_recording(attrs) do
     :ok = Simulators.stop_recording(attrs.recording_port)
+    # When we stop the recording, the file is not immediately available for reading
+    Sleeper.sleep(100)
 
     # Only upload recording if there was at least one action performed
     if Map.has_key?(attrs, :last_action_timestamp) do

--- a/server/runner/lib/runner/qa/simulators.ex
+++ b/server/runner/lib/runner/qa/simulators.ex
@@ -134,7 +134,7 @@ defmodule Runner.QA.Simulators do
   """
   def start_recording(%SimulatorDevice{udid: device_udid}, output_path) do
     cmd =
-      "/usr/local/bin/axe stream-video --udid #{device_udid} --fps 30 --format ffmpeg | ffmpeg -y -loglevel quiet -f image2pipe -framerate 30 -i - -vf \"scale=1178:2556\" -c:v libx264 -preset ultrafast -f mp4 \"#{output_path}\""
+      "/opt/homebrew/bin/axe stream-video --udid #{device_udid} --fps 30 --format ffmpeg | ffmpeg -y -loglevel quiet -f image2pipe -framerate 30 -i - -vf \"scale=1178:2556\" -c:v libx264 -preset ultrafast -f mp4 \"#{output_path}\""
 
     Port.open({:spawn_executable, System.find_executable("sh")}, [
       :binary,

--- a/server/runner/lib/runner/qa/tools.ex
+++ b/server/runner/lib/runner/qa/tools.ex
@@ -822,7 +822,7 @@ defmodule Runner.QA.Tools do
     started_at = DateTime.utc_now()
     full_params = args ++ ["--udid", simulator_uuid]
 
-    case System.cmd("/usr/local/bin/axe", full_params) do
+    case System.cmd("/opt/homebrew/bin/axe", full_params) do
       {output, 0} ->
         {:ok, %{output: String.trim(output), started_at: started_at}}
 

--- a/server/runner/test/qa/tools_test.exs
+++ b/server/runner/test/qa/tools_test.exs
@@ -110,7 +110,7 @@ defmodule Runner.QA.ToolsTest do
       image_data = <<137, 80, 78, 71, 13, 10, 26, 10>>
       upload_url = "https://s3.example.com/upload-url"
 
-      expect(System, :cmd, fn "/usr/local/bin/axe", ["tap", "-x", "100", "-y", "200", "--udid", ^simulator_uuid] ->
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe", ["tap", "-x", "100", "-y", "200", "--udid", ^simulator_uuid] ->
         {"Tap completed", 0}
       end)
 
@@ -149,7 +149,7 @@ defmodule Runner.QA.ToolsTest do
       # Given
       simulator_uuid = "test-uuid"
 
-      expect(System, :cmd, fn "/usr/local/bin/axe", ["tap", "-x", "100", "-y", "200", "--udid", ^simulator_uuid] ->
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe", ["tap", "-x", "100", "-y", "200", "--udid", ^simulator_uuid] ->
         {"Tap failed", 1}
       end)
 
@@ -241,7 +241,7 @@ defmodule Runner.QA.ToolsTest do
       simulator_uuid = "test-uuid"
       text = "Hello World"
 
-      expect(System, :cmd, fn "/usr/local/bin/axe", ["type", ^text, "--udid", ^simulator_uuid] ->
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe", ["type", ^text, "--udid", ^simulator_uuid] ->
         {"Text typed", 0}
       end)
 
@@ -291,7 +291,7 @@ defmodule Runner.QA.ToolsTest do
       to_x = 300
       to_y = 400
 
-      expect(System, :cmd, fn "/usr/local/bin/axe",
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe",
                               [
                                 "swipe",
                                 "--start-x",
@@ -357,7 +357,7 @@ defmodule Runner.QA.ToolsTest do
       simulator_uuid = "test-uuid"
       duration = 1.5
 
-      expect(System, :cmd, fn "/usr/local/bin/axe",
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe",
                               [
                                 "swipe",
                                 "--start-x",
@@ -426,7 +426,7 @@ defmodule Runner.QA.ToolsTest do
       simulator_uuid = "test-uuid"
       preset = "scroll-up"
 
-      expect(System, :cmd, fn "/usr/local/bin/axe", ["gesture", ^preset, "--udid", ^simulator_uuid] ->
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe", ["gesture", ^preset, "--udid", ^simulator_uuid] ->
         {"Gesture completed", 0}
       end)
 
@@ -474,7 +474,7 @@ defmodule Runner.QA.ToolsTest do
       duration = 1.0
       delta = 200
 
-      expect(System, :cmd, fn "/usr/local/bin/axe",
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe",
                               [
                                 "gesture",
                                 ^preset,
@@ -536,7 +536,7 @@ defmodule Runner.QA.ToolsTest do
       simulator_uuid = "test-uuid"
       button = "home"
 
-      expect(System, :cmd, fn "/usr/local/bin/axe", ["button", ^button, "--udid", ^simulator_uuid] ->
+      expect(System, :cmd, fn "/opt/homebrew/bin/axe", ["button", ^button, "--udid", ^simulator_uuid] ->
         {"Button pressed", 0}
       end)
 


### PR DESCRIPTION
Since `stream-video` PR was merged, we can move back to using `axe` from `brew`