### PR TITLE
fix(app): do not use binary cache when releasing the iOS app

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -91,7 +91,7 @@ jobs:
           restore-keys: .build
       - uses: jdx/mise-action@v2
       - name: Generate TuistApp
-        run: mise x -- tuist generate TuistApp
+        run: mise x -- tuist generate TuistApp --no-binary-cache
       - name: Build TuistApp
         run: mise x -- tuist xcodebuild build -scheme TuistApp -destination "generic/platform=iOS Simulator" -workspace Tuist.xcworkspace CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCHS="arm64"
       - name: Share TuistApp


### PR DESCRIPTION
We don't recommend using the cache for App Store releases. Additionally, there's currently a bug when we try to do that: https://github.com/tuist/tuist/actions/runs/17942592393/job/51022474189#step:10:982