### PR TITLE
fix(app): release without binary cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,7 +286,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -422,7 +422,7 @@ jobs:
           COMMIT_COUNT=$(git rev-list --count HEAD)
           sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"$COMMIT_COUNT\",/g" "Project.swift"
       - name: Generate TuistApp
-        run: mise x -- tuist generate TuistApp
+        run: mise x -- tuist generate TuistApp --no-binary-cache
       - name: Upload iOS App to App Store Connect
         run: mise run app:upload-ios
         env:


### PR DESCRIPTION
Trying with the `macos26` image to fix the macOS app release since it fails with a weird apple event timeout when creating the `dmg`: https://github.com/create-dmg/create-dmg/issues/177

Additionally, applying the `--no-binary-cache` to the right place...