### PR TITLE
fix(app): attach app artifacts with the app release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,8 +384,8 @@ jobs:
             app/CHANGELOG.md
             app/Project.swift
             app/appcast.xml
-            build/Tuist.zip
-            build/Tuist.dmg
+            build/artifacts/Tuist.zip
+            build/artifacts/Tuist.dmg
           retention-days: 1
 
   release-ios:
@@ -657,8 +657,8 @@ jobs:
           tag_name: ${{ needs.check-releases.outputs.app-next-version }}
           body: ${{ needs.release-app.outputs.release-notes }}
           files: |
-            build/Tuist.zip
-            build/Tuist.dmg
+            build/artifacts/Tuist.zip
+            build/artifacts/Tuist.dmg
 
       - name: Create Server GitHub Release
         if: needs.check-releases.outputs.server-should-release == 'true' && needs.release-server.result == 'success'


### PR DESCRIPTION
The artifacts produced by `mise run app:bundle` are put into the `build/artifacts` directory, not directly in `build/artifacts`. We should reflect that when uploading and downloading these artifacts in GH Actions.