### PR TITLE
fix(cli): Downgrade `ProjectDescription` Swift version to 6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
       - uses: jdx/mise-action@v2
       - name: Initialize TuistCacheEE submodule
         env:


### PR DESCRIPTION
We mistakenly bumped the Xcode version that we use to release the CLI causing the `ProjectDescription` framework to be incompatible with Swift versions < 6.2 (e.g. Swift 6.1 bundled in Xcode 16.x). This PR reverts that because some users are still on Xcode 16 and need more time to update.