### PR TITLE
fix(server): upload QA recording with standard mp4 format

### DIFF
--- a/server/runner/lib/runner/qa/agent.ex
+++ b/server/runner/lib/runner/qa/agent.ex
@@ -258,6 +258,20 @@ defmodule Runner.QA.Agent do
       {:ok, trimmed_path} = Briefly.create(extname: ".mp4")
       duration_seconds = duration_ms / 1000.0
 
+      {recording_duration_output, 0} =
+        System.cmd("ffprobe", [
+          "-v",
+          "quiet",
+          "-print_format",
+          "json",
+          "-show_format",
+          attrs.recording_path
+        ])
+
+      {:ok, recording_info} = JSON.decode(recording_duration_output)
+      recording_duration = recording_info["format"]["duration"]
+      duration_seconds = min(duration_seconds, recording_duration)
+
       {_, 0} =
         System.cmd("ffmpeg", [
           "-i",

--- a/server/runner/lib/runner/qa/simulators.ex
+++ b/server/runner/lib/runner/qa/simulators.ex
@@ -134,7 +134,7 @@ defmodule Runner.QA.Simulators do
   """
   def start_recording(%SimulatorDevice{udid: device_udid}, output_path) do
     cmd =
-      "/opt/homebrew/bin/axe stream-video --udid #{device_udid} --fps 30 --format ffmpeg | ffmpeg -y -loglevel quiet -f image2pipe -framerate 30 -i - -vf \"scale=1178:2556\" -c:v libx264 -preset ultrafast -f mp4 \"#{output_path}\""
+      "/opt/homebrew/bin/axe stream-video --udid #{device_udid} --fps 30 --format ffmpeg | ffmpeg -y -loglevel quiet -f image2pipe -framerate 30 -i - -vf \"scale=1178:2556\" -c:v libx264 -preset ultrafast -pix_fmt yuv420p -movflags +faststart -f mp4 \"#{output_path}\""
 
     Port.open({:spawn_executable, System.find_executable("sh")}, [
       :binary,

--- a/server/runner/test/qa/agent_test.exs
+++ b/server/runner/test/qa/agent_test.exs
@@ -133,7 +133,11 @@ defmodule Runner.QA.AgentTest do
 
       expect(Simulators, :stop_recording, fn ^recording_port -> :ok end)
 
-      expect(System, :cmd, 1, fn "ffmpeg", _args ->
+      expect(System, :cmd, fn "ffprobe", _args ->
+        {~s({"format": {"duration": "30.0"}}), 0}
+      end)
+
+      expect(System, :cmd, fn "ffmpeg", _args ->
         {"", 0}
       end)
 
@@ -438,7 +442,11 @@ defmodule Runner.QA.AgentTest do
 
       expect(Simulators, :stop_recording, fn 12_345 -> :ok end)
 
-      expect(System, :cmd, 1, fn "ffmpeg", _args ->
+      expect(System, :cmd, fn "ffprobe", _args ->
+        {~s({"format": {"duration": "30.0"}}), 0}
+      end)
+
+      expect(System, :cmd, fn "ffmpeg", _args ->
         {"", 0}
       end)
 
@@ -583,7 +591,11 @@ defmodule Runner.QA.AgentTest do
 
       expect(Simulators, :stop_recording, fn 12_345 -> :ok end)
 
-      expect(System, :cmd, 1, fn "ffmpeg", _args ->
+      expect(System, :cmd, fn "ffprobe", _args ->
+        {~s({"format": {"duration": "30.0"}}), 0}
+      end)
+
+      expect(System, :cmd, fn "ffmpeg", _args ->
         {"", 0}
       end)
 


### PR DESCRIPTION
The video produced by the current `ffmpeg` command when piping the `axe stream-video` output was producing a non-standard mp4 only playable by quicktime. I'm adding additional `ffmpeg` options to ensure the video format is standard.

Additionally, I'm ensuring we don't try to trim with a value that's longer than the actual video (happened once during local testing – shouldn't really happen, but feels like a good safeguard)