### PR TITLE
ci(cli): use correct Tuist config token

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   CI: true
   RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_EXT_CONFIG_TOKEN }}
+  TUIST_CONFIG_TOKEN: ${{ secrets.TUIST_CONFIG_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PNPM_HOME: ~/.pnpm
   MISE_SOPS_AGE_KEY: ${{ secrets.MISE_SOPS_AGE_KEY }}


### PR DESCRIPTION
When we moved to using the `tuist/tuist` repository for the server cache acceptance tests, we haven't changed the tuist token, leading to failures on upload of analytics: https://github.com/tuist/tuist/actions/runs/18006749056/job/51229434242#step:7:7621