### PR TITLE
fix(cli): Fix cache warming when external targets are excluded by platform conditions

### DIFF
--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/.gitignore
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Project.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Project.swift
@@ -1,0 +1,37 @@
+import ProjectDescription
+
+let project = Project(
+    name: "TuistCacheIssue",
+    targets: [
+        .target(
+            name: "TuistCacheIssue",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.TuistCacheIssue",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                ]
+            ),
+            sources: ["TuistCacheIssue/Sources/**"],
+            resources: ["TuistCacheIssue/Resources/**"],
+            dependencies: []
+        ),
+        .target(
+            name: "TuistCacheIssueTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.TuistCacheIssueTests",
+            infoPlist: .default,
+            sources: ["TuistCacheIssue/Tests/**"],
+            resources: [],
+            dependencies: [
+                .target(name: "TuistCacheIssue"),
+                .external(name: "Nimble"),
+            ]
+        ),
+    ]
+)

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/README.md
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/README.md
@@ -1,0 +1,3 @@
+# Generated iOS App with external dependencies filtered out
+
+Tuist filters out destinations cascading platform condition filters down to external dependencies. This filtering can result in external targets with no destinations, and it's important that we delete them from the graph. Otherwise the cache warming logic might try to build binaries for them, even if they are not buildable.

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist/Package.resolved
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "c93f16c25af5770f0d3e6af27c9634640946b068",
+        "version" : "9.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist/Package.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/Tuist/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+@preconcurrency import PackageDescription
+
+#if TUIST
+    import ProjectDescription
+
+    let packageSettings = PackageSettings(
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "Dependencies",
+    // https://docs.tuist.io/documentation/tuist/dependencies
+    dependencies: [
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
+    ]
+)

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/Contents.json
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Sources/ContentView.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Sources/TuistCacheIssueApp.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Sources/TuistCacheIssueApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TuistCacheIssueApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Tests/TuistCacheIssueTests.swift
+++ b/cli/Fixtures/generated_ios_app_with_external_dependencies_filtered_out/TuistCacheIssue/Tests/TuistCacheIssueTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class TuistCacheIssueTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -62,6 +62,9 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
             target.destinations = target.destinations.filter { destination in
                 targetFilteredPlatforms.contains(destination.platform)
             }
+            if target.destinations.isEmpty {
+                target.metadata.tags = Set(Array(target.metadata.tags) + ["tuist:prunable"])
+            }
 
             // By changing the destinations we also need to adapt the deployment targets accordingly to account for possibly
             // removed destinations

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -143,6 +143,23 @@ struct TuistCacheEEAcceptanceTests {
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
         .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_ios_app_with_external_dependencies_filtered_out")
+    ) func generated_ios_app_with_external_dependencies_filtered_out() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+
+        // When: Cache the binaries
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["--path", fixtureDirectory.pathString]
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
         .withTestingSimulator("iPhone 17"),
         .withFixtureConnectedToCanary("ios_app_with_frameworks")
     ) func run_with_no_selective_testing() async throws {

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -116,7 +116,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         )
     }
 
-    func test_map_when_external_with_platform_filter2() async throws {
+    func test_map_when_external_dependencies_end_with_no_platforms() async throws {
         // Given
         let directory = try temporaryPath()
         let packagesDirectory = directory.appending(component: "Dependencies")


### PR DESCRIPTION
Our platform narrowing logic for external targets was leaving some external targets in the graph that ended up with no valid destinations after their platform conditions cascaded to external dependencies. This PR marks these orphaned targets as prunable so they get properly removed from the dependency graph.