### PR TITLE
fix(server): dark mode in private mode

### DIFF
--- a/server/assets/app/js/ThemeSwitcher.js
+++ b/server/assets/app/js/ThemeSwitcher.js
@@ -2,13 +2,22 @@ function setTheme(theme) {
   const resolvedColorScheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   document.documentElement.style.setProperty("color-scheme", theme === "system" ? "light dark" : theme);
   document.documentElement.setAttribute("data-theme", theme === "system" ? resolvedColorScheme : theme);
-  localStorage.setItem("preferred-theme", theme);
+  try {
+    localStorage.setItem("preferred-theme", theme);
+  } catch (e) {
+    // localStorage may not be available in private/incognito mode
+  }
   window.dispatchEvent(new CustomEvent("changed-preferred-theme", { detail: theme }));
 }
 
 function getPreferredTheme() {
-  const preferredTheme = localStorage.getItem("preferred-theme");
-  return preferredTheme === "null" ? "system" : preferredTheme;
+  try {
+    const preferredTheme = localStorage.getItem("preferred-theme");
+    return preferredTheme === "null" || preferredTheme === null ? "system" : preferredTheme;
+  } catch (e) {
+    // localStorage may not be available in private/incognito mode
+    return "system";
+  }
 }
 
 export function observeThemeChanges() {

--- a/server/lib/tuist_web/components/layouts/app.html.heex
+++ b/server/lib/tuist_web/components/layouts/app.html.heex
@@ -1,10 +1,31 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter:stable]" data-theme="light">
+<html lang="en" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csp-nonce" content={get_csp_nonce()} />
     <meta name="csrf-token" content={get_csrf_token()} />
+    <script nonce={get_csp_nonce()}>
+      (function() {
+        function getPreferredTheme() {
+          try {
+            const preferredTheme = localStorage.getItem("preferred-theme");
+            return preferredTheme === "null" || preferredTheme === null ? "system" : preferredTheme;
+          } catch (e) {
+            return "system";
+          }
+        }
+        
+        function setInitialTheme() {
+          const theme = getPreferredTheme();
+          const resolvedColorScheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          document.documentElement.style.setProperty("color-scheme", theme === "system" ? "light dark" : theme);
+          document.documentElement.setAttribute("data-theme", theme === "system" ? resolvedColorScheme : theme);
+        }
+        
+        setInitialTheme();
+      })();
+    </script>
     <.live_title>
       {assigns[:head_title] || "Tuist"}
     </.live_title>


### PR DESCRIPTION
Our dark mode handling was pretty broken in the incognito mode:
- There was always a flash on reload from light mode to dark mode css
- Some assets/css would stay in light mode even if you were on dark mode

And there were two related issues:
- `localStorage` can't be set in private mode
- to prevent flashing, we need to set `data-theme` based on the OS value in a separate `script` that can be executed _immediately_. Because of that, we can't share the theme-related code with the `ThemeSwitcher.js` but the whole script needs to be written directly in the `<head>` (at least I believe so)

Before:
<img width="1438" height="946" alt="image" src="https://github.com/user-attachments/assets/1c0cdf28-c87c-439e-a01d-ff70473fd62e" />

After:
<img width="1438" height="946" alt="image" src="https://github.com/user-attachments/assets/391e7fa1-0f92-4e37-98a1-007d182e4b61" />
