### PR TITLE
fix(server): latest preview link for non-main branch or multiple bundle ids

### DIFF
--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -105,6 +105,11 @@ To add the badge to your `README`, use the following markdown and replace the ac
 [![Tuist Preview](https://tuist.dev/{account-handle}/{project-handle}/previews/latest/badge.svg)](https://tuist.dev/{account-handle}/{project-handle}/previews/latest)
 ```
 
+If your project contains multiple apps with different bundle identifiers, you can specify which app's preview to link to by adding a `bundle-id` query parameter:
+```
+[![Tuist Preview](https://tuist.dev/{account-handle}/{project-handle}/previews/latest/badge.svg)](https://tuist.dev/{account-handle}/{project-handle}/previews/latest?bundle-id=com.example.app)
+```
+
 ## Automations {#automations}
 
 You can use the `--json` flag to get a JSON output from the `tuist share` command:

--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -28,17 +28,27 @@ defmodule TuistWeb.PreviewController do
 
   def latest(
         %{assigns: %{selected_project: project}} = conn,
-        %{"account_handle" => account_handle, "project_handle" => project_handle} = _params
+        %{"account_handle" => account_handle, "project_handle" => project_handle} = params
       ) do
-    case AppBuilds.latest_preview(project) do
-      latest_preview when not is_nil(latest_preview) ->
-        conn
-        |> redirect(to: ~p"/#{account_handle}/#{project_handle}/previews/#{latest_preview.id}")
-        |> halt()
+    bundle_id = params["bundle-id"]
+    latest_previews = AppBuilds.latest_previews_with_distinct_bundle_ids(project)
 
+    latest_preview =
+      if bundle_id do
+        Enum.find(latest_previews, fn preview -> preview.bundle_identifier == bundle_id end)
+      else
+        List.first(latest_previews)
+      end
+
+    case latest_preview do
       nil ->
         raise NotFoundError,
               "The page you are looking for doesn't exist or has been moved."
+
+      preview ->
+        conn
+        |> redirect(to: ~p"/#{account_handle}/#{project_handle}/previews/#{preview.id}")
+        |> halt()
     end
   end
 

--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -34,7 +34,7 @@ defmodule TuistWeb.PreviewController do
     latest_previews = AppBuilds.latest_previews_with_distinct_bundle_ids(project)
 
     latest_preview =
-      if bundle_id do
+      if not is_nil(bundle_id) do
         Enum.find(latest_previews, fn preview -> preview.bundle_identifier == bundle_id end)
       else
         List.first(latest_previews)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/8281

Fixes two issues:
- https://tuist.dev/:account_handle/:project_handle/previews/latest would return 404 if there were only previews from a non-main branch. This differs from our logic in the dashboard and is confusing just when you're starting to play with previews in your project (usually done in a non-main branch)
- the current link assumes there's only one app in a given project – that may not be true. I'm adding support for `?bundle-id=com.example.app` in the url, so users can specify the exact app in case they have multiple
