### PR TITLE
fix(cli): Only validate cache signatures on successful responses

### DIFF
--- a/cli/Sources/TuistTesting/Alerts/AlertController+Testing.swift
+++ b/cli/Sources/TuistTesting/Alerts/AlertController+Testing.swift
@@ -1,0 +1,25 @@
+import Testing
+import TuistSupport
+
+extension AlertController {
+    @TaskLocal public static var testingAlertController: AlertController = .init()
+}
+
+public struct AlertControllerTestingTrait: TestTrait, SuiteTrait, TestScoping {
+    public func provideScope(
+        for _: Test,
+        testCase _: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        try await AlertController.$current.withValue(AlertController()) {
+            try await function()
+        }
+    }
+}
+
+extension Trait where Self == AlertControllerTestingTrait {
+    /// Scopes the alert controller to the test using this trait.
+    public static func withScopedAlertController() -> Self {
+        return Self()
+    }
+}


### PR DESCRIPTION
We were validating signatures in non-success responses, causing misleading errors, for example unauthorized errors were reported as invalid signature, which is not true.