### PR TITLE
fix(server): Respond with bad request to image requests against HTML endpoints 

### DIFF
--- a/server/lib/tuist_web/controllers/preview_controller.ex
+++ b/server/lib/tuist_web/controllers/preview_controller.ex
@@ -34,10 +34,10 @@ defmodule TuistWeb.PreviewController do
     latest_previews = AppBuilds.latest_previews_with_distinct_bundle_ids(project)
 
     latest_preview =
-      if not is_nil(bundle_id) do
-        Enum.find(latest_previews, fn preview -> preview.bundle_identifier == bundle_id end)
-      else
+      if is_nil(bundle_id) do
         List.first(latest_previews)
+      else
+        Enum.find(latest_previews, fn preview -> preview.bundle_identifier == bundle_id end)
       end
 
     case latest_preview do

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -52,7 +52,6 @@ defmodule TuistWeb.Router do
     plug :disable_robot_indexing
     plug :fetch_session
     plug :fetch_live_flash
-    plug :put_root_layout, html: {TuistWeb.Layouts, :app}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_user

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -36,7 +36,19 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app do
-    plug :accepts, ["html", "svg", "png"]
+    plug :accepts, ["html"]
+    plug :disable_robot_indexing
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {TuistWeb.Layouts, :app}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+    plug :fetch_current_user
+    plug :content_security_policy
+  end
+
+  pipeline :browser_app_image do
+    plug :accepts, ["svg", "png"]
     plug :disable_robot_indexing
     plug :fetch_session
     plug :fetch_live_flash
@@ -550,6 +562,15 @@ defmodule TuistWeb.Router do
     ]
 
     get "/latest", PreviewController, :latest
+  end
+
+  scope "/:account_handle/:project_handle/previews", TuistWeb do
+    pipe_through [
+      :open_api,
+      :browser_app_image,
+      :analytics
+    ]
+
     get "/latest/badge.svg", PreviewController, :latest_badge
     get "/:id/icon.png", PreviewController, :download_icon
   end
@@ -557,7 +578,7 @@ defmodule TuistWeb.Router do
   scope "/:account_handle/:project_handle/qa/runs/:qa_run_id/screenshots", TuistWeb do
     pipe_through [
       :open_api,
-      :browser_app,
+      :browser_app_image,
       :analytics
     ]
 
@@ -573,6 +594,15 @@ defmodule TuistWeb.Router do
 
     get "/manifest.plist", PreviewController, :manifest
     get "/app.ipa", PreviewController, :download_archive
+  end
+
+  scope "/:account_handle/:project_handle/previews/:id", TuistWeb do
+    pipe_through [
+      :open_api,
+      :browser_app_image,
+      :analytics
+    ]
+
     get "/qr-code.svg", PreviewController, :download_qr_code_svg
     get "/qr-code.png", PreviewController, :download_qr_code_png
   end


### PR DESCRIPTION
AppSignal: https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/127/samples/timestamp/2025-09-26T11:13:00Z

Our `:browser_app` router pipeline accepts images, allowing anyone to send requests to those routes indicating that they accept images. However, not all the routes accept images, and when those requests reach the HTML routes, our server responses with a 5xx error and the error is raised on AppSignal:

```
** (FunctionClauseError) no function clause matching in Plug.Conn.resp/3
```

I created a pipeline specific of images, and I configured those routes to have its own pipeline.