### PR TITLE
fix(app): only commit and release after all builds are finished

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,7 +524,7 @@ jobs:
     name: Commit and Release
     needs:
       [check-releases, release-cli, release-app, release-ios, release-server]
-    if: always() && needs.check-releases.outputs.should-release-any == 'true'
+    if: success() && needs.check-releases.outputs.should-release-any == 'true'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}


### PR DESCRIPTION
Fixing a case when building the app gets cancelled but we still commit and release: https://github.com/tuist/tuist/actions/runs/18032921242/attempts/1