### PR TITLE
ci(app): release app with the GitHub runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,7 +287,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}


### PR DESCRIPTION
The namespace runner is failing with:
```
2025-09-26T14:22:57.3430000Z Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/var/folders/[redacted]1/1vwr9h554n14thzr7lx[redacted]rks[redacted][redacted][redacted][redacted][redacted]gn/T/createdmg.tmp.XXXXXXXXXX.7p9ZxRjv7P" "dmg.5AuWlW"
2025-09-26T14:24:57.7185980Z /var/folders/[redacted]1/1vwr9h554n14thzr7lx[redacted]rks[redacted][redacted][redacted][redacted][redacted]gn/T/createdmg.tmp.XXXXXXXXXX.7p9ZxRjv7P:394:4[redacted]6: execution error: Finder got an error: AppleEvent timed out. (-1712)[0m
2025-09-26T14:24:57.7222630Z Failed running AppleScript[0m
2025-09-26T14:24:57.7229940Z Unmounting disk image...
2025-09-26T14:24:57.7885460Z "disk49" ejected.
```

Let's see if the GH runners has better luck...