### PR TITLE
ci(app): don't skip commit when a dependent action is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,7 +524,9 @@ jobs:
     name: Commit and Release
     needs:
       [check-releases, release-cli, release-app, release-ios, release-server]
-    if: success() && needs.check-releases.outputs.should-release-any == 'true'
+    if: |
+      !cancelled() && !failure() &&
+      needs.check-releases.outputs.should-release-any == 'true'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}


### PR DESCRIPTION
What the title says