### PR TITLE
fix(app): release cancelled after being committed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,6 +528,9 @@ jobs:
       !cancelled() && !failure() &&
       needs.check-releases.outputs.should-release-any == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: commit-and-release-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
     steps:

--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -131,7 +131,7 @@ import TuistServer
 
                 try await authenticationService.signInWithEmailAndPassword(email: email, password: password)
             } catch {
-                // Skipping automatic log in, such as when the credentials are not passed
+                // Skipping automatic log in, such as when the credentials are not passed.
             }
         }
     }


### PR DESCRIPTION
Funnily enough ... now the release got cancelled halfway which makes things invalid when we commit it, but don't actually create a release 😢 

I'm changing the release, so that it's not cancelled by the commit the release workflow does ...