### PR TITLE
feat(docs): add note about runPostActionsOnFailure for insights

### DIFF
--- a/docs/docs/en/guides/features/insights.md
+++ b/docs/docs/en/guides/features/insights.md
@@ -27,6 +27,17 @@ To start tracking local build times, you can leverage the `tuist inspect build` 
 
 ![Post-action for inspecting builds](/images/guides/features/insights/inspect-build-scheme-post-action.png)
 
+> [!NOTE]
+> If you are not using <LocalizedLink href="/guides/features/projects">generated projects</LocalizedLink>, the post-scheme action is not executed in case the build fails.
+>
+> An undocumented feature in Xcode allows you to execute it even in this case. Set the attribute `runPostActionsOnFailure` to `YES` in your scheme's `BuildAction` in the relevant `project.pbxproj` file as follows:
+>
+> ```diff
+> <BuildAction
+>    buildImplicitDependencies="YES"
+>    parallelizeBuildables="YES"
+> +  runPostActionsOnFailure="YES">
+> ```
 
 In case you're using [Mise](https://mise.jdx.dev/), your script will need to activate `tuist` in the post-action environment:
 ```sh


### PR DESCRIPTION
I forgot to include a note about `runPostActionsOnFailure` that teams need to add if they want to gather insights for failed builds. Unfortunately, this is not surfaced in the Xcode UI.

In the future, we might want to include a command in the CLI, so users don't have to play with the `project.pbxproj` themselves.