### PR TITLE
feat(server): Add support for offline-validated licenses

### DIFF
--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -85,7 +85,10 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 
 | Environment variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
-| `TUIST_LICENSE` | The license provided after signing the service level agreement | Yes | | `******` |
+| `TUIST_LICENSE` | The license provided after signing the service level agreement | Yes* | | `******` |
+| `TUIST_LICENSE_CERTIFICATE_BASE64` | **Exceptional alternative to `TUIST_LICENSE`**. Base64-encoded public certificate for offline license validation in air-gapped environments where the server cannot contact external services. Only use when `TUIST_LICENSE` cannot be used | Yes* | | `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...` |
+
+\* Either `TUIST_LICENSE` or `TUIST_LICENSE_CERTIFICATE_BASE64` must be provided, but not both. Use `TUIST_LICENSE` for standard deployments.
 
 > [!IMPORTANT] EXPIRATION DATE
 > Licenses have an expiration date. Users will receive a warning while using Tuist commands that interact with the server if the license expires in less than 30 days. If you are interested in renewing your license, please reach out to [contact@tuist.dev](mailto:contact@tuist.dev).

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -86,9 +86,14 @@ defmodule Tuist.Environment do
     end
   end
 
-  def get_license_key(secrets \\ secrets()) do
+  def license_key(secrets \\ secrets()) do
     System.get_env("TUIST_LICENSE_KEY") ||
-      get([:license], secrets)
+      get([:license, :key], secrets) || get([:license], secrets)
+  end
+
+  def license_certificate_base64(secrets \\ secrets()) do
+    System.get_env("TUIST_LICENSE_CERTIFICATE_BASE64") ||
+      get([:license, :certificate, :base64], secrets)
   end
 
   def use_ipv6?(secrets \\ secrets()) do

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -46,7 +46,7 @@ defmodule Tuist.License do
         resolve_certificate()
 
       true ->
-        {:error, "No license key or certificate found"}
+        {:error, :license_not_found}
     end
   end
 
@@ -164,7 +164,7 @@ defmodule Tuist.License do
         {:ok, %{valid: true}} ->
           :ok
 
-        {:error, "No license key or certificate found"} ->
+        {:error, :license_not_found} ->
           raise "The license key exposed through the environment variable TUIST_LICENSE or TUIST_LICENSE_KEY is missing."
 
         {:ok, nil} ->

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -34,11 +34,127 @@ defmodule Tuist.License do
              ttl: Keyword.get(opts, :ttl, to_timeout(day: 1))
            ],
            fn ->
-             resolve_license(Tuist.Environment.get_license_key())
+             resolve_license(Tuist.Environment.license_key())
            end
          ) do
       {:ok, license} -> {:ok, license}
       {:error, error} -> {:error, error}
+    end
+  end
+
+  # ECDSA P-256 Public Key
+  def ecdsa_p256_public_key() do
+    "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFY2hMOEFTNFUxRStTV3JrS1hhdjA4ek5tc0tMTQpuaEg2MFNqdzlxQ214WmZnVTlLU2orUEo1NnpCb01GNUx3YTBZamhjNUNsSDdlZjliUnB4U3FJVmNBPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+  end
+
+  def license_certificate() do
+    Tuist.Environment.license_certificate_base64() |> Base.decode64!()
+  end
+
+  @doc """
+  Validates a license certificate against the ECDSA P-256 public key.
+
+  Returns {:ok, certificate_data} if valid, {:error, reason} otherwise.
+
+  Supports Keygen offline license format with ECDSA P-256 signatures.
+  """
+  def validate_license_certificate(public_key_pem \\ ecdsa_p256_public_key(), certificate \\ license_certificate()) do
+    try do
+      # Debug: log the first part of the certificate
+      IO.inspect(String.slice(certificate, 0, 100), label: "Certificate preview")
+
+      # Remove PEM headers if present
+      cert_content = certificate
+        |> String.replace("-----BEGIN LICENSE FILE-----", "")
+        |> String.replace("-----END LICENSE FILE-----", "")
+        |> String.replace("-----BEGIN LICENSE KEY-----", "")
+        |> String.replace("-----END LICENSE KEY-----", "")
+        |> String.trim()
+
+      # Try to decode as base64
+      decoded = case Base.decode64(cert_content) do
+        {:ok, decoded_data} ->
+          IO.inspect(String.slice(decoded_data, 0, 100), label: "Decoded preview")
+          decoded_data
+        :error ->
+          IO.puts("Base64 decode failed, using raw content")
+          cert_content
+      end
+      dbg(decoded)
+
+
+      # Parse the decoded content
+      case Jason.decode(decoded) do
+        {:ok, %{"enc" => enc_data, "sig" => sig_data, "alg" => alg}} ->
+          IO.inspect(alg, label: "Algorithm")
+          # This is a Keygen offline license with encryption and signature
+          verify_keygen_license(public_key_pem, enc_data, sig_data, alg)
+
+        {:ok, %{"data" => data, "sig" => sig, "alg" => alg}} ->
+          IO.inspect(alg, label: "Algorithm")
+          # Simplified format without encryption
+          verify_keygen_license(public_key_pem, data, sig, alg)
+
+        {:ok, payload} when is_map(payload) ->
+          IO.inspect(Map.keys(payload), label: "JSON keys")
+          # For dev/test, allow unsigned payloads
+          if Tuist.Environment.dev?() or Tuist.Environment.test?() do
+            {:ok, payload}
+          else
+            {:error, "Certificate missing signature - keys: #{inspect(Map.keys(payload))}"}
+          end
+
+        {:error, error} ->
+          IO.inspect(error, label: "JSON parse error")
+          {:error, "Invalid certificate format - not a valid Keygen license"}
+
+        other ->
+          IO.inspect(other, label: "Unexpected JSON result")
+          {:error, "Invalid certificate format"}
+      end
+    rescue
+      e ->
+        {:error, "Certificate validation failed: #{inspect(e)}"}
+    end
+  end
+
+  defp verify_keygen_license(public_key_pem, data, signature, algorithm) do
+    try do
+      # Decode the PEM public key
+      public_key = public_key_pem |> Base.decode64!()
+
+      # Determine the signing algorithm
+      case String.downcase(algorithm) do
+        alg when alg in ["ecdsa-p256", "base64+ecdsa-p256", "aes-256-gcm+ecdsa-p256"] ->
+          # Parse the public key for ECDSA
+          [{:SubjectPublicKeyInfo, der_public_key, _}] = :public_key.pem_decode(public_key)
+          ec_key = :public_key.der_decode(:SubjectPublicKeyInfo, der_public_key)
+
+          # Prepare the data for verification
+          data_to_verify = if is_binary(data), do: data, else: Jason.encode!(data)
+
+          # Decode the signature
+          sig_binary = Base.decode64!(signature)
+
+          # Verify using ECDSA with SHA256
+          case :public_key.verify(data_to_verify, :sha256, sig_binary, ec_key) do
+            true ->
+              # Parse the data if it's encoded
+              parsed_data = case Jason.decode(data_to_verify) do
+                {:ok, parsed} -> parsed
+                {:error, _} -> data
+              end
+              {:ok, parsed_data}
+            false ->
+              {:error, "Invalid signature"}
+          end
+
+        _ ->
+          {:error, "Unsupported algorithm: #{algorithm}"}
+      end
+    rescue
+      e ->
+        {:error, "Keygen license verification failed: #{inspect(e)}"}
     end
   end
 

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -103,7 +103,7 @@ defmodule Tuist.License do
       if :crypto.verify(:eddsa, :none, data_to_verify, sig_binary, [public_key, :ed25519]) do
         case Base.decode64(enc_data) do
           {:ok, decoded} ->
-            case Jason.decode(decoded) do
+            case JSON.decode(decoded) do
               {:ok, license_data} -> build_license_struct(license_data)
               {:error, _} -> {:error, "Failed to parse license data"}
             end

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -111,7 +111,11 @@
             <div data-part="metadata">
               <div data-part="title">{gettext("Category")}</div>
               <.badge
-                label={if is_nil(@run.category), do: gettext("Unknown"), else: @run.category |> Atom.to_string() |> String.capitalize()}
+                label={
+                  if is_nil(@run.category),
+                    do: gettext("Unknown"),
+                    else: @run.category |> Atom.to_string() |> String.capitalize()
+                }
                 style="fill"
               />
             </div>

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -2,29 +2,16 @@ defmodule Tuist.LicenseTest do
   use ExUnit.Case, async: true
   use Mimic
 
-  alias Tuist.Environment
-  alias Tuist.KeyValueStore
   alias Tuist.License
 
   setup :set_mimic_from_context
 
-  describe "assert_valid!/0" do
-    setup do
-      stub(Environment, :test?, fn -> false end)
-
-      stub(KeyValueStore, :get_or_update, fn _, _, func ->
-        func.()
-      end)
-
-      :ok
-    end
-
-    test "returns :ok when the license is valid" do
+  describe "resolve_license/1" do
+    test "returns a valid license when API returns valid data" do
       # Given
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
-      license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :license_key, fn -> license_key end)
+      license_key = UUIDv7.generate()
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:ok,
@@ -34,7 +21,8 @@ defmodule Tuist.LicenseTest do
              "data" => %{
                "id" => "1234",
                "attributes" => %{
-                 "expiry" => expiry
+                 "expiry" => expiry,
+                 "metadata" => %{"signingKey" => "test-key"}
                }
              },
              "meta" => %{
@@ -45,27 +33,43 @@ defmodule Tuist.LicenseTest do
       end)
 
       # When
-      got = License.assert_valid!()
+      {:ok, license} = License.resolve_license(license_key)
 
       # Then
-      assert got == :ok
+      assert license.valid == true
+      assert license.id == "1234"
+      assert license.signing_key == "test-key"
     end
 
-    test "raises an error when the license is absent" do
-      # When/Then
-      assert_raise RuntimeError,
-                   "The license key exposed through the environment variable TUIST_LICENSE or TUIST_LICENSE_KEY is missing.",
-                   fn ->
-                     License.assert_valid!()
-                   end
+    test "returns nil when the license key is nil" do
+      # When
+      result = License.resolve_license(nil)
+
+      # Then
+      assert result == {:ok, nil}
     end
 
-    test "raises an error when the server reports that the license is invalid" do
+    test "returns nil when API returns nil data" do
+      # Given
+      validation_url = License.get_validation_url()
+      license_key = UUIDv7.generate()
+
+      stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
+        {:ok, %{status: 200, body: %{"data" => nil}}}
+      end)
+
+      # When
+      result = License.resolve_license(license_key)
+
+      # Then
+      assert result == {:ok, nil}
+    end
+
+    test "returns invalid license when API returns valid: false" do
       # Given
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: -1) |> Timex.format!("{RFC3339}")
-      license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :license_key, fn -> license_key end)
+      license_key = UUIDv7.generate()
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:ok,
@@ -85,51 +89,189 @@ defmodule Tuist.LicenseTest do
          }}
       end)
 
-      # When/Then
-      assert_raise RuntimeError,
-                   "The license key is invalid or expired. Please, contact contact@tuist.dev to get a new one.",
-                   fn ->
-                     License.assert_valid!()
-                   end
+      # When
+      {:ok, license} = License.resolve_license(license_key)
+
+      # Then
+      assert license.valid == false
+      assert license.id == "1234"
     end
 
-    test "raises an error when the request to validate the license fails" do
+    test "returns error when the server responds with error status" do
       # Given
       validation_url = License.get_validation_url()
-      license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :license_key, fn -> license_key end)
+      license_key = UUIDv7.generate()
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
-        {:ok,
-         %{
-           status: 500
-         }}
+        {:ok, %{status: 500}}
       end)
 
-      # When/Then
-      assert_raise RuntimeError,
-                   "The license validation failed with the following error: The server to validate the license responded with a 500 status code.",
-                   fn ->
-                     License.assert_valid!()
-                   end
+      # When
+      result = License.resolve_license(license_key)
+
+      # Then
+      assert {:error, "The server to validate the license responded with a 500 status code."} = result
     end
 
-    test "raises an error when the Req errors" do
+    test "returns error when the Req errors" do
       # Given
       validation_url = License.get_validation_url()
-      license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :license_key, fn -> license_key end)
+      license_key = UUIDv7.generate()
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:error, "req error."}
       end)
 
-      # When/Then
-      assert_raise RuntimeError,
-                   "The license validation failed with the following error: \"req error.\"",
-                   fn ->
-                     License.assert_valid!()
-                   end
+      # When
+      result = License.resolve_license(license_key)
+
+      # Then
+      assert {:error, "\"req error.\""} = result
+    end
+  end
+
+  describe "resolve_certificate/2" do
+    test "returns valid license when certificate is valid with real signed data" do
+      # Generate a test Ed25519 key pair
+      {public_key, private_key} = :crypto.generate_key(:eddsa, :ed25519)
+
+      # Convert public key to hex for use as verify_key
+      verify_key = Base.encode16(public_key, case: :lower)
+
+      # Create license data with future expiry
+      license_payload = %{
+        "data" => %{
+          "id" => "test-license-id",
+          "type" => "licenses",
+          "attributes" => %{
+            "expiry" => DateTime.utc_now() |> DateTime.shift(day: 30) |> DateTime.to_iso8601(),
+            "metadata" => %{
+              "signingKey" => "test-signing-key-base64"
+            }
+          }
+        }
+      }
+
+      # Base64 encode the license data
+      encoded_data = license_payload |> Jason.encode!() |> Base.encode64()
+
+      # Create the data to sign (following Keygen's format)
+      data_to_sign = "license/" <> encoded_data
+
+      # Sign with the private key
+      signature = :crypto.sign(:eddsa, :none, data_to_sign, [private_key, :ed25519])
+      signature_base64 = Base.encode64(signature)
+
+      # Create the certificate
+      certificate =
+        %{
+          "enc" => encoded_data,
+          "sig" => signature_base64,
+          "alg" => "base64+ed25519"
+        }
+        |> Jason.encode!()
+        |> Base.encode64()
+
+      # When
+      result = License.resolve_certificate(verify_key, certificate)
+
+      # Then
+      assert {:ok, license} = result
+      assert license.id == "test-license-id"
+      assert license.valid == true
+      assert license.signing_key == "test-signing-key-base64"
+    end
+
+    test "returns error when signature is invalid" do
+      # Generate a test Ed25519 key pair
+      {public_key, _private_key} = :crypto.generate_key(:eddsa, :ed25519)
+
+      # Generate a DIFFERENT key pair for signing (to create invalid signature)
+      {_other_public, other_private} = :crypto.generate_key(:eddsa, :ed25519)
+
+      # Convert public key to hex for use as verify_key
+      verify_key = Base.encode16(public_key, case: :lower)
+
+      # Create license data
+      license_payload = %{
+        "data" => %{
+          "id" => "test-license-id",
+          "type" => "licenses",
+          "attributes" => %{
+            "expiry" => DateTime.utc_now() |> DateTime.shift(day: 30) |> DateTime.to_iso8601(),
+            "metadata" => %{}
+          }
+        }
+      }
+
+      # Base64 encode the license data
+      encoded_data = license_payload |> Jason.encode!() |> Base.encode64()
+
+      # Create the data to sign
+      data_to_sign = "license/" <> encoded_data
+
+      # Sign with the WRONG private key
+      signature = :crypto.sign(:eddsa, :none, data_to_sign, [other_private, :ed25519])
+      signature_base64 = Base.encode64(signature)
+
+      # Create the certificate
+      certificate =
+        %{
+          "enc" => encoded_data,
+          "sig" => signature_base64,
+          "alg" => "base64+ed25519"
+        }
+        |> Jason.encode!()
+        |> Base.encode64()
+
+      # When
+      result = License.resolve_certificate(verify_key, certificate)
+
+      # Then
+      assert {:error, "Invalid signature"} = result
+    end
+
+    test "returns error when certificate has invalid format" do
+      # Given
+      verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
+
+      # Invalid certificate - missing required fields
+      certificate =
+        %{
+          "data" => "some data"
+        }
+        |> Jason.encode!()
+        |> Base.encode64()
+
+      # When
+      result = License.resolve_certificate(verify_key, certificate)
+
+      # Then
+      assert {:error, "Invalid certificate format - missing required fields"} = result
+    end
+
+    test "returns error when certificate is not valid base64" do
+      # Given
+      verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
+      certificate = "not-valid-base64!!!"
+
+      # When
+      result = License.resolve_certificate(verify_key, certificate)
+
+      # Then
+      assert {:error, "Failed to decode base64 certificate"} = result
+    end
+
+    test "returns error when certificate contains invalid JSON" do
+      # Given
+      verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
+      certificate = Base.encode64("not json at all")
+
+      # When
+      result = License.resolve_certificate(verify_key, certificate)
+
+      # Then
+      assert {:error, _} = result
     end
   end
 end

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -8,7 +8,6 @@ defmodule Tuist.LicenseTest do
 
   describe "resolve_license/1" do
     test "returns a valid license when API returns valid data" do
-      # Given
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
       license_key = UUIDv7.generate()
@@ -32,25 +31,20 @@ defmodule Tuist.LicenseTest do
          }}
       end)
 
-      # When
       {:ok, license} = License.resolve_license(license_key)
 
-      # Then
       assert license.valid == true
       assert license.id == "1234"
       assert license.signing_key == "test-key"
     end
 
     test "returns nil when the license key is nil" do
-      # When
       result = License.resolve_license(nil)
 
-      # Then
       assert result == {:ok, nil}
     end
 
     test "returns nil when API returns nil data" do
-      # Given
       validation_url = License.get_validation_url()
       license_key = UUIDv7.generate()
 
@@ -58,15 +52,12 @@ defmodule Tuist.LicenseTest do
         {:ok, %{status: 200, body: %{"data" => nil}}}
       end)
 
-      # When
       result = License.resolve_license(license_key)
 
-      # Then
       assert result == {:ok, nil}
     end
 
     test "returns invalid license when API returns valid: false" do
-      # Given
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: -1) |> Timex.format!("{RFC3339}")
       license_key = UUIDv7.generate()
@@ -89,16 +80,13 @@ defmodule Tuist.LicenseTest do
          }}
       end)
 
-      # When
       {:ok, license} = License.resolve_license(license_key)
 
-      # Then
       assert license.valid == false
       assert license.id == "1234"
     end
 
     test "returns error when the server responds with error status" do
-      # Given
       validation_url = License.get_validation_url()
       license_key = UUIDv7.generate()
 
@@ -106,15 +94,12 @@ defmodule Tuist.LicenseTest do
         {:ok, %{status: 500}}
       end)
 
-      # When
       result = License.resolve_license(license_key)
 
-      # Then
       assert {:error, "The server to validate the license responded with a 500 status code."} = result
     end
 
     test "returns error when the Req errors" do
-      # Given
       validation_url = License.get_validation_url()
       license_key = UUIDv7.generate()
 
@@ -122,23 +107,17 @@ defmodule Tuist.LicenseTest do
         {:error, "req error."}
       end)
 
-      # When
       result = License.resolve_license(license_key)
 
-      # Then
       assert {:error, "\"req error.\""} = result
     end
   end
 
   describe "resolve_certificate/2" do
     test "returns valid license when certificate is valid with real signed data" do
-      # Generate a test Ed25519 key pair
       {public_key, private_key} = :crypto.generate_key(:eddsa, :ed25519)
-
-      # Convert public key to hex for use as verify_key
       verify_key = Base.encode16(public_key, case: :lower)
 
-      # Create license data with future expiry
       license_payload = %{
         "data" => %{
           "id" => "test-license-id",
@@ -152,17 +131,11 @@ defmodule Tuist.LicenseTest do
         }
       }
 
-      # Base64 encode the license data
       encoded_data = license_payload |> Jason.encode!() |> Base.encode64()
-
-      # Create the data to sign (following Keygen's format)
       data_to_sign = "license/" <> encoded_data
-
-      # Sign with the private key
       signature = :crypto.sign(:eddsa, :none, data_to_sign, [private_key, :ed25519])
       signature_base64 = Base.encode64(signature)
 
-      # Create the certificate
       certificate =
         %{
           "enc" => encoded_data,
@@ -172,10 +145,8 @@ defmodule Tuist.LicenseTest do
         |> Jason.encode!()
         |> Base.encode64()
 
-      # When
       result = License.resolve_certificate(verify_key, certificate)
 
-      # Then
       assert {:ok, license} = result
       assert license.id == "test-license-id"
       assert license.valid == true
@@ -183,16 +154,10 @@ defmodule Tuist.LicenseTest do
     end
 
     test "returns error when signature is invalid" do
-      # Generate a test Ed25519 key pair
       {public_key, _private_key} = :crypto.generate_key(:eddsa, :ed25519)
-
-      # Generate a DIFFERENT key pair for signing (to create invalid signature)
       {_other_public, other_private} = :crypto.generate_key(:eddsa, :ed25519)
-
-      # Convert public key to hex for use as verify_key
       verify_key = Base.encode16(public_key, case: :lower)
 
-      # Create license data
       license_payload = %{
         "data" => %{
           "id" => "test-license-id",
@@ -204,17 +169,11 @@ defmodule Tuist.LicenseTest do
         }
       }
 
-      # Base64 encode the license data
       encoded_data = license_payload |> Jason.encode!() |> Base.encode64()
-
-      # Create the data to sign
       data_to_sign = "license/" <> encoded_data
-
-      # Sign with the WRONG private key
       signature = :crypto.sign(:eddsa, :none, data_to_sign, [other_private, :ed25519])
       signature_base64 = Base.encode64(signature)
 
-      # Create the certificate
       certificate =
         %{
           "enc" => encoded_data,
@@ -224,18 +183,14 @@ defmodule Tuist.LicenseTest do
         |> Jason.encode!()
         |> Base.encode64()
 
-      # When
       result = License.resolve_certificate(verify_key, certificate)
 
-      # Then
       assert {:error, "Invalid signature"} = result
     end
 
     test "returns error when certificate has invalid format" do
-      # Given
       verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
 
-      # Invalid certificate - missing required fields
       certificate =
         %{
           "data" => "some data"
@@ -243,34 +198,26 @@ defmodule Tuist.LicenseTest do
         |> Jason.encode!()
         |> Base.encode64()
 
-      # When
       result = License.resolve_certificate(verify_key, certificate)
 
-      # Then
       assert {:error, "Invalid certificate format - missing required fields"} = result
     end
 
     test "returns error when certificate is not valid base64" do
-      # Given
       verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
       certificate = "not-valid-base64!!!"
 
-      # When
       result = License.resolve_certificate(verify_key, certificate)
 
-      # Then
       assert {:error, "Failed to decode base64 certificate"} = result
     end
 
     test "returns error when certificate contains invalid JSON" do
-      # Given
       verify_key = "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
       certificate = Base.encode64("not json at all")
 
-      # When
       result = License.resolve_certificate(verify_key, certificate)
 
-      # Then
       assert {:error, _} = result
     end
   end

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -24,7 +24,7 @@ defmodule Tuist.LicenseTest do
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: 1) |> Timex.format!("{RFC3339}")
       license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :get_license_key, fn -> license_key end)
+      stub(Environment, :license_key, fn -> license_key end)
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:ok,
@@ -65,7 +65,7 @@ defmodule Tuist.LicenseTest do
       validation_url = License.get_validation_url()
       expiry = DateTime.utc_now() |> DateTime.shift(day: -1) |> Timex.format!("{RFC3339}")
       license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :get_license_key, fn -> license_key end)
+      stub(Environment, :license_key, fn -> license_key end)
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:ok,
@@ -97,7 +97,7 @@ defmodule Tuist.LicenseTest do
       # Given
       validation_url = License.get_validation_url()
       license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :get_license_key, fn -> license_key end)
+      stub(Environment, :license_key, fn -> license_key end)
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:ok,
@@ -118,7 +118,7 @@ defmodule Tuist.LicenseTest do
       # Given
       validation_url = License.get_validation_url()
       license_key = String.to_atom(UUIDv7.generate())
-      stub(Environment, :get_license_key, fn -> license_key end)
+      stub(Environment, :license_key, fn -> license_key end)
 
       stub(Req, :post, fn ^validation_url, [json: %{meta: %{key: ^license_key}}] ->
         {:error, "req error."}


### PR DESCRIPTION
I'm adding support for validating on-premise licenses offline.