### PR TITLE
fix(server): Runtime error trying to access encrypted secrets

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -87,8 +87,7 @@ defmodule Tuist.Environment do
   end
 
   def license_key(secrets \\ secrets()) do
-    System.get_env("TUIST_LICENSE_KEY") ||
-      get([:license, :key], secrets) || get([:license], secrets)
+    System.get_env("TUIST_LICENSE_KEY") || get([:license], secrets) || get([:license, :key], secrets)
   end
 
   def license_certificate_base64(secrets \\ secrets()) do

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -724,7 +724,7 @@ defmodule Tuist.Environment do
       if System.get_env(env_variable) do
         System.get_env(env_variable)
       else
-        get_in(secrets, string_keys)
+        safe_get_in(secrets, string_keys)
       end
 
     if is_nil(value) do
@@ -733,6 +733,17 @@ defmodule Tuist.Environment do
       value
     end
   end
+
+  defp safe_get_in(data, []), do: data
+
+  defp safe_get_in(data, [key | rest]) when is_map(data) do
+    case Map.get(data, key) do
+      nil -> nil
+      value -> safe_get_in(value, rest)
+    end
+  end
+
+  defp safe_get_in(_data, _keys), do: nil
 
   def secrets do
     Application.get_env(:tuist, :secrets) || %{}


### PR DESCRIPTION
When I added support for offline validation, I introduced a regression that was caught when deploying the canary instance. Since our secrets have the license at `:license`, attempting to read [:license, :key]` first caused trying to treat the string as a map.

```
16:56:39.820 [notice] Application tuist exited: exited in: Tuist.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Access.get/3
            (elixir 1.18.4) lib/access.ex:320: Access.get("xxxx", "key", nil)
            (tuist 0.1.0) lib/tuist/environment.ex:728: Tuist.Environment.get/3
            (tuist 0.1.0) lib/tuist/environment.ex:91: Tuist.Environment.license_key/1
            (tuist 0.1.0) lib/tuist/license.ex:42: Tuist.License.fetch_license/0
            (tuist 0.1.0) lib/tuist/license.ex:163: Tuist.License.assert_valid!/1
            (tuist 0.1.0) lib/tuist/application.ex:33: Tuist.Application.start/2
```