### PR TITLE
fix(server): case insensitive comparison for invitations

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -998,14 +998,11 @@ defmodule Tuist.Accounts do
   end
 
   def get_invitation_by_token(token, %User{} = invitee) do
-    invitation = Invitation |> Repo.get_by(token: token) |> Repo.preload(inviter: :account)
+    invitation = Invitation |> Repo.get_by(token: token, invitee_email: invitee.email) |> Repo.preload(inviter: :account)
 
     cond do
       is_nil(invitation) ->
         {:error, :not_found}
-
-      invitation.invitee_email != invitee.email ->
-        {:error, :forbidden}
 
       !is_nil(invitation) ->
         {:ok, invitation}

--- a/server/lib/tuist/accounts/invitation.ex
+++ b/server/lib/tuist/accounts/invitation.ex
@@ -23,6 +23,7 @@ defmodule Tuist.Accounts.Invitation do
   def create_changeset(invitation, attrs \\ %{}) do
     invitation
     |> cast(attrs, [:token, :invitee_email, :inviter_id, :organization_id])
+    |> update_change(:invitee_email, &String.downcase/1)
     |> validate_required([:token, :invitee_email, :inviter_id, :organization_id])
     |> unique_constraint(:token, name: "index_invitations_on_token")
     |> unique_constraint([:invitee_email, :organization_id])

--- a/server/test/tuist/accounts/invitation_test.exs
+++ b/server/test/tuist/accounts/invitation_test.exs
@@ -109,5 +109,22 @@ defmodule Tuist.InvitationTest do
       # Then
       assert "has already been taken" in errors_on(got).invitee_email
     end
+
+    test "downcases invitee_email" do
+      # Given
+      invitation = %Invitation{}
+
+      # When
+      changeset =
+        Invitation.create_changeset(invitation, %{
+          token: "test-token",
+          invitee_email: "TEST@TUIST.IO",
+          inviter_id: 1,
+          organization_id: 1
+        })
+
+      # Then
+      assert changeset.changes.invitee_email == "test@tuist.io"
+    end
   end
 end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -864,7 +864,7 @@ defmodule Tuist.AccountsTest do
       assert got == Repo.preload(invitation, inviter: :account)
     end
 
-    test "returns :forbidden error when invitee email does not match" do
+    test "returns :not_found error when invitee email does not match" do
       # Given
       user = AccountsFixtures.user_fixture()
       organization = AccountsFixtures.organization_fixture(creator: user)
@@ -881,7 +881,7 @@ defmodule Tuist.AccountsTest do
       got = Accounts.get_invitation_by_token(invitation.token, invitee)
 
       # Then
-      assert got == {:error, :forbidden}
+      assert got == {:error, :not_found}
     end
 
     test "returns :not_found when an invitation with a given token does not exist" do
@@ -893,6 +893,26 @@ defmodule Tuist.AccountsTest do
 
       # Then
       assert got == {:error, :not_found}
+    end
+
+    test "returns invitation when invitee email case differs from invitation email" do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: user)
+      invitee = AccountsFixtures.user_fixture(email: "NEW@tuist.io")
+
+      {:ok, invitation} =
+        Accounts.invite_user_to_organization("neW@tuist.io", %{
+          inviter: user,
+          to: organization,
+          url: fn token -> token end
+        })
+
+      # When
+      {:ok, got} = Accounts.get_invitation_by_token(invitation.token, invitee)
+
+      # Then
+      assert got == Repo.preload(invitation, inviter: :account)
     end
   end
 


### PR DESCRIPTION
Even though both `user.email` and `invitation.email` columns are `:citext`, we would still not find the invitation when the casing differed.

`:citext` case insensitivity only kicks in Postgres queries but we were doing a comparison in Elixir.

The main fix is to change how we get the invitation, so we can use the natural Postgres properties.

Just to be on the safe side for the future, I also downcase the `invitation.email` as there's not really a point in storing in the database with a custom casing, but this change was not necessary for the fix.