### PR TITLE
Add an overlay to run the ClickHouse migrations from the beginning

### DIFF
--- a/server/rel/overlays/bin/migrate_clickhouse_from_beginning
+++ b/server/rel/overlays/bin/migrate_clickhouse_from_beginning
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./tuist eval Tuist.Release.migrate_clickhouse_from_beginning


### PR DESCRIPTION
Our server migrations are stateful persisting the last run migration in the DB. This is a problem for on-premise users that introduce ClickHouse in their infra because they have no way to run old ClickHouse migrations that were skipped because CH was not available. I'm adding a new overlay that they can manually run to force running the CH migrations from the beginning.