### PR TITLE
feat(docs): add Cloudflare Pages middleware for text/plain requests

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -257,6 +257,11 @@ export default defineConfig({
     hostname: "https://docs.tuist.io",
   },
   async buildEnd({ outDir }) {
+    // Copy functions directory to dist
+    const functionsSource = path.join(path.dirname(outDir), "functions");
+    const functionsDest = path.join(outDir, "functions");
+    await fs.cp(functionsSource, functionsDest, { recursive: true });
+
     const redirectsPath = path.join(outDir, "_redirects");
     const redirects = `
 /documentation/tuist/installation /guide/introduction/installation 301

--- a/docs/.vitepress/functions/_middleware.js
+++ b/docs/.vitepress/functions/_middleware.js
@@ -1,0 +1,25 @@
+export async function onRequest(context) {
+  const { request, next } = context;
+  const accept = request.headers.get('Accept');
+
+  // Check if the request accepts text/plain
+  if (accept && accept.includes('text/plain')) {
+    const url = new URL(request.url);
+
+    // Skip if the path already ends with .md
+    if (!url.pathname.endsWith('.md')) {
+      // Append .md to the pathname
+      url.pathname = url.pathname.endsWith('/')
+        ? `${url.pathname}index.md`
+        : `${url.pathname}.md`;
+
+      // Fetch the modified URL
+      return fetch(url.toString(), {
+        headers: request.headers
+      });
+    }
+  }
+
+  // Continue with the normal request
+  return next();
+}

--- a/handbook/.vitepress/config.mjs
+++ b/handbook/.vitepress/config.mjs
@@ -27,6 +27,11 @@ export default defineConfig({
     hostname: "https://handbook.tuist.io",
   },
   async buildEnd({ outDir }) {
+    // Copy functions directory to dist
+    const functionsSource = path.join(path.dirname(outDir), "functions");
+    const functionsDest = path.join(outDir, "functions");
+    await fs.cp(functionsSource, functionsDest, { recursive: true });
+
     const redirectsPath = path.join(outDir, "_redirects");
     const redirects = `
 /security/information-security-policy /security/information-security-framework/information-security-policy 301

--- a/handbook/.vitepress/functions/_middleware.js
+++ b/handbook/.vitepress/functions/_middleware.js
@@ -1,0 +1,25 @@
+export async function onRequest(context) {
+  const { request, next } = context;
+  const accept = request.headers.get('Accept');
+
+  // Check if the request accepts text/plain
+  if (accept && accept.includes('text/plain')) {
+    const url = new URL(request.url);
+
+    // Skip if the path already ends with .md
+    if (!url.pathname.endsWith('.md')) {
+      // Append .md to the pathname
+      url.pathname = url.pathname.endsWith('/')
+        ? `${url.pathname}index.md`
+        : `${url.pathname}.md`;
+
+      // Fetch the modified URL
+      return fetch(url.toString(), {
+        headers: request.headers
+      });
+    }
+  }
+
+  // Continue with the normal request
+  return next();
+}


### PR DESCRIPTION
This PR adds Cloudflare Pages middleware functions to the handbook and docs sites that redirect requests with `Accept: text/plain` header to markdown source files.

## Changes
- Added `_middleware.js` to both `handbook/.vitepress/functions/` and `docs/.vitepress/functions/`
- Updated VitePress build configs to copy functions directory to dist during build
- Middleware appends `.md` to paths (or `index.md` for trailing slashes) when `Accept: text/plain` header is present

## Benefits
- Enables CLI tools and LLM clients to fetch markdown source directly
- Automatically deployed with the sites via Cloudflare Pages