### PR TITLE
fix(cli): path to the PackageDescription in projects generated by tuist edit

### DIFF
--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -262,7 +262,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
                         "-D", "TUIST",
                     ]),
                     "SWIFT_INCLUDE_PATHS": .array([
-                        "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
+                        "$(DT_TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
                     ]),
                 ],
                 uniquingKeysWith: {

--- a/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -221,7 +221,7 @@ struct ProjectEditorMapperTests {
                         "-D", "TUIST",
                     ]),
                     "SWIFT_INCLUDE_PATHS": .array([
-                        "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
+                        "$(DT_TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI",
                     ]),
                     "SWIFT_VERSION": "5.0.0",
                 ],


### PR DESCRIPTION
Metal in Xcode 26 is installed as an additional toolchain. Unfortunately, for whatever reason, Xcode's `TOOLCHAIN_DIR` variable in build settings now resolves to the Metal toolchain instead of the Swift toolchain when Metal toolchain is installed on your machine.

The `DT_TOOLCHAIN_DIR`, however, seems to still point to the Swift toolchain, regardless of whether you have Metal toolchain locally or not.