### PR TITLE
feat(cli): Make implicit import detection work with buildable folders

### DIFF
--- a/cli/Sources/TuistKit/Services/TargetImportsScanner.swift
+++ b/cli/Sources/TuistKit/Services/TargetImportsScanner.swift
@@ -21,7 +21,8 @@ final class TargetImportsScanner: TargetImportsScanning {
     }
 
     func imports(for target: XcodeGraph.Target) async throws -> Set<String> {
-        var filesToScan = target.sources.map(\.path)
+        var filesToScan = target.sources.map(\.path) + target.buildableFolders.flatMap(\.resolvedFiles).map(\.path)
+            .filter { Target.validSourceExtensions.contains($0.extension ?? "") }
         if let headers = target.headers {
             filesToScan.append(contentsOf: headers.private)
             filesToScan.append(contentsOf: headers.public)

--- a/cli/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
+++ b/cli/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
@@ -55,6 +55,58 @@ struct TargetImportsScannerTests {
         }
     }
 
+    @Test func imports_in_buildable_folder_sources() async throws {
+        // Given
+        try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+            let targetPath = temporaryDirectory.appending(components: "FirstTarget", "Sources")
+
+            let targetFirstFile = targetPath.appending(component: "FirstFile.swift")
+            let targetSecondFile = targetPath.appending(component: "SecondFile.swift")
+
+            try await fileSystem.makeDirectory(at: targetPath)
+
+            try await fileSystem.writeText(
+                """
+                import SecondTarget
+                import A
+
+                let a = 5
+                """,
+                at: targetFirstFile
+            )
+
+            try await fileSystem.writeText(
+                """
+                @testable import ThirdTarget
+
+                func main() { }
+                """,
+                at: targetSecondFile
+            )
+
+            let target = Target.test(
+                name: "FirstTarget",
+                buildableFolders: [
+                    BuildableFolder(
+                        path: "/Sources",
+                        exceptions: [],
+                        resolvedFiles: [
+                            BuildableFolderFile(path: targetFirstFile, compilerFlags: nil),
+                            BuildableFolderFile(path: targetSecondFile, compilerFlags: nil),
+                        ]
+                    ),
+                ]
+            )
+
+            // When
+            let result = try await TargetImportsScanner()
+                .imports(for: target)
+
+            // Then
+            #expect(result == ["SecondTarget", "ThirdTarget", "A"])
+        }
+    }
+
     @Test func imports_when_filesAreAbsent() async throws {
         try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
             // Given


### PR DESCRIPTION
The logic assumed `Target.sources` is the only source of truth for the sources that belong to a target. This is no longer true, so I'm fixing it.