### PR TITLE
chore(server): Create the command_events table on ClickHouse when running the migration in on-premise environments

### DIFF
--- a/server/priv/ingest_repo/migrations/20250702083710_create_command_events_clickhouse.exs
+++ b/server/priv/ingest_repo/migrations/20250702083710_create_command_events_clickhouse.exs
@@ -3,7 +3,8 @@ defmodule Tuist.ClickHouseRepo.Migrations.CreateCommandEventsClickhouse do
 
   def up do
     # In production, these are created by Clickhouse Pipes.
-    if Tuist.Environment.dev?() || Tuist.Environment.test?() do
+    if Tuist.Environment.dev?() || Tuist.Environment.test?() ||
+         not Tuist.Environment.tuist_hosted?() do
       # excellent_migrations:safety-assured-for-next-line raw_sql_executed
       execute """
        CREATE TABLE command_events


### PR DESCRIPTION
I'm adjusting the migration that creates the command_events table in ClickHouse to create it in on-premise environments. If they are moving from a Postgres setup, this means they'll lose those events. If they want to keep them, the data migration is a bit more involved.

To force re-running that migration, the on-premise instance will have to delete the following row:

```sql
DELETE FROM schema_migrations WHERE version = '20250702083710';
```