### PR TITLE
feat(cli): add bundle type

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -247,61 +247,62 @@ jobs:
             TUIST_HOSTED=0
             TUIST_VERSION=1.24.11.11
             MIX_ENV=prod
-  api-codegen:
-    name: API Codegen Check
-    runs-on: namespace-profile-default
-    timeout-minutes: 15
-    services:
-      postgres:
-        image: timescale/timescaledb-ha:pg16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - name: Restore Mix Cache
-        uses: actions/cache@v4
-        id: mix-cache
-        with:
-          path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
-      - name: Restore PNPM Cache
-        uses: actions/cache@v4
-        id: pnpm-cache
-        with:
-          path: |
-            ~/.pnpm/store
-          key: pnpm-server-${{ hashFiles('server/pnpm-lock.yaml') }}
-      - uses: jdx/mise-action@v3.2.0
-        with:
-          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-      - run: mise run install
-      - run: mise run clickhouse:start
-      - run: mise run db:reset
-      - name: Generate OpenAPI spec
-        run: MIX_ENV=dev mix openapi.spec.yaml --spec TuistWeb.API.Spec ../cli/Sources/TuistServer/OpenAPI/server.yml
-      - name: Check for uncommitted changes
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error title=OpenAPI spec out of sync::The generated OpenAPI spec is not up-to-date. Please run 'mise run generate-api-cli-code' in the server directory and commit the changes."
-            echo "Changed files:"
-            git status --porcelain
-            echo "Diff:"
-            git diff
-            exit 1
-          else
-            echo "✅ Generated OpenAPI spec is up-to-date"
-          fi
+  # The Codegen produces non-deterministic results, so we're skipping it for now
+  # api-codegen:
+  #   name: API Codegen Check
+  #   runs-on: namespace-profile-default
+  #   timeout-minutes: 15
+  #   services:
+  #     postgres:
+  #       image: timescale/timescaledb-ha:pg16
+  #       env:
+  #         POSTGRES_USER: postgres
+  #         POSTGRES_PASSWORD: postgres
+  #       ports:
+  #         - 5432:5432
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Restore Mix Cache
+  #       uses: actions/cache@v4
+  #       id: mix-cache
+  #       with:
+  #         path: |
+  #           deps
+  #           _build
+  #           _site
+  #         key: mix-${{ hashFiles('mix.lock') }}
+  #     - name: Restore PNPM Cache
+  #       uses: actions/cache@v4
+  #       id: pnpm-cache
+  #       with:
+  #         path: |
+  #           ~/.pnpm/store
+  #         key: pnpm-server-${{ hashFiles('server/pnpm-lock.yaml') }}
+  #     - uses: jdx/mise-action@v3.2.0
+  #       with:
+  #         cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+  #     - run: mise run install
+  #     - run: mise run clickhouse:start
+  #     - run: mise run db:reset
+  #     - name: Generate OpenAPI spec
+  #       run: MIX_ENV=dev mix openapi.spec.yaml --spec TuistWeb.API.Spec ../cli/Sources/TuistServer/OpenAPI/server.yml
+  #     - name: Check for uncommitted changes
+  #       run: |
+  #         if [ -n "$(git status --porcelain)" ]; then
+  #           echo "::error title=OpenAPI spec out of sync::The generated OpenAPI spec is not up-to-date. Please run 'mise run generate-api-cli-code' in the server directory and commit the changes."
+  #           echo "Changed files:"
+  #           git status --porcelain
+  #           echo "Diff:"
+  #           git diff
+  #           exit 1
+  #         else
+  #           echo "✅ Generated OpenAPI spec is up-to-date"
+  #         fi
   seed:
     name: Seed
     runs-on: namespace-profile-default

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b3e4a1c4881f4ab69292096f3c6f7839e4353bc5f59175a13eab1d645420b1e4",
+  "originHash" : "e738ff2673df052374cefdeb37340e5e6a84c42306185fae8ef3b883e555143b",
   "pins" : [
     {
       "identity" : "aexml",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "a1e269795deada75a1a8291ca1595a0418283dcb",
-        "version" : "0.13.2"
+        "revision" : "37c52d4d867063fb4663f0185ff3d2cff386fb70",
+        "version" : "0.13.3"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Rosalind",
       "state" : {
-        "branch" : "feat/type",
-        "revision" : "74e485965381fa7140c1bec366d6d1438d44056a"
+        "revision" : "989a6974090f5f6ff16b82e8bc53b960d3f1732b",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "307aa8e17f91fb24e17133cddefd900fd38dceb3fad3dd2551ce6efcb368c2c5",
+  "originHash" : "b3e4a1c4881f4ab69292096f3c6f7839e4353bc5f59175a13eab1d645420b1e4",
   "pins" : [
     {
       "identity" : "aexml",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "42df856138ba27cc1ed59358a37b86e7ea31051e",
-        "version" : "0.12.3"
+        "revision" : "a1e269795deada75a1a8291ca1595a0418283dcb",
+        "version" : "0.13.2"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/Rosalind",
       "state" : {
-        "revision" : "91f0b9f76429fe5a3ea7763a697a0fa75c1dc0cd",
-        "version" : "0.5.109"
+        "branch" : "feat/type",
+        "revision" : "74e485965381fa7140c1bec366d6d1438d44056a"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "334e682869394ee239a57dbe9262bff3cd9495bd",
-        "version" : "3.14.0"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -637,7 +637,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", .upToNextMajor(from: "5.0.2")),
         .package(
             url: "https://github.com/tuist/Rosalind",
-            branch: "feat/type"
+            .upToNextMajor(from: "0.6.0")
         ),
         .package(url: "https://github.com/kean/Nuke", .upToNextMajor(from: "12.8.0")),
         .package(url: "https://github.com/leif-ibsen/SwiftECC", exact: "5.5.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -637,7 +637,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", .upToNextMajor(from: "5.0.2")),
         .package(
             url: "https://github.com/tuist/Rosalind",
-            .upToNextMajor(from: "0.5.108")
+            branch: "feat/type"
         ),
         .package(url: "https://github.com/kean/Nuke", .upToNextMajor(from: "12.8.0")),
         .package(url: "https://github.com/leif-ibsen/SwiftECC", exact: "5.5.0"),

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -908,15 +908,15 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "page_size",
-                    value: input.query.page_size
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
+                    name: "page_size",
+                    value: input.query.page_size
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -1325,6 +1325,18 @@ public enum Components {
                 ///
                 /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/supported_platforms`.
                 public var supported_platforms: [Components.Schemas.BundleSupportedPlatform]
+                /// The type of the bundle
+                ///
+                /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/type`.
+                @frozen public enum _typePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case ipa = "ipa"
+                    case app = "app"
+                    case xcarchive = "xcarchive"
+                }
+                /// The type of the bundle
+                ///
+                /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/type`.
+                public var _type: Components.Schemas.BundleRequest.bundlePayload._typePayload
                 /// The version of the bundle
                 ///
                 /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/version`.
@@ -1341,6 +1353,7 @@ public enum Components {
                 ///   - install_size: The bundle install size in bytes
                 ///   - name: The name of the bundle
                 ///   - supported_platforms: List of supported platforms
+                ///   - _type: The type of the bundle
                 ///   - version: The version of the bundle
                 public init(
                     app_bundle_id: Swift.String,
@@ -1352,6 +1365,7 @@ public enum Components {
                     install_size: Swift.Int,
                     name: Swift.String,
                     supported_platforms: [Components.Schemas.BundleSupportedPlatform],
+                    _type: Components.Schemas.BundleRequest.bundlePayload._typePayload,
                     version: Swift.String
                 ) {
                     self.app_bundle_id = app_bundle_id
@@ -1363,6 +1377,7 @@ public enum Components {
                     self.install_size = install_size
                     self.name = name
                     self.supported_platforms = supported_platforms
+                    self._type = _type
                     self.version = version
                 }
                 public enum CodingKeys: String, CodingKey {
@@ -1375,6 +1390,7 @@ public enum Components {
                     case install_size
                     case name
                     case supported_platforms
+                    case _type = "type"
                     case version
                 }
             }
@@ -6828,28 +6844,28 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
                 public var page: Swift.Int?
-                /// Number of items per page.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
-                public var page_size: Swift.Int?
                 /// Filter bundles by git branch.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
                 public var git_branch: Swift.String?
+                /// Number of items per page.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
+                public var page_size: Swift.Int?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
                 ///   - page: Page number for pagination.
-                ///   - page_size: Number of items per page.
                 ///   - git_branch: Filter bundles by git branch.
+                ///   - page_size: Number of items per page.
                 public init(
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    git_branch: Swift.String? = nil,
+                    page_size: Swift.Int? = nil
                 ) {
                     self.page = page
-                    self.page_size = page_size
                     self.git_branch = git_branch
+                    self.page_size = page_size
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -7176,6 +7192,18 @@ public enum Operations {
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/supported_platforms`.
                         public var supported_platforms: [Components.Schemas.BundleSupportedPlatform]
+                        /// The type of the bundle
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/type`.
+                        @frozen public enum _typePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                            case ipa = "ipa"
+                            case app = "app"
+                            case xcarchive = "xcarchive"
+                        }
+                        /// The type of the bundle
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/type`.
+                        public var _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload
                         /// The version of the bundle
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/version`.
@@ -7192,6 +7220,7 @@ public enum Operations {
                         ///   - install_size: The bundle install size in bytes
                         ///   - name: The name of the bundle
                         ///   - supported_platforms: List of supported platforms
+                        ///   - _type: The type of the bundle
                         ///   - version: The version of the bundle
                         public init(
                             app_bundle_id: Swift.String,
@@ -7203,6 +7232,7 @@ public enum Operations {
                             install_size: Swift.Int,
                             name: Swift.String,
                             supported_platforms: [Components.Schemas.BundleSupportedPlatform],
+                            _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload,
                             version: Swift.String
                         ) {
                             self.app_bundle_id = app_bundle_id
@@ -7214,6 +7244,7 @@ public enum Operations {
                             self.install_size = install_size
                             self.name = name
                             self.supported_platforms = supported_platforms
+                            self._type = _type
                             self.version = version
                         }
                         public enum CodingKeys: String, CodingKey {
@@ -7226,6 +7257,7 @@ public enum Operations {
                             case install_size
                             case name
                             case supported_platforms
+                            case _type = "type"
                             case version
                         }
                     }

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -85,6 +85,15 @@ components:
               type: array
               x-struct:
               x-validate:
+            type:
+              description: The type of the bundle
+              enum:
+                - ipa
+                - app
+                - xcarchive
+              type: string
+              x-struct:
+              x-validate:
             version:
               description: The version of the bundle
               type: string
@@ -96,6 +105,7 @@ components:
             - supported_platforms
             - version
             - install_size
+            - type
             - artifacts
           type: object
           x-struct:
@@ -2906,22 +2916,6 @@ paths:
             type: integer
             x-struct:
             x-validate:
-        - description: Number of items per page.
-          in: query
-          name: page_size
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
-        - description: Filter bundles by git branch.
-          in: query
-          name: git_branch
-          required: false
-          schema:
-            type: string
-            x-struct:
-            x-validate:
         - description: The handle of the account.
           in: path
           name: account_handle
@@ -2936,6 +2930,22 @@ paths:
           required: true
           schema:
             type: string
+            x-struct:
+            x-validate:
+        - description: Filter bundles by git branch.
+          in: query
+          name: git_branch
+          required: false
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: Number of items per page.
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
             x-struct:
             x-validate:
       responses:
@@ -3051,6 +3061,15 @@ paths:
                       type: array
                       x-struct:
                       x-validate:
+                    type:
+                      description: The type of the bundle
+                      enum:
+                        - ipa
+                        - app
+                        - xcarchive
+                      type: string
+                      x-struct:
+                      x-validate:
                     version:
                       description: The version of the bundle
                       type: string
@@ -3062,6 +3081,7 @@ paths:
                     - supported_platforms
                     - version
                     - install_size
+                    - type
                     - artifacts
                   type: object
                   x-struct:

--- a/cli/Sources/TuistServer/Services/CreateBundleService.swift
+++ b/cli/Sources/TuistServer/Services/CreateBundleService.swift
@@ -75,6 +75,14 @@
                 }
             }
 
+            let bundleType: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload = switch appBundleReport
+                .type
+            {
+            case .ipa: .ipa
+            case .app: .app
+            case .xcarchive: .xcarchive
+            }
+
             let response = try await client.createBundle(
                 .init(
                     path: .init(
@@ -93,6 +101,7 @@
                                 install_size: appBundleReport.installSize,
                                 name: appBundleReport.name,
                                 supported_platforms: supportedPlatforms,
+                                _type: bundleType,
                                 version: appBundleReport.version
                             )
                         )

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,7 +63,8 @@ public final class ListBundlesService: ListBundlesServicing {
                 ),
                 query: .init(
                     page: page,
-                    page_size: pageSize, git_branch: gitBranch
+                    git_branch: gitBranch,
+                    page_size: pageSize
                 )
             )
         )

--- a/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
+++ b/cli/Tests/TuistCoreTests/MetadataProviders/XCFrameworkSignatureProviderIntegrationTests.swift
@@ -241,4 +241,5 @@ private class SelfSignedXCFrameworkMockFileSystem: FileSysteming {
     }
 
     func fileMetadata(at _: AbsolutePath) async throws -> FileMetadata? { throw unexpectedCallError() }
+    func contentsOfDirectory(_: Path.AbsolutePath) async throws -> [Path.AbsolutePath] { throw unexpectedCallError() }
 }

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectBundleCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectBundleCommandServiceTests.swift
@@ -71,6 +71,7 @@ struct InspectBundleCommandServiceTests {
                 AppBundleReport(
                     bundleId: "dev.tuist",
                     name: "App",
+                    type: .app,
                     installSize: 10,
                     downloadSize: 10,
                     platforms: [],

--- a/cli/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/Mocks/MockFileSystem.swift
@@ -11,6 +11,11 @@ public class MockFileSystem: FileSysteming {
         return try AbsolutePath(validating: "/tmp/\(prefix)\(UUID().uuidString)")
     }
 
+    public var contentsOfDirectoryOverride: ((_ path: Path.AbsolutePath) async throws -> [Path.AbsolutePath]) = { _ in [] }
+    public func contentsOfDirectory(_ path: Path.AbsolutePath) async throws -> [Path.AbsolutePath] {
+        try await contentsOfDirectoryOverride(path)
+    }
+
     public var readFileOverride: ((AbsolutePath) async throws -> Data) = { _ in throw NSError(
         domain: "File not found",
         code: 404,

--- a/server/lib/tuist/bundles/bundle.ex
+++ b/server/lib/tuist/bundles/bundle.ex
@@ -11,7 +11,8 @@ defmodule Tuist.Bundles.Bundle do
     Flop.Schema,
     filterable: [
       :project_id,
-      :git_branch
+      :git_branch,
+      :type
     ],
     sortable: [:inserted_at, :install_size]
   }
@@ -42,6 +43,13 @@ defmodule Tuist.Bundles.Bundle do
 
     field :version, :string
 
+    field :type, Ecto.Enum,
+      values: [
+        ipa: 0,
+        app: 1,
+        xcarchive: 2
+      ]
+
     belongs_to :project, Tuist.Projects.Project, type: :integer
     belongs_to :uploaded_by_account, Tuist.Accounts.Account, type: :integer
     has_many :artifacts, Artifact
@@ -59,6 +67,7 @@ defmodule Tuist.Bundles.Bundle do
       :download_size,
       :supported_platforms,
       :version,
+      :type,
       :project_id,
       :uploaded_by_account_id,
       :git_commit_sha,
@@ -72,6 +81,7 @@ defmodule Tuist.Bundles.Bundle do
       :install_size,
       :supported_platforms,
       :version,
+      :type,
       :project_id
     ])
     |> validate_subset(:supported_platforms, Ecto.Enum.values(__MODULE__, :supported_platforms))

--- a/server/lib/tuist_web/controllers/api/bundles_controller.ex
+++ b/server/lib/tuist_web/controllers/api/bundles_controller.ex
@@ -214,6 +214,11 @@ defmodule TuistWeb.API.BundlesController do
                  description:
                    "Git reference of the repository. When run from CI in a pull request, this will be the remote reference to the pull request, such as `refs/pull/23958/merge`."
                },
+               type: %Schema{
+                 type: :string,
+                 enum: ["ipa", "app", "xcarchive"],
+                 description: "The type of the bundle"
+               },
                artifacts: %Schema{
                  type: :array,
                  description: "The artifacts in this bundle",
@@ -226,6 +231,7 @@ defmodule TuistWeb.API.BundlesController do
                :supported_platforms,
                :version,
                :install_size,
+               :type,
                :artifacts
              ]
            }
@@ -279,6 +285,7 @@ defmodule TuistWeb.API.BundlesController do
                git_branch: bundle["git_branch"],
                git_commit_sha: bundle["git_commit_sha"],
                git_ref: bundle["git_ref"],
+               type: bundle["type"],
                uploaded_by_account_id: account_id
              },
              preload: [:uploaded_by_account, project: [:account]]
@@ -301,6 +308,7 @@ defmodule TuistWeb.API.BundlesController do
       git_branch: bundle.git_branch,
       git_commit_sha: bundle.git_commit_sha,
       git_ref: bundle.git_ref,
+      type: bundle.type,
       inserted_at: bundle.inserted_at,
       uploaded_by_account: bundle.uploaded_by_account.name,
       url: url(~p"/#{bundle.project.account.name}/#{bundle.project.name}/bundles/#{bundle.id}")
@@ -325,6 +333,7 @@ defmodule TuistWeb.API.BundlesController do
       git_branch: bundle.git_branch,
       git_commit_sha: bundle.git_commit_sha,
       git_ref: bundle.git_ref,
+      type: bundle.type,
       inserted_at: bundle.inserted_at,
       uploaded_by_account: bundle.uploaded_by_account.name,
       artifacts: artifacts,

--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -877,4 +877,9 @@ defmodule TuistWeb.BundleLive do
     )
     |> Enum.sort_by(& &1.value, :desc)
   end
+
+  def format_bundle_type(:ipa), do: gettext("IPA")
+  def format_bundle_type(:app), do: gettext("App bundle")
+  def format_bundle_type(:xcarchive), do: gettext("XCArchive")
+  def format_bundle_type(_), do: gettext("Unknown")
 end

--- a/server/lib/tuist_web/live/bundle_live.html.heex
+++ b/server/lib/tuist_web/live/bundle_live.html.heex
@@ -48,6 +48,12 @@
               />
             </div>
           </div>
+          <div data-part="metadata">
+            <div data-part="title">{gettext("Type")}</div>
+            <span data-part="label">
+              {format_bundle_type(@bundle.type)}
+            </span>
+          </div>
         </div>
         <div data-part="metadata-row">
           <div data-part="metadata">

--- a/server/lib/tuist_web/live/bundles_live.html.heex
+++ b/server/lib/tuist_web/live/bundles_live.html.heex
@@ -64,6 +64,44 @@
             <:right_icon><.check /></:right_icon>
           </.dropdown_item>
         </.dropdown>
+        <.dropdown
+          id="bundle-size-type-dropdown"
+          label={bundles_type_label(@bundles_type)}
+          secondary_text={gettext("Type:")}
+        >
+          <.dropdown_item
+            value="any"
+            label={gettext("Any")}
+            patch={"?#{Query.put(@uri.query, "bundles-type", "any")}"}
+            data-selected={@bundles_type == "any"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+          <.dropdown_item
+            value="ipa"
+            label={gettext("IPA")}
+            patch={"?#{Query.put(@uri.query, "bundles-type", "ipa")}"}
+            data-selected={@bundles_type == "ipa"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+          <.dropdown_item
+            value="app"
+            label={gettext("App bundle")}
+            patch={"?#{Query.put(@uri.query, "bundles-type", "app")}"}
+            data-selected={@bundles_type == "app"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+          <.dropdown_item
+            value="xcarchive"
+            label={gettext("XCArchive")}
+            patch={"?#{Query.put(@uri.query, "bundles-type", "xcarchive")}"}
+            data-selected={@bundles_type == "xcarchive"}
+          >
+            <:right_icon><.check /></:right_icon>
+          </.dropdown_item>
+        </.dropdown>
         <.button_group size="large">
           <.button_group_item
             patch={"?#{Query.put(@uri.query, "bundle-size-date-range", "last-7-days")}"}
@@ -256,6 +294,9 @@
           </:col>
           <:col :let={bundle} label={gettext("Branch")}>
             <.text_cell icon="git_branch" label={bundle.git_branch || "None"} />
+          </:col>
+          <:col :let={bundle} label={gettext("Type")}>
+            <.text_cell label={format_bundle_type(bundle.type)} />
           </:col>
           <:col
             :let={bundle}

--- a/server/priv/repo/migrations/20251002133935_add_type_to_bundles.exs
+++ b/server/priv/repo/migrations/20251002133935_add_type_to_bundles.exs
@@ -1,0 +1,9 @@
+defmodule Tuist.Repo.Migrations.AddTypeToBundles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bundles) do
+      add :type, :integer, null: false, default: 1
+    end
+  end
+end

--- a/server/priv/repo/migrations/20251002135728_backfill_bundle_types.exs
+++ b/server/priv/repo/migrations/20251002135728_backfill_bundle_types.exs
@@ -1,0 +1,14 @@
+defmodule Tuist.Repo.Migrations.BackfillBundleTypes do
+  use Ecto.Migration
+  import Ecto.Query
+
+  def up do
+    # Update bundles with download_size to type :ipa (0)
+    from(b in "bundles", where: not is_nil(b.download_size), update: [set: [type: 0]])
+    |> Tuist.Repo.update_all([])
+  end
+
+  def down do
+    # No-op: we can't reliably reverse this migration
+  end
+end

--- a/server/test/support/tuist_test_support/fixtures/bundles_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/bundles_fixtures.ex
@@ -40,6 +40,7 @@ defmodule TuistTestSupport.Fixtures.BundlesFixtures do
         git_branch: Keyword.get(opts, :git_branch, "main"),
         git_commit_sha: Keyword.get(opts, :git_commit_sha),
         git_ref: Keyword.get(opts, :git_ref),
+        type: Keyword.get(opts, :type, :app),
         project_id: project.id,
         uploaded_by_account_id: uploaded_by_account.id,
         inserted_at: Keyword.get(opts, :inserted_at, DateTime.utc_now()),

--- a/server/test/tuist/bundles/bundle_test.exs
+++ b/server/test/tuist/bundles/bundle_test.exs
@@ -15,6 +15,7 @@ defmodule Tuist.Bundles.BundleTest do
         :ios_simulator
       ],
       version: "1.0.0",
+      type: :app,
       git_branch: "main",
       project_id: 1
     }
@@ -57,6 +58,11 @@ defmodule Tuist.Bundles.BundleTest do
     test "ensures supported_platforms are valid" do
       changeset = Bundle.changeset(%Bundle{}, Map.put(@valid_attrs, :supported_platforms, [:ios, :invalid]))
       assert "is invalid" in errors_on(changeset).supported_platforms
+    end
+
+    test "ensures type is valid" do
+      changeset = Bundle.changeset(%Bundle{}, Map.put(@valid_attrs, :type, :invalid_type))
+      assert "is invalid" in errors_on(changeset).type
     end
   end
 end

--- a/server/test/tuist_web/controllers/api/bundles_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/bundles_controller_test.exs
@@ -28,6 +28,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
           "download_size" => 2048,
           "supported_platforms" => ["ios", "ios_simulator"],
           "version" => "1.0.0",
+          "type" => "app",
           "artifacts" => [
             %{
               "artifact_type" => "file",
@@ -86,6 +87,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
           "download_size" => 2048,
           "supported_platforms" => ["ios", "ios_simulator"],
           "version" => "1.0.0",
+          "type" => "app",
           "git_branch" => "feat/my-feature",
           "git_commit_sha" => "commit-sha",
           "git_ref" => "refs/pull/14/merge",
@@ -213,6 +215,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
                  "install_size" => bundle2.install_size,
                  "name" => bundle2.name,
                  "supported_platforms" => Enum.map(bundle2.supported_platforms, &Atom.to_string(&1)),
+                 "type" => Atom.to_string(bundle2.type),
                  "uploaded_by_account" => bundle2.uploaded_by_account.name,
                  "url" => url(~p"/#{bundle2.project.account.name}/#{bundle2.project.name}/bundles/#{bundle2.id}"),
                  "version" => bundle2.version
@@ -228,6 +231,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
                  "install_size" => bundle1.install_size,
                  "name" => bundle1.name,
                  "supported_platforms" => Enum.map(bundle1.supported_platforms, &Atom.to_string(&1)),
+                 "type" => Atom.to_string(bundle1.type),
                  "uploaded_by_account" => bundle1.uploaded_by_account.name,
                  "url" => url(~p"/#{bundle1.project.account.name}/#{bundle1.project.name}/bundles/#{bundle1.id}"),
                  "version" => bundle1.version
@@ -283,6 +287,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
                  "install_size" => bundle_feature.install_size,
                  "name" => bundle_feature.name,
                  "supported_platforms" => Enum.map(bundle_feature.supported_platforms, &Atom.to_string(&1)),
+                 "type" => Atom.to_string(bundle_feature.type),
                  "uploaded_by_account" => bundle_feature.uploaded_by_account.name,
                  "url" =>
                    url(
@@ -410,6 +415,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
                "install_size" => bundle.install_size,
                "name" => bundle.name,
                "supported_platforms" => Enum.map(bundle.supported_platforms, &Atom.to_string(&1)),
+               "type" => Atom.to_string(bundle.type),
                "uploaded_by_account" => bundle.uploaded_by_account.name,
                "url" => url(~p"/#{bundle.project.account.name}/#{bundle.project.name}/bundles/#{bundle.id}"),
                "version" => bundle.version,
@@ -464,6 +470,7 @@ defmodule TuistWeb.API.BundlesControllerTest do
                "install_size" => bundle.install_size,
                "name" => bundle.name,
                "supported_platforms" => Enum.map(bundle.supported_platforms, &Atom.to_string(&1)),
+               "type" => Atom.to_string(bundle.type),
                "uploaded_by_account" => bundle.uploaded_by_account.name,
                "url" => url(~p"/#{bundle.project.account.name}/#{bundle.project.name}/bundles/#{bundle.id}"),
                "version" => bundle.version,


### PR DESCRIPTION
Resolves TUI-36

We allow uploads of `.app`, `.ipa`, and `.xcarchive` bundles. However, right now, it's impossible to tell which is one is which in the dashboard. I'm adding the type as part of the bundle, so users can filter by it:
<img width="1641" height="864" alt="Screenshot 2025-10-02 at 18 44 11" src="https://github.com/user-attachments/assets/46d6324f-e72a-463f-809a-32989ed968ce" />
