### PR TITLE
feat(cli): Support linking static libraries from dynamic ones when the dynamic one has no dependent targets

### DIFF
--- a/cli/Fixtures/generated_macos_dylib_linking_static_lib/Project.swift
+++ b/cli/Fixtures/generated_macos_dylib_linking_static_lib/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(
+    name: "DynamicLibrary",
+    targets: [
+        .target(
+            name: "DynamicLibrary",
+            destinations: .macOS,
+            product: .dynamicLibrary,
+            bundleId: "dev.tuist.DynamicLibrary",
+            buildableFolders: [
+                .folder("Sources/DynamicLibrary"),
+            ],
+            dependencies: [
+                .target(name: "StaticLibrary"),
+            ]
+        ),
+        .target(
+            name: "StaticLibrary",
+            destinations: .macOS,
+            product: .dynamicLibrary,
+            bundleId: "dev.tuist.StaticLibrary",
+            buildableFolders: [
+                .folder("Sources/StaticLibrary"),
+            ],
+            dependencies: []
+        ),
+    ]
+)

--- a/cli/Fixtures/generated_macos_dylib_linking_static_lib/Sources/DynamicLibrary/Dynamic.swift
+++ b/cli/Fixtures/generated_macos_dylib_linking_static_lib/Sources/DynamicLibrary/Dynamic.swift
@@ -1,0 +1,9 @@
+import StaticLibrary
+
+public struct Dynamic {
+    let `static` = Static()
+
+    func exercise() {
+        `static`.exercise()
+    }
+}

--- a/cli/Fixtures/generated_macos_dylib_linking_static_lib/Sources/StaticLibrary/Static.swift
+++ b/cli/Fixtures/generated_macos_dylib_linking_static_lib/Sources/StaticLibrary/Static.swift
@@ -1,0 +1,4 @@
+public struct Static {
+    public init() {}
+    public func exercise() {}
+}

--- a/cli/Fixtures/generated_macos_dylib_linking_static_lib/Tuist.swift
+++ b/cli/Fixtures/generated_macos_dylib_linking_static_lib/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist()

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -429,6 +429,10 @@ public class GraphTraverser: GraphTraversing {
         try linkableDependencies(path: path, name: name, shouldExcludeHostAppDependencies: true)
     }
 
+    private func hasDependentTargets(_ targetGraphDependency: GraphDependency) -> Bool {
+        dependencies.flatMap(\.value).contains(targetGraphDependency)
+    }
+
     // swiftlint:disable:next function_body_length
     public func linkableDependencies(
         path: Path.AbsolutePath,
@@ -441,7 +445,7 @@ public class GraphTraverser: GraphTraversing {
         let targetGraphDependency = GraphDependency.target(name: name, path: path)
 
         // System libraries and frameworks
-        if target.target.canLinkStaticProducts() {
+        if target.target.canLinkStaticProducts() || !hasDependentTargets(targetGraphDependency) {
             let transitiveSystemLibraries = transitiveStaticDependencies(
                 from: targetGraphDependency
             )

--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -607,6 +607,7 @@ public class GraphLinter: GraphLinting {
         ],
         LintableTarget(platform: .macOS, product: .dynamicLibrary): [
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
+            LintableTarget(platform: .macOS, product: .staticLibrary),
             LintableTarget(platform: .macOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .macro),
         ],

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -8,6 +8,17 @@ import XcodeProj
 import XCTest
 
 struct GeneratorAcceptanceTests {
+    @Test(.withFixture("generated_macos_dylib_linking_static_lib")) func generated_macos_dylib_linking_static_lib() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+
+        // When
+        try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
+
+        // Then
+        try await TuistTest.run(BuildCommand.self, ["DynamicLibrary", "--path", fixtureDirectory.pathString])
+    }
+
     @Test(.withFixture("app_with_framework_and_tests")) func app_with_framework_and_tests() async throws {
         // Given
         let fixtureDirectory = try #require(TuistTest.fixtureDirectory)


### PR DESCRIPTION
Needed for: https://github.com/tuist/tuist/pull/8366

As part of [this work](https://github.com/tuist/tuist/pull/8366) where we need to export the CAS plugin as a dynamic library, I noticed Tuist flagged any static dependencies as invalid. Then I modified it to be a supported linking, but the build phase didn't get added. It turns out that our logic that gets the linkable dependencies checks if the product can link static libraries. This is done to ensure we don't end up with duplicated symbols, but I believe in cases like this one, where the dynamic library doesn't have dependent targets, is totally fine and it should indeed do the linking.

This PR checks if the dynamic library has dependent target, and if it does not, it links the static libraries.