### PR TITLE
fix(cli): Ensure buildableFolder resources are handled with project-defined resourceSynthesizers.

### DIFF
--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -415,7 +415,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                         BuildableFolderFile(path: otfFont, compilerFlags: nil),
                         BuildableFolderFile(path: ttcFont, compilerFlags: nil),
                         BuildableFolderFile(path: lottieFile, compilerFlags: nil),
-                    ])
+                    ]),
                 ]
             )
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -332,6 +332,307 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         }
     }
 
+    func testMap_whenUseBuildableFolders() async throws {
+        try await withMockedDependencies {
+            // Given
+            var templateStrings: [String] = []
+            var parserOptionsStrings: [ResourceSynthesizer.Parser: String] = [:]
+            synthesizedResourceInterfacesGenerator.renderStub = { parser, parserOptions, templateString, _, _, paths in
+                templateStrings.append(templateString)
+                parserOptionsStrings[parser] = parserOptions.map { "\($0.key): \($0.value.value)" }.sorted()
+                    .joined(separator: ", ")
+                let content = paths.map { $0.components.suffix(2).joined(separator: "/") }.joined(separator: ", ")
+                return content
+            }
+
+            let projectPath = try temporaryPath()
+            let targetAPath = projectPath.appending(component: "TargetA")
+            let aAssets = targetAPath.appending(component: "a.xcassets")
+            let aAsset = aAssets.appending(component: "asset")
+            let frenchStrings = targetAPath.appending(components: "fr.lproj", "aStrings.strings")
+            let frenchStringsDict = targetAPath.appending(components: "fr.lproj", "aStrings.stringsdict")
+            let englishStrings = targetAPath.appending(components: "en.lproj", "aStrings.strings")
+            let englishStringsDict = targetAPath.appending(components: "en.lproj", "aStrings.stringsdict")
+            let environmentPlist = targetAPath.appending(component: "Environment.plist")
+            let emptyPlist = targetAPath.appending(component: "Empty.plist")
+            let ttfFont = targetAPath.appending(component: "ttfFont.ttf")
+            let otfFont = targetAPath.appending(component: "otfFont.otf")
+            let ttcFont = targetAPath.appending(component: "ttcFont.ttc")
+            let lottieFile = targetAPath.appending(component: "LottieAnimation.lottie")
+            let coreDataModelFolder = targetAPath.appending(component: "CoreDataModel.xcdatamodeld")
+            let coreDataModelVersionFile = targetAPath.appending(
+                components: "CoreDataModel.xcdatamodeld",
+                "CoreDataModel.xcdatamodel"
+            )
+
+            try fileHandler.createFolder(aAssets)
+            try fileHandler.touch(aAsset)
+            try fileHandler.touch(frenchStrings)
+            try fileHandler.touch(frenchStringsDict)
+            try fileHandler.touch(englishStrings)
+            try fileHandler.touch(englishStringsDict)
+            try fileHandler.touch(coreDataModelVersionFile)
+            try fileHandler.write("a", path: frenchStrings, atomically: true)
+            try fileHandler.write("a", path: frenchStringsDict, atomically: true)
+            try fileHandler.write("a", path: englishStrings, atomically: true)
+            try fileHandler.write("a", path: englishStringsDict, atomically: true)
+            try fileHandler.touch(emptyPlist)
+            try fileHandler.write("a", path: environmentPlist, atomically: true)
+            try fileHandler.write("a", path: ttfFont, atomically: true)
+            try fileHandler.write("a", path: otfFont, atomically: true)
+            try fileHandler.write("a", path: ttcFont, atomically: true)
+            let lottieTemplatePath = projectPath.appending(component: "Lottie.stencil")
+            try fileHandler.write("lottie template", path: lottieTemplatePath, atomically: true)
+            try fileHandler.write("a", path: lottieFile, atomically: true)
+            let stringsTemplatePath = projectPath.appending(component: "Strings.stencil")
+            try fileHandler.write("strings template", path: stringsTemplatePath, atomically: true)
+            let coreDataTemplatePath = projectPath.appending(component: "CoreData.stencil")
+            try fileHandler.write("core data template", path: coreDataTemplatePath, atomically: true)
+            try fileHandler.createFolder(coreDataModelFolder)
+            try fileHandler.write("a", path: coreDataModelVersionFile, atomically: true)
+
+            let targetA = Target.test(
+                name: "TargetA",
+                coreDataModels: [
+                    CoreDataModel(
+                        path: coreDataModelFolder,
+                        versions: [
+                            coreDataModelVersionFile,
+                        ],
+                        currentVersion: "CoreDataModel"
+                    ),
+                ],
+                buildableFolders: [
+                    .init(path: "/Sources", exceptions: [], resolvedFiles: [
+                        BuildableFolderFile(path: aAssets, compilerFlags: nil),
+                        BuildableFolderFile(path: frenchStrings, compilerFlags: nil),
+                        BuildableFolderFile(path: frenchStringsDict, compilerFlags: nil),
+                        BuildableFolderFile(path: englishStrings, compilerFlags: nil),
+                        BuildableFolderFile(path: englishStringsDict, compilerFlags: nil),
+                        BuildableFolderFile(path: emptyPlist, compilerFlags: nil),
+                        BuildableFolderFile(path: environmentPlist, compilerFlags: nil),
+                        BuildableFolderFile(path: ttfFont, compilerFlags: nil),
+                        BuildableFolderFile(path: otfFont, compilerFlags: nil),
+                        BuildableFolderFile(path: ttcFont, compilerFlags: nil),
+                        BuildableFolderFile(path: lottieFile, compilerFlags: nil),
+                    ])
+                ]
+            )
+
+            let resourceSynthesizers: [ResourceSynthesizer] = [
+                .init(
+                    parser: .assets,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["xcassets"],
+                    template: .defaultTemplate("Assets")
+                ),
+                .init(
+                    parser: .strings,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["strings", "stringsdict"],
+                    template: .file(stringsTemplatePath)
+                ),
+                .init(
+                    parser: .plists,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["plist"],
+                    template: .defaultTemplate("Plists")
+                ),
+                .init(
+                    parser: .fonts,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["otf", "ttc", "ttf", "woff"],
+                    template: .defaultTemplate("Fonts")
+                ),
+                .init(
+                    parser: .json,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["lottie"],
+                    template: .file(lottieTemplatePath)
+                ),
+                .init(
+                    parser: .coreData,
+                    parserOptions: [
+                        "stringValue": "test",
+                        "intValue": 999,
+                        "boolValue": true,
+                        "doubleValue": 1.0,
+                    ],
+                    extensions: ["xcdatamodeld"],
+                    template: .file(coreDataTemplatePath)
+                ),
+            ]
+
+            let project = Project.test(
+                path: projectPath,
+                targets: [
+                    targetA,
+                ],
+                resourceSynthesizers: resourceSynthesizers
+            )
+
+            // When
+            let (mappedProject, sideEffects) = try subject.map(project: project)
+
+            // Then
+            let derivedPath = projectPath
+                .appending(component: Constants.DerivedDirectory.name)
+            let derivedSourcesPath = derivedPath
+                .appending(component: Constants.DerivedDirectory.sources)
+            XCTAssertEqual(
+                sideEffects,
+                [
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistAssets+TargetA.swift"),
+                            contents: "TargetA/a.xcassets".data(using: .utf8)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistStrings+TargetA.swift"),
+                            contents: "en.lproj/aStrings.strings, en.lproj/aStrings.stringsdict"
+                                .data(using: .utf8)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistPlists+TargetA.swift"),
+                            contents: "TargetA/Environment.plist".data(using: .utf8)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistFonts+TargetA.swift"),
+                            contents: "TargetA/otfFont.otf, TargetA/ttcFont.ttc, TargetA/ttfFont.ttf".data(using: .utf8)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistLottie+TargetA.swift"),
+                            contents: "TargetA/LottieAnimation.lottie".data(using: .utf8)
+                        )
+                    ),
+                    .file(
+                        FileDescriptor(
+                            path: derivedSourcesPath.appending(component: "TuistCoreData+TargetA.swift"),
+                            contents: "TargetA/CoreDataModel.xcdatamodeld".data(using: .utf8)
+                        )
+                    ),
+                ]
+            )
+            XCTAssertEqual(
+                mappedProject,
+                Project.test(
+                    path: projectPath,
+                    targets: [
+                        Target.test(
+                            name: targetA.name,
+                            sources: [
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistAssets+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher.hash("TargetA/a.xcassets".data(using: .utf8)!)
+                                ),
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistStrings+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher.hash(
+                                        "en.lproj/aStrings.strings, en.lproj/aStrings.stringsdict".data(using: .utf8)!
+                                    )
+                                ),
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistPlists+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher.hash("TargetA/Environment.plist".data(using: .utf8)!)
+                                ),
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistFonts+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher
+                                        .hash("TargetA/otfFont.otf, TargetA/ttcFont.ttc, TargetA/ttfFont.ttf".data(using: .utf8)!)
+                                ),
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistLottie+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher.hash("TargetA/LottieAnimation.lottie".data(using: .utf8)!)
+                                ),
+                                SourceFile(
+                                    path: derivedSourcesPath
+                                        .appending(component: "TuistCoreData+TargetA.swift"),
+                                    compilerFlags: nil,
+                                    contentHash: try contentHasher.hash("TargetA/CoreDataModel.xcdatamodeld".data(using: .utf8)!)
+                                ),
+                            ],
+                            resources: targetA.resources,
+                            coreDataModels: targetA.coreDataModels
+                        ),
+                    ],
+                    resourceSynthesizers: resourceSynthesizers
+                )
+            )
+            XCTAssertEqual(
+                templateStrings,
+                [
+                    SynthesizedResourceInterfaceTemplates.assetsTemplate,
+                    "strings template",
+                    SynthesizedResourceInterfaceTemplates.plistsTemplate,
+                    SynthesizedResourceInterfaceTemplates.fontsTemplate,
+                    "lottie template",
+                    "core data template",
+                ]
+            )
+            [
+                ResourceSynthesizer.Parser.assets,
+                ResourceSynthesizer.Parser.strings,
+                ResourceSynthesizer.Parser.plists,
+                ResourceSynthesizer.Parser.fonts,
+                ResourceSynthesizer.Parser.json,
+                ResourceSynthesizer.Parser.coreData,
+            ].forEach { parser in
+                XCTAssertEqual(
+                    parserOptionsStrings[parser],
+                    "boolValue: true, doubleValue: 1.0, intValue: 999, stringValue: test"
+                )
+            }
+            XCTAssertPrinterContains(
+                "Skipping synthesizing accessors for \(emptyPlist.pathString) because its contents are empty.",
+                at: .warning,
+                ==
+            )
+        }
+    }
+
     func testMap_whenDisableSynthesizedResourceAccessors() throws {
         // Given
         var templateStrings: [String] = []


### PR DESCRIPTION
### Description
In cases where resources registered via `buildableFolders` were processed by ResourceSynthesizer, only the extensions defined in `Target.validResourceCompatibleFolderExtensions` and `Target.validResourceExtensions` were previously recognized.

This change updates the logic to reference the parent `Project`’s resourceSynthesizers, ensuring that all supported extensions are properly handled.

### How to test locally

You can verify this change by comparing the behavior of `SynthesizedResourceInterfaceProjectMapper` before and after the fix using the `testMap_whenUseBuildableFolders()` test case defined in `SynthesizedResourceInterfaceProjectMapperTests`.