### PR TITLE
docs: document custom build configurations in PackageSettings

### DIFF
--- a/docs/docs/en/guides/features/projects/dependencies.md
+++ b/docs/docs/en/guides/features/projects/dependencies.md
@@ -107,6 +107,25 @@ let package = Package(
 > [!TIP] PACKAGE SETTINGS
 > The `PackageSettings` instance wrapped in a compiler directive allows you to configure how packages are integrated. For example, in the example above it's used to override the default product type used for packages. By default, you shouldn't need it.
 
+> [!IMPORTANT] CUSTOM BUILD CONFIGURATIONS
+> If your project uses custom build configurations (configurations other than the standard `Debug` and `Release`), you must specify them in the `PackageSettings` using `baseSettings`. External dependencies need to know about your project's configurations to build correctly. For example:
+>
+> ```swift
+> #if TUIST
+>     import ProjectDescription
+>
+>     let packageSettings = PackageSettings(
+>         productTypes: [:],
+>         baseSettings: .settings(configurations: [
+>             .debug(name: "Base"),
+>             .release(name: "Production")
+>         ])
+>     )
+> #endif
+> ```
+>
+> See [#8345](https://github.com/tuist/tuist/issues/8345) for more details.
+
 The `Package.swift` file is just an interface to declare external dependencies, nothing else. That's why you don't define any targets or products in the package. Once you have the dependencies defined, you can run the following command to resolve and pull the dependencies into the `Tuist/Dependencies` directory:
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents how to configure `PackageSettings` when using custom build configurations
- Adds important note explaining that external dependencies need to know about non-standard configurations
- Includes code example showing how to specify custom configurations in `baseSettings`
- References issue #8345

## Test plan
- [x] Documentation builds without errors
- [x] Example code is syntactically correct
- [x] Links and references are valid

Fixes #8345

🤖 Generated with [Claude Code](https://claude.com/claude-code)