### PR TITLE
fix(server): name for created by of VCS connection

### DIFF
--- a/server/lib/tuist_web/live/integrations_live.ex
+++ b/server/lib/tuist_web/live/integrations_live.ex
@@ -155,7 +155,7 @@ defmodule TuistWeb.IntegrationsLive do
     else
       gettext("Connected %{time_ago} by %{name}",
         time_ago: time_ago,
-        name: vcs_connection.created_by.name
+        name: vcs_connection.created_by.account.name
       )
     end
   end
@@ -167,7 +167,7 @@ defmodule TuistWeb.IntegrationsLive do
       Tuist.Repo.preload(
         account,
         [
-          projects: [vcs_connection: [:created_by, :project]]
+          projects: [vcs_connection: [created_by: [:account], project: []]]
         ],
         force: force
       )


### PR DESCRIPTION
Resolves: https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/320/samples/timestamp/2025-10-06T11:59:00Z

During refactoring, I changed `:created_by` to be a `User` entity instead of `Account`. But we need to get the name of the account – the fix is to preload it.