### PR TITLE
feat(infra): add grafana alloy

### DIFF
--- a/infra/grafana-alloy/Dockerfile
+++ b/infra/grafana-alloy/Dockerfile
@@ -1,0 +1,7 @@
+FROM grafana/alloy:v1.11.0
+
+COPY config.alloy /etc/alloy/config.alloy
+
+# We are overriding `http.listen-addr` to bind to all interfaces since Render requires even private services to have an HTTP endpoint for health checks.
+# This is not exposed to the internet since Alloy is defined as `pserv.`
+CMD ["run", "/etc/alloy/config.alloy", "--storage.path=/var/lib/alloy/data", "--server.http.listen-addr=0.0.0.0:12345"]

--- a/infra/grafana-alloy/config.alloy
+++ b/infra/grafana-alloy/config.alloy
@@ -1,0 +1,27 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+prometheus.scrape "tuist" {
+  targets = [
+    {"__address__" = "tuist:9091", "instance" = "production"},
+    {"__address__" = "tuist-canary:9091", "instance" = "canary"},
+    {"__address__" = "tuist-staging:9091", "instance" = "staging"},
+  ]
+
+  metrics_path    = "/metrics"
+  scrape_interval = "10s"
+
+  forward_to = [prometheus.remote_write.grafanacloud.receiver]
+}
+
+prometheus.remote_write "grafanacloud" {
+  endpoint {
+    url = "https://prometheus-prod-24-prod-eu-west-2.grafana.net/api/prom/push"
+      basic_auth {
+        username = sys.env("PROMETHEUS_USERNAME")
+        password = sys.env("PROMETHEUS_TOKEN")
+      }
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,6 @@ services:
     runtime: docker
     repo: https://github.com/tuist/tuist
     rootDir: server/
-    dockerfilePath: ./Dockerfile
     dockerCommand: /app/bin/start
     autoDeployTrigger: "off"
     plan: pro plus
@@ -92,3 +91,17 @@ services:
 
   - <<: *redis-base
     name: redis-staging
+
+  - type: pserv
+    name: grafana-alloy
+    runtime: docker
+    region: frankfurt
+    repo: https://github.com/tuist/tuist
+    rootDir: infra/grafana-alloy/
+    plan: standard
+    autoDeployTrigger: commit
+    envVars:
+      - key: PROMETHEUS_TOKEN
+        sync: false
+      - key: PROMETHEUS_USERNAME
+        sync: false


### PR DESCRIPTION
Adds a new `grafana-alloy` service that scrapes our server for metrics and forwards them to Grafana Cloud.