### PR TITLE
chore(ci): remove manual deploy confirmations

### DIFF
--- a/.github/workflows/server-canary-deployment.yml
+++ b/.github/workflows/server-canary-deployment.yml
@@ -58,11 +58,3 @@ jobs:
       - name: Trigger canary deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.2.0" -- cli_v2.2.0 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"
-      - name: Notify about the deployment in Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            commit: "${{ github.sha }}"
-            environment: "server-canary"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -126,14 +126,6 @@ jobs:
       - name: Trigger canary deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.2.0" -- cli_v2.2.0 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
-      - name: Notify about the deployment in Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            commit: "${{ github.sha }}"
-            environment: "production"
   production-hotfix:
     environment: server-production
     name: Hotfix Production Deployment
@@ -167,11 +159,3 @@ jobs:
       - name: Trigger canary deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.2.0" -- cli_v2.2.0 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
-      - name: Notify about the deployment in Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            commit: "${{ github.sha }}"
-            environment: "production"

--- a/.github/workflows/server-staging-deployment.yml
+++ b/.github/workflows/server-staging-deployment.yml
@@ -50,11 +50,3 @@ jobs:
       - name: Trigger canary deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.2.0" -- cli_v2.2.0 deploys create srv-d35uk7pr0fns73bg0gq0 --output json --confirm --wait --commit "$GITHUB_SHA"
-      - name: Notify about the deployment in Slack
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            commit: "${{ github.sha }}"
-            environment: "staging"


### PR DESCRIPTION
Instead of manually posting a message to Slack through webhooks on success only (and that is CLI success, not actual visibility into infrastructure), I have added the Render app to our Slack to get notified on deploy success, failure and other failure modes (out of memory, ...), which should give us more accurate, more informational notifications.
At the same time, this disabled the email notifications we get for failed deploys that show up in Plain.