### PR TITLE
fix(cli): don't convert script input and output file list paths relative to manifest paths or with build variables to absolute

### DIFF
--- a/cli/Fixtures/ios_app_with_actions/App/.package.resolved
+++ b/cli/Fixtures/ios_app_with_actions/App/.package.resolved
@@ -1,0 +1,87 @@
+{
+  "originHash" : "c3373633343d643cf4275c42d63c44d7be89c54076117a694350d515b60c2b83",
+  "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
+        "version" : "0.34.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "59ed009d2c4a5a6b78f75a25679b6417ac040dcf",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-07-04-a"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "9eaecbedce469a51bd8487effbd4ab46ec8384ae",
+        "version" : "0.52.4"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/cli/Fixtures/ios_app_with_actions/App/Framework/Framework.swift
+++ b/cli/Fixtures/ios_app_with_actions/App/Framework/Framework.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct Framework {
+    public static let version = "1.0.0"
+
+    public init() {}
+
+    public func greet() -> String {
+        return "Hello from Framework!"
+    }
+}

--- a/cli/Fixtures/ios_app_with_actions/App/Project.swift
+++ b/cli/Fixtures/ios_app_with_actions/App/Project.swift
@@ -24,11 +24,6 @@ let project = Project(
                     name: "Tuist",
                     inputPaths: ["Sources/**/*.swift"]
                 ),
-                .pre(
-                    path: "script-with-dependency.sh",
-                    name: "PhaseWithDependency",
-                    dependencyFile: "$TEMP_DIR/dependencies.d"
-                ),
                 .post(
                     script: "echo 'Hello World from install build'",
                     name: "Embedded script install build",
@@ -42,6 +37,22 @@ let project = Project(
             ],
             dependencies: [
                 .package(product: "SwiftLintPlugin", type: .plugin),
+                .target(name: "Framework"),
+            ]
+        ),
+        .target(
+            name: "Framework",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.Framework",
+            sources: "Framework/**",
+            scripts: [
+                .pre(
+                    path: "script-with-dependency.sh",
+                    name: "PhaseWithDependency",
+                    inputFileListPaths: ["inputs.xcfilelist"],
+                    dependencyFile: "$TEMP_DIR/dependencies.d"
+                ),
             ]
         ),
     ]

--- a/cli/Fixtures/ios_app_with_actions/App/inputs.xcfilelist
+++ b/cli/Fixtures/ios_app_with_actions/App/inputs.xcfilelist
@@ -1,0 +1,2 @@
+$(SRCROOT)/Sources/App.swift
+$(SRCROOT)/Sources/ContentView.swift


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8031

`inputFileListPaths` and `outputFileListPaths`, when relative to manifest or with build variables, are currently converted to absolute paths, leading to either invalid paths or to paths that change across machines/environments.