### PR TITLE
fix(server): fix http request buckets

### DIFF
--- a/server/lib/tuist/http/prom_ex_plugin.ex
+++ b/server/lib/tuist/http/prom_ex_plugin.ex
@@ -41,7 +41,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :duration,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           )
         ]
@@ -83,7 +83,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :duration,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           ),
           distribution(
@@ -95,7 +95,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :idle_time,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           )
         ]
@@ -125,7 +125,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :duration,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           )
         ]
@@ -158,7 +158,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :duration,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           )
         ]
@@ -191,7 +191,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             measurement: :duration,
             unit: {:native, :nanosecond},
             reporter_options: [
-              buckets: exponential!(50, 2, 15)
+              buckets: exponential!(2_000_000, 2.15, 15)
             ]
           )
         ]


### PR DESCRIPTION
The metrics reported by Finch are in nanoseconds.
We were creating histogram buckets as `exponential!(50, 2, 15)`, which expands to `[50, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600, 819200]`, meaning the highest bucket was 0.82 milliseconds.
This obviously means that _every_ request lands in that bucket, making any histogram creation impossible.
This updates the buckets to range from 2 milliseconds to 90 seconds, which should project our usual range of requests much better.