### PR TITLE
feat(server): make registry publicly accessible with optional authentication

### DIFF
--- a/cli/Sources/TuistKit/Commands/Registry/RegistrySetupCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Registry/RegistrySetupCommand.swift
@@ -18,9 +18,16 @@ struct RegistrySetupCommand: AsyncParsableCommand {
     )
     var path: String?
 
+    @Flag(
+        name: .long,
+        help: "Set up the registry with account authentication for higher rate limits."
+    )
+    var authenticated: Bool = false
+
     func run() async throws {
         try await RegistrySetupCommandService().run(
-            path: path
+            path: path,
+            authenticated: authenticated
         )
     }
 }

--- a/docs/docs/en/guides/features/registry.md
+++ b/docs/docs/en/guides/features/registry.md
@@ -7,27 +7,51 @@
 ---
 # Registry {#registry}
 
+As the number of dependencies grows, so does the time to resolve them. While other package managers like [CocoaPods](https://cocoapods.org/) or [npm](https://www.npmjs.com/) are centralized, Swift Package Manager is not. Because of that, SwiftPM needs to resolve dependencies by doing a deep clone of each repository, which can be time-consuming and takes up more memory than a centralized approach would. To address this, Tuist provides an implementation of the [Package Registry](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/PackageRegistryUsage.md), so you can download only the commits you _actually need_. The packages in the registry are based on the [Swift Package Index](https://swiftpackageindex.com/) – if you can find a package there, the package is also available in the Tuist Registry. Additionally, the packages are distributed across the globe using an edge storage for minimum latency when resolving them.
+
+## Usage {#usage}
+
+Tuist Registry supports two modes of access:
+
+### Unauthenticated Access (Default) {#unauthenticated-access}
+
+This mode allows you to use the registry without authentication. It's the simplest way to get started and requires no account setup.
+
+To set up the registry without authentication, run:
+
+```bash
+tuist registry setup
+```
+
+This command generates a registry configuration file. To ensure the rest of your team can access the registry, commit the generated file to your repository.
+
+**Rate Limits:** Unauthenticated access has standard rate limits (1000 requests per minute).
+
+### Authenticated Access (Higher Rate Limits) {#authenticated-access}
+
 ::: warning REQUIREMENTS
 <!-- -->
 - A <LocalizedLink href="/guides/server/accounts-and-projects">Tuist account and project</LocalizedLink>
 <!-- -->
 :::
 
-As the number of dependencies grows, so does the time to resolve them. While other package managers like [CocoaPods](https://cocoapods.org/) or [npm](https://www.npmjs.com/) are centralized, Swift Package Manager is not. Because of that, SwiftPM needs to resolve dependencies by doing a deep clone of each repository, which can be time-consuming and takes up more memory than a centralized approach would. To address this, Tuist provides an implementation of the [Package Registry](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/PackageRegistryUsage.md), so you can download only the commits you _actually need_. The packages in the registry are based on the [Swift Package Index](https://swiftpackageindex.com/) – if you can find a package there, the package is also available in the Tuist Registry. Additionally, the packages are distributed across the globe using an edge storage for minimum latency when resolving them.
+This mode provides higher rate limits by authenticating with your Tuist account. Use this if you need more requests or are experiencing rate limit issues.
 
-## Usage {#usage}
-
-To set up and log in to the registry, run the following command in your project's directory:
+To set up the registry with account authentication, run:
 
 ```bash
-tuist registry setup
+tuist registry setup --authenticated
 ```
 
-This command generates a registry configuration files and logs you in to the registry. To ensure the rest of your team can access the registry, ensure the generated files is committed and that your team members run the following command to log in:
+This command:
+1. Generates a registry configuration file
+2. Logs you into the registry with your account credentials
 
-```bash
-tuist registry login
-```
+To ensure the rest of your team can access the registry with authentication:
+1. Commit the generated configuration file to your repository
+2. Have team members run `tuist registry login` to authenticate
+
+**Rate Limits:** Authenticated access has no practical rate limits for normal usage.
 
 Now you can access the registry! To resolve dependencies from the registry instead of from source control, continue reading based on your project setup:
 - <LocalizedLink href="/guides/features/registry/xcode-project">Xcode project</LocalizedLink>

--- a/docs/docs/en/guides/features/registry/continuous-integration.md
+++ b/docs/docs/en/guides/features/registry/continuous-integration.md
@@ -7,7 +7,15 @@
 ---
 # Continuous Integration (CI) {#continuous-integration-ci}
 
-To use the registry on your CI, you need to ensure that you have logged in to the registry by running `tuist registry login` as part of your workflow.
+The setup for CI depends on whether you're using authenticated or unauthenticated access to the registry.
+
+## Unauthenticated Access {#unauthenticated-access}
+
+If you're using unauthenticated access (the default mode), no special CI setup is required. Simply ensure your registry configuration file (`.swiftpm/configuration/registries.json`) is committed to your repository. The registry will work automatically in CI with standard rate limits.
+
+## Authenticated Access {#authenticated-access}
+
+If you're using authenticated access for higher rate limits, you need to ensure that you have logged in to the registry by running `tuist registry login` as part of your workflow.
 
 ::: info ONLY XCODE INTEGRATION
 <!-- -->

--- a/server/lib/tuist_web/plugs/loader_plug.ex
+++ b/server/lib/tuist_web/plugs/loader_plug.ex
@@ -58,6 +58,10 @@ defmodule TuistWeb.Plugs.LoaderPlug do
     end
   end
 
+  def call(%{path_params: path_params} = conn, _opts) when path_params == %{} do
+    conn
+  end
+
   def call(%{body_params: %{project_id: project_slug}} = conn, _opts) do
     assign_selected_project(conn, project_slug)
   end

--- a/server/lib/tuist_web/rate_limit/registry.ex
+++ b/server/lib/tuist_web/rate_limit/registry.ex
@@ -1,0 +1,22 @@
+defmodule TuistWeb.RateLimit.Registry do
+  @moduledoc """
+  Rate limiting for registry endpoints, particularly for unauthenticated access.
+  """
+  alias TuistWeb.RateLimit.InMemory
+  alias TuistWeb.RateLimit.PersistentTokenBucket
+
+  def hit(conn) do
+    key = "registry:#{TuistWeb.RemoteIp.get(conn)}"
+    bucket_size = 1000
+
+    if is_nil(Tuist.Environment.redis_url()) do
+      # 1000 requests per minute for in-memory
+      InMemory.hit(key, to_timeout(minute: 1), bucket_size)
+    else
+      # Token bucket: 1 token per second (60 per minute)
+      fill_rate = 1 / 1
+      tokens_per_hit = 1
+      PersistentTokenBucket.hit(key, fill_rate, bucket_size, tokens_per_hit)
+    end
+  end
+end

--- a/server/priv/marketing/blog/2025/10/06/tuist-registry-now-public.md
+++ b/server/priv/marketing/blog/2025/10/06/tuist-registry-now-public.md
@@ -1,0 +1,139 @@
+---
+title: "Tuist Registry is Now Public"
+category: "product"
+tags: ["Announcement", "Registry"]
+excerpt: "We're opening up the Tuist Registry to everyone – no account required. Speed up your Swift package resolution in seconds."
+author: pepicrft
+---
+
+When we [launched the Tuist Registry](/blog/announcing-tuist-registry) earlier this year, we had a hunch we were onto something. We'd been watching developers wait – sometimes for minutes – as SwiftPM cloned the entire Git history of packages they just wanted to use. We'd seen CI bills climb as teams stored gigabytes of unnecessary Git data. We knew there had to be a better way.
+
+So we built it. And the response exceeded our expectations.
+
+Teams integrated the registry and immediately saw build times drop. CI costs decreased. That frustrating wait during `swift package resolve` became almost instant. Developers who'd grown accustomed to context-switching during dependency resolution suddenly found themselves staying in flow.
+
+But here's the thing: we launched the registry exclusively for Tuist users. You needed an account. You needed a project setup. It worked beautifully for our users, but every time someone outside the Tuist ecosystem asked about it, we had to say "sorry, you need to sign up first."
+
+That never felt right.
+
+If the registry could save time for our users, why shouldn't it save time for everyone? The Swift community has given us so much – from SwiftPM itself to the thousands of open-source packages we all rely on. It was time to give something back.
+
+Today, we're making the Tuist Registry available to everyone. **No account required. No sign-up flow. No barriers.**
+
+Just faster package resolution for the entire Swift community.
+
+## The Problem We All Face
+
+Swift Package Manager's decentralized approach is philosophically beautiful – no central authority, no gatekeepers, just packages living in their repositories. But this design choice comes with a cost that we pay every single day.
+
+When you add a dependency, SwiftPM performs a deep clone of the entire Git repository. Not just the version you need – the entire history. Every commit, every branch, every tag. If you're adding Alamofire, you're downloading years of development history you'll never need. Multiply that by dozens of dependencies, and you're looking at gigabytes of wasted space and minutes of wasted time.
+
+In local development, it's annoying. In CI, where you start fresh on every build, it's expensive and slow.
+
+The Tuist Registry solves this by implementing the [Swift Package Registry protocol](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/PackageRegistryUsage.md). Instead of cloning repositories, it serves immutable snapshots of specific package versions – just the source code you actually need, nothing more. And thanks to our Tigris-based storage, these packages are distributed globally and served from edge locations close to you, ensuring minimal latency no matter where your team or CI infrastructure is located.
+
+The numbers speak for themselves. Teams reported **91% smaller disk usage**, dropping from 6.6 GB to 600 MB. This dramatic reduction in local copy size means CI caching becomes significantly faster – restoring and saving caches that used to take 2 minutes now complete in 20 seconds. Some teams calculated they were saving hours of CI time per week, which translated directly to lower infrastructure costs.
+
+## Real Impact for Real Teams
+
+The feedback we've received since launch has been humbling. We've heard from solo developers who were frustrated by slow package resolution eating into their flow state. From small teams whose CI bills were climbing faster than their revenue. From large organizations managing dozens of internal projects, each with sprawling dependency graphs.
+
+One team told us they'd been considering whether to stick with SwiftPM or move to a different dependency manager entirely. The registry kept them in the ecosystem. Another calculated that the time saved on CI alone paid for their entire Tuist subscription multiple times over.
+
+But the stories that resonated most were simpler: developers who just appreciated not having to wait anymore. Who could `git clone` a fresh checkout and run `swift build` without making coffee first. Who didn't have to explain to new team members why their first build would take 10 minutes.
+
+Here's what teams consistently report:
+
+- **Smaller local copies**: 91% reduction in disk usage means your dependencies take up far less space
+- **Faster CI caching**: Smaller caches restore and save significantly faster on every CI run
+- **Low-latency access**: Packages served from edge locations close to your team via Tigris-based global storage
+- **More deterministic builds**: Serving immutable snapshots instead of relying on Git tags eliminates a whole class of reproducibility issues
+- **Lower infrastructure costs**: Smaller cache sizes translate directly to reduced storage and bandwidth costs in CI
+
+The registry mirrors all packages from the [Swift Package Index](https://swiftpackageindex.com/), serving over 8,400 packages and 130,000 releases. Our Tigris-based storage infrastructure distributes these artifacts globally, ensuring they're served from edge locations near you for minimal latency.
+
+## Going Public
+
+We built the registry initially for Tuist users, requiring an account for access. But as we watched the impact it had, we realized this shouldn't be limited to our users. The entire Swift community deserves faster, more reliable package resolution.
+
+The decision to go public wasn't just philosophical – it was practical. We've built infrastructure that can handle massive scale. We're serving millions of package requests every month with edge storage distributed globally. We've solved the hard problems around security, reliability, and performance. Keeping it locked behind an account requirement felt like artificial scarcity.
+
+So we're removing the gate.
+
+Starting today, **anyone can use the Tuist Registry without creating a Tuist account**. Just run one command in your project:
+
+```bash
+tuist registry setup
+```
+
+That's it. No sign-up, no authentication, no configuration files to manage. The command generates a registry configuration file that you commit to your repository, and your entire team benefits immediately.
+
+We're betting that the value we provide – faster resolution, lower costs, better developer experience – will speak for itself. Some teams will eventually want our other features and become Tuist users. Others won't, and that's perfectly fine. The registry is useful on its own, and we're happy to provide it to the community.
+
+## Choose Your Experience
+
+We're offering two modes of access to fit different needs:
+
+### Unauthenticated Access (Default)
+
+Perfect for most projects and teams. No account required, no authentication needed. Standard rate limits (1,000 requests per minute) are more than sufficient for typical development workflows.
+
+```bash
+tuist registry setup
+```
+
+### Authenticated Access
+
+For teams with heavy usage patterns or large monorepos that need higher throughput, authenticated access removes rate limits entirely. This mode requires a Tuist account and project:
+
+```bash
+tuist registry setup --authenticated
+```
+
+With authenticated access, only one person needs to run the setup command. Team members just run `tuist registry login` to authenticate themselves using the configuration already in the repository.
+
+## Getting Started
+
+If you don't have Tuist installed yet, [install it](https://docs.tuist.dev/en/guides/quick-start/install-tuist) first. Then, in your project directory:
+
+```bash
+tuist registry setup
+```
+
+The registry works with any Swift package setup – whether you're using Tuist, plain Xcode projects, or pure SwiftPM packages. No changes to your project structure required.
+
+### How Package Resolution Works
+
+When you reference a package, you can use the registry identifier convention instead of the Git URL. For example, instead of:
+
+```swift
+.package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0")
+```
+
+You can use:
+
+```swift
+.package(id: "alamofire.alamofire", from: "5.0.0")
+```
+
+The registry identifier follows the pattern `{organization}.{repository}` (all lowercase). When you use this identifier, SwiftPM automatically pulls the package from the Tuist Registry instead of cloning the Git repository. The identifier can't contain more than one dot – if the repository name contains a dot, it's replaced with an underscore (e.g., `GRDB.swift` becomes `groue.grdb_swift`).
+
+You can continue using Git URLs if you prefer – the registry configuration works with both approaches. Using identifiers is optional but recommended for maximum efficiency.
+
+For detailed setup instructions and integration guides for different project types, check out our [documentation](https://docs.tuist.dev/en/guides/features/registry).
+
+## Our Commitment to the Community
+
+The Tuist Registry is our contribution to making the Swift ecosystem better for everyone. We've contributed bug fixes to SwiftPM's registry implementation and even [contributed a PR to parallelize package retrieval](https://github.com/swiftlang/swift-package-manager/pull/8220) that has been merged and will make resolution up to 2x faster for everyone in the next Swift release – whether they use a registry or not.
+
+We take security seriously. We mirror only packages from the Swift Package Index, pull sources directly from original repositories, and rely on SwiftPM's built-in checksum verification to ensure package integrity. We're proud to be **SOC 2 Type II compliant**, providing formal verification that our security practices meet the highest industry standards. Your dependencies deserve that level of protection.
+
+## What's Next
+
+Opening the registry to everyone is just the beginning. We're committed to making it faster, more reliable, and more useful. If you have ideas, feedback, or questions, we'd love to hear from you on our [community forum](https://community.tuist.dev/) or [GitHub](https://github.com/tuist/tuist).
+
+Try it today. We think you'll love how much time you save.
+
+```bash
+tuist registry setup
+```


### PR DESCRIPTION
## Summary

This PR makes the Tuist Registry available to everyone without requiring a Tuist account, while offering authenticated access for higher rate limits.

## Changes

### Server
- **New unauthenticated routes**: `/api/registry/swift/*` - accessible without authentication
- **Existing authenticated routes**: `/api/accounts/:account_handle/registry/swift/*` - for higher rate limits
- **Rate limiting**: Unauthenticated access limited to 1000 requests/minute
- **Controller updates**: Handle both authenticated and unauthenticated requests gracefully
- **Authorization**: Allow unauthenticated access to registry endpoints
- **Tests**: Comprehensive test coverage for both modes (26 tests passing ✅)

### CLI
- **New flag**: `--authenticated` for `tuist registry setup` command
  - Default (no flag): Unauthenticated access, no account needed
  - With `--authenticated`: Account-based access with higher rate limits
- **Smart configuration**: Generated config adapts based on selected mode
- **Clear feedback**: Users informed about rate limits and how to switch modes

### Documentation
- **Registry guide**: Updated to explain both access modes clearly
- **CI guide**: Separate instructions for authenticated and unauthenticated modes
- **Rate limits**: Documented for each mode

### Blog Post
- **New announcement**: `/blog/tuist-registry-now-public`
- Explains the benefits of public access
- Clear setup instructions for both modes

## Testing

```bash
# Server tests
mix test test/tuist_web/controllers/api/registry/swift_controller_test.exs
# ✅ 26 tests, 0 failures

# CLI build
xcodebuild build -workspace Tuist.xcworkspace -scheme tuist
# ✅ Build succeeded
```

## Usage

### Unauthenticated (Default)
```bash
tuist registry setup
```
- No account required
- 1000 requests/minute
- Perfect for most projects

### Authenticated
```bash
tuist registry setup --authenticated
```
- Requires Tuist account and project
- No practical rate limits
- Team members run `tuist registry login`

## Migration

No breaking changes. Existing users continue to work as before. The authenticated flow is now opt-in via the `--authenticated` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>