### PR TITLE
fix(ci): cache acceptance tests hanging

### DIFF
--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -9,6 +9,7 @@ on:
       - mise/tasks/cli/ee.sh
       - "cli/TuistCacheEE"
       - "cli/TuistCacheEE/**"
+      - "cli/Tests/TuistCacheEEAcceptanceTests/**"
       - "cli/Sources/**"
       - "cli/Tests/**"
       - "*.swift"
@@ -23,6 +24,7 @@ on:
       - mise/tasks/cli/ee.sh
       - "cli/TuistCacheEE"
       - "cli/TuistCacheEE/**"
+      - "cli/Tests/TuistCacheEEAcceptanceTests/**"
       - "cli/Sources/**"
       - "cli/Tests/**"
       - "*.swift"
@@ -134,7 +136,7 @@ jobs:
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
   acceptance-tests:
     name: Acceptance Tests
-    runs-on: macos-26
+    runs-on: namespace-profile-default-macos
     timeout-minutes: 15
     needs: [check-team-membership]
     if: |


### PR DESCRIPTION
The tests were hanging but not anymore ... at least I'm putting the cache acceptance tests to namespace, so we get a faster check on these in PRs, so we don't end up blocking deployment