### PR TITLE
fix(server): make bundle type optional

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -908,15 +908,15 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "page_size",
-                    value: input.query.page_size
+                    name: "git_branch",
+                    value: input.query.git_branch
                 )
                 try converter.setQueryItemAsURI(
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "git_branch",
-                    value: input.query.git_branch
+                    name: "page_size",
+                    value: input.query.page_size
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -1345,7 +1345,7 @@ public enum Components {
                 /// The type of the bundle
                 ///
                 /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/type`.
-                public var _type: Components.Schemas.BundleRequest.bundlePayload._typePayload
+                public var _type: Components.Schemas.BundleRequest.bundlePayload._typePayload?
                 /// The version of the bundle
                 ///
                 /// - Remark: Generated from `#/components/schemas/BundleRequest/bundle/version`.
@@ -1374,7 +1374,7 @@ public enum Components {
                     install_size: Swift.Int,
                     name: Swift.String,
                     supported_platforms: [Components.Schemas.BundleSupportedPlatform],
-                    _type: Components.Schemas.BundleRequest.bundlePayload._typePayload,
+                    _type: Components.Schemas.BundleRequest.bundlePayload._typePayload? = nil,
                     version: Swift.String
                 ) {
                     self.app_bundle_id = app_bundle_id
@@ -6861,28 +6861,28 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
                 public var page: Swift.Int?
-                /// Number of items per page.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
-                public var page_size: Swift.Int?
                 /// Filter bundles by git branch.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
                 public var git_branch: Swift.String?
+                /// Number of items per page.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
+                public var page_size: Swift.Int?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
                 ///   - page: Page number for pagination.
-                ///   - page_size: Number of items per page.
                 ///   - git_branch: Filter bundles by git branch.
+                ///   - page_size: Number of items per page.
                 public init(
                     page: Swift.Int? = nil,
-                    page_size: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    git_branch: Swift.String? = nil,
+                    page_size: Swift.Int? = nil
                 ) {
                     self.page = page
-                    self.page_size = page_size
                     self.git_branch = git_branch
+                    self.page_size = page_size
                 }
             }
             public var query: Operations.listBundles.Input.Query
@@ -7220,7 +7220,7 @@ public enum Operations {
                         /// The type of the bundle
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/type`.
-                        public var _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload
+                        public var _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload?
                         /// The version of the bundle
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/POST/requestBody/json/bundle/version`.
@@ -7249,7 +7249,7 @@ public enum Operations {
                             install_size: Swift.Int,
                             name: Swift.String,
                             supported_platforms: [Components.Schemas.BundleSupportedPlatform],
-                            _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload,
+                            _type: Operations.createBundle.Input.Body.jsonPayload.bundlePayload._typePayload? = nil,
                             version: Swift.String
                         ) {
                             self.app_bundle_id = app_bundle_id

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -105,7 +105,6 @@ components:
             - supported_platforms
             - version
             - install_size
-            - type
             - artifacts
           type: object
           x-struct:
@@ -2932,20 +2931,20 @@ paths:
             type: string
             x-struct:
             x-validate:
-        - description: Number of items per page.
-          in: query
-          name: page_size
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
         - description: Filter bundles by git branch.
           in: query
           name: git_branch
           required: false
           schema:
             type: string
+            x-struct:
+            x-validate:
+        - description: Number of items per page.
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
             x-struct:
             x-validate:
       responses:
@@ -3081,7 +3080,6 @@ paths:
                     - supported_platforms
                     - version
                     - install_size
-                    - type
                     - artifacts
                   type: object
                   x-struct:

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -63,8 +63,8 @@ public final class ListBundlesService: ListBundlesServicing {
                 ),
                 query: .init(
                     page: page,
-                    page_size: pageSize,
-                    git_branch: gitBranch
+                    git_branch: gitBranch,
+                    page_size: pageSize
                 )
             )
         )

--- a/server/lib/tuist_web/controllers/api/bundles_controller.ex
+++ b/server/lib/tuist_web/controllers/api/bundles_controller.ex
@@ -231,7 +231,6 @@ defmodule TuistWeb.API.BundlesController do
                :supported_platforms,
                :version,
                :install_size,
-               :type,
                :artifacts
              ]
            }
@@ -270,6 +269,9 @@ defmodule TuistWeb.API.BundlesController do
         %AuthenticatedAccount{account: account} -> account.id
       end
 
+    # Derive type if not provided for older CLI versions: :ipa if download_size is specified, :app otherwise
+    type = bundle["type"] || derive_bundle_type(bundle["download_size"])
+
     with {:ok, %Bundles.Bundle{} = bundle} <-
            Bundles.create_bundle(
              %{
@@ -285,7 +287,7 @@ defmodule TuistWeb.API.BundlesController do
                git_branch: bundle["git_branch"],
                git_commit_sha: bundle["git_commit_sha"],
                git_ref: bundle["git_ref"],
-               type: bundle["type"],
+               type: type,
                uploaded_by_account_id: account_id
              },
              preload: [:uploaded_by_account, project: [:account]]
@@ -295,6 +297,9 @@ defmodule TuistWeb.API.BundlesController do
       |> json(bundle_to_map(bundle))
     end
   end
+
+  defp derive_bundle_type(download_size) when is_nil(download_size), do: "app"
+  defp derive_bundle_type(_download_size), do: "ipa"
 
   defp bundle_list_to_map(bundle) do
     %{


### PR DESCRIPTION
I've made the bundle type optional in https://github.com/tuist/tuist/pull/8363 which breaks older CLI versions. Instead, the `type` should be optional and we should use a default type value for CLI versions that don't send the `:type` value.