### PR TITLE
feat(server): allow users with ops access to do any :read operations

### DIFF
--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -32,6 +32,9 @@ defmodule Tuist.Authorization do
       desc("Allows the authenticated project to read the run if it matches the project whose run is being read.")
 
       allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows users with ops access to read any run.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :update do
@@ -76,6 +79,9 @@ defmodule Tuist.Authorization do
       desc("Allows the authenticated project to read the bundle if it matches the project whose bundle is being read.")
 
       allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows users with ops access to read any bundle.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 
@@ -105,6 +111,9 @@ defmodule Tuist.Authorization do
       desc("Allows the authenticated project to read the cache if it matches the project whose cache is being read.")
 
       allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows users with ops access to read any cache.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :update do
@@ -154,6 +163,9 @@ defmodule Tuist.Authorization do
       desc("Allows the authenticated project to read the cache if it matches the project whose cache is being read.")
 
       allow([:authenticated_as_project, :accounts_match])
+
+      desc("Allows users with ops access to read any registry.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 
@@ -184,6 +196,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read account tokens.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any account tokens.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :delete do
@@ -248,6 +263,9 @@ defmodule Tuist.Authorization do
       desc("Allows the authenticated project to read the preview if it matches the project whose preview is being read.")
 
       allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows users with ops access to read any preview.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :delete do
@@ -280,6 +298,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read projects.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any projects.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :update do
@@ -312,6 +333,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read private project dashboards.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any dashboard.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 
@@ -319,6 +343,9 @@ defmodule Tuist.Authorization do
     action :read do
       desc("Allows admins to read billing information for Tuist hosted accounts.")
       allow([:authenticated_as_user, :billing_access])
+
+      desc("Allows users with ops access to read any billing information.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :update do
@@ -332,6 +359,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read organization token usage.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any organization token usage.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 
@@ -342,6 +372,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read projects.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any projects.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 
@@ -352,6 +385,9 @@ defmodule Tuist.Authorization do
 
       desc("Allows the admin of an account to read organization info.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any organization info.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :update do
@@ -374,6 +410,9 @@ defmodule Tuist.Authorization do
     action :read do
       desc("Allows the admin of an account to read invitations.")
       allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows users with ops access to read any invitations.")
+      allow([:authenticated_as_user, :ops_access])
     end
 
     action :delete do
@@ -412,6 +451,9 @@ defmodule Tuist.Authorization do
       desc("Allows reading command events if the user can read the associated project or if the project is public.")
 
       allow(:command_event_project_access)
+
+      desc("Allows users with ops access to read any command events.")
+      allow([:authenticated_as_user, :ops_access])
     end
   end
 

--- a/server/lib/tuist/authorization/checks.ex
+++ b/server/lib/tuist/authorization/checks.ex
@@ -123,6 +123,10 @@ defmodule Tuist.Authorization.Checks do
     end
   end
 
+  def ops_access(_, _) do
+    false
+  end
+
   def repository_permission_check(%User{} = user, %{project: %Project{} = project, repository: repository}) do
     account = Accounts.get_account_by_id(project.account_id)
 

--- a/server/test/tuist/authorization/checks_test.exs
+++ b/server/test/tuist/authorization/checks_test.exs
@@ -303,4 +303,38 @@ defmodule Tuist.Authorization.ChecksTest do
              ) == false
     end
   end
+
+  describe "ops_access/2" do
+    test "returns true when user is in ops_user_handles", %{user: user} do
+      # Given
+      expect(Tuist.Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+      # When/Then
+      assert Checks.ops_access(user, nil) == true
+    end
+
+    test "returns false when user is not in ops_user_handles", %{user: user} do
+      # Given
+      expect(Tuist.Environment, :ops_user_handles, fn -> ["other_user"] end)
+
+      # When/Then
+      assert Checks.ops_access(user, nil) == false
+    end
+
+    test "returns false when user is nil" do
+      # When/Then
+      assert Checks.ops_access(nil, nil) == false
+    end
+
+    test "returns false for non-user subjects", %{organization: organization} do
+      # Given
+      project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
+      authenticated_account = %AuthenticatedAccount{account: organization.account, scopes: []}
+
+      # When/Then
+      assert Checks.ops_access(project, nil) == false
+      assert Checks.ops_access(authenticated_account, nil) == false
+      assert Checks.ops_access("string", nil) == false
+    end
+  end
 end


### PR DESCRIPTION
It's a bit annoying that if we get a report, teams often send us a link to take a look – but we currently don't have a way to disable authorization to be able to check those links.

I'm updating the authorization, so that ops users have access to all pages (with `:read` access only).

I was also thinking of showing some warning that you're accessing a page you would normally not have access to – but it would be a bit difficult under our current authorization model. I think since we're a small team, we can ensure that everybody is aware they are accessing live pages of projects they would normally not have access to. Long-term, probably worth implementing something like that, however.

Note that we already have access to this data through the database – so this is really about making it more convenient for us to debug issues of customers/users.