### PR TITLE
Add env var for custom .package.resolved filename

### DIFF
--- a/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/cli/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -48,7 +48,7 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
             return
         }
 
-        let rootPackageResolvedPath = path.appending(component: ".package.resolved")
+        let rootPackageResolvedPath = path.appending(component: packageResolvedFilename())
         let workspacePackageResolvedFolderPath = path
             .appending(try RelativePath(validating: "\(workspaceName)/xcshareddata/swiftpm"))
         let workspacePackageResolvedPath = workspacePackageResolvedFolderPath.appending(component: "Package.resolved")

--- a/cli/Sources/TuistHasher/GraphContentHasher.swift
+++ b/cli/Sources/TuistHasher/GraphContentHasher.swift
@@ -141,7 +141,7 @@ public struct GraphContentHasher: GraphContentHashing {
         for graph: Graph
     ) async throws -> String? {
         if let lockFilePath = try await rootDirectoryLocator.locate(from: graph.path)
-            .map({ $0.appending(component: ".package.resolved") }),
+            .map({ $0.appending(component: packageResolvedFilename()) }),
             try await fileSystem.exists(lockFilePath)
         {
             return try await contentHasher.hash(

--- a/cli/Sources/TuistSupport/Utils/PackageResolvedFilename.swift
+++ b/cli/Sources/TuistSupport/Utils/PackageResolvedFilename.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public func packageResolvedFilename(
+    environment: Environmenting = Environment.current
+) -> String {
+    guard
+        let value = environment.variables["TUIST_PACKAGE_RESOLVED_NAME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !value.isEmpty
+    else {
+        return ".package.resolved"
+    }
+    return value
+}

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1186,7 +1186,8 @@ final class GenerateAcceptanceTesAppWithLocalSPMModuleWithRemoteDependencies: Tu
 
         let workspacePackageResolved = try workspacePath
             .appending(RelativePath(validating: "xcshareddata/swiftpm/Package.resolved"))
-        let fixturePackageResolved = try fixturePath.appending(RelativePath(validating: ".package.resolved"))
+        let fixturePackageResolved = try fixturePath
+            .appending(RelativePath(validating: packageResolvedFilename()))
         let workspacePackageResolvedData = try Data(contentsOf: workspacePackageResolved.url)
         let fixturePackageResolvedData = try Data(contentsOf: fixturePackageResolved.url)
         XCTAssertEqual(workspacePackageResolvedData, fixturePackageResolvedData)

--- a/cli/Tests/TuistGeneratorTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -62,7 +62,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         try await subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename)
 
         // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
+        let exists = try await fileSystem.exists(temporaryPath.appending(component: packageResolvedFilename()))
         XCTAssertTrue(exists)
     }
 
@@ -95,7 +95,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         try await subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename)
 
         // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
+        let exists = try await fileSystem.exists(temporaryPath.appending(component: packageResolvedFilename()))
         XCTAssertTrue(exists)
     }
 
@@ -145,7 +145,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         )
 
         // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
+        let exists = try await fileSystem.exists(temporaryPath.appending(component: packageResolvedFilename()))
         XCTAssertTrue(exists)
     }
 
@@ -176,7 +176,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
             name: project.name,
             projects: [project.path]
         )
-        let rootPackageResolvedPath = temporaryPath.appending(component: ".package.resolved")
+        let rootPackageResolvedPath = temporaryPath.appending(component: packageResolvedFilename())
         try FileHandler.shared.write("package", path: rootPackageResolvedPath, atomically: false)
 
         let workspacePath = temporaryPath.appending(component: workspace.name + ".xcworkspace")
@@ -219,7 +219,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         try await subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename)
 
         // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
+        let exists = try await fileSystem.exists(temporaryPath.appending(component: packageResolvedFilename()))
         XCTAssertFalse(exists)
     }
 
@@ -268,7 +268,7 @@ final class SwiftPackageManagerInteractorTests: TuistTestCase {
         )
 
         // Then
-        let exists = try await fileSystem.exists(temporaryPath.appending(component: ".package.resolved"))
+        let exists = try await fileSystem.exists(temporaryPath.appending(component: packageResolvedFilename()))
         XCTAssertTrue(exists)
     }
 

--- a/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
@@ -5,6 +5,7 @@ import Path
 import Testing
 import TuistCore
 import TuistRootDirectoryLocator
+import TuistSupport
 import TuistTesting
 import XcodeGraph
 
@@ -121,7 +122,7 @@ struct GraphContentHasherTests {
             given(rootDirectoryLocator)
                 .locate(from: .any)
                 .willReturn(temporaryDirectory)
-            let lockFilePath = temporaryDirectory.appending(component: ".package.resolved")
+            let lockFilePath = temporaryDirectory.appending(component: packageResolvedFilename())
             try await fileSystem.touch(lockFilePath)
             let targetContentHasher = MockTargetContentHashing()
             given(targetContentHasher)


### PR DESCRIPTION
In order to avoid confusion with a checked-in `Package.resolved` file in our repo, it would be great to have a way to rename this file to something clearer for our case.