### PR TITLE
fix(docs): correct link to new project guide

### DIFF
--- a/docs/docs/en/guides/features/projects/adoption/migrate/xcode-project.md
+++ b/docs/docs/en/guides/features/projects/adoption/migrate/xcode-project.md
@@ -7,7 +7,7 @@
 ---
 # Migrate an Xcode project {#migrate-an-xcode-project}
 
-Unless you <LocalizedLink href="/guides/start/new-project">create a new project using Tuist</LocalizedLink>, in which case you get everything configured automatically, you'll have to define your Xcode projects using Tuist's primitives. How tedious this process is, depends on how complex your projects are.
+Unless you <LocalizedLink href="/guides/features/projects/adoption/new-project">create a new project using Tuist</LocalizedLink>, in which case you get everything configured automatically, you'll have to define your Xcode projects using Tuist's primitives. How tedious this process is, depends on how complex your projects are.
 
 As you probably know, Xcode projects can become messy and complex over time: groups that don't match the directory structure, files that are shared across targets, or file references that point to nonexisting files (to mention some). All that accumulated complexity makes it hard for us to provide a command that reliably migrates project.
 


### PR DESCRIPTION
## Summary
- Fixed broken internal link in xcode-project.md migration guide that was pointing to incorrect path `/guides/start/new-project` instead of `/guides/features/projects/adoption/new-project`

## Test plan
- [x] Verified the correct target path exists in the documentation
- [x] Link now points to the correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)