### PR TITLE
fix(cli): extend inspect build to 5 seconds

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -130,7 +130,7 @@ struct InspectBuildCommandService {
     ) async throws -> AbsolutePath {
         var mostRecentActivityLogPath: AbsolutePath!
         try await withTimeout(
-            .seconds(1),
+            .seconds(5),
             onTimeout: {
                 throw InspectBuildCommandServiceError.mostRecentActivityLogNotFound(projectPath)
             }


### PR DESCRIPTION
Xcode might be taking longer to generate the `.xcactivitylog` than expected.