### PR TITLE
chore(cli): add back cache acceptance test

### DIFF
--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -121,10 +121,8 @@ struct CASServiceTests {
         let response = try await subject.save(request: request, context: context)
 
         // Then
-        let expectedDigest = SHA512.hash(data: testData).description
-        let expectedCASIDData = expectedDigest.data(using: .utf8)!
-
-        #expect(response.casID.id == expectedCASIDData)
+        let fingerprint = "E32E670195BD1ED06BA6A20D7B560BED8F9F91596EEC7B050BB783FD05045D0F"
+        #expect(response.casID.id == fingerprint.data(using: .utf8)!)
         switch response.contents {
         case .casID:
             break
@@ -137,7 +135,7 @@ struct CASServiceTests {
         verify(saveCacheCASService)
             .saveCacheCAS(
                 .value(testData),
-                casId: .value(expectedDigest),
+                casId: .value(fingerprint),
                 fullHandle: .value(fullHandle),
                 serverURL: .value(serverURL)
             )

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -237,7 +237,7 @@ struct TuistCacheEEAcceptanceTests {
             "CODE_SIGN_IDENTITY=",
             "CODE_SIGNING_REQUIRED=NO",
             "CODE_SIGNING_ALLOWED=NO",
-            "COMPILATION_CACHE_REMOTE_SERVICE_PATH=\(remoteCacheServicePath.pathString)"
+            "COMPILATION_CACHE_REMOTE_SERVICE_PATH=\(remoteCacheServicePath.pathString)",
         ]
         try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
         TuistTest.expectLogs("note: 0 hits / 60 cacheable tasks (0%)")


### PR DESCRIPTION
We needed to keep this acceptance test initially commented out until the changes were on canary.