### PR TITLE
chore(ci): run CLI unit tests on Nmaespace

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -118,7 +118,7 @@ jobs:
 
   cli-unit-tests:
     name: Unit Tests
-    runs-on: macos-26
+    runs-on: namespace-profile-default-macos
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode


### PR DESCRIPTION
I'm moving CLI unit tests on Namespace as I generally don't want to merge PRs without waiting for these to run, while I'm sometimes willing to merge without waiting for some other checks (like acceptance tests)