### PR TITLE
fix(cli): ignore unit test host app in inspect redundant dependencies

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -68,7 +68,8 @@ final class GraphImportsLinter: GraphImportsLinting {
             let explicitTargetDependencies = explicitTargetDependencies(
                 graphTraverser: graphTraverser,
                 target: target,
-                includeExternalDependencies: inspectType == .implicit
+                includeExternalDependencies: inspectType == .implicit,
+                excludeAppDependenciesForUnitTests: inspectType == .redundant
             )
 
             let observedImports = switch inspectType {
@@ -88,7 +89,8 @@ final class GraphImportsLinter: GraphImportsLinting {
     private func explicitTargetDependencies(
         graphTraverser: GraphTraverser,
         target: GraphTarget,
-        includeExternalDependencies: Bool
+        includeExternalDependencies: Bool,
+        excludeAppDependenciesForUnitTests: Bool
     ) -> Set<String> {
         let targetDependencies = if includeExternalDependencies {
             graphTraverser
@@ -121,6 +123,15 @@ final class GraphImportsLinter: GraphImportsLinting {
                          .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App:
                         return true
                     }
+                case .unitTests:
+                    switch dependency.target.product {
+                    case .app:
+                        return !excludeAppDependenciesForUnitTests
+                    case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
+                         .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
+                         .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
+                        return true
+                    }
                 case .uiTests:
                     switch dependency.target.product {
                     case .app:
@@ -130,7 +141,7 @@ final class GraphImportsLinter: GraphImportsLinting {
                          .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
                         return true
                     }
-                case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .bundle,
+                case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .bundle,
                      .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
                      .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2Extension:
                     return true

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectRedundantImportsServiceTests.swift
@@ -388,4 +388,36 @@ final class LintRedundantImportsServiceTests: TuistUnitTestCase {
 
         try await subject.run(path: path.pathString)
     }
+
+    func test_run_doesntThrowAnyErrorsWithUnitTestsTarget_when_testTargetDependsOnApp() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let config = Tuist.test()
+
+        let app = Target.test(
+            name: "App",
+            product: .app
+        )
+
+        let unitTests = Target.test(
+            name: "AppTests",
+            product: .unitTests,
+            dependencies: [TargetDependency.target(name: "App")]
+        )
+
+        let project = Project.test(path: path, targets: [app, unitTests])
+        let graph = Graph.test(path: path, projects: [path: project], dependencies: [
+            .target(name: unitTests.name, path: project.path): [
+                .target(name: app.name, path: project.path),
+            ],
+        ])
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(unitTests)).willReturn(Set([]))
+        given(targetScanner).imports(for: .value(app)).willReturn(Set([]))
+
+        try await subject.run(path: path.pathString)
+    }
 }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/8101>

Unit tests can depend on a host app, which `tuist inspect redundant-imports` should not flag as redundant despite not being directly imported in the unit test target source.

### How to test locally

1. Extract https://github.com/user-attachments/files/22013383/Berlin.zip
2. `tuist inspect redundant-imports`

Expected:

```
[1m[36mLoading and constructing the graph[0m[1m[0m
It might take a while if the cache is empty
We did not find any redundant dependencies in your project.
Program ended with exit code: 0
```