### PR TITLE
fix(server): add name attributes to text_input components in user registration

### DIFF
--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -127,50 +127,40 @@ defmodule TuistWeb.UserRegistrationLive do
                 size="small"
                 title={Flash.get(@flash, :error)}
               />
-              <.text_input
-                field={@form[:email]}
-                id="email"
-                label={gettext("Email address")}
-                type="email"
-                placeholder="hello@tuist.dev"
-                show_prefix={false}
-                required
-                tabindex={1}
-              />
-              <% password_errors =
-                case Map.get(@errors, :password) do
-                  nil ->
-                    nil
-
-                  errors when is_binary(errors) ->
-                    String.trim_trailing(errors, ".")
-
-                  errors when is_list(errors) ->
-                    (errors
-                     |> Enum.map(&String.trim_trailing(&1, "."))
-                     |> Enum.join(". ")) <> "."
-                end %>
-              <.text_input
-                field={@form[:password]}
-                label={gettext("Password")}
-                id="password"
-                input_type="password"
-                error={password_errors}
-                show_prefix={false}
-                required
-                tabindex={2}
-              />
-              <.text_input
-                field={@form[:username]}
-                label={gettext("Username")}
-                id="Username"
-                type="basic"
-                hint={gettext("Username may only contain alphanumeric characters")}
-                error={Map.get(@errors, :name)}
-                show_prefix={false}
-                required
-                tabindex={3}
-              />
+               <.text_input
+                 field={@form[:email]}
+                 name="user[email]"
+                 id="email"
+                 label={gettext("Email address")}
+                 type="email"
+                 placeholder="hello@tuist.dev"
+                 show_prefix={false}
+                 required
+                 tabindex={1}
+               />
+               <.text_input
+                 field={@form[:password]}
+                 name="user[password]"
+                 label={gettext("Password")}
+                 id="password"
+                 input_type="password"
+                 error={format_password_error(@errors)}
+                 show_prefix={false}
+                 required
+                 tabindex={2}
+               />
+               <.text_input
+                 field={@form[:username]}
+                 name="user[username]"
+                 label={gettext("Username")}
+                 id="Username"
+                 type="basic"
+                 hint={gettext("Username may only contain alphanumeric characters")}
+                 error={Map.get(@errors, :name)}
+                 show_prefix={false}
+                 required
+                 tabindex={3}
+               />
               <.button variant="primary" size="large" label={gettext("Sign up")} tabindex={4} />
             </.form>
           </div>
@@ -222,6 +212,21 @@ defmodule TuistWeb.UserRegistrationLive do
   defp oauth_configured? do
     Environment.github_oauth_configured?() || Environment.google_oauth_configured?() ||
       Environment.okta_oauth_configured?() || Environment.apple_oauth_configured?()
+  end
+
+  defp format_password_error(errors) do
+    case Map.get(errors, :password) do
+      nil ->
+        nil
+
+      errors when is_binary(errors) ->
+        String.trim_trailing(errors, ".")
+
+      errors when is_list(errors) ->
+        (errors
+         |> Enum.map(&String.trim_trailing(&1, "."))
+         |> Enum.join(". ")) <> "."
+    end
   end
 
   def mount(_params, _session, socket) do


### PR DESCRIPTION
Attempts to fix https://appsignal.com/tuist-cloud/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1192/samples/last

Disclosure: written by Haiku 4.5 under my eyes.

## Summary
- Fixed KeyError when rendering text_input components with form fields by explicitly passing the `name` attribute
- Moved password error formatting logic into a helper function to preserve LiveView change tracking