### PR TITLE
feat(server): clean CAS

### DIFF
--- a/server/lib/tuist/projects/workers/clean_project_worker.ex
+++ b/server/lib/tuist/projects/workers/clean_project_worker.ex
@@ -17,6 +17,7 @@ defmodule Tuist.Projects.Workers.CleanProjectWorker do
       project_slug = "#{project.account.name}/#{project.name}"
 
       Task.await_many([
+        Task.async(fn -> Storage.delete_all_objects("#{project_slug}/cas", project.account) end),
         Task.async(fn -> Storage.delete_all_objects("#{project_slug}/builds", project.account) end),
         Task.async(fn -> Storage.delete_all_objects("#{project_slug}/tests", project.account) end),
         Task.async(fn -> CacheActionItems.delete_all_action_items(%{project: project}) end)

--- a/server/test/tuist/projects/workers/clean_project_worker_test.exs
+++ b/server/test/tuist/projects/workers/clean_project_worker_test.exs
@@ -22,8 +22,10 @@ defmodule Tuist.Projects.Workers.CleanProjectWorkerTest do
         :ok
       end)
 
+      cas_objects = "#{project_slug}/cas"
       binaries_objects = "#{project_slug}/builds"
       tests_objects = "#{project_slug}/tests"
+      expect(Storage, :delete_all_objects, fn ^cas_objects, _actor -> :ok end)
       expect(Storage, :delete_all_objects, fn ^binaries_objects, _actor -> :ok end)
       expect(Storage, :delete_all_objects, fn ^tests_objects, _actor -> :ok end)
 


### PR DESCRIPTION
We should clean the CAS storage on `tuist clean --remote`.