### PR TITLE
fix(server): clean cache entries

### DIFF
--- a/server/lib/tuist/cache.ex
+++ b/server/lib/tuist/cache.ex
@@ -46,4 +46,17 @@ defmodule Tuist.Cache do
   def get_entries_by_cas_id_and_project_id(cas_id, project_id) do
     IngestRepo.all(from(e in Entry, where: e.cas_id == ^cas_id and e.project_id == ^project_id))
   end
+
+  @doc """
+  Deletes all cache entries for a given project.
+
+  ## Examples
+
+      iex> delete_entries_by_project_id(123)
+      {:ok, 5}
+
+  """
+  def delete_entries_by_project_id(project_id) do
+    IngestRepo.delete_all(from(e in Entry, where: e.project_id == ^project_id))
+  end
 end

--- a/server/lib/tuist/projects/workers/clean_project_worker.ex
+++ b/server/lib/tuist/projects/workers/clean_project_worker.ex
@@ -4,6 +4,7 @@ defmodule Tuist.Projects.Workers.CleanProjectWorker do
   # we don't schedule another one. Otherwise we might end up with a race condition.
   use Oban.Worker, unique: [keys: [:project_id], states: [:scheduled]]
 
+  alias Tuist.Cache
   alias Tuist.CacheActionItems
   alias Tuist.Storage
 
@@ -20,7 +21,8 @@ defmodule Tuist.Projects.Workers.CleanProjectWorker do
         Task.async(fn -> Storage.delete_all_objects("#{project_slug}/cas", project.account) end),
         Task.async(fn -> Storage.delete_all_objects("#{project_slug}/builds", project.account) end),
         Task.async(fn -> Storage.delete_all_objects("#{project_slug}/tests", project.account) end),
-        Task.async(fn -> CacheActionItems.delete_all_action_items(%{project: project}) end)
+        Task.async(fn -> CacheActionItems.delete_all_action_items(%{project: project}) end),
+        Task.async(fn -> Cache.delete_entries_by_project_id(project.id) end)
       ])
 
       :ok

--- a/server/test/tuist/projects/workers/clean_project_worker_test.exs
+++ b/server/test/tuist/projects/workers/clean_project_worker_test.exs
@@ -2,6 +2,7 @@ defmodule Tuist.Projects.Workers.CleanProjectWorkerTest do
   use TuistTestSupport.Cases.DataCase
   use Mimic
 
+  alias Tuist.Cache
   alias Tuist.CacheActionItems
   alias Tuist.Projects
   alias Tuist.Projects.Workers.CleanProjectWorker
@@ -13,7 +14,7 @@ defmodule Tuist.Projects.Workers.CleanProjectWorkerTest do
   end
 
   describe "perform" do
-    test "deletes binaries, selective testing, and cache action items", %{project: project} do
+    test "deletes binaries, selective testing, cache action items, and cache entries", %{project: project} do
       # Given
       project_id = project.id
       project_slug = "#{project.account.name}/#{project.name}"
@@ -28,6 +29,10 @@ defmodule Tuist.Projects.Workers.CleanProjectWorkerTest do
       expect(Storage, :delete_all_objects, fn ^cas_objects, _actor -> :ok end)
       expect(Storage, :delete_all_objects, fn ^binaries_objects, _actor -> :ok end)
       expect(Storage, :delete_all_objects, fn ^tests_objects, _actor -> :ok end)
+
+      expect(Cache, :delete_entries_by_project_id, 1, fn ^project_id ->
+        {5, nil}
+      end)
 
       # When
       result = CleanProjectWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})


### PR DESCRIPTION
When cleaning the remote cache, we should clean also the cache entries in the database.

We will need to figure out how to clean the worker cache cc @cschmatzler.