### PR TITLE
feat(cli): don't restrict which kind of token is used based on the environment

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -221,8 +221,8 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         async throws -> AuthenticationToken?
     {
         #if canImport(TuistSupport)
-            if Environment.current.isCI {
-                return try await ciAuthenticationToken()
+            if let environmentToken = try await environmentToken() {
+                return environmentToken
             } else {
                 return try await authenticationTokenRefreshingIfNeeded(
                     serverURL: serverURL,
@@ -552,7 +552,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         }
     }
 
-    private func ciAuthenticationToken() async throws -> AuthenticationToken? {
+    private func environmentToken() async throws -> AuthenticationToken? {
         #if canImport(TuistSupport)
             if let configToken = Environment.current.tuistVariables[
                 Constants.EnvironmentVariables.token


### PR DESCRIPTION
It's a bit annoying that on the CI we force the usage of `TUIST_CONFIG_TOKEN` and in local environment, such a token is not used.

Especially in local environments, we might want to allow teams to specify a custom account token that would be then specific with the env variable.

But also on the CI, it's sometimes useful to use the `tuist auth login` flow – especially right now when the project token is limited in what it can do.

The motivation here is to make our cache [benchmarking](https://github.com/tuist/cache-benchmark) easier, but I think it's a reasonable change either way.