### PR TITLE
feat(docs): document .tuistignore file for editing projects

### DIFF
--- a/docs/docs/en/guides/features/projects/editing.md
+++ b/docs/docs/en/guides/features/projects/editing.md
@@ -37,6 +37,22 @@ The project includes a `Manifests` directory that you can build to ensure all yo
 <!-- -->
 :::
 
+### Ignoring manifest files {#ignoring-manifest-files}
+
+If your project contains Swift files with the same name as manifest files (e.g., `Project.swift`) in subdirectories that are not actual Tuist manifests, you can create a `.tuistignore` file at the root of your project to exclude them from the editing project.
+
+The `.tuistignore` file uses glob patterns to specify which files should be ignored:
+
+```gitignore
+# Ignore all Project.swift files in the Sources directory
+Sources/**/Project.swift
+
+# Ignore specific subdirectories
+Tests/Fixtures/**/Workspace.swift
+```
+
+This is particularly useful when you have test fixtures or example code that happens to use the same naming convention as Tuist manifest files.
+
 ## Edit and generate workflow {#edit-and-generate-workflow}
 
 As you might have noticed, the editing can't be done from the generated Xcode project.


### PR DESCRIPTION
## Summary
- Documents the `.tuistignore` file feature in the project editing documentation
- Explains how to use glob patterns to exclude manifest-like files from `tuist edit`
- Provides examples for common use cases like test fixtures

## Test plan
- [x] Added documentation with clear examples
- [x] Included use case explanation
- [ ] Verify handbook builds successfully

This feature is useful when projects contain Swift files with the same name as manifest files (e.g., `Project.swift`) in subdirectories that are not actual Tuist manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)