### PR TITLE
feat(cli): Only use binaries for external dependencies when no focus target is passed to `tuist generate`

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -227,11 +227,17 @@ public final class GraphMapperFactory: GraphMapperFactorying {
                 mappers.append(FocusTargetsGraphMappers(includedTargets: cacheSources))
                 mappers.append(TreeShakePrunedTargetsGraphMapper())
             }
+            
+            let decider: TargetReplacementDeciding = if cacheSources.isEmpty {
+                ExternalOnlyTargetReplacementDecider()
+            } else {
+                AllPossibleTargetReplacementDecider(exceptions: cacheSources)
+            }
 
             if !ignoreBinaryCache {
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                     config: config,
-                    decider: AllPossibleTargetReplacementDecider(exceptions: cacheSources),
+                    decider: decider,
                     configuration: configuration,
                     cacheStorage: cacheStorage
                 )


### PR DESCRIPTION
With the introduction of an interface to _decide_ which targets to replace with binaries, we introduced a regression where `tuist generate` would try to use as many binaries as possible. This PR fixes that.