### PR TITLE
fix(server): width of cards in about

### DIFF
--- a/server/assets/marketing/css/routes/about.css
+++ b/server/assets/marketing/css/routes/about.css
@@ -144,6 +144,10 @@
       gap: var(--noora-spacing-5);
       padding-left: 0;
 
+      @media (max-width: 1024px) {
+        max-width: min(424px, calc(100vw - var(--noora-spacing-9)));
+      }
+
       @media (min-width: 1024px) {
         flex-direction: row;
       }
@@ -159,7 +163,6 @@
         border-radius: var(--noora-radius-xlarge);
         background: var(--noora-surface-background-primary);
         width: 100%;
-        max-width: 424px;
         overflow: hidden;
 
         @media (min-width: 1024px) {


### PR DESCRIPTION
Fixing phantom horizontal scrolling in the about page that was happening due to the cards stretching outside of the bounds.

<img width="1088" height="928" alt="image" src="https://github.com/user-attachments/assets/41cd84d6-6ee6-47e0-a5d5-2b160d4a3d8c" />

