### PR TITLE
fix(server): navbar not being sticky in the about page

### DIFF
--- a/server/assets/marketing/css/routes/about.css
+++ b/server/assets/marketing/css/routes/about.css
@@ -8,12 +8,6 @@
     gap: var(--noora-spacing-11);
   }
 
-  & > section,
-  & > header {
-    position: relative;
-    z-index: var(--noora-z-index-2);
-  }
-
   & > [data-part="header"] {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Changing the `header` position to `relative` breaks the stickiness of the navbar. I haven't figured out why this CSS code was even there and I don't see anything else breaking when I removed it ... so should be good? 🤷‍♂️ 