### PR TITLE
fix(cli): improve error messages of cache daemon

### DIFF
--- a/cli/Sources/TuistCAS/Extensions/Error+Description.swift
+++ b/cli/Sources/TuistCAS/Extensions/Error+Description.swift
@@ -1,0 +1,18 @@
+import Foundation
+import OpenAPIRuntime
+import TuistServer
+
+extension Error {
+    /// Returns a user-friendly error description, with special handling for ClientError and ServerClientAuthenticationError
+    func userFriendlyDescription() -> String {
+        if let clientError = self as? ClientError,
+           let underlyingServerClientError = clientError.underlyingError as? ServerClientAuthenticationError
+        {
+            return underlyingServerClientError.errorDescription ?? "Unknown error"
+        } else if let localizedError = self as? LocalizedError {
+            return localizedError.errorDescription ?? localizedError.localizedDescription
+        } else {
+            return localizedDescription
+        }
+    }
+}

--- a/cli/Sources/TuistCAS/Services/CASService.swift
+++ b/cli/Sources/TuistCAS/Services/CASService.swift
@@ -59,7 +59,7 @@ public struct CASService: CompilationCacheService_Cas_V1_CASDBService.SimpleServ
         } catch {
             response.outcome = .error
             var responseError = CompilationCacheService_Cas_V1_ResponseError()
-            responseError.description_p = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            responseError.description_p = error.userFriendlyDescription()
             response.error = responseError
             response.contents = .error(responseError)
         }
@@ -80,7 +80,7 @@ public struct CASService: CompilationCacheService_Cas_V1_CASDBService.SimpleServ
                 data = try await fileSystem.readFile(at: absolutePath)
             } catch {
                 var responseError = CompilationCacheService_Cas_V1_ResponseError()
-                responseError.description_p = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                responseError.description_p = error.userFriendlyDescription()
                 response.error = responseError
                 response.contents = .error(responseError)
                 return response
@@ -106,7 +106,7 @@ public struct CASService: CompilationCacheService_Cas_V1_CASDBService.SimpleServ
             response.contents = .casID(message)
         } catch {
             var responseError = CompilationCacheService_Cas_V1_ResponseError()
-            responseError.description_p = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            responseError.description_p = error.userFriendlyDescription()
             response.error = responseError
             response.contents = .error(responseError)
         }

--- a/cli/Sources/TuistCAS/Services/KeyValueService.swift
+++ b/cli/Sources/TuistCAS/Services/KeyValueService.swift
@@ -45,7 +45,7 @@ public struct KeyValueService: CompilationCacheService_Keyvalue_V1_KeyValueDB.Si
             return response
         } catch {
             var responseError = CompilationCacheService_Keyvalue_V1_ResponseError()
-            responseError.description_p = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            responseError.description_p = error.userFriendlyDescription()
             response.error = responseError
             return response
         }
@@ -78,7 +78,7 @@ public struct KeyValueService: CompilationCacheService_Keyvalue_V1_KeyValueDB.Si
             }
         } catch {
             var responseError = CompilationCacheService_Keyvalue_V1_ResponseError()
-            responseError.description_p = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            responseError.description_p = error.userFriendlyDescription()
             response.error = responseError
             response.outcome = .keyNotFound
         }

--- a/cli/Tests/TuistCASTests/CASServiceTests.swift
+++ b/cli/Tests/TuistCASTests/CASServiceTests.swift
@@ -2,6 +2,7 @@ import CryptoKit
 import Foundation
 import GRPCCore
 import Mockable
+import OpenAPIRuntime
 import Path
 import Testing
 import TuistServer
@@ -164,6 +165,64 @@ struct CASServiceTests {
         switch response.contents {
         case let .error(error):
             #expect(error.description_p == "Upload denied")
+        case .casID:
+            #expect(Bool(false), "Expected error, but got casID")
+        case .none:
+            #expect(Bool(false), "Expected error, but contents is nil")
+        }
+    }
+
+    @Test
+    func load_when_client_error_with_auth_error() async throws {
+        // Given
+        let casID = "test-cas-id"
+        let authError = ServerClientAuthenticationError.notAuthenticated
+        let clientError = ClientError(
+            operationID: "loadCacheCAS",
+            operationInput: "",
+            causeDescription: "Authentication failed",
+            underlyingError: authError
+        )
+
+        var request = CompilationCacheService_Cas_V1_CASLoadRequest()
+        request.casID.id = casID.data(using: .utf8)!
+
+        let context = ServerContext.test()
+
+        given(loadCacheCASService)
+            .loadCacheCAS(casId: .any, fullHandle: .any, serverURL: .any)
+            .willThrow(clientError)
+
+        // When
+        let response = try await subject.load(request: request, context: context)
+
+        // Then
+        #expect(response.outcome == .error)
+        #expect(response.error.description_p == "You must be logged in to do this.")
+    }
+
+    @Test
+    func save_when_generic_error() async throws {
+        // Given
+        let testData = Data("test data".utf8)
+        let genericError = NSError(domain: "TestDomain", code: 500, userInfo: nil)
+
+        var request = CompilationCacheService_Cas_V1_CASSaveRequest()
+        request.data.blob.data = testData
+
+        let context = ServerContext.test()
+
+        given(saveCacheCASService)
+            .saveCacheCAS(.any, casId: .any, fullHandle: .any, serverURL: .any)
+            .willThrow(genericError)
+
+        // When
+        let response = try await subject.save(request: request, context: context)
+
+        // Then
+        switch response.contents {
+        case let .error(error):
+            #expect(error.description_p == genericError.localizedDescription)
         case .casID:
             #expect(Bool(false), "Expected error, but got casID")
         case .none:

--- a/cli/Tests/TuistCASTests/KeyValueServiceTests.swift
+++ b/cli/Tests/TuistCASTests/KeyValueServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GRPCCore
 import Mockable
+import OpenAPIRuntime
 import Path
 import Testing
 import TuistServer
@@ -168,6 +169,58 @@ struct KeyValueServiceTests {
 
         // Then
         #expect(response.error.description_p == "Invalid token")
+        #expect(response.outcome == .keyNotFound)
+    }
+
+    @Test
+    func putValue_when_client_error_with_auth_error() async throws {
+        // Given
+        let key = Data("0test-key".utf8)
+        let authError = ServerClientAuthenticationError.notAuthenticated
+        let clientError = ClientError(
+            operationID: "putCacheValue",
+            operationInput: "",
+            causeDescription: "Authentication failed",
+            underlyingError: authError
+        )
+
+        var request = CompilationCacheService_Keyvalue_V1_PutValueRequest()
+        request.key = key
+
+        let context = ServerContext.test()
+
+        given(putCacheValueService)
+            .putCacheValue(casId: .any, entries: .any, fullHandle: .any, serverURL: .any)
+            .willThrow(clientError)
+
+        // When
+        let response = try await subject.putValue(request: request, context: context)
+
+        // Then
+        #expect(response.hasError == true)
+        #expect(response.error.description_p == "You must be logged in to do this.")
+    }
+
+    @Test
+    func getValue_when_generic_error() async throws {
+        // Given
+        let key = Data("0test-key".utf8)
+        let genericError = NSError(domain: "TestDomain", code: 123, userInfo: nil)
+
+        var request = CompilationCacheService_Keyvalue_V1_GetValueRequest()
+        request.key = key
+
+        let context = ServerContext.test()
+
+        given(getCacheValueService)
+            .getCacheValue(casId: .any, fullHandle: .any, serverURL: .any)
+            .willThrow(genericError)
+
+        // When
+        let response = try await subject.getValue(request: request, context: context)
+
+        // Then
+        #expect(response.error.description_p == genericError.localizedDescription)
         #expect(response.outcome == .keyNotFound)
     }
 }


### PR DESCRIPTION
If the user is not authenticated, the current error message that's included in the build logs is not ... nice:

```
warning: CAS error: Client encountered an error invoking the operation 
```

Adding a similar kind of error handling to improve the error message as we have in the `TuistCommand`.