### PR TITLE
docs(handbook): add warning about static libraries and resources

### DIFF
--- a/docs/docs/en/guides/features/projects/best-practices.md
+++ b/docs/docs/en/guides/features/projects/best-practices.md
@@ -63,3 +63,18 @@ let target = Target(
 ```
 <!-- -->
 :::
+
+::: warning Static libraries and resources
+When working with static libraries that include resources, **do not** use buildable folders to include resources. Instead, use the explicit `Target.resources` interface:
+
+```swift
+let target = Target(
+  name: "MyStaticLibrary",
+  product: .staticLibrary,
+  buildableFolders: ["MyStaticLibrary/Sources"], // OK for sources
+  resources: ["MyStaticLibrary/Resources/**"]    // Use explicit resources
+)
+```
+
+This ensures resources are properly bundled and accessible when the static library is linked into your application.
+:::


### PR DESCRIPTION
## Summary

Adds a warning note in the best practices documentation to recommend using `Target.resources` instead of buildable folders when working with static libraries that include resources.

The buildable folders section currently recommends using buildable folders for both sources and resources, but this can cause issues with static libraries where resources may not be properly bundled.

## Changes

- Added a warning box in the "Buildable folders" section of the best practices guide
- Included a code example showing the recommended approach: using `buildableFolders` for sources but explicit `resources` for resources in static libraries
- Added explanation about why this is important for proper resource bundling

Fixes https://github.com/tuist/tuist/issues/8336

🤖 Generated with [Claude Code](https://claude.com/claude-code)