### PR TITLE
fix(cli): Multiple targets with same hash

### DIFF
--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -131,6 +131,7 @@ public final class TargetContentHasher: TargetContentHashing {
             let hash = try contentHasher.hash(
                 [
                     projectHash,
+                    graphTarget.target.name,
                     graphTarget.target.product.rawValue,
                     projectSettingsHash,
                     settingsHash,
@@ -142,6 +143,7 @@ public final class TargetContentHasher: TargetContentHashing {
             Target content hash for \(graphTarget.target.name) (external project): \(hash)
               Components:
                 project: \(projectHash)
+                name: \(graphTarget.target.name)
                 product: \(graphTarget.target.product.rawValue)
                 projectSettings: \(projectSettingsHash)
                 targetSettings: \(settingsHash ?? "nil")

--- a/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -101,7 +101,7 @@ struct TargetContentHasherTests {
         )
 
         // Then
-        #expect(got.hash == "hash-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone")
+        #expect(got.hash == "hash-Target-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone")
     }
 
     @Test func hash_when_targetBelongsToExternalProjectWithHash_with_additional_string() async throws {
@@ -120,7 +120,7 @@ struct TargetContentHasherTests {
         // Then
         #expect(
             got.hash ==
-                "hash-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone-additional_string_one-additional_string_two"
+                "hash-Target-app-settings_hash-settings_hash-dependencies_hash-iPad-iPhone-additional_string_one-additional_string_two"
         )
     }
 


### PR DESCRIPTION
Our hashing logic did not include the target name, resulting in multiple external targets that share the same source hash being assigned identical hashes. As a consequence, the cache would end up with hash directories containing multiple products, a scenario that we could handle, but that would lead to race conditions. We encountered one such race condition where the cache ended up with hash directories missing artifacts.
Two targets that don't represent the same thing should not have the same hash. So I'm including the target name in the hashing logic.