### PR TITLE
fix(server): Add padding at the bottom of marketing pages

### DIFF
--- a/server/assets/marketing/css/routes/shared/page.css
+++ b/server/assets/marketing/css/routes/shared/page.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   gap: var(--noora-spacing-11);
   z-index: var(--noora-z-index-1);
+  padding-bottom: var(--noora-spacing-15);
 
   @media (min-width: 370px) {
     gap: var(--noora-spacing-9);


### PR DESCRIPTION
Old:

<img width="715" height="168" alt="Screenshot 2025-10-31 at 12 10 06 PM" src="https://github.com/user-attachments/assets/c0a30505-b4f0-412e-abd6-42f6ddc19b9f" />

New:

<img width="686" height="237" alt="Screenshot 2025-10-31 at 12 10 27 PM" src="https://github.com/user-attachments/assets/fb24e556-4e4e-4753-af5a-7cc1a56184d6" />
