### PR TITLE
fix(cli): fix content hashing to use relative path when file does not exist

### DIFF
--- a/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetScriptsContentHasherTests.swift
@@ -299,12 +299,16 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         given(contentHasher)
             .hash(path: .value(sourceRootPath.appending(try RelativePath(validating: "srcroot/replaced.txt"))))
             .willReturn(absoluteInputHash)
+        
+        given(contentHasher)
+            .hash(path: .value(sourceRootPath.appending(try RelativePath(validating: "relative/not-existing.txt"))))
+            .willThrow(FileHandlerError.fileNotFound(try AbsolutePath(validating: "/")))
 
         let targetScript = TargetScript(
             name: "TestScript",
             order: .pre,
             script: .tool(path: "tool", args: ["arg"]),
-            inputPaths: ["relative/input.txt"],
+            inputPaths: ["relative/input.txt", "relative/not-existing.txt"],
             inputFileListPaths: ["$(SRCROOT)/srcroot/replaced.txt"],
             outputPaths: ["relative/output.txt"],
             outputFileListPaths: ["$(SRCROOT)/srcroot/output.txt"],
@@ -317,6 +321,7 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         // Then
         let expected = [
             relativeInputHash,
+            "relative/not-existing.txt",
             absoluteInputHash,
             "relative/output.txt",
             "srcroot/output.txt",


### PR DESCRIPTION

Fixes an issue with `TargetScriptsContentHasher` which would throw an error when running `tuist cache` if an input file for a target script did not exist.  

### How to test locally

Tests have been updated for this case. 
