### PR TITLE
fix(server): reduce HTTP metrics cardinality by removing request_path tag

### DIFF
--- a/server/lib/tuist/http/prom_ex_plugin.ex
+++ b/server/lib/tuist/http/prom_ex_plugin.ex
@@ -144,7 +144,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             [:tuist, :http, :send, :duration, :nanoseconds, :sum],
             event_name: [:finch, :send, :stop],
             tag_values: &send_metadata_to_tag_values/1,
-            tags: [:request_method, :request_host, :request_path],
+            tags: [:request_method, :request_host],
             description: "Summary of the time it takes to finish sending the request to the server.",
             measurement: :duration,
             unit: {:native, :nanosecond}
@@ -153,7 +153,7 @@ defmodule Tuist.HTTP.PromExPlugin do
             [:tuist, :http, :send, :duration, :nanoseconds],
             event_name: [:finch, :send, :stop],
             tag_values: &send_metadata_to_tag_values/1,
-            tags: [:request_method, :request_host, :request_path],
+            tags: [:request_method, :request_host],
             description: "Summary of the time it takes to finish sending the request to the server.",
             measurement: :duration,
             unit: {:native, :nanosecond},


### PR DESCRIPTION
## Summary
- Remove `:request_path` tag from HTTP send duration metrics to prevent high cardinality
- This was causing excessive Grafana costs due to unique metric series for every URL path
- Keep `:request_method` and `:request_host` tags for meaningful monitoring without cardinality explosion
- I double checked and we're not using the `request_path` for anything for now