### PR TITLE
fix(server): use configured app_url for oauth redirect_uri

### DIFF
--- a/server/lib/tuist_web/plugs/ueberauth_host_plug.ex
+++ b/server/lib/tuist_web/plugs/ueberauth_host_plug.ex
@@ -1,0 +1,21 @@
+defmodule TuistWeb.Plugs.UeberauthHostPlug do
+  @moduledoc """
+  Sets the correct host header for Ueberauth OAuth callbacks when behind a load balancer.
+
+  When using a load balancer (e.g., Cloudflare) that forwards requests with a different
+  Host header than the public-facing domain, Ueberauth will build OAuth callback URLs
+  using the internal host. This plug ensures the public app URL is used instead.
+  """
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    app_url = Tuist.Environment.app_url([route_type: :app])
+    %{host: app_host, scheme: app_scheme} = URI.parse(app_url)
+
+    conn
+    |> put_req_header("x-forwarded-host", app_host)
+    |> put_req_header("x-forwarded-proto", app_scheme)
+  end
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -66,6 +66,7 @@ defmodule TuistWeb.Router do
     plug :fetch_live_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug TuistWeb.Plugs.UeberauthHostPlug
     plug Ueberauth
   end
 
@@ -78,6 +79,7 @@ defmodule TuistWeb.Router do
     plug :fetch_live_flash
     plug :put_root_layout, html: {TuistWeb.Layouts, :app}
     plug :put_secure_browser_headers
+    plug TuistWeb.Plugs.UeberauthHostPlug
     plug Ueberauth
     plug :fetch_current_user
     plug :content_security_policy
@@ -91,6 +93,7 @@ defmodule TuistWeb.Router do
     plug :put_root_layout, html: {TuistWeb.Marketing.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug TuistWeb.Plugs.UeberauthHostPlug
     plug Ueberauth
     plug :fetch_current_user
     plug :assign_current_path

--- a/server/test/tuist_web/plugs/ueberauth_host_plug_test.exs
+++ b/server/test/tuist_web/plugs/ueberauth_host_plug_test.exs
@@ -1,0 +1,86 @@
+defmodule TuistWeb.Plugs.UeberauthHostPlugTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias TuistWeb.Plugs.UeberauthHostPlug
+
+  setup :set_mimic_from_context
+
+  describe "call/2" do
+    test "sets x-forwarded-host header to the configured app URL host" do
+      # Given
+      conn = build_conn(:get, "/users/auth/github")
+      opts = UeberauthHostPlug.init([])
+
+      Tuist.Environment
+      |> expect(:app_url, fn [route_type: :app] ->
+        "https://tuist.dev"
+      end)
+
+      # When
+      conn = UeberauthHostPlug.call(conn, opts)
+
+      # Then
+      assert Plug.Conn.get_req_header(conn, "x-forwarded-host") == ["tuist.dev"]
+    end
+
+    test "sets x-forwarded-proto header to the configured app URL scheme" do
+      # Given
+      conn = build_conn(:get, "/users/auth/github")
+      opts = UeberauthHostPlug.init([])
+
+      Tuist.Environment
+      |> expect(:app_url, fn [route_type: :app] ->
+        "https://tuist.dev"
+      end)
+
+      # When
+      conn = UeberauthHostPlug.call(conn, opts)
+
+      # Then
+      assert Plug.Conn.get_req_header(conn, "x-forwarded-proto") == ["https"]
+    end
+
+    test "handles app URLs with non-standard ports" do
+      # Given
+      conn = build_conn(:get, "/users/auth/github")
+      opts = UeberauthHostPlug.init([])
+
+      Tuist.Environment
+      |> expect(:app_url, fn [route_type: :app] ->
+        "http://localhost:4000"
+      end)
+
+      # When
+      conn = UeberauthHostPlug.call(conn, opts)
+
+      # Then
+      assert Plug.Conn.get_req_header(conn, "x-forwarded-host") == ["localhost"]
+      assert Plug.Conn.get_req_header(conn, "x-forwarded-proto") == ["http"]
+    end
+
+    test "overrides existing x-forwarded-host header from load balancer" do
+      # Given
+      conn =
+        build_conn(:get, "/users/auth/github")
+        |> Plug.Conn.put_req_header("x-forwarded-host", "tuist.onrender.com")
+        |> Map.put(:host, "tuist.onrender.com")
+
+      opts = UeberauthHostPlug.init([])
+
+      Tuist.Environment
+      |> expect(:app_url, fn [route_type: :app] ->
+        "https://tuist.dev"
+      end)
+
+      # When
+      conn = UeberauthHostPlug.call(conn, opts)
+
+      # Then
+      # Should override the load balancer's forwarded host
+      assert Plug.Conn.get_req_header(conn, "x-forwarded-host") == ["tuist.dev"]
+      # Original host field remains unchanged
+      assert conn.host == "tuist.onrender.com"
+    end
+  end
+end


### PR DESCRIPTION
We're having a circular dependency issue:
1. For the cache nodes, we need a Cloudflare load balancer on `tuist.dev`.
2. When adding a custom domain `tuist.dev` on Render, it assumes ownership of the domain and overrides the load balancer since they themselves use Cloudflare.
3. When using the `tuist.onrender.com` domain as `HOST`, Ueberauth will use this as `redirect_uri` instead of the Cloudflare LB domain.

Ueberauth automatically builds the `redirect_uri` from the `X-Forwarded-Host` header, which in the
`Cloudflare tuist.dev -> Render tuist.onrender.com -> Phoenix` chain is, by default, `tuist.onrender.com` since Render's reverse proxy overrides the Cloudflare one.

This PR adds a Plug that overrides the header _again_ on application level, to whatever `app_url` we have configured.