### PR TITLE
fix(server): apply ueberauth host plug to browser_app pipeline for Okta

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -44,6 +44,7 @@ defmodule TuistWeb.Router do
     plug :put_root_layout, html: {TuistWeb.Layouts, :app}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug TuistWeb.Plugs.UeberauthHostPlug
     plug :fetch_current_user
     plug :content_security_policy
   end


### PR DESCRIPTION
co-authored by Sonnet 4.5

#8569 added the new plug only to the `ueberauth` pipeline.
the Okta controller uses the `browser_app` pipeline, though.