### PR TITLE
chore(ci): skip expensive workflow jobs on draft PRs

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -73,7 +73,8 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
-      !contains(needs.*.result, 'failure')
+      !contains(needs.*.result, 'failure') &&
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -114,7 +115,8 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
-      !contains(needs.*.result, 'failure')
+      !contains(needs.*.result, 'failure') &&
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -147,7 +149,8 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
-      !contains(needs.*.result, 'failure')
+      !contains(needs.*.result, 'failure') &&
+      (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode

--- a/.github/workflows/cas-worker.yml
+++ b/.github/workflows/cas-worker.yml
@@ -36,6 +36,7 @@ jobs:
     name: Test
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Restore PNPM Cache

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -70,6 +70,7 @@ jobs:
   cli-spm-build:
     name: SwiftPM Build
     runs-on: macos-26
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -119,6 +120,7 @@ jobs:
   cli-unit-tests:
     name: Unit Tests
     runs-on: namespace-profile-default-macos
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -144,6 +146,7 @@ jobs:
     name: Automation Acceptance Tests
     runs-on: macos-26
     timeout-minutes: 60
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -175,6 +178,7 @@ jobs:
     name: Dependencies Acceptance Tests
     runs-on: macos-26
     timeout-minutes: 60
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -213,6 +217,7 @@ jobs:
     name: Generator Acceptance Tests
     runs-on: macos-26
     timeout-minutes: 60
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
@@ -244,6 +249,7 @@ jobs:
     name: Kit Acceptance Tests
     runs-on: macos-26
     timeout-minutes: 60
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ jobs:
   build-deploy:
     name: Build & Deploy
     runs-on: macos-26
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Restore PNPM Cache

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -32,6 +32,7 @@ jobs:
     name: Build & Deploy
     runs-on: "ubuntu-latest"
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Restore PNPM Cache

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,6 +37,7 @@ jobs:
     name: Gettext (Marketing)
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Restore Mix Cache
@@ -142,6 +143,7 @@ jobs:
     name: Test
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: timescale/timescaledb-ha:pg16
@@ -186,6 +188,7 @@ jobs:
     name: Credo
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Restore Mix Cache
@@ -244,6 +247,7 @@ jobs:
     name: esbuild
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4 # v4
       - name: Restore Mix Cache
@@ -289,6 +293,7 @@ jobs:
     name: Security
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Restore Mix Cache
@@ -318,6 +323,7 @@ jobs:
     name: Docker build
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -418,6 +424,7 @@ jobs:
     name: Seed
     runs-on: namespace-profile-default
     timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
         image: timescale/timescaledb-ha:pg16


### PR DESCRIPTION
## Summary

This PR optimizes CI resource usage by skipping expensive workflow jobs when pull requests are in draft status. Lightweight checks (formatting, linting, PR title validation) continue to run on all PRs, while resource-intensive operations (tests, builds, deployments) only run when PRs are ready for review or when pushing to main.

Changes made to the following workflows:

- **server.yml**: Skip gettext checks, tests (with PostgreSQL), credo analysis, esbuild, security scans, docker builds, and database seeding
- **cli.yml**: Skip SwiftPM builds, unit tests, and all acceptance test suites (automation, dependencies, generator, kit)
- **app.yml**: Skip all iOS app builds, tests, and device builds
- **docs.yml**: Skip documentation generation and deployment
- **handbook.yml**: Skip handbook building
- **cas-worker.yml**: Skip test suite

### Benefits

- **Reduced CI costs**: Expensive jobs don't consume runner minutes during development
- **Faster feedback**: Developers get quick format/lint checks without waiting for full test suites
- **Maintained quality**: All checks still run when PR is marked ready for review
- **No workflow disruption**: Push to main and merge groups continue running all jobs normally

### Implementation

All modified jobs include the condition:
```yaml
if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
```

This ensures:
- ✅ Draft PRs: Only lightweight checks run
- ✅ Ready for review: All jobs run
- ✅ Main branch pushes: All jobs run
- ✅ Merge groups: All jobs run

## Test plan

- [x] Create a draft PR and verify only lightweight checks run
- [x] Mark PR as ready for review and verify all jobs execute
- [x] Verify workflows still run on push to main
- [x] Confirm conventional-pr check still validates PR titles on drafts

🤖 Generated with [Claude Code](https://claude.com/claude-code)