### PR TITLE
feat(cache): move to x-accel-redirect

### DIFF
--- a/cache/lib/cache/disk.ex
+++ b/cache/lib/cache/disk.ex
@@ -92,6 +92,16 @@ defmodule Cache.Disk do
   end
 
   @doc """
+  Build the internal X-Accel-Redirect path for a CAS artifact.
+
+  The returned path maps to the nginx internal location that aliases the
+  physical CAS storage directory.
+  """
+  def internal_accel_path(account_handle, project_handle, id) do
+    "/internal/cas/" <> cas_key(account_handle, project_handle, id)
+  end
+
+  @doc """
   Returns the configured storage directory for CAS artifacts.
 
   Defaults to "tmp/cas" if not configured.

--- a/cache/lib/cache_web/router.ex
+++ b/cache/lib/cache_web/router.ex
@@ -19,11 +19,7 @@ defmodule CacheWeb.Router do
     get "/keyvalue/:cas_id", KeyValueController, :get_value
     put "/keyvalue/:cas_id", KeyValueController, :get_value
     put "/keyvalue", KeyValueController, :put_value
+    get "/cas/:id", CASController, :download
     post "/cas/:id", CASController, :save
-  end
-
-  scope "/auth", CacheWeb do
-    pipe_through :api_json
-    get "/cas", CASController, :authorize
   end
 end

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -39,44 +39,13 @@
           client_body_timeout 30m;
         '';
 
-        locations."~ ^/api/cache/cas/(.+)$" = {
-          root = "/";
-          extraConfig = ''
-            error_page 405 = @phoenix_cas;
-            if ($request_method !~ ^(GET|HEAD)$) { return 405; }
-
-            set $account $arg_account_handle;
-            set $project $arg_project_handle;
-
-            auth_request /_auth_cas;
-
-            default_type application/octet-stream;
-            rewrite ^/api/cache/cas/(.*)$ /$1 break;
-            try_files /cas/$account/$project/cas$uri =404;
-
-            gzip off;
-            add_header Cache-Control "public, max-age=31536000, immutable";
-          '';
-        };
-
-        locations."@phoenix_cas" = {
-          proxyPass = "http://127.0.0.1:4000";
-          proxyWebsockets = false;
-          extraConfig = ''
-            proxy_buffering off;
-            proxy_request_buffering off;
-          '';
-        };
-
-        locations."=/_auth_cas" = {
+        locations."/internal/cas/" = {
           extraConfig = ''
             internal;
-            proxy_pass_request_body off;
-            proxy_set_header Content-Length "";
-            proxy_set_header X-Request-ID $request_id;
-            proxy_set_header Authorization $http_authorization;
-            proxy_method GET;
-            proxy_pass http://127.0.0.1:4000/auth/cas?account_handle=$account&project_handle=$project;
+            alias /cas/;
+            default_type application/octet-stream;
+            gzip off;
+            add_header Cache-Control "public, max-age=31536000, immutable";
           '';
         };
 

--- a/cache/test/cache/disk_test.exs
+++ b/cache/test/cache/disk_test.exs
@@ -135,6 +135,19 @@ defmodule Cache.DiskTest do
     end
   end
 
+  describe "internal_accel_path/3" do
+    test "builds internal X-Accel-Redirect path for simple id" do
+      path = Disk.internal_accel_path(@test_account, @test_project, @test_id)
+      assert path == "/internal/cas/#{@test_key}"
+    end
+
+    test "builds internal path for nested id" do
+      nested_id = "deeply/nested/artifact"
+      path = Disk.internal_accel_path(@test_account, @test_project, nested_id)
+      assert path == "/internal/cas/#{@test_account}/#{@test_project}/cas/#{nested_id}"
+    end
+  end
+
   describe "integration test" do
     test "put and exists roundtrip" do
       original_data = "This is test artifact content for roundtrip testing"


### PR DESCRIPTION
This PR moves from `auth_request` and a direct file server to the Elixir node setting files.
1. Simplifies nginx configuration.
2. Required step for being able to return S3-presigned URLs.

Flow is basically exactly the same, but we don't return an empty response from the auth endpoint anymore and instead return the file path nginx should serve.