### PR TITLE
fix(server): extract subscription plan regardless of status

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -181,10 +181,8 @@ defmodule Tuist.Billing do
         # ignore the webhooks for those customers.
         :ok
 
-      is_nil(current_subscription) and plan == :none ->
-        # If there's no existing subscription and we can't determine the plan from
-        # the subscription items (e.g., unrecognized price IDs), skip creating a record.
-        :ok
+      plan == :none ->
+        raise "Unable to determine plan from subscription items. Subscription ID: #{subscription.id}, Price IDs: #{inspect(Enum.map(subscription.items.data, & &1.price.id))}"
 
       is_nil(current_subscription) ->
         %Subscription{}
@@ -198,19 +196,10 @@ defmodule Tuist.Billing do
         })
         |> Repo.insert!()
 
-      plan != :none ->
+      true ->
         current_subscription
         |> Subscription.update_changeset(%{
           plan: plan,
-          status: subscription.status,
-          default_payment_method: subscription.default_payment_method,
-          trial_end: trial_end
-        })
-        |> Repo.update!()
-
-      plan == :none ->
-        current_subscription
-        |> Subscription.update_changeset(%{
           status: subscription.status,
           default_payment_method: subscription.default_payment_method,
           trial_end: trial_end


### PR DESCRIPTION
## Problem

We were experiencing `Ecto.InvalidChangesetError` crashes when processing Stripe webhooks for canceled subscriptions:

```
Errors: %{plan: [{"is invalid", [validation: :inclusion, enum: ["air", "enterprise", "open_source", "pro"]]}]}
Applied changes: %{status: "canceled", account_id: 4432, subscription_id: "sub_1SPO5jLWue9IBlPSiR3Oein6"}
Params: %{"plan" => :none, "status" => "canceled", ...}
```

## Root Cause

The `get_plan/1` function was returning `:none` for any subscription that wasn't in 'active' or 'trialing' status, including canceled subscriptions. When a webhook arrived for a canceled subscription, the code tried to create/update a database record with `plan: :none`, but `:none` is not a valid value in the `Ecto.Enum` (only `:enterprise`, `:air`, `:pro`, `:open_source` are valid).

## Solution

### 1. Extract plan regardless of status
Modified `get_plan/1` to extract the plan from subscription items' price IDs **regardless of subscription status**. The subscription status is already stored separately in the `status` field.

This approach:
- Prevents the changeset validation error
- Maintains full history of which plan a subscription was on, even after cancellation
- Properly separates concerns: `plan` = which tier (extracted from price IDs), `status` = subscription state (active, canceled, etc.)

### 2. Raise error on unrecognized price IDs
Instead of silently returning `:none` when price IDs don't match our configuration, we now raise an error with diagnostic information. This helps catch configuration bugs or missing price mappings early.

If we can't determine the plan, it's a bug that needs attention - either:
- Our Stripe price configuration is out of sync
- Stripe has price IDs we don't recognize
- There's a subscription with unexpected items

The error message includes the subscription ID and price IDs to aid debugging.

## Testing

All existing tests pass, including the test for canceled subscriptions (test/tuist/billing_test.exs:313) which validates this exact scenario.

```bash
mix test test/tuist/billing_test.exs
# 28 tests, 0 failures
```