### PR TITLE
chore(cli): update post-build actions to work when a global tuist version is not set

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -13,9 +13,7 @@ func inspectBuildPostAction(target: TargetReference) -> ExecutionAction {
     .executionAction(
         title: "Inspect build",
         scriptText: """
-        eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
-
-        tuist inspect build
+        $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
         """,
         target: target
     )

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -23,9 +23,7 @@ func tuistMenuBarDependencies() -> [TargetDependency] {
 let inspectBuildPostAction: ExecutionAction = .executionAction(
     title: "Inspect build",
     scriptText: """
-    eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
-
-    tuist inspect build
+    $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
     """
 )
 


### PR DESCRIPTION
This brings the project in line with our recommended integration.