### PR TITLE
feat(server): enable Russian locale on marketing site

### DIFF
--- a/server/assets/marketing/css/layouts/components/navbar.css
+++ b/server/assets/marketing/css/layouts/components/navbar.css
@@ -531,7 +531,8 @@
           border-radius: var(--noora-radius-xlarge);
           background: #fff;
 
-          &.show {
+          &.show,
+          &[data-open="true"] {
             transform: translateX(-50%) translateY(0);
             visibility: visible;
             opacity: 1;

--- a/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
+++ b/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
@@ -125,7 +125,7 @@ resources_items = [
 ] %>
 <header id="marketing-navbar">
   <div data-part="bar">
-    <.link href={~p"/"} data-part="tuist">
+    <.link href={TuistWeb.Marketing.MarketingHTML.localized_href("/")} data-part="tuist">
       <img data-part="logo" src={~p"/marketing/images/components/navbar/logo.webp"} alt="Tuist" />
       <h3 data-part="title">Tuist</h3>
     </.link>
@@ -285,88 +285,37 @@ resources_items = [
       </div>
     </nav>
     <nav data-part="actions" aria-label="Call to action">
-      <%!-- <div data-part="menu" phx-hook="NavbarDropdown" id="marketing-navbar-languages-menu">
-      <div data-part="action">
-        <span data-part="title">
-          <.language />
-        </span>
-        <span data-part="chevron"><.chevron_down /></span>
+      <div
+        data-part="menu"
+        phx-hook="NavbarDropdown"
+        id="marketing-navbar-languages-menu"
+        data-open="false"
+      >
+        <div data-part="action" data-open="false">
+          <span data-part="title">
+            <.language />
+          </span>
+          <span data-part="chevron"><.chevron_down /></span>
+        </div>
+        <div data-part="dropdown" data-dropdown="languages" data-open="false">
+          <.link href={
+            TuistWeb.Marketing.Localization.localized_href(
+              TuistWeb.Marketing.Localization.current_path(assigns),
+              "en"
+            )
+          }>
+            English
+          </.link>
+          <.link href={
+            TuistWeb.Marketing.Localization.localized_href(
+              TuistWeb.Marketing.Localization.current_path(assigns),
+              "ru"
+            )
+          }>
+            Русский <span>(Russian)</span>
+          </.link>
+        </div>
       </div>
-      <div data-part="dropdown" data-dropdown="languages">
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "en"
-          )
-        }>
-          English
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "ko"
-          )
-        }>
-          한국어 <span>(Korean)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "ja"
-          )
-        }>
-          日本語 <span>(Japanese)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "ru"
-          )
-        }>
-          Русский <span>(Russian)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "es"
-          )
-        }>
-          Castellano <span>(Spanish)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "pt"
-          )
-        }>
-          Português <span>(Portuguese)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "ar"
-          )
-        }>
-          العربية <span>(Arabic)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "zh"
-          )
-        }>
-          中文 <span>(Chinese)</span>
-        </.link>
-        <.link href={
-          TuistWeb.Marketing.Localization.localized_href(
-            TuistWeb.Marketing.Localization.current_path(assigns),
-            "pl"
-          )
-        }>
-          Polski <span>(Polish)</span>
-        </.link>
-      </div>
-    </div> --%>
       <.button
         :if={is_nil(TuistWeb.Authentication.current_user(assigns))}
         href={~p"/users/register"}

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -293,13 +293,17 @@ defmodule TuistWeb.Marketing.MarketingController do
         &Tuist.Environment.app_url(path: ~p"/newsletter/issues/#{&1.number}")
       )
 
-    entries =
-      [
-        Tuist.Environment.app_url(path: ~p"/"),
-        Tuist.Environment.app_url(path: ~p"/pricing"),
-        Tuist.Environment.app_url(path: ~p"/blog"),
-        Tuist.Environment.app_url(path: ~p"/changelog")
-      ] ++ page_urls ++ post_urls ++ newsletter_issue_urls
+    base_paths = [~p"/", ~p"/pricing", ~p"/blog", ~p"/changelog"]
+
+    # Generate URLs for all locales
+    localized_entries =
+      for locale <- Localization.all_locales(),
+          path <- base_paths do
+        localized_path = Localization.localized_href(path, locale)
+        Tuist.Environment.app_url(path: localized_path)
+      end
+
+    entries = localized_entries ++ page_urls ++ post_urls ++ newsletter_issue_urls
 
     conn
     |> assign(:entries, entries)

--- a/server/lib/tuist_web/marketing/controllers/marketing_html.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html.ex
@@ -8,30 +8,43 @@ defmodule TuistWeb.Marketing.MarketingHTML do
 
   alias Tuist.Marketing.Blog
 
-  embed_templates "marketing_html/*"
+  embed_templates("marketing_html/*")
 
   # Delegate to Localization module
   defdelegate localized_href(href), to: TuistWeb.Marketing.Localization
 
-  attr :title, :string, required: true
-  attr :primary_action_title, :string, required: false
-  attr :primary_action_href, :string, required: false
-  attr :primary_action_target, :string, default: "_blank"
-  attr :secondary_action_title, :string, required: false
-  attr :secondary_action_href, :string, required: false
-  attr :secondary_action_target, :string, default: "_blank"
+  attr(:title, :string, required: true)
+  attr(:primary_action_title, :string, required: false)
+  attr(:primary_action_href, :string, required: false)
+  attr(:primary_action_target, :string, default: "_blank")
+  attr(:secondary_action_title, :string, required: false)
+  attr(:secondary_action_href, :string, required: false)
+  attr(:secondary_action_target, :string, default: "_blank")
 
   defp marketing_banner(assigns) do
     default_primary_href = localized_href("https://docs.tuist.dev/")
 
     assigns =
       assigns
-      |> assign(:primary_action_title, Map.get(assigns, :primary_action_title, dgettext("marketing", "Get started")))
-      |> assign(:primary_action_href, Map.get(assigns, :primary_action_href, default_primary_href))
-      |> assign(:secondary_action_title, Map.get(assigns, :secondary_action_title, dgettext("marketing", "Talk to us")))
+      |> assign(
+        :primary_action_title,
+        Map.get(assigns, :primary_action_title, dgettext("marketing", "Get started"))
+      )
+      |> assign(
+        :primary_action_href,
+        Map.get(assigns, :primary_action_href, default_primary_href)
+      )
+      |> assign(
+        :secondary_action_title,
+        Map.get(assigns, :secondary_action_title, dgettext("marketing", "Talk to us"))
+      )
       |> assign(
         :secondary_action_href,
-        Map.get(assigns, :secondary_action_href, "https://cal.tuist.dev/team/tuist/tuist?overlayCalendar=true")
+        Map.get(
+          assigns,
+          :secondary_action_href,
+          "https://cal.tuist.dev/team/tuist/tuist?overlayCalendar=true"
+        )
       )
 
     ~H"""
@@ -57,13 +70,13 @@ defmodule TuistWeb.Marketing.MarketingHTML do
     """
   end
 
-  attr :name, :string, required: true
-  attr :role, :string, required: true
-  attr :photo_src, :string, required: true
-  attr :github_handle, :string, required: true
-  attr :mastodon_url, :string, required: true
-  attr :bluesky_url, :string, required: false
-  attr :linkedin_url, :string, required: false
+  attr(:name, :string, required: true)
+  attr(:role, :string, required: true)
+  attr(:photo_src, :string, required: true)
+  attr(:github_handle, :string, required: true)
+  attr(:mastodon_url, :string, required: true)
+  attr(:bluesky_url, :string, required: false)
+  attr(:linkedin_url, :string, required: false)
 
   defp about_team_member(assigns) do
     ~H"""
@@ -104,6 +117,34 @@ defmodule TuistWeb.Marketing.MarketingHTML do
         </.neutral_button>
       </div>
     </div>
+    """
+  end
+
+  def language(assigns) do
+    ~H"""
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 18.3333C14.6024 18.3333 18.3333 14.6024 18.3333 10C18.3333 5.39763 14.6024 1.66667 10 1.66667C5.39763 1.66667 1.66667 5.39763 1.66667 10C1.66667 14.6024 5.39763 18.3333 10 18.3333Z"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M1.66667 10H18.3333"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M10 1.66667C12.0844 3.94863 13.2698 6.91003 13.3333 10C13.2698 13.09 12.0844 16.0514 10 18.3333C7.91561 16.0514 6.73021 13.09 6.66667 10C6.73021 6.91003 7.91561 3.94863 10 1.66667Z"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
     """
   end
 
@@ -153,12 +194,12 @@ defmodule TuistWeb.Marketing.MarketingHTML do
     """
   end
 
-  attr :quote, :string, required: true
-  attr :name, :string, required: true
-  attr :role, :string, required: true
-  attr :avatar_src, :string, required: true
-  attr :rest, :global
-  slot :logo, required: false
+  attr(:quote, :string, required: true)
+  attr(:name, :string, required: true)
+  attr(:role, :string, required: true)
+  attr(:avatar_src, :string, required: true)
+  attr(:rest, :global)
+  slot(:logo, required: false)
 
   defp home_testimonial_card(assigns) do
     ~H"""

--- a/server/lib/tuist_web/marketing/layouts/root.html.heex
+++ b/server/lib/tuist_web/marketing/layouts/root.html.heex
@@ -10,6 +10,29 @@
     </.live_title>
     <TuistWeb.LayoutComponents.head_meta_meta_tags {assigns} />
     <TuistWeb.LayoutComponents.head_x_meta_tags {assigns} />
+    <!-- Language alternates for SEO -->
+    <%= for locale <- TuistWeb.Marketing.Localization.all_locales() do %>
+      <link
+        rel="alternate"
+        hreflang={locale}
+        href={
+          Tuist.Environment.app_url(
+            path:
+              TuistWeb.Marketing.Localization.localized_href(
+                TuistWeb.Marketing.Localization.current_path(assigns),
+                locale
+              )
+          )
+        }
+      />
+    <% end %>
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href={
+        Tuist.Environment.app_url(path: TuistWeb.Marketing.Localization.current_path(assigns))
+      }
+    />
     <script
       :for={
         structured_data <-

--- a/server/lib/tuist_web/marketing/localization.ex
+++ b/server/lib/tuist_web/marketing/localization.ex
@@ -10,9 +10,7 @@ defmodule TuistWeb.Marketing.Localization do
 
   import Plug.Conn
 
-  # @additional_locales ["ko", "ja", "ru", "es", "pt", "ar", "zh", "pl"]
-
-  @additional_locales []
+  @additional_locales ["ru"]
 
   def init(:put_locale), do: :put_locale
   def init(:redirect_to_localized_route), do: :redirect_to_localized_route


### PR DESCRIPTION
This PR enables Russian locale support on the marketing site alongside English.

Changes:
- Enable Russian (ru) as an additional locale
- Add language selector dropdown in navbar
- Add language icon component
- Fix CSS for dropdown visibility
- Localize navbar logo link