### PR TITLE
fix(server): add GitHub authentication to releases API requests

### DIFF
--- a/server/lib/tuist/github/releases.ex
+++ b/server/lib/tuist/github/releases.ex
@@ -57,7 +57,8 @@ defmodule Tuist.GitHub.Releases do
   end
 
   defp req_releases do
-    req_opts = [finch: Tuist.Finch] ++ Retry.retry_options()
+    headers = github_auth_headers()
+    req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
 
     case Req.get(releases_url(), req_opts) do
       {:ok, %Req.Response{status: 200, body: releases}} ->
@@ -68,6 +69,19 @@ defmodule Tuist.GitHub.Releases do
 
       {:error, _reason} ->
         []
+    end
+  end
+
+  defp github_auth_headers do
+    case Tuist.Environment.github_token_update_package_releases() do
+      nil ->
+        []
+
+      token ->
+        [
+          {"Accept", "application/vnd.github.v3+json"},
+          {"Authorization", "Bearer #{token}"}
+        ]
     end
   end
 
@@ -86,7 +100,8 @@ defmodule Tuist.GitHub.Releases do
 
   defp fetch_latest_app_release(opts \\ []) do
     url = Keyword.get(opts, :url, releases_url())
-    req_opts = [finch: Tuist.Finch] ++ Retry.retry_options()
+    headers = github_auth_headers()
+    req_opts = [finch: Tuist.Finch, headers: headers] ++ Retry.retry_options()
 
     case Req.get(url, req_opts) do
       {:ok, %Req.Response{status: 200, body: releases, headers: headers}} ->


### PR DESCRIPTION
Resolves https://appsignal.com/tuist/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/117/samples/timestamp/2025-11-07T12:22:00Z

## Problem

GitHub API was returning 403 rate limit errors when fetching release information. Unauthenticated requests are limited to 60 per hour, which was being exceeded.

Error message:
```
API rate limit exceeded for 18.156.42.200. (But here's the good news: Authenticated requests get a higher rate limit...)
```

## Solution

Added GitHub authentication headers to all release API requests in `Tuist.GitHub.Releases`:

- Created `github_auth_headers/0` helper function that uses the existing `github_token_update_package_releases` configuration
- Updated `req_releases/0` to include authentication headers
- Updated `fetch_latest_app_release/1` to include authentication headers

This increases the rate limit from 60 to 5,000 requests per hour.

## Testing

- ✅ All existing tests pass
- ✅ Follows the same authentication pattern used in `Tuist.GitHub.Client`
- ✅ Gracefully handles missing token (returns empty headers list)