### PR TITLE
feat(cache): disk eviction 

### DIFF
--- a/cache/.formatter.exs
+++ b/cache/.formatter.exs
@@ -1,5 +1,5 @@
 [
-  import_deps: [:phoenix],
+  import_deps: [:phoenix, :ecto],
   inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"],
   line_length: 120,
   plugins: [Styler]

--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -24,10 +24,23 @@ config :cache, CacheWeb.Endpoint,
 config :cache, Oban,
   repo: Cache.Repo,
   engine: Oban.Engines.Lite,
-  queues: [s3_uploads: 10],
+  queues: [
+    s3_uploads: 10,
+    s3_downloads: 10,
+    maintenance: 1
+  ],
   plugins: [
-    Oban.Plugins.Pruner
+    Oban.Plugins.Pruner,
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"*/10 * * * *", Cache.DiskEvictionWorker}
+     ]}
   ]
+
+config :cache, :cas,
+  storage_dir: "tmp/cas",
+  disk_usage_high_watermark_percent: 85.0,
+  disk_usage_target_percent: 70.0
 
 config :cache, ecto_repos: [Cache.Repo]
 

--- a/cache/config/deploy.staging.yml
+++ b/cache/config/deploy.staging.yml
@@ -38,3 +38,4 @@ env:
 
 volumes:
   - /cas:/cas:rw
+  - /etc/hostname:/etc/host_hostname:ro

--- a/cache/config/deploy.yml
+++ b/cache/config/deploy.yml
@@ -37,3 +37,4 @@ env:
 
 volumes:
   - /cas:/cas:rw
+  - /etc/hostname:/etc/host_hostname:ro

--- a/cache/config/runtime.exs
+++ b/cache/config/runtime.exs
@@ -37,7 +37,9 @@ if config_env() == :prod do
 
   config :cache, :cas,
     server_url: System.get_env("SERVER_URL") || raise("environment variable SERVER_URL is missing"),
-    storage_dir: System.get_env("CAS_STORAGE_DIR") || raise("environment variable CAS_STORAGE_DIR is missing")
+    storage_dir: System.get_env("CAS_STORAGE_DIR") || raise("environment variable CAS_STORAGE_DIR is missing"),
+    disk_usage_high_watermark_percent: Cache.Config.float_env("CAS_DISK_HIGH_WATERMARK_PERCENT", 85.0),
+    disk_usage_target_percent: Cache.Config.float_env("CAS_DISK_TARGET_PERCENT", 70.0)
 
   config :cache, :s3, bucket: System.get_env("S3_BUCKET") || raise("environment variable S3_BUCKET is missing")
 

--- a/cache/config/test.exs
+++ b/cache/config/test.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :appsignal, :config, active: false
+
 config :cache, Cache.Repo,
   database: Path.expand("../test.sqlite3", __DIR__),
   pool: Ecto.Adapters.SQL.Sandbox,

--- a/cache/lib/cache/cas_artifact.ex
+++ b/cache/lib/cache/cas_artifact.ex
@@ -1,0 +1,21 @@
+defmodule Cache.CASArtifact do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "cas_artifacts" do
+    field :key, :string
+    field :size_bytes, :integer
+    field :last_accessed_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  def changeset(artifact, attrs) do
+    artifact
+    |> cast(attrs, [:key, :size_bytes, :last_accessed_at])
+    |> validate_required([:key, :last_accessed_at])
+  end
+end

--- a/cache/lib/cache/cas_artifacts.ex
+++ b/cache/lib/cache/cas_artifacts.ex
@@ -1,0 +1,73 @@
+defmodule Cache.CASArtifacts do
+  @moduledoc """
+  Persists CAS artifact metadata to support eviction decisions.
+  """
+
+  import Ecto.Query
+
+  alias Cache.CASArtifact
+  alias Cache.Disk
+  alias Cache.Repo
+
+  @default_batch_size 500
+
+  @doc """
+  Returns the oldest artifacts up to `limit`, ordered by last access time.
+  """
+
+  def oldest(limit \\ @default_batch_size) do
+    CASArtifact
+    |> order_by([a], asc: a.last_accessed_at)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  @doc """
+  Deletes the metadata entry for a given key.
+  """
+
+  def delete_by_key(key) do
+    key |> by_key_query() |> Repo.delete_all()
+    :ok
+  end
+
+  @doc """
+  Tracks access to a CAS artifact by updating its metadata in the database.
+  
+  Creates or updates a CASArtifact record with the current file size and access time.
+  Uses upsert logic to handle conflicts on the key field.
+  """
+  def track_artifact_access(key) do
+    size_bytes = file_size_for(key)
+
+    attrs = %{
+      key: key,
+      size_bytes: size_bytes,
+      last_accessed_at: DateTime.utc_now()
+    }
+
+    changeset = CASArtifact.changeset(%CASArtifact{}, attrs)
+
+    case Repo.insert(changeset,
+           conflict_target: :key,
+           on_conflict: {:replace, [:size_bytes, :last_accessed_at, :updated_at]}
+         ) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp file_size_for(key) do
+    key
+    |> Disk.artifact_path()
+    |> File.stat()
+    |> case do
+      {:ok, %File.Stat{size: size}} -> size
+      _ -> nil
+    end
+  end
+
+  defp by_key_query(key) do
+    from(a in CASArtifact, where: a.key == ^key)
+  end
+end

--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -1,0 +1,18 @@
+defmodule Cache.Config do
+  @moduledoc false
+
+  def float_env(name, default) when is_binary(name) do
+    name
+    |> System.get_env()
+    |> parse_float(default)
+  end
+
+  defp parse_float(nil, default), do: default
+
+  defp parse_float(value, default) do
+    case Float.parse(value) do
+      {float, _} -> float
+      :error -> default
+    end
+  end
+end

--- a/cache/lib/cache/disk_eviction_worker.ex
+++ b/cache/lib/cache/disk_eviction_worker.ex
@@ -1,0 +1,193 @@
+defmodule Cache.DiskEvictionWorker do
+  @moduledoc """
+  Oban worker that evicts least-recently-used CAS artifacts when local disk
+  usage crosses the configured high watermark.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 1
+
+  alias Cache.CASArtifacts
+  alias Cache.Disk
+
+  require Logger
+
+  @batch_size 500
+
+  @impl Oban.Worker
+  def perform(_job) do
+    storage_dir = Disk.storage_dir()
+
+    case Disk.usage(storage_dir) do
+      {:ok, stats} ->
+        config = eviction_config()
+
+        if stats.percent_used >= config.high_watermark do
+          evict(storage_dir, stats, config)
+        else
+          :ok
+        end
+
+      {:error, reason} ->
+        Logger.warning("Failed to inspect disk usage for eviction: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  defp eviction_config do
+    cas_config = Application.get_env(:cache, :cas, [])
+
+    high_watermark =
+      cas_config
+      |> Keyword.get(:disk_usage_high_watermark_percent, 85.0)
+      |> max(0.0)
+
+    target =
+      cas_config
+      |> Keyword.get(:disk_usage_target_percent, high_watermark * 0.85)
+      |> max(0.0)
+
+    target_percent =
+      if target >= high_watermark do
+        max(high_watermark - 5.0, 0.0)
+      else
+        target
+      end
+
+    %{
+      high_watermark: high_watermark,
+      target_percent: target_percent
+    }
+  end
+
+  defp evict(storage_dir, stats, config) do
+    do_evict(storage_dir, stats, config, stats.used_bytes, %{freed_bytes: 0, files: 0})
+  end
+
+  defp do_evict(storage_dir, stats, config, used_bytes, summary) do
+    current_percent = percent_used(used_bytes, stats.total_bytes)
+
+    if current_percent <= config.target_percent do
+      log_summary(stats, config, used_bytes, summary)
+    else
+      batch = CASArtifacts.oldest(@batch_size)
+
+      if batch == [] do
+        Logger.warning(
+          "Disk usage #{format_percent(stats.percent_used)} exceeded #{format_percent(config.high_watermark)} but no CAS metadata entries were available for eviction"
+        )
+
+        :ok
+      else
+        {next_used_bytes, next_summary, removed} =
+          process_batch(batch, storage_dir, stats, config, used_bytes, summary)
+
+        if removed == 0 do
+          Logger.info(
+            "Eviction halted: unable to remove any artifacts despite usage at #{format_percent(current_percent)}"
+          )
+
+          :ok
+        else
+          do_evict(storage_dir, stats, config, next_used_bytes, next_summary)
+        end
+      end
+    end
+  end
+
+  defp process_batch(batch, storage_dir, stats, config, used_bytes, summary) do
+    Enum.reduce_while(batch, {used_bytes, summary, 0}, fn entry, {acc_used, acc_summary, removed} ->
+      current_percent = percent_used(acc_used, stats.total_bytes)
+
+      if current_percent <= config.target_percent do
+        {:halt, {acc_used, acc_summary, removed}}
+      else
+        {next_used, next_summary, removed_delta} =
+          handle_entry(entry, storage_dir, acc_used, acc_summary)
+
+        {:cont, {next_used, next_summary, removed + removed_delta}}
+      end
+    end)
+  end
+
+  defp handle_entry(entry, storage_dir, used_bytes, summary) do
+    path = Disk.artifact_path(entry.key)
+    size = entry.size_bytes || file_size(path) || 0
+
+    case File.rm(path) do
+      :ok ->
+        cleanup_empty_parents(path, storage_dir)
+        :ok = CASArtifacts.delete_by_key(entry.key)
+
+        {
+          max(used_bytes - size, 0),
+          %{summary | freed_bytes: summary.freed_bytes + size, files: summary.files + 1},
+          1
+        }
+
+      {:error, :enoent} ->
+        :ok = CASArtifacts.delete_by_key(entry.key)
+        {used_bytes, summary, 1}
+
+      {:error, reason} ->
+        Logger.warning("Failed to evict #{entry.key}: #{inspect(reason)}")
+        {used_bytes, summary, 0}
+    end
+  end
+
+  defp log_summary(stats, config, _final_used_bytes, %{files: 0}) do
+    Logger.info(
+      "Disk usage #{format_percent(stats.percent_used)} exceeded #{format_percent(config.high_watermark)}, but no artifacts could be evicted"
+    )
+
+    :ok
+  end
+
+  defp log_summary(stats, _config, final_used_bytes, %{freed_bytes: freed, files: count}) do
+    final_percent = percent_used(final_used_bytes, stats.total_bytes)
+
+    Logger.info(
+      "Evicted #{count} artifacts freeing #{format_bytes(freed)}; disk usage #{format_percent(stats.percent_used)} -> #{format_percent(final_percent)}"
+    )
+
+    :ok
+  end
+
+  defp cleanup_empty_parents(path, storage_dir) do
+    dir = Path.dirname(path)
+
+    cond do
+      dir == storage_dir ->
+        :ok
+
+      String.starts_with?(dir, storage_dir) ->
+        case File.ls(dir) do
+          {:ok, []} ->
+            _ = File.rmdir(dir)
+            cleanup_empty_parents(dir, storage_dir)
+
+          _ ->
+            :ok
+        end
+
+      true ->
+        :ok
+    end
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      _ -> nil
+    end
+  end
+
+  defp percent_used(_used, 0), do: 0.0
+  defp percent_used(used, total), do: used / total * 100.0
+
+  defp format_percent(value), do: "~.2f%" |> :io_lib.format([value]) |> to_string()
+
+  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1024, 2)} KB"
+  defp format_bytes(bytes) when bytes < 1_073_741_824, do: "#{Float.round(bytes / 1_048_576, 2)} MB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_073_741_824, 2)} GB"
+end

--- a/cache/lib/cache_web/controllers/cas_controller.ex
+++ b/cache/lib/cache_web/controllers/cas_controller.ex
@@ -2,6 +2,7 @@ defmodule CacheWeb.CASController do
   use CacheWeb, :controller
 
   alias Cache.BodyReader
+  alias Cache.CASArtifacts
   alias Cache.Disk
   alias Cache.S3
   alias Cache.S3DownloadWorker
@@ -12,6 +13,7 @@ defmodule CacheWeb.CASController do
   def download(conn, %{"id" => id, "account_handle" => account_handle, "project_handle" => project_handle}) do
     :telemetry.execute([:cache, :cas, :download, :hit], %{}, %{})
     key = Disk.cas_key(account_handle, project_handle, id)
+    :ok = CASArtifacts.track_artifact_access(key)
 
     if Disk.exists?(account_handle, project_handle, id) do
       local_path = Disk.local_accel_path(account_handle, project_handle, id)
@@ -99,6 +101,7 @@ defmodule CacheWeb.CASController do
     case Disk.put(account_handle, project_handle, id, data) do
       :ok ->
         :telemetry.execute([:cache, :cas, :upload, :success], %{size: size}, %{})
+        :ok = CASArtifacts.track_artifact_access(Disk.cas_key(account_handle, project_handle, id))
         S3UploadWorker.enqueue_upload(account_handle, project_handle, id)
         send_resp(conn, :no_content, "")
 

--- a/cache/priv/repo/migrations/20250204120000_create_cas_artifacts.exs
+++ b/cache/priv/repo/migrations/20250204120000_create_cas_artifacts.exs
@@ -1,0 +1,16 @@
+defmodule Cache.Repo.Migrations.CreateCasArtifacts do
+  use Ecto.Migration
+
+  def change do
+    create table(:cas_artifacts) do
+      add :key, :text, null: false
+      add :size_bytes, :bigint
+      add :last_accessed_at, :utc_datetime_usec, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:cas_artifacts, [:key])
+    create index(:cas_artifacts, [:last_accessed_at])
+  end
+end

--- a/cache/rel/overlays/bin/server
+++ b/cache/rel/overlays/bin/server
@@ -3,9 +3,21 @@ set -eu
 
 cd -P -- "$(dirname -- "$0")"
 
-# Set PHX_HOST based on hostname if not already set
-if [ -z "${PHX_HOST:-}" ]; then
-  export PHX_HOST="$(hostname).tuist.dev"
+# Kamal mounts the server's hostname into the container at this path.
+host_file="/etc/host_hostname"
+if [ ! -f "$host_file" ]; then
+  echo "Expected $host_file to be mounted" >&2
+  exit 1
 fi
+
+host_name=$(head -n 1 "$host_file" | tr -d '\r\n')
+host_name=${host_name%% *}
+
+if [ -z "$host_name" ]; then
+  echo "Host name from $host_file is empty" >&2
+  exit 1
+fi
+
+export PHX_HOST="$host_name.tuist.dev"
 
 PHX_SERVER=true exec ./cache start

--- a/cache/test/cache/disk_eviction_worker_test.exs
+++ b/cache/test/cache/disk_eviction_worker_test.exs
@@ -1,0 +1,98 @@
+defmodule Cache.DiskEvictionWorkerTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Ecto.Query
+
+  alias Cache.CASArtifact
+  alias Cache.CASArtifacts
+  alias Cache.Disk
+  alias Cache.DiskEvictionWorker
+  alias Cache.Repo
+  alias Ecto.Adapters.SQL.Sandbox
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+
+    {:ok, storage_dir} = Briefly.create(directory: true)
+
+    stub(Disk, :storage_dir, fn -> storage_dir end)
+
+    {:ok, storage_dir: storage_dir}
+  end
+
+  test "skips eviction when usage is below threshold", %{storage_dir: storage_dir} do
+    key = "account/project/cas/file"
+    path = Disk.artifact_path(key)
+
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, :binary.copy("a", 1024))
+
+    :ok = CASArtifacts.track_artifact_access(key)
+
+    expect(Disk, :usage, fn ^storage_dir ->
+      {:ok,
+       %{
+         total_bytes: 1_000_000,
+         used_bytes: 500_000,
+         available_bytes: 500_000,
+         percent_used: 50.0
+       }}
+    end)
+
+    assert :ok = DiskEvictionWorker.perform(%Oban.Job{args: %{}})
+    assert File.exists?(path)
+  end
+
+  test "evicts least recently used artifacts when disk usage is high", %{storage_dir: storage_dir} do
+    key_old = "acct/project/cas/old"
+    key_new = "acct/project/cas/new"
+    key_newest = "acct/project/cas/newest"
+
+    older = Disk.artifact_path(key_old)
+    newer = Disk.artifact_path(key_new)
+    newest = Disk.artifact_path(key_newest)
+
+    File.mkdir_p!(Path.dirname(older))
+
+    File.write!(older, :binary.copy("o", 400_000))
+    File.write!(newer, :binary.copy("n", 300_000))
+    File.write!(newest, :binary.copy("N", 200_000))
+
+    :ok = CASArtifacts.track_artifact_access(key_old)
+    :ok = CASArtifacts.track_artifact_access(key_new)
+    :ok = CASArtifacts.track_artifact_access(key_newest)
+
+    set_last_access(key_old, ~U[2024-01-01 00:00:00Z])
+    set_last_access(key_new, ~U[2024-06-01 00:00:00Z])
+    set_last_access(key_newest, DateTime.utc_now())
+
+    expect(Disk, :usage, fn ^storage_dir ->
+      {:ok,
+       %{
+         total_bytes: 1_000_000,
+         used_bytes: 900_000,
+         available_bytes: 100_000,
+         percent_used: 90.0
+       }}
+    end)
+
+    assert :ok = DiskEvictionWorker.perform(%Oban.Job{args: %{}})
+
+    refute File.exists?(older)
+    assert File.exists?(newer)
+    assert File.exists?(newest)
+
+    assert [] = Repo.all(from a in CASArtifact, where: a.key == ^key_old)
+    assert [_] = Repo.all(from a in CASArtifact, where: a.key == ^key_new)
+    assert [_] = Repo.all(from a in CASArtifact, where: a.key == ^key_newest)
+  end
+
+  defp set_last_access(key, timestamp) do
+    Repo.update_all(from(a in CASArtifact, where: a.key == ^key),
+      set: [last_accessed_at: timestamp, updated_at: timestamp]
+    )
+
+    :ok
+  end
+end

--- a/cache/test/cache/s3_download_worker_test.exs
+++ b/cache/test/cache/s3_download_worker_test.exs
@@ -53,9 +53,6 @@ defmodule Cache.Workers.S3DownloadWorkerTest do
   describe "perform/1" do
     test "successfully downloads file from S3 when it exists" do
       key = "test_account/test_project/cas/test_hash"
-      account_handle = "test_account"
-      project_handle = "test_project"
-      id = "test_hash"
       {:ok, tmp_dir} = Briefly.create(directory: true)
       local_path = Path.join(tmp_dir, "test_hash")
 
@@ -73,10 +70,7 @@ defmodule Cache.Workers.S3DownloadWorkerTest do
 
       job = %Oban.Job{
         args: %{
-          "key" => key,
-          "account_handle" => account_handle,
-          "project_handle" => project_handle,
-          "id" => id
+          "key" => key
         }
       }
 
@@ -111,9 +105,6 @@ defmodule Cache.Workers.S3DownloadWorkerTest do
 
     test "handles S3 download failure" do
       key = "test_account/test_project/cas/test_hash"
-      account_handle = "test_account"
-      project_handle = "test_project"
-      id = "test_hash"
       {:ok, tmp_dir} = Briefly.create(directory: true)
       local_path = Path.join(tmp_dir, "test_hash")
 
@@ -130,10 +121,7 @@ defmodule Cache.Workers.S3DownloadWorkerTest do
 
       job = %Oban.Job{
         args: %{
-          "key" => key,
-          "account_handle" => account_handle,
-          "project_handle" => project_handle,
-          "id" => id
+          "key" => key
         }
       }
 

--- a/cache/test/test_helper.exs
+++ b/cache/test/test_helper.exs
@@ -1,5 +1,6 @@
 Mimic.copy(Cache.Authentication)
 Mimic.copy(Cache.Disk)
+Mimic.copy(Cache.CASArtifacts)
 Mimic.copy(Cache.KeyValueStore)
 Mimic.copy(ExAws.S3.Upload)
 Mimic.copy(ExAws.S3)


### PR DESCRIPTION
Adds a LRU cache for items on disk by
- keeping track of downloads in SQLite
- running a worker every 10 minutes that checks for disk usage
- deletes the least recently used items from disk if disk usage exceeds 80%