### PR TITLE
fix(cli): Add extended string delimiter to Strings value in PlistsTemplate

### DIFF
--- a/cli/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/cli/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -45,7 +45,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
     {% macro valueBlock value metadata %}
       {%- if metadata.type == "String" -%}
-        "{{ value }}"
+        #"{{ value }}"#
       {%- elif metadata.type == "Date" -%}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
       {%- elif metadata.type == "Optional" -%}


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/7593>

Fixes build errors when Plist-Files contain nested strings, for example a JSON object. Strings are now wrapped with an extended string delimiter, which escapes quotation marks within the string, as well as special character sequences like `\n`.

Example file illustrating the problem (add this to a project and run `tuist generate`):


Before:
```
public enum MyDefaultValues: Sendable {
    public static let myJsonValue: String = "{"key": "value"}" // ❌ Error: Consecutive declarations on a line must be separated by ';'
}
```

After:
```
public enum MyDefaultValues: Sendable {
    public static let myJsonValue: String = #"{"key": "value"}"# // ✅ Success
}
```

### How to test locally

- Create a Tuist project and add a .plist-File with a nested string. An example is provided as attachment.
- Run `tuist run tuist generate --path <PATH_TO_PROJECT>`
- Verify that the generated project builds without errors.


### Example File
Save as .plist file to test:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>myJsonValue</key>
	<string>{&quot;key&quot;: &quot;value&quot;}</string>
</dict>
</plist>
```

