### PR TITLE
fix(server): handle 404 errors gracefully in Swift package registry

### DIFF
--- a/server/lib/tuist/github/client.ex
+++ b/server/lib/tuist/github/client.ex
@@ -303,7 +303,7 @@ defmodule Tuist.GitHub.Client do
         end
 
       {:ok, %Req.Response{status: status}} ->
-        {:error, "Unexpected status code: #{status} when getting tags at #{url}."}
+        {:error, {:http_error, status}}
 
       {:error, _reason} = error ->
         error

--- a/server/test/tuist/github/client_test.exs
+++ b/server/test/tuist/github/client_test.exs
@@ -330,8 +330,7 @@ defmodule Tuist.GitHub.ClientTest do
 
       # Then
       assert got ==
-               {:error,
-                "Unexpected status code: 404 when getting tags at https://api.github.com/repos/tuist/tuist/tags?page_size=100."}
+               {:error, {:http_error, 404}}
     end
   end
 

--- a/server/test/tuist/registry/swift/packages_test.exs
+++ b/server/test/tuist/registry/swift/packages_test.exs
@@ -249,6 +249,30 @@ defmodule Tuist.Registry.Swift.PackagesTest do
       # Then
       assert Enum.map(got, & &1.version) == ["5.10.2"]
     end
+
+    test "returns empty list when repository returns 404" do
+      # Given
+      package =
+        PackagesFixtures.package_fixture(
+          scope: "Alamofire",
+          name: "Alamofire",
+          repository_full_handle: "metatronsw/BinaryCodableNil"
+        )
+
+      stub(VCS, :get_tags, fn _ ->
+        {:error, {:http_error, 404}}
+      end)
+
+      # When
+      got =
+        Packages.get_missing_package_versions(%{
+          package: Repo.preload(package, :package_releases),
+          token: "github_token"
+        })
+
+      # Then
+      assert got == []
+    end
   end
 
   describe "paginated_packages/1" do


### PR DESCRIPTION
## Summary
- Updates GitHub client to return structured error tuples for better error handling
- Handles 404 errors gracefully when fetching Swift package tags
- Logs and skips packages from repositories that don't exist or aren't accessible
- Prevents registry sync failures due to missing repositories

## Test plan
- [x] Added test case for 404 error handling
- [x] Updated existing test to match new error format
- [x] Verified packages with inaccessible repositories are skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)