### PR TITLE
fix(server): fix flaky DailySlackReportWorker test

### DIFF
--- a/server/test/support/tuist_test_support/cases/data_case.ex
+++ b/server/test/support/tuist_test_support/cases/data_case.ex
@@ -37,6 +37,8 @@ defmodule TuistTestSupport.Cases.DataCase do
   setup tags do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
 
+    TuistTestSupport.Utilities.truncate_clickhouse_tables()
+
     on_exit(fn ->
       TuistTestSupport.Utilities.truncate_clickhouse_tables()
     end)


### PR DESCRIPTION
## Summary
- Fixes flaky test by truncating ClickHouse tables at the start of each test
- Command events are stored in ClickHouse, and previous test data was bleeding through
- Tables were only cleaned after tests, creating a race condition

## Root Cause
The test expected "Total: 1" command event but sometimes got "Total: 2" because previous test data wasn't cleaned up before the test started.

## Test plan
- [x] Ran the flaky test 15 times consecutively - all passed
- [x] Ran all ops tests - 3 tests passed
- [x] Ran 276 additional tests involving ClickHouse - all passed

This fix improves reliability for all tests using DataCase that interact with ClickHouse data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)