### PR TITLE
feat(server): show empty state when there's no latency or throughput data

### DIFF
--- a/server/lib/tuist_web/components/percentile_dropdown_widget.ex
+++ b/server/lib/tuist_web/components/percentile_dropdown_widget.ex
@@ -41,6 +41,7 @@ defmodule TuistWeb.PercentileDropdownWidget do
   attr(:selected_type, :string, required: true, values: ~w(avg p99 p90 p50))
   attr(:event_name, :string, required: true, doc: "Phoenix event name for selection changes")
   attr(:empty, :boolean, default: false)
+  attr(:empty_label, :string, default: nil)
   attr(:legend_color, :string, default: nil)
   attr(:selected, :boolean, default: false)
   attr(:trend_value, :any, default: nil)
@@ -57,6 +58,7 @@ defmodule TuistWeb.PercentileDropdownWidget do
       value={@value}
       id={@id}
       empty={@empty}
+      empty_label={@empty_label}
       legend_color={@legend_color}
       selected={@selected}
       trend_value={@trend_value}

--- a/server/lib/tuist_web/components/widget.ex
+++ b/server/lib/tuist_web/components/widget.ex
@@ -120,6 +120,8 @@ defmodule TuistWeb.Widget do
 
   attr(:empty, :boolean, default: false, doc: "Whether the widget is empty")
 
+  attr(:empty_label, :string, default: nil, doc: "Custom label to display when widget is empty")
+
   attr(:phx_click, :string, default: nil, doc: "Phoenix event to trigger on widget click")
 
   attr(:phx_value_widget, :string, default: nil, doc: "Widget ID value to pass with phx-click event")
@@ -137,7 +139,7 @@ defmodule TuistWeb.Widget do
           <span data-part="title">{@title}</span>
         </div>
         <span data-part="empty-label">
-          {gettext("No data yet")}
+          {if @empty_label, do: @empty_label, else: gettext("No data yet")}
         </span>
       </.card_section>
     <% else %>

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -829,6 +829,13 @@
                 }
                 selected_type={@selected_read_latency_type}
                 event_name="select_read_latency_type"
+                empty={
+                  @cacheable_task_latency_metrics.avg_read_duration == 0 and
+                    @cacheable_task_latency_metrics.p99_read_duration == 0 and
+                    @cacheable_task_latency_metrics.p90_read_duration == 0 and
+                    @cacheable_task_latency_metrics.p50_read_duration == 0
+                }
+                empty_label={gettext("No data")}
               />
               <.percentile_dropdown_widget
                 id="widget-avg-write-latency"
@@ -877,6 +884,13 @@
                 }
                 selected_type={@selected_write_latency_type}
                 event_name="select_write_latency_type"
+                empty={
+                  @cacheable_task_latency_metrics.avg_write_duration == 0 and
+                    @cacheable_task_latency_metrics.p99_write_duration == 0 and
+                    @cacheable_task_latency_metrics.p90_write_duration == 0 and
+                    @cacheable_task_latency_metrics.p50_write_duration == 0
+                }
+                empty_label={gettext("No data")}
               />
             </div>
             <div data-part="filters">
@@ -1151,6 +1165,8 @@
                   )
                 }
                 id="widget-download-throughput"
+                empty={@cas_metrics.time_weighted_avg_download_throughput == 0}
+                empty_label={gettext("No data")}
               />
               <.widget
                 title={gettext("Upload throughput")}
@@ -1163,6 +1179,8 @@
                   )
                 }
                 id="widget-upload-throughput"
+                empty={@cas_metrics.time_weighted_avg_upload_throughput == 0}
+                empty_label={gettext("No data")}
               />
             </div>
             <div data-part="filters">


### PR DESCRIPTION
Show an empty widget state when there's no latency or throughput data.

`No data yet` doesn't make a ton of sense for finished builds, so I made the `widget` `label` configurable, so the text can be just `No data`

<img width="1608" height="526" alt="image" src="https://github.com/user-attachments/assets/73fed361-cc88-4650-80d6-1327facf26eb" />
