### PR TITLE
fix(server): truncate cas node

### DIFF
--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -980,6 +980,7 @@
                       size="small"
                       icon_only
                       phx-hook="Clipboard"
+                      phx-click={JS.exec("event.stopPropagation()", to: "window")}
                       data-clipboard-value={task.key}
                     >
                       <.copy />
@@ -1259,7 +1260,7 @@
                     sort_icon(@cas_outputs_sort_order)
                 }
               >
-                <.text_cell label={output.node_id} />
+                <.text_cell label={String.slice(output.node_id, 0, 30) <> if(String.length(output.node_id) > 30, do: "...", else: "")} />
               </:col>
               <:col :let={output} label={gettext("Status")}>
                 <%= case output.operation do %>


### PR DESCRIPTION
This PR:
- truncates the CAS node
- stops propagation of events from the copy button, so clicking the copy button doesn't also expand the cell

<img width="1608" height="526" alt="image" src="https://github.com/user-attachments/assets/bf7d371e-a225-4dad-972a-5bc237219d0f" />
