### PR TITLE
feat(cache): export metrics to Grafana Cloud

### DIFF
--- a/cache/lib/cache_web/router.ex
+++ b/cache/lib/cache_web/router.ex
@@ -9,6 +9,10 @@ defmodule CacheWeb.Router do
     plug CacheWeb.Plugs.AuthPlug
   end
 
+  scope "/" do
+    forward "/metrics", PromEx.Plug, prom_ex_module: Cache.PromEx
+  end
+
   scope "/", CacheWeb do
     get "/up", UpController, :index
   end

--- a/cache/platform/alloy.nix
+++ b/cache/platform/alloy.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  pkgs,
+  ...
+}: let
+  grafanaCloudUrl = config.services.onepassword-secrets.secrets.grafanaCloudPromRemoteWriteUrl.path;
+  grafanaCloudUsername = config.services.onepassword-secrets.secrets.grafanaCloudPromUsername.path;
+  grafanaCloudPassword = config.services.onepassword-secrets.secrets.grafanaCloudPromPassword.path;
+
+  alloyConfig = ''
+    local.file "grafana_cloud_url" {
+      filename = "${grafanaCloudUrl}"
+    }
+
+    local.file "grafana_cloud_username" {
+      filename = "${grafanaCloudUsername}"
+    }
+
+    local.file "grafana_cloud_password" {
+      filename = "${grafanaCloudPassword}"
+      is_secret = true
+    }
+
+    prometheus.remote_write "grafana_cloud" {
+      endpoint {
+        url = local.file.grafana_cloud_url.content
+
+        basic_auth {
+          username = local.file.grafana_cloud_username.content
+          password = local.file.grafana_cloud_password.content
+        }
+      }
+    }
+
+    prometheus.scrape "cache_promex" {
+      targets = [
+        {
+          __address__ = "127.0.0.1:80",
+          __scheme__ = "http",
+          __metrics_path__ = "/metrics",
+    	instance = "${config.networking.hostName}",
+        },
+      ]
+
+      scrape_interval = "15s"
+
+      forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+    }
+  '';
+in {
+  users.users.grafana-alloy = {
+    isSystemUser = true;
+    group = "grafana-alloy";
+    description = "Grafana Alloy service user";
+  };
+
+  users.groups.grafana-alloy = {};
+
+  environment.etc."grafana/alloy/config.alloy" = {
+    mode = "0444";
+    text = alloyConfig;
+  };
+
+  systemd.services.grafana-alloy = {
+    description = "Grafana Alloy agent";
+    wantedBy = ["multi-user.target"];
+    after = ["onepassword-secrets.service"];
+
+    serviceConfig = {
+      ExecStart = "${pkgs.grafana-alloy}/bin/alloy run /etc/grafana/alloy/config.alloy --storage.path=/var/lib/grafana-alloy";
+      Restart = "on-failure";
+      RestartSec = 5;
+      User = "grafana-alloy";
+      Group = "grafana-alloy";
+      StateDirectory = "grafana-alloy";
+      SupplementaryGroups = ["keys" "systemd-journal"];
+    };
+  };
+}

--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -9,6 +9,8 @@
     (modulesPath + "/profiles/qemu-guest.nix")
     ./disk-config.nix
     ./nginx.nix
+    ./secrets.nix
+    ./alloy.nix
   ];
   system.stateVersion = "25.11";
 

--- a/cache/platform/flake.lock
+++ b/cache/platform/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760701190,
-        "narHash": "sha256-y7UhnWlER8r776JsySqsbTUh2Txf7K30smfHlqdaIQw=",
+        "lastModified": 1762276996,
+        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3a9450b26e69dcb6f8de6e2b07b3fc1c288d85f5",
+        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
         "type": "github"
       },
       "original": {
@@ -20,13 +20,31 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761808999,
-        "narHash": "sha256-0ATrHK1W9cdW+IOY4Ug3zenvOCcSoxe7gQGQpWPvWFY=",
+        "lastModified": 1763026294,
+        "narHash": "sha256-unMEIA7tLfO5zGDMYn+Tdyx8SMVYSuFwWbVT7IcQWp4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "feb25712dc8e94766c21e7371ec391fd1c3e87d7",
+        "rev": "c438b2cb3de520bb6c9c03e67294f9a5f6551fdb",
         "type": "github"
       },
       "original": {
@@ -36,10 +54,47 @@
         "type": "github"
       }
     },
+    "opnix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761503988,
+        "narHash": "sha256-MlMZXCTtPeXq/cDtJcL2XM8wCN33XOT9V2dB3PLV6f0=",
+        "owner": "brizzbuzz",
+        "repo": "opnix",
+        "rev": "48fdb078b5a1cd0b20b501fccf6be2d1279d6fe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "brizzbuzz",
+        "repo": "opnix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "disko": "disko",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "opnix": "opnix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/cache/platform/flake.nix
+++ b/cache/platform/flake.nix
@@ -2,10 +2,13 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
   inputs.disko.url = "github:nix-community/disko";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.opnix.url = "github:brizzbuzz/opnix";
+  inputs.opnix.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {
     nixpkgs,
     disko,
+    opnix,
     ...
   }: let
     machines = [
@@ -22,6 +25,7 @@
         system = "x86_64-linux";
         modules = [
           disko.nixosModules.disko
+          opnix.nixosModules.default
           ./configuration.nix
           ./users.nix
           {

--- a/cache/platform/secrets.nix
+++ b/cache/platform/secrets.nix
@@ -1,0 +1,42 @@
+{config, ...}: {
+  services.onepassword-secrets = {
+    enable = true;
+    tokenFile = "/etc/opnix-token";
+
+    secrets = {
+      grafanaCloudPromRemoteWriteUrl = {
+        reference = "op://cache/Grafana-Alloy/GRAFANA_CLOUD_PROM_REMOTE_WRITE_URL";
+        path = "/run/secrets/grafana-cloud-prom-remote-write-url";
+        mode = "0400";
+        owner = config.systemd.services.grafana-alloy.serviceConfig.User or "root";
+        group = config.systemd.services.grafana-alloy.serviceConfig.Group or "root";
+        services = ["grafana-alloy"];
+      };
+
+      grafanaCloudPromUsername = {
+        reference = "op://cache/Grafana-Alloy/GRAFANA_CLOUD_PROM_USERNAME";
+        path = "/run/secrets/grafana-cloud-prom-username";
+        mode = "0400";
+        owner = config.systemd.services.grafana-alloy.serviceConfig.User or "root";
+        group = config.systemd.services.grafana-alloy.serviceConfig.Group or "root";
+        services = ["grafana-alloy"];
+      };
+
+      grafanaCloudPromPassword = {
+        reference = "op://cache/Grafana-Alloy/GRAFANA_CLOUD_PROM_PASSWORD";
+        path = "/run/secrets/grafana-cloud-prom-password";
+        mode = "0400";
+        owner = config.systemd.services.grafana-alloy.serviceConfig.User or "root";
+        group = config.systemd.services.grafana-alloy.serviceConfig.Group or "root";
+        services = ["grafana-alloy"];
+      };
+    };
+
+    systemdIntegration = {
+      enable = true;
+      services = ["grafana-alloy"];
+      restartOnChange = true;
+      changeDetection.enable = true;
+    };
+  };
+}

--- a/cache/platform/users.nix
+++ b/cache/platform/users.nix
@@ -11,13 +11,13 @@
     ];
   };
 
-	users.users.mfort = {
-		isNormalUser = true;
-		extraGroups = ["wheel" "docker"];
-		openssh.authorizedKeys.keys = [
-			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB/Y8pQ/HHZ1BKE+DILq/gE7cd8tSiGHcT8pj5wR2f4W marek@tuist.dev"
-		];
-	};
+  users.users.mfort = {
+    isNormalUser = true;
+    extraGroups = ["wheel" "docker"];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB/Y8pQ/HHZ1BKE+DILq/gE7cd8tSiGHcT8pj5wR2f4W marek@tuist.dev"
+    ];
+  };
 
   users.users.github-actions = {
     isNormalUser = true;


### PR DESCRIPTION
This PR does two and a half (three?, four?) things:
- sets up [opnix](https://github.com/brizzbuzz/opnix) for secrets handling on our cache nodes, linked to our 1Password
- adds a `/metrics` route to the Phoenix app
- sets up nginx to serve that route on localhost, while 404ing on the public internet (meaning we don't need auth)
- sets up Grafana Alloy to scrape that endpoint and forward to Grafana Cloud Prometheus, using the secrets from step 1