### PR TITLE
fix(cache): handle upload cancellations

### DIFF
--- a/cache/lib/cache_web/controllers/cas_controller.ex
+++ b/cache/lib/cache_web/controllers/cas_controller.ex
@@ -91,6 +91,10 @@ defmodule CacheWeb.CASController do
         :telemetry.execute([:cache, :cas, :upload, :error], %{count: 1}, %{reason: :timeout})
         send_error(conn_after, :request_timeout, "Request body read timed out")
 
+      {:error, :cancelled, conn_after} ->
+        :telemetry.execute([:cache, :cas, :upload, :cancelled], %{count: 1}, %{})
+        send_resp(conn_after, :no_content, "")
+
       {:error, _reason, conn_after} ->
         :telemetry.execute([:cache, :cas, :upload, :error], %{count: 1}, %{reason: :read_error})
         send_error(conn_after, :internal_server_error, "Failed to persist artifact")

--- a/cache/test/cache/body_reader_test.exs
+++ b/cache/test/cache/body_reader_test.exs
@@ -1,0 +1,72 @@
+defmodule Cache.BodyReaderTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Cache.BodyReader
+  alias Plug.Adapters.Test.Conn
+
+  describe "read/1" do
+    test "handles Bandit.TransportError during initial read" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+
+      expect(Plug.Conn, :read_body, fn _conn, _opts ->
+        raise Bandit.TransportError, message: "Unrecoverable error: closed", error: :closed
+      end)
+
+      assert {:error, :cancelled, ^conn} = BodyReader.read(conn)
+    end
+
+    test "handles Bandit.TransportError during chunked read" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      # First call returns :more to trigger chunked read, second call raises
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Unrecoverable error: closed", error: :closed
+        end
+      end)
+
+      assert {:error, :cancelled, ^conn} = BodyReader.read(conn)
+    end
+  end
+
+  describe "drain/1" do
+    test "handles Bandit.TransportError during drain" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+
+      expect(Plug.Conn, :read_body, fn _conn, _opts ->
+        raise Bandit.TransportError, message: "Unrecoverable error: closed", error: :closed
+      end)
+
+      assert {:error, ^conn} = BodyReader.drain(conn)
+    end
+
+    test "handles Bandit.TransportError during chunked drain" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Unrecoverable error: closed", error: :closed
+        end
+      end)
+
+      assert {:error, ^conn} = BodyReader.drain(conn)
+    end
+  end
+end

--- a/cache/test/test_helper.exs
+++ b/cache/test/test_helper.exs
@@ -8,5 +8,6 @@ Mimic.copy(ExAws)
 Mimic.copy(ExAws.Config)
 Mimic.copy(Cache.S3)
 Mimic.copy(Oban)
+Mimic.copy(Plug.Conn)
 
 ExUnit.start()


### PR DESCRIPTION
Don't crash on upload cancellations, but handle them gracefully.
Solves https://appsignal.com/tuist/sites/69147b033622541e2e2c46dd/exceptions/incidents/12