### PR TITLE
fix(cli): add Emerge Tools SnapshottingTests to the list of targets that depend on XCTest

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1077,6 +1077,7 @@ extension ProjectDescription.Settings {
             "MockableTest", // https://github.com/Kolos65/Mockable.git
             "Testing", // https://github.com/apple/swift-testing
             "Cuckoo", // https://github.com/Brightify/Cuckoo
+            "SnapshottingTests", // https://github.com/EmergeTools/SnapshotPreviews
             "_SwiftSyntaxTestSupport", // https://github.com/swiftlang/swift-syntax
             "SwiftSyntaxMacrosTestSupport", // https://github.com/swiftlang/swift-syntax
         ]


### PR DESCRIPTION
This pull request updates the list of targets that depend on the XCTest framework within the Tuist configuration.

The change is specifically to include the SnapshottingTests target. This target is required for projects utilizing the SnapshotPreviews library (from https://github.com/EmergeTools/SnapshotPreviews), as it relies on XCTest for its testing infrastructure.

By adding this target, we ensure that Tuist correctly recognizes the necessary dependencies for these tests, preventing build failures for projects using this snapshot testing approach.

### How to test locally

Since this change is a metadata update within Tuist's build configuration, testing requires generating a project that utilizes this specific test target.

1.  **Set up an environment:** Ensure you have a project using the `SnapshotPreviews` dependency or create a minimal fixture that includes a target named `SnapshottingTests` which relies on `XCTest`.
2.  **Run Tuist:**
    ```bash
    # Use your locally built tuist executable to generate the test project
    /path/to/local/tuist generate --path /path/to/test/project
    ```
3.  **Verify:** Open the generated Xcode project (`.xcworkspace`) and confirm that the `SnapshottingTests` target successfully links against the `XCTest` framework and **builds without any errors**.
