### PR TITLE
fix(cache): fix locale setting in container

### DIFF
--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update -y && \
 	apt-get install -y libstdc++6 openssl locales ca-certificates \
 	&& apt-get clean && rm -f /var/lib/apt/lists/*_*
 
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Fixes
```
warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
```