### PR TITLE
fix(cli): Revert static framework with resources embedding

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1614,8 +1614,4 @@ extension GraphDependency {
     fileprivate var xcframeworkDependency: GraphDependency.XCFramework? {
         if case let .xcframework(xcframework) = self { xcframework } else { nil }
     }
-
-    private var isPrecompiledAndLinkable: Bool {
-        if case .xcframework = self { true } else { isPrecompiledDynamicAndLinkable }
-    }
 }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/8614>

### Short description 📝
Fixed the issue related to static frameworks with resources getting embedded, this was done by reverting some of the code which was introduced https://github.com/tuist/tuist/pull/7006, the later PR was meant to be reverted in https://github.com/tuist/tuist/pull/7232, but it was a partial revert, and didn't cover the part that includes static frameworks that has resources.

### How to test locally 🧐
This was tested and validated by:

- Test 1: Generating the sample project [EmbeddingIssue2.zip](https://github.com/user-attachments/files/23457369/EmbeddingIssue2.zip) from  [#8614](https://github.com/tuist/tuist/issues/8614)

| before | after |
|--------|--------|
| <img width="400" src="https://github.com/user-attachments/assets/2d94f6b6-ee04-43bb-81a5-05443cee450f" /> | <img width="400" src="https://github.com/user-attachments/assets/134e733c-26c8-45e7-a828-5b7d1cfcb5f9" /> | 

- Test 2: Used the locally generated Tuist cli product to the Bitrise workflow, and the archive step now passed ✅ 
