### PR TITLE
fix(cli): fix false negative implicit import detection of transitive local dependencies

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -153,8 +153,12 @@ final class GraphImportsLinter: GraphImportsLinting {
                 }
             }
             .map { dependency in
-                if case .external = dependency.graphTarget.project.type { return graphTraverser
-                    .allTargetDependencies(path: target.project.path, name: target.target.name)
+                if case .external = dependency.graphTarget.project.type {
+                    let targets = [dependency.graphTarget] + graphTraverser.allTargetDependencies(
+                        path: dependency.graphTarget.project.path,
+                        name: dependency.graphTarget.target.name
+                    )
+                    return Set(targets)
                 } else {
                     return Set(arrayLiteral: dependency.graphTarget)
                 }

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -60,6 +60,58 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         await XCTAssertThrowsSpecific(try await subject.run(path: path.pathString), expectedError)
     }
 
+    func test_run_throwsAnError_when_transitiveLocalDependencyIsImplicitlyImported() async throws {
+        // Given
+        let config = Tuist.test()
+
+        let path = try AbsolutePath(validating: "/project")
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: path, targets: [app])
+
+        let packageTarget = Target.test(name: "PackageTarget", product: .app)
+        let packageTargetPath = try AbsolutePath(validating: "/p")
+        let packageTargetProject = Project.test(path: packageTargetPath, targets: [packageTarget], type: .external(hash: "hash"))
+
+        let testTarget = Target.test(name: "TestTarget", product: .app)
+        let testTargetPath = try AbsolutePath(validating: "/a")
+        let testTargetProject = Project.test(path: testTargetPath, targets: [testTarget])
+
+        let testTargetDependency = Target.test(name: "TestTargetDependency", product: .app)
+        let testTargetDependencyPath = try AbsolutePath(validating: "/b")
+        let testTargetDependencyProject = Project.test(path: testTargetDependencyPath, targets: [testTargetDependency])
+
+        let graph = Graph.test(
+            path: path,
+            projects: [
+                path: project,
+                testTargetPath: testTargetProject,
+                testTargetDependencyPath: testTargetDependencyProject,
+                packageTargetPath: packageTargetProject,
+            ],
+            dependencies: [
+                .target(name: "App", path: path): [
+                    .target(name: "PackageTarget", path: packageTargetPath),
+                    .target(name: "TestTarget", path: testTargetPath),
+                ],
+                .target(name: "TestTarget", path: testTargetPath): [
+                    .target(name: "TestTargetDependency", path: testTargetDependencyPath),
+                ],
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(app)).willReturn(Set(["TestTargetDependency"]))
+        given(targetScanner).imports(for: .value(testTarget)).willReturn(Set())
+        given(targetScanner).imports(for: .value(testTargetDependency)).willReturn(Set())
+
+        let expectedError = LintingError()
+
+        // When / Then
+        await XCTAssertThrowsSpecific(try await subject.run(path: path.pathString), expectedError)
+    }
+
     func test_run_when_external_package_target_is_implicitly_imported() async throws {
         // Given
         let path = try AbsolutePath(validating: "/project")
@@ -116,25 +168,25 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         let config = Tuist.test()
         let app = Target.test(name: "App", product: .app)
         let project = Project.test(path: path, targets: [app])
-        let testTarget = Target.test(name: "PackageTarget", product: .app)
-        let externalTargetDependency = Target.test(name: "PackageTargetDependency", product: .app)
-        let externalProject = Project.test(
-            path: path,
-            targets: [testTarget, externalTargetDependency],
+
+        let packagePath = try AbsolutePath(validating: "/a")
+        let packageTarget = Target.test(name: "PackageTarget", product: .app)
+        let packageTargetDependency = Target.test(name: "PackageTargetDependency", product: .app)
+        let packageProject = Project.test(
+            path: packagePath,
+            targets: [packageTarget, packageTargetDependency],
             type: .external(hash: "hash")
         )
         let graph = Graph.test(
             path: path,
-            projects: [path: project, "/a": externalProject],
+            projects: [path: project, packagePath: packageProject],
             dependencies: [
                 GraphDependency.target(name: "App", path: path): Set([
-                    GraphDependency.target(name: "PackageTarget", path: "/a"),
+                    GraphDependency.target(name: "PackageTarget", path: packagePath),
                 ]),
-                GraphDependency
-                    .target(
-                        name: "PackageTarget",
-                        path: "/a"
-                    ): Set([GraphDependency.target(name: "PackageTargetDependency", path: "/a")]),
+                GraphDependency.target(name: "PackageTarget", path: packagePath): Set([
+                    GraphDependency.target(name: "PackageTargetDependency", path: packagePath),
+                ]),
             ]
         )
 


### PR DESCRIPTION
## Issue

I noticed, that `tuist inspect implicit-imports` does not throw an error for **implicit imports of local targets that are transitive dependencies**.

Given the following graph:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/04be1319-5f40-4234-b6dc-7f7c7f4d4514" />


When using `import TestTargetDependency` in `App`, `tuist inspect implicit-imports` does not throw an error, which is unexpected since `TestTargetDependency` is not listed as an explicit dependency of `App`.

Created a minimal repro with this example graph [here](https://github.com/Kolos65/tuist/tree/repro/false-negative-implicit-imports/cli/Repro/ImplicitImports). Notice that no implicit imports are found when running `tuist inspect implicit-imports`.

## Bug

https://github.com/tuist/tuist/pull/7000 introduced a **fix for SPM target dependencies** to follow what SPM allows and added an exception to implicit import detection to **ignore transitive dependencies of SPM deps**.

After some debugging, I have found that change had a bug:

```swift
// ...
let explicitTargetDependencies = targetDependencies
    // ...
    .map { dependency in
        if case .external = dependency.graphTarget.project.type {
            return graphTraverser.allTargetDependencies(
                path: target.project.path,
                name: target.target.name
            )
        } else {
            return Set(arrayLiteral: dependency.graphTarget)
        }
    }
    // ...
```

For external dependencies, the current implementation traverses the dependency graph form `target` instead of `dependency.graphTarget`, **that will result in a full recursive search of not just the external target deps but ALL dependencies of the inspected target.**

You can verify this in the [minimal repro](https://github.com/Kolos65/tuist/tree/repro/false-negative-implicit-imports/cli/Repro/ImplicitImports) by removing the external dependency from the App project's dependencies, which will result in the above traversal not running and `tuist inspect` finding the implicit `TestTargetDependency` import correctly.

## Fix

This PR fixes the issue by traversing the graph only from the external target - to gather its transitive dependencies - then adds those dependencies along with the original external target.

## Tests

I added a unit test to cover implicit imports of transitive local dependencies and made sure the test was failing before the fix.

My changes broke `test_run_when_external_package_target_is_implicitly_imported` but I noticed the setup there was incorrect since the path used in the external project definition was different from the one used in the graph. `externalProject` used `path` while `/a` was used in the graph mock.

## Impact

The changes in this PR - if accepted - will have a significant impact on existing projects that are using `tuist inspect` as part of their workflows. I believe this issue hid many implicit imports given the only precondition was the presence of a single external dependency.
