### PR TITLE
refactor(cache): only send nginx error logs to Grafana Cloud

### DIFF
--- a/cache/platform/alloy.nix
+++ b/cache/platform/alloy.nix
@@ -78,20 +78,6 @@
        forward_to = [loki.write.grafana_cloud.receiver]
      }
 
-     loki.source.file "nginx_access" {
-       targets    = [
-         {
-           __path__ = "/var/log/nginx/access.log",
-           labels   = {
-             job     = "nginx",
-             stream   = "access",
-             instance = "${config.networking.hostName}",
-           },
-         },
-       ]
-       forward_to = [loki.write.grafana_cloud.receiver]
-     }
-
      loki.source.file "nginx_error" {
        targets    = [
          {


### PR DESCRIPTION
Reduce log usage - we basically log every request twice right now; once in nginx, once in Phoenix. That _can_ be helpful, but in success scenarios is a tiny bit wasteful.