### PR TITLE
refactor(all): replace all remaining .io domains with .dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ mise run dev                   # Start development server
 ```
 
 **Test User Account:**
-- Email: `tuistrocks@tuist.io`
+- Email: `tuistrocks@tuist.dev`
 - Password: `tuistrocks`
 
 ## Common Development Commands

--- a/Project.swift
+++ b/Project.swift
@@ -42,7 +42,7 @@ func acceptanceTestsEnvironmentVariables() -> [String: EnvironmentVariable] {
     [
         "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
         "TUIST_FRAMEWORK_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
-        "TUIST_AUTH_EMAIL": "tuistrocks@tuist.io",
+        "TUIST_AUTH_EMAIL": "tuistrocks@tuist.dev",
         "TUIST_AUTH_PASSWORD": "tuistrocks",
     ]
 }

--- a/server/README.md
+++ b/server/README.md
@@ -30,7 +30,7 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. We already have a pre-made user account that you can use to test the server:
 
 ```
-Email: tuistrocks@tuist.io
+Email: tuistrocks@tuist.dev
 Pass: tuistrocks
 ```
 

--- a/server/test/tuist/accounts/user_test.exs
+++ b/server/test/tuist/accounts/user_test.exs
@@ -49,10 +49,10 @@ defmodule Tuist.Accounts.UserTest do
   describe "gravatar_url/1" do
     test "generates the right avatar" do
       # When
-      got = [email: "tuist@tuist.io"] |> AccountsFixtures.user_fixture() |> User.gravatar_url()
+      got = [email: "tuist@tuist.dev"] |> AccountsFixtures.user_fixture() |> User.gravatar_url()
 
       # Then
-      assert got == "https://www.gravatar.com/avatar/0f3e9af754a1574f7b5fb3ab36e9b0b8?d=404"
+      assert got == "https://www.gravatar.com/avatar/20781daad983fcf18cbd592ae46aa57e?d=404"
     end
   end
 end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -365,7 +365,7 @@ defmodule Tuist.AccountsTest do
           provider: :okta,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -398,7 +398,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -428,7 +428,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -516,7 +516,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -597,7 +597,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2126,12 +2126,12 @@ defmodule Tuist.AccountsTest do
           provider: :github,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           }
         })
 
       # Then
-      assert user.email == "tuist@tuist.io"
+      assert user.email == "tuist@tuist.dev"
     end
 
     test "creates a user from a google identity with a hosted domain" do
@@ -2144,7 +2144,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2156,7 +2156,7 @@ defmodule Tuist.AccountsTest do
         })
 
       # Then
-      assert user.email == "tuist@tuist.io"
+      assert user.email == "tuist@tuist.dev"
       oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, 123)
       assert oauth2_identity.provider_organization_id == "tuist.io"
     end
@@ -2171,7 +2171,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2183,20 +2183,20 @@ defmodule Tuist.AccountsTest do
         })
 
       # Then
-      assert user.email == "tuist@tuist.io"
+      assert user.email == "tuist@tuist.dev"
       oauth2_identity = Accounts.get_oauth2_identity_by_provider_and_id(:google, 123)
       assert oauth2_identity.provider_organization_id == nil
     end
 
     test "updates an existing user with a new github identity" do
-      user = user_fixture(email: "tuist@tuist.io")
+      user = user_fixture(email: "tuist@tuist.dev")
 
       got =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :github,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           }
         })
 
@@ -2205,14 +2205,14 @@ defmodule Tuist.AccountsTest do
     end
 
     test "updates an existing user with a new okta identity" do
-      user = user_fixture(email: "tuist@tuist.io")
+      user = user_fixture(email: "tuist@tuist.dev")
 
       got =
         Accounts.find_or_create_user_from_oauth2(%{
           provider: :okta,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2322,7 +2322,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2448,7 +2448,7 @@ defmodule Tuist.AccountsTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -2500,7 +2500,7 @@ defmodule Tuist.AccountsTest do
           provider: :okta,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -114,7 +114,7 @@ defmodule Tuist.ProjectsTest do
         provider: :google,
         uid: 123,
         info: %{
-          email: "tuist@tuist.io"
+          email: "tuist@tuist.dev"
         },
         extra: %{
           raw_info: %{

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -21,7 +21,7 @@ defmodule TuistWeb.AnalyticsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
 
     stub(Environment, :github_app_configured?, fn -> true end)
     %{user: user}

--- a/server/test/tuist_web/controllers/api/cache/cas_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache/cas_controller_test.exs
@@ -9,7 +9,7 @@ defmodule TuistWeb.API.CASControllerTest do
   alias TuistWeb.Errors.NotFoundError
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
     project = ProjectsFixtures.project_fixture(account_id: user.account.id)
 
     %{

--- a/server/test/tuist_web/controllers/api/cache/key_value_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache/key_value_controller_test.exs
@@ -9,7 +9,7 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
   alias TuistWeb.Errors.NotFoundError
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
     project = ProjectsFixtures.project_fixture(account_id: user.account.id)
 
     %{

--- a/server/test/tuist_web/controllers/api/invitations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/invitations_controller_test.exs
@@ -7,7 +7,7 @@ defmodule TuistWeb.API.InvitationsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
     %{user: user}
   end
 

--- a/server/test/tuist_web/controllers/api/organizations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/organizations_controller_test.exs
@@ -10,7 +10,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
     %{user: user}
   end
 
@@ -361,7 +361,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -453,7 +453,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -498,7 +498,7 @@ defmodule TuistWeb.API.OrganizationsControllerTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -15,7 +15,7 @@ defmodule TuistWeb.PreviewsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = %{account: account} = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+    user = %{account: account} = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
     project = ProjectsFixtures.project_fixture(account_id: account.id)
     %{user: user, project: project, account: account}
   end

--- a/server/test/tuist_web/controllers/api/projects_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/projects_controller_test.exs
@@ -11,7 +11,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
     %{user: user}
   end
 
@@ -309,7 +309,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
           provider: :google,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           },
           extra: %{
             raw_info: %{
@@ -574,7 +574,7 @@ defmodule TuistWeb.API.ProjectsControllerTest do
           provider: :github,
           uid: 123,
           info: %{
-            email: "tuist@tuist.io"
+            email: "tuist@tuist.dev"
           }
         })
 

--- a/server/test/tuist_web/controllers/api/qa_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/qa_controller_test.exs
@@ -12,7 +12,7 @@ defmodule TuistWeb.API.QAControllerTest do
   alias TuistWeb.Authentication
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
     project = ProjectsFixtures.project_fixture(account_id: user.account.id)
     preview = AppBuildsFixtures.preview_fixture(project: project)
     app_build = AppBuildsFixtures.app_build_fixture(preview: preview)

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -226,7 +226,7 @@ defmodule TuistWeb.API.RunsControllerTest do
   describe "POST /api/projects/:account_handle/:project_handle/runs" do
     test "creates a new build when authenticated as user", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -381,7 +381,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build when authenticatd as project", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -425,7 +425,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "returns an existing build run if it already exists", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
       id = UUIDv7.generate()
 
@@ -467,7 +467,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build when non-required parameters are missing", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -512,7 +512,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with GitHub CI metadata", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -553,7 +553,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with GitLab CI metadata including a custom host", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -593,7 +593,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with cacheable tasks and calculates counts correctly", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When - randomize order of cacheable tasks
@@ -672,7 +672,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with empty cacheable tasks array", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -715,7 +715,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with CAS outputs", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When
@@ -821,7 +821,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "returns :not_found when project doesn't exist", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       non_existent_project_name = UUIDv7.generate()
       non_existent_account_name = UUIDv7.generate()
       project_slug = "#{non_existent_account_name}/#{non_existent_project_name}"
@@ -852,7 +852,7 @@ defmodule TuistWeb.API.RunsControllerTest do
       conn: conn
     } do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account])
 
       # When
@@ -874,7 +874,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
     test "creates a new build with cacheable tasks that have cas_output_node_ids", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(preload: [:account], email: "tuist@tuist.dev")
       project = ProjectsFixtures.project_fixture(preload: [:account], account_id: user.account.id)
 
       # When

--- a/server/test/tuist_web/controllers/api_controller_test.exs
+++ b/server/test/tuist_web/controllers/api_controller_test.exs
@@ -5,7 +5,7 @@ defmodule TuistWeb.APIControllerTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   setup do
-    user = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+    user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
     %{user: user}
   end
 

--- a/server/test/tuist_web/controllers/billing_controller_test.exs
+++ b/server/test/tuist_web/controllers/billing_controller_test.exs
@@ -13,7 +13,7 @@ defmodule TuistWeb.BillingControllerTest do
       %{account: account} =
         user =
         AccountsFixtures.user_fixture(
-          email: "tuist@tuist.io",
+          email: "tuist@tuist.dev",
           customer_id: nil,
           preload: [:account]
         )
@@ -44,7 +44,7 @@ defmodule TuistWeb.BillingControllerTest do
     test "redirects to Stripe when user has permission and billing returns an external redirect request",
          %{conn: conn} do
       %{account: account} =
-        user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+        user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
 
       success_url = url(~p"/#{account.name}/billing") <> "?new_plan=pro"
 
@@ -68,7 +68,7 @@ defmodule TuistWeb.BillingControllerTest do
       conn: conn
     } do
       %{account: account} =
-        user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+        user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
 
       success_url = url(~p"/#{account.name}/billing") <> "?new_plan=pro"
 
@@ -91,7 +91,7 @@ defmodule TuistWeb.BillingControllerTest do
     test "raises UnauthorizedError when user does not have permission", %{conn: conn} do
       organization = AccountsFixtures.organization_fixture()
       organization_account = Accounts.get_account_from_organization(organization)
-      user = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
 
       assert_raise UnauthorizedError, fn ->
         conn
@@ -106,7 +106,7 @@ defmodule TuistWeb.BillingControllerTest do
       %{account: account} =
         user =
         AccountsFixtures.user_fixture(
-          email: "tuist@tuist.io",
+          email: "tuist@tuist.dev",
           customer_id: nil,
           preload: [:account]
         )
@@ -133,7 +133,7 @@ defmodule TuistWeb.BillingControllerTest do
 
     test "redirects to Stripe when user has permission", %{conn: conn} do
       %{account: account} =
-        user = AccountsFixtures.user_fixture(email: "tuist@tuist.io", preload: [:account])
+        user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
 
       expect(Billing, :create_session, fn _ -> %{url: "https://stripe.com"} end)
 
@@ -152,7 +152,7 @@ defmodule TuistWeb.BillingControllerTest do
     test "raises UnauthorizedError when user does not have permission", %{conn: conn} do
       organization = AccountsFixtures.organization_fixture()
       organization_account = Accounts.get_account_from_organization(organization)
-      user = AccountsFixtures.user_fixture(email: "tuist@tuist.io")
+      user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev")
 
       assert_raise UnauthorizedError, fn ->
         conn


### PR DESCRIPTION
Got tired of needing two tries at authenticating every time on canary.