### PR TITLE
refactor(cache): store blobs on network volume

### DIFF
--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -46,6 +46,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+RUN groupadd -g 990 cache && useradd -u 990 -g cache cache
+
 WORKDIR "/app"
 
 ENV MIX_ENV="prod"

--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -77,7 +77,7 @@
     pkgs.gitMinimal
     pkgs.parted
     pkgs.gptfdisk
-		pkgs.sqlite
+    pkgs.sqlite
   ];
 
   systemd.tmpfiles.rules = [

--- a/cache/platform/disk-config.nix
+++ b/cache/platform/disk-config.nix
@@ -21,7 +21,7 @@
               };
             };
             root = {
-              size = "40G";
+              size = "100%";
               content = {
                 type = "filesystem";
                 format = "ext4";
@@ -34,6 +34,15 @@
                 ];
               };
             };
+          };
+        };
+      };
+      sdb = {
+        type = "disk";
+        device = "/dev/sdb";
+        content = {
+          type = "gpt";
+          partitions = {
             cas = {
               size = "100%";
               content = {

--- a/cache/platform/users.nix
+++ b/cache/platform/users.nix
@@ -30,5 +30,10 @@
   users.users.cache = {
     isSystemUser = true;
     group = "cache";
+    uid = 990;
+  };
+
+  users.groups.cache = {
+    gid = 990;
   };
 }


### PR DESCRIPTION
Moves CAS blobs to be saved on network block storage for easier scaling.