### PR TITLE
feat(server): add S3 CA certificate configuration for air-gapped environments

### DIFF
--- a/docs/docs/en/guides/server/self-host/install.md
+++ b/docs/docs/en/guides/server/self-host/install.md
@@ -221,6 +221,7 @@ You can use any S3-compliant storage provider to store artifacts. The following 
 | `TUIST_S3_REGION` or `AWS_REGION` | The region where the bucket is located | No | `auto` | `us-west-2` |
 | `TUIST_S3_ENDPOINT` or `AWS_ENDPOINT` | The endpoint of the storage provider | Yes | | `https://s3.us-west-2.amazonaws.com` |
 | `TUIST_S3_BUCKET_NAME` | The name of the bucket where the artifacts will be stored | Yes | | `tuist-artifacts` |
+| `TUIST_S3_CA_CERT_PEM` | PEM-encoded CA certificate for verifying S3 HTTPS connections. Useful for air-gapped environments with self-signed certificates or internal Certificate Authorities. | No | System CA bundle | `-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----` |
 | `TUIST_S3_CONNECT_TIMEOUT` | The timeout (in milliseconds) for establishing a connection to the storage provider | No | `3000` | `3000` |
 | `TUIST_S3_RECEIVE_TIMEOUT` | The timeout (in milliseconds) for receiving data from the storage provider | No | `5000` | `5000` |
 | `TUIST_S3_POOL_TIMEOUT` | The timeout (in milliseconds) for the connection pool to the storage provider. Use `infinity` for no timeout | No | `5000` | `5000` |

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -134,6 +134,21 @@ defmodule Tuist.Application do
     )
   end
 
+  defp s3_ca_cert_opts do
+    case Environment.s3_ca_cert_pem() do
+      nil ->
+        [cacertfile: CAStore.file_path()]
+
+      pem_content ->
+        der_certs =
+          pem_content
+          |> :public_key.pem_decode()
+          |> Enum.map(fn {_, der, _} -> der end)
+
+        [cacerts: der_certs]
+    end
+  end
+
   defp finch_pools do
     if Environment.test?() do
       %{:default => [size: 10]}
@@ -159,11 +174,11 @@ defmodule Tuist.Application do
           conn_opts: [
             log: true,
             protocols: Environment.s3_protocols(),
-            transport_opts: [
-              inet6: Environment.use_ipv6?() in ~w(true 1),
-              cacertfile: CAStore.file_path(),
-              verify: :verify_peer
-            ]
+            transport_opts:
+              [
+                inet6: Environment.use_ipv6?() in ~w(true 1),
+                verify: :verify_peer
+              ] ++ s3_ca_cert_opts()
           ],
           size: Environment.s3_pool_size(),
           count: Environment.s3_pool_count(),
@@ -174,11 +189,11 @@ defmodule Tuist.Application do
           conn_opts: [
             log: true,
             protocols: Environment.s3_protocols(),
-            transport_opts: [
-              inet6: Environment.use_ipv6?() in ~w(true 1),
-              cacertfile: CAStore.file_path(),
-              verify: :verify_peer
-            ]
+            transport_opts:
+              [
+                inet6: Environment.use_ipv6?() in ~w(true 1),
+                verify: :verify_peer
+              ] ++ s3_ca_cert_opts()
           ],
           size: Environment.s3_pool_size(),
           count: Environment.s3_pool_count(),

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -393,6 +393,10 @@ defmodule Tuist.Environment do
     end
   end
 
+  def s3_ca_cert_pem(secrets \\ secrets()) do
+    System.get_env("TUIST_S3_CA_CERT_PEM") || get([:s3, :ca_cert_pem], secrets)
+  end
+
   def slack_tuist_token(secrets \\ secrets()) do
     get([:slack, :tuist, :token], secrets)
   end

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -154,4 +154,38 @@ defmodule Tuist.EnvironmentTest do
       assert is_nil(result)
     end
   end
+
+  describe "s3_ca_cert_pem/1" do
+    test "returns PEM content from secrets" do
+      # Given
+      pem_content = """
+      -----BEGIN CERTIFICATE-----
+      MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKqzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+      -----END CERTIFICATE-----
+      """
+
+      secrets = %{
+        "s3" => %{
+          "ca_cert_pem" => pem_content
+        }
+      }
+
+      # When
+      result = Environment.s3_ca_cert_pem(secrets)
+
+      # Then
+      assert result == pem_content
+    end
+
+    test "returns nil when not configured" do
+      # Given
+      secrets = %{}
+
+      # When
+      result = Environment.s3_ca_cert_pem(secrets)
+
+      # Then
+      assert is_nil(result)
+    end
+  end
 end


### PR DESCRIPTION
Add support for a custom CA certificate when connecting to S3-compatible storage providers. This enables deployment in air-gapped environments with self-signed certificates or internal Certificate Authorities.
