### PR TITLE
fix(cli): resolve token refresh data race in ServerAuthenticationController

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -198,7 +198,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             refreshAuthTokenService: RefreshAuthTokenServicing = RefreshAuthTokenService(),
             fileSystem: FileSysteming = FileSystem(),
             backgroundProcessRunner: BackgroundProcessRunning = BackgroundProcessRunner(),
-            cachedValueStore: CachedValueStoring = CachedValueStore()
+            cachedValueStore: CachedValueStoring = CachedValueStore.current
         ) {
             self.refreshAuthTokenService = refreshAuthTokenService
             self.fileSystem = fileSystem
@@ -209,7 +209,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         public init(
             refreshAuthTokenService: RefreshAuthTokenServicing = RefreshAuthTokenService(),
             fileSystem: FileSysteming = FileSystem(),
-            cachedValueStore: CachedValueStoring = CachedValueStore()
+            cachedValueStore: CachedValueStoring = CachedValueStore.current
         ) {
             self.refreshAuthTokenService = refreshAuthTokenService
             self.fileSystem = fileSystem


### PR DESCRIPTION
Related TUI-259

I'm not able to reproduce the issue as of now, so turning to agents ... the changes make sense to me, so I'd suggest going ahead, shipping that to teams using xcode cache, and then doing deeper investigations if this doesn't help.

## Summary

- Fixed data race where multiple `ServerAuthenticationController` instances could refresh tokens simultaneously by using shared `CachedValueStore.current` instead of creating new instances
- Fixed race condition in `CachedValueStore` where task reference could be cleared before being awaited

🤖 Generated with [Claude Code](https://claude.com/claude-code)