### PR TITLE
fix(server): keep build counts in overview up-to-date

### DIFF
--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -162,7 +162,7 @@ defmodule TuistWeb.OverviewLive do
     recent_build_runs_chart_data = recent_build_runs_chart_data(recent_build_runs)
 
     %{successful_count: passed_build_runs_count, failed_count: failed_build_runs_count} =
-      Runs.recent_build_status_counts(project.id, limit: 30, order: :asc)
+      Runs.recent_build_status_counts(project.id, limit: 30)
 
     socket
     |> assign(


### PR DESCRIPTION
Resolves TUI-268

The build counts in the overview page would be always stale once you had over 30 builds as we were getting the counts from an ascending order ... which meant we would always get the _first_ 30 builds, instead of the 30 latest builds 😅 