### PR TITLE
fix(ci): skip using Xcode cache from forks

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -135,7 +135,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Run tests
-        run: mise x -- tuist test TuistUnitTests
+        run: mise x -- tuist test TuistUnitTests ${{ github.event.pull_request.head.repo.fork == true && '-- COMPILATION_CACHE_ENABLE_PLUGIN=NO' || '' }}
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4
@@ -167,7 +167,7 @@ jobs:
       - name: Download Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
       - name: Run TuistAutomationAcceptanceTests
-        run: mise x -- tuist test TuistAutomationAcceptanceTests
+        run: mise x -- tuist test TuistAutomationAcceptanceTests ${{ github.event.pull_request.head.repo.fork == true && '-- COMPILATION_CACHE_ENABLE_PLUGIN=NO' || '' }}
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4
@@ -206,7 +206,7 @@ jobs:
           security default-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p $KEYCHAIN_PASSWORD $KEYCHAIN_PATH
       - name: Run TuistDependenciesAcceptanceTests
-        run: mise x -- tuist test TuistDependenciesAcceptanceTests
+        run: mise x -- tuist test TuistDependenciesAcceptanceTests ${{ github.event.pull_request.head.repo.fork == true && '-- COMPILATION_CACHE_ENABLE_PLUGIN=NO' || '' }}
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4
@@ -238,7 +238,7 @@ jobs:
       - name: Download Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
       - name: Run TuistGeneratorAcceptanceTests
-        run: mise x -- tuist test TuistGeneratorAcceptanceTests
+        run: mise x -- tuist test TuistGeneratorAcceptanceTests ${{ github.event.pull_request.head.repo.fork == true && '-- COMPILATION_CACHE_ENABLE_PLUGIN=NO' || '' }}
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4
@@ -268,7 +268,7 @@ jobs:
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
       - name: Run TuistKitAcceptanceTests
-        run: mise x -- tuist test TuistKitAcceptanceTests
+        run: mise x -- tuist test TuistKitAcceptanceTests ${{ github.event.pull_request.head.repo.fork == true && '-- COMPILATION_CACHE_ENABLE_PLUGIN=NO' || '' }}
       - name: Save cache
         id: cache-save
         uses: actions/cache/save@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
   build-deploy:
     name: Build & Deploy
     runs-on: macos-26
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    if: github.event.pull_request.head.repo.fork != true && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v4
       - name: Restore PNPM Cache


### PR DESCRIPTION
forks don't have access to the Xcode cache. We can probably look into enabling that for public projects, in the meantime, we can skip using the remote Xcode cache from forks.