### PR TITLE
fix(cli): refreshing token data race

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -302,7 +302,8 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         }
 
         switch (
-            try await tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh), inBackground,
+            try await tokenStatus(serverURL: serverURL, forceRefresh: forceRefresh),
+            inBackground,
             locking
         ) {
         case let (.valid(token), _, _):
@@ -316,15 +317,23 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                 )
             } else {
                 #if canImport(TuistSupport)
-                    return try await fileSystemLocked(
-                        serverURL: serverURL,
-                        action: { deleteLockfile in
-                            _ = try await executeRefresh(
-                                serverURL: serverURL, forceRefresh: forceRefresh
-                            )
-                            try await deleteLockfile()
-                        }, fetchActionResult: fetchActionResult
-                    )
+                    return try await cachedValueStore.getValue(key: lockKey(serverURL: serverURL)) {
+                        let token = try await fileSystemLocked(
+                            serverURL: serverURL,
+                            action: { deleteLockfile in
+                                _ = try await executeRefresh(
+                                    serverURL: serverURL, forceRefresh: forceRefresh
+                                )
+                                try await deleteLockfile()
+                            }, fetchActionResult: fetchActionResult
+                        )
+                        switch token {
+                        case .project:
+                            return (token, nil as Date?)
+                        case let .user(accessToken: _, refreshToken: refreshToken):
+                            return (token, refreshToken.expiryDate)
+                        }
+                    }
                 #else
                     return try await inProcessLockedRefresh(
                         serverURL: serverURL, forceRefresh: forceRefresh
@@ -335,14 +344,22 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             return try await executeRefresh(serverURL: serverURL, forceRefresh: forceRefresh)?.value
         case (.expired, true, true): // Background with locking
             #if canImport(TuistSupport)
-                return try await Self.fileSystemLockActor.withLock(
-                    lockfilePath: lockFilePath(serverURL: serverURL),
-                    serverURL: serverURL,
-                    action: { _ in
-                        try await spawnRefreshProcess(serverURL: serverURL)
-                    },
-                    fetchActionResult: fetchActionResult
-                )
+                return try await cachedValueStore.getValue(key: lockKey(serverURL: serverURL)) {
+                    let token = try await Self.fileSystemLockActor.withLock(
+                        lockfilePath: lockFilePath(serverURL: serverURL),
+                        serverURL: serverURL,
+                        action: { _ in
+                            try await spawnRefreshProcess(serverURL: serverURL)
+                        },
+                        fetchActionResult: fetchActionResult
+                    )
+                    switch token {
+                    case .project:
+                        return (token, nil as Date?)
+                    case let .user(accessToken: _, refreshToken: refreshToken):
+                        return (token, refreshToken.expiryDate)
+                    }
+                }
             #else
                 return nil
             #endif


### PR DESCRIPTION
We currently have a file system lock, but in highly parallel processes, like Xcode cache, that's still prune to data races. To fix the issue, I'm wrapping the file system locks with `CachedValueStore` which ensures data race safety in the same program.

I was able to reproduce the issue by:
- Forcing the program to refresh very often by updating `30` to `590` [here](https://github.com/tuist/tuist/blob/main/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift#L452) and and [here](https://github.com/tuist/tuist/blob/main/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift#L484).
- Running `cache-start tuist/cas` in the `xcode_project_with_ios_app_and_cas` fixture
- Cleaning derived data for that project and the compilation cache
- Running build in the fixture
- Seeing multiple token refresh requests (and only one with this fix)