### PR TITLE
refactor(cache): refactor eviction worker

### DIFF
--- a/cache/lib/cache/cas_artifacts.ex
+++ b/cache/lib/cache/cas_artifacts.ex
@@ -32,6 +32,15 @@ defmodule Cache.CASArtifacts do
   end
 
   @doc """
+  Deletes metadata entries for multiple keys in a single query.
+  """
+
+  def delete_by_keys(keys) when is_list(keys) do
+    Repo.delete_all(from(a in CASArtifact, where: a.key in ^keys))
+    :ok
+  end
+
+  @doc """
   Tracks access to a CAS artifact by updating its metadata in the database.
 
   Creates or updates a CASArtifact record with the current file size and access time.


### PR DESCRIPTION
Attempts to fix two failure modes:
 - database lock contention when deleting keys one-by-one, instead batching them (this should also help the "Database busy" reports we've been seing)
 - deleting parent directories while files are still being uploaded, which would fail with `Directory not empty` - directories don't take up any space, so we're just not deleting them anymore