### PR TITLE
fix(server): limit projects encoded in jwt

### DIFF
--- a/cache/lib/cache/authentication.ex
+++ b/cache/lib/cache/authentication.ex
@@ -63,8 +63,8 @@ defmodule Cache.Authentication do
       {:error, :not_jwt} ->
         fetch_and_cache_projects(auth_header, cache_key, conn)
 
-      {:error, :project_not_found} ->
-        cache_result(cache_key, {:error, 404, "Unauthorized or not found"}, failure_ttl())
+      {:error, :project_not_in_jwt} ->
+        fetch_and_cache_projects(auth_header, cache_key, conn)
 
       {:error, _reason} ->
         fetch_and_cache_projects(auth_header, cache_key, conn)
@@ -84,7 +84,7 @@ defmodule Cache.Authentication do
           ttl = calculate_ttl(exp)
           {:ok, ttl}
         else
-          {:error, :project_not_found}
+          {:error, :project_not_in_jwt}
         end
 
       {:error, _reason} ->

--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -65,7 +65,7 @@ defmodule Tuist.Authentication do
            old_claims
            |> Map.drop(["jti", "iss", "iat", "nbf", "exp"])
            |> Map.put("preferred_username", preferred_username),
-         {:ok, new_token, new_claims} <- Tuist.Guardian.encode_and_sign(user, new_claims, opts) do
+         {:ok, new_token, new_claims} <- __MODULE__.encode_and_sign(user, new_claims, opts) do
       Tuist.Guardian.on_revoke(old_claims, old_token)
       {:ok, {old_token, old_claims}, {new_token, new_claims}}
     else
@@ -84,7 +84,7 @@ defmodule Tuist.Authentication do
   def encode_and_sign(resource, claims \\ %{}, opts \\ []) do
     projects =
       resource
-      |> Projects.get_all_project_accounts()
+      |> Projects.get_all_project_accounts(recent: 5)
       |> Enum.map(& &1.handle)
 
     claims = Map.put(claims, "projects", projects)

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -10,6 +10,7 @@ defmodule Tuist.AuthenticationTest do
   alias Tuist.Projects
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   test "authenticated_subject returns nil if the token associated subject doesn't exist" do
@@ -134,6 +135,8 @@ defmodule Tuist.AuthenticationTest do
       user = AccountsFixtures.user_fixture()
       project1 = ProjectsFixtures.project_fixture(account: user.account)
       project2 = ProjectsFixtures.project_fixture(account: user.account)
+      CommandEventsFixtures.command_event_fixture(project_id: project1.id)
+      CommandEventsFixtures.command_event_fixture(project_id: project2.id)
 
       # When
       {:ok, _token, claims} =
@@ -173,6 +176,7 @@ defmodule Tuist.AuthenticationTest do
       organization = AccountsFixtures.organization_fixture()
       Accounts.add_user_to_organization(user, organization, role: :admin)
       project = ProjectsFixtures.project_fixture(account: organization.account)
+      CommandEventsFixtures.command_event_fixture(project_id: project.id)
 
       # When
       {:ok, _token, claims} =

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1829,4 +1829,45 @@ defmodule Tuist.CommandEventsTest do
       assert got == 50.0
     end
   end
+
+  describe "get_project_last_interaction_data/1" do
+    test "returns last interaction time for specified projects only" do
+      project1 = ProjectsFixtures.project_fixture()
+      project2 = ProjectsFixtures.project_fixture()
+      project3 = ProjectsFixtures.project_fixture()
+
+      now = DateTime.utc_now()
+      CommandEventsFixtures.command_event_fixture(project_id: project1.id, ran_at: DateTime.add(now, -5, :day))
+      CommandEventsFixtures.command_event_fixture(project_id: project2.id, ran_at: DateTime.add(now, -3, :day))
+      CommandEventsFixtures.command_event_fixture(project_id: project3.id, ran_at: DateTime.add(now, -1, :day))
+
+      result = CommandEvents.get_project_last_interaction_data([project1.id, project3.id])
+
+      assert map_size(result) == 2
+      assert Map.has_key?(result, project1.id)
+      assert Map.has_key?(result, project3.id)
+      refute Map.has_key?(result, project2.id)
+    end
+
+    test "returns most recent interaction when multiple events exist" do
+      project = ProjectsFixtures.project_fixture()
+
+      now = DateTime.utc_now()
+      CommandEventsFixtures.command_event_fixture(project_id: project.id, ran_at: DateTime.add(now, -10, :day))
+      CommandEventsFixtures.command_event_fixture(project_id: project.id, ran_at: DateTime.add(now, -5, :day))
+      most_recent = CommandEventsFixtures.command_event_fixture(project_id: project.id, ran_at: DateTime.add(now, -1, :day))
+
+      result = CommandEvents.get_project_last_interaction_data([project.id])
+
+      assert result[project.id] == most_recent.ran_at
+    end
+
+    test "returns empty map when no interactions found" do
+      project = ProjectsFixtures.project_fixture()
+
+      result = CommandEvents.get_project_last_interaction_data([project.id])
+
+      assert result == %{}
+    end
+  end
 end

--- a/server/test/tuist/oauth/token_generator_test.exs
+++ b/server/test/tuist/oauth/token_generator_test.exs
@@ -6,11 +6,13 @@ defmodule Tuist.OAuth.TokenGeneratorTest do
   alias Tuist.OAuth.Clients
   alias Tuist.OAuth.TokenGenerator
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   setup do
     user = AccountsFixtures.user_fixture()
     project = ProjectsFixtures.project_fixture(account: user.account)
+    CommandEventsFixtures.command_event_fixture(project_id: project.id)
 
     client = %{
       id: "test-client-id",


### PR DESCRIPTION
Ok, so it turns out our canary account has _a lot_ of projects from testing.
Encoding them all into the JWT makes it explode to a nice 68KB, which breaks all API requests because it's too large for a header.

This PR limits the projects to the 5 most recent ones, which should be more than enough for most accounts.