### PR TITLE
feat(docs): update registry with optional authentication

### DIFF
--- a/docs/docs/en/guides/features/registry.md
+++ b/docs/docs/en/guides/features/registry.md
@@ -7,29 +7,35 @@
 ---
 # Registry {#registry}
 
-::: warning REQUIREMENTS
-<!-- -->
-- A <LocalizedLink href="/guides/server/accounts-and-projects">Tuist account and project</LocalizedLink>
-<!-- -->
-:::
-
 As the number of dependencies grows, so does the time to resolve them. While other package managers like [CocoaPods](https://cocoapods.org/) or [npm](https://www.npmjs.com/) are centralized, Swift Package Manager is not. Because of that, SwiftPM needs to resolve dependencies by doing a deep clone of each repository, which can be time-consuming and takes up more memory than a centralized approach would. To address this, Tuist provides an implementation of the [Package Registry](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/PackageRegistryUsage.md), so you can download only the commits you _actually need_. The packages in the registry are based on the [Swift Package Index](https://swiftpackageindex.com/) – if you can find a package there, the package is also available in the Tuist Registry. Additionally, the packages are distributed across the globe using an edge storage for minimum latency when resolving them.
 
 ## Usage {#usage}
 
-To set up and log in to the registry, run the following command in your project's directory:
+To set up the registry, run the following command in your project's directory:
 
 ```bash
 tuist registry setup
 ```
 
-This command generates a registry configuration files and logs you in to the registry. To ensure the rest of your team can access the registry, ensure the generated files is committed and that your team members run the following command to log in:
+This command generates a registry configuration file that enables the registry for your project. Ensure this file is committed so your team can also benefit from the registry.
+
+### Authentication (optional) {#authentication}
+
+Authentication is **optional**. Without authentication, you can use the registry with a rate limit of **1,000 requests per minute** per IP address. To get a higher rate limit of **20,000 requests per minute**, you can authenticate by running:
 
 ```bash
 tuist registry login
 ```
 
-Now you can access the registry! To resolve dependencies from the registry instead of from source control, continue reading based on your project setup:
+::: info
+<!-- -->
+Authentication requires a <LocalizedLink href="/guides/server/accounts-and-projects">Tuist account and project</LocalizedLink>.
+<!-- -->
+:::
+
+### Resolving dependencies {#resolving-dependencies}
+
+To resolve dependencies from the registry instead of from source control, continue reading based on your project setup:
 - <LocalizedLink href="/guides/features/registry/xcode-project">Xcode project</LocalizedLink>
 - <LocalizedLink href="/guides/features/registry/generated-project">Generated project with the Xcode package integration</LocalizedLink>
 - <LocalizedLink href="/guides/features/registry/xcodeproj-integration">Generated project with the XcodeProj-based package integration</LocalizedLink>


### PR DESCRIPTION
We should highlight that the registry authentication is now optional and should be used only if higher rate limits are required.