### PR TITLE
fix(cli): external dependency case insensitive lookup

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -30,6 +30,12 @@ extension XcodeGraph.TargetDependency {
         generatorPaths: GeneratorPaths,
         externalDependencies: [String: [XcodeGraph.TargetDependency]]
     ) throws -> [XcodeGraph.TargetDependency] {
+        // Normalize dictionary keys to lowercase for case-insensitive lookup
+        let normalizedExternalDependencies = externalDependencies
+            .reduce(into: [String: [XcodeGraph.TargetDependency]]()) { result, entry in
+                result[entry.key.lowercased()] = entry.value
+            }
+
         switch manifest {
         case let .target(name, status, condition):
             return [.target(
@@ -100,7 +106,7 @@ extension XcodeGraph.TargetDependency {
         case .xctest:
             return [.xctest]
         case let .external(name, condition):
-            guard let dependencies = externalDependencies[name] else {
+            guard let dependencies = normalizedExternalDependencies[name.lowercased()] else {
                 throw TargetDependencyMapperError.invalidExternalDependency(name: name)
             }
 

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -271,4 +271,26 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(name, "ARKit.framework")
         XCTAssertEqual(status, .required)
     }
+
+    func test_from_when_external_target_casing_differs() throws {
+        // Given
+        let dependency = ProjectDescription.TargetDependency.external(name: "MyLibrary")
+        let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"), rootDirectory: "/")
+
+        // When
+        let got = try XcodeGraph.TargetDependency.from(
+            manifest: dependency,
+            generatorPaths: generatorPaths,
+            externalDependencies: ["myLibrary": [.project(target: "MyLibrary", path: "/Project")]]
+        )
+
+        // Then - should resolve successfully with case-insensitive lookup
+        XCTAssertEqual(got.count, 1)
+        guard case let .project(target, path, _, _) = got[0] else {
+            XCTFail("Dependency should be project")
+            return
+        }
+        XCTAssertEqual(target, "MyLibrary")
+        XCTAssertEqual(path, "/Project")
+    }
 }


### PR DESCRIPTION
And ... this is why dogfooding is so important 😅 

When migrating our repo to the registry, I noticed our package info mapper had a variation of a bug I fixed a while ago in `swift-package-manager` (https://github.com/swiftlang/swift-package-manager/pull/8194) where the dependency wouldn't be found when the casing differed – but the lookup should be case insensitive.