### PR TITLE
fix(cli): prefer products with matching casing

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -106,7 +106,7 @@ extension XcodeGraph.TargetDependency {
         case .xctest:
             return [.xctest]
         case let .external(name, condition):
-            guard let dependencies = normalizedExternalDependencies[name.lowercased()] else {
+            guard let dependencies = externalDependencies[name] ?? normalizedExternalDependencies[name.lowercased()] else {
                 throw TargetDependencyMapperError.invalidExternalDependency(name: name)
             }
 


### PR DESCRIPTION
[This](https://github.com/tuist/tuist/commit/8f62c0813c5460b4ead314f286b3cde139363197) commit broke projects where dependencies have the same product with the different casing – in which case the product with the same casing should be preferred.