### PR TITLE
fix(server): Disable Plain's floating button in iframes embedded in blog posts

### DIFF
--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -6,7 +6,7 @@ defmodule TuistWeb.LayoutComponents do
 
   import TuistWeb.CSP, only: [get_csp_nonce: 0]
 
-  attr :current_user, :map, default: nil
+  attr(:current_user, :map, default: nil)
 
   def head_plain_script(assigns) do
     current_user = Map.get(assigns, :current_user)
@@ -33,7 +33,10 @@ defmodule TuistWeb.LayoutComponents do
     assigns = assign(assigns, :plain_opts, plain_opts)
 
     ~H"""
-    <script :if={Tuist.Environment.analytics_enabled?()} nonce={get_csp_nonce()}>
+    <script
+      :if={Tuist.Environment.analytics_enabled?() and not Map.get(assigns, :plain_disabled?, false)}
+      nonce={get_csp_nonce()}
+    >
       (function(d, script) {
         script = d.createElement('script');
         script.async = false;
@@ -101,7 +104,7 @@ defmodule TuistWeb.LayoutComponents do
     """
   end
 
-  attr :page_section, :string, default: nil
+  attr(:page_section, :string, default: nil)
 
   def head_analytics_scripts(assigns) do
     posthog_opts =

--- a/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
@@ -27,6 +27,7 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeController do
     |> put_resp_content_type("text/html")
     |> put_layout(false)
     |> put_view(MarketingHTML)
+    |> assign(:plain_disabled?, true)
     |> render(template)
   end
 end

--- a/server/lib/tuist_web/marketing/layouts/root.html.heex
+++ b/server/lib/tuist_web/marketing/layouts/root.html.heex
@@ -92,7 +92,7 @@
 <!-- hCaptcha -->
     <script nonce={get_csp_nonce()} src="https://js.hcaptcha.com/1/api.js" async defer>
     </script>
-    <TuistWeb.LayoutComponents.head_plain_script current_user={@current_user} />
+    <TuistWeb.LayoutComponents.head_plain_script current_user={@current_user} {assigns} />
     <link rel="canonical" href={Tuist.Environment.app_url(path: @current_path)} />
   </head>
   <body data-scrollable="true">


### PR DESCRIPTION
In our last blog post, we embedded interactive animations using iframes which load server-rendered pages, and it turns out that we forgot to disable including Plain's button in that layout. As a result, those iframes would show with the button in them, which looks quite odd. This PR removes it.