### PR TITLE
fix(server): remove replacement of product names in mirrored packages in registry

### DIFF
--- a/server/test/tuist/registry/swift/packages_test.exs
+++ b/server/test/tuist/registry/swift/packages_test.exs
@@ -442,14 +442,14 @@ defmodule Tuist.Registry.Swift.PackagesTest do
                             name: "xcbeautify",
                             dependencies: [
                                 "XcbeautifyLib",
-                                .product(name: "SwiftGen", package: "SwiftGen"),
+                                "SwiftGen",
                                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                             ]
                         ),
                         .target(
                             name: "XcbeautifyLib",
                             dependencies: [
-                                .product(name: "Colorizer", package: "Colorizer"),
+                                "Colorizer",
                                 .product(name: "XMLCoder", package: "XMLCoder"),
                             ]
                         ),


### PR DESCRIPTION
The original issue was solved via https://github.com/swiftlang/swift-package-manager/pull/8194 and is now in all recent SwiftPM and Xcode versions, so we no longer need it. Plus the logic has never been perfect and it does cause issues in some instances like `swift-sdk`.