### PR TITLE
refactor(server): improve projects in JWT

### DIFF
--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -84,8 +84,8 @@ defmodule Tuist.Authentication do
   def encode_and_sign(resource, claims \\ %{}, opts \\ []) do
     projects =
       resource
-      |> Projects.get_all_project_accounts(recent: 5)
-      |> Enum.map(& &1.handle)
+      |> Projects.list_accessible_projects(recent: 5)
+      |> Enum.map(&"#{&1.account.name}/#{&1.name}")
 
     claims = Map.put(claims, "projects", projects)
     Tuist.Guardian.encode_and_sign(resource, claims, opts)

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -78,7 +78,7 @@ defmodule Tuist.ProjectsTest do
     # Given
     organization = AccountsFixtures.organization_fixture()
     account = Accounts.get_account_from_organization(organization)
-    project = ProjectsFixtures.project_fixture(account_id: account.id, preload: [])
+    project = ProjectsFixtures.project_fixture(account_id: account.id, preload: [:account])
     user = AccountsFixtures.user_fixture()
     Accounts.add_user_to_organization(user, organization, role: :user)
     organization_two = AccountsFixtures.organization_fixture()
@@ -201,7 +201,7 @@ defmodule Tuist.ProjectsTest do
       # Given
       organization = AccountsFixtures.organization_fixture()
       account = Accounts.get_account_from_organization(organization)
-      project = ProjectsFixtures.project_fixture(account_id: account.id, preload: [])
+      project = ProjectsFixtures.project_fixture(account_id: account.id, preload: [:account])
 
       # When
       got = Projects.get_all_project_accounts(account)
@@ -218,8 +218,8 @@ defmodule Tuist.ProjectsTest do
 
     test "get all project accounts for an authenticated account subject" do
       account = AccountsFixtures.account_fixture()
-      project_one = ProjectsFixtures.project_fixture(account_id: account.id, preload: [])
-      project_two = ProjectsFixtures.project_fixture(account_id: account.id, preload: [])
+      project_one = ProjectsFixtures.project_fixture(account_id: account.id, preload: [:account])
+      project_two = ProjectsFixtures.project_fixture(account_id: account.id, preload: [:account])
 
       got = Projects.get_all_project_accounts(%AuthenticatedAccount{account: account, scopes: []})
 
@@ -259,13 +259,13 @@ defmodule Tuist.ProjectsTest do
       # Given
       organization = AccountsFixtures.organization_fixture()
       account = Accounts.get_account_from_organization(organization)
-      project_one = ProjectsFixtures.project_fixture(account_id: account.id, preload: [])
+      project_one = ProjectsFixtures.project_fixture(account_id: account.id, preload: [:account])
       user = AccountsFixtures.user_fixture()
       user_account = Accounts.get_account_from_user(user)
       Accounts.add_user_to_organization(user, organization, role: :user)
 
       project_two =
-        ProjectsFixtures.project_fixture(account_id: user_account.id, preload: [])
+        ProjectsFixtures.project_fixture(account_id: user_account.id, preload: [:account])
 
       # When
       got = Projects.get_all_project_accounts(user)


### PR DESCRIPTION
Addresses the comments on https://github.com/tuist/tuist/pull/8709

> this is N + 1 – can we get the data via a join? 

It's not actually N+1:
```
  def get_project_last_interaction_data(project_ids) do
    from(ce in Event,
      where: ce.project_id in ^project_ids,
      group_by: ce.project_id,
      select: %{project_id: ce.project_id, last_interacted_at: max(ce.ran_at)}
    )
    |> ClickHouseRepo.all()
    |> Map.new(fn %{project_id: id, last_interacted_at: time} -> {id, time} end)
  end
```
The function does two database calls: one to Postgres for Projects, one to ClickHouse for CommandEvents. Can't join cross-database, so this is maximally efficient.

> I would also consider adding the last_interaction as a column to the projects table.

I don't think this is a good idea, as any insertion into ClickHouse would then also require a write to Postgres; without transaction guarantees. Doing two queries at read time should be more efficient.


