### PR TITLE
fix(cli): pin swift-collections below 1.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5b4e465e93c4a88e77276415461f9a32069965f8c835324d56b1a158d1c8266b",
+  "originHash" : "039f4f19cb8616d51d370fc598ec2f1dbaf36c0e6b54ac7b5ba7d4aa03a60baa",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -62,7 +62,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.3.0"
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -670,7 +670,8 @@ let package = Package(
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.11.0")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.8.0")),
         .package(id: "sparkle-project.Sparkle", from: "2.6.4"),
-        .package(id: "apple.swift-collections", .upToNextMajor(from: "1.1.4")),
+        // swift-collections 1.3.0 requires Swift 6.2.0
+        .package(id: "apple.swift-collections", "1.1.4" ..< "1.3.0"),
         .package(
             id: "apple.swift-service-context", .upToNextMajor(from: "1.0.0")
         ),


### PR DESCRIPTION
## Summary
- Pins `swift-collections` to versions `< 1.3.0` because version 1.3.0 requires Swift 6.2.0
- Fixes the Release CLI job failure: https://github.com/tuist/tuist/actions/runs/19634683010/job/56222579361

## Test plan
- [ ] Verify CI Release workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)