### PR TITLE
fix(server): backfill migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ Tuist/Dependencies/graph.json
 *.p12
 ./minio
 !.github
+cli/Tests/Fixtures/test.xcresult/database.sqlite3

--- a/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
+++ b/server/priv/ingest_repo/migrations/20251118211224_backfill_test_runs_from_command_events.exs
@@ -2,6 +2,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
   alias Tuist.IngestRepo
   use Ecto.Migration
   import Ecto.Query
+  require Logger
 
   @disable_ddl_transaction true
   @disable_migration_lock true
@@ -144,7 +145,7 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
         args when is_binary(args) -> String.split(args)
       end
 
-    scheme = extract_scheme_from_command_arguments(command_arguments)
+    scheme = extract_scheme_from_command_arguments(command_arguments) || ""
 
     %{
       id: Ecto.UUID.generate(),
@@ -183,6 +184,8 @@ defmodule Tuist.IngestRepo.Migrations.BackfillTestRunsFromCommandEvents do
        )
 
   defp throttle_change_in_batches(query_fun, change_fun, last_created_at) do
+    Logger.info("Processing events since #{last_created_at}")
+
     case IngestRepo.all(query_fun.(last_created_at), log: :info, timeout: :infinity) do
       [] ->
         :ok


### PR DESCRIPTION
try to fix the backfill migration by defaulting the `scheme` to an empty string over nil.