### PR TITLE
fix(server): add Connection: close header to early API rejections

### DIFF
--- a/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
@@ -74,6 +74,7 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
         end
 
       conn
+      |> put_resp_header("connection", "close")
       |> put_status(status)
       |> json(%{
         message: "You are not authorized to #{Atom.to_string(action)} #{Atom.to_string(category)}"
@@ -123,6 +124,7 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
       conn
     else
       conn
+      |> put_resp_header("connection", "close")
       |> put_status(:forbidden)
       |> json(%{
         message: "#{subject.account.name} is not authorized to #{Atom.to_string(action)} #{Atom.to_string(category)}"

--- a/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
@@ -26,6 +26,7 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
 
       _ ->
         conn
+        |> put_resp_header("connection", "close")
         |> put_status(:payment_required)
         |> json(%{
           message: ~s"""
@@ -65,6 +66,7 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
 
       {:enterprise, false, _, account_handle} ->
         conn
+        |> put_resp_header("connection", "close")
         |> put_status(:payment_required)
         |> json(%{
           message: ~s"""
@@ -78,6 +80,7 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
 
       {:air, _, true, account_handle} ->
         conn
+        |> put_resp_header("connection", "close")
         |> put_status(:payment_required)
         |> json(%{
           message: ~s"""
@@ -88,6 +91,7 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
 
       {:pro, false, _, account_handle} ->
         conn
+        |> put_resp_header("connection", "close")
         |> put_status(:payment_required)
         |> json(%{
           message: ~s"""
@@ -101,6 +105,7 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
 
       {:open_source, false, _, account_handle} ->
         conn
+        |> put_resp_header("connection", "close")
         |> put_status(:payment_required)
         |> json(%{
           message: ~s"""

--- a/server/lib/tuist_web/plugs/authentication_plug.ex
+++ b/server/lib/tuist_web/plugs/authentication_plug.ex
@@ -35,6 +35,7 @@ defmodule TuistWeb.AuthenticationPlug do
       :open_api = response_type
 
       conn
+      |> put_resp_header("connection", "close")
       |> put_status(:unauthorized)
       |> json(%{message: "You need to be authenticated to access this resource."})
       |> halt()

--- a/server/lib/tuist_web/plugs/render_api_error_plug.ex
+++ b/server/lib/tuist_web/plugs/render_api_error_plug.ex
@@ -9,6 +9,7 @@ defmodule TuistWeb.RenderAPIErrorPlug do
 
   def call(conn, errors) when is_list(errors) do
     conn
+    |> put_resp_header("connection", "close")
     |> put_status(:bad_request)
     |> json(%{message: Enum.map_join(errors, "\n", &to_string/1)})
   end


### PR DESCRIPTION
## Summary

- Add `Connection: close` header to all API plugs that reject requests early (before the body is fully read)
- This tells Bandit it doesn't need to drain the body since the connection is closing anyway
- Fixes "Body read timeout" errors when clients send large upload requests that get rejected early

## Problem

When a client sends a large upload request with `Content-Length: <large_value>`, the server's plugs may reject the request early (e.g., auth failure, billing issue) before reading the body. Without `Connection: close`, Bandit expects to drain the body before reusing the connection, which can timeout if the client is slow or if the body is very large.

## Solution

Add `put_resp_header("connection", "close")` to all early rejection paths in:
- `AuthorizationPlug` - authorization failures (403, 401)
- `BillingPlug` - payment required responses (402)
- `AuthenticationPlug` - unauthorized responses (401)
- `RenderAPIErrorPlug` - validation errors from OpenApiSpex (400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)