### PR TITLE
fix(ci): cli tests

### DIFF
--- a/cli/Sources/TuistXCResultService/ActionLogSection.swift
+++ b/cli/Sources/TuistXCResultService/ActionLogSection.swift
@@ -158,6 +158,7 @@ extension ActionLogSection {
               let millisecondRange = Range(match.range(at: 7), in: text)
         else { return nil }
 
+        let timeZone = TimeZone.current()
         var dateComponents = DateComponents()
         dateComponents.year = Int(text[yearRange]) ?? 0
         dateComponents.month = Int(text[monthRange]) ?? 0
@@ -166,10 +167,10 @@ extension ActionLogSection {
         dateComponents.minute = Int(text[minuteRange]) ?? 0
         dateComponents.second = Int(text[secondRange]) ?? 0
         dateComponents.nanosecond = (Int(text[millisecondRange]) ?? 0) * 1_000_000
-        dateComponents.timeZone = TimeZone.current
+        dateComponents.timeZone = timeZone
 
         var calendar = Calendar.current
-        calendar.timeZone = TimeZone.current
+        calendar.timeZone = timeZone
         guard let date = calendar.date(from: dateComponents) else { return nil }
 
         return date.timeIntervalSince1970

--- a/cli/Sources/TuistXCResultService/TimeZone+Current.swift
+++ b/cli/Sources/TuistXCResultService/TimeZone+Current.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension TimeZone {
+    @TaskLocal static var current: () -> TimeZone = { TimeZone.autoupdatingCurrent }
+}

--- a/cli/Sources/TuistXCResultService/XCResultService.swift
+++ b/cli/Sources/TuistXCResultService/XCResultService.swift
@@ -105,14 +105,10 @@ public struct XCResultService: XCResultServicing {
                 "--path", path.pathString,
             ]
         ).concatenatedString()
-        print("tests output", outputString)
 
         let jsonString = extractJSON(from: outputString)
-        
-        print("extracted json", jsonString)
 
         guard let outputData = jsonString.data(using: .utf8) else {
-            print("failed to parse the test-results json")
             throw XCResultServiceError.failedToParseOutput(path)
         }
 
@@ -127,7 +123,7 @@ public struct XCResultService: XCResultServicing {
         else {
             return output
         }
-        return String(output[jsonStartIndex...jsonEndIndex])
+        return String(output[jsonStartIndex ... jsonEndIndex])
     }
 
     private func parseTestOutput(
@@ -399,7 +395,6 @@ public struct XCResultService: XCResultServicing {
                     "/usr/bin/xcrun xcresulttool get log --type action --compact --path '\(xcresultPath.pathString)' > '\(tempFile.pathString)'",
                 ]
             ).concatenatedString()
-            print(outputString)
 
             let logData = try await fileSystem.readFile(at: tempFile)
             return try JSONDecoder().decode(ActionLogSection.self, from: logData)

--- a/cli/Tests/TuistXCResultServiceTests/XCResultServiceTests.swift
+++ b/cli/Tests/TuistXCResultServiceTests/XCResultServiceTests.swift
@@ -1,4 +1,5 @@
 import FileSystemTesting
+import Foundation
 import Path
 import Testing
 @testable import TuistXCResultService
@@ -11,9 +12,12 @@ struct XCResultServiceTests {
         // Given
         let xcresult = try AbsolutePath(validating: #file).parentDirectory
             .appending(try RelativePath(validating: "../Fixtures/test.xcresult"))
+        let cet = TimeZone(identifier: "Europe/Berlin")!
 
         // When
-        let got = try #require(await subject.parse(path: xcresult, rootDirectory: nil))
+        let got = try #require(await TimeZone.$current.withValue({ cet }) {
+            try await subject.parse(path: xcresult, rootDirectory: nil)
+        })
 
         // Then
         #expect(got.status == .failed)


### PR DESCRIPTION
There were two issues causing some of our unit and acceptance tests failing:
- the `xcresulttool` output didn't include just a JSON on the CI but extra logs like `[DataLayer] Releasing database lock for result bundle at /Users/runner/work/tuist/tuist/cli/Tests/Fixtures/test.xcresult/`
- since we need to get some durations from the logs, and the timestamps in the logs don't include the timezone, we need to override the timezone in tests. In regular workflows, we should be able to assume `tuist inspect test` is run for an `.xcresult` that was created on that same machine (with the same timezone)