### PR TITLE
fix(server): add Connection: close header to cache loader plug

### DIFF
--- a/server/test/tuist_web/controllers/api/cache/cas_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache/cas_controller_test.exs
@@ -6,7 +6,6 @@ defmodule TuistWeb.API.CASControllerTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.Authentication
-  alias TuistWeb.Errors.NotFoundError
 
   setup do
     user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
@@ -89,10 +88,13 @@ defmodule TuistWeb.API.CASControllerTest do
 
       cas_id = "0~YWoYNXX123"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         get(conn, ~p"/api/cache/cas/#{cas_id}?account_handle=nonexistent-account&project_handle=#{project_handle}")
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns not found when project doesn't exist", %{
@@ -106,10 +108,13 @@ defmodule TuistWeb.API.CASControllerTest do
 
       cas_id = "0~YWoYNXX123"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         get(conn, ~p"/api/cache/cas/#{cas_id}?account_handle=#{account_handle}&project_handle=nonexistent-project")
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns forbidden when user doesn't have permission", %{
@@ -222,15 +227,18 @@ defmodule TuistWeb.API.CASControllerTest do
       cas_id = "0~YWoYNXX123"
       artifact_content = "artifact content"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         conn
         |> put_req_header("content-type", "application/octet-stream")
         |> post(
           ~p"/api/cache/cas/#{cas_id}?account_handle=nonexistent-account&project_handle=#{project_handle}",
           artifact_content
         )
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns not found when project doesn't exist", %{
@@ -245,15 +253,18 @@ defmodule TuistWeb.API.CASControllerTest do
       cas_id = "0~YWoYNXX123"
       artifact_content = "artifact content"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         conn
         |> put_req_header("content-type", "application/octet-stream")
         |> post(
           ~p"/api/cache/cas/#{cas_id}?account_handle=#{account_handle}&project_handle=nonexistent-project",
           artifact_content
         )
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns forbidden when user doesn't have permission", %{

--- a/server/test/tuist_web/controllers/api/cache/key_value_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache/key_value_controller_test.exs
@@ -6,7 +6,6 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.Authentication
-  alias TuistWeb.Errors.NotFoundError
 
   setup do
     user = AccountsFixtures.user_fixture(email: "tuist@tuist.dev", preload: [:account])
@@ -93,10 +92,13 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
 
       cas_id = "test_cas_id"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         get(conn, ~p"/api/cache/keyvalue/#{cas_id}?account_handle=nonexistent-account&project_handle=#{project_handle}")
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns not found when project doesn't exist", %{
@@ -110,10 +112,13 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
 
       cas_id = "test_cas_id"
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         get(conn, ~p"/api/cache/keyvalue/#{cas_id}?account_handle=#{account_handle}&project_handle=nonexistent-project")
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns forbidden when user doesn't have permission", %{
@@ -204,15 +209,18 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
         "entries" => [%{"value" => "test_value"}]
       }
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         conn
         |> put_req_header("content-type", "application/json")
         |> put(
           ~p"/api/cache/keyvalue?account_handle=nonexistent-account&project_handle=#{project_handle}",
           body
         )
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns not found when project doesn't exist", %{
@@ -229,15 +237,18 @@ defmodule TuistWeb.API.Cache.KeyValueControllerTest do
         "entries" => [%{"value" => "test_value"}]
       }
 
-      # When/Then
-      assert_raise NotFoundError, fn ->
+      # When
+      conn =
         conn
         |> put_req_header("content-type", "application/json")
         |> put(
           ~p"/api/cache/keyvalue?account_handle=#{account_handle}&project_handle=nonexistent-project",
           body
         )
-      end
+
+      # Then
+      assert conn.status == 404
+      assert get_resp_header(conn, "connection") == ["close"]
     end
 
     test "returns forbidden when user doesn't have permission", %{

--- a/server/test/tuist_web/controllers/api/cache/plugs/loader_query_plug_test.exs
+++ b/server/test/tuist_web/controllers/api/cache/plugs/loader_query_plug_test.exs
@@ -3,8 +3,6 @@ defmodule TuistWeb.API.Cache.Plugs.LoaderQueryPlugTest do
 
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistWeb.API.Cache.Plugs.LoaderQueryPlug
-  alias TuistWeb.Errors.BadRequestError
-  alias TuistWeb.Errors.NotFoundError
 
   describe "call/2" do
     test "loads project and account from query parameters", %{conn: conn} do
@@ -31,14 +29,14 @@ defmodule TuistWeb.API.Cache.Plugs.LoaderQueryPlugTest do
     end
   end
 
-  test "raises NotFoundError when project is not found", %{conn: conn} do
+  test "returns not found error when project is not found", %{conn: conn} do
     # Given
     account_handle = "nonexistent"
     project_handle = "project"
     project_slug = "#{account_handle}/#{project_handle}"
     plug_opts = LoaderQueryPlug.init([])
 
-    # When/Then
+    # When
     conn_with_query = %{
       conn
       | query_params: %{
@@ -47,49 +45,66 @@ defmodule TuistWeb.API.Cache.Plugs.LoaderQueryPlugTest do
         }
     }
 
-    assert_raise NotFoundError,
-                 "The project #{project_slug} was not found.",
-                 fn ->
-                   LoaderQueryPlug.call(conn_with_query, plug_opts)
-                 end
+    result = LoaderQueryPlug.call(conn_with_query, plug_opts)
+
+    # Then
+    assert result.halted
+    assert result.status == 404
+    assert get_resp_header(result, "connection") == ["close"]
+    assert JSON.decode!(result.resp_body) == %{"message" => "The project #{project_slug} was not found."}
   end
 
-  test "raises BadRequestError when account_handle is missing", %{conn: conn} do
+  test "returns bad request error when account_handle is missing", %{conn: conn} do
     # Given
     plug_opts = LoaderQueryPlug.init([])
     conn_with_partial_query = %{conn | query_params: %{"project_handle" => "project"}}
 
-    # When/Then
-    assert_raise BadRequestError,
-                 "account_handle and project_handle query parameters are required",
-                 fn ->
-                   LoaderQueryPlug.call(conn_with_partial_query, plug_opts)
-                 end
+    # When
+    result = LoaderQueryPlug.call(conn_with_partial_query, plug_opts)
+
+    # Then
+    assert result.halted
+    assert result.status == 400
+    assert get_resp_header(result, "connection") == ["close"]
+
+    assert JSON.decode!(result.resp_body) == %{
+             "message" => "account_handle and project_handle query parameters are required"
+           }
   end
 
-  test "raises BadRequestError when project_handle is missing", %{conn: conn} do
+  test "returns bad request error when project_handle is missing", %{conn: conn} do
     # Given
     plug_opts = LoaderQueryPlug.init([])
     conn_with_partial_query = %{conn | query_params: %{"account_handle" => "account"}}
 
-    # When/Then
-    assert_raise BadRequestError,
-                 "account_handle and project_handle query parameters are required",
-                 fn ->
-                   LoaderQueryPlug.call(conn_with_partial_query, plug_opts)
-                 end
+    # When
+    result = LoaderQueryPlug.call(conn_with_partial_query, plug_opts)
+
+    # Then
+    assert result.halted
+    assert result.status == 400
+    assert get_resp_header(result, "connection") == ["close"]
+
+    assert JSON.decode!(result.resp_body) == %{
+             "message" => "account_handle and project_handle query parameters are required"
+           }
   end
 
-  test "raises BadRequestError when both parameters are missing", %{conn: conn} do
+  test "returns bad request error when both parameters are missing", %{conn: conn} do
     # Given
     plug_opts = LoaderQueryPlug.init([])
     conn_with_no_query = %{conn | query_params: %{}}
 
-    # When/Then
-    assert_raise BadRequestError,
-                 "account_handle and project_handle query parameters are required",
-                 fn ->
-                   LoaderQueryPlug.call(conn_with_no_query, plug_opts)
-                 end
+    # When
+    result = LoaderQueryPlug.call(conn_with_no_query, plug_opts)
+
+    # Then
+    assert result.halted
+    assert result.status == 400
+    assert get_resp_header(result, "connection") == ["close"]
+
+    assert JSON.decode!(result.resp_body) == %{
+             "message" => "account_handle and project_handle query parameters are required"
+           }
   end
 end


### PR DESCRIPTION
[Related](https://github.com/tuist/tuist/pull/8751)

It turns out that if we fail a request without including the `connection: close` header, Bandid will continue reading the body, potentially timing out. If the Plug/Phoenix-level logic fails a request, we need to make sure we include that header, otherwise we'll experience those timeouts. 

## Summary

- Changed `LoaderQueryPlug` to return JSON error responses with `Connection: close` header instead of raising exceptions
- This prevents Bandit body read timeouts when clients send large uploads that get rejected early (e.g., project not found)

This follows the same pattern as the fix in db8f525726 which was applied to AuthorizationPlug, BillingPlug, AuthenticationPlug, and RenderAPIErrorPlug.

## Test plan

- [x] All existing tests updated and passing
- [x] Tests verify `Connection: close` header is set on error responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)