### PR TITLE
fix(server): use command event ID for result bundle download URL in test run page

### DIFF
--- a/server/lib/tuist_web/live/test_run_live.html.heex
+++ b/server/lib/tuist_web/live/test_run_live.html.heex
@@ -28,9 +28,9 @@
       </h1>
     </div>
     <.button
-      :if={@has_result_bundle.ok? && @has_result_bundle.result}
+      :if={@has_result_bundle.ok? && @has_result_bundle.result && @command_event}
       href={
-        ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@run.id}/download"
+        ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@command_event.id}/download"
       }
       label={gettext("Download result")}
       variant="secondary"


### PR DESCRIPTION
Fixed the download result button on the test run detail page to use the command event ID instead of the test run ID since the result bundle is associated with the command event, not with the test run.