### PR TITLE
fix(server): change oauth_tokens state column to text type

### DIFF
--- a/server/priv/repo/migrations/20251125165658_change_oauth_tokens_state_to_text.exs
+++ b/server/priv/repo/migrations/20251125165658_change_oauth_tokens_state_to_text.exs
@@ -1,0 +1,15 @@
+defmodule Tuist.Repo.Migrations.ChangeOauthTokensStateToText do
+  use Ecto.Migration
+
+  def up do
+    alter table(:oauth_tokens) do
+      modify :state, :text
+    end
+  end
+
+  def down do
+    alter table(:oauth_tokens) do
+      modify :state, :string, size: 10_000
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to: https://github.com/tuist/tuist/pull/8734

Instead of a `varchar` with a limit, we should move to `text` and we're applying the limit at the Elixir level. Supabase recommends to use `text` over `varchar` unless you have a very specific reason.