### PR TITLE
fix(docs): build and deploy timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
   build-deploy:
     name: Build & Deploy
     runs-on: macos-26
-    timeout-minutes: 40
+    timeout-minutes: 60
     if: github.event.pull_request.head.repo.fork != true && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
the build and deploy of the documentation seems to be taking slightly more than 40 minutes, bumping the timeout to 60 (although we should probably look into why it's taking so long...)