### PR TITLE
Fix CTAs expanding page's width beyond the viewport

### DIFF
--- a/server/assets/marketing/css/routes/home.css
+++ b/server/assets/marketing/css/routes/home.css
@@ -1506,6 +1506,9 @@
   & > [data-part="cta"] {
     margin-bottom: var(--noora-spacing-11);
     padding-top: var(--noora-spacing-14);
-    width: 100%;
+
+    @media (min-width: 1024px) {
+      width: 100%;
+    }
   }
 }

--- a/server/assets/marketing/css/routes/pricing.css
+++ b/server/assets/marketing/css/routes/pricing.css
@@ -475,12 +475,12 @@
     margin-bottom: var(--noora-spacing-11);
     margin-left: var(--noora-spacing-6);
     padding-top: var(--noora-spacing-9);
-    width: 100%;
 
     @media (min-width: 1024px) {
       margin-right: var(--noora-spacing-14);
       margin-left: var(--noora-spacing-14);
       padding-top: var(--noora-spacing-14);
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
While checking the website in Chinese, I noticed the CTA shrunk to match the size of the content in large view ports. To fix that, I set the width to fill the space, but turns out that caused the content width to be larger than the viewport in small viewports. This PR fixes it by only applying it in large viewports.