### PR TITLE
fix(server): don't require :type in build insights API to fix a breaking change

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -3024,7 +3024,7 @@ public enum Components {
                 /// The type of the run, which is 'build' in this case.
                 ///
                 /// - Remark: Generated from `#/components/schemas/RunParams/case1/type`.
-                public var _type: Components.Schemas.RunParams.Case1Payload._typePayload
+                public var _type: Components.Schemas.RunParams.Case1Payload._typePayload?
                 /// The version of Xcode used during the run.
                 ///
                 /// - Remark: Generated from `#/components/schemas/RunParams/case1/xcode_version`.
@@ -3079,7 +3079,7 @@ public enum Components {
                     scheme: Swift.String? = nil,
                     status: Components.Schemas.RunParams.Case1Payload.statusPayload? = nil,
                     targets: Components.Schemas.RunParams.Case1Payload.targetsPayload? = nil,
-                    _type: Components.Schemas.RunParams.Case1Payload._typePayload,
+                    _type: Components.Schemas.RunParams.Case1Payload._typePayload? = nil,
                     xcode_version: Swift.String? = nil
                 ) {
                     self.cacheable_tasks = cacheable_tasks
@@ -5535,7 +5535,7 @@ public enum Components {
             /// The type of the run, which is 'build' in this case.
             ///
             /// - Remark: Generated from `#/components/schemas/BuildRun/type`.
-            public var _type: Components.Schemas.BuildRun._typePayload
+            public var _type: Components.Schemas.BuildRun._typePayload?
             /// The version of Xcode used during the run.
             ///
             /// - Remark: Generated from `#/components/schemas/BuildRun/xcode_version`.
@@ -5590,7 +5590,7 @@ public enum Components {
                 scheme: Swift.String? = nil,
                 status: Components.Schemas.BuildRun.statusPayload? = nil,
                 targets: Components.Schemas.BuildRun.targetsPayload? = nil,
-                _type: Components.Schemas.BuildRun._typePayload,
+                _type: Components.Schemas.BuildRun._typePayload? = nil,
                 xcode_version: Swift.String? = nil
             ) {
                 self.cacheable_tasks = cacheable_tasks
@@ -23499,7 +23499,7 @@ public enum Operations {
                         /// The type of the run, which is 'build' in this case.
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/POST/requestBody/json/case1/type`.
-                        public var _type: Operations.createRun.Input.Body.jsonPayload.Case1Payload._typePayload
+                        public var _type: Operations.createRun.Input.Body.jsonPayload.Case1Payload._typePayload?
                         /// The version of Xcode used during the run.
                         ///
                         /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/runs/POST/requestBody/json/case1/xcode_version`.
@@ -23554,7 +23554,7 @@ public enum Operations {
                             scheme: Swift.String? = nil,
                             status: Operations.createRun.Input.Body.jsonPayload.Case1Payload.statusPayload? = nil,
                             targets: Operations.createRun.Input.Body.jsonPayload.Case1Payload.targetsPayload? = nil,
-                            _type: Operations.createRun.Input.Body.jsonPayload.Case1Payload._typePayload,
+                            _type: Operations.createRun.Input.Body.jsonPayload.Case1Payload._typePayload? = nil,
                             xcode_version: Swift.String? = nil
                         ) {
                             self.cacheable_tasks = cacheable_tasks

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -1218,7 +1218,6 @@ components:
               x-struct:
               x-validate:
           required:
-            - type
             - id
             - duration
             - is_ci
@@ -2854,7 +2853,6 @@ components:
           x-struct:
           x-validate:
       required:
-        - type
         - id
         - duration
         - is_ci
@@ -7318,7 +7316,6 @@ paths:
                       x-struct:
                       x-validate:
                   required:
-                    - type
                     - id
                     - duration
                     - is_ci

--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -520,7 +520,6 @@ defmodule TuistWeb.API.RunsController do
                }
              },
              required: [
-               :type,
                :id,
                :duration,
                :is_ci
@@ -733,7 +732,7 @@ defmodule TuistWeb.API.RunsController do
       |> Map.put(:project, selected_project)
       |> Map.put(:account, Authentication.authenticated_subject_account(conn))
 
-    case Map.get(body_params, :type) do
+    case Map.get(body_params, :type, "build") do
       "build" ->
         case get_or_create_build(run_params) do
           {:ok, build} ->


### PR DESCRIPTION
I've accidentally made a breaking API change as part of https://github.com/tuist/tuist/pull/8347 by making the`:type` field required for the `POST /runs` endpoint. This PR fixes the issue by default to the `build` type if the `type` is not specified.