### PR TITLE
fix(server): add revenuecat/purchases-ios-spm to registry denylist

### DIFF
--- a/server/lib/tuist/registry/swift/workers/sync_packages_worker.ex
+++ b/server/lib/tuist/registry/swift/workers/sync_packages_worker.ex
@@ -29,7 +29,8 @@ defmodule Tuist.Registry.Swift.Workers.SyncPackagesWorker do
   @unsupported_packages [
     "monzo/nearby",
     "awslabs/aws-crt-swift",
-    "apple/swift-protobuf"
+    "apple/swift-protobuf",
+    "RevenueCat/purchases-ios-spm"
   ]
 
   @impl Oban.Worker


### PR DESCRIPTION
As reported by a user, https://github.com/RevenueCat/purchases-ios-spm/blob/main/LocalReceiptParsing is a submodule which we don't currently support.