### PR TITLE
feat(server): bump registry limits

### DIFF
--- a/server/lib/tuist_web/rate_limit/registry.ex
+++ b/server/lib/tuist_web/rate_limit/registry.ex
@@ -33,12 +33,12 @@ defmodule TuistWeb.RateLimit.Registry do
       if authenticated? do
         {
           "registry:auth:#{get_subject_key(conn)}",
-          20_000
+          100_000
         }
       else
         {
           "registry:unauth:#{TuistWeb.RemoteIp.get(conn)}",
-          1_000
+          10_000
         }
       end
 

--- a/server/priv/marketing/blog/2025/11/26/opening-registry.md
+++ b/server/priv/marketing/blog/2025/11/26/opening-registry.md
@@ -30,7 +30,7 @@ swift package-registry set https://tuist.dev/api/registry/swift
 
 Either of these commands will create a configuration file, with its location depending on your setup. For Swift packages, this would be in `.swiftpm/configuration/registries.json`, for Xcode projects, it would be in `YourProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/configuration/registries.json`. Make sure to commit this configuration file, so all your colleagues and your CI have access to the registry.
 
-When unauthenticated, you will be rate-limited to 1000 requests per minute – more than enough for resolving hundreds of packages in a typical clean build. If you are running into limits, you can still authenticate with your Tuist account to increase your rate limit to 10,000 requests per minute:
+When unauthenticated, you will be rate-limited to 10,000 requests per minute – more than enough for resolving hundreds of packages in a typical clean build. If you are running into limits, you can still authenticate with your Tuist account to increase your rate limit to 100,000 requests per minute:
 
 ```sh
 tuist registry login

--- a/server/test/tuist_web/rate_limit/registry_test.exs
+++ b/server/test/tuist_web/rate_limit/registry_test.exs
@@ -20,7 +20,7 @@ defmodule TuistWeb.RateLimit.RegistryTest do
       hit_key = "registry:auth:project:#{project_id}"
       timeout = to_timeout(minute: 1)
 
-      expect(InMemory, :hit, fn ^hit_key, ^timeout, 20_000 ->
+      expect(InMemory, :hit, fn ^hit_key, ^timeout, 100_000 ->
         {:allow, 1}
       end)
 
@@ -46,7 +46,7 @@ defmodule TuistWeb.RateLimit.RegistryTest do
       hit_key = "registry:auth:account:#{account_id}"
       timeout = to_timeout(minute: 1)
 
-      expect(InMemory, :hit, fn ^hit_key, ^timeout, 20_000 ->
+      expect(InMemory, :hit, fn ^hit_key, ^timeout, 100_000 ->
         {:allow, 1}
       end)
 
@@ -67,7 +67,7 @@ defmodule TuistWeb.RateLimit.RegistryTest do
       hit_key = "registry:unauth:#{ip}"
       timeout = to_timeout(minute: 1)
 
-      expect(InMemory, :hit, fn ^hit_key, ^timeout, 1_000 ->
+      expect(InMemory, :hit, fn ^hit_key, ^timeout, 10_000 ->
         {:allow, 1}
       end)
 
@@ -87,8 +87,8 @@ defmodule TuistWeb.RateLimit.RegistryTest do
       hit_key = "registry:auth:project:#{project_id}"
       timeout = to_timeout(minute: 1)
 
-      expect(InMemory, :hit, fn ^hit_key, ^timeout, 20_000 ->
-        {:deny, 20_000}
+      expect(InMemory, :hit, fn ^hit_key, ^timeout, 100_000 ->
+        {:deny, 100_000}
       end)
 
       # When
@@ -108,8 +108,8 @@ defmodule TuistWeb.RateLimit.RegistryTest do
       hit_key = "registry:unauth:#{ip}"
       timeout = to_timeout(minute: 1)
 
-      expect(InMemory, :hit, fn ^hit_key, ^timeout, 1_000 ->
-        {:deny, 1_000}
+      expect(InMemory, :hit, fn ^hit_key, ^timeout, 10_000 ->
+        {:deny, 10_000}
       end)
 
       # When


### PR DESCRIPTION
I ran into limits as a part of this [PR](https://github.com/tuist/tuist/pull/8739). I think we set them initially too low, so I'm bumping them. Also updating the registry article since it's quite fresh, so would be good to keep in sync.