### PR TITLE
Fix installation step in our post about making AI read Xcode build data

### DIFF
--- a/server/priv/marketing/blog/2025/11/27/teaching-ai-to-read-xcode-builds.md
+++ b/server/priv/marketing/blog/2025/11/27/teaching-ai-to-read-xcode-builds.md
@@ -608,7 +608,7 @@ For real-time features and richer causality data, we've open-sourced [Argus](htt
 Install Argus globally using [mise](https://mise.jdx.dev/):
 
 ```bash
-mise use -g ubi:tuist/argus
+mise use -g github:tuist/argus
 ```
 
 Then add the following to your agent's memory or system prompt to enable build observability:


### PR DESCRIPTION
Installing `argus` through `ubi` doesn't install some bundles that are necessary for the tool to work. I'm adjusting the blog post to suggest to use Mise's github backend instead.