### PR TITLE
fix(server): increase the number of retries for username

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -568,7 +568,7 @@ defmodule Tuist.Accounts do
     suffix = Keyword.get(opts, :suffix, "")
 
     cond do
-      Utils.unique_error?(changeset, :name) and attempt < 5 ->
+      Utils.unique_error?(changeset, :name) and attempt < 20 ->
         next_suffix = if suffix == "", do: 1, else: String.to_integer(suffix) + 1
 
         opts =
@@ -578,7 +578,7 @@ defmodule Tuist.Accounts do
 
         create_user(email, opts)
 
-      Utils.unique_error?(changeset, :name) and attempt >= 5 ->
+      Utils.unique_error?(changeset, :name) and attempt >= 20 ->
         {:error, :account_handle_taken}
 
       true ->

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -737,15 +737,14 @@ defmodule TuistWeb.API.CacheController do
     send_resp(conn, :no_content, "")
   end
 
-  defp retry_get_object_size(object_key, actor, retries_left, attempt, skip_sleep)
-       when retries_left > 0 do
+  defp retry_get_object_size(object_key, actor, retries_left, attempt, skip_sleep) when retries_left > 0 do
     case Storage.get_object_size(object_key, actor) do
       {:ok, size} ->
         {:ok, size}
 
       {:error, :not_found} ->
         # Wait with exponential backoff: 100ms, 200ms, 400ms
-        unless skip_sleep do
+        if !skip_sleep do
           (100 * :math.pow(2, attempt - 1)) |> round() |> Process.sleep()
         end
 

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -1605,11 +1605,10 @@ defmodule Tuist.AccountsTest do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
       Accounts.create_user("foo@tuist.io")
-      Accounts.create_user("foo1@tuist.io")
-      Accounts.create_user("foo2@tuist.io")
-      Accounts.create_user("foo3@tuist.io")
-      Accounts.create_user("foo4@tuist.io")
-      Accounts.create_user("foo5@tuist.io")
+
+      for i <- 1..20 do
+        Accounts.create_user("foo#{i}@tuist.io")
+      end
 
       # When
       {:error, :account_handle_taken} = Accounts.create_user("foo@tuist.test")


### PR DESCRIPTION
Related: https://appsignal.com/tuist/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/287

Some emails start with a pretty common prefix, like `me@whatever.com`, so it's likely we exhaust these. This "fix" increases the limit, but the proper fix should be to allow choosing a username when signing up with OAuth providers, like GitHub.