### PR TITLE
fix(cli): false positive for a .uiTests implicit import of .app

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -67,7 +67,7 @@ final class GraphImportsLinter: GraphImportsLinting {
                 graphTraverser: graphTraverser,
                 target: target,
                 includeExternalDependencies: inspectType == .implicit,
-                excludeAppDependenciesForUnitTests: inspectType == .redundant
+                excludeAppDependenciesForTests: inspectType == .redundant
             )
 
             let observedImports = switch inspectType {
@@ -88,7 +88,7 @@ final class GraphImportsLinter: GraphImportsLinting {
         graphTraverser: GraphTraverser,
         target: GraphTarget,
         includeExternalDependencies: Bool,
-        excludeAppDependenciesForUnitTests: Bool
+        excludeAppDependenciesForTests: Bool
     ) -> Set<String> {
         let targetDependencies = if includeExternalDependencies {
             graphTraverser
@@ -125,19 +125,10 @@ final class GraphImportsLinter: GraphImportsLinting {
                          .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App:
                         return true
                     }
-                case .unitTests:
+                case .unitTests, .uiTests:
                     switch dependency.target.product {
                     case .app:
-                        return !excludeAppDependenciesForUnitTests
-                    case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
-                         .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
-                         .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:
-                        return true
-                    }
-                case .uiTests:
-                    switch dependency.target.product {
-                    case .app:
-                        return false
+                        return !excludeAppDependenciesForTests
                     case .staticLibrary, .dynamicLibrary, .framework, .staticFramework, .unitTests, .uiTests, .bundle,
                          .commandLineTool, .tvTopShelfExtension, .appClip, .xpc, .systemExtension, .macro, .appExtension,
                          .stickerPackExtension, .messagesExtension, .extensionKitExtension, .watch2App, .watch2Extension:

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectImplicitImportsServiceTests.swift
@@ -272,4 +272,41 @@ final class LintImplicitImportsServiceTests: TuistUnitTestCase {
         // When
         try await subject.run(path: path.pathString)
     }
+
+    func test_run_doesntThrowErrorWithUITests_when_testExplicitlyDependsOnAppAndImportsIt() async throws {
+        // Given
+        let path = try AbsolutePath(validating: "/project")
+        let config = Tuist.test()
+
+        let app = Target.test(
+            name: "App",
+            product: .app
+        )
+
+        let uiTests = Target.test(
+            name: "AppUITests",
+            product: .uiTests,
+            dependencies: [TargetDependency.target(name: "App")]
+        )
+
+        let project = Project.test(path: path, targets: [app, uiTests])
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: [
+                .target(name: uiTests.name, path: project.path): [
+                    .target(name: app.name, path: project.path),
+                ],
+            ]
+        )
+
+        given(configLoader).loadConfig(path: .value(path)).willReturn(config)
+        given(generatorFactory).defaultGenerator(config: .value(config), includedTargets: .any).willReturn(generator)
+        given(generator).load(path: .value(path), options: .any).willReturn(graph)
+        given(targetScanner).imports(for: .value(uiTests)).willReturn(Set(["App"]))
+        given(targetScanner).imports(for: .value(app)).willReturn(Set([]))
+
+        // When
+        try await subject.run(path: path.pathString)
+    }
 }


### PR DESCRIPTION
This [PR](https://github.com/tuist/tuist/pull/7757) fixed a false positive for a redundant import when the import was there to add `.app` target as a host app of a `.uiTests` or `.unitTests` target.

We already made sure that we were not throwing a false positive _implicit import_ warning when the `.unitTests` target had an `import App` statement. Now, we are adding the same logic for a `.uiTests` target (`.uiTests` target should generally not have imports of their host apps – as those should act as black boxes – but we still shouldn't throw a false positive)