### PR TITLE
Fix typo in Bazel project migration guide

### DIFF
--- a/docs/docs/en/guides/features/projects/adoption/migrate/bazel-project.md
+++ b/docs/docs/en/guides/features/projects/adoption/migrate/bazel-project.md
@@ -39,7 +39,7 @@ let project = Project(
 <!-- -->
 :::
 
-Here's another example but compating how to define unit tests in Bazel and Tuist:
+Here's another example but comparing how to define unit tests in Bazel and Tuist:
 
 ::: code-group
 ```txt [BUILD (Bazel)]


### PR DESCRIPTION
I'm fixing a typo in the docs
