### PR TITLE
fix(cli): respect explicit cache profile none with target focus

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/Tuist+CacheProfileResolver.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/Tuist+CacheProfileResolver.swift
@@ -31,6 +31,11 @@ extension Tuist {
             return .none
         }
 
+        if case .some(.none) = cacheProfile {
+            Logger.current.debug("Using cache profile none")
+            return .none
+        }
+
         if !includedTargets.isEmpty {
             Logger.current.debug("Using cache profile all-possible")
             return .allPossible

--- a/cli/Tests/TuistKitTests/Commands/TuistCacheProfileResolverTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/TuistCacheProfileResolverTests.swift
@@ -5,7 +5,7 @@ import TuistCore
 @testable import TuistKit
 
 struct TuistCacheProfileResolverTests {
-    @Test func resolves_allPossible_when_targets_focused_even_if_explicit_set() throws {
+    @Test func explicit_cache_profile_overrides_target_focus() throws {
         // Given
         let config = Tuist.test(project: .testGeneratedProject())
 
@@ -14,6 +14,36 @@ struct TuistCacheProfileResolverTests {
             ignoreBinaryCache: false,
             includedTargets: ["App"],
             cacheProfile: CacheProfileType.none
+        )
+
+        // Then
+        #expect(result == .none)
+    }
+
+    @Test func target_focus_implies_allPossible_when_no_explicit_cache_profile() throws {
+        // Given
+        let config = Tuist.test(project: .testGeneratedProject())
+
+        // When
+        let result = try config.resolveCacheProfile(
+            ignoreBinaryCache: false,
+            includedTargets: ["App"],
+            cacheProfile: nil
+        )
+
+        // Then
+        #expect(result == .allPossible)
+    }
+
+    @Test func target_focus_overrides_explicit_onlyExternal() throws {
+        // Given
+        let config = Tuist.test(project: .testGeneratedProject())
+
+        // When
+        let result = try config.resolveCacheProfile(
+            ignoreBinaryCache: false,
+            includedTargets: ["App"],
+            cacheProfile: CacheProfileType.onlyExternal
         )
 
         // Then


### PR DESCRIPTION
## Context

Fixes #8823

When running `tuist generate Foo --cache-profile none` where `Foo` is a target name, the CLI was ignoring the explicit `--cache-profile none` flag and downloading binaries anyway.

This fix updates the cache profile resolution logic to check for explicit `--cache-profile none` before applying target focus behavior. The priority order is now:
1. `--no-binary-cache` flag (highest priority)
2. Explicit `--cache-profile none` (overrides target focus)
3. Target focus (implies `allPossible` even if an explicit profile is given, like `onlyExternal`)
4. Other explicit profiles
5. Config defaults
6. System default (`.onlyExternal`)

## Testing

To verify this fix:
1. In a project with multiple targets, run `tuist generate <TargetName> --cache-profile none`
2. Verify that NO binaries are downloaded (should build everything from source)
3. Run `tuist generate <TargetName>` (without the flag)
4. Verify that binaries ARE downloaded (target focus behavior still works)
5. Run `tuist generate <TargetName> --cache-profile only-external`
6. Verify that binaries ARE downloaded (target focus still wins over other profiles)

## Checklist

- [x] The code follows the project's coding standards
- [x] Tests have been added/updated to cover the changes
- [x] All tests pass locally
- [x] Documentation has been updated (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
