### PR TITLE
feat(server): Add /api/registry/swift root endpoint returning 200

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -461,6 +461,8 @@ defmodule TuistWeb.Router do
 
     post "/auth", AuthController, :authenticate
     post "/auth/apple", AuthController, :authenticate_apple
+
+    get "/registry/swift", Registry.SwiftController, :availability
   end
 
   scope "/oauth2", TuistWeb.Oauth do

--- a/server/test/tuist_web/controllers/api/registry/swift_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/registry/swift_controller_test.exs
@@ -24,6 +24,16 @@ defmodule TuistWeb.API.Registry.SwiftControllerTest do
     %{conn: conn, account: account}
   end
 
+  describe "GET /api/registry/swift" do
+    test "returns :ok response", %{conn: conn} do
+      # When
+      conn = get(conn, ~p"/api/registry/swift")
+
+      # Then
+      assert conn.status == 200
+    end
+  end
+
   describe "GET /api/registry/swift/availability" do
     test "returns :ok response for availability", %{conn: conn} do
       # When


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8843

Some registry solutions can proxy to other registries (e.g. ours) and they use a successful response from the base URL as a tool to determine if the registry is healthy or not. This PR adds a new route to respond with a 200 such that those registries can proxy to us.

## Summary
- Adds a new endpoint at `/api/registry/swift` that returns a 200 status with an empty body
- The endpoint is accessible without authentication
- Includes a test for the new endpoint

## Test plan
- [x] Added unit test for the new endpoint
- [x] Verified the test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)