### PR TITLE
feat(server): add TTL to xcode tables

### DIFF
--- a/server/priv/ingest_repo/migrations/20251205140000_add_ttl_to_xcode_tables.exs
+++ b/server/priv/ingest_repo/migrations/20251205140000_add_ttl_to_xcode_tables.exs
@@ -1,0 +1,30 @@
+defmodule Tuist.IngestRepo.Migrations.AddTtlToXcodeTables do
+  use Ecto.Migration
+
+  def up do
+    # Add TTL to automatically delete records older than 30 days
+    # This prevents unbounded table growth
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_targets MODIFY TTL inserted_at + INTERVAL 30 DAY"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_projects MODIFY TTL inserted_at + INTERVAL 30 DAY"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_graphs MODIFY TTL inserted_at + INTERVAL 30 DAY"
+  end
+
+  def down do
+    # Remove TTL from tables (keeps all data indefinitely)
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_targets REMOVE TTL"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_projects REMOVE TTL"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_graphs REMOVE TTL"
+  end
+end


### PR DESCRIPTION
The Xcode tables grow very quickly, but the data is not being processed for longer periods. I'm setting a TTL of 30 days.