### PR TITLE
fix(server): materialize xcode_targets projection

### DIFF
--- a/server/priv/ingest_repo/migrations/20251208125255_materialize_xcode_targets_projection.exs
+++ b/server/priv/ingest_repo/migrations/20251208125255_materialize_xcode_targets_projection.exs
@@ -1,0 +1,13 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeXcodeTargetsProjection do
+  use Ecto.Migration
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE xcode_targets MATERIALIZE PROJECTION proj_by_command_event"
+  end
+
+  def down do
+    # Materialization cannot be undone - the projection will remain materialized
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a ClickHouse migration to materialize the `proj_by_command_event` projection on the `xcode_targets` table

## Context
The projection was added in #8832 but materialization was skipped in #8845. This PR adds the materialization step to populate the projection with existing data for improved query performance.

## Test plan
- [ ] Migration runs successfully against ClickHouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)