### PR TITLE
fix(server): add missing handle_params/3 callback to ProjectSettingsLive

### DIFF
--- a/server/lib/tuist_web/live/project_settings_live.ex
+++ b/server/lib/tuist_web/live/project_settings_live.ex
@@ -27,6 +27,11 @@ defmodule TuistWeb.ProjectSettingsLive do
   end
 
   @impl true
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
   def handle_event(
         "rename_project",
         %{"project" => %{"name" => name}} = _params,

--- a/server/test/tuist_web/live/project_settings_live_test.exs
+++ b/server/test/tuist_web/live/project_settings_live_test.exs
@@ -1,0 +1,33 @@
+defmodule TuistWeb.ProjectSettingsLiveTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.StubCase, dashboard_project: true
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  test "renders the project settings page", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    # When
+    {:ok, _lv, html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/settings")
+
+    # Then
+    assert html =~ "Settings"
+  end
+
+  test "handles URL parameter changes via live_patch", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    # When
+    {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/settings")
+
+    # Patch the URL with query params - this triggers handle_params
+    assert render_patch(lv, ~p"/#{organization.account.name}/#{project.name}/settings?tab=general") =~
+             "Settings"
+  end
+end


### PR DESCRIPTION
## Summary
- Added missing `handle_params/3` callback to `ProjectSettingsLive`
- Added tests for the project settings page

## Problem
The `ProjectSettingsLive` module was missing the required `handle_params/3` callback, causing an `UndefinedFunctionError` in production when users navigated to the project settings page.

This callback is required because `layout_live.ex` attaches a hook for `:handle_params` that returns `{:cont, socket}`, which tells Phoenix to continue and call the LiveView's own `handle_params/3` callback.

Fixes #8847

## Test plan
- [x] Added test that verifies page renders correctly
- [x] Added test that triggers `handle_params` via `render_patch` to ensure no crash occurs
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)