### PR TITLE
fix(server): disable PostHog in blog iframe pages

### DIFF
--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -107,6 +107,9 @@ defmodule TuistWeb.LayoutComponents do
   attr(:page_section, :string, default: nil)
 
   def head_analytics_scripts(assigns) do
+    analytics_enabled =
+      Tuist.Environment.analytics_enabled?() and not Map.get(assigns, :analytics_disabled?, false)
+
     posthog_opts =
       Map.merge(
         %{api_host: Tuist.Environment.posthog_url(), person_profiles: "identified_only"},
@@ -135,12 +138,13 @@ defmodule TuistWeb.LayoutComponents do
       |> maybe_add_group("account", assigns[:selected_account])
 
     analytics_opts = %{
-      enabled: Tuist.Environment.analytics_enabled?(),
+      enabled: analytics_enabled,
       page_section: assigns.page_section
     }
 
     assigns =
       assigns
+      |> assign(:analytics_enabled, analytics_enabled)
       |> assign(:posthog_opts, posthog_opts)
       |> assign(:analytics_opts, analytics_opts)
       |> assign(:posthog_identity, posthog_identity)
@@ -151,31 +155,31 @@ defmodule TuistWeb.LayoutComponents do
     <script nonce={get_csp_nonce()}>
       globalThis.analytics = <%= raw JSON.encode!(@analytics_opts) %>;
     </script>
-    <script :if={Tuist.Environment.analytics_enabled?()} nonce={get_csp_nonce()}>
+    <script :if={@analytics_enabled} nonce={get_csp_nonce()}>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Ce js Ls Te Fs Ds capture Ye calculateEventProperties Us register register_once register_for_session unregister unregister_for_session Ws getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Bs zs createPersonProfile Hs Ms Gs opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Ns debug L qs getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('<%= Tuist.Environment.posthog_api_key() %>', <%= raw JSON.encode!(@posthog_opts) %>)
     </script>
     <script
-      :if={Tuist.Environment.analytics_enabled?() and not is_nil(@posthog_identity)}
+      :if={@analytics_enabled and not is_nil(@posthog_identity)}
       nonce={get_csp_nonce()}
     >
       posthog.identify('<%= elem(@posthog_identity, 0) %>', <%= raw JSON.encode!(elem(@posthog_identity, 1)) %>)
     </script>
     <script
-      :if={Tuist.Environment.analytics_enabled?() and not is_nil(@posthog_alias)}
+      :if={@analytics_enabled and not is_nil(@posthog_alias)}
       nonce={get_csp_nonce()}
     >
       posthog.alias('<%= @posthog_alias %>')
     </script>
     <script
       :for={{group_type, group_key, group_properties} <- @posthog_groups}
-      :if={Tuist.Environment.analytics_enabled?() and length(@posthog_groups) > 0}
+      :if={@analytics_enabled and length(@posthog_groups) > 0}
       nonce={get_csp_nonce()}
     >
       posthog.group('<%= group_type %>', '<%= group_key %>', <%= raw JSON.encode!(group_properties) %>)
     </script>
     <script
-      :if={Tuist.Environment.analytics_enabled?() and not is_nil(@analytics_opts.page_section)}
+      :if={@analytics_enabled and not is_nil(@analytics_opts.page_section)}
       nonce={get_csp_nonce()}
     >
       posthog.register({page_section: '<%= @analytics_opts.page_section %>'})

--- a/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
@@ -36,6 +36,7 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeController do
         |> put_layout(false)
         |> put_view(MarketingHTML)
         |> assign(:plain_disabled?, true)
+        |> assign(:analytics_disabled?, true)
         |> render(template)
     end
   end


### PR DESCRIPTION
## Summary
- Disable PostHog analytics in blog post iframe pages to prevent double-tracking of page views
- Added `analytics_disabled?` assign to conditionally disable PostHog while keeping CSS tokens

## Problem
Blog posts can embed iframes (e.g., D3.js visualizations from `/blog/.../iframe.html`) that load internal pages. These iframe pages were loading PostHog analytics through the root marketing layout, causing page views to be tracked twice - once for the parent blog post and once for each embedded iframe.

## Solution
- Modified `head_analytics_scripts/1` in `LayoutComponents` to check for an `analytics_disabled?` assign
- When set to `true`, PostHog scripts are not rendered (but `globalThis.analytics` still gets set with `enabled: false`)
- The iframe controller now sets `analytics_disabled?: true` to disable PostHog while keeping the root layout for CSS tokens

## Test Plan
- [x] Verified `mix test test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs` passes
- [x] Verified project compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)