### PR TITLE
fix(server): use ran_at instead of created_at for command_events ordering

### DIFF
--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -110,7 +110,7 @@ defmodule TuistWeb.API.RunsController do
         page: page,
         page_size: page_size,
         filters: filters,
-        order_by: [:created_at],
+        order_by: [:ran_at],
         order_directions: [:desc]
       })
 

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -223,7 +223,7 @@ defmodule TuistWeb.CacheRunsLive do
 
     options = %{
       filters: flop_filters,
-      order_by: [Keyword.get(attrs, :order_by, :created_at)],
+      order_by: [Keyword.get(attrs, :order_by, :ran_at)],
       order_directions: [Keyword.get(attrs, :order_direction, :desc)]
     }
 

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -163,7 +163,7 @@ defmodule TuistWeb.GenerateRunsLive do
         %{field: :name, op: :in, value: ["generate"]}
         | build_flop_filters(Keyword.get(attrs, :filters, []))
       ],
-      order_by: [Keyword.get(attrs, :order_by, :created_at)],
+      order_by: [Keyword.get(attrs, :order_by, :ran_at)],
       order_directions: [Keyword.get(attrs, :order_direction, :desc)]
     }
 


### PR DESCRIPTION
## Summary
- Changed default sort from `created_at` to `ran_at` for command_events queries
- Aligns query ORDER BY with the ClickHouse table's primary key `(project_id, name, ran_at)`
- Fixes slow query performance (p50 > 300ms)

## Problem
The `command_events` table in ClickHouse is sorted by `(project_id, name, ran_at)`. Queries filtering by `project_id` and `name` but ordering by `created_at` could not use the primary key ordering efficiently.

## Solution
Changed the default sort from `created_at` to `ran_at` in:
- `RunsController` (API endpoint)
- `CacheRunsLive`
- `GenerateRunsLive`

Since `ran_at` (CLI timestamp) and `created_at` (DB insertion timestamp) are nearly identical, this produces the same practical ordering while allowing ClickHouse to serve queries efficiently using its primary key.

## Test plan
- [x] All existing tests pass
- [x] Verified compile with `--warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)