### PR TITLE
fix(ci): bump tuist cache timeout

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -104,7 +104,7 @@ jobs:
   cli-cache:
     name: Cache
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 60
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I noticed the `tuist cache` job was timing out. It's reasonable for this command to run over 30 mins when the whole cache is invalidated (such as when the CLI version is updated)