### PR TITLE
fix(server): add projection to optimize command_events ORDER BY ran_at DESC queries

### DIFF
--- a/server/priv/ingest_repo/migrations/20251208200000_add_command_events_ran_at_desc_projection.exs
+++ b/server/priv/ingest_repo/migrations/20251208200000_add_command_events_ran_at_desc_projection.exs
@@ -1,0 +1,29 @@
+defmodule Tuist.ClickHouseRepo.Migrations.AddCommandEventsRanAtDescProjection do
+  @moduledoc """
+  Adds a projection to optimize queries that filter by project_id and name,
+  then order by ran_at DESC with a LIMIT.
+
+  Without this projection, such queries read ALL matching rows from ALL parts
+  (e.g., 309K rows / 3.38 GB), merge-sort them, then return just 21 rows.
+
+  With this projection, ClickHouse can read data already sorted by ran_at DESC
+  and stop early after finding the LIMIT rows.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE command_events ADD PROJECTION projection_by_project_name_ran_at_desc
+    (
+      SELECT *
+      ORDER BY project_id, name, ran_at DESC
+    )
+    """)
+  end
+
+  def down do
+    execute(
+      "ALTER TABLE command_events DROP PROJECTION IF EXISTS projection_by_project_name_ran_at_desc"
+    )
+  end
+end

--- a/server/priv/ingest_repo/migrations/20251208200001_materialize_command_events_ran_at_desc_projection.exs
+++ b/server/priv/ingest_repo/migrations/20251208200001_materialize_command_events_ran_at_desc_projection.exs
@@ -1,0 +1,19 @@
+defmodule Tuist.ClickHouseRepo.Migrations.MaterializeCommandEventsRanAtDescProjection do
+  @moduledoc """
+  Materializes the projection for existing data.
+
+  This is separated from the projection creation because materialization
+  can take significant time for large tables.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute(
+      "ALTER TABLE command_events MATERIALIZE PROJECTION projection_by_project_name_ran_at_desc"
+    )
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary

- Adds ClickHouse projection to optimize slow queries on `command_events` table
- Queries with `WHERE project_id = ? AND name IN (?) ORDER BY ran_at DESC LIMIT ?` were reading 300K+ rows (3+ GB) to return just 21 rows

## Problem

The `command_events` table is ordered by `(project_id, name, ran_at)`, but data is spread across 27+ parts. When executing ORDER BY ran_at DESC with LIMIT, ClickHouse had to:
1. Read ALL matching rows from ALL parts (309K rows / 3.38 GB)
2. Merge-sort them all
3. Return top 21

This resulted in p50 latency > 2 seconds.

## Solution

Added a projection ordered by `(project_id, name, ran_at DESC)`. With this projection:
- ClickHouse reads data already in the correct order
- It can stop early after finding LIMIT rows
- Expected to read ~21 rows instead of 300K+

## Test plan

After deployment:
1. Run `EXPLAIN` on the query - should show the projection being used
2. Check query metrics - should see dramatic reduction in rows read
3. Monitor p50 latency - should drop from >2s to <100ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)