### PR TITLE
fix(cli): handle cross-project dependencies in redundant import inspection

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -187,6 +187,20 @@ public class GraphTraverser: GraphTraversing {
         return Set(convertToGraphTargetReferences(localTargetDependencies, for: target))
     }
 
+    public func directNonExternalTargetDependencies(path: Path.AbsolutePath, name: String) -> Set<
+        GraphTargetReference
+    > {
+        directTargetDependencies(path: path, name: name)
+            .filter { reference in
+                switch reference.graphTarget.project.type {
+                case .local:
+                    return true
+                case .external:
+                    return false
+                }
+            }
+    }
+
     /// Returns all direct target dependencies where the target is in another project.
     private func directNonLocalTargetDependencies(path: Path.AbsolutePath, name: String) -> Set<GraphTargetReference> {
         let dependencies = directTargetDependencies(path: path, name: name)

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -79,20 +79,32 @@ public protocol GraphTraversing {
     /// - Returns: All direct and transitive target dependencies, traversing from the passed targets
     func allTargetDependencies(traversingFromTargets: [GraphTarget]) -> Set<GraphTarget>
 
-    /// Given a project directory and target name, it returns **all** its direct target dependencies present in the same project.
+    /// Given a project directory and target name, it returns **all** its direct target dependencies (including external
+    /// dependencies).
     /// If you want only direct target dependencies present in the same project as the target, use `directLocalTargetDependencies`
-    /// instead
+    /// instead.
     /// - Parameters:
     ///   - path: Path to the directory that contains the target's project.
     ///   - name: Target name.
     func directTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTargetReference>
 
-    /// Given a project directory and target name, it returns all its direct target dependencies present in the same project.
-    /// To get **all** direct target dependencies use the method `directTargetDependencies` instead
+    /// Given a project directory and target name, it returns direct target dependencies from the **same project only** (same
+    /// path).
+    /// Excludes dependencies from other projects in the workspace AND external dependencies.
+    /// To get all local (non-external) dependencies, use `directNonExternalTargetDependencies`.
     /// - Parameters:
     ///   - path: Path to the directory that contains the project.
     ///   - name: Target name.
     func directLocalTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTargetReference>
+
+    /// Given a project directory and target name, it returns all its direct target dependencies from local projects (excluding
+    /// external dependencies).
+    /// This includes dependencies from the same project AND other local projects in the workspace.
+    /// To get only dependencies from the same project, use `directLocalTargetDependencies`.
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - name: Target name.
+    func directNonExternalTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTargetReference>
 
     /// Given a project directory and a target name, it returns all the dependencies that are extensions.
     /// - Parameters:

--- a/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/GraphImportsLinter.swift
@@ -95,7 +95,7 @@ final class GraphImportsLinter: GraphImportsLinting {
                 .directTargetDependencies(path: target.project.path, name: target.target.name)
         } else {
             graphTraverser
-                .directLocalTargetDependencies(path: target.project.path, name: target.target.name)
+                .directNonExternalTargetDependencies(path: target.project.path, name: target.target.name)
         }
 
         let explicitTargetDependencies = targetDependencies


### PR DESCRIPTION
`tuist inspect redundant-imports` fails to report redundant dependencies from a different (local) project. This adds a new `directNonExternalTargetDependencies` method to `GraphTraverser` and uses it in the inspection.