### PR TITLE
fix(ci): only use .build cache on exact key match

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-          restore-keys: .build
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -138,7 +137,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-          restore-keys: .build
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -176,7 +174,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-          restore-keys: .build
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -121,7 +121,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -168,7 +167,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -215,7 +213,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -91,7 +90,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -120,7 +118,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -149,7 +146,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -178,7 +174,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -213,7 +208,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -255,7 +249,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -290,7 +283,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-          restore-keys: .build
       - name: Update version
         working-directory: app
         run: |

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-cli-
       - uses: jdx/mise-action@v2
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''

--- a/docs/docs/en/guides/features/registry/continuous-integration.md
+++ b/docs/docs/en/guides/features/registry/continuous-integration.md
@@ -81,7 +81,6 @@ Here's an example workflow for GitHub Actions for resolving and caching dependen
   with:
     path: .build
     key: ${{ runner.os }}-${{ hashFiles('App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-    restore-keys: .build
 - name: Resolve dependencies
   if: steps.cache-restore.outputs.cache-hit != 'true'
   run: xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .build


### PR DESCRIPTION
SwiftPM is notoriously bad at removing old artifacts. Additionally, we are skipping `tuist install` on a cache hit – but that only makes sense if we only restore the cache on an exact match.

I'm updating the pipelines to align with that.