### PR TITLE
fix(server): handle AuthenticatedAccount in analytics subject_parameters

### DIFF
--- a/server/lib/tuist/analytics.ex
+++ b/server/lib/tuist/analytics.ex
@@ -101,4 +101,8 @@ defmodule Tuist.Analytics do
   def subject_parameters(%Tuist.Accounts.User{id: id}) do
     %{user_id: id}
   end
+
+  def subject_parameters(%Tuist.Accounts.AuthenticatedAccount{account: %{id: id}}) do
+    %{account_id: id}
+  end
 end


### PR DESCRIPTION
## Summary
- Fixed `FunctionClauseError` in `Tuist.Analytics.subject_parameters/1` when using OIDC tokens
- Added function clause to handle `AuthenticatedAccount` struct

## Problem
When using OIDC tokens for authentication, the `current_subject` is an `AuthenticatedAccount` struct instead of a `User` struct. Analytics functions like `cache_artifact_download/2` and `preview_upload/1` were failing with:

```
** (FunctionClauseError) no function clause matching in Tuist.Analytics.subject_parameters/1
```

This affected:
- Cache artifact downloads via `/api/cache`
- Preview uploads via `/api/projects/:handle/:name/previews/complete`

## Solution
Added a new function clause for `AuthenticatedAccount` that extracts the `account_id` from the nested `account` field.

## Test plan
- [x] Added test for `preview_upload/1` with `AuthenticatedAccount`
- [x] Added test for `cache_artifact_download/2` with `AuthenticatedAccount`
- [x] All 2504 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)