### PR TITLE
fix(cache, server): do not report Bandit.TransportError to AppSignal

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -1,9 +1,12 @@
 import Config
 
+# Bandit.TransportError is raised when the client disconnects mid-request (e.g. cancelled upload).
+# These are expected and not actionable errors.
 config :appsignal, :config,
   otp_app: :cache,
   name: "Cache",
-  active: true
+  active: true,
+  ignore_errors: ["Bandit.TransportError"]
 
 config :cache, Cache.PromEx,
   disabled: false,

--- a/cache/lib/cache/body_reader.ex
+++ b/cache/lib/cache/body_reader.ex
@@ -6,8 +6,6 @@ defmodule Cache.BodyReader do
   to avoid memory pressure.
   """
 
-  require Logger
-
   @max_upload_bytes 25 * 1024 * 1024
   @default_opts [length: @max_upload_bytes, read_length: 262_144, read_timeout: 60_000]
 
@@ -44,8 +42,7 @@ defmodule Cache.BodyReader do
     |> Plug.Conn.read_body(opts)
     |> handle_read_result(conn, opts, mode)
   rescue
-    e in Bandit.TransportError ->
-      Logger.info("Client cancelled upload during #{mode}: #{e.message}")
+    Bandit.TransportError ->
       {:error, :cancelled, conn}
   end
 
@@ -108,8 +105,7 @@ defmodule Cache.BodyReader do
     |> Plug.Conn.read_body(opts)
     |> handle_loop_result(conn, opts, device, bytes_read, writer)
   rescue
-    e in Bandit.TransportError ->
-      Logger.info("Client cancelled upload during chunked read: #{e.message}")
+    Bandit.TransportError ->
       {:error, :cancelled, conn}
   end
 

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -210,6 +210,9 @@ if Tuist.Environment.error_tracking_enabled?() do
     env: env,
     active: true,
     ignore_errors: [
+      # Bandit.TransportError is raised when the client disconnects mid-request.
+      # These are expected and not actionable errors.
+      "Bandit.TransportError",
       "TuistWeb.Errors.BadRequestError",
       "TuistWeb.Errors.NotFoundError",
       "TuistWeb.Errors.TooManyRequestsError",


### PR DESCRIPTION
`Bandit.TransportError` is an expected arrow when the connection closes before a request finishes.
As such, we should not report it to AppSignal for error reporting since it's not actionable.

Keeps the `rescue` in cache for telemetry and metrics.

This does not yet also add `HTTPError`, I want to see how it behaves first.