### PR TITLE
fix(server): pin nodejs

### DIFF
--- a/server/mise.toml
+++ b/server/mise.toml
@@ -1,6 +1,6 @@
 [tools]
   pnpm = "10.17.1"
-  node = "24"
+  node = "24.11.0"
   sops = "3.9.3"
   age = "1.2.1"
   "ubi:aquasecurity/trivy" = "0.63.0"


### PR DESCRIPTION
mise keeps a copy of node's release keys [here](https://github.com/jdx/mise/blob/main/src/assets/gpg/node.asc)

24.12.0 changed the keys - mise has not been updated with the new keys yet, so installation fails.
Pinning our version to 24.11.0 which installs cleanly with the old keys.