### PR TITLE
fix(server): scroll top margin for changelog entries

### DIFF
--- a/server/assets/marketing/css/routes/changelog.css
+++ b/server/assets/marketing/css/routes/changelog.css
@@ -155,6 +155,11 @@
       gap: var(--noora-spacing-9);
       margin-bottom: var(--noora-spacing-10);
       min-width: 0;
+      scroll-margin-top: 80px;
+
+      @media (min-width: 768px) {
+        scroll-margin-top: 120px;
+      }
 
       @media (min-width: 1024px) {
         grid-column: 3;


### PR DESCRIPTION
Right now, if you click (or link) to a specific entry, the link is actually shown at the viewport top, being behind the navbar. I'm adding a scroll top margin, so the whole entry is actually shown.

Before:
<img width="1354" height="805" alt="image" src="https://github.com/user-attachments/assets/32705c09-2a58-45f9-90b5-66fc68045ede" />

After:
<img width="1354" height="805" alt="image" src="https://github.com/user-attachments/assets/6cff8e1b-8d4e-4620-a1ee-99cde2a9b2ce" />