### PR TITLE
fix(cli): skip tuist auth login in forks

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -64,6 +64,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -94,6 +95,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -124,6 +126,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -154,6 +157,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -184,6 +188,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -220,6 +225,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -263,6 +269,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
@@ -299,6 +306,7 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
+        if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''


### PR DESCRIPTION
## Summary
- Skip `tuist auth login` step when CI workflow runs from a fork PR
- Forks don't have access to repository secrets, so auth would fail

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test with a fork PR to confirm auth step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)