### PR TITLE
fix(docs): de-fly.io documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,14 +201,10 @@ The CI pipeline will fail if any `.po` files are modified by anyone other than `
 
 ## Deployment
 
-The application deploys to Fly.io with different environments:
+The application deploys to Render with different environments:
 - `mise run deploy:staging` - Deploy to staging
 - `mise run deploy:canary` - Deploy to canary
 - `mise run deploy:production` - Deploy to production
-
-**Remote Console Access:**
-- `mise run fly:console:staging`
-- `mise run fly:console:production`
 
 ## Important Notes
 
@@ -282,7 +278,7 @@ When creating or modifying security policies:
 3. **Key considerations**:
    - Keep policies practical for a 4-person company
    - Reference the [shared responsibility model](/security/shared-responsibility-model) when discussing infrastructure
-   - Infrastructure providers (Fly.io, Supabase, Tigris, Cloudflare) handle their own layer security
+   - Infrastructure providers (Render, Supabase, Tigris, Cloudflare) handle their own layer security
    - Focus on application-layer responsibilities
 
 ## Navigation Configuration
@@ -332,7 +328,7 @@ description: Brief description of the page content
    - Practical implementation requirements
 
 3. **Infrastructure responsibilities**: Remember that Tuist relies on:
-   - Fly.io for application hosting
+   - Render for application hosting
    - Supabase for database services
    - Tigris for data storage
    - Cloudflare for CDN and edge services

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -2,12 +2,6 @@ import Foundation
 
 private func tuistURLSessionConfiguration() -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
-    // Our API design leads to an inefficient usage of the transport layer, which leads to Fly having to spin
-    // new machines suddenly, and that causes URLSession to time out. The high timeouts here are temporary
-    // until we change the server-side API to lead to a more efficient using of the transport layer.
-    //
-    // I noticed on Fly https://fly.io/apps/tuist-cloud/metrics that the peaks can reach up to
-    // 100 seconds, hence why I set the limit to 120.
     configuration.timeoutIntervalForRequest = 120 // 2 minutes
     configuration.timeoutIntervalForResource = 300 // 5 minutes
     configuration.allowsCellularAccess = true

--- a/handbook/handbook/security/business-continuity-and-data-protection/network-traffic-management-policy.md
+++ b/handbook/handbook/security/business-continuity-and-data-protection/network-traffic-management-policy.md
@@ -16,13 +16,13 @@ To establish comprehensive rules and procedures for monitoring, controlling, man
 
 ## Scope
 
-This policy applies to all network traffic related to Tuist GmbH applications and services, while recognizing the shared responsibility model with our infrastructure provider Fly.io as documented in our [Shared Responsibility Model](/security/shared-responsibility-model).
+This policy applies to all network traffic related to Tuist GmbH applications and services, while recognizing the shared responsibility model with our infrastructure provider Render as documented in our [Shared Responsibility Model](/security/shared-responsibility-model).
 
 ## Shared Responsibility Model for Network Traffic Management
 
-Tuist GmbH operates its infrastructure on Fly.io, which creates a shared responsibility model for network traffic management:
+Tuist GmbH operates its infrastructure on Render, which creates a shared responsibility model for network traffic management:
 
-### Fly.io Responsibilities:
+### Render Responsibilities:
 - Physical network infrastructure security
 - Network perimeter security including DDoS protection
 - Core network monitoring and management

--- a/handbook/handbook/security/secure-development-and-operations/penetration-testing-policy.md
+++ b/handbook/handbook/security/secure-development-and-operations/penetration-testing-policy.md
@@ -18,7 +18,7 @@ This policy establishes the requirements for regular penetration testing of Tuis
 
 This policy applies to all systems, applications, and infrastructure owned, operated, or maintained by Tuist GmbH that are business-critical and/or process, store, or transmit Confidential data. It applies to all employees, contractors, and third parties involved in planning, conducting, or responding to penetration testing activities.
 
-This policy operates within Tuist's [shared responsibility model](/security/shared-responsibility-model), recognizing that infrastructure providers (Fly.io, Supabase, Tigris, and Cloudflare) are responsible for penetration testing of their underlying infrastructure layers.
+This policy operates within Tuist's [shared responsibility model](/security/shared-responsibility-model), recognizing that infrastructure providers (Render, Supabase, Tigris, and Cloudflare) are responsible for penetration testing of their underlying infrastructure layers.
 
 ## Policy Statement
 
@@ -59,8 +59,8 @@ In accordance with our [shared responsibility model](/security/shared-responsibi
 - Business logic vulnerabilities
 
 **Infrastructure Provider Responsibility (covered by provider testing):**
-- Physical data center security (Fly.io, Supabase, Tigris)
-- Network infrastructure and DDoS protection (Fly.io, Cloudflare)
+- Physical data center security (Render, Supabase, Tigris)
+- Network infrastructure and DDoS protection (Render, Cloudflare)
 - Platform-level vulnerabilities and patches (all providers)
 - Database engine security (Supabase, Tigris)
 - CDN and edge security (Cloudflare)

--- a/handbook/handbook/security/secure-development-and-operations/secure-development-policy.md
+++ b/handbook/handbook/security/secure-development-and-operations/secure-development-policy.md
@@ -102,7 +102,7 @@ Testing of security functionality shall be performed at defined periods during t
 deployed to Tuist GmbH production systems without documented, successful test results and evidence of security
 remediation activities.
 
-Comprehensive penetration testing shall be performed at least annually on applications and cloud resources according to the requirements outlined in the Penetration Testing Policy. As per our [Shared Responsibility Model](/security/shared-responsibility-model), network infrastructure penetration testing is the responsibility of our cloud provider Fly.io.
+Comprehensive penetration testing shall be performed at least annually on applications and cloud resources according to the requirements outlined in the Penetration Testing Policy. As per our [Shared Responsibility Model](/security/shared-responsibility-model), network infrastructure penetration testing is the responsibility of our cloud provider Render.
 
 Application-level network traffic shall be monitored, controlled, managed, and periodically evaluated to identify vulnerabilities, anomalies, and capacity issues in accordance with the [Network Traffic Management Policy](/security/business-continuity-and-data-protection/network-traffic-management-policy).
 

--- a/handbook/handbook/security/shared-responsibility-model.md
+++ b/handbook/handbook/security/shared-responsibility-model.md
@@ -7,27 +7,27 @@
 ---
 # Shared responsibility model
 
-At Tuist, we rely on trusted infrastructure providers, such as [Fly.io](https://fly.io), [Tigris](https://tigrisdata.com) and [Supabase](https://supabase.com), to manage key aspects of our infrastructure security. These partnerships enable us to deliver reliable and secure services while focusing on application and data-level security.
+At Tuist, we rely on trusted infrastructure providers, such as [Render](https://render.com), [Tigris](https://tigrisdata.com) and [Supabase](https://supabase.com), to manage key aspects of our infrastructure security. These partnerships enable us to deliver reliable and secure services while focusing on application and data-level security.
 
 This document outlines the shared responsibility model between Tuist and its infrastructure providers, detailing the security areas managed by each party.
 
-## Fly.io: Security Responsibilities
+## Render: Security Responsibilities
 
-[Fly.io](https://fly.io) ensures the security of its platform through the following mechanisms:
+[Render](https://render.com) ensures the security of its platform through the following mechanisms:
 
-### **Fly.io's Responsibilities:**
+### **Render's Responsibilities:**
 1. **Data Center Security**
    - Physical access control, environmental safeguards, and compliance with industry standards (e.g., SOC 2, ISO 27001).
 2. **Network Security**
    - Firewall protection, DDoS mitigation, and secure routing of traffic across their global network.
 3. **Platform Updates and Patch Management**
-   - Continuous monitoring and patching of vulnerabilities in the Fly.io platform and underlying infrastructure.
+   - Continuous monitoring and patching of vulnerabilities in the Render platform and underlying infrastructure.
 4. **Application Security (AppSec)**
    - Secure isolation of customer workloads to prevent unauthorized access between applications running on their platform.
 
-For more details, refer to Fly.io's [Shared Responsibility Model](https://fly.io/docs/security/shared-responsibility/) and [Application Security](https://fly.io/docs/security/security-at-fly-io/#application-security-appsec).
+For more details, refer to Render's [Shared Responsibility Model](https://render.com/docs/shared-responsibility-model) and [Security and Trust](https://render.com/trust) documentation.
 
-### **Tuist's Responsibilities on Fly.io:**
+### **Tuist's Responsibilities on Render:**
 - Securing the Tuist application code and dependencies.
 - Managing access controls and encryption for data at rest and in transit.
 - Implementing monitoring and incident response measures for application-layer threats.

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -376,8 +376,6 @@ config :tuist, Tuist.PromEx,
   manual_metrics_start_delay: :no_delay,
   drop_metrics_groups: [],
   grafana: :disabled,
-  # Fly.io polls every 15 seconds, so I'm setting the interval to 20 seconds to avoid
-  # missing data.
   ets_flush_interval: 20_000,
   metrics_server: [
     port: 9091,


### PR DESCRIPTION
Removes the rest of the mentions of Fly.io and replaces it with Render