### PR TITLE
refactor(cache): use directory sharding in disk storage

### DIFF
--- a/cache/test/cache/disk_test.exs
+++ b/cache/test/cache/disk_test.exs
@@ -161,15 +161,15 @@ defmodule Cache.DiskTest do
   end
 
   describe "local_accel_path/3" do
-    test "builds internal X-Accel-Redirect path for simple id" do
+    test "builds internal X-Accel-Redirect path with sharded structure" do
       path = Disk.local_accel_path(@test_account, @test_project, @test_id)
-      assert path == "/internal/local/#{@test_key}"
+      assert path == "/internal/local/#{@test_account}/#{@test_project}/cas/ab/c1/#{@test_id}"
     end
 
-    test "builds internal path for nested id" do
+    test "builds internal path for nested id with sharded structure" do
       nested_id = "deeply/nested/artifact"
       path = Disk.local_accel_path(@test_account, @test_project, nested_id)
-      assert path == "/internal/local/#{@test_account}/#{@test_project}/cas/#{nested_id}"
+      assert path == "/internal/local/#{@test_account}/#{@test_project}/cas/de/ep/#{nested_id}"
     end
   end
 

--- a/cache/test/cache_web/controllers/cas_controller_test.exs
+++ b/cache/test/cache_web/controllers/cas_controller_test.exs
@@ -239,7 +239,7 @@ defmodule CacheWeb.CASControllerTest do
       end)
 
       expect(CASArtifacts, :track_artifact_access, fn key ->
-        assert key == "#{account_handle}/#{project_handle}/cas/#{id}"
+        assert key == "#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
         :ok
       end)
 
@@ -251,7 +251,7 @@ defmodule CacheWeb.CASControllerTest do
       assert conn.status == 200
 
       assert get_resp_header(conn, "x-accel-redirect") == [
-               "/internal/local/#{account_handle}/#{project_handle}/cas/#{id}"
+               "/internal/local/#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
              ]
 
       assert conn.resp_body == ""
@@ -271,14 +271,14 @@ defmodule CacheWeb.CASControllerTest do
       end)
 
       expect(CASArtifacts, :track_artifact_access, fn key ->
-        assert key == "#{account_handle}/#{project_handle}/cas/#{id}"
+        assert key == "#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
         :ok
       end)
 
       # Stub presign to return a deterministic URL
       expect(Cache.S3, :presign_download_url, fn key ->
-        assert key == "#{account_handle}/#{project_handle}/cas/#{id}"
-        {:ok, "https://example.com/prefix/#{account_handle}/#{project_handle}/cas/#{id}?token=abc"}
+        assert key == "#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
+        {:ok, "https://example.com/prefix/#{account_handle}/#{project_handle}/cas/ab/c1/#{id}?token=abc"}
       end)
 
       conn =
@@ -289,7 +289,7 @@ defmodule CacheWeb.CASControllerTest do
       assert conn.status == 200
 
       assert get_resp_header(conn, "x-accel-redirect") == [
-               "/internal/remote/https/example.com/prefix/#{account_handle}/#{project_handle}/cas/#{id}?token=abc"
+               "/internal/remote/https/example.com/prefix/#{account_handle}/#{project_handle}/cas/ab/c1/#{id}?token=abc"
              ]
 
       assert conn.resp_body == ""
@@ -309,13 +309,13 @@ defmodule CacheWeb.CASControllerTest do
       end)
 
       expect(CASArtifacts, :track_artifact_access, fn key ->
-        assert key == "#{account_handle}/#{project_handle}/cas/#{id}"
+        assert key == "#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
         :ok
       end)
 
       expect(Cache.S3, :presign_download_url, fn key ->
-        assert key == "#{account_handle}/#{project_handle}/cas/#{id}"
-        {:ok, "https://example.com/prefix/#{account_handle}/#{project_handle}/cas/#{id}?token=abc"}
+        assert key == "#{account_handle}/#{project_handle}/cas/ab/c1/#{id}"
+        {:ok, "https://example.com/prefix/#{account_handle}/#{project_handle}/cas/ab/c1/#{id}?token=abc"}
       end)
 
       capture_log(fn ->
@@ -327,7 +327,7 @@ defmodule CacheWeb.CASControllerTest do
         assert conn.status == 200
 
         assert get_resp_header(conn, "x-accel-redirect") == [
-                 "/internal/remote/https/example.com/prefix/#{account_handle}/#{project_handle}/cas/#{id}?token=abc"
+                 "/internal/remote/https/example.com/prefix/#{account_handle}/#{project_handle}/cas/ab/c1/#{id}?token=abc"
                ]
 
         assert conn.resp_body == ""


### PR DESCRIPTION
So, yeah, this is a thing:
> [1466831.512209] EXT4-fs warning (device sdb1): ext4_dx_add_entry:2528: Directory (ino: 8388611) index full, reach max htree level :2

So, sharding the directory will help.
This is not backwards compatible, but artifacts will be served from S3 and then backfilled, so we're good.