### PR TITLE
fix(server): remove localized_href from API docs link

### DIFF
--- a/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
+++ b/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
@@ -75,7 +75,7 @@ developers_items = [
     icon: :api,
     title: dgettext("marketing", "API Documentation"),
     subtitle: dgettext("marketing", "Check out our REST API documentation"),
-    href: TuistWeb.Marketing.MarketingHTML.localized_href("/api/docs")
+    href: "/api/docs"
   },
   %{
     icon: :brand_github,


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/8906

## Summary
- Remove `localized_href` wrapper from the API docs link in the navbar
- The `/api/docs` endpoint is not a localized route, so wrapping it was incorrect