### PR TITLE
fix(cache): prune oban jobs less aggressively

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -14,6 +14,8 @@ config :cache, Cache.PromEx,
   drop_metrics_groups: [],
   grafana: :disabled
 
+config :cache, Cache.Repo, busy_timeout: 10_000
+
 config :cache, CacheWeb.Endpoint,
   url: [host: "localhost"],
   adapter: Bandit.PhoenixAdapter,
@@ -33,7 +35,7 @@ config :cache, Oban,
     s3_transfers: 1
   ],
   plugins: [
-    Oban.Plugins.Pruner,
+    {Oban.Plugins.Pruner, interval: to_timeout(minute: 5), max_age: to_timeout(day: 1)},
     {Oban.Plugins.Cron,
      crontab: [
        {"*/10 * * * *", Cache.DiskEvictionWorker},


### PR DESCRIPTION
Another attempt to fix database lock contention with SQLite's single-writer limitation.