### PR TITLE
fix(server): use custom_data key for AppSignal sample data

### DIFF
--- a/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
+++ b/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
@@ -29,8 +29,6 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
             %{}
         end
 
-      set_sample_data(span, "auth", auth_data)
-
       selection_data =
         case {conn.assigns[:selected_project], conn.assigns[:selected_account]} do
           {%{id: project_id, name: project_handle}, %{id: account_id, name: account_handle}} ->
@@ -48,7 +46,12 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
             %{}
         end
 
-      set_sample_data(span, "selection", selection_data)
+      custom_data =
+        %{}
+        |> maybe_put(:auth, auth_data)
+        |> maybe_put(:selection, selection_data)
+
+      set_sample_data(span, "custom_data", custom_data)
     end
 
     conn
@@ -61,4 +64,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
   defp set_sample_data(span, key, data) do
     Appsignal.Span.set_sample_data(span, key, data)
   end
+
+  defp maybe_put(map, _key, value) when value == %{}, do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
+++ b/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
   import Plug.Test
@@ -33,11 +33,13 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "auth", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 user_id: user.id,
-                 account_id: user.account.id,
-                 account_handle: user.account.name
+                 auth: %{
+                   user_id: user.id,
+                   account_id: user.account.id,
+                   account_handle: user.account.name
+                 }
                }
 
         :ok
@@ -59,11 +61,13 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "auth", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 project_id: project.id,
-                 account_id: project.account.id,
-                 account_handle: project.account.name
+                 auth: %{
+                   project_id: project.id,
+                   account_id: project.account.id,
+                   account_handle: project.account.name
+                 }
                }
 
         :ok
@@ -86,8 +90,8 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "auth", data ->
-        assert data == %{account_id: account.id, account_handle: account.name}
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+        assert data == %{auth: %{account_id: account.id, account_handle: account.name}}
         :ok
       end)
 
@@ -108,23 +112,20 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, 2, fn ^span, key, data ->
-        case key do
-          "auth" ->
-            assert data == %{
-                     user_id: user.id,
-                     account_id: user.account.id,
-                     account_handle: user.account.name
-                   }
-
-          "selection" ->
-            assert data == %{
-                     project_id: project.id,
-                     project_name: project.name,
-                     account_id: project.account.id,
-                     account_handle: project.account.name
-                   }
-        end
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+        assert data == %{
+                 auth: %{
+                   user_id: user.id,
+                   account_id: user.account.id,
+                   account_handle: user.account.name
+                 },
+                 selection: %{
+                   project_id: project.id,
+                   project_name: project.name,
+                   account_id: project.account.id,
+                   account_handle: project.account.name
+                 }
+               }
 
         :ok
       end)
@@ -148,18 +149,15 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, 2, fn ^span, key, data ->
-        case key do
-          "auth" ->
-            assert data == %{
-                     user_id: user.id,
-                     account_id: user.account.id,
-                     account_handle: user.account.name
-                   }
-
-          "selection" ->
-            assert data == %{account_id: account.id, account_handle: account.name}
-        end
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+        assert data == %{
+                 auth: %{
+                   user_id: user.id,
+                   account_id: user.account.id,
+                   account_handle: user.account.name
+                 },
+                 selection: %{account_id: account.id, account_handle: account.name}
+               }
 
         :ok
       end)


### PR DESCRIPTION
## Summary
- Fixed invalid AppSignal sample data keys causing warnings
- Changed from using "auth" and "selection" as top-level keys to nesting them under the valid "custom_data" key
- AppSignal only accepts specific keys for set_sample_data: `params`, `tags`, `custom_data`, `session_data`, and `headers`