### PR TITLE
fix(server): validate sort_by parameter in TestCasesLive

### DIFF
--- a/server/lib/tuist_web/live/test_cases_live.ex
+++ b/server/lib/tuist_web/live/test_cases_live.ex
@@ -287,12 +287,15 @@ defmodule TuistWeb.TestCasesLive do
     params["analytics_selected_widget"] || "test_case_run_count"
   end
 
+  @allowed_sort_fields ~w(name last_duration avg_duration last_ran_at)
+  @default_sort_field "last_ran_at"
+
   defp assign_test_cases(%{assigns: %{selected_project: project}} = socket, params) do
     filters =
       Filter.Operations.decode_filters_from_query(params, socket.assigns.available_filters)
 
     page = parse_page(params["page"])
-    sort_by = params["sort_by"] || "last_ran_at"
+    sort_by = validate_sort_by(params["sort_by"])
     sort_order = params["sort_order"] || "desc"
     search = params["search"] || ""
 
@@ -324,6 +327,10 @@ defmodule TuistWeb.TestCasesLive do
   defp parse_page(nil), do: 1
   defp parse_page(page) when is_binary(page), do: String.to_integer(page)
   defp parse_page(page) when is_integer(page), do: page
+
+  defp validate_sort_by(nil), do: @default_sort_field
+  defp validate_sort_by(field) when field in @allowed_sort_fields, do: field
+  defp validate_sort_by(_invalid), do: @default_sort_field
 
   defp build_flop_filters(filters, search) do
     flop_filters = Filter.Operations.convert_filters_to_flop(filters)

--- a/server/test/tuist_web/live/test_cases_live_test.exs
+++ b/server/test/tuist_web/live/test_cases_live_test.exs
@@ -110,6 +110,19 @@ defmodule TuistWeb.TestCasesLiveTest do
       # Then - verify the page loads with the date range param
       assert has_element?(lv, "[data-part='analytics']")
     end
+
+    test "handles invalid sort_by parameter gracefully", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      # When - navigate with an invalid sort_by parameter (ran_at instead of last_ran_at)
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases?sort_by=ran_at")
+
+      # Then - page should load successfully with default sort
+      assert has_element?(lv, "[data-part='test-cases']")
+    end
   end
 
   defp create_test_run_with_cases(project, account) do


### PR DESCRIPTION
## Summary
- Fixes #8914
- Validates the `sort_by` URL parameter in TestCasesLive against allowed Flop sortable fields
- Invalid values (e.g., `ran_at` from old bookmarks) now fall back to the default `last_ran_at`

## Problem
Users with bookmarked URLs containing `sort_by=ran_at` were seeing crashes because the TestCase Flop schema only allows `[:name, :last_duration, :avg_duration, :last_ran_at]`.

## Test plan
- [x] Added test case that verifies invalid sort_by parameters are handled gracefully
- [x] All existing TestCasesLive tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)