### PR TITLE
chore(cli): fix socket timeout for external contributors

### DIFF
--- a/.env.json
+++ b/.env.json
@@ -53,6 +53,7 @@
 	"TUIST_OPENAI_API_KEY": "ENC[AES256_GCM,data:/BK6TzalY66jdYwKz8gkaJpcBYRtP/81aCqiEGcHxiJw7rCNdFTPXwyY3cqy7/3pPeFfCPsFABy2+7VQhqKA3uid6NTbFqout+ubEcirl0oj1ssfKzjlbKKDVgyUJTX3xiV2+R+o10MyChCBPOm1RHXgSWPCUVUX5YMcJBYsrgsUCyOE3OTlgIWfNuTtEKGBjvEjYLsb9SoH3LPBh9K2Q1iPZTc=,iv:uoVcvx5Rk245kPiIW2wDx4HKKds9wCpept/MeAFQ6m0=,tag:lchZ3Bdc3ClKG1neynhcGA==,type:str]",
 	"TUIST_APP_PRIVATE_SPARKLE_KEY": "ENC[AES256_GCM,data:rvQ1m5CAJxL6HVxaxYUsbonWNNbVqF2UsF3RZfm2znyWdaSWebrFJk9S/oE=,iv:B+rg7PLHvePxb0OGMnRPrzX1YEcJBpW/EEHzhJzo8nE=,tag:voHYImTaNtOZkLdyEvunTA==,type:str]",
 	"TUIST_CACHE_API_KEY": "ENC[AES256_GCM,data:+tA15kqk0tHbuHkk/SZ7uQclBFqIvWkGayjRtEU93/GZclDmCMEEzcKLv71ttxKrCbnaUt5SomMBBxS4szF/Ug==,iv:PLgs3VwIchYKunRu8/2v8fct5VaRs4zKqmnNut7IFO4=,tag:Doo1eNyoyR5G0cTxLGQsww==,type:str]",
+	"TUIST_ENABLE_CACHING": "ENC[AES256_GCM,data:GWnWSw==,iv:mqrpgkvLSPNFF3xKL87MVOHmr5f4dKycsxDTUSAGGT4=,tag:s8uXwCeoLBFiwrLWW6Zcjw==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -64,8 +65,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYZ2puNW1sK0lvT0s1UVoy\nbDVzL3FQR2taUCs0M2JDVGNBYml5ZDZ3S2xBCnV1dEUzNGhISEJlYVdibHphSGNX\nVVYxSUxpMkFtS1JneitWZ3hlakxuR2sKLS0tIDkzbzhackplOHRndGFYMVlaQWY4\neVVZSjQ2WUZkMW51WXFXN1RhMjlMcU0KMs8B/Kl7ZjL9HP+egua7J+KKo4e8crYI\n08XmnY1jrBYzPL9FYR/yNv1s6oXIs039fUx2EW6cXxCpHUOPzVuL+A==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2025-11-13T13:10:04Z",
-		"mac": "ENC[AES256_GCM,data:WJckeN6XELe75rP1dKY8JySJb+/28Xk2muXDE9P1kdlszN+S7E1oj3b7++Rj+3WbRrCWsunzuIfVH8QfqCIFptFnivHnOdcs1u5tUdPHzjMiNK4vyGMQPSEuPRuXYd7IazRD1SIhCKY0IPrULdN7kHZCVLoYCIfYwpaGYm7a49g=,iv:vBJZmplESUljcyAvdtWcrdFrrprC0ndM6ErqxGl3r7A=,tag:6GyG3QiLsRi7/kMBJZxCXA==,type:str]",
+		"lastmodified": "2025-12-15T22:36:30Z",
+		"mac": "ENC[AES256_GCM,data:NVBdFBEACW8ZfNolBWWMSSTHWhVI15PRoRYx75JtYrORyf/P1cp6OdHb1fHda2LBpCQ2fRjfr8yPJy3pILVYdW2LBjvSCmf1iLjXvcw2QfFU7NTjCjghosX6nAPqAitGxr5qVq1DmMYB88Gm9z2htO3L8bSosn6ilpbRYGGv7W0=,iv:ig2L7geyxnBNBRNIZnCPjaJisDc1kNfgFAgV1uGgPW4=,tag:W5edqNnHLuPQ5U8KjephGg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.3"

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -6,7 +6,7 @@ let tuist = Tuist(
         generationOptions: .options(
             optionalAuthentication: true,
             disableSandbox: true,
-            enableCaching: true
+            enableCaching: Environment.enableCaching.getBoolean(default: false)
         ),
         installOptions: .options(
             passthroughSwiftPackageManagerArguments: [


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8916

When we integrated Xcode Cache into the Tuist project, we haven't taken into account that open source contributors don't have access to it. I'm only enabling the Xcode Cache when the mise secrets can be loaded – which includes the CI, except forks.