### PR TITLE
fix(server): add frame-ancestors CSP directive to prevent clickjacking

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -19,6 +19,7 @@ defmodule TuistWeb.Router do
 
   pipeline :content_security_policy do
     plug :put_content_security_policy,
+      frame_ancestors: "'self'",
       img_src:
         "'self' data: https://github.com https://*.githubusercontent.com https://*.gravatar.com https://*.s3.amazonaws.com",
       media_src:


### PR DESCRIPTION
## Summary

- Adds `frame-ancestors: 'self'` to the Content Security Policy

This prevents other websites from embedding tuist.dev pages in iframes, which protects against clickjacking attacks.

Phoenix 1.8 removed `X-Frame-Options` from the default security headers (it was deprecated by browsers in favor of CSP). Our CSP was missing the equivalent `frame-ancestors` directive.

## Test plan

- [x] Verify the header is present: `curl -I https://tuist.dev/users/log_in | grep -i content-security-policy` should include `frame-ancestors 'self'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)