### PR TITLE
fix(cache): compile ruby

### DIFF
--- a/cache/mise.toml
+++ b/cache/mise.toml
@@ -3,3 +3,6 @@ elixir = "1.19.2"
 erlang = "28.1"
 ruby = "3.3.10"
 "gem:kamal" = "2.10.1"
+
+[settings]
+ruby.compile = true


### PR DESCRIPTION
https://github.com/jdx/mise/pull/7263 seems to have broken `gem:kamal` - trying to compile Ruby from source in CI.