### PR TITLE
fix(cache): fix RequestContextPlug compilation in prod environment

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -97,3 +97,26 @@ jobs:
         run: mise run install
       - name: Run tests
         run: mise run test
+
+  compile-prod:
+    name: Compile (prod)
+    runs-on: namespace-profile-default
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Mix Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            cache/deps
+            cache/_build
+          key: cache-mix-${{ hashFiles('cache/mix.lock') }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+          working_directory: cache
+      - name: Install dependencies
+        run: mise run install
+      - name: Compile with MIX_ENV=prod
+        run: MIX_ENV=prod mix compile --warnings-as-errors

--- a/cache/lib/cache_web/plugs/request_context_plug.ex
+++ b/cache/lib/cache_web/plugs/request_context_plug.ex
@@ -9,7 +9,9 @@ defmodule CacheWeb.Plugs.RequestContextPlug do
   @behaviour Plug
 
   def init(opts) do
-    appsignal_active_fn = Keyword.get(opts, :appsignal_active_fn, &appsignal_active?/0)
+    appsignal_active_fn =
+      Keyword.get(opts, :appsignal_active_fn, &__MODULE__.appsignal_active?/0)
+
     %{appsignal_active_fn: appsignal_active_fn}
   end
 
@@ -29,7 +31,8 @@ defmodule CacheWeb.Plugs.RequestContextPlug do
     conn
   end
 
-  defp appsignal_active? do
+  @doc false
+  def appsignal_active? do
     case Application.get_env(:appsignal, :config) do
       nil -> false
       config -> config[:active] || false


### PR DESCRIPTION
## Summary

- Fixes `RequestContextPlug` to compile in `MIX_ENV=prod`
- Adds CI job to compile with `MIX_ENV=prod` to catch similar issues

## Problem

The plug used a local function reference `&appsignal_active?/0` as the default option. Plug's compile-time macro cannot escape local function references - only remote functions in the format `&Mod.fun/arity` are supported.

This only failed in `MIX_ENV=prod` because Phoenix Endpoint fully compiles the plug pipeline in production, but not in dev/test (to support code reloading).

## Solution

1. Changed `&appsignal_active?/0` to `&__MODULE__.appsignal_active?/0` (remote reference)
2. Made the function public with `@doc false`
3. Added a `compile-prod` CI job to catch these issues before deployment

## Test plan

- [x] `MIX_ENV=prod mix compile` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)