### PR TITLE
fix(server): flatten AppSignal custom data for link templates

### DIFF
--- a/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
+++ b/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
@@ -17,13 +17,21 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
       auth_data =
         case TuistWeb.Authentication.authenticated_subject(conn) do
           %User{id: user_id, account: %{id: account_id, name: account_handle}} ->
-            %{user_id: user_id, account_id: account_id, account_handle: account_handle}
+            %{
+              auth_user_id: user_id,
+              auth_account_id: account_id,
+              auth_account_handle: account_handle
+            }
 
           %Project{id: project_id, account: %{id: account_id, name: account_handle}} ->
-            %{project_id: project_id, account_id: account_id, account_handle: account_handle}
+            %{
+              auth_project_id: project_id,
+              auth_account_id: account_id,
+              auth_account_handle: account_handle
+            }
 
           %AuthenticatedAccount{account: %{id: account_id, name: account_handle}} ->
-            %{account_id: account_id, account_handle: account_handle}
+            %{auth_account_id: account_id, auth_account_handle: account_handle}
 
           nil ->
             %{}
@@ -31,25 +39,30 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
 
       selection_data =
         case {conn.assigns[:selected_project], conn.assigns[:selected_account]} do
-          {%{id: project_id, name: project_handle}, %{id: account_id, name: account_handle}} ->
-            %{
-              project_id: project_id,
-              project_name: project_handle,
-              account_id: account_id,
-              account_handle: account_handle
-            }
+          {%{id: project_id, name: project_handle}, %{id: account_id, name: account_handle, customer_id: customer_id}} ->
+            maybe_put(
+              %{
+                selected_project_id: project_id,
+                selected_project_name: project_handle,
+                selected_account_id: account_id,
+                selected_account_handle: account_handle
+              },
+              :selected_account_customer_id,
+              customer_id
+            )
 
-          {_, %{id: account_id, name: account_handle}} ->
-            %{account_id: account_id, account_handle: account_handle}
+          {_, %{id: account_id, name: account_handle, customer_id: customer_id}} ->
+            maybe_put(
+              %{selected_account_id: account_id, selected_account_handle: account_handle},
+              :selected_account_customer_id,
+              customer_id
+            )
 
           _ ->
             %{}
         end
 
-      custom_data =
-        %{}
-        |> maybe_put(:auth, auth_data)
-        |> maybe_put(:selection, selection_data)
+      custom_data = Map.merge(auth_data, selection_data)
 
       set_sample_data(span, "custom_data", custom_data)
     end
@@ -65,6 +78,6 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
     Appsignal.Span.set_sample_data(span, key, data)
   end
 
-  defp maybe_put(map, _key, value) when value == %{}, do: map
+  defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
+++ b/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
@@ -35,11 +35,9 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
 
       expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 auth: %{
-                   user_id: user.id,
-                   account_id: user.account.id,
-                   account_handle: user.account.name
-                 }
+                 auth_user_id: user.id,
+                 auth_account_id: user.account.id,
+                 auth_account_handle: user.account.name
                }
 
         :ok
@@ -63,11 +61,9 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
 
       expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 auth: %{
-                   project_id: project.id,
-                   account_id: project.account.id,
-                   account_handle: project.account.name
-                 }
+                 auth_project_id: project.id,
+                 auth_account_id: project.account.id,
+                 auth_account_handle: project.account.name
                }
 
         :ok
@@ -91,7 +87,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
       expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
-        assert data == %{auth: %{account_id: account.id, account_handle: account.name}}
+        assert data == %{auth_account_id: account.id, auth_account_handle: account.name}
         :ok
       end)
 
@@ -114,17 +110,14 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
 
       expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 auth: %{
-                   user_id: user.id,
-                   account_id: user.account.id,
-                   account_handle: user.account.name
-                 },
-                 selection: %{
-                   project_id: project.id,
-                   project_name: project.name,
-                   account_id: project.account.id,
-                   account_handle: project.account.name
-                 }
+                 auth_user_id: user.id,
+                 auth_account_id: user.account.id,
+                 auth_account_handle: user.account.name,
+                 selected_project_id: project.id,
+                 selected_project_name: project.name,
+                 selected_account_id: project.account.id,
+                 selected_account_handle: project.account.name,
+                 selected_account_customer_id: project.account.customer_id
                }
 
         :ok
@@ -151,12 +144,12 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
 
       expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
         assert data == %{
-                 auth: %{
-                   user_id: user.id,
-                   account_id: user.account.id,
-                   account_handle: user.account.name
-                 },
-                 selection: %{account_id: account.id, account_handle: account.name}
+                 auth_user_id: user.id,
+                 auth_account_id: user.account.id,
+                 auth_account_handle: user.account.name,
+                 selected_account_id: account.id,
+                 selected_account_handle: account.name,
+                 selected_account_customer_id: account.customer_id
                }
 
         :ok


### PR DESCRIPTION
## Summary
- Flatten nested `auth` and `selection` objects in AppSignal custom_data
- Use prefixes (`auth_`, `selected_`) instead of nested structures
- AppSignal link templates don't support nested objects, this change enables proper link template usage

## Test plan
- [x] All existing tests updated and passing
- [x] Verified the flattened structure works with `Map.merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)