### PR TITLE
fix(server): use tags instead of custom_data for AppSignal attribution

### DIFF
--- a/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
+++ b/server/lib/tuist_web/plugs/appsignal_attribution_plug.ex
@@ -43,7 +43,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
             maybe_put(
               %{
                 selected_project_id: project_id,
-                selected_project_name: project_handle,
+                selected_project_handle: project_handle,
                 selected_account_id: account_id,
                 selected_account_handle: account_handle
               },
@@ -62,20 +62,20 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlug do
             %{}
         end
 
-      custom_data = Map.merge(auth_data, selection_data)
+      tags = Map.merge(auth_data, selection_data)
 
-      set_sample_data(span, "custom_data", custom_data)
+      set_tags(span, tags)
     end
 
     conn
   end
 
-  defp set_sample_data(_span, _key, data) when data == %{} do
+  defp set_tags(_span, tags) when tags == %{} do
     :ok
   end
 
-  defp set_sample_data(span, key, data) do
-    Appsignal.Span.set_sample_data(span, key, data)
+  defp set_tags(span, tags) do
+    Appsignal.Span.set_sample_data(span, "tags", tags)
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
+++ b/server/test/tuist_web/plugs/appsignal_attribution_plug_test.exs
@@ -26,14 +26,14 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "sets auth sample data for authenticated user" do
+    test "sets auth tags for authenticated user" do
       user = AccountsFixtures.user_fixture(preload: [:account])
       span = make_ref()
 
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "tags", data ->
         assert data == %{
                  auth_user_id: user.id,
                  auth_account_id: user.account.id,
@@ -52,14 +52,14 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "sets auth sample data for authenticated project" do
+    test "sets auth tags for authenticated project" do
       project = ProjectsFixtures.project_fixture(preload: [:account])
       span = make_ref()
 
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "tags", data ->
         assert data == %{
                  auth_project_id: project.id,
                  auth_account_id: project.account.id,
@@ -78,7 +78,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "sets auth sample data for authenticated account" do
+    test "sets auth tags for authenticated account" do
       account = AccountsFixtures.account_fixture()
       authenticated_account = %AuthenticatedAccount{account: account, scopes: [:registry_read]}
       span = make_ref()
@@ -86,7 +86,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "tags", data ->
         assert data == %{auth_account_id: account.id, auth_account_handle: account.name}
         :ok
       end)
@@ -100,7 +100,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "sets selection sample data for selected project and account" do
+    test "sets selection tags for selected project and account" do
       user = AccountsFixtures.user_fixture(preload: [:account])
       project = ProjectsFixtures.project_fixture(preload: [:account])
       span = make_ref()
@@ -108,13 +108,13 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "tags", data ->
         assert data == %{
                  auth_user_id: user.id,
                  auth_account_id: user.account.id,
                  auth_account_handle: user.account.name,
                  selected_project_id: project.id,
-                 selected_project_name: project.name,
+                 selected_project_handle: project.name,
                  selected_account_id: project.account.id,
                  selected_account_handle: project.account.name,
                  selected_account_customer_id: project.account.customer_id
@@ -134,7 +134,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "sets selection sample data for only selected account" do
+    test "sets selection tags for only selected account" do
       user = AccountsFixtures.user_fixture(preload: [:account])
       account = AccountsFixtures.account_fixture()
       span = make_ref()
@@ -142,7 +142,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)
       stub(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "tags", data ->
         assert data == %{
                  auth_user_id: user.id,
                  auth_account_id: user.account.id,
@@ -165,7 +165,7 @@ defmodule TuistWeb.Plugs.AppsignalAttributionPlugTest do
       assert conn
     end
 
-    test "does not set sample data when no authentication or selection" do
+    test "does not set tags when no authentication or selection" do
       span = make_ref()
 
       stub(Tuist.Environment, :error_tracking_enabled?, fn -> true end)


### PR DESCRIPTION
## Summary
- Changed `AppsignalAttributionPlug` to send data as tags instead of custom_data, since Link Templates in AppSignal don't support custom_data
- Renamed `selected_project_name` to `selected_project_handle` for consistency with other field names

## Test plan
- [x] Existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)