### PR TITLE
chore(ci): enable Xcode cache

### DIFF
--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import TuistAuthentication
 import TuistServer
-// Triggering workflows
 
 #if os(macOS)
     import FluidMenuBarExtra


### PR DESCRIPTION
We had to disable Xcode Cache because the mise path changed. Enabling the Xcode Cache again since a new version of tuist was released with a fix.