### PR TITLE
fix(server): add git merge driver for PO files to avoid rebase conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 CHANGELOG merge=union
+server/priv/gettext/**/*.po merge=merge-gettext-po

--- a/bin/git-merge-po
+++ b/bin/git-merge-po
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Git merge driver for PO files with fallback
+# %O = ancestor, %A = current, %B = other
+
+O="$1"
+A="$2"
+B="$3"
+
+# Try Weblate's driver first (available on Weblate servers)
+if command -v git-merge-gettext-po >/dev/null 2>&1; then
+    exec git-merge-gettext-po "$O" "$A" "$B"
+fi
+
+# Fallback to msgcat if available (brew install gettext)
+if command -v msgcat >/dev/null 2>&1; then
+    msgcat --use-first -o "$A" "$A" "$B" 2>/dev/null && exit 0
+fi
+
+# Final fallback: use Git's built-in merge
+exec git merge-file "$A" "$O" "$B"

--- a/mise/tasks/install.sh
+++ b/mise/tasks/install.sh
@@ -3,6 +3,10 @@
 
 set -eo pipefail
 
+# Configure git merge driver for PO files (fallback for developers without Weblate's driver)
+git config --local merge.merge-gettext-po.name "Gettext PO merge driver"
+git config --local merge.merge-gettext-po.driver "bin/git-merge-po %O %A %B"
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
   if [[ -z "$CI" ]]; then
     tuist install


### PR DESCRIPTION
## Problem

Weblate automatically updates PO file headers whenever translations are modified. These headers include metadata like:

- `PO-Revision-Date` - timestamp of last update
- `Last-Translator` - who made the change
- `X-Generator` - Weblate version
- `Language-Team` - team URL

When developers rebase their branches on main after Weblate has merged translation updates, Git often produces merge conflicts on these header lines - even though the actual translation content has no conflicts.

This is especially frustrating because:
1. The conflicts are purely metadata, not actual translation content
2. They happen frequently since Weblate updates headers on every translation change
3. Resolving them manually is tedious and error-prone

## Solution

This PR configures a custom Git merge driver for PO files that handles these merges intelligently:

**On Weblate servers:** Uses `git-merge-gettext-po`, Weblate's built-in driver that understands PO file structure and merges headers correctly.

**On developer machines:** After running `mise install`, a fallback driver is configured that:
1. Tries `git-merge-gettext-po` if available
2. Falls back to `msgcat` (from gettext) for intelligent PO merging
3. Falls back to Git's standard merge as a last resort

## Changes

- `.gitattributes` - Routes PO files to the `merge-gettext-po` driver
- `bin/git-merge-po` - Fallback script with graceful degradation
- `mise/tasks/install.sh` - Auto-configures the driver for developers

## Test plan

- [ ] Verify Weblate can still merge translation PRs without issues
- [ ] Run `mise install` locally and verify config: `git config --local --get merge.merge-gettext-po.driver`
- [ ] Test rebasing a branch with PO changes on top of main with header modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)