### PR TITLE
fix(server): remove localization from /download link

### DIFF
--- a/server/lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex
+++ b/server/lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex
@@ -156,7 +156,7 @@
           </.link>
           <.link
             data-part="link"
-            href={TuistWeb.Marketing.MarketingHTML.localized_href("/download")}
+            href="/download"
           >
             {dgettext("marketing", "Download")}
           </.link>

--- a/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
+++ b/server/lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex
@@ -87,7 +87,7 @@ developers_items = [
     icon: :download,
     title: dgettext("marketing", "Download"),
     subtitle: dgettext("marketing", "Download our iOS and macOS apps"),
-    href: TuistWeb.Marketing.MarketingHTML.localized_href("/download")
+    href: "/download"
   }
 ]
 


### PR DESCRIPTION
Fixes: https://github.com/tuist/tuist/issues/8941

## Summary
- Removes `localized_href()` wrapper from `/download` links in navbar and footer
- The `/download` route is not localized (it redirects to a GitHub release), so the link was incorrectly pointing to `/ko/download` for Korean users

## Test plan
- [x] Visit the marketing site in Korean locale
- [x] Verify that the Download link in navbar and footer points to `/download` instead of `/ko/download`

🤖 Generated with [Claude Code](https://claude.com/claude-code)