### PR TITLE
fix(server): do not raise when Slack is not configured

### DIFF
--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -33,6 +33,8 @@ defmodule Tuist.Slack do
         {:ok, _} -> :ok
         {:error, reason} -> {:error, reason}
       end
+    else
+      :ok
     end
   end
 


### PR DESCRIPTION
Fixes https://appsignal.com/tuist/sites/66967a1394809a7074e5bc90/exceptions/incidents/317