### PR TITLE
fix(server): handle GitHub 403s when syncing packages

### DIFF
--- a/server/lib/tuist/registry/swift/packages.ex
+++ b/server/lib/tuist/registry/swift/packages.ex
@@ -102,9 +102,12 @@ defmodule Tuist.Registry.Swift.Packages do
            provider: :github,
            token: token
          }) do
-      {:error, {:http_error, 404}} ->
+      {:error, {:http_error, status}} when status in [403, 404] ->
         Logger.debug("Skipping #{scope}/#{name} (#{repository_full_handle}): repository not found or not accessible")
+        []
 
+      {:error, {:http_error, status}} ->
+        Logger.debug("Skipping #{scope}/#{name} (#{repository_full_handle}): HTTP error #{status}")
         []
 
       tags ->


### PR DESCRIPTION
Fixes https://appsignal.com/tuist/sites/66967a1394809a7074e5bc90/exceptions/incidents/320