### PR TITLE
fix(server): force HTTPS clones for submodules

### DIFF
--- a/server/lib/tuist/registry/swift/packages.ex
+++ b/server/lib/tuist/registry/swift/packages.ex
@@ -282,6 +282,8 @@ defmodule Tuist.Registry.Swift.Packages do
     case System.cmd(
            "git",
            [
+             "-c",
+             "url.https://github.com/.insteadOf=git@github.com:",
              "clone",
              "--depth",
              "1",


### PR DESCRIPTION
Fixes https://appsignal.com/tuist/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1106

Our server does not have SSH keys configured - when cloning package submodules that are configured as `ssh://git@github.com`, such as `https://github.com/RevenueCat/purchases-ios-spm`, the clone then fails.
We can force the `git` CLI to override it to HTTPS.