### PR TITLE
feat(handbook): add 2026 6-week cycles calendar

### DIFF
--- a/handbook/handbook/company/6-week-cycles.md
+++ b/handbook/handbook/company/6-week-cycles.md
@@ -65,3 +65,73 @@ With our current company size, most projects will typically involve one full-tim
 - **Week 1:** December 8 - December 14
 - **Week 2:** December 15 - December 21
 - **Week 3:** December 22 - December 31 (extended week to match year-end)
+
+## 2026 Calendar
+
+### 1st Cycle / January 5 - February 15, 2026
+- **Week 1:** January 5 - January 11
+- **Week 2:** January 12 - January 18
+- **Week 3:** January 19 - January 25
+- **Week 4:** January 26 - February 1
+- **Week 5:** February 2 - February 8
+- **Week 6:** February 9 - February 15
+- **Cooldown Week:** February 16 - February 22
+
+### 2nd Cycle / February 23 - April 5, 2026
+- **Week 1:** February 23 - March 1
+- **Week 2:** March 2 - March 8
+- **Week 3:** March 9 - March 15
+- **Week 4:** March 16 - March 22
+- **Week 5:** March 23 - March 29
+- **Week 6:** March 30 - April 5
+- **Cooldown Week:** April 6 - April 12
+
+### 3rd Cycle / April 13 - May 24, 2026
+- **Week 1:** April 13 - April 19
+- **Week 2:** April 20 - April 26
+- **Week 3:** April 27 - May 3
+- **Week 4:** May 4 - May 10
+- **Week 5:** May 11 - May 17
+- **Week 6:** May 18 - May 24
+- **Cooldown Week:** May 25 - May 31
+
+### 4th Cycle / June 1 - July 12, 2026
+- **Week 1:** June 1 - June 7
+- **Week 2:** June 8 - June 14
+- **Week 3:** June 15 - June 21
+- **Week 4:** June 22 - June 28
+- **Week 5:** June 29 - July 5
+- **Week 6:** July 6 - July 12
+- **Cooldown Week:** July 13 - July 19
+
+### 5th Cycle / July 20 - August 30, 2026
+- **Week 1:** July 20 - July 26
+- **Week 2:** July 27 - August 2
+- **Week 3:** August 3 - August 9
+- **Week 4:** August 10 - August 16
+- **Week 5:** August 17 - August 23
+- **Week 6:** August 24 - August 30
+- **Cooldown Week:** August 31 - September 6
+
+### 6th Cycle / September 7 - October 18, 2026
+- **Week 1:** September 7 - September 13
+- **Week 2:** September 14 - September 20
+- **Week 3:** September 21 - September 27
+- **Week 4:** September 28 - October 4
+- **Week 5:** October 5 - October 11
+- **Week 6:** October 12 - October 18
+- **Cooldown Week:** October 19 - October 25
+
+### 7th Cycle / October 26 - December 6, 2026
+- **Week 1:** October 26 - November 1
+- **Week 2:** November 2 - November 8
+- **Week 3:** November 9 - November 15
+- **Week 4:** November 16 - November 22
+- **Week 5:** November 23 - November 29
+- **Week 6:** November 30 - December 6
+- **Cooldown Week:** December 7 - December 13
+
+### 8th Cycle / December 14 - December 31, 2026 (Shortened Cycle)
+- **Week 1:** December 14 - December 20
+- **Week 2:** December 21 - December 27
+- **Week 3:** December 28 - December 31 (extended week to match year-end)


### PR DESCRIPTION
## Summary
- Add the complete 2026 calendar with 8 cycles to the handbook
- Cycles follow the established pattern: 6 working weeks + 1 cooldown week
- Year starts with Cycle 1 on January 5, 2026 (first Monday of the year)
- Year ends with a shortened Cycle 8 (December 14-31)

## Test plan
- [x] Verified handbook builds successfully with `npm run build`
- [x] Review calendar dates for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)