### PR TITLE
refactor(ci): allow multi-scope releases

### DIFF
--- a/app/cliff.toml
+++ b/app/cliff.toml
@@ -89,16 +89,16 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    # Include commits with (app) scope
-    { message = "^feat\\(app\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\(app\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\(app\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\(app\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\(app\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\(app\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\(app\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\(app\\)", skip = true },
-    { message = "^ci\\(app\\)", skip = true },
+    # Include commits with (app) scope (supports multi-scope like "feat(cache,app)")
+    { message = "^feat\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test\\([^)]*\\bapp\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\([^)]*\\bapp\\b[^)]*\\)", skip = true },
+    { message = "^ci\\([^)]*\\bapp\\b[^)]*\\)", skip = true },
     # Skip any other scoped commits
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]

--- a/cli/cliff.toml
+++ b/cli/cliff.toml
@@ -89,16 +89,16 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    # Include commits with (cli) scope
-    { message = "^feat\\(cli\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\(cli\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\(cli\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\(cli\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\(cli\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\(cli\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\(cli\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\(cli\\)", skip = true },
-    { message = "^ci\\(cli\\)", skip = true },
+    # Include commits with (cli) scope (supports multi-scope like "feat(cache,cli)")
+    { message = "^feat\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test\\([^)]*\\bcli\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\([^)]*\\bcli\\b[^)]*\\)", skip = true },
+    { message = "^ci\\([^)]*\\bcli\\b[^)]*\\)", skip = true },
     # Skip any other scoped commits
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]

--- a/server/cliff.toml
+++ b/server/cliff.toml
@@ -89,16 +89,16 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    # Include commits with (server) scope
-    { message = "^feat\\(server\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\(server\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\(server\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\(server\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\(server\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\(server\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\(server\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\(server\\)", skip = true },
-    { message = "^ci\\(server\\)", skip = true },
+    # Include commits with (server) scope (supports multi-scope like "feat(cache,server)")
+    { message = "^feat\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test\\([^)]*\\bserver\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\([^)]*\\bserver\\b[^)]*\\)", skip = true },
+    { message = "^ci\\([^)]*\\bserver\\b[^)]*\\)", skip = true },
     # Skip any other scoped commits
     { message = "^[a-z]+\\([^)]+\\)", skip = true },
 ]


### PR DESCRIPTION
Since moving to a monorepo, a whole bunch of our merges to `main` include changes across different projects; the main one being updates to the API that also include the relevant client updates to the CLI.  
Up until now, releases were only tagged when there was an exact match on a single scope, such as `feat(cli): ...` or `feat(server)`. 
This PR changes the cliff configuration to allow multi-scope PR titles, such as `feat(cache,cli)`.