### PR TITLE
fix(docs): Fix broken link to server license in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,4 +30,4 @@ SOFTWARE.
 
 ## Server Directory
 
-Content in the `server/` directory is licensed under a separate license. See [`server/LICENSE`](server/LICENSE) for details.
+Content in the `server/` directory is licensed under a separate license. See [`server/LICENSE.md`](server/LICENSE.md) for details.


### PR DESCRIPTION
While browsing your repo, I noticed that the link in `LICENSE.md` was broken; it was missing the `.md` suffix.

This pull request fixes it.
 
