### PR TITLE
chore(ci): disable cache releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -592,7 +592,8 @@ jobs:
   release-cache:
     name: Release Cache
     needs: check-releases
-    if: needs.check-releases.outputs.cache-should-release == 'true'
+    # Temporarily disabled: https://github.com/mise-plugins/mise-tuist/pull/3
+    if: false && needs.check-releases.outputs.cache-should-release == 'true'
     runs-on: namespace-profile-default
     timeout-minutes: 30
     env:


### PR DESCRIPTION
Disables cache releases until https://github.com/mise-plugins/mise-tuist/pull/3 is merged and available.