### PR TITLE
feat(cache): add reference docker-compose

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -119,3 +119,12 @@ jobs:
         run: mise run install
       - name: Compile with MIX_ENV=prod
         run: MIX_ENV=prod mix compile --warnings-as-errors
+
+  docker-compose:
+    name: Docker Compose
+    runs-on: namespace-profile-default
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate docker-compose.yml
+        run: docker compose config --quiet

--- a/cache/docker-compose.yml
+++ b/cache/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  cache:
+    image: ghcr.io/tuist/cache
+    container_name: cache-app
+    command: ["/app/bin/cache", "start"]
+    volumes:
+      - cache_socket:/run/cache:rw
+      - cas_data:/cas:rw
+      - sqlite_data:/data:rw
+    environment:
+      PHX_HOST: ${PHX_HOST}
+      PHX_SERVER: "true"
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      SERVER_URL: ${SERVER_URL}
+      CAS_STORAGE_DIR: /cas
+      PHX_SOCKET_PATH: /run/cache/cache.sock
+      PHX_SOCKET_LINK: /run/cache/current.sock
+      S3_BUCKET: ${S3_BUCKET}
+      S3_HOST: ${S3_HOST}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
+      S3_REGION: ${S3_REGION}
+    networks:
+      - cache_network
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    container_name: cache-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      - cache_socket:/run/cache:ro
+      - cas_data:/cas:ro
+    depends_on:
+      - cache
+    networks:
+      - cache_network
+    restart: unless-stopped
+
+volumes:
+  cas_data:
+  sqlite_data:
+  cache_socket:
+
+networks:
+  cache_network:
+    driver: bridge

--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -1,0 +1,112 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    keepalive_requests 10000;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+        '"$request" $status $body_bytes_sent '
+        '"$http_referer" "$http_user_agent" '
+        'rt=$request_time '
+        'uct=$upstream_connect_time '
+        'uht=$upstream_header_time '
+        'urt=$upstream_response_time '
+        'upstream_addr=$upstream_addr '
+        'cache=$upstream_cache_status';
+
+    access_log /var/log/nginx/access.log timed_combined;
+
+    # Localhost-only metrics endpoint
+    server {
+        listen 127.0.0.1:80 default_server;
+        listen [::1]:80 default_server;
+        server_name localhost;
+
+        location = /metrics {
+            proxy_pass http://unix:/run/cache/current.sock:/metrics;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+        }
+    }
+
+    # Main server
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name _;
+
+        client_max_body_size 0;
+        client_body_timeout 30m;
+
+        location /metrics {
+            return 404;
+        }
+
+        location / {
+            proxy_pass http://unix:/run/cache/current.sock:/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header Host $host;
+
+            proxy_connect_timeout 30m;
+            proxy_send_timeout 30m;
+            proxy_read_timeout 30m;
+            send_timeout 30m;
+
+            proxy_buffering off;
+            proxy_request_buffering off;
+        }
+
+        location /internal/local/ {
+            internal;
+            alias /cas/;
+            default_type application/octet-stream;
+            gzip off;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        location ~ ^/internal/remote/(.*?)/(.*?)/(.*) {
+            internal;
+            resolver 1.1.1.1 ipv6=off;
+            set $download_url $1://$2/$3;
+            proxy_set_header Host $2;
+            proxy_pass $download_url$is_args$args;
+            proxy_request_buffering off;
+            proxy_buffering off;
+            proxy_intercept_errors on;
+            error_page 301 302 307 = @handle_remote_redirect;
+        }
+
+        location @handle_remote_redirect {
+            set $saved_redirect_location $upstream_http_location;
+            proxy_pass $saved_redirect_location;
+        }
+    }
+}


### PR DESCRIPTION
depends on #8990 

adds a docker-compose and nginx configuration that allows spinning up a cache node with one `docker-compose up`
will need some more testing but good to merge for now