### PR TITLE
fix(docs): remove deprecated tuist build command mentions

### DIFF
--- a/docs/docs/en/guides/features/cache/module-cache.md
+++ b/docs/docs/en/guides/features/cache/module-cache.md
@@ -136,7 +136,7 @@ The following are some examples of common workflows:
 
 ### A developer pushes changes upstream {#a-developer-pushes-changes-upstream}
 
-1. The CI pipeline will run `tuist build` or `tuist test` to build or test the project.
+1. The CI pipeline will run `xcodebuild build` or `tuist test` to build or test the project.
 2. The workflow will pull the most recent binaries from `main` and generate the project with them.
 3. It will then build or test the project incrementally.
 

--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -27,8 +27,9 @@ When building for device, it is currently your responsibility to ensure the app 
 
 ::: code-group
 ```bash [Tuist Project]
-tuist build App # Build the app for the simulator
-tuist build App -- -destination 'generic/platform=iOS' # Build the app for the device
+tuist generate App
+xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -sdk iphonesimulator # Build the app for the simulator
+xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App
 ```
 ```bash [Xcode Project]

--- a/docs/docs/en/guides/features/projects/adoption/migrate/xcode-project.md
+++ b/docs/docs/en/guides/features/projects/adoption/migrate/xcode-project.md
@@ -80,7 +80,7 @@ To ensure the migration of each change is valid, we recommend extending your con
 ```bash
 tuist install
 tuist generate
-tuist build -- ...{xcodebuild flags} # or tuist test
+xcodebuild build {xcodebuild flags} # or tuist test
 ```
 
 ## Extract the project build settings into `.xcconfig` files {#extract-the-project-build-settings-into-xcconfig-files}
@@ -218,11 +218,11 @@ If the target has an associated test target, you should define it in the `Projec
 
 ### Validate the target migration {#validate-the-target-migration}
 
-Run `tuist build` and `tuist test` to ensure the project builds and tests pass. Additionally, you can use [xcdiff](https://github.com/bloomberg/xcdiff) to compare the generated Xcode project with the existing one to ensure that the changes are correct.
+Run `tuist generate` followed by `xcodebuild build` to ensure the project builds, and `tuist test` to ensure the tests pass. Additionally, you can use [xcdiff](https://github.com/bloomberg/xcdiff) to compare the generated Xcode project with the existing one to ensure that the changes are correct.
 
 ### Repeat {#repeat}
 
-Repeat until all the targets are fully migrated. Once you are done, we recommend updating your CI and CD pipelines to build and test the project using `tuist build` and `tuist test` commands to benefit from the speed and reliability that Tuist provides.
+Repeat until all the targets are fully migrated. Once you are done, we recommend updating your CI and CD pipelines to build and test the project using `tuist generate` followed by `xcodebuild build` and `tuist test`.
 
 ## Troubleshooting {#troubleshooting}
 

--- a/docs/docs/en/guides/features/projects/dependencies.md
+++ b/docs/docs/en/guides/features/projects/dependencies.md
@@ -265,7 +265,7 @@ tuist generate
 
 ::: warning BUILD AND TEST
 <!-- -->
-If you build and test your project through `tuist build` and `tuist test`, you will similarly need to ensure that the Carthage-resolved dependencies are present by running the `carthage update` command before `tuist build` or `tuist test` are run.
+If you build and test your project through `xcodebuild build` and `tuist test`, you will similarly need to ensure that the Carthage-resolved dependencies are present by running the `carthage update` command before building or testing.
 <!-- -->
 :::
 


### PR DESCRIPTION
## Summary
- Remove references to deprecated `tuist build` command from documentation
- Replace with recommended workflow: `tuist generate` + `xcodebuild build`
- Keep `tuist test` for testing workflows

## Test plan
- [x] Verify documentation renders correctly
- [x] Confirm all `tuist build` references have been replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)