### PR TITLE
fix(server): truncate DateTime microseconds for ClickHouse compatibility

### DIFF
--- a/server/lib/tuist_web/helpers/date_picker.ex
+++ b/server/lib/tuist_web/helpers/date_picker.ex
@@ -42,7 +42,7 @@ defmodule TuistWeb.Helpers.DatePicker do
     preset = params[range_key] || default_preset
 
     if preset == "custom" do
-      now = DateTime.utc_now()
+      now = truncate_microseconds(DateTime.utc_now())
       start_datetime = parse_custom_datetime(params[start_key]) || DateTime.add(now, -default_days, :day)
       end_datetime = parse_custom_datetime(params[end_key]) || now
 
@@ -53,7 +53,7 @@ defmodule TuistWeb.Helpers.DatePicker do
   end
 
   defp period_for_preset(preset) do
-    now = DateTime.utc_now()
+    now = truncate_microseconds(DateTime.utc_now())
 
     start_datetime =
       case preset do
@@ -71,8 +71,12 @@ defmodule TuistWeb.Helpers.DatePicker do
 
   defp parse_custom_datetime(datetime_string) when is_binary(datetime_string) do
     case DateTime.from_iso8601(datetime_string) do
-      {:ok, datetime, _offset} -> datetime
+      {:ok, datetime, _offset} -> truncate_microseconds(datetime)
       {:error, _} -> nil
     end
+  end
+
+  defp truncate_microseconds(datetime) do
+    %{datetime | microsecond: {0, 0}}
   end
 end

--- a/server/test/tuist_web/helpers/date_picker_test.exs
+++ b/server/test/tuist_web/helpers/date_picker_test.exs
@@ -1,0 +1,102 @@
+defmodule TuistWeb.Helpers.DatePickerTest do
+  use ExUnit.Case, async: true
+
+  alias TuistWeb.Helpers.DatePicker
+
+  describe "date_picker_params/3" do
+    test "returns DateTime values without microseconds for default preset" do
+      # Given
+      params = %{}
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then - DateTimes should have no microseconds to be compatible with ClickHouse DateTime type
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds for last-24-hours preset" do
+      # Given
+      params = %{"analytics-date-range" => "last-24-hours"}
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds for last-7-days preset" do
+      # Given
+      params = %{"analytics-date-range" => "last-7-days"}
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds for last-12-months preset" do
+      # Given
+      params = %{"analytics-date-range" => "last-12-months"}
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds for custom date range" do
+      # Given
+      params = %{
+        "analytics-date-range" => "custom",
+        "analytics-start-date" => "2024-01-01T00:00:00Z",
+        "analytics-end-date" => "2024-01-31T23:59:59Z"
+      }
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds when custom dates include microseconds" do
+      # Given - ISO8601 with microseconds
+      params = %{
+        "analytics-date-range" => "custom",
+        "analytics-start-date" => "2024-01-01T00:00:00.123456Z",
+        "analytics-end-date" => "2024-01-31T23:59:59.654321Z"
+      }
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then - microseconds should be truncated
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+
+    test "returns DateTime values without microseconds when custom start date is missing" do
+      # Given - missing start date should use fallback
+      params = %{
+        "analytics-date-range" => "custom",
+        "analytics-end-date" => "2024-01-31T23:59:59Z"
+      }
+
+      # When
+      %{period: {start_datetime, end_datetime}} = DatePicker.date_picker_params(params, "analytics")
+
+      # Then
+      assert start_datetime.microsecond == {0, 0}
+      assert end_datetime.microsecond == {0, 0}
+    end
+  end
+end

--- a/server/test/tuist_web/live/xcode_cache_live_test.exs
+++ b/server/test/tuist_web/live/xcode_cache_live_test.exs
@@ -2,11 +2,8 @@ defmodule TuistWeb.XcodeCacheLiveTest do
   use TuistTestSupport.Cases.ConnCase, async: false
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
-  use Mimic
 
   import Phoenix.LiveViewTest
-
-  alias Tuist.Runs.Analytics
 
   describe "xcode cache page" do
     test "displays analytics widgets", %{
@@ -14,21 +11,8 @@ defmodule TuistWeb.XcodeCacheLiveTest do
       organization: organization,
       project: project
     } do
-      stub(Analytics, :combined_cache_analytics, fn _, _ ->
-        [
-          %{dates: ["2024-01-01"], values: [1000], total_size: 1000, trend: 10.0},
-          %{dates: ["2024-01-01"], values: [5000], total_size: 5000, trend: 20.0},
-          %{dates: ["2024-01-01"], values: [75.5], avg_hit_rate: 75.5, trend: 5.0},
-          %{dates: ["2024-01-01"], values: [80.0], total_percentile_hit_rate: 80.0, trend: 3.0},
-          %{dates: ["2024-01-01"], values: [78.0], total_percentile_hit_rate: 78.0, trend: 4.0},
-          %{dates: ["2024-01-01"], values: [70.0], total_percentile_hit_rate: 70.0, trend: 6.0}
-        ]
-      end)
-
-      # When
       {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/xcode-cache")
 
-      # Then
       assert has_element?(lv, "#widget-cache-uploads")
       assert has_element?(lv, "#widget-cache-downloads")
       assert has_element?(lv, "#widget-cache-hit-rate")


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8993

## Summary
- Fixed a bug where the Xcode Cache page crashed with ClickHouse `BAD_QUERY_PARAMETER` error code 457
- `DateTime.utc_now()` returns values with microseconds (e.g., `1763830957.763915`) which ClickHouse's `DateTime` type cannot parse (only `DateTime64` can)
- Added `truncate_microseconds/1` helper in `DatePicker` to strip microseconds before passing to analytics queries

## Test plan
- [x] Added unit tests for `DatePicker` verifying DateTime values have no microseconds
- [x] Updated `XcodeCacheLiveTest` to exercise real ClickHouse queries (no longer stubs Analytics)
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)