### PR TITLE
chore(ci): correct cache paths in server CI workflow

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -47,10 +47,11 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         id: pnpm-cache
@@ -110,10 +111,11 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         id: pnpm-cache
@@ -262,10 +264,11 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         id: pnpm-cache
@@ -294,12 +297,13 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: |
@@ -323,12 +327,13 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: |
@@ -353,10 +358,11 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         id: pnpm-cache
@@ -399,12 +405,13 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: |
@@ -427,16 +434,17 @@ jobs:
         with:
           submodules: false
       - name: Restore Mix Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pnpm-cache
         with:
           path: |
@@ -543,10 +551,11 @@ jobs:
         id: mix-cache
         with:
           path: |
-            deps
-            _build
-            _site
-          key: mix-${{ hashFiles('mix.lock') }}
+            server/deps
+            server/_build
+          key: mix-${{ hashFiles('server/mix.lock') }}
+          restore-keys: |
+            mix-
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         id: pnpm-cache


### PR DESCRIPTION
## Summary
- Fixes broken Mix cache configuration in server workflow
- Cache paths were pointing to repo root instead of `server/` directory
- Hash key was using non-existent `mix.lock` instead of `server/mix.lock`
- Upgrades all cache actions to v4 and adds `restore-keys` for partial cache hits

## Context
The Elixir compilation cache was never working because:
1. `hashFiles('mix.lock')` returned empty (file is at `server/mix.lock`)
2. Cache paths `deps`, `_build` resolved to repo root, not `server/deps`, `server/_build`

This caused every CI run to recompile Elixir from scratch, adding ~1-2 minutes to each job.

## Test plan
- [x] Verify first run creates cache entries with `mix-*` prefix
- [x] Verify subsequent runs show cache hits in "Restore Mix Cache" step
- [x] Observe reduced job times (especially Test, Credo, Format, Security jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)