### PR TITLE
chore(server): Fix the changelog page layout on mobile

### DIFF
--- a/server/assets/marketing/css/routes/changelog.css
+++ b/server/assets/marketing/css/routes/changelog.css
@@ -1,8 +1,8 @@
 #marketing-changelog {
   display: flex;
   flex-direction: column;
-  padding-bottom: var(--noora-spacing-12);
   gap: var(--noora-spacing-9);
+  padding-bottom: var(--noora-spacing-12);
 
   @media (min-width: 1024px) {
     gap: var(--noora-spacing-11);
@@ -17,13 +17,12 @@
     align-self: stretch;
     gap: var(--noora-spacing-7);
 
-
     @media (min-width: 1024px) {
-      padding-top: var(--noora-spacing-12);
-      padding-bottom: var(--noora-spacing-8);
       flex-direction: row;
       align-items: flex-end;
+      padding-top: var(--noora-spacing-12);
       padding-right: calc(var(--noora-spacing-6) + var(--noora-spacing-6));
+      padding-bottom: var(--noora-spacing-8);
       padding-left: calc(var(--noora-spacing-6) + var(--noora-spacing-6));
     }
 


### PR DESCRIPTION
The spacing between elements in the changelog page was not aligned with the design for small viewports.

### Before

<img width="332" height="720" alt="image" src="https://github.com/user-attachments/assets/060fda7e-95ad-41d9-8f17-66e991dce454" />
 

### After

<img width="385" height="704" alt="image" src="https://github.com/user-attachments/assets/e2244066-654b-4cdd-a657-82fd9d299e5d" />
