### PR TITLE
feat(cli): Support addition Path and String

### DIFF
--- a/cli/Sources/ProjectDescription/Path.swift
+++ b/cli/Sources/ProjectDescription/Path.swift
@@ -55,3 +55,8 @@ public struct Path: ExpressibleByStringInterpolation, Codable, Hashable, Sendabl
         }
     }
 }
+
+/// for xcconfig: .extensions.widget + "/Configs/debug.xcconfig")
+public func + (lhs: Path, rhs: Path) -> Path {
+    .path("\(lhs.pathString)\(rhs.pathString)")
+}

--- a/cli/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/cli/Sources/ProjectDescription/ResourceFileElements.swift
@@ -22,3 +22,13 @@ extension ResourceFileElements: ExpressibleByArrayLiteral {
         self.init(resources: elements)
     }
 }
+
+/// for resources: [.extensions.widget + "/Resources/**"]
+public func + (lhs: Path, rhs: String) -> ResourceFileElement {
+    .init(stringLiteral: "\(lhs.pathString)\(rhs)")
+}
+
+/// for resources: .extensions.widget + "/Resources/**"
+public func + (lhs: Path, rhs: String) -> ResourceFileElements {
+    .init(stringLiteral: "\(lhs.pathString)\(rhs)")
+}

--- a/cli/Sources/ProjectDescription/SourceFilesList.swift
+++ b/cli/Sources/ProjectDescription/SourceFilesList.swift
@@ -152,3 +152,13 @@ extension SourceFilesList: ExpressibleByArrayLiteral {
         self.init(globs: elements)
     }
 }
+
+/// for sources: [.extensions.widget + "/Sources/**"]
+public func + (lhs: Path, rhs: String) -> SourceFileGlob {
+    .init(stringLiteral: "\(lhs.pathString)\(rhs)")
+}
+
+/// for sources: .extensions.widget + "/Sources/**"
+public func + (lhs: Path, rhs: String) -> SourceFilesList {
+    .init(stringLiteral: "\(lhs.pathString)\(rhs)")
+}


### PR DESCRIPTION
# Support Addition Path and String
## When
```swift
public extension Path {
    static var extensions: Extensions { Extensions() }
    
    struct Extensions {
        public var widget: Path { .relativeToCurrentFile("Extensions/Widget") }
    }
}
```

## For Source List
```swift
sources: .extensions.widget + "/Sources/**",
```
```swift
sources: [.extensions.widget + "/Sources/**"],
```

## For Resource List
```swift
resources: .extensions.widget + "/Resources/**",
```
```swift
resources: [.extensions.widget + "/Resources/**"],
```

## For Config
```swift
xcconfig: .extensions.widget + "/Configs/debug.xcconfig"),
```

# How to test locally
Build Minifests with

```swift
sources: .extensions.widget + "/Sources/**",
            resources: .extensions.widget + "/Resources/**",
            dependencies: [],
            settings: .settings(configurations: [
                .debug(
                    name: "Debug",
                    xcconfig: .extensions.widget + "/Configs/debug.xcconfig"),
                .release(
                    name: "Release",
                    xcconfig: .extensions.widget + "/Configs/release.xcconfig")
            ])
```

I don't know where I have to put the test code.
