### PR TITLE
Fix Sparkle appcast tool path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,16 +436,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Generate Sparkle appcast
-        run: |
-          SPARKLE_GENERATE_APPCAST=".build/artifacts/sparkle/Sparkle/bin/generate_appcast"
-          if [ ! -x "$SPARKLE_GENERATE_APPCAST" ]; then
-            SPARKLE_GENERATE_APPCAST=".build/artifacts/sparkle-project.Sparkle/Sparkle/bin/generate_appcast"
-          fi
-          if [ ! -x "$SPARKLE_GENERATE_APPCAST" ]; then
-            echo "generate_appcast not found in .build or DerivedData artifacts" >&2
-            exit 1
-          fi
-          op read "op://tuist/Tuist App Private Sparkle Key/credential" | "$SPARKLE_GENERATE_APPCAST" --link https://github.com/tuist/tuist/releases --download-url-prefix https://github.com/tuist/tuist/releases/download/${{ needs.check-releases.outputs.app-next-version }}/Tuist.dmg -o app/appcast.xml app/build/artifacts --ed-key-file -
+        run: op read "op://tuist/Tuist App Private Sparkle Key/credential" | .build/artifacts/sparkle-project.Sparkle/Sparkle/bin/generate_appcast --link https://github.com/tuist/tuist/releases --download-url-prefix https://github.com/tuist/tuist/releases/download/${{ needs.check-releases.outputs.app-next-version }}/Tuist.dmg -o app/appcast.xml app/build/artifacts --ed-key-file -
 
       - name: Upload App artifacts
         id: upload


### PR DESCRIPTION
## Why
The release workflow expected the Sparkle appcast generator under .build/artifacts/sparkle/..., but after switching to the Tuist registry the artifacts live under .build/artifacts/sparkle-project.Sparkle/.... This caused the appcast step to fail.

## What
- Add fallback paths for both Sparkle artifact layouts (old and new) and DerivedData in the release workflow.

## Testing
- Not run (workflow change).