### PR TITLE
fix(cli): add missing tuist install step in release-ios job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,9 @@ jobs:
           VERSION_NUMBER="${VERSION_NUMBER#app@}"
           sed -i '' -e "s/CFBundleShortVersionString.*/CFBundleShortVersionString\": \"$VERSION_NUMBER\",/g" "Project.swift"
           sed -i '' -e "s/CFBundleVersion.*/CFBundleVersion\": \"${{ github.run_number }}\",/g" "Project.swift"
+      - name: Install Tuist dependencies
+        if: steps.cache-restore.outputs.cache-matched-key == ''
+        run: tuist install
       - name: Generate TuistApp
         run: mise x -- tuist generate TuistApp --no-binary-cache
       - name: Upload iOS App to App Store Connect


### PR DESCRIPTION
The release-ios job in the release workflow was failing because it tried to run `tuist generate` without first installing external dependencies. This adds the missing `tuist install` step, following the same conditional pattern used in other jobs where it only runs if the cache wasn't restored.

Fixes the error: "We could not find external dependencies. Run tuist install before you continue."