### PR TITLE
fix(cache,server): don't log http timeouts

### DIFF
--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -11,6 +11,7 @@ defmodule Cache.Application do
 
     Cache.Telemetry.attach()
     Oban.Telemetry.attach_default_logger()
+    attach_appsignal_error_filter()
 
     children = [
       Cache.PromEx,
@@ -36,6 +37,13 @@ defmodule Cache.Application do
     for repo <- repos do
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
+  end
+
+  defp attach_appsignal_error_filter do
+    :logger.add_primary_filter(
+      :appsignal_error_filter,
+      {&Cache.Appsignal.ErrorFilter.filter/2, []}
+    )
   end
 
   @impl true

--- a/cache/lib/cache/appsignal/error_filter.ex
+++ b/cache/lib/cache/appsignal/error_filter.ex
@@ -1,0 +1,32 @@
+defmodule Cache.Appsignal.ErrorFilter do
+  @moduledoc """
+  A Logger filter that prevents specific expected errors from being reported to AppSignal.
+
+  This filter intercepts log messages before they reach AppSignal's Error Backend and
+  drops errors that are expected and not actionable, such as client disconnections
+  during body reads.
+
+  ## Filtered Errors
+
+  - `Bandit.HTTPError` with message "Body read timeout" - occurs when clients
+    interrupt uploads, which is expected behavior and not actionable.
+  """
+
+  @doc """
+  Logger filter function that drops expected Bandit errors.
+
+  Returns `:stop` to prevent the log message from being processed further,
+  or `:ignore` to allow it through.
+  """
+  @spec filter(:logger.log_event(), term()) :: :stop | :ignore
+  def filter(%{meta: %{crash_reason: {%Bandit.HTTPError{message: message}, _stacktrace}}}, _opts)
+      when is_binary(message) do
+    if String.contains?(message, "Body read timeout") do
+      :stop
+    else
+      :ignore
+    end
+  end
+
+  def filter(_log_event, _opts), do: :ignore
+end

--- a/cache/test/cache/appsignal/error_filter_test.exs
+++ b/cache/test/cache/appsignal/error_filter_test.exs
@@ -1,0 +1,91 @@
+defmodule Cache.Appsignal.ErrorFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Cache.Appsignal.ErrorFilter
+
+  describe "filter/2" do
+    test "stops Bandit.HTTPError with 'Body read timeout' message" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Body read timeout", plug_status: 408},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :stop
+    end
+
+    test "stops Bandit.HTTPError with message containing 'Body read timeout'" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Body read timeout after 30s", plug_status: 408},
+            [{:some_module, :some_function, 1, []}]
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :stop
+    end
+
+    test "ignores Bandit.HTTPError with other messages" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Connection reset by peer", plug_status: 500},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events without crash_reason in meta" do
+      log_event = %{
+        meta: %{
+          some_other_key: "value"
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with empty meta" do
+      log_event = %{meta: %{}}
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with non-Bandit crash reasons" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %RuntimeError{message: "some error"},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with atom crash reasons" do
+      log_event = %{
+        meta: %{
+          crash_reason: {:some_atom, []}
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores arbitrary log events" do
+      assert ErrorFilter.filter(%{level: :info, msg: "hello"}, []) == :ignore
+      assert ErrorFilter.filter(:some_atom, []) == :ignore
+      assert ErrorFilter.filter(nil, []) == :ignore
+    end
+  end
+end

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -111,6 +111,7 @@ defmodule Tuist do
       VCS,
       UUIDv7,
       OAuth.Apple,
-      OAuth.Okta
+      OAuth.Okta,
+      Appsignal.ErrorFilter
     ]
 end

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -57,6 +57,11 @@ defmodule Tuist.Application do
   defp start_error_tracking do
     run_if_error_tracking_enabled do
       Appsignal.Phoenix.LiveView.attach()
+
+      :logger.add_primary_filter(
+        :appsignal_error_filter,
+        {&Tuist.Appsignal.ErrorFilter.filter/2, []}
+      )
     end
   end
 

--- a/server/lib/tuist/appsignal/error_filter.ex
+++ b/server/lib/tuist/appsignal/error_filter.ex
@@ -1,0 +1,32 @@
+defmodule Tuist.Appsignal.ErrorFilter do
+  @moduledoc """
+  A Logger filter that prevents specific expected errors from being reported to AppSignal.
+
+  This filter intercepts log messages before they reach AppSignal's Error Backend and
+  drops errors that are expected and not actionable, such as client disconnections
+  during body reads.
+
+  ## Filtered Errors
+
+  - `Bandit.HTTPError` with message "Body read timeout" - occurs when clients
+    interrupt uploads, which is expected behavior and not actionable.
+  """
+
+  @doc """
+  Logger filter function that drops expected Bandit errors.
+
+  Returns `:stop` to prevent the log message from being processed further,
+  or `:ignore` to allow it through.
+  """
+  @spec filter(:logger.log_event(), term()) :: :stop | :ignore
+  def filter(%{meta: %{crash_reason: {%Bandit.HTTPError{message: message}, _stacktrace}}}, _opts)
+      when is_binary(message) do
+    if String.contains?(message, "Body read timeout") do
+      :stop
+    else
+      :ignore
+    end
+  end
+
+  def filter(_log_event, _opts), do: :ignore
+end

--- a/server/test/tuist/appsignal/error_filter_test.exs
+++ b/server/test/tuist/appsignal/error_filter_test.exs
@@ -1,0 +1,91 @@
+defmodule Tuist.Appsignal.ErrorFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Appsignal.ErrorFilter
+
+  describe "filter/2" do
+    test "stops Bandit.HTTPError with 'Body read timeout' message" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Body read timeout", plug_status: 408},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :stop
+    end
+
+    test "stops Bandit.HTTPError with message containing 'Body read timeout'" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Body read timeout after 30s", plug_status: 408},
+            [{:some_module, :some_function, 1, []}]
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :stop
+    end
+
+    test "ignores Bandit.HTTPError with other messages" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %Bandit.HTTPError{message: "Connection reset by peer", plug_status: 500},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events without crash_reason in meta" do
+      log_event = %{
+        meta: %{
+          some_other_key: "value"
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with empty meta" do
+      log_event = %{meta: %{}}
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with non-Bandit crash reasons" do
+      log_event = %{
+        meta: %{
+          crash_reason: {
+            %RuntimeError{message: "some error"},
+            []
+          }
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores log events with atom crash reasons" do
+      log_event = %{
+        meta: %{
+          crash_reason: {:some_atom, []}
+        }
+      }
+
+      assert ErrorFilter.filter(log_event, []) == :ignore
+    end
+
+    test "ignores arbitrary log events" do
+      assert ErrorFilter.filter(%{level: :info, msg: "hello"}, []) == :ignore
+      assert ErrorFilter.filter(:some_atom, []) == :ignore
+      assert ErrorFilter.filter(nil, []) == :ignore
+    end
+  end
+end


### PR DESCRIPTION
This should block exceptions with Body read timeout from reaching AppSignal. These are expected from clients cancelling uploads.