### PR TITLE
fix(server,cache): use valid AppSignal sample data key for request context

### DIFF
--- a/cache/lib/cache_web/plugs/request_context_plug.ex
+++ b/cache/lib/cache_web/plugs/request_context_plug.ex
@@ -20,10 +20,10 @@ defmodule CacheWeb.Plugs.RequestContextPlug do
       span = Appsignal.Tracer.root_span()
 
       if span do
-        Appsignal.Span.set_sample_data(span, "request_context", %{
-          path: conn.request_path,
-          method: conn.method,
-          query_string: conn.query_string
+        Appsignal.Span.set_sample_data(span, "custom_data", %{
+          request_path: conn.request_path,
+          request_method: conn.method,
+          request_query_string: conn.query_string
         })
       end
     end

--- a/cache/test/cache_web/plugs/request_context_plug_test.exs
+++ b/cache/test/cache_web/plugs/request_context_plug_test.exs
@@ -13,10 +13,10 @@ defmodule CacheWeb.Plugs.RequestContextPlugTest do
       span = %{}
       expect(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "request_context", data ->
-        assert data.path == "/cas/abc123"
-        assert data.method == "GET"
-        assert data.query_string == ""
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+        assert data.request_path == "/cas/abc123"
+        assert data.request_method == "GET"
+        assert data.request_query_string == ""
         :ok
       end)
 

--- a/server/lib/tuist_web/plugs/request_context_plug.ex
+++ b/server/lib/tuist_web/plugs/request_context_plug.ex
@@ -20,10 +20,10 @@ defmodule TuistWeb.Plugs.RequestContextPlug do
       span = Appsignal.Tracer.root_span()
 
       if span do
-        Appsignal.Span.set_sample_data(span, "request_context", %{
-          path: conn.request_path,
-          method: conn.method,
-          query_string: conn.query_string
+        Appsignal.Span.set_sample_data(span, "custom_data", %{
+          request_path: conn.request_path,
+          request_method: conn.method,
+          request_query_string: conn.query_string
         })
       end
     end

--- a/server/test/tuist_web/plugs/request_context_plug_test.exs
+++ b/server/test/tuist_web/plugs/request_context_plug_test.exs
@@ -13,10 +13,10 @@ defmodule TuistWeb.Plugs.RequestContextPlugTest do
       span = %{}
       expect(Appsignal.Tracer, :root_span, fn -> span end)
 
-      expect(Appsignal.Span, :set_sample_data, fn ^span, "request_context", data ->
-        assert data.path == "/api/projects"
-        assert data.method == "GET"
-        assert data.query_string == "foo=bar"
+      expect(Appsignal.Span, :set_sample_data, fn ^span, "custom_data", data ->
+        assert data.request_path == "/api/projects"
+        assert data.request_method == "GET"
+        assert data.request_query_string == "foo=bar"
         :ok
       end)
 


### PR DESCRIPTION
## Summary

The `RequestContextPlug` was using `"request_context"` as the key for `Appsignal.Span.set_sample_data`, but this is not a valid key. AppSignal only recognizes specific keys (`tags`, `custom_data`, `params`, `session_data`, `request_headers`), and invalid keys are silently ignored - which is why the context wasn't showing up in error reports.

Changed to use `"custom_data"` which is the appropriate key for additional debugging information. After this fix, request path, method, and query string will appear in the "Custom data" section of AppSignal incident samples.