### PR TITLE
fix(server): handle invalid page parameter in blog pagination

### DIFF
--- a/server/lib/tuist_web/marketing/live/marketing_blog_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_blog_live.ex
@@ -39,7 +39,12 @@ defmodule TuistWeb.Marketing.MarketingBlogLive do
     all_entries = Content.get_entries()
     search_query = Map.get(params, "search", "")
     category = Map.get(params, "category")
-    page = params |> Map.get("page", "1") |> String.to_integer()
+
+    page =
+      case Integer.parse(Map.get(params, "page", "1")) do
+        {num, ""} when num > 0 -> num
+        _ -> 1
+      end
 
     # Check if page changed (for scroll behavior)
     previous_page = Map.get(socket.assigns, :current_page, 1)

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -876,7 +876,7 @@ msgstr ""
 msgid "QA"
 msgstr ""
 
-#: lib/tuist_web/marketing/live/marketing_blog_live.ex:107
+#: lib/tuist_web/marketing/live/marketing_blog_live.ex:112
 #: lib/tuist_web/marketing/structured_markup.ex:186
 #, elixir-autogen, elixir-format
 msgid "Read engaging stories and expert insights."


### PR DESCRIPTION
[AppSignal error](https://appsignal.com/tuist/sites/6607b64d83eb6789e61c8ba7/exceptions/incidents/1394/samples/timestamp/2026-01-04T09:48:00Z)

The blog page was crashing when users manually entered invalid values in the `page` query parameter. This happened because `String.to_integer/1` raises an `ArgumentError` for non-numeric strings.

This switches to using `Integer.parse/1` which safely handles invalid input, falling back to page 1 for any malformed values.