### PR TITLE
fix(server): filter out non-semantic versions in registry ingestion

### DIFF
--- a/server/lib/tuist/registry/swift/packages.ex
+++ b/server/lib/tuist/registry/swift/packages.ex
@@ -117,7 +117,11 @@ defmodule Tuist.Registry.Swift.Packages do
           # Matches semantic version as per: https://semver.org/
           # Examples: 1.0.0, 1.0.0-alpha, 1.0.0-alpha.1, 1.1
           # Skip dev versions like 0.9.3-dev1985
-          Regex.match?(~r/^v?\d+\.\d+(\.\d+)?[0-9A-Za-z-]*(\.[0-9A-Za-z]*)?$/, version) and
+          # Skip non-semantic versions like 3.2.0.1 (four-part versions)
+          Regex.match?(
+            ~r/^v?\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/,
+            version
+          ) and
             not Regex.match?(~r/-dev/, version) and
             not Enum.any?(package.package_releases, &(&1.version == semantic_version(version)))
         end)


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/8884

As a follow-up to this PR, we should purge package releases with this invalid version format from the database.

## Summary
- Fixed a bug where the Swift package registry was accepting non-semantic versions like `3.2.0.1` and `6.5.0.0`
- Updated the version validation regex to properly follow [semver spec](https://semver.org/)
- Pre-release identifiers must now start with `-` (e.g., `1.0.0-alpha`)
- Build metadata must now start with `+` (e.g., `1.0.0+build.123`)

## Test plan
- [x] Added test case verifying that versions like `3.2.0.1`, `6.5.0.0`, and `1.2.3.4.5` are filtered out
- [x] Verified valid versions like `7.2.1` and `v7.2.0` still pass through
- [x] All existing tests pass (26 tests in packages_test.exs)

Closes #8884

🤖 Generated with [Claude Code](https://claude.com/claude-code)