### PR TITLE
fix(cache): fix oban credential evaluation

### DIFF
--- a/cache/lib/cache/config.ex
+++ b/cache/lib/cache/config.ex
@@ -42,13 +42,17 @@ defmodule Cache.Config do
   end
 
   def oban_dashboard_enabled? do
-    case Application.get_env(:cache, :oban_web_basic_auth) do
+    case oban_web_credentials() do
       [username: u, password: p] when is_binary(u) and u != "" and is_binary(p) and p != "" ->
         true
 
       _ ->
         false
     end
+  end
+
+  def oban_web_credentials do
+    Application.get_env(:cache, :oban_web_basic_auth, [])
   end
 
   defp parse_float(nil, default), do: default

--- a/cache/lib/cache_web/plugs/oban_auth.ex
+++ b/cache/lib/cache_web/plugs/oban_auth.ex
@@ -1,8 +1,17 @@
 defmodule CacheWeb.Plugs.ObanAuth do
   @moduledoc false
+
+  import Plug.Conn
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    Plug.BasicAuth.basic_auth(conn, Application.fetch_env!(:cache, :oban_web_basic_auth))
+    if Cache.Config.oban_dashboard_enabled?() do
+      Plug.BasicAuth.basic_auth(conn, Cache.Config.oban_web_credentials())
+    else
+      conn
+      |> send_resp(404, "Not Found")
+      |> halt()
+    end
   end
 end

--- a/cache/lib/cache_web/router.ex
+++ b/cache/lib/cache_web/router.ex
@@ -31,12 +31,10 @@ defmodule CacheWeb.Router do
     forward "/metrics", PromEx.Plug, prom_ex_module: Cache.PromEx
   end
 
-  if Cache.Config.oban_dashboard_enabled?() do
-    scope "/" do
-      pipe_through [:browser, :oban_auth]
+  scope "/" do
+    pipe_through [:browser, :oban_auth]
 
-      oban_dashboard("/oban")
-    end
+    oban_dashboard("/oban")
   end
 
   scope "/", CacheWeb do

--- a/cache/test/cache_web/plugs/oban_auth_test.exs
+++ b/cache/test/cache_web/plugs/oban_auth_test.exs
@@ -1,0 +1,68 @@
+defmodule CacheWeb.Plugs.ObanAuthTest do
+  use ExUnit.Case, async: true
+
+  import Mimic
+  import Plug.Conn
+  import Plug.Test
+
+  alias CacheWeb.Plugs.ObanAuth
+
+  setup :verify_on_exit!
+
+  describe "call/2" do
+    test "returns 404 when oban dashboard is disabled" do
+      expect(Cache.Config, :oban_dashboard_enabled?, fn -> false end)
+
+      conn = conn(:get, "/oban")
+      result = ObanAuth.call(conn, ObanAuth.init([]))
+
+      assert result.status == 404
+      assert result.halted == true
+    end
+
+    test "requires basic auth when oban dashboard is enabled" do
+      expect(Cache.Config, :oban_dashboard_enabled?, fn -> true end)
+      expect(Cache.Config, :oban_web_credentials, fn -> [username: "admin", password: "secret"] end)
+
+      conn = conn(:get, "/oban")
+      result = ObanAuth.call(conn, ObanAuth.init([]))
+
+      assert result.status == 401
+      assert get_resp_header(result, "www-authenticate") == ["Basic realm=\"Application\""]
+    end
+
+    test "allows access with valid credentials when oban dashboard is enabled" do
+      expect(Cache.Config, :oban_dashboard_enabled?, fn -> true end)
+      expect(Cache.Config, :oban_web_credentials, fn -> [username: "admin", password: "secret"] end)
+
+      credentials = Base.encode64("admin:secret")
+
+      conn =
+        :get
+        |> conn("/oban")
+        |> put_req_header("authorization", "Basic #{credentials}")
+
+      result = ObanAuth.call(conn, ObanAuth.init([]))
+
+      refute result.halted
+      refute result.status == 401
+    end
+
+    test "rejects invalid credentials when oban dashboard is enabled" do
+      expect(Cache.Config, :oban_dashboard_enabled?, fn -> true end)
+      expect(Cache.Config, :oban_web_credentials, fn -> [username: "admin", password: "secret"] end)
+
+      credentials = Base.encode64("admin:wrong")
+
+      conn =
+        :get
+        |> conn("/oban")
+        |> put_req_header("authorization", "Basic #{credentials}")
+
+      result = ObanAuth.call(conn, ObanAuth.init([]))
+
+      assert result.status == 401
+      assert result.halted == true
+    end
+  end
+end


### PR DESCRIPTION
The `if` in `router.ex` gets evaluated at compile time, the credentials are set at runtime. Meaning... Oban is always disabled no matter what.
This PR changes the `dashboard_enabled?` check to runtime, in the plug, rather than compiling the entire route away.