### PR TITLE
fix(server): update AI marketing copy for better grammar

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex
@@ -41,7 +41,7 @@
     </section>
 
     <section data-part="cta">
-      <.marketing_banner title={dgettext("marketing", "AI writes faster. So should your builds.")} />
+      <.marketing_banner title={dgettext("marketing", "AI moves fast. So should your builds.")} />
     </section>
   </main>
 

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex
@@ -80,7 +80,7 @@
     </section>
 
     <section data-part="cta">
-      <.marketing_banner title={dgettext("marketing", "AI writes faster. So should your builds.")} />
+      <.marketing_banner title={dgettext("marketing", "AI moves fast. So should your builds.")} />
     </section>
   </main>
 </TuistWeb.Marketing.Layouts.marketing>

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -1606,12 +1606,6 @@ msgstr ""
 msgid "per additional unit"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:44
-#: lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex:83
-#, elixir-autogen, elixir-format
-msgid "AI writes faster. So should your builds."
-msgstr ""
-
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "A Tuist command execution that interacts with the server pull test result information. As an estimate, this is roughly equivalent to the number of test runs on CI."
@@ -1739,4 +1733,10 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "See how leading tech companies are scaling their development with Tuist."
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:44
+#: lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex:83
+#, elixir-autogen, elixir-format
+msgid "AI moves fast. So should your builds."
 msgstr ""


### PR DESCRIPTION
Updates the marketing banner copy from "AI writes faster. So should your builds." to "AI moves fast. So should your builds." for improved grammatical correctness.

The change affects the blog post and case study pages where this banner appears.