### PR TITLE
fix(cli): Sanitize identifier name for generated resource bundle files

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -259,6 +259,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
     static func objcHeaderFileContent(
         targetName: String
     ) -> String {
+        let sanitizedTargetName = sanitizeObjcIdentifier(targetName)
         return """
         #import <Foundation/Foundation.h>
 
@@ -266,9 +267,9 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         extern "C" {
         #endif
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void);
+        NSBundle* \(sanitizedTargetName)_SWIFTPM_MODULE_BUNDLE(void);
 
-        #define SWIFTPM_MODULE_BUNDLE \(targetName)_SWIFTPM_MODULE_BUNDLE()
+        #define SWIFTPM_MODULE_BUNDLE \(sanitizedTargetName)_SWIFTPM_MODULE_BUNDLE()
 
         #if __cplusplus
         }
@@ -280,20 +281,21 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         targetName: String,
         bundleName: String
     ) -> String {
+        let sanitizedTargetName = sanitizeObjcIdentifier(targetName)
         return """
         #import <Foundation/Foundation.h>
         #import "TuistBundle+\(targetName).h"
 
-        @interface \(targetName)BundleFinder : NSObject
+        @interface \(sanitizedTargetName)BundleFinder : NSObject
         @end
 
-        @implementation \(targetName)BundleFinder
+        @implementation \(sanitizedTargetName)BundleFinder
         @end
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
+        NSBundle* \(sanitizedTargetName)_SWIFTPM_MODULE_BUNDLE(void) {
             NSString *bundleName = @"\(bundleName)";
 
-            NSURL *bundleURL = [[NSBundle bundleForClass:\(targetName)BundleFinder.self] resourceURL];
+            NSURL *bundleURL = [[NSBundle bundleForClass:\(sanitizedTargetName)BundleFinder.self] resourceURL];
             NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
                                           [[NSBundle mainBundle] resourceURL],
                                           bundleURL,
@@ -409,6 +411,12 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
             static let module = Bundle(for: BundleFinder.self)
         }
         """
+    }
+
+    /// Sanitizes a target name to be used as a valid Objective-C identifier
+    /// by removing invalid characters like hyphens
+    private static func sanitizeObjcIdentifier(_ identifier: String) -> String {
+        return identifier.replacingOccurrences(of: "-", with: "")
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/8705

This PR fixes a compilation issue where SPM dependencies with hyphens in their names (e.g., `YoutubePlayer-in-WKWebView`) cause build failures due to invalid Objective-C identifiers.

The problem occurs when Tuist generates bundle accessor code for external packages. Target names containing hyphens were used directly in Objective-C class names and function names, which is invalid since hyphens are not allowed in Objective-C identifiers.

The fix introduces a `sanitizeObjcIdentifier` method that removes hyphens from target names before using them in generated Objective-C code. This ensures that class names like `YoutubePlayer-in-WKWebViewBundleFinder` become `YoutubePlayerinWKWebViewBundleFinder`.

### How to test locally
1. Create a test project that depends on an SPM package with hyphens in the name (e.g., [YoutubePlayer-in-WKWebView](https://github.com/hmhv/YoutubePlayer-in-WKWebView))
2. Run `tuist install` to resolve dependencies
3. Run `tuist generate` to generate the Xcode project
4. Build the project - it should compile successfully without errors about invalid Objective-C identifiers
5. Verify that the generated bundle accessor files in `tuist-derived/<PackageName>/Sources/` contain valid Objective-C class names without hyphens
