### PR TITLE
docs: add intent layer nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+This file is the root Intent Node for the Tuist repository. It provides high-level guidance and points to deeper context in subdirectories. Follow downlinks for the area you are changing.
+
+## Repository Map
+- `cli/` - Tuist CLI (Swift)
+- `server/` - Tuist Server (Elixir/Phoenix)
+- `cache/` - Tuist cache service (Elixir/Phoenix)
+- `app/` - Tuist iOS and macOS app
+- `handbook/` - Company handbook (VitePress)
+- `docs/` - Documentation and guides
+- `infra/` - Infrastructure and deployment assets
+
+## Git and Pull Requests
+Use conventional commit scopes:
+- `app` - Tuist iOS and macOS app
+- `server` - Tuist server (Elixir/Phoenix)
+- `cache` - Tuist cache service (Elixir/Phoenix)
+- `cli` - Tuist CLI (Swift)
+- `docs` - Documentation
+- `handbook` - Handbook/guides
+
+Examples:
+- `feat(server): add new telemetry sanitizer module`
+- `fix(cli): resolve cache artifact upload issue`
+- `feat(cache): add new S3 transfer worker`
+- `docs(handbook): update project setup guide`
+
+## Global Guardrails
+- Do not modify `CHANGELOG.md` (auto-generated).
+- Do not edit translation `.po` files; only the `tuistit` bot should change them.
+- Do not modify content in languages other than English (source language).
+
+## Intent Layer Maintenance
+When making changes in a directory with an `AGENTS.md`, keep that node up to date. If a new subsystem or boundary is introduced, add a new leaf `AGENTS.md` and link it from the nearest parent node.
+
+## CLI Workflow
+- The Xcode project is generated with Tuist running `tuist generate --no-open`.
+- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace` instead of `swift build`.
+- When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests` instead of `swift test`.
+- Prefer running test suites or individual test cases (not the whole test target) for performance.
+
+## Related Context (Downlinks)
+- Tuist CLI: `cli/AGENTS.md`
+- Tuist Server: `server/AGENTS.md`
+- Tuist Cache service: `cache/AGENTS.md`
+- Tuist Handbook: `handbook/AGENTS.md`
+
+For deeper subsystem context, follow the downlinks inside each of the files above.

--- a/cache/AGENTS.md
+++ b/cache/AGENTS.md
@@ -1,0 +1,14 @@
+# Tuist Cache Service (Elixir/Phoenix)
+
+This service provides caching infrastructure for Tuist. It shares tooling and conventions with the Tuist Server.
+
+## Key Boundaries
+- Web/API layer: `cache/lib/cache_web`
+- Cache domain and storage: `cache/lib/cache`
+- Nginx and host-level config: `cache/platform`
+
+## Related Context (Downlinks)
+- Cache web layer: `cache/lib/cache_web/AGENTS.md`
+- Cache domain and storage: `cache/lib/cache/AGENTS.md`
+- Platform/nginx config: `cache/platform/AGENTS.md`
+- Server conventions and tooling: `server/AGENTS.md`

--- a/cache/lib/cache/AGENTS.md
+++ b/cache/lib/cache/AGENTS.md
@@ -1,0 +1,12 @@
+# Cache Domain (Storage and Auth)
+
+This directory contains core cache domain logic, storage backends, and auth helpers.
+
+## Responsibilities
+- CAS storage and eviction logic.
+- Key-value storage and cache metadata.
+- Authentication against the Tuist Server.
+
+## Related Context
+- Web/API layer: `cache/lib/cache_web/AGENTS.md`
+- Cache service overview: `cache/README.md`

--- a/cache/lib/cache_web/AGENTS.md
+++ b/cache/lib/cache_web/AGENTS.md
@@ -1,0 +1,11 @@
+# CacheWeb (API Layer)
+
+This directory contains the Phoenix web layer for cache APIs.
+
+## Responsibilities
+- REST endpoints for key-value and CAS operations.
+- Auth gate before handing off to nginx for direct file serving.
+
+## Related Context
+- Cache domain: `cache/lib/cache/AGENTS.md`
+- Cache service overview: `cache/README.md`

--- a/cache/platform/AGENTS.md
+++ b/cache/platform/AGENTS.md
@@ -1,0 +1,11 @@
+# Cache Platform (NixOS + Nginx)
+
+This directory configures the cache service host (NixOS) and nginx.
+
+## Responsibilities
+- NixOS system configuration for the cache host.
+- Nginx configuration for CAS read/write flows.
+
+## Related Context
+- Cache web layer: `cache/lib/cache_web/AGENTS.md`
+- Cache service overview: `cache/README.md`

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,74 @@
+# Tuist CLI (Swift)
+
+This node covers the Tuist CLI workspace under `cli/`. Follow downlinks for subsystem boundaries.
+
+## Key Boundaries
+- Entry points and command wiring live in `cli/Sources/tuist` and `cli/Sources/TuistKit` (legacy; avoid adding new code as work moves into smaller modules).
+- Core domain models and shared abstractions live in `cli/Sources/TuistCore`.
+- Common utilities and infra (logging, file system helpers, etc.) live in `cli/Sources/TuistSupport`.
+- Project generation pipeline lives in `cli/Sources/TuistGenerator`.
+- External-facing modules live in:
+  - Tuist Server client: `cli/Sources/TuistServer`
+  - Cache client: `cli/Sources/TuistCache`
+  - Dependencies tooling: `cli/Sources/TuistDependencies`
+  - Manifest loading: `cli/Sources/TuistLoader`
+
+## Code Style
+- Do not add one-line comments unless they are truly useful.
+
+## Testing
+- Use Swift Testing framework with custom traits for tests that need temporary directories.
+- For temporary directories, use `@Test(.inTemporaryDirectory)` and access it via `FileSystem.temporaryTestDirectory`.
+- Import `FileSystemTesting` when using `.inTemporaryDirectory`.
+- Example:
+  ```swift
+  import FileSystemTesting
+  import Testing
+
+  @Test(.inTemporaryDirectory) func test_example() async throws {
+      let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+      // Test implementation
+  }
+  ```
+
+## Linting
+- Check: `mise run lint`
+- Auto-fix: `mise run lint --fix`
+
+## Related Context (Downlinks)
+- CLI entry point: `cli/Sources/tuist/AGENTS.md`
+- Command definitions and wiring: `cli/Sources/TuistKit/AGENTS.md`
+- Core domain models: `cli/Sources/TuistCore/AGENTS.md`
+- Shared utilities: `cli/Sources/TuistSupport/AGENTS.md`
+- Project generation: `cli/Sources/TuistGenerator/AGENTS.md`
+- Dependency management: `cli/Sources/TuistDependencies/AGENTS.md`
+- Manifest loading: `cli/Sources/TuistLoader/AGENTS.md`
+- Server integration: `cli/Sources/TuistServer/AGENTS.md`
+- Cache integration: `cli/Sources/TuistCache/AGENTS.md`
+- Project description models: `cli/Sources/ProjectDescription/AGENTS.md`
+- Project automation: `cli/Sources/ProjectAutomation/AGENTS.md`
+- Tuist automation: `cli/Sources/TuistAutomation/AGENTS.md`
+- Acceptance testing support: `cli/Sources/TuistAcceptanceTesting/AGENTS.md`
+- CAS support: `cli/Sources/TuistCAS/AGENTS.md`
+- CAS analytics: `cli/Sources/TuistCASAnalytics/AGENTS.md`
+- CI integration: `cli/Sources/TuistCI/AGENTS.md`
+- Environment management: `cli/Sources/TuistEnvKit/AGENTS.md`
+- Git integration: `cli/Sources/TuistGit/AGENTS.md`
+- HTTP client: `cli/Sources/TuistHTTP/AGENTS.md`
+- Hashing utilities: `cli/Sources/TuistHasher/AGENTS.md`
+- Launchd integration: `cli/Sources/TuistLaunchctl/AGENTS.md`
+- Migration utilities: `cli/Sources/TuistMigration/AGENTS.md`
+- OIDC integration: `cli/Sources/TuistOIDC/AGENTS.md`
+- Plugin system: `cli/Sources/TuistPlugin/AGENTS.md`
+- Process execution: `cli/Sources/TuistProcess/AGENTS.md`
+- Root directory resolution: `cli/Sources/TuistRootDirectoryLocator/AGENTS.md`
+- Scaffold generation: `cli/Sources/TuistScaffold/AGENTS.md`
+- Simulator integration: `cli/Sources/TuistSimulator/AGENTS.md`
+- Test helpers: `cli/Sources/TuistTesting/AGENTS.md`
+- XCActivityLog parsing: `cli/Sources/TuistXCActivityLog/AGENTS.md`
+- XCResult handling: `cli/Sources/TuistXCResultService/AGENTS.md`
+- Xcode project/workspace path resolution: `cli/Sources/TuistXcodeProjectOrWorkspacePathLocator/AGENTS.md`
+- Benchmark tooling: `cli/Sources/tuistbenchmark/AGENTS.md`
+- Fixture generation tooling: `cli/Sources/tuistfixturegenerator/AGENTS.md`
+
+Note: `cli/TuistCacheEE` is a git submodule; keep any intent nodes for that package within the submodule itself.

--- a/cli/Sources/ProjectAutomation/AGENTS.md
+++ b/cli/Sources/ProjectAutomation/AGENTS.md
@@ -1,0 +1,18 @@
+# ProjectAutomation (CLI Module)
+
+This module provides the serialized output schema used by automation tooling.
+
+## Responsibilities
+- Define `Graph`, `Project`, `Target`, `Scheme`, and related types for automation outputs.
+- Provide a stable, `Codable` representation of the generated Xcode project graph.
+
+## Boundaries
+- This is an output schema, not the manifest DSL (`ProjectDescription`) or generator logic.
+
+## Invariants
+- Types are `Codable`/`Equatable` and reflect generated project state (paths, targets, schemes).
+
+## Related Context
+- cli/Sources/ProjectDescription/AGENTS.md
+- cli/Sources/TuistAutomation/AGENTS.md
+- cli/Sources/TuistGenerator/AGENTS.md

--- a/cli/Sources/ProjectDescription/AGENTS.md
+++ b/cli/Sources/ProjectDescription/AGENTS.md
@@ -1,0 +1,19 @@
+# ProjectDescription (CLI Module)
+
+This module provides manifest-facing types used to describe projects, targets, and settings.
+
+## Responsibilities
+- Define the public manifest DSL: `Project`, `Target`, `Scheme`, actions, settings, and resource definitions.
+- Encode manifest structures as `Codable` so they can be loaded and serialized by `TuistLoader`.
+
+## Boundaries
+- Manifest loading/evaluation lives in `cli/Sources/TuistLoader`.
+- Graph and generation logic lives in `cli/Sources/TuistGenerator`/`TuistCore`.
+
+## Invariants
+- Manifest types are `Codable`/`Equatable` and designed to be stable across versions.
+- `Project` maps 1:1 to `Project.swift` manifests and includes targets, schemes, settings, and packages.
+
+## Related Context
+- cli/Sources/TuistLoader/AGENTS.md
+- cli/Sources/TuistGenerator/AGENTS.md

--- a/cli/Sources/TuistAcceptanceTesting/AGENTS.md
+++ b/cli/Sources/TuistAcceptanceTesting/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistAcceptanceTesting (CLI Module)
+
+This module provides helpers used by CLI acceptance tests.
+
+## Responsibilities
+- Provide assertions over generated Xcode projects (framework linking, bundles, xcframework embedding).
+- Use Swift Testing `Issue` recording to report assertion failures.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistTesting/AGENTS.md
+
+## Invariants
+- Assertions read `XcodeProj` files directly and inspect build phases.

--- a/cli/Sources/TuistAutomation/AGENTS.md
+++ b/cli/Sources/TuistAutomation/AGENTS.md
@@ -1,0 +1,19 @@
+# TuistAutomation (CLI Module)
+
+This module provides automation workflows and helpers used by CLI commands.
+
+## Responsibilities
+- Provide device automation via `devicectl` (install/launch apps, list devices).
+- Apply project mappers to enable/disable testing targets for automation workflows.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/ProjectAutomation/AGENTS.md
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- Device discovery relies on `xcrun devicectl` JSON output.
+- Unit/UI test targets are tagged `tuist:prunable` to enable pruning.

--- a/cli/Sources/TuistCAS/AGENTS.md
+++ b/cli/Sources/TuistCAS/AGENTS.md
@@ -1,0 +1,14 @@
+# TuistCAS (CLI Module)
+
+This module provides content-addressable storage (CAS) protobuf and gRPC stubs used by cache features.
+
+## Responsibilities
+- Define gRPC/protobuf types for CAS and key-value operations (`cas.pb.swift`, `keyvalue.pb.swift`).
+- Expose generated gRPC clients used by cache integrations.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistCache/AGENTS.md

--- a/cli/Sources/TuistCASAnalytics/AGENTS.md
+++ b/cli/Sources/TuistCASAnalytics/AGENTS.md
@@ -1,0 +1,15 @@
+# TuistCASAnalytics (CLI Module)
+
+This module provides CAS analytics storage helpers used by cache features.
+
+## Responsibilities
+- Persist metadata about CAS outputs and key-value entries.
+- Provide stores for reading/writing metadata (e.g., `CASNodeStore`, `KeyValueMetadataStore`).
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistCAS/AGENTS.md
+- cli/Sources/TuistCache/AGENTS.md

--- a/cli/Sources/TuistCI/AGENTS.md
+++ b/cli/Sources/TuistCI/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistCI (CLI Module)
+
+This module provides CI detection and metadata extraction for CLI workflows.
+
+## Responsibilities
+- Detect CI providers (GitHub Actions, GitLab, Bitrise, CircleCI, Buildkite, Codemagic).
+- Produce `CIInfo` with provider, run ID, and project handle.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md
+
+## Invariants
+- CI detection is purely environment-variable based.

--- a/cli/Sources/TuistCache/AGENTS.md
+++ b/cli/Sources/TuistCache/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistCache (Cache Integration)
+
+This module handles CLI integration with the cache service and cache features.
+
+## Responsibilities
+- Compute cache content hashes for graph targets.
+- Define cache versioning and invalidation boundaries.
+- Support selective testing by identifying cached tests.
+
+## Related Context
+- Cache service: `cache/AGENTS.md`
+
+## Invariants
+- Only cacheable products are hashed (frameworks, static frameworks, bundles, macros).
+- Targets that depend on XCTest are excluded from cache hashing.
+- Cache version bumps invalidate incompatible artifacts.

--- a/cli/Sources/TuistCore/AGENTS.md
+++ b/cli/Sources/TuistCore/AGENTS.md
@@ -1,0 +1,19 @@
+# TuistCore (Domain Core)
+
+This module contains core domain abstractions and shared models used across the CLI.
+
+## Responsibilities
+- Cross-cutting domain models for command runs and analytics (e.g., `CommandEvent`, `RunGraph`).
+- Shared run metadata and cache-related telemetry types.
+
+## Boundaries
+- Avoid direct dependency on CLI command wiring (`TuistKit`) or entry points.
+- Keep IO-heavy or integration-specific logic in feature modules (HTTP, Server, Cache).
+
+## Invariants
+- Analytics types are Codable and designed for transport to the server.
+- Models encode run metadata (command args, environment, git info, cache endpoints).
+
+## Related Context
+- Shared utilities: `cli/Sources/TuistSupport/AGENTS.md`
+- Project generation: `cli/Sources/TuistGenerator/AGENTS.md`

--- a/cli/Sources/TuistDependencies/AGENTS.md
+++ b/cli/Sources/TuistDependencies/AGENTS.md
@@ -1,0 +1,14 @@
+# TuistDependencies (Dependency Management)
+
+This module manages external dependencies (e.g., Swift packages) used by Tuist projects.
+
+## Responsibilities
+- Apply workspace/project mapping for external dependencies (e.g., rewriting paths under `.build/checkouts`).
+- Ensure external project settings (like `SRCROOT`) are consistent for generated projects.
+
+## Related Context
+- Project generation: `cli/Sources/TuistGenerator/AGENTS.md`
+
+## Invariants
+- External projects under SwiftPM checkouts are remapped into derived dependencies directories.
+- Local packages outside `.build/checkouts` are not remapped.

--- a/cli/Sources/TuistEnvKit/AGENTS.md
+++ b/cli/Sources/TuistEnvKit/AGENTS.md
@@ -1,0 +1,13 @@
+# TuistEnvKit (CLI Module)
+
+This module provides lightweight environment helpers for CLI tooling.
+
+## Responsibilities
+- Provide shared logging scope for env-related utilities.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md

--- a/cli/Sources/TuistGenerator/AGENTS.md
+++ b/cli/Sources/TuistGenerator/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistGenerator (Project Generation)
+
+This module implements the project generation pipeline (transforming manifests into Xcode projects/workspaces).
+
+## Responsibilities
+- Build descriptors (`ProjectDescriptor`, `WorkspaceDescriptor`, `SchemeDescriptor`) used to write `.xcodeproj`.
+- Orchestrate side effects required for generation (e.g., writing schemes, side-effect descriptors).
+- Translate `ProjectDescription`/graph models into `XcodeProj` structures.
+
+## Related Context
+- Core domain models: `cli/Sources/TuistCore/AGENTS.md`
+- Manifest loading: `cli/Sources/TuistLoader/AGENTS.md`
+
+## Invariants
+- `ProjectDescriptor`/`WorkspaceDescriptor` are the handoff types to XcodeProj writers.
+- Side effects are collected explicitly and executed outside pure mapping.

--- a/cli/Sources/TuistGit/AGENTS.md
+++ b/cli/Sources/TuistGit/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistGit (CLI Module)
+
+This module provides Git-related helpers and repository interactions.
+
+## Responsibilities
+- Execute git operations (clone, checkout, log) and query repo metadata.
+- Provide `GitInfo` with CI-aware fallbacks for refs, branches, and PR IDs.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md
+
+## Invariants
+- `GitController` uses the system to execute git commands and tolerates missing repos.
+- CI environment variables are used to infer branch and PR refs when git data is unavailable.

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -1,0 +1,19 @@
+# TuistHTTP (CLI Module)
+
+This module provides HTTP client helpers used by server and cache integrations.
+
+## Responsibilities
+- Provide file upload/download client (`FileClient`) with explicit error modeling.
+- Provide middleware and auth helpers for API clients (request IDs, output warnings).
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistServer/AGENTS.md
+- cli/Sources/TuistCache/AGENTS.md
+
+## Invariants
+- File transfers treat non-2xx responses as fatal errors.
+- Default URL session uses explicit request/resource timeouts.

--- a/cli/Sources/TuistHasher/AGENTS.md
+++ b/cli/Sources/TuistHasher/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistHasher (CLI Module)
+
+This module provides hashing utilities used across CLI modules.
+
+## Responsibilities
+- Provide content hashing for files, strings, and structured inputs.
+- Offer cached hashing (`CachedContentHasher`) to avoid recomputation.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md
+
+## Invariants
+- Cached hashes are stored in-memory and keyed by absolute file path.

--- a/cli/Sources/TuistKit/AGENTS.md
+++ b/cli/Sources/TuistKit/AGENTS.md
@@ -1,0 +1,23 @@
+# TuistKit (CLI Commands)
+
+This module houses CLI command definitions, command wiring, and high-level orchestration.
+
+## Responsibilities
+- Define the root command (`TuistCommand`) and subcommand groups.
+- Load config, server URL, and trackable command execution lifecycle.
+- Centralize error handling, logging, and Noora integration.
+
+## Boundaries
+- Keep orchestration here; domain logic lives in feature modules (e.g., generator, cache, server).
+- Avoid direct file system or graph logic that belongs in `TuistCore`, `TuistGenerator`, or `TuistSupport`.
+
+## Invariants
+- `TuistCommand` groups commands into: Get started, Develop, Share, AI, Account, Other.
+- `TuistCommand.main` initializes cache directories, loads config, resolves server URL, and runs `TrackableCommand`.
+- Noora logging is reinitialized after command execution to ensure logs are captured in verbose logs.
+
+## Related Context
+- CLI entry point: `cli/Sources/tuist/AGENTS.md`
+- Core domain models: `cli/Sources/TuistCore/AGENTS.md`
+- Project generation: `cli/Sources/TuistGenerator/AGENTS.md`
+- Server integration: `cli/Sources/TuistServer/AGENTS.md`

--- a/cli/Sources/TuistLaunchctl/AGENTS.md
+++ b/cli/Sources/TuistLaunchctl/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistLaunchctl (CLI Module)
+
+This module provides launchctl integration helpers for macOS automation.
+
+## Responsibilities
+- Load/unload LaunchAgents and LaunchDaemons via `launchctl`.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistAutomation/AGENTS.md
+
+## Invariants
+- Uses `/bin/launchctl` and waits for command completion.

--- a/cli/Sources/TuistLoader/AGENTS.md
+++ b/cli/Sources/TuistLoader/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistLoader (Manifest Loading)
+
+This module loads and evaluates Tuist manifests (e.g., `Project.swift`, `Workspace.swift`).
+
+## Responsibilities
+- Discover manifest files and validate root manifests exist.
+- Load manifests via `ManifestLoader`, handling sandboxing and caching.
+- Build `ProjectDescription` helpers and decode JSON manifest output.
+
+## Related Context
+- Core domain models: `cli/Sources/TuistCore/AGENTS.md`
+- Project generation: `cli/Sources/TuistGenerator/AGENTS.md`
+
+## Invariants
+- Manifest loading emits clear `FatalError` types for missing or malformed manifests.
+- `ManifestLoader` uses start/end tokens to parse manifest output and caches results.

--- a/cli/Sources/TuistMigration/AGENTS.md
+++ b/cli/Sources/TuistMigration/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistMigration (CLI Module)
+
+This module provides migration helpers for evolving manifests or workflows.
+
+## Responsibilities
+- Validate and extract settings during migrations (e.g., detect empty build settings).
+- Provide utilities to evolve or analyze Xcode projects during migrations.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistLoader/AGENTS.md
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- Migration utilities fail with `FatalError` when required Xcode project data is missing or invalid.

--- a/cli/Sources/TuistOIDC/AGENTS.md
+++ b/cli/Sources/TuistOIDC/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistOIDC (CLI Module)
+
+This module provides OIDC auth helpers for CLI/server integration.
+
+## Responsibilities
+- Fetch OIDC tokens using a bearer request token and audience.
+- Validate token request URLs and surface request failures.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistServer/AGENTS.md
+
+## Invariants
+- OIDC token fetch expects HTTP 200 and a JSON payload with `value`.

--- a/cli/Sources/TuistPlugin/AGENTS.md
+++ b/cli/Sources/TuistPlugin/AGENTS.md
@@ -1,0 +1,19 @@
+# TuistPlugin (CLI Module)
+
+This module provides plugin system support and plugin execution helpers.
+
+## Responsibilities
+- Load local and remote plugins from config.
+- Fetch remote plugins via git or release artifacts, cache them, and build helper plugins.
+- Expose template paths and resource synthesizers contributed by plugins.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- Remote plugins must be fetched before loading; missing cached plugins produce a `FatalError`.
+- Git tags may use release artifacts; SHA refs use the repository path only.

--- a/cli/Sources/TuistProcess/AGENTS.md
+++ b/cli/Sources/TuistProcess/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistProcess (CLI Module)
+
+This module provides process execution helpers and process lifecycle utilities.
+
+## Responsibilities
+- Run background processes with controlled environment and silent output.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Invariants
+- Background processes are detached with stdout/stderr to null device.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md

--- a/cli/Sources/TuistRootDirectoryLocator/AGENTS.md
+++ b/cli/Sources/TuistRootDirectoryLocator/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistRootDirectoryLocator (CLI Module)
+
+This module provides helpers to resolve the Tuist root directory.
+
+## Responsibilities
+- Locate the root by walking up the tree and checking for `Tuist/`, `Tuist.swift`, `Plugin.swift`, or `.git`.
+- Cache discovered root directories to avoid repeated traversal.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistLoader/AGENTS.md
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- Root detection is ordered: Tuist dir, Tuist manifest, Plugin manifest, .git.

--- a/cli/Sources/TuistScaffold/AGENTS.md
+++ b/cli/Sources/TuistScaffold/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistScaffold (CLI Module)
+
+This module provides scaffolding helpers for creating new projects or files.
+
+## Responsibilities
+- Render template manifests using Stencil and user-provided attributes.
+- Generate directories and files, respecting `.stencil` templating rules.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- `.stencil` files are rendered; non-stencil files are copied verbatim.
+- Empty rendered content is skipped unless the file is `.gitkeep`.

--- a/cli/Sources/TuistServer/AGENTS.md
+++ b/cli/Sources/TuistServer/AGENTS.md
@@ -1,0 +1,15 @@
+# TuistServer (Server Integration)
+
+This module handles CLI integration with the Tuist Server APIs.
+
+## Responsibilities
+- Resolve server environment (base URL, OAuth client ID) with env var overrides.
+- Provide cache storage factories and API clients for server-backed features.
+- Map CLI actions to server operations (projects, previews, analytics, registry).
+
+## Related Context
+- Server codebase: `server/AGENTS.md`
+
+## Invariants
+- `TUIST_URL` overrides config URL and must be a valid URL.
+- OAuth client ID defaults to a built-in value if not provided.

--- a/cli/Sources/TuistSimulator/AGENTS.md
+++ b/cli/Sources/TuistSimulator/AGENTS.md
@@ -1,0 +1,16 @@
+# TuistSimulator (CLI Module)
+
+This module provides simulator-related helpers used by CLI workflows.
+
+## Responsibilities
+- Model destination types (simulator vs device) and derive build product paths.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistKit/AGENTS.md
+
+## Invariants
+- Simulator/device destination paths use platform-specific SDK suffixes.

--- a/cli/Sources/TuistSupport/AGENTS.md
+++ b/cli/Sources/TuistSupport/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistSupport (Shared Utilities)
+
+This module provides low-level helpers and shared infrastructure used across the CLI.
+
+## Responsibilities
+- Logging infrastructure and log handlers (console, detailed, OSLog, JSON).
+- Error modeling (`FatalError`) and common system helpers (process, environment, Xcode detection).
+- Shared constants and utilities used across CLI modules.
+
+## Boundaries
+- Keep this module dependency-light; it should not depend on higher-level feature modules.
+
+## Invariants
+- Logger configuration honors environment variables (quiet, osLog, detailed, verbose).
+- `FatalError` types are used to classify user-facing failures vs. unexpected errors.
+
+## Related Context
+- Core domain abstractions: `cli/Sources/TuistCore/AGENTS.md`

--- a/cli/Sources/TuistTesting/AGENTS.md
+++ b/cli/Sources/TuistTesting/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistTesting (CLI Module)
+
+This module provides testing helpers used by CLI modules and tests.
+
+## Responsibilities
+- Provide test-only helpers and fixtures (e.g., `MockFatalError`, test data extensions).
+- Supply data builders for HTTP responses and fixtures.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistSupport/AGENTS.md
+
+## Invariants
+- Test helpers must avoid mutating global process environment.

--- a/cli/Sources/TuistXCActivityLog/AGENTS.md
+++ b/cli/Sources/TuistXCActivityLog/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistXCActivityLog (CLI Module)
+
+This module provides XCActivityLog parsing helpers, especially for CAS output analysis.
+
+## Responsibilities
+- Model CAS outputs and their types (swift artifacts, diagnostics, dependency scans).
+- Track CAS operations (upload/download) with size and duration metadata.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistGenerator/AGENTS.md
+
+## Invariants
+- CAS output types map to compiler artifact identifiers (e.g., `swiftdoc`, `swiftinterface`).

--- a/cli/Sources/TuistXCResultService/AGENTS.md
+++ b/cli/Sources/TuistXCResultService/AGENTS.md
@@ -1,0 +1,17 @@
+# TuistXCResultService (CLI Module)
+
+This module provides XCResult handling helpers for test results.
+
+## Responsibilities
+- Model test results (`TestCase`, `TestModule`, `TestStatus`) and failures.
+- Provide structures to parse and surface xcresult data.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistGenerator/AGENTS.md
+
+## Invariants
+- Test results track status, duration, and structured failures for reporting.

--- a/cli/Sources/TuistXcodeProjectOrWorkspacePathLocator/AGENTS.md
+++ b/cli/Sources/TuistXcodeProjectOrWorkspacePathLocator/AGENTS.md
@@ -1,0 +1,18 @@
+# TuistXcodeProjectOrWorkspacePathLocator (CLI Module)
+
+This module provides helpers for resolving Xcode project/workspace paths.
+
+## Responsibilities
+- Locate `.xcworkspace` or `.xcodeproj` under a given path.
+- Honor `TUIST_WORKSPACE_PATH` (via `Environment.current.workspacePath`) when set.
+
+## Boundaries
+- Keep CLI command wiring in `cli/Sources/TuistKit`.
+- Keep shared low-level utilities in `cli/Sources/TuistSupport`.
+
+## Related Context
+- cli/Sources/TuistGenerator/AGENTS.md
+- cli/Sources/TuistLoader/AGENTS.md
+
+## Invariants
+- Workspace has precedence over project; falls back to project if workspace is missing.

--- a/cli/Sources/tuist/AGENTS.md
+++ b/cli/Sources/tuist/AGENTS.md
@@ -1,0 +1,16 @@
+# CLI Entry Point (tuist)
+
+This module defines the CLI entry point for the `tuist` binary.
+
+## Responsibilities
+- Boot the CLI runtime by calling `initDependencies` and delegating to `TuistCommand.main`.
+- Provide the `@main` entry that wires the binary to `TuistKit` command execution.
+
+## Invariants
+- Entrypoint should remain thin: no command logic or option parsing here.
+- Logging and error presentation remain centralized in `TuistKit`.
+
+## Related Context
+- Command definitions and wiring: `cli/Sources/TuistKit/AGENTS.md`
+- Core domain abstractions: `cli/Sources/TuistCore/AGENTS.md`
+- Shared utilities: `cli/Sources/TuistSupport/AGENTS.md`

--- a/cli/Sources/tuistbenchmark/AGENTS.md
+++ b/cli/Sources/tuistbenchmark/AGENTS.md
@@ -1,0 +1,14 @@
+# tuistbenchmark (CLI Tooling)
+
+This target provides benchmark tooling for CLI workflows.
+
+## Responsibilities
+- Run or orchestrate benchmark scenarios.
+- Keep benchmarking logic isolated from production command paths.
+
+## Boundaries
+- Avoid introducing production command wiring here; keep that in `cli/Sources/TuistKit`.
+
+## Related Context
+- CLI entry point: `cli/Sources/tuist/AGENTS.md`
+- Command wiring: `cli/Sources/TuistKit/AGENTS.md`

--- a/cli/Sources/tuistfixturegenerator/AGENTS.md
+++ b/cli/Sources/tuistfixturegenerator/AGENTS.md
@@ -1,0 +1,14 @@
+# tuistfixturegenerator (CLI Tooling)
+
+This target provides fixture generation tooling for tests and examples.
+
+## Responsibilities
+- Generate fixtures used by tests and sample projects.
+- Keep fixture generation logic isolated from production command paths.
+
+## Boundaries
+- Avoid introducing production command wiring here; keep that in `cli/Sources/TuistKit`.
+
+## Related Context
+- CLI entry point: `cli/Sources/tuist/AGENTS.md`
+- Command wiring: `cli/Sources/TuistKit/AGENTS.md`

--- a/handbook/AGENTS.md
+++ b/handbook/AGENTS.md
@@ -1,0 +1,72 @@
+# Tuist Handbook
+
+The handbook is a VitePress documentation site covering company policies, procedures, and guidelines.
+
+## Build and Test
+- Build (also checks for dead links): `mise run handbook:build`
+- Dev server (run from `handbook/`): `mise run handbook:dev`
+- Deployment: Cloudflare Pages at handbook.tuist.io
+
+## Directory Structure
+```
+handbook/
+├── .vitepress/
+│   └── config.mjs
+├── handbook/
+│   ├── company/
+│   ├── security/
+│   ├── engineering/
+│   ├── people/
+│   ├── marketing/
+│   ├── product/
+│   ├── support/
+│   └── community/
+└── package.json
+```
+
+## Security Policy Updates
+- Follow the standard format: frontmatter, policy owner, effective date, and consistent sections.
+- Keep policies practical for a small team.
+- Reference the shared responsibility model: `/security/shared-responsibility-model`.
+- Infrastructure providers handle their layer; focus on application-layer responsibilities.
+
+## Navigation
+- Sidebar should mirror directory structure.
+- Add new pages to `.vitepress/config.mjs`.
+- Redirects for moved pages live in the buildEnd hook.
+
+## Writing Guidelines
+- Clear, concise language for a small technical team.
+- Avoid bureaucratic wording; stay practical.
+- Use standard GitHub-flavored markdown.
+
+**Frontmatter**
+```yaml
+---
+title: Page Title
+titleTemplate: :title | Section | Tuist Handbook
+description: Brief description of the page content
+---
+```
+
+## Common Tasks
+**Add a page**
+1. Create the markdown file.
+2. Add frontmatter.
+3. Update `.vitepress/config.mjs`.
+4. Run `mise run handbook:build`.
+5. Create PR with `@tuist/company` as reviewer.
+
+**Update content**
+1. Make changes.
+2. Verify internal links.
+3. Run `mise run handbook:build`.
+4. Create PR with `@tuist/company` as reviewer.
+
+**Move/rename pages**
+1. Move/rename file.
+2. Update navigation.
+3. Add redirect in buildEnd hook if needed.
+4. Update internal links.
+5. Run `mise run handbook:build`.
+6. Create PR with `@tuist/company` as reviewer.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,130 @@
+# Tuist Server (Elixir/Phoenix)
+
+This node covers the Tuist Server application under `server/`. Follow downlinks for subsystem boundaries.
+
+## Project Architecture
+Tuist Server is an Elixir/Phoenix web application that extends the Tuist CLI. It provides binary caching, app preview deployment, build analytics, and Swift package registry services.
+
+**Key Technologies**
+- Backend: Elixir 1.18.3 with Phoenix 1.7.12
+- Databases: PostgreSQL with TimescaleDB (primary), ClickHouse (analytics; write via IngestRepo, read via ClickHouseRepo)
+- Frontend: Phoenix LiveView with JavaScript/TypeScript and esbuild
+- Package management: pnpm for JavaScript dependencies
+
+**Core Components**
+- `lib/tuist/` - Business logic modules (accounts, billing, bundles, projects, registry, etc.)
+- `lib/tuist_web/` - Web interface (controllers, LiveView, marketing site)
+- `priv/repo/migrations/` - PostgreSQL migrations
+- `priv/ingest_repo/migrations/` - ClickHouse migrations (analytics)
+- `assets/` - Frontend assets (JS/CSS)
+- `config/` - Application configuration
+
+## Main Business Domains
+- Accounts (auth, orgs, billing)
+- Projects (tokens, permissions)
+- Bundles (binary cache)
+- Previews (iOS app preview deployment)
+- Registry (Swift package registry)
+- Command Events (CLI analytics)
+
+## Development Setup
+**Prerequisites**
+- PostgreSQL 16 with TimescaleDB extension
+- Mise development environment manager
+- Private key from 1Password for `priv/secrets/dev.key`
+
+**Setup Commands**
+```bash
+mise install
+brew services start postgresql@16
+mise run clickhouse:start
+mise run db:create
+mise run db:load
+mise run db:seed
+mise run dev
+```
+
+**Test User Account**
+- Email: `tuistrocks@tuist.dev`
+- Password: `tuistrocks`
+
+## Common Commands
+**Database**
+- `mise run db:setup`
+- `mise run db:reset`
+- `mix ecto.migrate`
+- `mix ecto.rollback`
+
+**Server**
+- `mise run dev`
+- `mix phx.server`
+- `iex -S mix phx.server`
+
+**Testing**
+- `mix test`
+- `mix test test/path/to/specific_test.exs`
+- `mix test test/path/to/test_file.exs:line_number_of_test`
+- `mix test --only tag_name`
+
+**Code Quality**
+- `mix credo`
+- `mise run format`
+- `mix sobelow`
+- `mise run security`
+
+**Assets**
+- `mix assets.setup`
+- `mix assets.build`
+- `mix assets.deploy`
+
+**Database Utilities**
+- `mix ecto.dump`
+- `mix ecto.load`
+- `mix excellent_migrations.check_safety`
+
+## Key Configuration Files
+- `.mise.toml` - Tool versions
+- `mix.exs` - Elixir project configuration
+- `package.json` - JS dependencies (pnpm)
+- `config/` - Phoenix configuration
+- `priv/secrets/dev.key` - Development secrets (not in repo)
+
+## Testing Guidelines
+- Tests use ExUnit; files follow `test/**/module_name_test.exs`.
+- Tests run with a clean database.
+- Never modify System environment variables in tests (shared state).
+- Use mocks/stubs/DI for environment-dependent behavior.
+
+## Code Style Guidelines
+- Use `alias` for modules used multiple times; avoid `import` unless using DSLs (e.g., Ecto.Query).
+- Declare aliases at the module level, not inside functions.
+- Copy modules for mocking in `server/test/test_helper.exs`, not inside functions.
+- Prefer `{:ok, value}` / `{:error, reason}` for recoverable failures.
+- Credo rules:
+  - Timestamps in migrations: `:timestamptz`
+  - Timestamps in `lib/`: `:utc_datetime`
+- Add comments for complex logic; remove `TODO` once addressed.
+
+## Translation Management (Gettext)
+- Translations are managed through Weblate. Do not edit `.po` files.
+- Only update `.pot` templates when adding/changing strings.
+- Do not run `mix gettext.extract --merge` (modifies `.po`).
+- Currency symbols/amounts are not translatable; surrounding text is.
+- CI will fail if `.po` files are modified by anyone other than `tuistit`.
+
+## Important Notes
+- Run `mix ecto.migrate` after pulling migrations.
+- Use `mise run install` after dependency changes.
+- TimescaleDB extension is required.
+- Local development connects to `http://localhost:8080` for Tuist CLI integration.
+
+## Data Export Documentation
+Update `server/data-export.md` whenever you change stored customer data (schema, storage, retention, or new data collection). This is required for legal compliance.
+
+## Related Context (Downlinks)
+- Business logic: `server/lib/tuist/AGENTS.md`
+- Web/UI layer: `server/lib/tuist_web/AGENTS.md`
+- Assets pipeline: `server/assets/AGENTS.md`
+- Configuration: `server/config/AGENTS.md`
+- Migrations and seeds: `server/priv/AGENTS.md`
+- Test conventions: `server/test/AGENTS.md`

--- a/server/assets/AGENTS.md
+++ b/server/assets/AGENTS.md
@@ -1,0 +1,10 @@
+# Server Assets (JS/CSS)
+
+This directory contains frontend assets for the Phoenix app (LiveView, marketing, apidocs).
+
+## Responsibilities
+- JS/CSS sources built by esbuild.
+- Asset builds for development and production.
+
+## Related Context
+- Web layer: `server/lib/tuist_web/AGENTS.md`

--- a/server/config/AGENTS.md
+++ b/server/config/AGENTS.md
@@ -1,0 +1,10 @@
+# Server Configuration
+
+This directory holds Phoenix configuration for the server.
+
+## Responsibilities
+- Environment-specific configuration (dev, test, prod).
+- Runtime config and endpoint settings.
+
+## Related Context
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist/AGENTS.md
+++ b/server/lib/tuist/AGENTS.md
@@ -1,0 +1,54 @@
+# Tuist (Business Logic)
+
+This directory contains the core business logic and domain modules for the server.
+
+## Responsibilities
+- Ecto schemas, contexts, and domain services.
+- Business rules for accounts, projects, bundles, previews, registry, and analytics.
+
+## Boundaries
+- Web controllers and LiveView code live in `server/lib/tuist_web`.
+- Data migrations live in `server/priv`.
+
+## Related Context (Downlinks)
+- Accounts: `server/lib/tuist/accounts/AGENTS.md`
+- Api: `server/lib/tuist/api/AGENTS.md`
+- App Builds: `server/lib/tuist/app_builds/AGENTS.md`
+- Authentication: `server/lib/tuist/authentication/AGENTS.md`
+- Authorization: `server/lib/tuist/authorization/AGENTS.md`
+- Aws: `server/lib/tuist/aws/AGENTS.md`
+- Billing: `server/lib/tuist/billing/AGENTS.md`
+- Bundles: `server/lib/tuist/bundles/AGENTS.md`
+- Cache: `server/lib/tuist/cache/AGENTS.md`
+- Cache Action Items: `server/lib/tuist/cache_action_items/AGENTS.md`
+- Command Events: `server/lib/tuist/command_events/AGENTS.md`
+- Earmark: `server/lib/tuist/earmark/AGENTS.md`
+- Ecto: `server/lib/tuist/ecto/AGENTS.md`
+- Github: `server/lib/tuist/github/AGENTS.md`
+- Http: `server/lib/tuist/http/AGENTS.md`
+- Ingestion: `server/lib/tuist/ingestion/AGENTS.md`
+- Key Value Store: `server/lib/tuist/key_value_store/AGENTS.md`
+- Marketing: `server/lib/tuist/marketing/AGENTS.md`
+- Namespace: `server/lib/tuist/namespace/AGENTS.md`
+- Oauth: `server/lib/tuist/oauth/AGENTS.md`
+- Ops: `server/lib/tuist/ops/AGENTS.md`
+- Posthog: `server/lib/tuist/posthog/AGENTS.md`
+- Projects: `server/lib/tuist/projects/AGENTS.md`
+- Prom Ex: `server/lib/tuist/prom_ex/AGENTS.md`
+- Qa: `server/lib/tuist/qa/AGENTS.md`
+- Registry: `server/lib/tuist/registry/AGENTS.md`
+- Repo: `server/lib/tuist/repo/AGENTS.md`
+- Result Bundle: `server/lib/tuist/result_bundle/AGENTS.md`
+- Runs: `server/lib/tuist/runs/AGENTS.md`
+- Slack: `server/lib/tuist/slack/AGENTS.md`
+- Storage: `server/lib/tuist/storage/AGENTS.md`
+- Telemetry: `server/lib/tuist/telemetry/AGENTS.md`
+- Utilities: `server/lib/tuist/utilities/AGENTS.md`
+- Vault: `server/lib/tuist/vault/AGENTS.md`
+- Vcs: `server/lib/tuist/vcs/AGENTS.md`
+- Xcode: `server/lib/tuist/xcode/AGENTS.md`
+
+## Related Context
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations and seeds: `server/priv/AGENTS.md`
+- Data export requirements: `server/data-export.md`

--- a/server/lib/tuist/accounts/AGENTS.md
+++ b/server/lib/tuist/accounts/AGENTS.md
@@ -1,0 +1,21 @@
+# Accounts (Context)
+
+This context owns business logic and data related to accounts, users, organizations, roles, and auth tokens.
+
+## Responsibilities
+- Manage accounts and organizations, including billing metadata and SSO credentials.
+- Issue and validate account/user tokens, device codes, and invitations.
+- Resolve organization membership and role assignments.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data (users, organizations, tokens), update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/api/AGENTS.md
+++ b/server/lib/tuist/api/AGENTS.md
@@ -1,0 +1,20 @@
+# Api (Context)
+
+This context owns API ingestion pipeline logic.
+
+## Responsibilities
+- Batch and process API events via Broadway pipeline.
+- Push events asynchronously to the configured producer (OffBroadway memory buffer).
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/app_builds/AGENTS.md
+++ b/server/lib/tuist/app_builds/AGENTS.md
@@ -1,0 +1,21 @@
+# App Builds (Context)
+
+This context owns business logic and data related to app builds and previews.
+
+## Responsibilities
+- Create previews and app builds, and link builds to previews.
+- Find latest previews by bundle identifier/branch/track and supported platforms.
+- List previews with pagination and distinct bundle identifiers.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/authentication/AGENTS.md
+++ b/server/lib/tuist/authentication/AGENTS.md
@@ -1,0 +1,21 @@
+# Authentication (Context)
+
+This context owns authentication flows and token handling.
+
+## Responsibilities
+- Resolve authenticated subjects from JWTs, user tokens, and account/project tokens.
+- Refresh tokens while updating `preferred_username` claims.
+- Encode/sign tokens with recent accessible project handles.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/authorization/AGENTS.md
+++ b/server/lib/tuist/authorization/AGENTS.md
@@ -1,0 +1,20 @@
+# Authorization (Context)
+
+This context owns authorization policies for server resources.
+
+## Responsibilities
+- Define LetMe policies for resources (runs, bundles, cache, registry, account, project, etc.).
+- Gate access based on subject type (user, project, account token) and scopes.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/aws/AGENTS.md
+++ b/server/lib/tuist/aws/AGENTS.md
@@ -1,0 +1,20 @@
+# Aws (Context)
+
+This context provides AWS HTTP client integration for ExAws.
+
+## Responsibilities
+- Implement ExAws HTTP client using Req + Finch.
+- Apply configurable request options for ExAws requests.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/billing/AGENTS.md
+++ b/server/lib/tuist/billing/AGENTS.md
@@ -1,0 +1,21 @@
+# Billing (Context)
+
+This context owns billing, plan management, and Stripe integration.
+
+## Responsibilities
+- Define plan metadata (Air/Pro/Enterprise) and pricing thresholds.
+- Create Stripe customers, billing portal sessions, and manage subscriptions.
+- Record usage-based metering events (e.g., remote cache hits).
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Billing data is customer data; update `server/data-export.md` for schema or usage changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/bundles/AGENTS.md
+++ b/server/lib/tuist/bundles/AGENTS.md
@@ -1,0 +1,21 @@
+# Bundles (Context)
+
+This context owns bundle metadata and artifact trees.
+
+## Responsibilities
+- Create bundles with artifacts using `Ecto.Multi` and batch inserts.
+- Fetch bundles and build nested artifact trees in memory.
+- Compute install size deviations and list distinct bundles per project.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Bundle and artifact data is customer data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/cache/AGENTS.md
+++ b/server/lib/tuist/cache/AGENTS.md
@@ -1,0 +1,21 @@
+# Cache (Context)
+
+This context owns cache entries and CAS analytics ingestion.
+
+## Responsibilities
+- Create cache entries in ClickHouse via `IngestRepo`.
+- Query cache entries by CAS ID and project ID.
+- Batch insert CAS analytics events (upload/download sizes).
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Cache entries and CAS analytics are stored in ClickHouse; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/cache_action_items/AGENTS.md
+++ b/server/lib/tuist/cache_action_items/AGENTS.md
@@ -1,0 +1,20 @@
+# Cache Action Items (Context)
+
+This context owns cache action item tracking (per-project hashes).
+
+## Responsibilities
+- Insert cache action items idempotently (conflict on project/hash).
+- Fetch and delete action items for a project.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Cache action items are stored in Postgres; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/command_events/AGENTS.md
+++ b/server/lib/tuist/command_events/AGENTS.md
@@ -1,0 +1,22 @@
+# Command Events (Context)
+
+This context owns command event ingestion and analytics retrieval.
+
+## Responsibilities
+- Query and paginate command events from ClickHouse (including test runs).
+- Resolve associated user/project metadata and normalize enums.
+- Manage result bundle storage keys and signed download URLs.
+- Enqueue command event ingestion into the buffer.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Command events and artifacts are stored in ClickHouse/S3; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/earmark/AGENTS.md
+++ b/server/lib/tuist/earmark/AGENTS.md
@@ -1,0 +1,20 @@
+# Earmark (Context)
+
+This context customizes Earmark markdown rendering.
+
+## Responsibilities
+- Override AST processing for code blocks and headings.
+- Inject marketing-specific HTML wrappers and anchor links.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/ecto/AGENTS.md
+++ b/server/lib/tuist/ecto/AGENTS.md
@@ -1,0 +1,19 @@
+# Ecto (Context)
+
+This context provides Ecto helper utilities.
+
+## Responsibilities
+- Provide changeset error helpers (unique constraint detection, error formatting).
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/github/AGENTS.md
+++ b/server/lib/tuist/github/AGENTS.md
@@ -1,0 +1,21 @@
+# Github (Context)
+
+This context integrates with the GitHub API and GitHub App.
+
+## Responsibilities
+- Fetch installation repositories, users, comments, and repository content.
+- Download source archives for tags and handle pagination/link headers.
+- Provide retry logic and request headers for GitHub API calls.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/http/AGENTS.md
+++ b/server/lib/tuist/http/AGENTS.md
@@ -1,0 +1,20 @@
+# Http (Context)
+
+This context defines HTTP PromEx metrics integration.
+
+## Responsibilities
+- Emit Prometheus metrics for Finch request lifecycle (queue, connection, send, receive).
+- Sanitize tags for request metrics.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/ingestion/AGENTS.md
+++ b/server/lib/tuist/ingestion/AGENTS.md
@@ -1,0 +1,20 @@
+# Ingestion (Context)
+
+This context owns ingestion buffers for ClickHouse writes.
+
+## Responsibilities
+- Buffer RowBinary inserts in memory and flush on size/time thresholds.
+- Provide a GenServer interface for async insert and flush operations.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/key_value_store/AGENTS.md
+++ b/server/lib/tuist/key_value_store/AGENTS.md
@@ -1,0 +1,21 @@
+# Key Value Store (Context)
+
+This context owns key-value caching with Redis and in-memory fallbacks.
+
+## Responsibilities
+- Provide `get_or_update` with optional locking.
+- Use Redis when available, falling back to Cachex on connection failure.
+- Manage cache TTL and key normalization.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Cache is ephemeral; do not rely on it for durable state.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/marketing/AGENTS.md
+++ b/server/lib/tuist/marketing/AGENTS.md
@@ -1,0 +1,20 @@
+# Marketing (Context)
+
+This context owns marketing content aggregation (blog posts, case studies, changelogs).
+
+## Responsibilities
+- Load and aggregate content entries, categories, and metadata.
+- Provide helpers for blog, case study, and changelog content rendering.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/namespace/AGENTS.md
+++ b/server/lib/tuist/namespace/AGENTS.md
@@ -1,0 +1,20 @@
+# Namespace (Context)
+
+This context owns Namespace integration (JWT generation and instance metadata).
+
+## Responsibilities
+- Generate Namespace OIDC ID tokens and JWKS entries.
+- Provide issuer and trusted issuer metadata.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/oauth/AGENTS.md
+++ b/server/lib/tuist/oauth/AGENTS.md
@@ -1,0 +1,20 @@
+# Oauth (Context)
+
+This context owns OAuth2 token/client handling (Boruta).
+
+## Responsibilities
+- Implement Boruta access token behavior with cache-backed lookups.
+- Issue and revoke access/refresh tokens with custom client fetching.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/ops/AGENTS.md
+++ b/server/lib/tuist/ops/AGENTS.md
@@ -1,0 +1,20 @@
+# Ops (Context)
+
+This context owns ops reporting workers.
+
+## Responsibilities
+- Schedule Slack reports for daily/hourly business metrics.
+- Query growth stats for users, orgs, projects, and command events.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/posthog/AGENTS.md
+++ b/server/lib/tuist/posthog/AGENTS.md
@@ -1,0 +1,19 @@
+# Posthog (Context)
+
+This context owns PostHog HTTP integration.
+
+## Responsibilities
+- Provide PostHog HTTP client using Req + Finch.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/projects/AGENTS.md
+++ b/server/lib/tuist/projects/AGENTS.md
@@ -1,0 +1,21 @@
+# Projects (Context)
+
+This context owns project records, tokens, and account/project handle resolution.
+
+## Responsibilities
+- Resolve projects by handles, tokens (legacy and new), and slugs.
+- List accessible projects based on account/org membership.
+- Manage project tokens and VCS connections.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Project data is customer data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/prom_ex/AGENTS.md
+++ b/server/lib/tuist/prom_ex/AGENTS.md
@@ -1,0 +1,19 @@
+# Prom Ex (Context)
+
+This context owns PromEx helpers and buckets configuration.
+
+## Responsibilities
+- Provide custom bucket configuration for PromEx/Peep distributions.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/qa/AGENTS.md
+++ b/server/lib/tuist/qa/AGENTS.md
@@ -1,0 +1,20 @@
+# Qa (Context)
+
+This context owns QA run schemas and artifacts (steps, recordings, screenshots).
+
+## Responsibilities
+- Define schemas and changesets for QA runs and related artifacts.
+- Support QA workflows with launch arguments, logs, and recordings.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- QA run data is customer data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/registry/AGENTS.md
+++ b/server/lib/tuist/registry/AGENTS.md
@@ -1,0 +1,21 @@
+# Registry (Context)
+
+This context owns Swift package registry behavior.
+
+## Responsibilities
+- Manage Swift package metadata, releases, and manifests.
+- Fetch repository tags via VCS and map versions to SwiftPM semantics.
+- Store package artifacts in object storage.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Registry data and artifacts are customer data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/repo/AGENTS.md
+++ b/server/lib/tuist/repo/AGENTS.md
@@ -1,0 +1,20 @@
+# Repo (Context)
+
+This context owns the primary Ecto repository and DB pool utilities.
+
+## Responsibilities
+- Define the Postgres repo and check Timescale availability.
+- Surface connection pool metrics for monitoring.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/result_bundle/AGENTS.md
+++ b/server/lib/tuist/result_bundle/AGENTS.md
@@ -1,0 +1,20 @@
+# Result Bundle (Context)
+
+This context models xcresult/action result bundle structures.
+
+## Responsibilities
+- Define schemas for action invocation records, test plans, and references.
+- Parse and structure result bundle metadata for server-side processing.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Result bundles are stored in object storage; update `server/data-export.md` when schema or keys change.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/runs/AGENTS.md
+++ b/server/lib/tuist/runs/AGENTS.md
@@ -1,0 +1,21 @@
+# Runs (Context)
+
+This context owns build/test run ingestion and analytics.
+
+## Responsibilities
+- Create builds/tests and ingest related data (files, targets, issues, cacheable tasks, CAS outputs).
+- Query runs and test runs from ClickHouse with pagination.
+- Broadcast build creation events via PubSub.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Runs and analytics live in ClickHouse; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/slack/AGENTS.md
+++ b/server/lib/tuist/slack/AGENTS.md
@@ -1,0 +1,21 @@
+# Slack (Context)
+
+This context owns Slack app installations and reporting workflows.
+
+## Responsibilities
+- Store and manage Slack installation records for accounts.
+- Generate Slack report payloads from analytics and bundle metrics.
+- Deliver scheduled Slack notifications via background workers.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Slack installation data is customer data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/storage/AGENTS.md
+++ b/server/lib/tuist/storage/AGENTS.md
@@ -1,0 +1,21 @@
+# Storage (Context)
+
+This context owns object storage access (S3-compatible).
+
+## Responsibilities
+- Generate presigned URLs for upload/download (including multipart uploads).
+- Stream and upload objects, check existence, and delete by prefix.
+- Emit telemetry for storage operations.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Storage keys are customer data; update `server/data-export.md` when keys/paths change.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/telemetry/AGENTS.md
+++ b/server/lib/tuist/telemetry/AGENTS.md
@@ -1,0 +1,19 @@
+# Telemetry (Context)
+
+This context defines telemetry event names used across the server.
+
+## Responsibilities
+- Provide consistent event name helpers for storage, cache, repo pool, and run events.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/utilities/AGENTS.md
+++ b/server/lib/tuist/utilities/AGENTS.md
@@ -1,0 +1,19 @@
+# Utilities (Context)
+
+This context provides small formatting helpers for reporting.
+
+## Responsibilities
+- Format byte sizes, dates, and throughput for UI/reporting.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/vault/AGENTS.md
+++ b/server/lib/tuist/vault/AGENTS.md
@@ -1,0 +1,19 @@
+# Vault (Context)
+
+This context provides encryption types for Ecto fields.
+
+## Responsibilities
+- Define Cloak-backed encrypted binary types.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/vcs/AGENTS.md
+++ b/server/lib/tuist/vcs/AGENTS.md
@@ -1,0 +1,20 @@
+# Vcs (Context)
+
+This context owns VCS models and GitHub App integrations.
+
+## Responsibilities
+- Model VCS entities (comments, users, installations, repositories).
+- Provide workers for VCS-related background tasks.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- If changes add or modify stored customer data, update `server/data-export.md`.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist/xcode/AGENTS.md
+++ b/server/lib/tuist/xcode/AGENTS.md
@@ -1,0 +1,21 @@
+# Xcode (Context)
+
+This context owns Xcode graph ingestion and analytics.
+
+## Responsibilities
+- Ingest Xcode graphs and targets into ClickHouse buffers.
+- Compute selective testing and binary cache analytics for runs.
+- Provide counts for cache hits/misses and selective testing hits.
+
+## Boundaries
+- HTTP/API and UI code live in `server/lib/tuist_web`.
+- Configuration belongs in `server/config`.
+- Schema changes and migrations live in `server/priv`.
+
+## Guardrails
+- Xcode graph data is analytics data; update `server/data-export.md` on schema changes.
+
+## Related Context
+- Parent business logic: `server/lib/tuist/AGENTS.md`
+- Web layer: `server/lib/tuist_web/AGENTS.md`
+- Migrations: `server/priv/AGENTS.md`

--- a/server/lib/tuist_web/AGENTS.md
+++ b/server/lib/tuist_web/AGENTS.md
@@ -1,0 +1,28 @@
+# TuistWeb (Controllers, LiveView, API)
+
+This directory contains the web interface: Phoenix controllers, LiveView, and API endpoints.
+
+## Responsibilities
+- HTTP routing, controllers, and API surface.
+- LiveView components for the UI and marketing site.
+
+## Boundaries
+- Business logic should remain in `server/lib/tuist`.
+- Frontend assets (JS/CSS) are in `server/assets`.
+
+## Related Context (Downlinks)
+- Api: `server/lib/tuist_web/api/AGENTS.md`
+- Channels: `server/lib/tuist_web/channels/AGENTS.md`
+- Components: `server/lib/tuist_web/components/AGENTS.md`
+- Controllers: `server/lib/tuist_web/controllers/AGENTS.md`
+- Errors: `server/lib/tuist_web/errors/AGENTS.md`
+- Helpers: `server/lib/tuist_web/helpers/AGENTS.md`
+- Live: `server/lib/tuist_web/live/AGENTS.md`
+- Marketing: `server/lib/tuist_web/marketing/AGENTS.md`
+- Plugs: `server/lib/tuist_web/plugs/AGENTS.md`
+- Rate Limit: `server/lib/tuist_web/rate_limit/AGENTS.md`
+- Utilities: `server/lib/tuist_web/utilities/AGENTS.md`
+
+## Related Context
+- Business logic: `server/lib/tuist/AGENTS.md`
+- Assets pipeline: `server/assets/AGENTS.md`

--- a/server/lib/tuist_web/api/AGENTS.md
+++ b/server/lib/tuist_web/api/AGENTS.md
@@ -1,0 +1,15 @@
+# Api (Web Layer)
+
+This area owns the OpenAPI spec and schema definitions for the server API.
+
+## Responsibilities
+- Define the OpenAPI spec (`TuistWeb.API.Spec`) and security schemes.
+- Provide schema modules used by the API controllers and docs.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/channels/AGENTS.md
+++ b/server/lib/tuist_web/channels/AGENTS.md
@@ -1,0 +1,15 @@
+# Channels (Web Layer)
+
+This area owns Phoenix channels for real-time features.
+
+## Responsibilities
+- Handle WebSocket channels (e.g., QA log streaming).
+- Authorize channel access via `Tuist.Authorization`.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/components/AGENTS.md
+++ b/server/lib/tuist_web/components/AGENTS.md
@@ -1,0 +1,15 @@
+# Components (Web Layer)
+
+This area owns shared UI components for LiveView and templates.
+
+## Responsibilities
+- Provide reusable UI components (navigation, auth components, forms).
+- Keep rendering logic here; avoid domain logic.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/controllers/AGENTS.md
+++ b/server/lib/tuist_web/controllers/AGENTS.md
@@ -1,0 +1,15 @@
+# Controllers (Web Layer)
+
+This area owns Phoenix controllers for HTML and API endpoints.
+
+## Responsibilities
+- Handle request/response flow and rendering for controller actions.
+- Delegate business logic to `server/lib/tuist` contexts.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/errors/AGENTS.md
+++ b/server/lib/tuist_web/errors/AGENTS.md
@@ -1,0 +1,14 @@
+# Errors (Web Layer)
+
+This area owns structured error modules used in the web layer.
+
+## Responsibilities
+- Define error types for request validation and 404/400 scenarios.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/helpers/AGENTS.md
+++ b/server/lib/tuist_web/helpers/AGENTS.md
@@ -1,0 +1,14 @@
+# Helpers (Web Layer)
+
+This area owns helper functions for views, forms, and UI utilities.
+
+## Responsibilities
+- Provide helpers for formatting, rendering, and UI convenience.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/live/AGENTS.md
+++ b/server/lib/tuist_web/live/AGENTS.md
@@ -1,0 +1,15 @@
+# Live (Web Layer)
+
+This area owns LiveView pages and components for the web UI.
+
+## Responsibilities
+- Render LiveView pages and handle UI events.
+- Orchestrate UI state while delegating domain operations to `server/lib/tuist`.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/marketing/AGENTS.md
+++ b/server/lib/tuist_web/marketing/AGENTS.md
@@ -1,0 +1,15 @@
+# Marketing (Web Layer)
+
+This area owns marketing controllers and components for the public site.
+
+## Responsibilities
+- Render marketing pages and UI components.
+- Bridge marketing content from `Tuist.Marketing` into controllers/views.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/plugs/AGENTS.md
+++ b/server/lib/tuist_web/plugs/AGENTS.md
@@ -1,0 +1,15 @@
+# Plugs (Web Layer)
+
+This area owns Plug middleware for request processing.
+
+## Responsibilities
+- Implement request/response middleware (auth, analytics, rate limiting).
+- Enforce cross-cutting concerns before controllers/LiveViews.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/rate_limit/AGENTS.md
+++ b/server/lib/tuist_web/rate_limit/AGENTS.md
@@ -1,0 +1,15 @@
+# Rate Limit (Web Layer)
+
+This area owns request rate limiting helpers.
+
+## Responsibilities
+- Apply auth rate limits with in-memory or Redis-backed token buckets.
+- Compute rate limit keys using client IP.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist_web/utilities/AGENTS.md
+++ b/server/lib/tuist_web/utilities/AGENTS.md
@@ -1,0 +1,15 @@
+# Utilities (Web Layer)
+
+This area owns web-layer utilities (query helpers, hashing).
+
+## Responsibilities
+- Provide query string manipulation utilities.
+- Provide helpers like SHA and misc web utilities.
+
+## Boundaries
+- Domain logic belongs in `server/lib/tuist` contexts.
+- Frontend assets are in `server/assets`.
+
+## Related Context
+- Web layer overview: `server/lib/tuist_web/AGENTS.md`
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/priv/AGENTS.md
+++ b/server/priv/AGENTS.md
@@ -1,0 +1,14 @@
+# Server Private Assets (Migrations, Seeds)
+
+This directory contains database migrations and other private assets.
+
+## Responsibilities
+- PostgreSQL migrations: `server/priv/repo/migrations`
+- ClickHouse migrations: `server/priv/ingest_repo/migrations`
+
+## Guardrails
+- If you change stored customer data, update `server/data-export.md`.
+- Use `:timestamptz` for migration timestamps (per Credo rules).
+
+## Related Context
+- Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/test/AGENTS.md
+++ b/server/test/AGENTS.md
@@ -1,0 +1,12 @@
+# Server Tests
+
+This directory contains ExUnit tests for the Tuist Server.
+
+## Testing Guidelines
+- Tests are `async: true` by default; avoid global state and make architectural changes to support concurrency.
+- Tests run with a clean database.
+- Never modify System environment variables in tests (shared state).
+- Use mocks/stubs/DI for environment-dependent behavior.
+
+## Related Context
+- Business logic: `server/lib/tuist/AGENTS.md`


### PR DESCRIPTION
## Summary
- Add root intent layer node in AGENTS.md to guide Claude Code and AI assistants
- Add AGENTS.md nodes across CLI, server, cache, and handbook directories
- Provide context for each module and subsystem to improve AI assistance

## Details
The intent layer provides high-level guidance and points to deeper context in subdirectories. This follows the pattern established in AGENTS.md where:

- Root nodes provide overview and repository map
- Each major directory (cli/, server/, cache/) has its own AGENTS.md
- Subdirectories have focused AGENTS.md with specific responsibilities
- Follow downlinks for the area you're changing

This is documentation-only with no code changes.

## Testing
N/A (docs-only)