### PR TITLE
feat(cli): add excluding parameter to FileElement glob

### DIFF
--- a/cli/Sources/ProjectDescription/FileElement.swift
+++ b/cli/Sources/ProjectDescription/FileElement.swift
@@ -6,9 +6,19 @@
 /// Note: For convenience, an element can be represented as a string literal
 ///       `"some/pattern/**"` is the equivalent of `FileElement.glob(pattern: "some/pattern/**")`
 public enum FileElement: Codable, Equatable, Sendable {
-    /// A file path (or glob pattern) to include. For convenience, a string literal can be used as an alternate way to specify
-    /// this option.
-    case glob(pattern: Path)
+    /// A file path (or glob pattern) to include, with optional exclusions.
+    ///
+    /// For convenience, a string literal can be used as an alternate way to specify this option.
+    ///
+    /// - Parameters:
+    ///   - pattern: A glob pattern for files to include.
+    ///   - excluding: An array of glob patterns to exclude from the matched files.
+    ///
+    /// Example:
+    /// ```swift
+    /// .glob(pattern: "Documentation/**/*.md", excluding: ["Documentation/internal/**"])
+    /// ```
+    case glob(pattern: Path, excluding: [Path] = [])
 
     /// A directory path to include as a folder reference.
     case folderReference(path: Path)

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -1167,6 +1167,19 @@ final class GenerateAcceptanceTestAppWithGlobs: TuistAcceptanceTestCase {
         try await setUpFixture("generated_app_with_globs")
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
+
+        let xcodeproj = try XcodeProj(pathString: xcodeprojPath.pathString)
+        let allFileReferences = xcodeproj.pbxproj.fileReferences
+        let allFilePaths = allFileReferences.compactMap(\.path)
+
+        XCTAssertTrue(
+            allFilePaths.contains(where: { $0.contains(".hidden.yml") }),
+            "Expected .hidden.yml to be included in the project"
+        )
+        XCTAssertFalse(
+            allFilePaths.contains(where: { $0.contains(".secret.yml") }),
+            "Expected .secret.yml to be excluded from the project"
+        )
     }
 }
 

--- a/examples/xcode/generated_app_with_globs/App/Internal/.secret.yml
+++ b/examples/xcode/generated_app_with_globs/App/Internal/.secret.yml
@@ -1,0 +1,2 @@
+# This file should be excluded from additionalFiles
+secret: true

--- a/examples/xcode/generated_app_with_globs/Project.swift
+++ b/examples/xcode/generated_app_with_globs/Project.swift
@@ -24,7 +24,7 @@ let project = Project(
             ],
             dependencies: [],
             additionalFiles: [
-                "**/.*.yml",
+                .glob(pattern: "**/.*.yml", excluding: ["App/Internal/**"]),
                 "App/*.{entitlements,xcconfig}",
             ]
         ),


### PR DESCRIPTION
## Summary
- Add `excluding` parameter to `FileElement.glob` case, allowing users to exclude files from glob patterns in `additionalFiles`
- Update the manifest mapper to handle the excluding patterns
- Add unit test and acceptance test to verify the functionality

## Context
Closes #9084

This change adds the ability to exclude files from `FileElement` globs, similar to how `SourceFileGlob` and `ResourceFileElement` already support excluding.

### Usage Example
```swift
additionalFiles: [
    .glob(pattern: "Documentation/**/*.md", excluding: ["Documentation/internal/**"]),
    .folderReference(path: "Website")
]
```

## Test plan
- [x] Unit test `test_from_excludes_files_matching_excluding_pattern` passes
- [x] Acceptance test `test_app_with_globs` passes and verifies excluded files are not in the project
- [x] All existing FileElement tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)