### PR TITLE
fix(docs): fix missing information on example code description

### DIFF
--- a/examples/xcode/generated_ios_app_with_framework_xcassets_and_default_internal_imports/README.md
+++ b/examples/xcode/generated_ios_app_with_framework_xcassets_and_default_internal_imports/README.md
@@ -1,3 +1,3 @@
-# iOS App with framework and buildable folders with xcassets
+# iOS App with framework and buildable folders with xcassets and default internal imports
 
-This project contains a framework that has .xcassets inside a buildable folder.
+This project contains a framework that includes .xcassets inside a buildable folder. It also enables "default internal imports" by setting the SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT build setting to YES.


### PR DESCRIPTION
Updated README to clarify project features including default internal imports. It was same with the examples/xcode/generated_ios_app_with_framework_buildable_folders_and_xcassets before.

<img width="378" height="291" alt="Screenshot 2026-01-10 at 23 29 20" src="https://github.com/user-attachments/assets/e8e2c20b-b48c-4f78-8556-9054a640aa4c" />

