### PR TITLE
fix(server): close modal after updating alert rule

### DIFF
--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -337,7 +337,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
     socket =
       socket
       |> assign_alert_defaults(assigns.selected_project)
-      |> push_event("close-modal", %{id: "edit-alert-modal-#{id}"})
+      |> push_event("close-modal", %{id: "update-alert-modal-#{id}"})
 
     {:noreply, socket}
   end


### PR DESCRIPTION
## Summary
- Fixed the alert rule update modal not closing after clicking "Update"
- The modal ID in the `push_event` was mismatched (`edit-alert-modal` vs `update-alert-modal`)

## Test plan
- [x] Open project notifications settings
- [x] Edit an existing alert rule
- [x] Click "Update" button
- [x] Verify the modal closes after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)