### PR TITLE
feat(server): make sidebar sticky while scrolling

### DIFF
--- a/server/assets/app/css/layouts.css
+++ b/server/assets/app/css/layouts.css
@@ -14,10 +14,14 @@
   flex: 1;
   flex-direction: row;
   background: var(--noora-surface-background-primary);
-  overflow: hidden;
 
   & .noora-sidebar {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
     margin-top: var(--noora-spacing-5);
+    max-height: 100vh;
+    overflow-y: auto;
   }
 }
 
@@ -33,5 +37,4 @@
   flex: 1;
 
   padding: var(--noora-spacing-5);
-  overflow-y: scroll;
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/9ec9ef5d-cfe6-4f80-9b5e-e9db8aed3b58


## Summary
- Makes the dashboard sidebar sticky so it stays visible while scrolling through content
- Removes overflow constraints that were preventing natural page scrolling
- Adds internal scroll to sidebar when its content exceeds viewport height

## Test plan
- [x] Navigate to a project dashboard page with content that requires scrolling
- [x] Scroll down and verify the sidebar stays fixed in place
- [x] Verify the header scrolls with the content
- [x] Test on mobile viewport to ensure responsive behavior still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)