### PR TITLE
fix(cli): preserve -enable-upcoming-feature flags in OTHER_SWIFT_FLAGS deduplication

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -249,7 +249,7 @@ extension SettingsDictionary {
         case let .array(value):
             var seen = Set<String>()
             let value = value.enumerated().filter {
-                if $0.element.starts(with: "-X") || $0.element == "-I" {
+                if $0.element.isFlagWithArgument {
                     if value.endIndex > $0.offset + 1 {
                         return !seen.contains($0.element + value[$0.offset + 1])
                     } else {
@@ -260,7 +260,7 @@ extension SettingsDictionary {
                         return seen.insert($0.element).inserted
                     } else {
                         let previousElement = value[$0.offset - 1]
-                        if previousElement.starts(with: "-X") || previousElement == "-I" {
+                        if previousElement.isFlagWithArgument {
                             return seen.insert(previousElement + $0.element).inserted
                         } else {
                             return seen.insert($0.element).inserted
@@ -306,5 +306,14 @@ extension GraphDependency.XCFramework {
     fileprivate func containsLibrary() -> Bool {
         infoPlist.libraries
             .contains(where: { $0.path.extension == "a" })
+    }
+}
+
+extension String {
+    fileprivate var isFlagWithArgument: Bool {
+        starts(with: "-X") ||
+            self == "-I" ||
+            self == "-enable-upcoming-feature" ||
+            self == "-enable-experimental-feature"
     }
 }

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -599,4 +599,38 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
             ]
         )
     }
+
+    func test_removeOtherSwiftDuplicates_preservesEnableUpcomingFeatureFlags() {
+        // Given
+        let settings: SettingsDictionary = [
+            "OTHER_SWIFT_FLAGS": .array(
+                [
+                    "-enable-upcoming-feature", "DeprecateApplicationMain",
+                    "-enable-upcoming-feature", "NonfrozenEnumExhaustivity",
+                    "-enable-upcoming-feature", "DeprecateApplicationMain",
+                    "-enable-experimental-feature", "StrictConcurrency",
+                    "-enable-experimental-feature", "TypedThrows",
+                    "-enable-experimental-feature", "StrictConcurrency",
+                ]
+            ),
+        ]
+
+        // When
+        let got = settings.removeOtherSwiftFlagsDuplicates()
+
+        // Then
+        XCTAssertEqual(
+            got,
+            [
+                "OTHER_SWIFT_FLAGS": .array(
+                    [
+                        "-enable-upcoming-feature", "DeprecateApplicationMain",
+                        "-enable-upcoming-feature", "NonfrozenEnumExhaustivity",
+                        "-enable-experimental-feature", "StrictConcurrency",
+                        "-enable-experimental-feature", "TypedThrows",
+                    ]
+                ),
+            ]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed `removeOtherSwiftFlagsDuplicates` incorrectly removing duplicate `-enable-upcoming-feature` and `-enable-experimental-feature` flags even when they had different arguments
- These flags are now treated the same as `-X...` and `-I` flags, where the flag and its argument are considered together when checking for duplicates
- Added test case to verify the fix

## Test plan
- [x] Added unit test `test_removeOtherSwiftDuplicates_preservesEnableUpcomingFeatureFlags` that verifies `-enable-upcoming-feature` and `-enable-experimental-feature` flags with different arguments are preserved
- [x] Verified existing test `test_removeOtherSwithDuplicates` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)