### PR TITLE
Speed up acceptance tests

### DIFF
--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -73,6 +73,23 @@ open class TuistAcceptanceTestCase: XCTestCase {
         try await parsedCommand.run()
     }
 
+    /// Runs InstallCommand with locking to prevent parallel SPM resolution conflicts.
+    /// This serializes install operations so tests can benefit from SPM's global cache.
+    public func run(_ command: InstallCommand.Type, _ arguments: [String] = []) async throws {
+        try await TestingInstall.acquiringPoolLock {
+            let arguments = [
+                "--path", fixturePath.pathString,
+            ] + arguments
+
+            var parsedCommand = try command.parse(arguments)
+            try await parsedCommand.run()
+        }
+    }
+
+    public func run(_ command: InstallCommand.Type, _ arguments: String...) async throws {
+        try await run(command, Array(arguments))
+    }
+
     public func run(_ command: InitCommand.Type, _ arguments: String...) async throws {
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -29,7 +29,8 @@ struct DependenciesAcceptanceTests {
         // When: Build
         try await TuistTest.run(
             InstallCommand.self,
-            ["--path", fixtureDirectory.pathString]
+            ["--path", fixtureDirectory.pathString],
+            options: [.useInstallLock]
         )
         try await TuistTest.run(
             GenerateCommand.self,
@@ -86,7 +87,8 @@ struct DependenciesAcceptanceTests {
         // When: Install dependencies
         try await TuistTest.run(
             InstallCommand.self,
-            ["--path", fixtureDirectory.pathString]
+            ["--path", fixtureDirectory.pathString],
+            options: [.useInstallLock]
         )
 
         // When: Generate and build


### PR DESCRIPTION
Resolves N/A

> Speed up acceptance tests by reusing shared external SwiftPM dependencies across fixtures, sharing the install via a lock + symlinked .build/Package.resolved, pooling simulators, and reducing redundant dependency test work. Acceptance schemes are parallelizable via the project definition.

### How to test locally

> tuist test TuistAcceptanceTests