### PR TITLE
fix(cli): disable Swift debug serialization to prevent LLDB warnings

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheService.swift
@@ -568,6 +568,7 @@ final class EmptyCacheService: CacheServicing {
                         .destination("generic/platform=\(platform.caseValue) Simulator"),
                         .xcarg("SKIP_INSTALL", "NO"),
                         .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
+                        .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                         .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                         .xcarg("CODE_SIGN_IDENTITY", ""),
                         .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
@@ -610,6 +611,7 @@ final class EmptyCacheService: CacheServicing {
 
             var deviceArguments: [XcodeBuildArgument] = [
                 .xcarg("SKIP_INSTALL", "NO"),
+                .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                 .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                 .xcarg("CODE_SIGN_IDENTITY", ""),
                 .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
@@ -690,6 +692,7 @@ final class EmptyCacheService: CacheServicing {
                     .destination("generic/platform=macOS,variant=Mac Catalyst"),
                     .xcarg("SKIP_INSTALL", "NO"),
                     .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
+                    .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                     .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                     .xcarg("CODE_SIGN_IDENTITY", ""),
                     .xcarg("CODE_SIGN_ENTITLEMENTS", ""),


### PR DESCRIPTION
[More info on the serialization of debuggin options.](https://wwdcnotes.com/documentation/wwdcnotes/wwdc22-110370-debug-swift-debugging-with-lldb/#Avoiding-serialized-search-paths-in-Swift-modules)

When using binary cache, users were experiencing hundreds of LLDB warnings about missing `.pcm` (precompiled module) files when debugging. The warnings looked like:

```
warning: '/var/folders/.../ModuleCache.noindex/Foundation-134E7VRRN9KSU.pcm' does not exist
Debugging will be degraded due to missing types.
```

This happens because Swift by default embeds absolute paths to precompiled modules in the debug info via `SWIFT_SERIALIZE_DEBUGGING_OPTIONS`. These paths reference temporary directories on the original build machine that don't exist when the cached binaries are used on another machine.

This PR sets `SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO` when building cache binaries for simulator, device, and Mac Catalyst targets. This prevents Swift from embedding these paths, eliminating the warnings while preserving debugging functionality.