### PR TITLE
fix(cli): update inspect acceptance tests for new output format

### DIFF
--- a/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
+++ b/cli/Tests/TuistKitAcceptanceTests/InspectAcceptanceTests.swift
@@ -133,7 +133,7 @@ final class LintAcceptanceTests: TuistAcceptanceTestCase {
         try await withMockedDependencies {
             try await setUpFixture("generated_ios_app_with_headers")
             try await run(InspectImplicitImportsCommand.self)
-            XCTAssertStandardOutput(pattern: "We did not find any implicit dependencies in your project.")
+            XCTAssertStandardOutput(pattern: "We did not find any dependency issues in your project (checked: implicit).")
         }
     }
 
@@ -165,7 +165,7 @@ final class LintAcceptanceTests: TuistAcceptanceTestCase {
             try await setUpFixture("generated_framework_with_macros_and_tests")
             try await run(InstallCommand.self)
             try await run(InspectRedundantImportsCommand.self)
-            XCTAssertStandardOutput(pattern: "We did not find any redundant dependencies in your project.")
+            XCTAssertStandardOutput(pattern: "We did not find any dependency issues in your project (checked: redundant).")
         }
     }
 }


### PR DESCRIPTION
## Summary

The recent unified inspect dependencies command (#8887) changed the success message format from specific messages like "We did not find any implicit dependencies in your project." to a generic format "We did not find any dependency issues in your project (checked: implicit/redundant).". This PR updates the acceptance tests to match the new output format.

## Test plan

- The two failing acceptance tests `test_ios_app_with_headers` and `test_framework_with_macros_redundant_imports` should now pass