### PR TITLE
feat(server): add AppSignal sampling for CacheController requests

### DIFF
--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -53,6 +53,7 @@ defmodule TuistWeb.Endpoint do
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
   plug TuistCommon.Plugs.RequestContextPlug, enabled_fn: &Tuist.Environment.error_tracking_enabled?/0
+  plug TuistWeb.Plugs.AppsignalSamplingPlug
   plug TuistWeb.Plugs.CloseConnectionOnErrorPlug
 
   plug Stripe.WebhookPlug,

--- a/server/lib/tuist_web/plugs/appsignal_sampling_plug.ex
+++ b/server/lib/tuist_web/plugs/appsignal_sampling_plug.ex
@@ -1,0 +1,49 @@
+defmodule TuistWeb.Plugs.AppsignalSamplingPlug do
+  @moduledoc """
+  A Plug that implements sampling for AppSignal transactions.
+  AppSignal bills for APM for every request, not just errors, so sampling
+  can help reduce costs, while still capturing all errors.
+
+  This plug only samples requests to specific controllers (e.g., CacheController).
+  All other requests are always traced.
+
+  For sampled controllers:
+  - All errors (HTTP status >= 400) are always sent to AppSignal
+  - 10% of successful requests are sampled
+  """
+
+  @behaviour Plug
+
+  @sample_rate 0.1
+
+  @sampled_controllers [
+    TuistWeb.API.CacheController
+  ]
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    Plug.Conn.register_before_send(conn, fn conn ->
+      apply_sampling(conn)
+      conn
+    end)
+  end
+
+  defp apply_sampling(conn) do
+    controller = conn.private[:phoenix_controller]
+
+    if controller in @sampled_controllers do
+      sample_request(conn)
+    else
+      :ok
+    end
+  end
+
+  defp sample_request(conn) do
+    cond do
+      conn.status >= 400 -> :ok
+      :rand.uniform() < @sample_rate -> :ok
+      true -> Appsignal.Tracer.ignore()
+    end
+  end
+end

--- a/server/test/tuist_web/plugs/appsignal_sampling_plug_test.exs
+++ b/server/test/tuist_web/plugs/appsignal_sampling_plug_test.exs
@@ -1,0 +1,63 @@
+defmodule TuistWeb.Plugs.AppsignalSamplingPlugTest do
+  use ExUnit.Case, async: true
+
+  import Mimic
+  import Plug.Conn
+  import Plug.Test
+
+  alias TuistWeb.API.CacheController
+  alias TuistWeb.Plugs.AppsignalSamplingPlug
+
+  setup :verify_on_exit!
+
+  describe "call/2" do
+    test "never ignores CacheController requests with error responses" do
+      reject(&Appsignal.Tracer.ignore/0)
+
+      for status <- [400, 401, 404, 500, 503] do
+        :get
+        |> conn("/api/cache")
+        |> put_private(:phoenix_controller, CacheController)
+        |> AppsignalSamplingPlug.call(AppsignalSamplingPlug.init([]))
+        |> resp(status, "")
+        |> send_resp()
+      end
+    end
+
+    test "samples CacheController requests with successful responses" do
+      stub(Appsignal.Tracer, :ignore, fn -> :ok end)
+
+      for status <- [200, 201, 204, 304] do
+        :get
+        |> conn("/api/cache")
+        |> put_private(:phoenix_controller, CacheController)
+        |> AppsignalSamplingPlug.call(AppsignalSamplingPlug.init([]))
+        |> resp(status, "")
+        |> send_resp()
+      end
+    end
+
+    test "never ignores non-CacheController requests" do
+      reject(&Appsignal.Tracer.ignore/0)
+
+      for status <- [200, 201, 400, 404, 500] do
+        :get
+        |> conn("/api/projects")
+        |> put_private(:phoenix_controller, TuistWeb.API.ProjectsController)
+        |> AppsignalSamplingPlug.call(AppsignalSamplingPlug.init([]))
+        |> resp(status, "")
+        |> send_resp()
+      end
+    end
+
+    test "never ignores requests without a controller" do
+      reject(&Appsignal.Tracer.ignore/0)
+
+      :get
+      |> conn("/some/path")
+      |> AppsignalSamplingPlug.call(AppsignalSamplingPlug.init([]))
+      |> resp(200, "")
+      |> send_resp()
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `AppsignalSamplingPlug` that samples only `CacheController` requests to reduce AppSignal costs
- For CacheController: traces all errors (status >= 400), samples 10% of successful requests
- All other endpoints are always traced (no sampling)

## Test plan
- [x] Unit tests cover CacheController error responses (never ignored)
- [x] Unit tests cover CacheController success responses (sampled)
- [x] Unit tests cover non-CacheController requests (never ignored)
- [x] Unit tests cover requests without a controller (never ignored)

🤖 Generated with [Claude Code](https://claude.ai/code)