### PR TITLE
Fix CLI cache keys for release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -131,7 +131,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -165,7 +165,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -199,7 +199,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -239,7 +239,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -286,7 +286,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -326,7 +326,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         run: tuist auth login


### PR DESCRIPTION
## Summary
- isolate release CLI cache with a dedicated key namespace
- include Xcode version in CLI cache keys to avoid toolchain-mismatched artifacts

## Testing
- not run (workflow change only)