### PR TITLE
fix(server): fix ClickHouse bloom_filter index migration syntax

### DIFF
--- a/server/priv/ingest_repo/migrations/20260113100000_add_is_flaky_columns.exs
+++ b/server/priv/ingest_repo/migrations/20260113100000_add_is_flaky_columns.exs
@@ -27,15 +27,9 @@ defmodule Tuist.IngestRepo.Migrations.AddIsFlakyColumns do
     ADD COLUMN IF NOT EXISTS is_flaky Bool DEFAULT false
     """)
 
-    execute("""
-    ALTER TABLE test_case_runs
-    ADD INDEX IF NOT EXISTS idx_cross_run_flaky (test_case_id, git_commit_sha, is_ci)
-    TYPE bloom_filter() GRANULARITY 1
-    """)
-
-    execute("""
-    ALTER TABLE test_case_runs MATERIALIZE INDEX idx_cross_run_flaky
-    """)
+    execute(
+      "ALTER TABLE test_case_runs ADD INDEX IF NOT EXISTS idx_cross_run_flaky (test_case_id, git_commit_sha, is_ci) TYPE bloom_filter GRANULARITY 1"
+    )
   end
 
   def down do


### PR DESCRIPTION
## Summary
- Fix failing ClickHouse migration by removing `MATERIALIZE INDEX` command that fails when `ADD INDEX IF NOT EXISTS` silently fails
- Use `bloom_filter` without parentheses for consistency with other indexes in the codebase

## Test plan
- [x] Verify migration runs successfully on fresh ClickHouse database

🤖 Generated with [Claude Code](https://claude.com/claude-code)