### PR TITLE
fix(cli): Compilation errors when a static framework contains resources

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1473,7 +1473,7 @@ public class GraphTraverser: GraphTraversing {
     private func isEmbeddableDependencyTarget(dependency: GraphDependency) -> Bool {
         testTarget(dependency: dependency) {
             $0.product.isDynamic ||
-                ($0.product == .staticFramework && ($0.containsResources || $0.containsMetalFiles))
+                ($0.product == .staticFramework && $0.containsMetalFiles)
         }
     }
 

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1243,6 +1243,35 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
     }
 
+    func test_embeddableFrameworks_when_dependencyIsStaticFrameworkWithResources() throws {
+        // Given
+        let target = Target.test(name: "Main", product: .app)
+        let staticFramework = Target.test(
+            name: "StaticResourcesFramework",
+            product: .staticFramework,
+            resources: .init([.file(path: "/Absolute/Asset.png")])
+        )
+        let project = Project.test(targets: [target, staticFramework])
+
+        // Given: Value Graph
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(
+                    name: target.name,
+                    path: project.path
+                ): Set(arrayLiteral: .target(name: staticFramework.name, path: project.path)),
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: project.path, name: target.name).sorted()
+
+        // Then
+        XCTAssertEqual(got, [])
+    }
+
     func test_embeddableFrameworks_when_appIsMergeableAndDependencyIsATarget() throws {
         // Given
         let target = Target.test(name: "Main", mergedBinaryType: .automatic)


### PR DESCRIPTION
## Problem
A regression in 4.122.2 causes iOS 26 simulator installs to fail when a static framework with resources is embedded in the app bundle. The simulator reports:

> Info.plist from bundle …/Frameworks/<Framework>.framework had none of the keys that we expect

Static frameworks are not valid runtime-embedded frameworks; iOS 26’s installer now validates embedded frameworks more strictly and rejects these bundles. This appears when a static framework includes resources and Tuist decides to embed it.

## Reproduction
1. Generate the sample: `/Users/pepicrft/Downloads/CLImageEditorTuistSample` 
[CLImageEditorTuistSample.zip](https://github.com/user-attachments/files/24674444/CLImageEditorTuistSample.zip)

2. Build the app.
3. Install on iOS 26 simulator:
   `xcrun simctl install <device> <app>.app`

On 4.122.2, install fails with the Info.plist validation error because the static framework is copied into `.app/Frameworks`.

## Root cause
`GraphTraverser.embeddableFrameworks` treated static frameworks that contain resources as embeddable, which drives the “Embed Frameworks” phase. That embeds the static framework into the app, and iOS 26 refuses to install it.

## Fix
Stop embedding static frameworks **just because they contain resources**. Static frameworks should only be embedded when they have Metal sources (because Metal generates `default.metallib` that must be packaged). This keeps the existing Metal exception but prevents invalid static framework embedding for resources.

## Tests
- Unable to run unit tests via `xcodebuild`: schemes in `Tuist.xcworkspace` are not configured with the test action.
- `mise run cli:lint --fix`

## Verification
Rebuilt Tuist, regenerated the sample, built the app, and installed on iOS 26 simulator. The app no longer contains `.app/Frameworks`, and install succeeds.
