### PR TITLE
perf(server): remove FINAL hint from TestCaseRun queries

### DIFF
--- a/server/lib/tuist/runs.ex
+++ b/server/lib/tuist/runs.ex
@@ -664,7 +664,6 @@ defmodule Tuist.Runs do
   def list_test_case_runs_by_test_case_id(test_case_id, attrs) do
     base_query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_case_id == ^test_case_id
       )
 
@@ -797,7 +796,6 @@ defmodule Tuist.Runs do
   defp get_existing_ci_runs_for_commit(test_case_ids, git_commit_sha) do
     query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_case_id in ^test_case_ids,
         where: tcr.git_commit_sha == ^git_commit_sha,
         where: tcr.is_ci == true,
@@ -1113,7 +1111,6 @@ defmodule Tuist.Runs do
   defp mark_test_case_runs_as_flaky(test_case_run_ids) when is_list(test_case_run_ids) do
     query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.id in ^test_case_run_ids
       )
 
@@ -1144,7 +1141,6 @@ defmodule Tuist.Runs do
   def get_flaky_runs_groups_count_for_test_case(test_case_id) do
     query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         select: fragment("count(DISTINCT (scheme, git_commit_sha))")
@@ -1164,7 +1160,6 @@ defmodule Tuist.Runs do
 
     groups_query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         group_by: [tcr.scheme, tcr.git_commit_sha],
@@ -1183,7 +1178,6 @@ defmodule Tuist.Runs do
 
     flaky_runs_query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         order_by: [desc: tcr.ran_at]
@@ -1270,7 +1264,6 @@ defmodule Tuist.Runs do
   def get_flaky_runs_for_test_run(test_run_id) do
     flaky_runs_query =
       from(tcr in TestCaseRun,
-        hints: ["FINAL"],
         where: tcr.test_run_id == ^test_run_id,
         where: tcr.is_flaky == true,
         order_by: [desc: tcr.ran_at]


### PR DESCRIPTION
## Summary
- Removes `hints: ["FINAL"]` from all `TestCaseRun` queries in `lib/tuist/runs.ex`
- Queries were reading 23-28M rows and taking 8-15 seconds due to FINAL forcing full table scans

## Why this is safe

The only field being updated on `test_case_runs` is `is_flaky` (from `false` → `true`). This means:

| Query | Why FINAL not needed |
|-------|---------------------|
| Queries filtering `is_flaky = true` | Old rows have `is_flaky = false`, so they're filtered out anyway |
| `get_existing_ci_runs_for_commit` | Only checks `status`, which never changes |
| `mark_test_case_runs_as_flaky` | Inserting another update row is idempotent |
| `list_test_case_runs_by_test_case_id` | Occasional duplicate may appear briefly before background merge - acceptable tradeoff |

## Expected improvements
| Metric | Before | After (expected) |
|--------|--------|------------------|
| Read rows | 23-28M | Thousands |
| Latency | 8-15s | <100ms |
| Memory | 1+ GiB | MBs |

## Test plan
- [x] All existing tests pass
- [ ] Deploy to staging and monitor query performance in ClickHouse
- [ ] Verify no duplicate rows appear in UI (or are acceptable if they do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)