### PR TITLE
fix(docs): temporarily disable untranslated languages

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -137,7 +137,7 @@ function getSearchOptionsForLocale(locale) {
   };
 }
 
-const allLocales = ["en", "ko", "ja", "ru", "es", "pt", "ar", "zh_Hans", "pl", "yue_Hant"];
+const allLocales = ["en", "ko", "ja", "ru", "es", "pt", "ar", "pl"];
 const enabledLocales = process.env.DOCS_LOCALES
   ? process.env.DOCS_LOCALES.split(",")
   : allLocales;


### PR DESCRIPTION
Documentation deploy is failing with
```
 ⛅️ wrangler 4.30.0 (update available 4.59.2)
─────────────────────────────────────────────

✘ [ERROR] Error: Pages only supports up to 20,000 files in a deployment. Ensure you have specified your build output directory correctly.
```

Disabling two languages that have no translations to reduce the locales x pages multiplier - will need to find a better solution.