### PR TITLE
feat(server): add flaky runs analytics chart to flaky tests page

### DIFF
--- a/server/assets/app/css/pages/flaky_tests.css
+++ b/server/assets/app/css/pages/flaky_tests.css
@@ -14,6 +14,30 @@
     gap: var(--noora-spacing-4);
   }
 
+  & > [data-part="analytics"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--noora-spacing-4);
+
+    & .noora-dropdown-item:not([data-selected]) svg {
+      visibility: hidden;
+    }
+
+    & > [data-part="analytics-chart-section"] {
+      padding: var(--noora-spacing-9) var(--noora-spacing-7);
+
+      & > [data-part="legends"] {
+        margin-left: var(--noora-spacing-5);
+        padding-bottom: unset;
+      }
+
+      & .noora-chart {
+        padding: var(--noora-spacing-3);
+        height: 148px;
+      }
+    }
+  }
+
   & [data-part="flaky-tests-section"] {
     display: flex;
     flex-direction: column;
@@ -34,11 +58,8 @@
     }
   }
 
-  & .noora-card {
-    overflow-x: hidden;
-  }
-
   & > [data-part="flaky-tests"] {
+    overflow-x: hidden;
     & .noora-dropdown-item:not([data-selected]) svg {
       visibility: hidden;
     }

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -1,4 +1,171 @@
 <div id="flaky-tests">
+  <.card title={dgettext("dashboard_tests", "Analytics")} icon="chart_arcs" data-part="analytics">
+    <:actions>
+      <.dropdown
+        id="flaky-tests-analytics-environment-dropdown"
+        label={@analytics_environment_label}
+        secondary_text={dgettext("dashboard_tests", "Environment:")}
+      >
+        <.dropdown_item
+          value="any"
+          label={dgettext("dashboard_tests", "Any")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "any")}"}
+          data-selected={@analytics_environment == "any"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_tests", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="ci"
+          label={dgettext("dashboard_tests", "CI")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
+          data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+      </.dropdown>
+      <.date_picker
+        id="flaky-tests-analytics-date-range-picker"
+        name="analytics-date-range"
+        presets={[
+          %{
+            id: "last-24-hours",
+            label: dgettext("dashboard_tests", "Last 24 hours"),
+            period: {24, :hour}
+          },
+          %{
+            id: "last-7-days",
+            label: dgettext("dashboard_tests", "Last 7 days"),
+            period: {7, :day}
+          },
+          %{
+            id: "last-30-days",
+            label: dgettext("dashboard_tests", "Last 30 days"),
+            period: {30, :day}
+          },
+          %{
+            id: "last-12-months",
+            label: dgettext("dashboard_tests", "Last 12 months"),
+            period: {12, :month}
+          },
+          %{id: "custom", label: dgettext("dashboard_tests", "Custom")}
+        ]}
+        selected_preset={@analytics_preset}
+        period={@analytics_period}
+        on_period_change="analytics_period_changed"
+        max={Date.utc_today()}
+      >
+        <:actions>
+          <.button
+            label={dgettext("dashboard_tests", "Cancel")}
+            variant="secondary"
+            phx-click={
+              JS.dispatch("phx:date-picker-cancel",
+                detail: %{id: "flaky-tests-analytics-date-range-picker"}
+              )
+            }
+          />
+          <.button
+            label={dgettext("dashboard_tests", "Apply")}
+            phx-click={
+              JS.dispatch("phx:date-picker-apply",
+                detail: %{id: "flaky-tests-analytics-date-range-picker"}
+              )
+            }
+          />
+        </:actions>
+      </.date_picker>
+    </:actions>
+    <.card_section :if={@flaky_runs_analytics.count != 0} data-part="analytics-chart-section">
+      <div data-part="legends">
+        <.legend
+          title={dgettext("dashboard_tests", "Flaky Runs")}
+          value={@flaky_runs_analytics.count}
+          style="flaky"
+        />
+      </div>
+      <.chart
+        id="flaky-runs-chart"
+        type="line"
+        extra_options={
+          %{
+            grid: %{
+              width: "97%",
+              left: "0.4%",
+              height: "88%",
+              top: "5%"
+            },
+            xAxis: %{
+              boundaryGap: false,
+              type: "category",
+              axisLabel: %{
+                color: "var:noora-surface-label-secondary",
+                formatter: "fn:toLocaleDate",
+                customValues: [
+                  @flaky_runs_analytics.dates |> List.first(),
+                  @flaky_runs_analytics.dates |> List.last()
+                ],
+                padding: [10, 0, 0, 0]
+              }
+            },
+            yAxis: %{
+              splitNumber: 4,
+              splitLine: %{
+                lineStyle: %{
+                  color: "var:noora-chart-lines"
+                }
+              },
+              axisLabel: %{
+                color: "var:noora-surface-label-secondary"
+              }
+            },
+            legend: %{
+              show: false
+            },
+            tooltip:
+              if @analytics_preset == "last-24-hours" do
+                %{dateFormat: "hour"}
+              else
+                %{}
+              end
+          }
+        }
+        series={[
+          %{
+            color: "var:noora-chart-flaky",
+            data:
+              Enum.zip(
+                @flaky_runs_analytics.dates,
+                @flaky_runs_analytics.values
+              )
+              |> Enum.map(&Tuple.to_list/1),
+            name: dgettext("dashboard_tests", "Flaky runs"),
+            type: "line",
+            smooth: 0.1,
+            symbol: "none"
+          }
+        ]}
+        y_axis_min={0}
+      />
+    </.card_section>
+    <.empty_card_section
+      :if={@flaky_runs_analytics.count == 0}
+      title={dgettext("dashboard_tests", "No data yet")}
+    >
+      <:image>
+        <img src="/images/empty_line_chart_light.png" data-theme="light" />
+        <img src="/images/empty_line_chart_dark.png" data-theme="dark" />
+      </:image>
+    </.empty_card_section>
+  </.card>
+
   <.card
     title={dgettext("dashboard_tests", "Flaky Tests")}
     icon="progress_x"

--- a/server/lib/tuist_web/live/tests_live.ex
+++ b/server/lib/tuist_web/live/tests_live.ex
@@ -186,7 +186,7 @@ defmodule TuistWeb.TestsLive do
       Task.await_many(
         [
           Task.async(fn -> Analytics.test_run_analytics(project.id, opts) end),
-          Task.async(fn -> Analytics.test_run_analytics(project.id, Keyword.put(opts, :status, "flaky")) end),
+          Task.async(fn -> Analytics.test_run_analytics(project.id, Keyword.put(opts, :is_flaky, true)) end),
           Task.async(fn -> Analytics.test_run_analytics(project.id, Keyword.put(opts, :status, "failure")) end),
           Task.async(fn -> Analytics.test_run_duration_analytics(project.id, opts) end)
         ],

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -31,6 +31,7 @@ msgstr ""
 msgid "All tests passed!"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:2
 #: lib/tuist_web/live/test_cases_live.html.heex:2
 #: lib/tuist_web/live/test_runs_live.html.heex:2
 #: lib/tuist_web/live/tests_live.html.heex:2
@@ -38,6 +39,8 @@ msgstr ""
 msgid "Analytics"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.ex:226
+#: lib/tuist_web/live/flaky_tests_live.html.heex:11
 #: lib/tuist_web/live/test_cases_live.ex:300
 #: lib/tuist_web/live/test_runs_live.ex:329
 #: lib/tuist_web/live/tests_live.ex:303
@@ -137,6 +140,8 @@ msgstr ""
 msgid "Build: %{scheme}"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.ex:228
+#: lib/tuist_web/live/flaky_tests_live.html.heex:27
 #: lib/tuist_web/live/test_case_live.ex:95
 #: lib/tuist_web/live/test_cases_live.ex:302
 #: lib/tuist_web/live/test_runs_live.ex:331
@@ -225,6 +230,7 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:7
 #: lib/tuist_web/live/test_cases_live.html.heex:7
 #: lib/tuist_web/live/test_runs_live.html.heex:7
 #: lib/tuist_web/live/tests_live.html.heex:7
@@ -326,7 +332,7 @@ msgstr ""
 msgid "Failures"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:58
+#: lib/tuist_web/live/flaky_tests_live.html.heex:225
 #: lib/tuist_web/live/test_case_live.html.heex:395
 #: lib/tuist_web/live/test_cases_live.html.heex:437
 #: lib/tuist_web/live/test_run_live.html.heex:641
@@ -393,6 +399,8 @@ msgstr ""
 msgid "Last status"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.ex:227
+#: lib/tuist_web/live/flaky_tests_live.html.heex:19
 #: lib/tuist_web/live/test_cases_live.ex:301
 #: lib/tuist_web/live/test_run_live.html.heex:1282
 #: lib/tuist_web/live/test_run_live.html.heex:1408
@@ -415,7 +423,7 @@ msgstr ""
 msgid "Missed"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:35
+#: lib/tuist_web/live/flaky_tests_live.ex:37
 #: lib/tuist_web/live/test_case_live.html.heex:49
 #: lib/tuist_web/live/test_cases_live.ex:52
 #: lib/tuist_web/live/test_run_live.html.heex:991
@@ -441,6 +449,7 @@ msgstr ""
 msgid "No data"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:160
 #: lib/tuist_web/live/test_cases_live.html.heex:377
 #: lib/tuist_web/live/test_cases_live.html.heex:563
 #: lib/tuist_web/live/test_runs_live.html.heex:372
@@ -582,7 +591,7 @@ msgstr ""
 msgid "Scheme"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:14
+#: lib/tuist_web/live/flaky_tests_live.html.heex:181
 #: lib/tuist_web/live/test_case_live.html.heex:360
 #: lib/tuist_web/live/test_cases_live.html.heex:393
 #: lib/tuist_web/live/test_run_live.html.heex:606
@@ -653,7 +662,7 @@ msgstr ""
 msgid "Slowest test cases"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:29
+#: lib/tuist_web/live/flaky_tests_live.html.heex:196
 #: lib/tuist_web/live/test_case_live.html.heex:374
 #: lib/tuist_web/live/test_cases_live.html.heex:408
 #: lib/tuist_web/live/test_run_live.html.heex:620
@@ -681,7 +690,7 @@ msgstr ""
 msgid "Success rate based on runs from the %{branch} branch. Falls back to all branches if no runs exist on %{branch}."
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:43
+#: lib/tuist_web/live/flaky_tests_live.ex:45
 #: lib/tuist_web/live/test_case_live.html.heex:56
 #: lib/tuist_web/live/test_cases_live.ex:60
 #, elixir-autogen, elixir-format
@@ -693,9 +702,9 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:24
-#: lib/tuist_web/live/flaky_tests_live.html.heex:41
-#: lib/tuist_web/live/flaky_tests_live.html.heex:81
+#: lib/tuist_web/live/flaky_tests_live.html.heex:191
+#: lib/tuist_web/live/flaky_tests_live.html.heex:208
+#: lib/tuist_web/live/flaky_tests_live.html.heex:248
 #: lib/tuist_web/live/test_cases_live.html.heex:403
 #: lib/tuist_web/live/test_cases_live.html.heex:420
 #: lib/tuist_web/live/test_cases_live.html.heex:460
@@ -1029,6 +1038,7 @@ msgstr ""
 msgid "•"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:76
 #: lib/tuist_web/live/test_cases_live.html.heex:74
 #: lib/tuist_web/live/test_runs_live.html.heex:74
 #: lib/tuist_web/live/tests_live.html.heex:76
@@ -1037,6 +1047,7 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:67
 #: lib/tuist_web/live/test_cases_live.html.heex:67
 #: lib/tuist_web/live/test_runs_live.html.heex:67
 #: lib/tuist_web/live/tests_live.html.heex:67
@@ -1045,6 +1056,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:58
 #: lib/tuist_web/live/test_cases_live.html.heex:58
 #: lib/tuist_web/live/test_runs_live.html.heex:58
 #: lib/tuist_web/live/tests_live.html.heex:58
@@ -1053,6 +1065,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:55
 #: lib/tuist_web/live/test_cases_live.html.heex:55
 #: lib/tuist_web/live/test_runs_live.html.heex:55
 #: lib/tuist_web/live/tests_live.html.heex:55
@@ -1061,6 +1074,7 @@ msgstr ""
 msgid "Last 12 months"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:40
 #: lib/tuist_web/live/test_cases_live.html.heex:40
 #: lib/tuist_web/live/test_runs_live.html.heex:40
 #: lib/tuist_web/live/tests_live.html.heex:40
@@ -1069,6 +1083,7 @@ msgstr ""
 msgid "Last 24 hours"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:50
 #: lib/tuist_web/live/test_cases_live.html.heex:50
 #: lib/tuist_web/live/test_runs_live.html.heex:50
 #: lib/tuist_web/live/tests_live.html.heex:50
@@ -1077,6 +1092,7 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:45
 #: lib/tuist_web/live/test_cases_live.html.heex:45
 #: lib/tuist_web/live/test_runs_live.html.heex:45
 #: lib/tuist_web/live/tests_live.html.heex:45
@@ -1116,6 +1132,7 @@ msgstr ""
 msgid "Flaky"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:89
 #: lib/tuist_web/live/test_case_live.html.heex:207
 #: lib/tuist_web/live/test_run_live.html.heex:114
 #: lib/tuist_web/live/test_run_live.html.heex:395
@@ -1126,15 +1143,16 @@ msgstr ""
 msgid "Flaky Runs"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:19
-#: lib/tuist_web/live/flaky_tests_live.html.heex:3
+#: lib/tuist_web/live/flaky_tests_live.ex:21
+#: lib/tuist_web/live/flaky_tests_live.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:26
-#: lib/tuist_web/live/flaky_tests_live.html.heex:33
-#: lib/tuist_web/live/flaky_tests_live.html.heex:109
+#: lib/tuist_web/live/flaky_tests_live.html.heex:149
+#: lib/tuist_web/live/flaky_tests_live.html.heex:193
+#: lib/tuist_web/live/flaky_tests_live.html.heex:200
+#: lib/tuist_web/live/flaky_tests_live.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
@@ -1150,9 +1168,9 @@ msgstr ""
 msgid "Flaky test runs"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:25
-#: lib/tuist_web/live/flaky_tests_live.html.heex:49
-#: lib/tuist_web/live/flaky_tests_live.html.heex:123
+#: lib/tuist_web/live/flaky_tests_live.html.heex:192
+#: lib/tuist_web/live/flaky_tests_live.html.heex:216
+#: lib/tuist_web/live/flaky_tests_live.html.heex:290
 #, elixir-autogen, elixir-format
 msgid "Last flaky run"
 msgstr ""
@@ -1167,7 +1185,7 @@ msgstr ""
 msgid "Most occurring flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:163
+#: lib/tuist_web/live/flaky_tests_live.html.heex:330
 #, elixir-autogen, elixir-format
 msgid "No flaky tests"
 msgstr ""


### PR DESCRIPTION
<img width="1264" height="503" alt="image" src="https://github.com/user-attachments/assets/2359b334-bd72-4351-870d-c6645af074f6" />

## Summary
- Add an Analytics card to the flaky tests page with a line chart showing flaky test runs over time
- Include environment filtering (Any/Local/CI) and date range selection with presets (Last 24 hours, 7 days, 30 days, 12 months, Custom)
- Display a legend with "Flaky Runs" title and total count above the chart

## Test plan
- [x] Navigate to a project's flaky tests page and verify the Analytics card appears
- [x] Verify the chart displays flaky runs data correctly
- [x] Test environment dropdown filters (Any/Local/CI)
- [x] Test date picker presets and custom date range selection
- [x] Verify empty state is shown when there's no flaky runs data

🤖 Generated with [Claude Code](https://claude.com/claude-code)