### PR TITLE
fix(server): handle large test case lists in ClickHouse queries

### DIFF
--- a/server/test/tuist/runs_test.exs
+++ b/server/test/tuist/runs_test.exs
@@ -845,6 +845,81 @@ defmodule Tuist.RunsTest do
       assert integration_test_case.test_suite_run_id
     end
 
+    test "creates a CI test with empty test cases" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+
+      test_attrs = %{
+        id: UUIDv7.generate(),
+        project_id: project.id,
+        account_id: account.id,
+        duration: 1000,
+        status: "success",
+        model_identifier: "Mac15,6",
+        macos_version: "14.0",
+        xcode_version: "15.0",
+        git_branch: "main",
+        git_commit_sha: "abc123def456",
+        ran_at: NaiveDateTime.utc_now(),
+        is_ci: true,
+        test_modules: [
+          %{
+            name: "EmptyModule",
+            status: "success",
+            duration: 0,
+            test_cases: []
+          }
+        ]
+      }
+
+      # When / Then
+      {:ok, test} = Runs.create_test(test_attrs)
+      assert test.id == test_attrs.id
+    end
+
+    test "creates a CI test with a very large number of test cases" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+
+      test_cases =
+        for i <- 1..50_000 do
+          %{
+            name: "testCase#{i}",
+            status: "success",
+            duration: 100
+          }
+        end
+
+      test_attrs = %{
+        id: UUIDv7.generate(),
+        project_id: project.id,
+        account_id: account.id,
+        duration: 5_000_000,
+        status: "success",
+        model_identifier: "Mac15,6",
+        macos_version: "14.0",
+        xcode_version: "15.0",
+        git_branch: "main",
+        git_commit_sha: "abc123def456",
+        ran_at: NaiveDateTime.utc_now(),
+        is_ci: true,
+        test_modules: [
+          %{
+            name: "LargeTestModule",
+            status: "success",
+            duration: 5_000_000,
+            test_cases: test_cases
+          }
+        ]
+      }
+
+      # When / Then
+      {:ok, test} = Runs.create_test(test_attrs)
+      assert test.id == test_attrs.id
+    end
+
     test "creates a test with failures" do
       # Given
       project = ProjectsFixtures.project_fixture()


### PR DESCRIPTION
## Summary
- Fix `Ch.Error` when projects have very large numbers of test cases (50,000+)
- Replace large `IN` clauses with in-memory filtering using `MapSet` for O(1) lookups
- Queries now filter by other criteria first (commit SHA, branch, project_id) and filter results in memory

## Test plan
- [x] Added test case with 50,000 test cases that reproduces the error
- [x] Verified fix passes with the large test case (completes in ~1.4s)
- [x] Full test suite passes (139 tests)

Resolves #9180

🤖 Generated with [Claude Code](https://claude.ai/code)