### PR TITLE
docs(cli): recommend official mise install script over Homebrew

### DIFF
--- a/docs/docs/en/contributors/code/cli.md
+++ b/docs/docs/en/contributors/code/cli.md
@@ -23,7 +23,7 @@ The CLI is the heart of Tuist. It handles project generation, automation workflo
 ### Set up locally {#set-up-locally}
 
 - Clone the repository: `git clone git@github.com:tuist/tuist.git`
-- Install Mise and run `mise install`
+- Install Mise using [their official install script](https://mise.jdx.dev/getting-started.html) (not Homebrew) and run `mise install`
 - Install Tuist dependencies: `tuist install`
 - Generate the workspace: `tuist generate`
 


### PR DESCRIPTION
Contributing to tuist doesn't fully work when mise is installed via homebrew. Since none of the core team really has that set-up, I'd propose to update the documentation to include a note that mise must be installed using the official script instead of `brew`