### PR TITLE
perf(server): add ClickHouse projection to optimize branch CI query

### DIFF
--- a/server/priv/ingest_repo/migrations/20260121091606_add_branch_ci_projection_to_test_case_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260121091606_add_branch_ci_projection_to_test_case_runs.exs
@@ -1,0 +1,19 @@
+defmodule Tuist.IngestRepo.Migrations.AddBranchCiProjectionToTestCaseRuns do
+  use Ecto.Migration
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_case_runs
+    ADD PROJECTION proj_by_branch_ci (
+      SELECT git_branch, is_ci, ran_at, test_case_id
+      ORDER BY git_branch, is_ci, ran_at, test_case_id
+    )
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_branch_ci"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260121091607_materialize_branch_ci_projection.exs
+++ b/server/priv/ingest_repo/migrations/20260121091607_materialize_branch_ci_projection.exs
@@ -1,0 +1,12 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeBranchCiProjection do
+  use Ecto.Migration
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_by_branch_ci"
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary

- Add a new ClickHouse projection `proj_by_branch_ci` ordered by `(git_branch, is_ci, ran_at, test_case_id)` to optimize the query that fetches distinct test_case_ids filtered by branch and CI status
- The query `SELECT DISTINCT test_case_id FROM test_case_runs WHERE git_branch = ? AND is_ci = ? AND ran_at >= ?` was slow (p90 ~1.1s in production) because the existing projection is ordered by `(test_case_id, ran_at)`, which doesn't help when filtering by `git_branch` and `is_ci` first

## Test plan

- [x] Verified projection is used via `EXPLAIN` output showing `ReadFromMergeTree (proj_by_branch_ci)`
- [x] Tested in dev: rows scanned reduced by ~72% (from 824k to 231k)
- [ ] Monitor p90 latency in production after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)