### PR TITLE
fix(cli): prevent race condition when creating logs directory

### DIFF
--- a/cli/Sources/TuistKit/Utils/LogsController.swift
+++ b/cli/Sources/TuistKit/Utils/LogsController.swift
@@ -9,9 +9,8 @@ private actor AsyncLock {
     }
 }
 
-private let logsDirectoryLock = AsyncLock()
-
 public struct LogsController {
+    private static let logsDirectoryLock = AsyncLock()
     private let fileSystem: FileSystem
 
     public init(fileSystem: FileSystem = FileSystem()) {
@@ -68,7 +67,7 @@ public struct LogsController {
         let logFilePath = stateDirectory.appending(components: [
             "logs", "\(UUID().uuidString).log",
         ])
-        try await logsDirectoryLock.withLock {
+        try await Self.logsDirectoryLock.withLock {
             if try await !fileSystem.exists(logFilePath.parentDirectory) {
                 try await fileSystem.makeDirectory(at: logFilePath.parentDirectory)
             }


### PR DESCRIPTION
When multiple async tasks call into `LogsController` concurrently, they could race to create the logs directory, causing one to fail with "File already exists" error.

This adds an actor-based lock to serialize the check-and-create operation, ensuring only one task creates the directory while others wait.