### PR TITLE
fix(server): improve Slack OAuth error message for expired tokens

### DIFF
--- a/server/lib/tuist_web/controllers/slack_oauth_controller.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_controller.ex
@@ -22,7 +22,7 @@ defmodule TuistWeb.SlackOAuthController do
   @channel_selection_scopes "incoming-webhook"
 
   def callback(conn, %{"error" => "access_denied", "state" => state_token}) do
-    case verify_state_token(state_token) do
+    case Slack.verify_state_token(state_token) do
       {:ok, %{type: :alert_channel_selection}} ->
         render_popup_close(conn, nil, nil)
 
@@ -35,7 +35,14 @@ defmodule TuistWeb.SlackOAuthController do
       {:ok, account_id} when is_integer(account_id) ->
         redirect_after_account_cancel(conn, account_id)
 
-      {:error, :invalid_state_token} ->
+      {:error, :expired} ->
+        raise BadRequestError,
+              dgettext(
+                "dashboard_slack",
+                "Authorization request expired. Please start the Slack connection process again."
+              )
+
+      {:error, :invalid} ->
         raise BadRequestError,
               dgettext("dashboard_slack", "Invalid authorization request. Please try again.")
     end
@@ -43,7 +50,7 @@ defmodule TuistWeb.SlackOAuthController do
 
   def callback(conn, %{"code" => code, "state" => state_token})
       when is_binary(code) and code != "" and is_binary(state_token) do
-    case verify_state_token(state_token) do
+    case Slack.verify_state_token(state_token) do
       {:ok, %{type: :alert_channel_selection} = payload} ->
         handle_alert_channel_selection(conn, code, payload)
 
@@ -56,7 +63,14 @@ defmodule TuistWeb.SlackOAuthController do
       {:ok, account_id} when is_integer(account_id) ->
         handle_account_installation(conn, code, account_id)
 
-      {:error, :invalid_state_token} ->
+      {:error, :expired} ->
+        raise BadRequestError,
+              dgettext(
+                "dashboard_slack",
+                "Authorization request expired. Please start the Slack connection process again."
+              )
+
+      {:error, :invalid} ->
         raise BadRequestError,
               dgettext("dashboard_slack", "Invalid authorization request. Please try again.")
     end
@@ -195,13 +209,6 @@ defmodule TuistWeb.SlackOAuthController do
       {:error, :not_found} ->
         raise BadRequestError,
               dgettext("dashboard_slack", "Account not found. Please try again.")
-    end
-  end
-
-  defp verify_state_token(state_token) do
-    case Slack.verify_state_token(state_token) do
-      {:ok, payload} -> {:ok, payload}
-      {:error, _reason} -> {:error, :invalid_state_token}
     end
   end
 

--- a/server/priv/gettext/dashboard_slack.pot
+++ b/server/priv/gettext/dashboard_slack.pot
@@ -11,48 +11,54 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:105
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:182
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:197
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:119
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:196
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "Account not found. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:113
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "Failed to save Slack installation. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:67
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "Invalid Slack authorization. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:40
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:61
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:47
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "Invalid authorization request. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:109
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:127
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:143
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:161
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:123
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:141
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:157
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:175
 #, elixir-autogen, elixir-format
 msgid "Slack authorization failed: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:147
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:161
 #, elixir-autogen, elixir-format
 msgid "Failed to save channel selection. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:193
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:207
 #, elixir-autogen, elixir-format
 msgid "Project not found. Please try again."
 msgstr ""
 
-#: lib/tuist_web/controllers/slack_oauth_controller.ex:139
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:153
 #, elixir-autogen, elixir-format
 msgid "Alert rule not found. Please try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:40
+#: lib/tuist_web/controllers/slack_oauth_controller.ex:68
+#, elixir-autogen, elixir-format
+msgid "Authorization request expired. Please start the Slack connection process again."
 msgstr ""

--- a/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
+++ b/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
@@ -49,6 +49,16 @@ defmodule TuistWeb.SlackOAuthControllerTest do
       end
     end
 
+    test "raises BadRequestError with expiration message when state token is expired", %{conn: conn} do
+      # Given
+      stub(Slack, :verify_state_token, fn _token -> {:error, :expired} end)
+
+      # When/Then
+      assert_raise BadRequestError, ~r/Authorization request expired/, fn ->
+        get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => "expired_token"})
+      end
+    end
+
     test "raises BadRequestError when account is not found", %{conn: conn} do
       # Given
       non_existent_account_id = 999_999_999


### PR DESCRIPTION
## Summary
- Distinguish between expired and invalid state tokens in the Slack OAuth callback
- Users now see a clearer error message when their authorization request has expired (>10 minutes): "Authorization request expired. Please start the Slack connection process again."
- Invalid tokens continue to show the generic "Invalid authorization request" message

## Test plan
- [x] Added test for expired token scenario
- [x] Existing tests pass
- [ ] Manually test by waiting >10 minutes during Slack OAuth flow to verify the new message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)