### PR TITLE
fix(cache/platform): increase open file descriptor limit

### DIFF
--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -28,6 +28,8 @@
       "net.core.wmem_max" = 134217728;
       "net.ipv4.tcp_rmem" = "4096 87380 67108864";
       "net.ipv4.tcp_wmem" = "4096 65536 67108864";
+      "fs.file-max" = 1048576;
+      "fs.nr_open" = 1048576;
     };
   };
 
@@ -70,7 +72,20 @@
   virtualisation.docker = {
     enable = true;
     logDriver = "json-file";
+    daemon.settings = {
+      "default-ulimits" = {
+        nofile = {
+          Name = "nofile";
+          Soft = 65535;
+          Hard = 65535;
+        };
+      };
+    };
   };
+
+  systemd.extraConfig = ''
+    DefaultLimitNOFILE=65535
+  '';
 
   environment.systemPackages = map lib.lowPrio [
     pkgs.curl

--- a/cache/platform/flake.nix
+++ b/cache/platform/flake.nix
@@ -33,17 +33,21 @@
         targetHost = "${hostname}.tuist.dev";
         buildOnTarget = true;
       };
-      imports = sharedModules ++ [
-        {
-          networking.hostName = hostname;
-        }
-      ];
+      imports =
+        sharedModules
+        ++ [
+          {
+            networking.hostName = hostname;
+          }
+        ];
     };
   in {
-    colmena = {
-      meta = {
-        nixpkgs = import nixpkgs {system = "x86_64-linux";};
-      };
-    } // nixpkgs.lib.genAttrs machines mkColmenaNode;
+    colmena =
+      {
+        meta = {
+          nixpkgs = import nixpkgs {system = "x86_64-linux";};
+        };
+      }
+      // nixpkgs.lib.genAttrs machines mkColmenaNode;
   };
 }


### PR DESCRIPTION
Resolves AppSignal issues 43, 45, 46, 47

Docker by default has a very low open file descriptor limit of 1024. With the concurrency of CAS, that's.. not enough, resulting in `too many open files` and `:emfile` errors.
This raises the limit to a still-somewhat-conservative limit of 65535. In the next step, I'll add platform-level monitoring for open file descriptors and alerting so we'll know if and when we need to increase it again.

This will increase RAM pressure on the nodes, but we have plenty of headroom on all our instances.

⚠️ This will require a reboot of the nodes, so I will apply them staggered
eu-central tonight
us-east tomorrow morning (nighttime Eastern)

ap-southeast and us-west are not affected because of significantly lower load, will reboot them when nobody uses them.