### PR TITLE
feat(cli): add debug logs to project generation

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -45,6 +45,7 @@ final class ConfigGenerator: ConfigGenerating {
         pbxproj: PBXProj,
         fileElements: ProjectFileElements
     ) async throws -> XCConfigurationList {
+        Logger.current.debug("Generating project config for \(project.name)")
         // Configuration list
         let defaultConfiguration = project.settings.defaultReleaseBuildConfiguration()
             ?? project.settings.defaultDebugBuildConfiguration()
@@ -54,7 +55,9 @@ final class ConfigGenerator: ConfigGenerating {
         )
         pbxproj.add(object: configurationList)
 
-        for item in project.settings.configurations.sortedByBuildConfigurationName() {
+        let configurations = project.settings.configurations.sortedByBuildConfigurationName()
+        Logger.current.debug("Generating \(configurations.count) build configurations for project \(project.name)")
+        for item in configurations {
             try await generateProjectSettingsFor(
                 buildConfiguration: item.key,
                 configuration: item.value,
@@ -65,6 +68,7 @@ final class ConfigGenerator: ConfigGenerating {
             )
         }
 
+        Logger.current.debug("Finished generating project config for \(project.name)")
         return configurationList
     }
 
@@ -78,6 +82,7 @@ final class ConfigGenerator: ConfigGenerating {
         graphTraverser: GraphTraversing,
         sourceRootPath: AbsolutePath
     ) async throws {
+        Logger.current.debug("Generating target config for \(target.name) in project \(project.name)")
         let defaultConfiguration = projectSettings.defaultReleaseBuildConfiguration()
             ?? projectSettings.defaultDebugBuildConfiguration()
         let configurationList = XCConfigurationList(
@@ -101,6 +106,7 @@ final class ConfigGenerator: ConfigGenerating {
         let configurations = Dictionary(uniqueKeysWithValues: configurationsTuples)
         let nonEmptyConfigurations = !configurations.isEmpty ? configurations : Settings.default.configurations
         let orderedConfigurations = nonEmptyConfigurations.sortedByBuildConfigurationName()
+        Logger.current.debug("Generating \(orderedConfigurations.count) build configurations for target \(target.name)")
         for orderedConfiguration in orderedConfigurations {
             try await generateTargetSettingsFor(
                 target: target,
@@ -114,6 +120,7 @@ final class ConfigGenerator: ConfigGenerating {
                 sourceRootPath: sourceRootPath
             )
         }
+        Logger.current.debug("Finished generating target config for \(target.name)")
     }
 
     // MARK: - Fileprivate

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -78,7 +78,9 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         generatedProjects: [AbsolutePath: GeneratedProject],
         graphTraverser: GraphTraversing
     ) throws -> [SchemeDescriptor] {
+        Logger.current.debug("SchemeDescriptorsGenerator: Generating \(workspace.schemes.count) workspace schemes")
         let schemes = try workspace.schemes.map { scheme in
+            Logger.current.debug("SchemeDescriptorsGenerator: Generating workspace scheme \(scheme.name)")
             return try generateScheme(
                 scheme: scheme,
                 path: workspace.xcWorkspacePath.parentDirectory,
@@ -87,7 +89,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 lastUpgradeCheck: workspace.generationOptions.lastXcodeUpgradeCheck
             )
         }
-
+        Logger.current.debug("SchemeDescriptorsGenerator: Finished generating workspace schemes")
         return schemes
     }
 
@@ -96,8 +98,10 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         generatedProject: GeneratedProject,
         graphTraverser: GraphTraversing
     ) throws -> [SchemeDescriptor] {
-        try project.schemes.map { scheme in
-            try generateScheme(
+        Logger.current.debug("SchemeDescriptorsGenerator: Generating \(project.schemes.count) project schemes for \(project.name)")
+        let result = try project.schemes.map { scheme in
+            Logger.current.debug("SchemeDescriptorsGenerator: Generating project scheme \(scheme.name)")
+            return try generateScheme(
                 scheme: scheme,
                 path: project.xcodeProjPath.parentDirectory,
                 graphTraverser: graphTraverser,
@@ -105,6 +109,8 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 lastUpgradeCheck: project.lastUpgradeCheck
             )
         }
+        Logger.current.debug("SchemeDescriptorsGenerator: Finished generating project schemes for \(project.name)")
+        return result
     }
 
     // swiftlint:disable function_body_length


### PR DESCRIPTION
## Summary
- Add debug Logger logs throughout the generator classes (ProjectDescriptorGenerator, WorkspaceDescriptorGenerator, ConfigGenerator, TargetGenerator, SchemeDescriptorsGenerator)
- Logs trace execution through all major generation steps to help diagnose issues where generation appears to stall
- Logs are visible when running with `--verbose` flag

## Test plan
- [ ] Run `tuist generate --verbose` and verify debug logs appear between "Generating project" and side effects logs
- [ ] Verify logs show each generation step (workspace data, project constants, groups, files, config, targets, schemes, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)