### PR TITLE
refactor(cache): adjust timeouts and pools

### DIFF
--- a/cache/config/deploy.production.yml
+++ b/cache/config/deploy.production.yml
@@ -10,4 +10,4 @@ env:
   clear:
     SERVER_URL: https://tuist.dev
     APPSIGNAL_ENV: prod
-    POOL_SIZE: "5"
+    POOL_SIZE: "10"

--- a/cache/lib/cache/s3.ex
+++ b/cache/lib/cache/s3.ex
@@ -82,7 +82,7 @@ defmodule Cache.S3 do
 
       case local_path
            |> Upload.stream_file()
-           |> ExAws.S3.upload(bucket, key)
+           |> ExAws.S3.upload(bucket, key, timeout: 120_000)
            |> ExAws.request() do
         {:ok, _response} ->
           :ok

--- a/cache/lib/cache/s3_transfer_worker.ex
+++ b/cache/lib/cache/s3_transfer_worker.ex
@@ -42,7 +42,7 @@ defmodule Cache.S3TransferWorker do
             {transfer, result}
           end,
           max_concurrency: @concurrency,
-          timeout: 60_000,
+          timeout: to_timeout(minute: 5),
           on_timeout: :kill_task
         )
         |> Enum.map(&handle_result(type, &1))

--- a/cache/test/cache/s3_test.exs
+++ b/cache/test/cache/s3_test.exs
@@ -111,7 +111,7 @@ defmodule Cache.S3Test do
 
       expect(Upload, :stream_file, fn ^local_path -> {:stream, local_path} end)
 
-      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key ->
+      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key, [timeout: 120_000] ->
         {:upload_operation, "test-bucket", key}
       end)
 
@@ -145,7 +145,7 @@ defmodule Cache.S3Test do
 
       expect(Upload, :stream_file, fn ^local_path -> {:stream, local_path} end)
 
-      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key ->
+      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key, [timeout: 120_000] ->
         {:upload_operation, "test-bucket", key}
       end)
 
@@ -169,7 +169,7 @@ defmodule Cache.S3Test do
 
       expect(Upload, :stream_file, fn ^local_path -> {:stream, local_path} end)
 
-      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key ->
+      expect(ExAws.S3, :upload, fn {:stream, ^local_path}, "test-bucket", ^key, [timeout: 120_000] ->
         {:upload_operation, "test-bucket", key}
       end)
 


### PR DESCRIPTION
Module cache artifacts can get very big - default timeout of 30 seconds in ex_aws is too little, especially when saturating the network connection to Tigris. Resolves https://appsignal.com/tuist/sites/69147b033622541e2e2c46dd/exceptions/incidents/47

Also increases SQLite pool size again. Resolves https://appsignal.com/tuist/sites/69147b033622541e2e2c46dd/exceptions/incidents/8