### PR TITLE
fix(server): use user ID instead of account ID in ran_by filter

### DIFF
--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -92,11 +92,11 @@ defmodule TuistWeb.CacheRunsLive do
             field: :ran_by,
             display_name: dgettext("dashboard_cache", "Ran by"),
             type: :option,
-            options: [:ci] ++ Enum.map(users, fn user -> user.account.id end),
+            options: [:ci] ++ Enum.map(users, fn user -> user.id end),
             options_display_names:
               Map.merge(
                 %{ci: "CI"},
-                Map.new(users, fn user -> {user.account.id, user.account.name} end)
+                Map.new(users, fn user -> {user.id, user.account.name} end)
               ),
             operator: :==,
             value: nil

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -311,11 +311,11 @@ defmodule TuistWeb.GenerateRunsLive do
             field: :ran_by,
             display_name: dgettext("dashboard_builds", "Ran by"),
             type: :option,
-            options: [:ci] ++ Enum.map(users, fn user -> user.account.id end),
+            options: [:ci] ++ Enum.map(users, fn user -> user.id end),
             options_display_names:
               Map.merge(
                 %{ci: "CI"},
-                Map.new(users, fn user -> {user.account.id, user.account.name} end)
+                Map.new(users, fn user -> {user.id, user.account.name} end)
               ),
             operator: :==,
             value: nil


### PR DESCRIPTION
The "Ran by" filter in the Module Cache pages (Generate Runs and Cache Runs) was not returning any results when filtering by a specific user.

The filter options were built using `user.account.id` but the query was filtering on `user_id`. Since Account belongs to User, these are different IDs. Changed to use `user.id` so the filter value matches what the database query expects.