### PR TITLE
fix(server): remove clickhouse pid file

### DIFF
--- a/server/mise.toml
+++ b/server/mise.toml
@@ -1,12 +1,7 @@
 [env]
 TUIST_SECRET_KEY_BASE = "rpux4+W/oBey0drSFOctyIbppOG2A9VUUuTMC1WaM8xZgYxA6gg4yryG/LkOoqkj"
 
-[hooks]
-enter = "mise x pitchfork -- pitchfork supervisor start && mise x pitchfork -- pitchfork start clickhouse -q"
-leave = "mise x pitchfork -- pitchfork stop clickhouse"
-
 [tools]
-  pitchfork = "latest"
   pnpm = "10.17.1"
   node = "24.11.0"
   sops = "3.9.3"

--- a/server/mise/tasks/clickhouse/start.sh
+++ b/server/mise/tasks/clickhouse/start.sh
@@ -1,24 +1,19 @@
 #!/usr/bin/env bash
-#MISE description="Start ClickHouse server"
+#MISE description="Start ClickHouse server as daemon"
 
 set -euo pipefail
 
-# Create config.d with query_log enabled and reduced logging (ClickHouse merges this with embedded defaults)
+# Create config.d with query_log enabled (ClickHouse merges this with embedded defaults)
 mkdir -p config.d
-cat > config.d/server.xml << 'EOF'
+cat > config.d/query_log.xml << 'EOF'
 <clickhouse>
     <query_log>
         <database>system</database>
         <table>query_log</table>
     </query_log>
-    <logger>
-        <level>warning</level>
-        <console>true</console>
-    </logger>
 </clickhouse>
 EOF
 
-# Start ClickHouse in foreground (pitchfork manages the daemon lifecycle)
+# Start ClickHouse in background (--daemon flag doesn't pick up config.d correctly)
 # Set keep_alive_timeout to 30 seconds to prevent connection issues
-export TZ=UTC
-exec clickhouse server -- --keep_alive_timeout=30
+TZ=UTC nohup clickhouse server -- --keep_alive_timeout=30 > /dev/null 2>&1 &

--- a/server/mise/tasks/clickhouse/stop.sh
+++ b/server/mise/tasks/clickhouse/stop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="Stop ClickHouse server"
+
+set -euo pipefail
+
+if clickhouse client --query "SYSTEM SHUTDOWN" >/dev/null 2>&1; then
+  echo "ClickHouse stopped"
+else
+  echo "ClickHouse is not running"
+fi

--- a/server/pitchfork.toml
+++ b/server/pitchfork.toml
@@ -1,3 +1,0 @@
-[daemons.clickhouse]
-run = "mise run clickhouse:start"
-ready_port = 9000


### PR DESCRIPTION
## Summary

Drop the per-directory ClickHouse PID file to treat the service as global. Restore the previous ClickHouse start behavior and add a stop task that uses SYSTEM SHUTDOWN, so no .clickhouse.pid file is created or relied upon.

Benefits:
- Avoids stale .pid files
- Aligns with a shared, global ClickHouse instance across worktrees

