### PR TITLE
fix(cli): use patched swift-openapi-urlsession to fix crash

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf9550eab1b052edb70b8fe328b41fc130a3e0724440e6de9323fd34241fca31",
+  "originHash" : "dacc807f9b5aae585eff0aa32cd5858d403842b934b371531ffeb77742e2ad17",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -443,6 +443,14 @@
       }
     },
     {
+      "identity" : "pointfreeco.swift-custom-dump",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "1.3.4"
+      }
+    },
+    {
       "identity" : "pointfreeco.swift-snapshot-testing",
       "kind" : "registry",
       "location" : "",
@@ -480,15 +488,6 @@
       "location" : "",
       "state" : {
         "version" : "0.15.1"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "93a8aa4937030b606de42f44b17870249f49af0b",
-        "version" : "1.3.4"
       }
     },
     {
@@ -609,6 +608,15 @@
       "location" : "",
       "state" : {
         "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "tuist.swift-openapi-urlsession",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/swift-openapi-urlsession",
+      "state" : {
+        "branch" : "fix/wroteFinalChunk-closed-state-crash",
+        "revision" : "a617139ebad68a6a27439cf2b39dea578bd09171"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -361,7 +361,7 @@ let targets: [Target] = [
             pathDependency,
             .product(name: "OpenAPIRuntime", package: "apple.swift-openapi-runtime"),
             .product(name: "HTTPTypes", package: "apple.swift-http-types"),
-            .product(name: "OpenAPIURLSession", package: "apple.swift-openapi-urlsession"),
+            .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
             .product(name: "Rosalind", package: "tuist.Rosalind"),
         ],
         path: "cli/Sources/TuistServer",
@@ -428,7 +428,7 @@ let targets: [Target] = [
             xcodeGraphDependency,
             "TuistHasher",
             .product(name: "OpenAPIRuntime", package: "apple.swift-openapi-runtime"),
-            .product(name: "OpenAPIURLSession", package: "apple.swift-openapi-urlsession"),
+            .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
         ],
         path: "cli/Sources/TuistCache",
         exclude: ["OpenAPI/cache.yml", "AGENTS.md"],
@@ -719,7 +719,8 @@ let package = Package(
             id: "apple.swift-http-types", .upToNextMajor(from: "1.3.0")
         ),
         .package(
-            id: "apple.swift-openapi-urlsession", .upToNextMajor(from: "1.0.2")
+            url: "https://github.com/tuist/swift-openapi-urlsession",
+            branch: "fix/wroteFinalChunk-closed-state-crash"
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.0")),
         .package(id: "tuist.XcodeGraph", .upToNextMajor(from: "1.31.0")),


### PR DESCRIPTION
## Summary

Temporarily points to tuist/swift-openapi-urlsession fork with a fix for the `wroteFinalChunk` crash that occurs when the stream is closed while the HTTP body producer is finishing.

## The Bug

The crash happens during multipart cache uploads when the server disconnects or an error occurs right as the upload completes:

```
Fatal error: wroteFinalChunk() called in invalid state: closed (error: nil)
```

**Root cause:** Race condition in `HTTPBodyOutputStreamBridge.State` where:
1. Producer finishes sending all chunks, state is `.waitingForBytes`
2. Stream is closed externally (server disconnect, error, or task cancellation) → state becomes `.closed`
3. Producer's iteration completes, calls `wroteFinalChunk()`
4. Crash because `.closed` wasn't handled

## The Fix

The fix handles `.closed` state gracefully in `wroteFinalChunk()` by returning `.none`, since the stream is already closed and no further action is needed.

## Test plan

- [x] Regression test added in upstream PR that reproduces and verifies the fix
- [x] All upstream tests pass

## References

- Upstream PR: https://github.com/apple/swift-openapi-urlsession/pull/82
- Related issue: https://github.com/apple/swift-openapi-urlsession/issues/75

## Note

This is a temporary workaround. Once the upstream PR is merged and released, we should switch back to the official package.

🤖 Generated with [Claude Code](https://claude.ai/code)