### PR TITLE
chore(cli): use registry variant for swift-protobuf dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf9550eab1b052edb70b8fe328b41fc130a3e0724440e6de9323fd34241fca31",
+  "originHash" : "e67bb4b6fa2a7d14ee86bb3c0bf13013395e48fc11c99331989644f02fd5410c",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -22,7 +22,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.6.2"
+        "version" : "1.7.0"
       }
     },
     {
@@ -102,7 +102,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "2.93.0"
+        "version" : "2.92.2"
       }
     },
     {
@@ -110,7 +110,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.32.0"
+        "version" : "1.31.3"
       }
     },
     {
@@ -443,6 +443,14 @@
       }
     },
     {
+      "identity" : "pointfreeco.swift-custom-dump",
+      "kind" : "registry",
+      "location" : "",
+      "state" : {
+        "version" : "1.3.4"
+      }
+    },
+    {
       "identity" : "pointfreeco.swift-snapshot-testing",
       "kind" : "registry",
       "location" : "",
@@ -480,15 +488,6 @@
       "location" : "",
       "state" : {
         "version" : "0.15.1"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "93a8aa4937030b606de42f44b17870249f49af0b",
-        "version" : "1.3.4"
       }
     },
     {
@@ -584,7 +583,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.51.2"
+        "version" : "0.54.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -549,7 +549,7 @@ let targets: [Target] = [
             "TuistCASAnalytics",
             .product(name: "GRPCCore", package: "grpc.grpc-swift-2"),
             .product(name: "GRPCProtobuf", package: "grpc.grpc-swift-protobuf"),
-            .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+            .product(name: "SwiftProtobuf", package: "apple.swift-protobuf"),
             .product(name: "libzstd", package: "facebook.zstd"),
             mockableDependency,
             pathDependency,
@@ -764,10 +764,7 @@ let package = Package(
             .upToNextMajor(from: "1.1.0")
         ),
         .package(id: "grpc.grpc-swift-2", from: "2.0.0"),
-        .package(
-            url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.32.0"
-        ),
+        .package(id: "apple.swift-protobuf", exact: "1.33.3"),
         .package(id: "grpc.grpc-swift-protobuf", from: "2.0.0"),
         .package(id: "grpc.grpc-swift-nio-transport", from: "2.0.0"),
         .package(id: "facebook.zstd", from: "1.5.0"),


### PR DESCRIPTION
## Summary
- Switch swift-protobuf from URL-based dependency to registry variant
- Pin to exact version 1.33.3

## Test plan
- [x] `tuist install` completed successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)