### PR TITLE
feat(cli): Add targetBuildableFolders support in PackageSettings for SPM packages

### DIFF
--- a/cli/Sources/ProjectDescription/PackageSettings.swift
+++ b/cli/Sources/ProjectDescription/PackageSettings.swift
@@ -45,6 +45,13 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.
     public var projectOptions: [String: Project.Options]
 
+    /// Targets that should use buildable folders instead of explicit file references.
+    /// When a target name is included in this set, its source files will be added as a
+    /// synchronized folder reference (buildable folder) instead of individual file references.
+    /// This eliminates the need to regenerate the project when files are added or removed.
+    /// **Note**: Requires Xcode 16 or later.
+    public var targetBuildableFolders: Set<String>
+
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
     /// - Parameters:
     ///     - productTypes: The custom `Product` types to be used for SPM targets.
@@ -52,18 +59,21 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     ///     - baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - targetBuildableFolders: Targets that should use buildable folders instead of explicit file references.
     public init(
         productTypes: [String: Product] = [:],
         productDestinations: [String: Destinations] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: Settings] = [:],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        targetBuildableFolders: Set<String> = []
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.targetBuildableFolders = targetBuildableFolders
         dumpIfNeeded(self)
     }
 
@@ -77,7 +87,7 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     @available(
         *,
         deprecated,
-        renamed: "init(productTypes:productDestinations:baseSettings:targetSettings:projectOptions:)",
+        renamed: "init(productTypes:productDestinations:baseSettings:targetSettings:projectOptions:targetBuildableFolders:)",
         message: """
         Consider using the 'Settings' type for parameter 'targetSettings' instead of 'SettingsDictionary'.
         """
@@ -87,13 +97,15 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         productDestinations: [String: Destinations] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: SettingsDictionary],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        targetBuildableFolders: Set<String> = []
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings.mapValues { .settings(base: $0) }
         self.projectOptions = projectOptions
+        self.targetBuildableFolders = targetBuildableFolders
         dumpIfNeeded(self)
     }
 }

--- a/cli/Sources/TuistCore/Models/PackageSettings.swift
+++ b/cli/Sources/TuistCore/Models/PackageSettings.swift
@@ -18,24 +18,30 @@ public struct PackageSettings: Equatable, Codable {
     /// The custom project options for each project generated from a swift package.
     public let projectOptions: [String: XcodeGraph.Project.Options]
 
+    /// Targets that should use buildable folders instead of explicit file references.
+    public let targetBuildableFolders: Set<String>
+
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
     ///    - baseSettings: The base settings to be used for targets generated from SwiftPackageManager
     ///    - targetSettings: The custom `SettingsDictionary` to be applied to denoted targets
     ///    - projectOptions: The custom project options for each project generated from a swift package
+    ///    - targetBuildableFolders: Targets that should use buildable folders
     public init(
         productTypes: [String: Product],
         productDestinations: [String: Destinations],
         baseSettings: Settings,
         targetSettings: [String: Settings],
-        projectOptions: [String: XcodeGraph.Project.Options] = [:]
+        projectOptions: [String: XcodeGraph.Project.Options] = [:],
+        targetBuildableFolders: Set<String> = []
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.targetBuildableFolders = targetBuildableFolders
     }
 }
 
@@ -46,14 +52,16 @@ public struct PackageSettings: Equatable, Codable {
             productDestinations: [String: Destinations] = [:],
             baseSettings: Settings = Settings.default,
             targetSettings: [String: Settings] = [:],
-            projectOptions: [String: XcodeGraph.Project.Options] = [:]
+            projectOptions: [String: XcodeGraph.Project.Options] = [:],
+            targetBuildableFolders: Set<String> = []
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,
                 productDestinations: productDestinations,
                 baseSettings: baseSettings,
                 targetSettings: targetSettings,
-                projectOptions: projectOptions
+                projectOptions: projectOptions,
+                targetBuildableFolders: targetBuildableFolders
             )
         }
     }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -22,13 +22,15 @@ extension TuistCore.PackageSettings {
         let projectOptions: [String: XcodeGraph.Project.Options] = manifest
             .projectOptions
             .mapValues { .from(manifest: $0) }
+        let targetBuildableFolders = manifest.targetBuildableFolders
 
         return .init(
             productTypes: productTypes,
             productDestinations: productDestinations,
             baseSettings: baseSettings,
             targetSettings: targetSettings,
-            projectOptions: projectOptions
+            projectOptions: projectOptions,
+            targetBuildableFolders: targetBuildableFolders
         )
     }
 }


### PR DESCRIPTION
### Summary

This adds a new `targetBuildableFolders` option to `PackageSettings` that allows users to specify which SPM package targets should use Xcode 16's buildable folders (`PBXFileSystemSynchronizedRootGroup`) instead of explicit file references.

### Motivation

When using Tuist with SPM packages, adding new source files requires regenerating the project. With Xcode 16's buildable folders feature, source files can be represented as synchronized folder references, enabling automatic detection of new files without regeneration.

This is particularly useful for:
- Large packages where manually listing all source files is impractical
- Development workflows that frequently add new files
- Teams wanting to reduce the frequency of project regeneration

### Changes

- Added `targetBuildableFolders: Set<String>` property to `PackageSettings` (ProjectDescription & TuistCore)
- Updated `PackageSettings+ManifestMapper` to map the new field
- Modified `PackageInfoMapper` to generate `buildableFolders` for targets in the set

### Example Usage

```swift
// Tuist/Package.swift
let packageSettings = PackageSettings(
    productTypes: ["MyPackage": .framework],
    targetBuildableFolders: ["MyPackage", "MyOtherTarget"]
)
```

### How to test locally

1. Create a project with an SPM package dependency
2. Add `targetBuildableFolders: ["YourTarget"]` to PackageSettings
3. Run `tuist generate`
4. Verify that `PBXFileSystemSynchronizedRootGroup` is generated for the specified targets
5. Add a new Swift file to the package source folder
6. Build without regenerating - the new file should be recognized
