### PR TITLE
fix(cache): send runtime errors in correct format

### DIFF
--- a/cache/lib/cache_web/controllers/error_json.ex
+++ b/cache/lib/cache_web/controllers/error_json.ex
@@ -1,9 +1,12 @@
 defmodule CacheWeb.ErrorJSON do
   @moduledoc """
   This module is invoked by your endpoint in case of errors on JSON requests.
+
+  Returns errors in the format expected by the CLI's OpenAPI client:
+  `%{message: "..."}` to match `CacheWeb.API.Schemas.Error`.
   """
 
   def render(template, _assigns) do
-    %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
+    %{message: Phoenix.Controller.status_message_from_template(template)}
   end
 end


### PR DESCRIPTION
Should fix `“Failed to upload OrderedCollections with hash 95b6e175a2568602a5fd644c0fedb3dd due to unexpected error: The data couldn’t be read because it is missing.”` of decoding error message when `message` isn't present.