### PR TITLE
feat(server): add remote upload stats to cache run

### DIFF
--- a/server/assets/app/css/pages/run_detail.css
+++ b/server/assets/app/css/pages/run_detail.css
@@ -146,7 +146,8 @@
       }
     }
 
-    & > [data-part="cacheable-targets-card-section"] {
+    & > [data-part="cacheable-targets-card-section"],
+    & > [data-part="upload-targets-card-section"] {
       display: flex;
       flex-direction: column;
       gap: var(--noora-spacing-5);

--- a/server/lib/tuist_web/live/run_detail_live.html.heex
+++ b/server/lib/tuist_web/live/run_detail_live.html.heex
@@ -367,6 +367,17 @@
           value={"#{@binary_cache_analytics.cache_hit_rate}%"}
           id="widget-optimization-summary-cache-hit-rate"
         />
+        <.widget
+          title={dgettext("dashboard_builds", "Remotely cached")}
+          description={
+            dgettext(
+              "dashboard_builds",
+              "Number of modules that were uploaded to the remote cache after being built locally."
+            )
+          }
+          value={Map.get(@binary_cache_analytics, :uploaded_count, 0)}
+          id="widget-optimization-summary-uploaded"
+        />
       </.card_section>
     </.card>
     <.card
@@ -513,6 +524,109 @@
             }
           />
         </.card_section>
+        <.card_section
+          :if={
+            Map.get(@binary_cache_analytics, :uploaded_count, 0) > 0 or
+            Map.get(@binary_cache_analytics, :not_uploaded_count, 0) > 0
+          }
+          data-part="upload-targets-card-section"
+        >
+          <div data-part="title">
+            <span data-part="label">
+              {dgettext("dashboard_builds", "Remotely cached targets:")}
+            </span>
+            <span data-part="value">
+              {Map.get(@binary_cache_analytics, :uploaded_count, 0) +
+                Map.get(@binary_cache_analytics, :not_uploaded_count, 0)}
+            </span>
+          </div>
+          <%
+            uploaded_count = Map.get(@binary_cache_analytics, :uploaded_count, 0)
+            not_uploaded_count = Map.get(@binary_cache_analytics, :not_uploaded_count, 0)
+          %>
+          <.chart
+            id="upload-targets-breakdown-chart"
+            type="bar"
+            extra_options={
+              %{
+                tooltip: %{
+                  trigger: "axis",
+                  axisPointer: %{
+                    type: "none"
+                  }
+                },
+                legend: %{
+                  left: "-0.3%",
+                  top: "bottom",
+                  orient: "horizontal",
+                  textStyle: %{
+                    color: "var:noora-surface-label-primary",
+                    fontFamily: "monospace",
+                    fontWeight: 400,
+                    fontSize: 10,
+                    lineHeight: 12
+                  },
+                  icon:
+                    "path://M0 6C0 4.89543 0.895431 4 2 4H6C7.10457 4 8 4.89543 8 6C8 7.10457 7.10457 8 6 8H2C0.895431 8 0 7.10457 0 6Z",
+                  itemWidth: 8,
+                  itemHeight: 4
+                },
+                grid: %{
+                  width: "99%",
+                  left: "0%",
+                  height: "60%",
+                  top: "0%"
+                },
+                xAxis: %{
+                  type: "value",
+                  axisLabel: %{
+                    show: false
+                  },
+                  splitLine: %{show: false}
+                },
+                yAxis: %{
+                  type: "category",
+                  data: [dgettext("dashboard_builds", "Remotely cached targets")],
+                  axisLabel: %{
+                    show: false
+                  }
+                }
+              }
+            }
+            series={[
+              %{
+                name: dgettext("dashboard_builds", "Already cached"),
+                type: "bar",
+                stack: "total",
+                emphasis: %{
+                  focus: "series"
+                },
+                data: [not_uploaded_count],
+                color: "var:hits-chart-legend-missed",
+                itemStyle: %{
+                  borderRadius:
+                    if(uploaded_count == 0, do: [6, 6, 6, 6], else: [6, 0, 0, 6])
+                }
+              },
+              %{
+                name: dgettext("dashboard_builds", "Uploaded"),
+                type: "bar",
+                stack: "total",
+                emphasis: %{
+                  focus: "series"
+                },
+                data: [uploaded_count],
+                color: "var:hits-chart-legend-remote",
+                itemStyle: %{
+                  borderRadius:
+                    if(not_uploaded_count == 0, do: [6, 6, 6, 6], else: [0, 6, 6, 0])
+                }
+              }
+            ]}
+            x_axis_min={0}
+            x_axis_max={uploaded_count + not_uploaded_count}
+          />
+        </.card_section>
         <div data-part="filters">
           <.form for={%{}} phx-change="search-binary-cache" phx-debounce="200">
             <.text_input
@@ -578,6 +692,17 @@
                   color="warning"
                   style="light-fill"
                 />
+            <% end %>
+          </:col>
+          <:col :let={binary_cache_module} label={dgettext("dashboard_builds", "Cached")}>
+            <%= if Map.get(binary_cache_module, :uploaded, false) do %>
+              <.badge_cell
+                label={dgettext("dashboard_builds", "Remote")}
+                color="focus"
+                style="light-fill"
+              />
+            <% else %>
+              <.text_cell label="-" />
             <% end %>
           </:col>
           <:col :let={binary_cache_module} label={dgettext("dashboard_builds", "Hash")}>


### PR DESCRIPTION
I've noticed that the stats shown on a cache run detail page are more related to the state of play before the caching has completed. I thought it would be helpful to see the result of the cache command, specifically which binaries have been cached and uploaded to the remote cache. I appreciate you can somewhat infer this from the success of the command, but after occasionally noticing network errors during this operation I wanted to dive into the information to see what had been successfully uploaded into the module cache and which targets had failed.

This PR essentially captures the essence of what I'm thinking could be a helpful addition to this page, I'm not confident on the quality as pretty new to these languages, so very happy to raise this as a prototype for an idea, and let you guys handle if you think it would be a good addition.

<img width="1713" height="960" alt="Screenshot 2026-01-26 at 2 55 26 pm" src="https://github.com/user-attachments/assets/8dfb0b00-7973-4f5c-9ffc-3f38d46452c8" />
