### PR TITLE
fix(server): use TUIST_ prefix for SECRET_KEY_BASE env var

### DIFF
--- a/server/mise.toml
+++ b/server/mise.toml
@@ -1,5 +1,5 @@
 [env]
-SECRET_KEY_BASE = "rpux4+W/oBey0drSFOctyIbppOG2A9VUUuTMC1WaM8xZgYxA6gg4yryG/LkOoqkj"
+TUIST_SECRET_KEY_BASE = "rpux4+W/oBey0drSFOctyIbppOG2A9VUUuTMC1WaM8xZgYxA6gg4yryG/LkOoqkj"
 
 [tools]
   pnpm = "10.17.1"


### PR DESCRIPTION
The environment variable in mise.toml should use the TUIST_ prefix to match the convention used by the get() function in Environment module, which automatically looks for TUIST_-prefixed environment variables.