### PR TITLE
fix(server,cache): ignore NoRouteError in error tracking

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -1,12 +1,13 @@
 import Config
 
 # Bandit.TransportError is raised when the client disconnects mid-request (e.g. cancelled upload).
+# Phoenix.Router.NoRouteError is raised when a request hits a non-existent route (e.g. bots scanning).
 # These are expected and not actionable errors.
 config :appsignal, :config,
   otp_app: :cache,
   name: "Cache",
   active: true,
-  ignore_errors: ["Bandit.TransportError"]
+  ignore_errors: ["Bandit.TransportError", "Phoenix.Router.NoRouteError"]
 
 config :cache, Cache.PromEx,
   disabled: false,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -215,6 +215,9 @@ if Tuist.Environment.error_tracking_enabled?() do
       # Bandit.TransportError is raised when the client disconnects mid-request.
       # These are expected and not actionable errors.
       "Bandit.TransportError",
+      # Phoenix.Router.NoRouteError is raised when a request hits a non-existent route.
+      # Users see a proper 404 page, so these are not actionable.
+      "Phoenix.Router.NoRouteError",
       "TuistWeb.Errors.BadRequestError",
       "TuistWeb.Errors.NotFoundError",
       "TuistWeb.Errors.TooManyRequestsError",


### PR DESCRIPTION
## Summary

- Add `Phoenix.Router.NoRouteError` to the `ignore_errors` list in AppSignal config for both server and cache
- These errors occur when requests hit non-existent routes (bots scanning for vulnerabilities, typos, etc.)
- Users already see proper 404 pages, so these are not actionable errors

Fixes:
- https://tuist.sentry.io/issues/91202825/
- https://tuist.sentry.io/issues/91192352/
- https://tuist.sentry.io/issues/91233745/