### PR TITLE
fix(cli): support BITRISE_IDENTITY_TOKEN env var for Bitrise OIDC auth

### DIFF
--- a/cli/Sources/TuistOIDC/CIOIDCAuthenticator.swift
+++ b/cli/Sources/TuistOIDC/CIOIDCAuthenticator.swift
@@ -97,7 +97,9 @@ public struct CIOIDCAuthenticator: CIOIDCAuthenticating {
     }
 
     private func bitriseOIDCToken() throws -> String {
-        guard let token = Environment.current.variables["BITRISE_OIDC_ID_TOKEN"] else {
+        guard let token = Environment.current.variables["BITRISE_OIDC_ID_TOKEN"]
+            ?? Environment.current.variables["BITRISE_IDENTITY_TOKEN"]
+        else {
             throw CIOIDCAuthenticatorError.missingBitriseOIDCToken
         }
 

--- a/cli/Tests/TuistOIDCTests/CIOIDCAuthenticatorTests.swift
+++ b/cli/Tests/TuistOIDCTests/CIOIDCAuthenticatorTests.swift
@@ -145,18 +145,35 @@ struct CIOIDCAuthenticatorTests {
     }
 
     @Test(.withMockedEnvironment())
-    func fetchOIDCToken_returns_bitrise_oidc_token() async throws {
+    func fetchOIDCToken_returns_bitrise_oidc_id_token() async throws {
         // Given
         let environment = try #require(Environment.mocked)
         environment.variables = [
             "BITRISE_IO": "true",
-            "BITRISE_OIDC_ID_TOKEN": "bitrise-oidc-token",
+            "BITRISE_OIDC_ID_TOKEN": "bitrise-oidc-id-token",
+            "BITRISE_IDENTITY_TOKEN": "bitrise-identity-token",
         ]
 
         // When
         let token = try await subject.fetchOIDCToken()
 
         // Then
-        #expect(token == "bitrise-oidc-token")
+        #expect(token == "bitrise-oidc-id-token")
+    }
+
+    @Test(.withMockedEnvironment())
+    func fetchOIDCToken_returns_bitrise_identity_token_when_oidc_id_token_missing() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.variables = [
+            "BITRISE_IO": "true",
+            "BITRISE_IDENTITY_TOKEN": "bitrise-identity-token",
+        ]
+
+        // When
+        let token = try await subject.fetchOIDCToken()
+
+        // Then
+        #expect(token == "bitrise-identity-token")
     }
 }


### PR DESCRIPTION
Bitrise's `get-identity-token` step exports the OIDC token as `BITRISE_IDENTITY_TOKEN` by default, but Tuist was only checking for `BITRISE_OIDC_ID_TOKEN`. This caused confusion during PoCs until users added a workaround in their pipelines.

This adds support for both env var names, with `BITRISE_OIDC_ID_TOKEN` taking precedence if both are present - following the same pattern we use for CircleCI's token env vars.

Resolves TUI-443