### PR TITLE
fix(server): correct analytics-environment query for test runs analytics

### DIFF
--- a/server/lib/tuist_web/live/test_runs_live.html.heex
+++ b/server/lib/tuist_web/live/test_runs_live.html.heex
@@ -9,7 +9,7 @@
         <.dropdown_item
           value="any"
           label="Any"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "any")}"}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "any")}"}
           data-selected={@analytics_environment == "any"}
         >
           <:right_icon><.check /></:right_icon>
@@ -17,7 +17,7 @@
         <.dropdown_item
           value="local"
           label="Local"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "local")}"}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
           data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
@@ -25,7 +25,7 @@
         <.dropdown_item
           value="ci"
           label="CI"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "ci")}"}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
         >
           <:right_icon><.check /></:right_icon>


### PR DESCRIPTION
The environment picker on the analytics card in the test run dashboard doesn't currently work/filter anything. Looks like a simple mismatch between the name of the parameter in the template and backend code.

<img width="179" height="174" alt="Screenshot 2026-01-27 at 12 45 35 pm" src="https://github.com/user-attachments/assets/dd8fae3b-7b96-4575-ac95-f3584144ba9d" />

