### PR TITLE
refactor(cache): enable FQDN longnames

### DIFF
--- a/cache/rel/env.sh.eex
+++ b/cache/rel/env.sh.eex
@@ -1,4 +1,20 @@
 #!/bin/sh
 
-export RELEASE_DISTRIBUTION="name"
-export RELEASE_NODE="cache@127.0.0.1"
+if [ -f /etc/host_hostname ]; then
+  host_name=$(cat /etc/host_hostname)
+  fqdn="${host_name}.tuist.dev"
+  export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-name}"
+  export RELEASE_NODE="${RELEASE_NODE:-cache@${fqdn}}"
+  
+  # Map own FQDN to localhost for local commands (remote, rpc).
+  # Other FQDNs resolve via DNS for cross-node clustering.
+  erl_inetrc="/run/cache/erl_inetrc"
+  cat > "$erl_inetrc" <<EOF
+{lookup, [file, native]}.
+{host, {127,0,0,1}, ["${fqdn}"]}.
+EOF
+  export ERL_INETRC="$erl_inetrc"
+else
+  export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-name}"
+  export RELEASE_NODE="${RELEASE_NODE:-cache@127.0.0.1}"
+fi


### PR DESCRIPTION
Before:
<img width="712" height="272" alt="CleanShot 2026-01-27 at 12 22 32@2x" src="https://github.com/user-attachments/assets/60992001-a277-42ea-a22e-3d0d2e7b7315" />
After:
<img width="686" height="222" alt="CleanShot 2026-01-27 at 14 15 33@2x" src="https://github.com/user-attachments/assets/01ce79ca-f7bd-4ff5-bbcf-236acd926467" />


Allows for proper clustering and locking for the upcoming registry update where all nodes being `cache@127.0.0.1` doesn't allow to differentiate.