### PR TITLE
feat(server): add terms of service and privacy policy links

### DIFF
--- a/server/assets/app/css/pages/auth.css
+++ b/server/assets/app/css/pages/auth.css
@@ -354,3 +354,27 @@
     gap: var(--noora-spacing-2);
   }
 }
+
+[data-part="terms-notice"] {
+  position: fixed;
+  bottom: var(--noora-spacing-8);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--noora-z-index-4);
+  text-align: center;
+
+  & span {
+    color: var(--noora-surface-label-secondary);
+    font: var(--noora-font-body-medium);
+  }
+
+  & a {
+    color: var(--noora-surface-label-secondary);
+    text-decoration: underline;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: var(--noora-surface-label-primary);
+    }
+  }
+}

--- a/server/lib/tuist_web/components/app_auth_components.ex
+++ b/server/lib/tuist_web/components/app_auth_components.ex
@@ -4,6 +4,24 @@ defmodule TuistWeb.AppAuthComponents do
   """
 
   use Phoenix.Component
+  use Gettext, backend: TuistWeb.Gettext
+
+  def terms_and_privacy(assigns) do
+    ~H"""
+    <div data-part="terms-notice">
+      <span>
+        {dgettext("dashboard_auth", "By continuing, you agree to Tuist's")}
+        <a href="https://tuist.dev/terms" target="_blank" rel="noopener noreferrer">
+          {dgettext("dashboard_auth", "Terms of Service")}
+        </a>
+        {dgettext("dashboard_auth", "and")}
+        <a href="https://tuist.dev/privacy" target="_blank" rel="noopener noreferrer">
+          {dgettext("dashboard_auth", "Privacy Policy")}
+        </a>
+      </span>
+    </div>
+    """
+  end
 
   def dots_light(assigns) do
     unique_id = UUIDv7.generate()

--- a/server/lib/tuist_web/live/accept_invitation_live.ex
+++ b/server/lib/tuist_web/live/accept_invitation_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.AcceptInvitationLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
 
   def mount(params, session, socket) do
@@ -167,6 +169,7 @@ defmodule TuistWeb.AcceptInvitationLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.ChooseUsernameLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
 
   @impl true
@@ -82,6 +84,7 @@ defmodule TuistWeb.ChooseUsernameLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/create_organization_live.ex
+++ b/server/lib/tuist_web/live/create_organization_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.CreateOrganizationLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
   alias Tuist.Accounts.Account
 
@@ -71,6 +73,7 @@ defmodule TuistWeb.CreateOrganizationLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/create_project_live.ex
+++ b/server/lib/tuist_web/live/create_project_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.CreateProjectLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Phoenix.Flash
   alias Tuist.Accounts
   alias Tuist.Authorization
@@ -112,6 +114,7 @@ defmodule TuistWeb.CreateProjectLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/device_codes_success_live.ex
+++ b/server/lib/tuist_web/live/device_codes_success_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.DeviceCodesSuccessLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
   alias TuistWeb.Authentication
 
@@ -70,6 +72,7 @@ defmodule TuistWeb.DeviceCodesSuccessLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/sso_login_live.ex
+++ b/server/lib/tuist_web/live/sso_login_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.SSOLoginLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Phoenix.Flash
   alias Tuist.Accounts
 
@@ -92,6 +94,7 @@ defmodule TuistWeb.SSOLoginLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_confirmation_live.ex
+++ b/server/lib/tuist_web/live/user_confirmation_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.UserConfirmationLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
 
   def render(assigns) do
@@ -65,6 +67,7 @@ defmodule TuistWeb.UserConfirmationLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_forgot_password_live.ex
+++ b/server/lib/tuist_web/live/user_forgot_password_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.UserForgotPasswordLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
 
   def render(assigns) do
@@ -79,6 +81,7 @@ defmodule TuistWeb.UserForgotPasswordLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_login_live.ex
+++ b/server/lib/tuist_web/live/user_login_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.UserLoginLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Phoenix.Flash
   alias Tuist.Environment
 
@@ -189,6 +191,7 @@ defmodule TuistWeb.UserLoginLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_okta_login_live.ex
+++ b/server/lib/tuist_web/live/user_okta_login_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.UserOktaLoginLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Phoenix.Flash
   alias Tuist.Accounts
 
@@ -96,6 +98,7 @@ defmodule TuistWeb.UserOktaLoginLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -199,6 +199,7 @@ defmodule TuistWeb.UserRegistrationLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     <div :if={@success} id="signup-success">
       <div data-part="wrapper">
@@ -231,6 +232,7 @@ defmodule TuistWeb.UserRegistrationLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/lib/tuist_web/live/user_reset_password_live.ex
+++ b/server/lib/tuist_web/live/user_reset_password_live.ex
@@ -3,6 +3,8 @@ defmodule TuistWeb.UserResetPasswordLive do
   use TuistWeb, :live_view
   use Noora
 
+  import TuistWeb.AppAuthComponents
+
   alias Tuist.Accounts
 
   def render(assigns) do
@@ -67,6 +69,7 @@ defmodule TuistWeb.UserResetPasswordLive do
         <div data-part="bottom-left-gradient"></div>
         <div data-part="shell"><.shell /></div>
       </div>
+      <.terms_and_privacy />
     </div>
     """
   end

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -22,7 +22,7 @@ msgstr ""
 msgid "$0.50"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:63
+#: lib/tuist_web/live/accept_invitation_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "%{inviter} has invited you to join the %{organization} organization"
 msgstr ""
@@ -33,7 +33,7 @@ msgid "%{month}/%{year}"
 msgstr ""
 
 #: lib/tuist/accounts/user_notifier.ex:175
-#: lib/tuist_web/live/accept_invitation_live.ex:75
+#: lib/tuist_web/live/accept_invitation_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Accept invitation"
 msgstr ""
@@ -105,7 +105,7 @@ msgstr ""
 #: lib/tuist_web/live/account_settings_live.html.heex:143
 #: lib/tuist_web/live/account_settings_live.html.heex:217
 #: lib/tuist_web/live/account_settings_live.html.heex:289
-#: lib/tuist_web/live/create_organization_live.ex:62
+#: lib/tuist_web/live/create_organization_live.ex:64
 #: lib/tuist_web/live/members_live.ex:157
 #: lib/tuist_web/live/members_live.ex:206
 #, elixir-autogen, elixir-format
@@ -163,17 +163,17 @@ msgstr ""
 msgid "Contact sales"
 msgstr ""
 
-#: lib/tuist_web/live/create_organization_live.ex:37
+#: lib/tuist_web/live/create_organization_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "Create a new organization"
 msgstr ""
 
-#: lib/tuist_web/live/create_organization_live.ex:35
+#: lib/tuist_web/live/create_organization_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Create an organization account to continue"
 msgstr ""
 
-#: lib/tuist_web/live/create_organization_live.ex:57
+#: lib/tuist_web/live/create_organization_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Create organization"
 msgstr ""
@@ -214,12 +214,12 @@ msgstr ""
 msgid "Custom terms: Tailored agreements to meet your specific needs"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:153
+#: lib/tuist_web/live/accept_invitation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:81
+#: lib/tuist_web/live/accept_invitation_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
@@ -374,17 +374,17 @@ msgstr ""
 msgid "If you didn't make this request, feel free to ignore this email."
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:105
+#: lib/tuist_web/live/accept_invitation_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invitation accepted!"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:88
+#: lib/tuist_web/live/accept_invitation_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Invitation not found"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:127
+#: lib/tuist_web/live/accept_invitation_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Invitation rejected"
 msgstr ""
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Most Popular"
 msgstr ""
 
-#: lib/tuist_web/live/create_organization_live.ex:49
+#: lib/tuist_web/live/create_organization_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -719,8 +719,8 @@ msgstr ""
 msgid "Try changing your search term"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:52
-#: lib/tuist_web/live/create_organization_live.ex:26
+#: lib/tuist_web/live/accept_invitation_live.ex:54
+#: lib/tuist_web/live/create_organization_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
 msgstr ""
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Via shared Slack channel"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:96
+#: lib/tuist_web/live/accept_invitation_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "We could not find the invitation you are trying to accept. Please try again."
 msgstr ""
@@ -855,22 +855,22 @@ msgstr ""
 msgid "You are not authorized to perform this action."
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:119
+#: lib/tuist_web/live/accept_invitation_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "You are now a part of %{organization} organization"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:107
+#: lib/tuist_web/live/accept_invitation_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "You have accepted the invite to join the organization"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:61
+#: lib/tuist_web/live/accept_invitation_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "You have been invited"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:129
+#: lib/tuist_web/live/accept_invitation_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "You have rejected the invite to join the organization"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "You were invited to join the %{organization_name} Tuist organization by %{inviter_email}"
 msgstr ""
 
-#: lib/tuist_web/live/accept_invitation_live.ex:141
+#: lib/tuist_web/live/accept_invitation_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "You won’t be able to access this organization unless invited again."
 msgstr ""

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -11,17 +11,17 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:25
+#: lib/tuist_web/live/user_confirmation_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Account confirmed!"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:292
+#: lib/tuist_web/live/user_registration_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "Account created successfully! Please log in."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:304
+#: lib/tuist_web/live/user_registration_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Account name is already taken"
 msgstr ""
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Already set up your Tuist project? Skip setup and go to the dashboard."
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:72
+#: lib/tuist_web/live/user_forgot_password_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Back to log in"
 msgstr ""
@@ -46,42 +46,42 @@ msgstr ""
 msgid "Binary caching"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:30
+#: lib/tuist_web/live/user_reset_password_live.ex:32
 #, elixir-autogen, elixir-format
 msgid "Change your password"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:40
+#: lib/tuist_web/live/user_forgot_password_live.ex:42
 #, elixir-autogen, elixir-format
 msgid "Check your email"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:219
+#: lib/tuist_web/live/user_registration_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Check your inbox for a confirmation email and click the link to continue."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:48
+#: lib/tuist_web/live/choose_username_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Choose a username"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:50
+#: lib/tuist_web/live/choose_username_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Choose a username for your personal account"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:50
+#: lib/tuist_web/live/user_reset_password_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Confirm password"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:217
+#: lib/tuist_web/live/user_registration_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Confirm your account"
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:44
+#: lib/tuist_web/live/user_confirmation_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Confirmation failed"
 msgstr ""
@@ -106,18 +106,18 @@ msgstr ""
 msgid "Connection successful"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:86
-#: lib/tuist_web/live/user_okta_login_live.ex:90
+#: lib/tuist_web/live/sso_login_live.ex:88
+#: lib/tuist_web/live/user_okta_login_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Contact us"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:73
+#: lib/tuist_web/live/choose_username_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:59
+#: lib/tuist_web/live/device_codes_success_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -127,21 +127,21 @@ msgstr ""
 msgid "Discover how selective testing is reducing your test time."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:178
+#: lib/tuist_web/live/user_login_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:69
-#: lib/tuist_web/live/user_forgot_password_live.ex:52
-#: lib/tuist_web/live/user_login_live.ex:135
-#: lib/tuist_web/live/user_okta_login_live.ex:72
+#: lib/tuist_web/live/sso_login_live.ex:71
+#: lib/tuist_web/live/user_forgot_password_live.ex:54
+#: lib/tuist_web/live/user_login_live.ex:137
+#: lib/tuist_web/live/user_okta_login_live.ex:74
 #: lib/tuist_web/live/user_registration_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:307
+#: lib/tuist_web/live/user_registration_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Email is already taken"
 msgstr ""
@@ -156,17 +156,17 @@ msgstr ""
 msgid "Explore how binary caching is enhancing your build times."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:166
+#: lib/tuist_web/live/user_login_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Forgot password?"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:29
+#: lib/tuist_web/live/user_forgot_password_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Forgot your password?"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:42
+#: lib/tuist_web/live/user_forgot_password_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "If your email exists in our records, you'll receive reset instructions shortly."
 msgstr ""
@@ -181,45 +181,45 @@ msgstr ""
 msgid "Instantly share your app using a URL."
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:81
-#: lib/tuist_web/live/user_okta_login_live.ex:84
+#: lib/tuist_web/live/sso_login_live.ex:83
+#: lib/tuist_web/live/user_okta_login_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Interested in SSO?"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:159
+#: lib/tuist_web/live/user_login_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:77
-#: lib/tuist_web/live/user_login_live.ex:15
-#: lib/tuist_web/live/user_login_live.ex:172
-#: lib/tuist_web/live/user_okta_login_live.ex:80
+#: lib/tuist_web/live/sso_login_live.ex:79
+#: lib/tuist_web/live/user_login_live.ex:17
+#: lib/tuist_web/live/user_login_live.ex:174
+#: lib/tuist_web/live/user_okta_login_live.ex:82
 #: lib/tuist_web/live/user_registration_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:52
-#: lib/tuist_web/live/user_login_live.ex:45
-#: lib/tuist_web/live/user_okta_login_live.ex:55
+#: lib/tuist_web/live/sso_login_live.ex:54
+#: lib/tuist_web/live/user_login_live.ex:47
+#: lib/tuist_web/live/user_okta_login_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Log in to Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:54
-#: lib/tuist_web/live/user_okta_login_live.ex:57
+#: lib/tuist_web/live/sso_login_live.ex:56
+#: lib/tuist_web/live/user_okta_login_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Log in to your enterprise account via Okta"
 msgstr ""
 
-#: lib/tuist_web/live/user_okta_login_live.ex:34
+#: lib/tuist_web/live/user_okta_login_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Logging in via Okta failed"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:42
+#: lib/tuist_web/live/user_reset_password_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Next steps"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:32
+#: lib/tuist_web/live/sso_login_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "No SSO organization found for this email"
 msgstr ""
@@ -239,18 +239,18 @@ msgstr ""
 msgid "OR"
 msgstr ""
 
-#: lib/tuist_web/live/user_okta_login_live.ex:15
+#: lib/tuist_web/live/user_okta_login_live.ex:17
 #, elixir-autogen, elixir-format
 msgid "Okta log in"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:146
+#: lib/tuist_web/live/user_login_live.ex:148
 #: lib/tuist_web/live/user_registration_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:94
+#: lib/tuist_web/live/user_reset_password_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Password reset successfully."
 msgstr ""
@@ -265,8 +265,8 @@ msgstr ""
 msgid "Project Ready? Proceed to dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:61
-#: lib/tuist_web/live/user_reset_password_live.ex:58
+#: lib/tuist_web/live/user_forgot_password_live.ex:63
+#: lib/tuist_web/live/user_reset_password_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Reset password"
 msgstr ""
@@ -286,9 +286,9 @@ msgstr ""
 msgid "Selective testing"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:183
+#: lib/tuist_web/live/user_login_live.ex:185
 #: lib/tuist_web/live/user_registration_live.ex:181
-#: lib/tuist_web/live/user_registration_live.ex:262
+#: lib/tuist_web/live/user_registration_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Sign up"
 msgstr ""
@@ -298,31 +298,31 @@ msgstr ""
 msgid "Sign up for Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:114
+#: lib/tuist_web/live/choose_username_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "This username has already been taken"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:39
+#: lib/tuist_web/live/device_codes_success_live.ex:41
 #, elixir-autogen, elixir-format
 msgid "Tuist CLI is connected!"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:40
-#: lib/tuist_web/live/device_codes_success_live.ex:26
-#: lib/tuist_web/live/sso_login_live.ex:44
-#: lib/tuist_web/live/user_confirmation_live.ex:16
-#: lib/tuist_web/live/user_forgot_password_live.ex:21
-#: lib/tuist_web/live/user_login_live.ex:37
-#: lib/tuist_web/live/user_okta_login_live.ex:47
+#: lib/tuist_web/live/choose_username_live.ex:42
+#: lib/tuist_web/live/device_codes_success_live.ex:28
+#: lib/tuist_web/live/sso_login_live.ex:46
+#: lib/tuist_web/live/user_confirmation_live.ex:18
+#: lib/tuist_web/live/user_forgot_password_live.ex:23
+#: lib/tuist_web/live/user_login_live.ex:39
+#: lib/tuist_web/live/user_okta_login_live.ex:49
 #: lib/tuist_web/live/user_registration_live.ex:67
-#: lib/tuist_web/live/user_registration_live.ex:209
-#: lib/tuist_web/live/user_reset_password_live.ex:22
+#: lib/tuist_web/live/user_registration_live.ex:210
+#: lib/tuist_web/live/user_reset_password_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:37
+#: lib/tuist_web/live/device_codes_success_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "Tuist app is connected!"
 msgstr ""
@@ -337,23 +337,23 @@ msgstr ""
 msgid "Tuist documentation"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:41
+#: lib/tuist_web/live/device_codes_success_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Tuist is connected!"
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:55
+#: lib/tuist_web/live/user_confirmation_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:63
+#: lib/tuist_web/live/choose_username_live.ex:65
 #: lib/tuist_web/live/user_registration_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:64
+#: lib/tuist_web/live/choose_username_live.ex:66
 #: lib/tuist_web/live/user_registration_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Username may only contain alphanumeric characters"
@@ -364,12 +364,12 @@ msgstr ""
 msgid "Waiting for connection"
 msgstr ""
 
-#: lib/tuist_web/live/user_forgot_password_live.ex:31
+#: lib/tuist_web/live/user_forgot_password_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "We'll send a password reset link to your inbox"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:47
+#: lib/tuist_web/live/user_login_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Welcome back! Please log in to continue"
 msgstr ""
@@ -379,37 +379,37 @@ msgstr ""
 msgid "Welcome! Create an account to continue"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:51
+#: lib/tuist_web/live/device_codes_success_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You can close the tab and continue"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:47
+#: lib/tuist_web/live/device_codes_success_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "You can close the tab and continue in the app"
 msgstr ""
 
-#: lib/tuist_web/live/device_codes_success_live.ex:49
+#: lib/tuist_web/live/device_codes_success_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "You can close the tab and continue in the terminal"
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:46
+#: lib/tuist_web/live/user_confirmation_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Your account could not be confirmed."
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:27
+#: lib/tuist_web/live/user_confirmation_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your account has been confirmed."
 msgstr ""
 
-#: lib/tuist_web/live/user_confirmation_live.ex:36
+#: lib/tuist_web/live/user_confirmation_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Your account has been confirmed. You will be redirected shortly..."
 msgstr ""
 
-#: lib/tuist_web/live/user_reset_password_live.ex:32
+#: lib/tuist_web/live/user_reset_password_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Your new password must be different to previously used passwords."
 msgstr ""
@@ -429,4 +429,24 @@ msgstr ""
 #: lib/tuist_web/live/connect_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "using CLI"
+msgstr ""
+
+#: lib/tuist_web/components/app_auth_components.ex:13
+#, elixir-autogen, elixir-format
+msgid "By continuing, you agree to Tuist's"
+msgstr ""
+
+#: lib/tuist_web/components/app_auth_components.ex:19
+#, elixir-autogen, elixir-format
+msgid "Privacy Policy"
+msgstr ""
+
+#: lib/tuist_web/components/app_auth_components.ex:15
+#, elixir-autogen, elixir-format
+msgid "Terms of Service"
+msgstr ""
+
+#: lib/tuist_web/components/app_auth_components.ex:17
+#, elixir-autogen, elixir-format
+msgid "and"
 msgstr ""

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -38,7 +38,7 @@ msgstr ""
 msgid "%{selective_tests_effectiveness}%"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:75
+#: lib/tuist_web/live/create_project_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -159,17 +159,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:77
+#: lib/tuist_web/live/create_project_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Choose an account to create your project or set up a new organization."
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:96
+#: lib/tuist_web/live/create_project_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:59
+#: lib/tuist_web/live/create_project_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Create a Tuist project to continue"
 msgstr ""
@@ -179,12 +179,12 @@ msgstr ""
 msgid "Create a new project"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:57
+#: lib/tuist_web/live/create_project_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Create a project"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:101
+#: lib/tuist_web/live/create_project_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Create organization"
 msgstr ""
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:66
+#: lib/tuist_web/live/create_project_live.ex:68
 #: lib/tuist_web/live/project_notifications_live.html.heex:309
 #: lib/tuist_web/live/project_notifications_live.html.heex:448
 #: lib/tuist_web/live/project_notifications_live.html.heex:527
@@ -325,7 +325,7 @@ msgstr ""
 msgid "Only organization members"
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:99
+#: lib/tuist_web/live/create_project_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Or set up a new organization"
 msgstr ""
@@ -420,7 +420,7 @@ msgstr ""
 msgid "Search projects..."
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:71
+#: lib/tuist_web/live/create_project_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Select account"
 msgstr ""
@@ -467,7 +467,7 @@ msgstr ""
 msgid "This action cannot be undone."
 msgstr ""
 
-#: lib/tuist_web/live/create_project_live.ex:49
+#: lib/tuist_web/live/create_project_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
 msgstr ""


### PR DESCRIPTION
Resolves TUI-366.

I’ve added the Terms of Service and Privacy Policy consent line across all auth pages. As discussed in [TUI-367](https://linear.app/tuist/issue/TUI-367/add-agreement-checkbox-in-the-sign-up-page), @pepicrft will handle the related business logic.

I still need to design a dedicated terms agreement page for existing users who signed up earlier but didn’t explicitly agree to the Terms of Service and Privacy Policy.
