### PR TITLE
feat(server,cache): track releases in Sentry using commit SHA

### DIFF
--- a/cache/rel/env.sh.eex
+++ b/cache/rel/env.sh.eex
@@ -1,11 +1,14 @@
 #!/bin/sh
 
+# Set Sentry release from Kamal version (automatically populated by Kamal)
+export SENTRY_RELEASE="${KAMAL_VERSION:-${RELEASE_VSN}}"
+
 if [ -f /etc/host_hostname ]; then
   host_name=$(cat /etc/host_hostname)
   fqdn="${host_name}.tuist.dev"
   export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-name}"
   export RELEASE_NODE="${RELEASE_NODE:-cache@${fqdn}}"
-  
+
   # Map own FQDN to localhost for local commands (remote, rpc).
   # Other FQDNs resolve via DNS for cross-node clustering.
   erl_inetrc="/run/cache/erl_inetrc"

--- a/server/rel/env.sh.eex
+++ b/server/rel/env.sh.eex
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Set Sentry release from the commit SHA (Render provides RENDER_GIT_COMMIT)
+export SENTRY_RELEASE="${RENDER_GIT_COMMIT:-${RELEASE_VSN}}"
+
 # configure node for distributed erlang with IPV6 support
 if [ ! -z "$TUIST_USE_IPV6" ]; then
   export ERL_AFLAGS="-proto_dist inet6_tcp"


### PR DESCRIPTION
## Summary

- Configures Sentry to use the commit SHA as the release identifier
- Server uses `RENDER_GIT_COMMIT` which Render provides automatically
- Cache passes `GITHUB_SHA` through Kamal deployment

This enables Sentry's release tracking features like regression detection and filtering errors by deployment.