### PR TITLE
fix(cli): update inspect implicit-imports to new command syntax

### DIFF
--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Initialize TuistCacheEE submodule
         run: mise run cli:ee
       - name: Run tests
-        run: mise x -- tuist inspect implicit-imports
+        run: mise x -- tuist inspect dependencies --only implicit
         env:
           TUIST_EE: 1
       - name: Save cache

--- a/mise/tasks/cli/lint.sh
+++ b/mise/tasks/cli/lint.sh
@@ -11,5 +11,5 @@ else
     # Check mode: only report issues without fixing
     swiftformat cli/ app/ --lint
     swiftlint lint --quiet --config .swiftlint.yml cli/Sources
-    tuist inspect implicit-imports
+    tuist inspect dependencies --only implicit
 fi


### PR DESCRIPTION
The `tuist inspect implicit-imports` command has been renamed to `tuist inspect dependencies --only implicit`. This PR updates the workflow and lint script to use the new syntax.