### PR TITLE
fix(server): increase request body size limit to 50MB

### DIFF
--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -75,10 +75,14 @@ defmodule TuistWeb.Endpoint do
     secret: {Tuist.Environment, :cache_api_key, []},
     signature_header: "x-cache-signature"
 
+  # The /api/runs endpoint can receive large payloads (files, cacheable_tasks, cas_outputs)
+  # for projects with thousands of files. 50MB should accommodate most projects.
+  # TODO: Consider streaming large arrays instead of loading everything into memory.
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
+    json_decoder: Phoenix.json_library(),
+    length: 50_000_000
 
   plug Plug.MethodOverride
   plug Plug.Head


### PR DESCRIPTION
## Summary

Large projects were hitting `Plug.Parsers.RequestTooLargeError` when uploading build analytics through the `/api/runs` endpoint. The payload includes arrays of files, cacheable_tasks, and cas_outputs which can exceed the default 8MB limit for projects with thousands of files.

This increases the limit to 50MB to accommodate large projects. A TODO comment notes we should consider streaming large arrays in the future instead of loading everything into memory.

## Test plan

- Deploy to staging and verify large build uploads succeed
- Monitor Sentry for `RequestTooLargeError` occurrences