### PR TITLE
feat(cli): add TUIST_CACHE_ENDPOINT environment variable override

### DIFF
--- a/cli/Sources/TuistCAS/Services/CacheURLStore.swift
+++ b/cli/Sources/TuistCAS/Services/CacheURLStore.swift
@@ -43,6 +43,14 @@
         }
 
         public func getCacheURL(for serverURL: URL, accountHandle: String?) async throws -> URL {
+            if let overrideEndpoint = Environment.current.variables["TUIST_CACHE_ENDPOINT"] {
+                guard let url = URL(string: overrideEndpoint) else {
+                    throw CacheURLStoreError.invalidURL(overrideEndpoint)
+                }
+                Logger.current.debug("Using cache endpoint override: \(overrideEndpoint)")
+                return url
+            }
+
             let key = "cache_url_\(serverURL.absoluteString)_\(accountHandle ?? "global")"
             let nsKey = key as NSString
 

--- a/cli/Tests/TuistCASTests/CacheURLStoreTests.swift
+++ b/cli/Tests/TuistCASTests/CacheURLStoreTests.swift
@@ -188,4 +188,36 @@ import TuistSupport
             .getCacheEndpoints(serverURL: .value(serverURL), accountHandle: .value(accountHandle))
             .called(1)
     }
+
+    @Test(.withMockedEnvironment())
+    func uses_override_endpoint_when_environment_variable_set() async throws {
+        // Given
+        let serverURL = URL(string: "https://tuist.dev")!
+        let overrideEndpoint = "https://override.example.com"
+        Environment.mocked?.variables["TUIST_CACHE_ENDPOINT"] = overrideEndpoint
+
+        // When
+        let result = try await subject.getCacheURL(for: serverURL, accountHandle: nil)
+
+        // Then
+        #expect(result.absoluteString == overrideEndpoint)
+        verify(getCacheEndpoints)
+            .getCacheEndpoints(serverURL: .any, accountHandle: .any)
+            .called(0)
+        verify(latencyService)
+            .measureLatency(for: .any)
+            .called(0)
+    }
+
+    @Test(.withMockedEnvironment())
+    func throws_when_override_endpoint_is_invalid_url() async throws {
+        // Given
+        let serverURL = URL(string: "https://tuist.dev")!
+        Environment.mocked?.variables["TUIST_CACHE_ENDPOINT"] = ""
+
+        // When/Then
+        await #expect(throws: CacheURLStoreError.invalidURL("")) {
+            _ = try await subject.getCacheURL(for: serverURL, accountHandle: nil)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `TUIST_CACHE_ENDPOINT` environment variable to override automatic latency-based cache endpoint selection
- When set, the specified endpoint is used directly without measuring latency to all available endpoints
- Useful for debugging cache performance by forcing a specific endpoint (e.g., us-east vs us-west)

## Test plan
- [x] Added test verifying override endpoint is used when env var is set
- [x] Added test verifying invalid URL throws appropriate error
- [x] Verified existing endpoint selection tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)