### PR TITLE
fix(server): disable link unfurling in Slack messages

### DIFF
--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -157,7 +157,7 @@ defmodule Tuist.Slack do
         {"Content-Type", "application/json"}
       ]
 
-      body = Jason.encode!(%{channel: channel, blocks: blocks})
+      body = Jason.encode!(%{channel: channel, blocks: blocks, unfurl_links: false, unfurl_media: false})
 
       response =
         @api_url

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -36,7 +36,7 @@ defmodule Tuist.Slack.Client do
       {"Content-Type", "application/json"}
     ]
 
-    body = JSON.encode!(%{channel: channel_id, blocks: blocks})
+    body = JSON.encode!(%{channel: channel_id, blocks: blocks, unfurl_links: false, unfurl_media: false})
 
     @chat_post_message_url
     |> Req.post(headers: headers, body: body)


### PR DESCRIPTION
## Summary
- Adds `unfurl_links: false` and `unfurl_media: false` to all Slack message payloads
- Prevents Slack from showing link previews in notifications

## Test plan
- [ ] Trigger a Slack notification (e.g., flaky test alert) and verify no link previews are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)