### PR TITLE
feat(cli): add debug logging to diagnose generation hangs

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -889,16 +889,19 @@ public class GraphTraverser: GraphTraversing {
     public func allProjectDependencies(path: Path.AbsolutePath) throws -> Set<
         GraphDependencyReference
     > {
+        let projectName = projects[path]?.name ?? path.basename
         let targets = targets(at: path)
         if targets.isEmpty { return Set() }
         var references: Set<GraphDependencyReference> = Set()
 
+        Logger.current.debug("allProjectDependencies: \(projectName) with \(targets.count) targets")
         // Linkable dependencies
         for target in targets {
             try references.formUnion(linkableDependencies(path: path, name: target.target.name))
             references.formUnion(embeddableFrameworks(path: path, name: target.target.name))
             references.formUnion(copyProductDependencies(path: path, name: target.target.name))
         }
+        Logger.current.debug("allProjectDependencies: \(projectName) finished with \(references.count) refs")
         return references
     }
 

--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -117,7 +117,9 @@ class ProjectFileElements {
         }
 
         // Dependencies
+        Logger.current.debug("Fetching all project dependencies for \(project.name)")
         let dependencies = try graphTraverser.allProjectDependencies(path: project.path).sorted()
+        Logger.current.debug("Fetched \(dependencies.count) dependencies for \(project.name)")
 
         try generate(
             dependencyReferences: Set(directProducts + dependencies),

--- a/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -97,7 +97,11 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         Logger.current.debug("Starting concurrent generation of \(projectCount) projects")
         let projects = try await Array(graphTraverser.projects.values)
             .concurrentCompactMap { project -> ProjectDescriptor? in
-                try await self.projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
+                let threadId = Thread.current.description
+                Logger.current.debug("Task STARTED for project \(project.name) on thread \(threadId)")
+                let result = try await self.projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
+                Logger.current.debug("Task COMPLETED for project \(project.name) on thread \(threadId)")
+                return result
             }
             .sorted(by: { $0.path < $1.path })
         Logger.current.debug("Finished concurrent generation of \(projects.count) projects")


### PR DESCRIPTION
## Summary

Add debug logs to help diagnose intermittent hangs during project generation.

## Context

We observed a hang during `tuist generate` where one project got stuck between "Generating project files" and "Generating project config". Analysis of the logs showed:
- All projects started concurrent generation
- All but one project completed successfully  
- One project never finished

## Hypotheses

### 1. Swift Concurrency Task Starvation
With many concurrent tasks competing for a limited thread pool (~8-16 threads), tasks could starve if they never get scheduled.

**How logs help:** If we see "Task STARTED" for other projects but never for the stuck project, this confirms the task was created but never executed.

### 2. Lock Contention
`GraphTraverser` uses `ThreadSafe` wrappers with `os_unfair_lock`. With many concurrent tasks accessing shared caches, severe lock contention could occur.

**How logs help:** If multiple projects' logs show they started "allProjectDependencies" but none finish, this suggests lock contention.

### 3. Complex Dependency Graph
The main app project typically has the most dependencies. The graph traversal methods could be particularly expensive for this project.

**How logs help:** The logs show target counts and reference counts, allowing comparison between projects.

### 4. Priority Inversion
Swift Concurrency + `os_unfair_lock` could cause priority inversion where a low-priority task holds a lock needed by high-priority tasks.

**How logs help:** Thread IDs in "Task STARTED" logs will show if the stuck project runs on a different thread than completing projects.

## Logs Added

**WorkspaceDescriptorGenerator** (per project):
```
Task STARTED for project X on thread Y
Task COMPLETED for project X on thread Y
```

**ProjectFileElements.generateProjectFiles**:
```
Fetching all project dependencies for X
Fetched N dependencies for X
```

**GraphTraverser.allProjectDependencies**:
```
allProjectDependencies: X with N targets
allProjectDependencies: X finished with N refs
```

## How to Interpret Results

| Scenario | Indicates |
|----------|-----------|
| No "Task STARTED" for stuck project | Task starvation confirmed |
| "Task STARTED" but no further logs | Hang before dependency fetching |
| "Fetching all project dependencies" but no "Fetched" | Hang in graph traversal |
| "allProjectDependencies" started but not finished | Hang during dependency resolution |
| Thread IDs show stuck project on different thread than completing projects | Possible priority inversion |

## Test plan

- [x] Build succeeds
- [ ] Run generation with verbose logging on a project that experiences hangs
- [ ] Analyze logs to identify hang location and confirm/disprove hypotheses

🤖 Generated with [Claude Code](https://claude.com/claude-code)