### PR TITLE
fix(cli): strip debug symbols (dSYM/DWARF) from cached XCFrameworks

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -546,7 +546,8 @@ import XcodeGraph
                     arguments: [
                         .destination("generic/platform=\(platform.caseValue) Simulator"),
                         .xcarg("SKIP_INSTALL", "NO"),
-                        .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
+                        .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf"),
+                        .xcarg("STRIP_INSTALLED_PRODUCT", "YES"),
                         .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                         .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                         .xcarg("CODE_SIGN_IDENTITY", ""),
@@ -590,6 +591,8 @@ import XcodeGraph
 
             var deviceArguments: [XcodeBuildArgument] = [
                 .xcarg("SKIP_INSTALL", "NO"),
+                .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf"),
+                .xcarg("STRIP_INSTALLED_PRODUCT", "YES"),
                 .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                 .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                 .xcarg("CODE_SIGN_IDENTITY", ""),
@@ -606,7 +609,6 @@ import XcodeGraph
             ] : [])
             if platform == .macOS {
                 deviceArguments.append(contentsOf: [
-                    .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
                     .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                 ])
             } else {
@@ -670,7 +672,8 @@ import XcodeGraph
                 arguments: [
                     .destination("generic/platform=macOS,variant=Mac Catalyst"),
                     .xcarg("SKIP_INSTALL", "NO"),
-                    .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
+                    .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf"),
+                    .xcarg("STRIP_INSTALLED_PRODUCT", "YES"),
                     .xcarg("SWIFT_SERIALIZE_DEBUGGING_OPTIONS", "NO"),
                     .xcarg("ONLY_ACTIVE_ARCH", "NO"),
                     .xcarg("CODE_SIGN_IDENTITY", ""),


### PR DESCRIPTION
## Summary

Instead of bundling dSYMs and remapping debug prefix paths with lldbinit files, this switches cached XCFrameworks to use DWARF-only debug format (no separate dSYM bundles) and strips debug symbols from the installed binaries. This prevents CI runner absolute paths from leaking into cached frameworks, which was causing LLDB warnings like `/Users/runner/work/...` in consumers' debug sessions.

Changes:
- Set `DEBUG_INFORMATION_FORMAT=dwarf` instead of `dwarf-with-dsym` (dSYM = Debug Symbol file generated alongside the binary; DWARF = debug info format embedded directly in the binary)
- Add `STRIP_INSTALLED_PRODUCT=YES` to strip debug symbols from framework binaries
- Remove `debug-prefix-map` and `fdebug-prefix-map` passthrough flags (no longer needed since symbols are stripped)
- Remove dSYM bundling when creating XCFrameworks
- Remove the LLDB init file infrastructure (`CacheLLDBInitFileKey`) since it's no longer needed
- Revert the TuistCacheEE submodule to main

## Test plan

- [x] `tuist generate --no-open` succeeds
- [x] `xcodebuild build` succeeds
- [x] Lint passes