### PR TITLE
fix(cli): include buildable folder resources in Target.containsResources

### DIFF
--- a/cli/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/cli/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -144,7 +144,11 @@ extension Target {
     }
 
     public var containsResources: Bool {
-        !resources.resources.isEmpty || !coreDataModels.isEmpty
+        if !resources.resources.isEmpty || !coreDataModels.isEmpty { return true }
+        let resourceExtensions = Self.validResourceExtensions + Self.validResourceCompatibleFolderExtensions
+        return buildableFolders.contains { folder in
+            folder.resolvedFiles.contains { resourceExtensions.contains($0.path.extension ?? "") }
+        }
     }
 
     /// Returns if target is a generated resources bundle.


### PR DESCRIPTION
Resolves #8165

`Target.containsResources` only checked `resources.resources` and `coreDataModels`, missing resources discovered through buildable folders. This meant static frameworks using buildable folders with resource files (e.g., `.md`, `.png`) never got a generated resource bundle target, causing a runtime crash when accessing `Bundle.module`.

The fix extends `containsResources` to also check buildable folder resolved files against `validResourceExtensions` and `validResourceCompatibleFolderExtensions`.

### How to test locally

1. Download the reproduction project from https://github.com/tuist/tuist/issues/8165
2. Run `tuist generate` — verify 3 targets are generated (App, StaticFramework, App_StaticFramework)
3. Build and run the app in the simulator — verify no crash on launch (previously crashed with "Unexpectedly found nil while unwrapping an Optional value")
4. Verify `App.app/App_StaticFramework.bundle/greeting.md` exists in the build output