### PR TITLE
fix(cache): scale nginx workers to avoid 502s

### DIFF
--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -7,6 +7,14 @@
     recommendedProxySettings = true;
     recommendedTlsSettings = false;
 
+    appendConfig = ''
+      worker_processes auto;
+    '';
+
+    eventsConfig = ''
+      worker_connections 4096;
+    '';
+
     appendHttpConfig = ''
       http2 on;
       ssl_session_cache shared:SSL:50m;


### PR DESCRIPTION
nginx was running with the default workers, which are very conservative. This lead to connections starving above a few thousand requests per second on a single node, which happened on eu-central this morning.