### PR TITLE
fix(cli): search host bundle paths in ObjC resource bundle accessor

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -341,12 +341,22 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                                           nil];
 
             // Tuist: For static frameworks, resources are inside the embedded framework bundle.
-            // Add framework locations to search for the framework bundle itself.
+            // Search both the host bundle (bundleForClass:) and the main bundle so the framework
+            // is found regardless of whether the static framework is linked into the app or into
+            // an intermediate dynamic framework.
             NSString *frameworkName = @"\(target.productNameWithExtension)";
+            NSBundle *hostBundle = [NSBundle bundleForClass:\(targetName)BundleFinder.self];
+            if (hostBundle.privateFrameworksURL) {
+                [candidates addObject:[hostBundle.privateFrameworksURL URLByAppendingPathComponent:frameworkName]];
+            }
+            [candidates addObject:[[hostBundle bundleURL] URLByAppendingPathComponent:[@"Frameworks/" stringByAppendingString:frameworkName]]];
+            [candidates addObject:[[hostBundle bundleURL] URLByAppendingPathComponent:frameworkName]];
+            [candidates addObject:[hostBundle.bundleURL URLByDeletingLastPathComponent]];
             if ([NSBundle mainBundle].privateFrameworksURL) {
                 [candidates addObject:[[NSBundle mainBundle].privateFrameworksURL URLByAppendingPathComponent:frameworkName]];
             }
             [candidates addObject:[[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:[@"Frameworks/" stringByAppendingString:frameworkName]]];
+            [candidates addObject:[[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:frameworkName]];
 
             NSString* override = [[[NSProcessInfo processInfo] environment] objectForKey:@"PACKAGE_RESOURCE_BUNDLE_PATH"];
             if (override) {


### PR DESCRIPTION
## Summary

The generated ObjC bundle accessor (`TuistBundle+*.m`) for external static frameworks with ObjC sources only searched `[NSBundle mainBundle]` paths when looking for the embedded framework bundle. This caused a runtime crash ("Unable to find bundle named ...") when the static framework was linked into an intermediate dynamic framework rather than directly into the app, because the framework was embedded in the dynamic framework's bundle, not the app's.

The fix adds `hostBundle` (`[NSBundle bundleForClass:]`) search paths to the ObjC accessor, matching the Swift accessor which already searches both `hostBundle` and `Bundle.main` paths. This ensures the framework bundle is found regardless of where the static framework code is linked.

This addresses the NYTPhotoViewer issue reported in the same context as https://github.com/tuist/tuist/issues/9289, where the `NYTPhotoViewer_NYTPhotoViewer` bundle target is no longer generated (since static frameworks now support resources natively), but the ObjC accessor couldn't find the embedded `NYTPhotoViewer.framework` at runtime.

## Test plan

- [x] All 27 `ResourcesProjectMapperTests` pass (including ObjC accessor tests)
- [x] All 149 `GraphTraverserTests` pass
- [x] Verified generated `TuistBundle+NYTPhotoViewer.m` now includes hostBundle search paths
- [x] Built demo project with NYTPhotoViewer dependency; framework is correctly embedded with resources