### PR TITLE
fix(cli): harden log cleanup

### DIFF
--- a/cli/Tests/TuistKitTests/Utils/LogsCleanerTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/LogsCleanerTests.swift
@@ -21,7 +21,10 @@ struct LogsControllerTests {
             try await fileSystem.touch(recentLogPath)
 
             try FileManager.default.setAttributes(
-                [FileAttributeKey.creationDate: oldDate],
+                [
+                    FileAttributeKey.creationDate: oldDate,
+                    FileAttributeKey.modificationDate: oldDate,
+                ],
                 ofItemAtPath: veryOldLogPath.pathString
             )
 
@@ -30,6 +33,7 @@ struct LogsControllerTests {
 
             // Then
             let got = try await fileSystem.glob(directory: temporaryDirectory, include: ["logs/*"]).collect()
+            #expect(got.contains(veryOldLogPath) == false)
             #expect(got.contains(recentLogPath) == true)
             #expect(got.contains(try #require(newLogFilePath)) == true)
         }


### PR DESCRIPTION
## Summary
- avoid deleting the active log during cleanup
- prefer modification date when deciding staleness
- re-touch log file if it went missing before logger init
- tighten log cleanup test coverage

## Testing
- xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination "platform=macOS,arch=arm64" -only-testing TuistKitTests/LogsControllerTests