### PR TITLE
refactor(cache): performance improvements

### DIFF
--- a/cache/config/deploy.yml
+++ b/cache/config/deploy.yml
@@ -42,6 +42,7 @@ env:
 
 volumes:
   - /cas:/storage:rw
+  - /cas/tmp:/tmp:rw
   - /var/lib/cache:/data:rw
   - /run/cache:/run/cache:rw
   - /etc/hostname:/etc/host_hostname:ro

--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -98,6 +98,7 @@
 
   systemd.tmpfiles.rules = [
     "Z /cas 0755 cache cache - -"
+    "d /cas/tmp 1777 cache cache - -"
     "d /var/lib/cache 0755 cache cache - -"
     "d /run/cache 0777 root root - -"
   ];


### PR DESCRIPTION
This PR does a few things:
1. mount /tmp on the artifact drive. This reduces network hops (`/cas` is mounted to a network drive, and the code that copies multipart parts over from `/tmp` to `/cas` will be on the same drive).
2. requests to `/api/cache` with completely missing Authorization headers are rejected on the nginx layer without even making it to the Elixir app at all, reducing request load
3. marks the reverse proxy connection to the app as `keepalive`, meaning we won't spawn a new connection for each request, which was slow _and_ created a ton of socket connections needlessly.