### PR TITLE
fix(server): use explicit query in get_build to avoid MultipleResultsError

### DIFF
--- a/server/lib/tuist/runs.ex
+++ b/server/lib/tuist/runs.ex
@@ -45,12 +45,7 @@ defmodule Tuist.Runs do
   def valid_ci_providers, do: ["github", "gitlab", "bitrise", "circleci", "buildkite", "codemagic"]
 
   def get_build(id) do
-    from(b in Build,
-      where: b.id == ^id,
-      order_by: [desc: b.inserted_at],
-      limit: 1
-    )
-    |> Repo.one()
+    Repo.one(from(b in Build, where: b.id == ^id, order_by: [desc: b.inserted_at], limit: 1))
   end
 
   def get_test(id, opts \\ []) do


### PR DESCRIPTION
[Sentry error](https://tuist.sentry.io/issues/92177218/?alert_rule_id=389667&alert_type=issue&environment=prod&notification_uuid=e35a564c-c082-4b3c-9073-64e9afa8701e&project=4510777094373456&referrer=slack)

## Summary

- `build_runs` is a TimescaleDB hypertable with a composite primary key `(id, inserted_at)`, so `Repo.get(Build, id)` can match multiple rows across partitions, causing `Ecto.MultipleResultsError`
- Replaced it with an explicit query using `ORDER BY inserted_at DESC LIMIT 1`, matching the pattern already used by `get_test/2`

## Test plan

- [x] Existing `get_build` tests pass
- [ ] Verify the fix in staging/canary before deploying to production