### PR TITLE
chore(cache): adjust configuration for buffers and transfers

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -15,7 +15,7 @@ config :cache, Cache.Repo,
   queue_interval: 1_000
 
 config :cache, Cache.SQLiteBuffer,
-  flush_interval_ms: 200,
+  flush_interval_ms: 500,
   flush_timeout_ms: 30_000,
   max_batch_size: 1000,
   shutdown_ms: 30_000

--- a/cache/lib/cache/s3_transfer_worker.ex
+++ b/cache/lib/cache/s3_transfer_worker.ex
@@ -18,7 +18,7 @@ defmodule Cache.S3TransferWorker do
 
   require Logger
 
-  @batch_size 5000
+  @batch_size 7500
   @concurrency 50
 
   @impl Oban.Worker


### PR DESCRIPTION
Adjusts two things:
- flush to SQLite less often: batch sizes haven't been that big, and 500ms is still plenty often. Will keep monitoring buffer sizes
- transfer batch size: the transfer queue has been quite big, especially when getting a lot of new CAS artifacts. sooner or later I think we should separate CAS and module cache transfers since they have very different shapes (lots of them, but tiny and uploading very fast, vs fewer, bigger ones that take more time to upload), but as it stands we can fit more uploads into a minute. Keeping `concurrency` the same to hopefully keep Tigris rate limits at bay.