### PR TITLE
fix(cache): force octet-stream for proxied S3 downloads

### DIFF
--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -94,6 +94,11 @@ http {
 
         location ~ ^/internal/remote/(.*?)/(.*?)/(.*) {
             internal;
+            # The cache download API contract expects application/octet-stream.
+            # When proxying a presigned S3 URL, nginx would otherwise forward S3's
+            # object metadata (often application/zip), which breaks strict clients.
+            proxy_hide_header Content-Type;
+            default_type application/octet-stream;
             resolver 1.1.1.1 ipv6=off;
             set $download_url $1://$2/$3;
             proxy_set_header Host $2;
@@ -106,6 +111,8 @@ http {
 
         location @handle_remote_redirect {
             set $saved_redirect_location $upstream_http_location;
+            proxy_hide_header Content-Type;
+            default_type application/octet-stream;
             proxy_pass $saved_redirect_location;
         }
     }

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -114,6 +114,11 @@
         locations."~ ^/internal/remote/(.*?)/(.*?)/(.*)" = {
           extraConfig = ''
             internal;
+            # The cache download API contract expects application/octet-stream.
+            # When proxying a presigned S3 URL, nginx would otherwise forward S3's
+            # object metadata (often application/zip), which breaks strict clients.
+            proxy_hide_header Content-Type;
+            default_type application/octet-stream;
             resolver 1.1.1.1 ipv6=off;
             set $download_url $1://$2/$3;
             proxy_set_header Host $2;
@@ -128,6 +133,8 @@
         locations."@handle_remote_redirect" = {
           extraConfig = ''
             set $saved_redirect_location $upstream_http_location;
+            proxy_hide_header Content-Type;
+            default_type application/octet-stream;
             proxy_pass $saved_redirect_location;
           '';
         };


### PR DESCRIPTION
In the case of a disk miss and S3 hit, the S3 redirect overrode the `application/octet-stream` response header set by the cache service, resulting in a 
```
▸ Failed to download Clocks with hash b77548542fb2da251b741d4bd4c1f213 due to unexpected error: Unexpected content type, expected: application/octet-stream, received: application/zip; charset=utf-8
```

error. This PR changes the nginx configuration to always override the header.