### PR TITLE
fix(app): iOS min version lowered to 18.0

### DIFF
--- a/app/Project.swift
+++ b/app/Project.swift
@@ -89,7 +89,10 @@ let project = Project(
             product: .app,
             productName: "Tuist",
             bundleId: bundleId,
-            deploymentTargets: .macOS("15.0.0"),
+            deploymentTargets: .multiplatform(
+                iOS: "18.0.0",
+                macOS:"15.0.0"
+            ),
             infoPlist: .extendingDefault(
                 with: [
                     "CFBundleDisplayName": "Tuist",


### PR DESCRIPTION
Resolves #9318 

Explicitly set the iOS min version to 18.0 to allow Tuist app running on older devices.

### How to test locally

Run the iOS app on any version of iOS lower than 26.2 and equal or above 18.0
