### PR TITLE
fix(server): prevent inline code from wrapping mid-word

### DIFF
--- a/server/assets/marketing/css/shared/prose.css
+++ b/server/assets/marketing/css/shared/prose.css
@@ -5,10 +5,16 @@
   font: var(--noora-font-weight-regular) var(--noora-font-body-large);
 
   & code.inline {
+    box-shadow:
+      0 1px 1px 0 rgba(14, 14, 14, 0.05),
+      0 0 0 1px rgba(46, 51, 56, 0.08),
+      0 1px 1px 0 rgba(46, 51, 56, 0.1);
+    border-radius: var(--noora-radius-small);
+    background: var(--noora-surface-background-secondary);
+    padding: var(--noora-spacing-1);
     color: var(--surface-label-primary);
     font: var(--noora-font-weight-regular) var(--noora-font-code-large);
-    word-break: break-word;
-    overflow-wrap: break-word;
+    white-space: nowrap;
   }
 
   & blockquote {


### PR DESCRIPTION
## Summary

Inline code (`code.inline`) in prose content was breaking mid-word, causing fragments like `-test-iterations` to wrap to the next line. This replaces `word-break`/`overflow-wrap` with `white-space: nowrap` so inline code stays on a single line.

<img width="414" height="215" alt="image" src="https://github.com/user-attachments/assets/feb2cdc6-bdcb-4aa3-906b-1eb239194a41" />


## Test plan

- Verify inline code snippets in marketing prose pages no longer wrap mid-word
- Check that long inline code snippets don't cause layout issues