### PR TITLE
Clean up temporary directories after archiving

### DIFF
--- a/cli/Sources/ProjectAutomation/Tuist.swift
+++ b/cli/Sources/ProjectAutomation/Tuist.swift
@@ -28,27 +28,23 @@ public enum Tuist {
     /// - parameter path: the path which graph should be loaded. If nil, the current path is used.
     public static func graph(at path: String? = nil) throws -> Graph {
         let temporaryDirectory = try createTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
-        do {
-            let graphPath = temporaryDirectory.appendingPathComponent("graph.json")
-            var arguments = [
-                "tuist",
-                "graph",
-                "--format", "legacyJSON",
-                "--output-path", temporaryDirectory.path,
-            ]
-            if let path {
-                arguments += ["--path", path]
-            }
-            try run(
-                arguments
-            )
-            let graphData = try Data(contentsOf: graphPath)
-            return try JSONDecoder().decode(Graph.self, from: graphData)
-        } catch {
-            try FileManager.default.removeItem(at: temporaryDirectory)
-            throw error
+        let graphPath = temporaryDirectory.appendingPathComponent("graph.json")
+        var arguments = [
+            "tuist",
+            "graph",
+            "--format", "legacyJSON",
+            "--output-path", temporaryDirectory.path,
+        ]
+        if let path {
+            arguments += ["--path", path]
         }
+        try run(
+            arguments
+        )
+        let graphData = try Data(contentsOf: graphPath)
+        return try JSONDecoder().decode(Graph.self, from: graphData)
     }
 
     private static func createTemporaryDirectory() throws -> URL {

--- a/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
+++ b/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
@@ -33,10 +33,14 @@ struct AnalyticsUploadCommandService {
 
     func run(eventFilePath: String, fullHandle: String, serverURL: String) async throws {
         let eventPath = try AbsolutePath(validating: eventFilePath)
+        let eventDirectory = eventPath.parentDirectory
 
         defer {
             Task {
                 try await fileSystem.remove(eventPath)
+                if eventDirectory.basename.hasPrefix("analytics-") {
+                    try? await fileSystem.remove(eventDirectory)
+                }
             }
         }
 


### PR DESCRIPTION
## Context
**Problem:** Temporary directories created during archiving/unarchiving and preview installs were left behind, accumulating over time.
**Scope:** CLI paths for previews, analytics artifacts, and project automation graph generation.

## Rationale
**Goal:** Ensure temp dirs are removed deterministically after use without breaking flows that need the files during install/upload.
**Approach:** Add best-effort cleanup at the call sites and scope preview app temp dirs to the install/launch window.

## Changes
- **Previews upload:** reuse a single IPA unarchive for icon/binary ID and delete after use; delete per-bundle archives post-upload.
- **Analytics artifacts:** delete result bundle archives after upload.
- **Preview run:** keep unarchived app until install/launch completes, then remove the directory.
- **ProjectAutomation graph:** always remove the temp graph directory via `defer`.
- **Analytics upload:** remove the analytics temp directory after upload completes.

## Alternatives Considered
- **Auto-delete in archiver/unarchiver deinit:** rejected because callers need explicit control and some flows require the directory to outlive a scope.
- **Use `runInTemporaryDirectory` everywhere:** not feasible where the path must survive beyond the closure.
