### PR TITLE
fix(cli): fix Gradle artifact download path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -869,6 +869,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle-artifacts
+          path: gradle
 
       - name: Create tags for successfully released components
         run: |


### PR DESCRIPTION
The Gradle plugin release was failing at the "Commit all changes and push" step with `fatal: pathspec 'gradle/CHANGELOG.md' did not match any files`.

The root cause is that `actions/upload-artifact@v4` strips the least common ancestor from uploaded paths. Since the Gradle artifact uploads both `gradle/CHANGELOG.md` and `gradle/src/main/kotlin/.../TuistBuildCache.kt`, the common prefix `gradle/` gets stripped. When `download-artifact` extracts without a `path`, the files end up at the repo root instead of inside `gradle/`, so `git add gradle/CHANGELOG.md` fails.

The fix adds `path: gradle` to the download step so files are extracted into the correct directory.