### PR TITLE
fix(cli): clean up Gradle home in e2e test teardown

### DIFF
--- a/e2e/gradle_cache.bats
+++ b/e2e/gradle_cache.bats
@@ -36,6 +36,10 @@ setup_file() {
     "$TUIST_EXECUTABLE" auth login --email tuistrocks@tuist.dev --password tuistrocks
 }
 
+teardown_file() {
+    rm -rf "${BATS_FILE_TMPDIR}/gradle-home" 2>/dev/null || true
+}
+
 @test "first build pushes artifacts to remote cache" {
     cd "$GRADLE_PROJECT_DIR"
 


### PR DESCRIPTION
Gradle leaves behind files with restrictive permissions in the `kotlin-dsl` cache directory, which causes bats' automatic `BATS_FILE_TMPDIR` cleanup to fail with "Directory not empty" errors. This made the Gradle Cache Acceptance CI job exit with a non-zero status even though all tests passed.

The fix adds a `teardown_file()` that forcefully removes the Gradle home before bats attempts its own cleanup.