### PR TITLE
fix(server): add create action to build and test authorization objects

### DIFF
--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -487,6 +487,23 @@ defmodule Tuist.Authorization do
   end
 
   object :test do
+    action :create do
+      desc("Allows users of a project to create a test.")
+      allow([:authenticated_as_user, user_role: :user])
+
+      desc("Allows the admin of a project to create a test.")
+      allow([:authenticated_as_user, user_role: :admin])
+
+      desc(
+        "Allows the authenticated project to create the test if it matches the project for which the test is being created."
+      )
+
+      allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows an account token with project:tests:write scope to create tests.")
+      allow([:authenticated_as_account, scopes_permit: "project:tests:write"])
+    end
+
     action :read do
       desc("Allows the authenticated subject to read a project's tests if the project is public.")
       allow(:public_project)
@@ -510,6 +527,23 @@ defmodule Tuist.Authorization do
   end
 
   object :build do
+    action :create do
+      desc("Allows users of a project to create a build.")
+      allow([:authenticated_as_user, user_role: :user])
+
+      desc("Allows the admin of a project to create a build.")
+      allow([:authenticated_as_user, user_role: :admin])
+
+      desc(
+        "Allows the authenticated project to create the build if it matches the project for which the build is being created."
+      )
+
+      allow([:authenticated_as_project, :projects_match])
+
+      desc("Allows an account token with project:builds:write scope to create builds.")
+      allow([:authenticated_as_account, scopes_permit: "project:builds:write"])
+    end
+
     action :read do
       desc("Allows the authenticated subject to read a project's builds if the project is public.")
       allow(:public_project)


### PR DESCRIPTION
## Summary
- Adds missing `action :create` blocks to `:build` and `:test` objects in the authorization policy
- This was a regression from #9332 which split `:run` into separate `:build` and `:test` objects but only copied the `:read` action, causing 403 errors on POST to `/builds` and `/tests`
- Should resolve canary acceptance tests failing: https://github.com/tuist/tuist/actions/runs/21706523656/job/62601167083#step:10:4564

## Test plan
- [x] Server compiles
- [x] `mix test test/tuist_web/controllers/api/builds_controller_test.exs` — 15 tests pass
- [x] `mix test test/tuist_web/controllers/api/runs_controller_test.exs` — 28 tests pass
- [x] `mix test test/tuist/authorization_test.exs test/tuist_web/plugs/api/authorization/authorization_plug_test.exs` — 129 tests pass
- [x] Manual test: `tuist inspect build` no longer returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)