### PR TITLE
fix(cli): deduplicate plugins with the same name in tuist edit

### DIFF
--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -264,7 +264,23 @@ final class ProjectEditor: ProjectEditing {
             )
         }
 
-        return Array(Set(loadedEditablePluginManifests + localEditablePluginManifests))
+        var seenPaths = Set<AbsolutePath>()
+        var seenNames = Set<String>()
+        let allManifests = loadedEditablePluginManifests + localEditablePluginManifests
+        let uniqueManifests = allManifests.compactMap { manifest -> EditablePluginManifest? in
+            guard seenPaths.insert(manifest.path).inserted else { return nil }
+            var name = manifest.name
+            if seenNames.contains(name) {
+                name = "\(manifest.path.parentDirectory.basename)-\(name)"
+                while seenNames.contains(name) {
+                    name = "_\(name)"
+                }
+            }
+            seenNames.insert(name)
+            return name == manifest.name ? manifest : EditablePluginManifest(name: name, path: manifest.path)
+        }
+
+        return uniqueManifests
     }
 
     /// - Returns: Builds all remote plugins and returns a list of the helper modules.

--- a/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/cli/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -133,7 +133,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             workspace: workspace,
             projects: graphProjects,
             packages: [:],
-            dependencies: Dictionary(uniqueKeysWithValues: graphDependencies),
+            dependencies: Dictionary(graphDependencies, uniquingKeysWith: { $0.union($1) }),
             dependencyConditions: [:]
         )
     }

--- a/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/cli/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -405,6 +405,62 @@ final class ProjectEditorTests: TuistUnitTestCase {
         XCTAssertEqual(mapArgs?.pluginProjectDescriptionHelpersModule, [])
     }
 
+    func test_edit_project_deduplicates_plugins_with_same_directory_name() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
+        let graph = Graph.test(name: "Edit")
+
+        let manifests = [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: directory.appending(component: "Project.swift")
+            ),
+        ]
+
+        // Multiple Plugin.swift files discovered by filesystem scan sharing the same directory name
+        let discoveredPluginPath1 = directory.appending(components: "examples", "app1", "LocalPlugin", "Plugin.swift")
+        let discoveredPluginPath2 = directory.appending(components: "examples", "app2", "LocalPlugin", "Plugin.swift")
+        let discoveredPluginPath3 = directory.appending(components: "fixtures", "LocalPlugin", "Plugin.swift")
+
+        let tuistPath = try AbsolutePath(validating: Environment.current.arguments.first!)
+
+        resourceLocator.projectDescriptionStub = { projectDescriptionPath }
+        given(manifestFilesLocator)
+            .locateProjectManifests(at: .any, excluding: .any, onlyCurrentDirectory: .any)
+            .willReturn(manifests)
+        given(manifestFilesLocator)
+            .locatePluginManifests(at: .any, excluding: .any, onlyCurrentDirectory: .any)
+            .willReturn([discoveredPluginPath1, discoveredPluginPath2, discoveredPluginPath3])
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(nil)
+        given(manifestFilesLocator)
+            .locateConfig(at: .any)
+            .willReturn(nil)
+        projectEditorMapper.mapStub = graph
+        generator.generateWorkspaceStub = { _ in
+            .test(xcworkspacePath: directory.appending(component: "Edit.xcworkspacepath"))
+        }
+        given(templatesDirectoryLocator)
+            .locateUserTemplates(at: .any)
+            .willReturn(nil)
+
+        // When
+        try _ = await subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .none)
+
+        // Then
+        XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
+        let mapArgs = projectEditorMapper.mapArgs.first
+        let pluginNames = try XCTUnwrap(mapArgs?.editablePluginManifests.map(\.name).sorted())
+        XCTAssertEqual(pluginNames.count, 3)
+        XCTAssertTrue(pluginNames.contains("LocalPlugin"))
+        let renamedNames = pluginNames.filter { $0 != "LocalPlugin" }
+        for name in renamedNames {
+            XCTAssertTrue(name.hasSuffix("-LocalPlugin"), "Expected parent directory prefix, got: \(name)")
+        }
+    }
+
     func test_edit_project_with_remote_plugin() async throws {
         // Given
         let directory = try temporaryPath()


### PR DESCRIPTION
## Summary

Running `tuist edit` from a repo root that contains multiple `Plugin.swift` files in directories with the same basename (e.g. `examples/app1/LocalPlugin/` and `fixtures/LocalPlugin/`) crashes with `Fatal error: Duplicate values for key: 'LocalPlugin'`.

The filesystem scan discovers all plugins recursively and uses the directory basename as the plugin name. The existing `Set`-based dedup only checks paths, so plugins with different paths but the same directory name all survive and get turned into targets with the same name, which crashes `Project.init`.

The fix deduplicates discovered plugins by name, keeping the first found, and adds a defensive `uniquingKeysWith` in the graph dependency dictionary as well.

## Test plan

- Added `test_edit_project_deduplicates_plugins_with_same_directory_name` covering the scenario
- All existing `ProjectEditorTests` and `ProjectEditorMapperTests` continue to pass