### PR TITLE
fix(cli): don't embed static precompiled xcframeworks

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -485,35 +485,6 @@ public class GraphTraverser: GraphTraversing {
             }
         )
 
-        // Static precompiled XCFrameworks that contain .framework bundles (e.g., from cache)
-        // These need to be embedded so the bundle accessor can find resources at runtime.
-        // We only embed XCFrameworks that contain .framework bundles, not .a static libraries,
-        // because .a libraries don't have an Info.plist and will fail to load at runtime.
-        // The binary is already statically linked, so embedding it is redundant but harmless
-        // (only resources are needed at runtime).
-        // We skip traversing through dynamic precompiled binaries because they link static
-        // dependencies themselves.
-        let staticXCFrameworks = filterDependencies(
-            from: .target(name: name, path: path),
-            test: { dependency in
-                guard case let .xcframework(xcframework) = dependency,
-                      xcframework.linking == .static
-                else { return false }
-                // Only embed XCFrameworks that contain .framework bundles, not .a static libraries
-                return xcframework.infoPlist.libraries.contains { $0.path.extension == "framework" }
-            },
-            skip: { self.canDependencyEmbedBinaries(dependency: $0) || $0.isPrecompiledMacro || $0.isDynamicPrecompiled }
-        )
-
-        references.formUnionPreferringRequiredStatus(
-            staticXCFrameworks.lazy.compactMap {
-                self.dependencyReference(
-                    to: $0,
-                    from: .target(name: name, path: path)
-                )
-            }
-        )
-
         // Exclude any products embed in unit test host apps
         if target.target.product == .unitTests {
             if let hostApp = unitTestHost(path: path, name: name) {


### PR DESCRIPTION
## Summary

- Stop embedding static precompiled xcframeworks in the app bundle
- This fixes runtime errors for frameworks like GoogleMapsCore whose inner `.framework` bundle lacks an `Info.plist`, causing "Failed to load Info.plist from bundle" errors at launch
- The binary is already statically linked so embedding is unnecessary, and resources are handled separately via `.bundle` dependencies in the graph

## Test plan

- [x] Updated `test_embeddableFrameworks_when_dependencyIsStaticXCFramework` to assert no embedding
- [x] Updated `test_embeddableFrameworks_when_dependencyIsTransitiveStaticXCFramework` to assert only the dynamic framework is embedded
- [x] Removed `test_embeddableFrameworks_when_dependencyIsStaticXCFrameworkWithStaticLibrary` (superseded by the broader fix)