### PR TITLE
fix(cli): use swift build --show-bin-path for Linux bundle

### DIFF
--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -35,8 +35,9 @@ mkdir -p $BUILD_DIRECTORY
 echo "==> Building tuist executable"
 swift build --target tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry
 
-echo "==> Copying binary"
-cp "$BUILD_PATH/release/tuist" $BUILD_DIRECTORY/tuist
+BIN_PATH=$(swift build --target tuist --configuration release --build-path "$BUILD_PATH" --show-bin-path)
+echo "==> Copying binary from $BIN_PATH"
+cp "$BIN_PATH/tuist" $BUILD_DIRECTORY/tuist
 
 ARCH=$(uname -m)
 


### PR DESCRIPTION
## Summary
- Swift 6.1 places binaries in a triple-specific directory (e.g. `.build/aarch64-unknown-linux-gnu/release/`) instead of `.build/release/`
- The Linux bundle script was hardcoding `.build/release/tuist` which doesn't exist
- Use `swift build --show-bin-path` to dynamically resolve the correct binary location

## Test plan
- [ ] Verify Linux release jobs succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)