### PR TITLE
fix(cli): use --product instead of --target in Linux bundle script

### DIFF
--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -33,9 +33,9 @@ rm -rf $BUILD_DIRECTORY
 mkdir -p $BUILD_DIRECTORY
 
 echo "==> Building tuist executable"
-swift build --target tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry
+swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry
 
-BIN_PATH=$(swift build --target tuist --configuration release --build-path "$BUILD_PATH" --show-bin-path)
+BIN_PATH=$(swift build --product tuist --configuration release --build-path "$BUILD_PATH" --show-bin-path)
 echo "==> Copying binary from $BIN_PATH"
 cp "$BIN_PATH/tuist" $BUILD_DIRECTORY/tuist
 


### PR DESCRIPTION
## Summary
- `swift build --target tuist` only compiles sources but does not link the executable, so no binary is produced at the bin path
- Changed to `swift build --product tuist` which compiles and links, producing the actual `tuist` binary
- This was causing `cp: cannot stat '.../release/tuist': No such file or directory` in the release workflow

## Test plan
- [ ] Verify Linux release jobs succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)