### PR TITLE
feat(cli): add support for custom `resourceSynthesizers` in SPM packages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b37457bb9cc49def870208f83c4803fef0d4e419d85e3d2ae99f57130a2fcd94",
+  "originHash" : "cfd69b81edbb5a850f329f4c1b7ce852686ca855d62a2180337f357957c87e64",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -639,8 +639,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
+        "version" : "1.8.1"
       }
     }
   ],

--- a/cli/Sources/ProjectDescription/PackageSettings.swift
+++ b/cli/Sources/ProjectDescription/PackageSettings.swift
@@ -45,6 +45,9 @@ public struct PackageSettings: Codable, Equatable, Sendable {
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.
     public var projectOptions: [String: Project.Options]
 
+    /// Custom resource synthesizers to be used for projects generated from SwiftPackageManager.
+    public let resourceSynthesizers: [String: [ResourceSynthesizer]]
+
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
     /// - Parameters:
     ///     - productTypes: The custom `Product` types to be used for SPM targets.
@@ -57,13 +60,15 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         productDestinations: [String: Destinations] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: Settings] = [:],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        resourceSynthesizers: [String: [ResourceSynthesizer]] = [:]
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.resourceSynthesizers = resourceSynthesizers
         dumpIfNeeded(self)
     }
 
@@ -87,13 +92,15 @@ public struct PackageSettings: Codable, Equatable, Sendable {
         productDestinations: [String: Destinations] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: SettingsDictionary],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        resourceSynthesizers: [String: [ResourceSynthesizer]] = [:]
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings.mapValues { .settings(base: $0) }
         self.projectOptions = projectOptions
+        self.resourceSynthesizers = resourceSynthesizers
         dumpIfNeeded(self)
     }
 }

--- a/cli/Sources/TuistCore/Models/PackageSettings.swift
+++ b/cli/Sources/TuistCore/Models/PackageSettings.swift
@@ -1,22 +1,26 @@
 import Foundation
 import XcodeGraph
+import ProjectDescription
 
 /// Contains the description of custom SPM settings
 public struct PackageSettings: Equatable, Codable {
     /// The custom `Product` types to be used for SPM targets.
-    public let productTypes: [String: Product]
+    public let productTypes: [String: XcodeGraph.Product]
 
     /// Custom destinations to be used for SPM products.
-    public let productDestinations: [String: Destinations]
+    public let productDestinations: [String: XcodeGraph.Destinations]
 
     /// The base settings to be used for targets generated from SwiftPackageManager.
-    public let baseSettings: Settings
+    public let baseSettings: XcodeGraph.Settings
 
     /// The custom `Settings` to be applied to SPM targets.
-    public let targetSettings: [String: Settings]
+    public let targetSettings: [String: XcodeGraph.Settings]
 
     /// The custom project options for each project generated from a swift package.
     public let projectOptions: [String: XcodeGraph.Project.Options]
+
+    /// The custom resource synthesizers to be used for SPM targets.
+    public let resourceSynthesizers: [String: [ProjectDescription.ResourceSynthesizer]]
 
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
@@ -24,36 +28,41 @@ public struct PackageSettings: Equatable, Codable {
     ///    - baseSettings: The base settings to be used for targets generated from SwiftPackageManager
     ///    - targetSettings: The custom `SettingsDictionary` to be applied to denoted targets
     ///    - projectOptions: The custom project options for each project generated from a swift package
+    ///    - resourceSynthesizers: The custom resource synthesizers to be used for SPM targets
     public init(
-        productTypes: [String: Product],
-        productDestinations: [String: Destinations],
-        baseSettings: Settings,
-        targetSettings: [String: Settings],
-        projectOptions: [String: XcodeGraph.Project.Options] = [:]
+        productTypes: [String: XcodeGraph.Product],
+        productDestinations: [String: XcodeGraph.Destinations],
+        baseSettings: XcodeGraph.Settings,
+        targetSettings: [String: XcodeGraph.Settings],
+        projectOptions: [String: XcodeGraph.Project.Options] = [:],
+        resourceSynthesizers: [String: [ProjectDescription.ResourceSynthesizer]] = [:]
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.resourceSynthesizers = resourceSynthesizers
     }
 }
 
 #if DEBUG
     extension PackageSettings {
         public static func test(
-            productTypes: [String: Product] = [:],
-            productDestinations: [String: Destinations] = [:],
-            baseSettings: Settings = Settings.default,
-            targetSettings: [String: Settings] = [:],
-            projectOptions: [String: XcodeGraph.Project.Options] = [:]
+            productTypes: [String: XcodeGraph.Product] = [:],
+            productDestinations: [String: XcodeGraph.Destinations] = [:],
+            baseSettings: XcodeGraph.Settings = XcodeGraph.Settings.default,
+            targetSettings: [String: XcodeGraph.Settings] = [:],
+            projectOptions: [String: XcodeGraph.Project.Options] = [:],
+            resourceSynthesizers: [String: [ProjectDescription.ResourceSynthesizer]] = [:]
         ) -> PackageSettings {
             PackageSettings(
                 productTypes: productTypes,
                 productDestinations: productDestinations,
                 baseSettings: baseSettings,
                 targetSettings: targetSettings,
-                projectOptions: projectOptions
+                projectOptions: projectOptions,
+                resourceSynthesizers: resourceSynthesizers
             )
         }
     }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -28,7 +28,8 @@ extension TuistCore.PackageSettings {
             productDestinations: productDestinations,
             baseSettings: baseSettings,
             targetSettings: targetSettings,
-            projectOptions: projectOptions
+            projectOptions: projectOptions,
+            resourceSynthesizers: manifest.resourceSynthesizers
         )
     }
 }

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -353,6 +353,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
             )
         }
 
+        let resourceSynthesizers = packageSettings.resourceSynthesizers[packageInfo.name]
+
         return ProjectDescription.Project(
             name: packageInfo.name,
             options: options,
@@ -362,7 +364,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 swiftToolsVersion: Version(stringLiteral: packageInfo.toolsVersion.description)
             ),
             targets: targets,
-            resourceSynthesizers: .default
+            resourceSynthesizers: resourceSynthesizers ?? .default
         )
     }
 


### PR DESCRIPTION
### Context

- **Goal:** Enable customization of **resource synthesizers** for local Swift Packages generated by Tuist.
- **Problem:** Previously, the `PackageInfoMapper` hardcoded `resourceSynthesizers` to `.default` for all packages. This prevented developers from using custom synthesizers (e.g., for JSON files) or disabling default accessors for specific local packages defined in `Package.swift`.

### Testing

- **Manual:** Verified that defining `.files(extensions: ["json"])` in `PackageSettings` for a local package correctly generates the corresponding accessors in the generated project.