### PR TITLE
chore(ci): rename canary deploy step names to production in production deployment workflow

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
-      - name: Trigger canary deploy with Render CLI
+      - name: Trigger production deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
   production-hotfix:
@@ -162,6 +162,6 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
-      - name: Trigger canary deploy with Render CLI
+      - name: Trigger production deploy with Render CLI
         run: |
           mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"


### PR DESCRIPTION
## Summary
- Renames the misleading "Trigger canary deploy with Render CLI" step names to "Trigger production deploy with Render CLI" in the `production` and `production-hotfix` jobs of the server production deployment workflow.