### PR TITLE
fix(cli): restore asset symbol generation for external static frameworks

### DIFF
--- a/cli/Sources/TuistConstants/Constants.swift
+++ b/cli/Sources/TuistConstants/Constants.swift
@@ -32,7 +32,7 @@ public enum Constants {
     /// The cache version.
     /// This should change only when it changes the logic to map a `XcodeGraph.Target` to a cached build artifact.
     /// Changing this results in changing the target hash and hence forcing a rebuild of its artifact.
-    public static let cacheVersion = "1.0.0"
+    public static let cacheVersion = "1.1.0"
 
     public enum SwiftPackageManager {
         public static let packageSwiftName = "Package.swift"

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3518,9 +3518,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
     func test_embeddableFrameworks_when_dependencyIsStaticXCFramework() throws {
         // Given
         // App depends on a static XCFramework directly
-        // Static precompiled XCFrameworks should NOT be embedded because embedding them
-        // can cause runtime errors when the inner .framework lacks an Info.plist.
-        // Resources are handled separately via .bundle dependencies.
+        // Static XCFrameworks with .framework bundles are embedded so their resources
+        // are accessible at runtime (resources live inside the .framework itself).
         let app = Target.test(name: "App", platform: .iOS, product: .app)
         let project = Project.test(targets: [app])
 
@@ -3549,7 +3548,9 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let got = subject.embeddableFrameworks(path: project.path, name: app.name).sorted()
 
         // Then
-        XCTAssertEqual(got.count, 0)
+        XCTAssertEqual(got, [
+            GraphDependencyReference(staticXCFramework),
+        ])
     }
 
     func test_embeddableFrameworks_when_dependencyIsTransitiveStaticXCFramework() throws {

--- a/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/cli/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -357,12 +357,12 @@ final class DependenciesAcceptanceTestAppWithObjCStaticFrameworkWithResources: T
             )
         }
 
-        // Verify the separate resource bundle exists (external static frameworks generate SPM-style bundles)
+        // External static frameworks keep resources inside the framework (no separate .bundle)
         let resourceBundlePath = appPath.appending(component: "SVProgressHUD_SVProgressHUD.bundle")
         let resourceBundleExists = await (try? fileSystem.exists(resourceBundlePath)) ?? false
-        XCTAssertTrue(
+        XCTAssertFalse(
             resourceBundleExists,
-            "SVProgressHUD_SVProgressHUD.bundle should exist in the app bundle for external static frameworks with resources"
+            "SVProgressHUD_SVProgressHUD.bundle should not exist; resources live inside the framework itself"
         )
 
         // Install the app


### PR DESCRIPTION
## Summary

PR #9344 generated separate resource bundles for external static frameworks, which broke Xcode's `GenerateAssetSymbols` build phase. Packages using `Image(.name)` syntax stopped compiling because the asset catalog was moved to the bundle target, and Xcode only generates `ImageResource` extensions for targets that directly contain asset catalogs.

This PR keeps resources inside the static framework itself (both for source builds and the cached XCFramework path), updates the Swift/ObjC bundle accessors to find resources there, and bumps the cache version so stale artifacts get rebuilt.

## Changes

- **ResourcesProjectMapper**: static frameworks no longer get a separate `.bundle` target. The Swift accessor uses `swiftStaticFrameworkBundleAccessorString` for all static frameworks (local and external). The ObjC accessor tries loading the `.framework` candidate directly before falling back to `.bundle`.
- **GraphTraverser**: direct static XCFrameworks whose libraries are `.framework` bundles are now embedded in the app, so their resources are reachable at runtime after `tuist cache`.
- **Cache version**: bumped from 1.0.0 to 1.1.0 to force a rebuild of cached artifacts.

Closes #9336