### PR TITLE
fix(server): handle FunctionClauseErrors in QA settings LiveView

### DIFF
--- a/server/test/tuist_web/live/qa_settings_live_test.exs
+++ b/server/test/tuist_web/live/qa_settings_live_test.exs
@@ -1,0 +1,47 @@
+defmodule TuistWeb.QASettingsLiveTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.StubCase, dashboard_project: true
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  describe "close_edit_launch_argument_modal" do
+    test "handles dismiss without id param", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/settings/qa")
+
+      assert render_click(lv, "close_edit_launch_argument_modal", %{})
+    end
+  end
+
+  describe "delete_launch_argument_group" do
+    test "handles non-existent launch argument group", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/settings/qa")
+
+      assert render_click(lv, "delete_launch_argument_group", %{"id" => Ecto.UUID.generate()})
+    end
+  end
+
+  describe "update_launch_argument_group" do
+    test "handles non-existent launch argument group", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/settings/qa")
+
+      assert render_click(lv, "update_launch_argument_group", %{
+               "id" => Ecto.UUID.generate(),
+               "launch_argument_group" => %{"name" => "test", "value" => "--test"}
+             })
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fix modal dismiss (`on_dismiss`) crashing when no `id` param is present (e.g. clicking outside the modal or pressing Escape)
- Fix delete and update launch argument group handlers crashing when `Enum.find` returns `nil` for a stale/non-existent group id

Fixes TUIST-42, TUIST-43, TUIST-44

## Test plan
- [x] Added `QASettingsLiveTest` with 3 tests covering all three crash scenarios
- [x] Existing QA LiveView tests still pass
- [ ] Verify on staging: dismiss edit modal by clicking outside — no crash
- [ ] Verify on staging: concurrent delete/update of launch argument groups — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)