### PR TITLE
fix(cli): statically link Swift stdlib in Linux builds

### DIFF
--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -33,7 +33,7 @@ rm -rf $BUILD_DIRECTORY
 mkdir -p $BUILD_DIRECTORY
 
 echo "==> Building tuist executable"
-swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry
+swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry --static-swift-stdlib
 
 BIN_PATH=$(swift build --product tuist --configuration release --build-path "$BUILD_PATH" --show-bin-path)
 echo "==> Copying binary from $BIN_PATH"


### PR DESCRIPTION
## Summary
- The Linux `tuist` binary was dynamically linked against the Swift runtime (`libswiftCore.so`, `libFoundation.so`, `libdispatch.so`, etc.)
- This meant the binary was unusable on systems without the Swift toolchain installed
- Adds `--static-swift-stdlib` to the Linux build command so all Swift runtime libraries are embedded in the binary

## Test plan
- [ ] CI builds the Linux binary successfully with the new flag
- [ ] Verify the resulting binary runs on a Linux system without Swift installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)