### PR TITLE
feat(server): bump minimum supported CLI version to 4.118.1

### DIFF
--- a/server/lib/tuist_web/plugs/warnings_header_plug.ex
+++ b/server/lib/tuist_web/plugs/warnings_header_plug.ex
@@ -11,7 +11,7 @@ defmodule TuistWeb.WarningsHeaderPlug do
 
   @assign_key :warnings
 
-  @minimum_supported_cli_version Version.parse!("4.56.1")
+  @minimum_supported_cli_version Version.parse!("4.118.1")
 
   def init(opts), do: opts
 

--- a/server/test/tuist_web/plugs/warnings_header_plug_test.exs
+++ b/server/test/tuist_web/plugs/warnings_header_plug_test.exs
@@ -25,7 +25,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
   describe "call/2" do
     test "it doesn't return the warnings if the version is lower than 4.11.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.56.1"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.118.1"} end)
 
       conn =
         :get
@@ -44,7 +44,7 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
 
     test "it returns the warnings if the version is higher or equal than 4.11.0" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.56.1"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.118.1"} end)
 
       conn =
         :get
@@ -61,19 +61,19 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
       warning = got |> Plug.Conn.get_resp_header("x-tuist-cloud-warnings") |> List.first()
 
       assert Jason.decode!(Base.decode64!(warning)) == [
-               "Your Tuist version 4.11.0 is deprecated. Please upgrade to version 4.56.1 for server-side features to continue working.",
+               "Your Tuist version 4.11.0 is deprecated. Please upgrade to version 4.118.1 for server-side features to continue working.",
                "warning"
              ]
     end
 
-    test "it returns a deprecation warning if the version is lower than 4.56.1" do
+    test "it returns a deprecation warning if the version is lower than 4.118.1" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.56.1"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.118.1"} end)
 
       conn =
         :get
         |> conn("/")
-        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.56.0")
+        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.118.0")
 
       # When
       got = WarningsHeaderPlug.call(conn, %{})
@@ -84,18 +84,18 @@ defmodule TuistWeb.WarningsHeaderPlugTest do
       warning = got |> Plug.Conn.get_resp_header("x-tuist-cloud-warnings") |> List.first()
 
       assert Jason.decode!(Base.decode64!(warning)) == [
-               "Your Tuist version 4.56.0 is deprecated. Please upgrade to version 4.56.1 for server-side features to continue working."
+               "Your Tuist version 4.118.0 is deprecated. Please upgrade to version 4.118.1 for server-side features to continue working."
              ]
     end
 
-    test "it doesn't return a deprecation warning if the version is higher or equal than 4.56.1" do
+    test "it doesn't return a deprecation warning if the version is higher or equal than 4.118.1" do
       # Given
-      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.56.1"} end)
+      Mimic.stub(Releases, :get_latest_cli_release, fn _opts -> %{name: "4.118.1"} end)
 
       conn =
         :get
         |> conn("/")
-        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.56.1")
+        |> Plug.Conn.put_req_header(Headers.cli_version_header(), "4.118.1")
 
       # When
       got = WarningsHeaderPlug.call(conn, %{})


### PR DESCRIPTION
## Summary

Bumps `@minimum_supported_cli_version` from `4.56.1` to `4.118.1` in `WarningsHeaderPlug`, so users on older versions see a deprecation warning nudging them to upgrade.

## Changes

- `server/lib/tuist_web/plugs/warnings_header_plug.ex`: `4.56.1` → `4.118.1`
- `server/test/tuist_web/plugs/warnings_header_plug_test.exs`: Updated test versions to match

## Test plan

```bash
mix test test/tuist_web/plugs/warnings_header_plug_test.exs
```