### PR TITLE
Update terms of service and add legal addendums

### DIFF
--- a/cli/Sources/TuistOrganizationCommand/Commands/OrganizationCreateCommand.swift
+++ b/cli/Sources/TuistOrganizationCommand/Commands/OrganizationCreateCommand.swift
@@ -8,7 +8,8 @@ public struct OrganizationCreateCommand: AsyncParsableCommand {
         CommandConfiguration(
             commandName: "create",
             _superCommandName: "organization",
-            abstract: "Create a new organization."
+            abstract: "Create a new organization.",
+            discussion: "By creating an organization, you agree to the Tuist Terms of Service: https://tuist.dev/terms"
         )
     }
 

--- a/server/priv/marketing/pages/data-act-addendum.md
+++ b/server/priv/marketing/pages/data-act-addendum.md
@@ -1,0 +1,288 @@
+---
+title: Data Act Addendum
+description: This Data Act Addendum implements the EU Data Act (Regulation 2023/2854) for switching and porting between data processing services provided by Tuist.
+last_updated: 2025-09-12
+---
+
+This Addendum implements the EU Data Act (as defined below) with effect from 12 September 2025. This Addendum is entered into between Tuist GmbH ("**Tuist**") and the Customer (as defined in the Agreement), and will be subject to, and governed by the terms in the Online Terms and Conditions (the "**Agreement**").
+
+In the event of a conflict between this Addendum, the Agreement or any Addenda or other schedule to the Agreement (other than the Data Processing Addendum), this Addendum will prevail. In case of conflict between this Addendum and the Data Processing Addendum, the Data Processing Addendum will prevail.
+
+## 1. Definitions
+
+For the purposes of this Addendum, capitalized terms used in this Addendum, but not defined herein, will have the meanings set forth in the Agreement and/or other applicable addenda. In addition, the following definitions apply:
+
+| Term | Definition |
+|---|---|
+| **"Agreement"** | means the contract between Tuist and the Customer with respect to the provisions of the Data Processing Service(s). |
+| **"Data"** | means the data as defined in Annex 1 of this Addendum. |
+| **"Data Processing Service(s)"** | means the Products and Services purchased by the Customer under the Agreement that qualify as a data processing service as defined by Art. 2(8) EU Data Act. |
+| **"Data Retrieval Period"** | means the period as defined in Clause 8.1. |
+| **"Destination Provider"** | means a different provider of data processing services, as defined in the EU Data Act, that is not Tuist. |
+| **"Digital Assets"** | means the data as defined in Annex 1 of this Addendum. |
+| **"Early Termination Charges"** | means the Fees as defined in Clause 9.2 of this Addendum. |
+| **"EU Data Act"** | means Regulation (EU) 2023/2854 of the European Parliament and of the Council of 13 December 2023 on harmonized rules on fair access to and use of data and amending Regulation (EU) 2017/2394 and Directive (EU) 2020/1828 (Data Act). |
+| **"Exportable Data"** | means Data and Digital Assets. |
+| **"Notice Period"** | means the two-month period (or such other period as agreed in writing by the Parties) commencing upon the receipt by Tuist of a Valid Request. |
+| **"ICT"** | means information and communication technology. |
+| **"Same Service Type"** | means a category of data processing service (as defined in the EU Data Act) that shares the same primary objective, data processing service model and main functionalities as the Data Processing Service(s) provided by Tuist under the Agreement and that is the subject of a Switching request. |
+| **"Switching"** | means the process whereby Customer changes from using a Data Processing Service of Tuist provided under the Agreement, if any, (i) to using another service of the Same Service Type offered by a Destination Provider, or (ii) to an on-premises ICT infrastructure, including through extracting, transforming and uploading the data. |
+| **"Switching Charges"** | means the costs for Switching defined in Clause 9.1 of this Addendum which are considered as Fees for the purposes of the Agreement. |
+| **"Transitional Period"** | means the period commencing on the date starting at the end of the Notice Period initiated by the receipt of a Valid Request. |
+| **"Valid Request"** | means a request satisfying the requirements in Clause 4.2 and 4.3. |
+| **"Working Days"** | means any day other than a Saturday, Sunday or a public holiday in the jurisdiction where Tuist is established. |
+
+## 2. Information Obligations of Tuist
+
+2.1. Customer acknowledges that before placing the order for the Data Processing Services, Tuist provided the Customer with clear information about:
+
+(a) available self-service automated switching tools for such services ("Switching Tools") and the conditions of their use;
+
+(b) Tuist's Fees and, where applicable, Early Termination Charges;
+
+(c) the Switching Charges including the fees to use the switching tools;
+
+(d) specific services where the obligations on Switching and exit do not apply, where relevant.
+
+2.2. Tuist provides an on-line register describing Data structures and formats, relevant standards and open interoperability specifications, where Exportable Data are available at [https://github.com/tuist/tuist/blob/main/server/data-export.md](https://github.com/tuist/tuist/blob/main/server/data-export.md).
+
+## 3. Switching and Exit Plan
+
+3.1. The switching checklist in Appendix 2, which forms an integral part of the Agreement, includes:
+
+(a) an exhaustive specification of categories of Data and Digital Assets that can be transferred with the use of Switching Tools, including at a minimum all Exportable Data;
+
+(b) an exhaustive specification of categories of Data specific to the internal functioning of the Provider's Data Processing Service that will be exempted from the obligation to export Data where there is a risk of breach of Tuist's trade secrets;
+
+(c) information on procedures for switching and porting with the use of Switching Tools, including methods and formats, restrictions and technical limitations, including those arising from the storage of Data outside of EU, procedures, instructions, documentation, as well when applicable, best practices, capabilities, technical support which Tuist will make available to the Customer (especially during testing, preparation for switching and switching), including any hotlines available for the Customers during the switching or alternative communication channels and tests scenarios. This information must explain how to switch all Exportable Data and Digital Assets in a coherent and consistent way fast enough for an effective switching.
+
+(d) an estimate of the time needed to export and transfer the Data and Digital Assets out of Tuist's environment, when the Switching Tools are used in accordance with Tuist's documentation;
+
+(e) clear information concerning known risks to continuity in the provision of the functions or services on the part of Tuist;
+
+(f) the resources, including IT Resources (such as servers, CPU, memory, I/O, bandwidth), which will be provided by Tuist to ensure effective switching and the procedure for obtaining additional IT Resources.
+
+3.2. Switching shall be treated as a Service under the Agreement.
+
+## 4. Switching Request, Procedure
+
+4.1. The Customer initiates the Switching by sending Tuist notice of its intent to switch in the form of a Valid Request, in accordance with this Clause 4 and as indicated in Clause 11. The Notice Period will commence when Tuist receives a Valid Request. If the Customer wishes to switch only with regard to certain Products and Services and the corresponding Data or Digital Assets, this must be specified in the Valid Request. The Customer may give notice by using the form in Appendix 3.
+
+4.2. Customer shall specify in the Valid Request the relevant Data Processing Service and whether the Customer intends:
+
+(a) to switch to a Destination Provider of the Same Service Type. In this case the Customer shall provide necessary details of the Destination Provider and the services offered by the Destination Provider;
+
+(b) to switch to Customer's on-premises ICT infrastructure;
+
+(c) erase their Exportable Data and give notice by using the form in Appendix 4.
+
+4.3. In addition to the information set out above, a Valid Request must include all other details necessary for Tuist to enable the Switching or the erasing of Exportable Data, including, as applicable, details about the Destination Provider, the destination ICT infrastructure, the envisaged timing and the Customer representative(s) responsible for the process. Determination of whether a specific service qualifies as the Same Service Type shall be made by Tuist in good faith, taking into account the primary purpose, essential features of the services as described in the Valid Request by the Customer. In the scenario contemplated by Clause 4.5, below, a Valid Request will also include the proof of authorization.
+
+4.4. Tuist confirms to the Customer the receipt of the switching notice using the same way of communication as the one used by the Customer. If the request received does not contain the information required to constitute a Valid Request, Tuist will promptly inform the Customer of which information is missing and Customer may resubmit the request with the missing information.
+
+4.5. A request for Switching may also be submitted by a third party authorized by the Customer, in which case the request must include proof of the Customer authorization to the third party.
+
+4.6. Tuist and the Customer shall, and the Customer shall ensure that any Destination Provider involved in the Switching will, cooperate in good faith to make the Switching effective, enable the timely transfer of data and maintain the continuity of the Data Processing Services concerned.
+
+## 5. Transitional Period
+
+5.1. The Transitional Period shall be thirty (30) days or such other time as agreed by the Parties in writing.
+
+5.2. If Tuist determines that it will not be technically feasible to complete the Switching within the agreed Transition Period, Tuist shall:
+
+(a) notify the Customer within 14 Working Days after receiving the Valid Request;
+
+(b) indicate an alternative Transitional Period, which must not exceed seven (7) months from the date of the Customer's Valid Request; and
+
+(c) explain why adhering to the Transition Period is not technically feasible.
+
+5.3. The Customer shall confirm the receipt of the notice for alternative Transitional Period within three (3) Working Days. Failure to confirm receipt will be treated as acceptance of the alternative proposal.
+
+5.4. The Customer may extend the Transitional Period once, for a period but in no case for any period longer than three (3) months ("Alternative Transition Period"). Customer shall notify Tuist of the change before the end of the original Transitional Period and indicates the Alternative Transitional Period. The Customer shall use the form set out in Appendix 5 to provide notice of its request for an Alternative Transition Period.
+
+## 6. Obligations of Tuist during the Switching
+
+Tuist shall provide reasonable assistance to the Customer and third parties authorized by the Customer to assist with the Switching once the Switching process starts and throughout its duration. To this effect, Tuist shall:
+
+(a) act with due care to maintain business continuity and continue to provide the functions or Data Processing Service(s) under the Agreement;
+
+(b) maintain a high level of security throughout the Switching, in particular for the security of the Data during their transfer, consistent with the level of security provided in accordance with the terms of this Agreement; and
+
+(c) if problems are detected during the switching and cannot be resolved through technical support, together with the Customer, analyse the causes and agree on the solutions.
+
+## 7. Obligations of the Customer during the Switching
+
+7.1. The Customer undertakes to take all reasonable measures to achieve effective Switching. The Customer undertakes to be responsible for the import and implementation of Data and Digital Assets in their ICT infrastructure or in the systems of the Destination Provider, including where the Customer uses the Data Processing Services of a third party for these actions.
+
+7.2. Customer shall notify Tuist of the successful Switching promptly and without undue delay. Any costs associated with Customer's delay shall be borne by the Customer.
+
+7.3. If applicable and without prejudice to Article 30(6) of the Data Act, the Customer and Tuist, or third parties mandated by them, undertake to respect the intellectual property rights of any materials provided in the Switching by Tuist, as well as Tuist's trade secrets, which are considered Confidential Information under the Agreement. The Customer undertakes to provide access to, and enable the use of these materials by third parties mandated by them only insofar as this is absolutely necessary to complete the Switching and only upon Tuist's explicit authorization and provided that such third parties are bound by appropriate contractual confidentiality obligations. The access to and use of Tuist's materials related to the Switching which are protected by intellectual property rights and/or trade secrets related to the Switching will be terminated no later than at the end of the agreed Transitional Period, including the Alternative Transitional Period, in full compliance with the confidentiality commitments and the intellectual property rights granted by Tuist. In all other aspects, the Customer's confidentiality obligations as provided by the Agreement shall remain unchanged by this Addendum.
+
+7.4. The Customer shall act in good faith to implement any instructions related to the Switching given by Tuist. The reasonable measures to achieve effective switching on the part of the Customer include, in particular:
+
+(a) Preparing the switching process internally (e.g. stopping all access to the Data and informing the user of the unavailability of the system. If a third party is entrusted with switching, providing appropriate instructions to such third party so that it respects the Agreement between the Customer and Tuist).
+
+(b) Monitoring the switching process (e.g. check the exported Data and Digital Assets during the switching to immediately identify any problems).
+
+(c) Appropriate contractual arrangements with the Destination Provider or ensuring appropriate resources for on-premises switching.
+
+## 8. Data Retrieval and Data Erasure
+
+8.1. The Customer may retrieve or erase their Exportable Data during the Data Retrieval Period. The period of the retrieval of Exportable Data shall be thirty (30) days ("**Data Retrieval Period**").
+
+8.2. At the end of Data Retrieval Period, and if the Switching has been successfully completed, Tuist shall erase all Exportable Data generated by the Customer or directly related to the Customer.
+
+## 9. Switching Charges and Early Termination Fees
+
+9.1. For each Valid Request made before 12 January 2027, Tuist may charge Customer for switching services provided by Tuist or a third party, as described in the Plan and based on the list of Switching charges provided to Customer before the Effective Date of the Agreement or by 12 September 2025 (whichever is later), or, absent such list, based on the hourly rate of net EUR 200 (excl. applicable taxes) and the time directly spent on the Switching concerned (rounded up or down to the next full hour, as applicable).
+
+9.2. If a Valid Request results in the termination of the Agreement pursuant to Clause 10 prior to the agreed fixed term of the Agreement, Tuist may invoice Customer for an amount equal to the Fees that would have been due or payable by Customer if the Agreement had not been terminated before the end of its term, minus any costs directly attributable to the performance of the Agreement that Tuist would have incurred by the end of that term but will not incur due to the early termination ("**Early Termination Charges**"). The Early Termination Charges shall become due and payable in accordance with the payment terms of the Agreement.
+
+## 10. Termination
+
+Notwithstanding any provision to the contrary in the Agreement, and without limitation to the termination rights set out in the Agreement, the Agreement will be considered terminated between the Parties on the date that one of the following events occurs:
+
+(a) Where applicable, upon the successful completion of the Switching. If the successful completion of the Switching occurs before the expiry of the agreed duration of the Agreement, then the Early Termination Fees set out in Clause 9.2 will become due; or
+
+(b) At the end of the Notice Period, if the Customer has requested the erasure of its Exportable Data, upon termination of the Data Processing Service, unless otherwise agreed by the Parties.
+
+## 11. Notices
+
+The Parties agree any notification between them in respect of switching and exit to be done as agreed in the Agreement.
+
+## 12. Order of Precedence
+
+In the event of any conflict or inconsistency between these clauses on switching and exit and any other applicable contractual arrangements, terms, conditions or other applicable Agreements related to switching between Data Processing Services, these clauses will take precedence.
+
+## Appendix 2:Switching Checklist
+
+Either the information required is explicitly mentioned hereunder or the information required can be found at [https://github.com/tuist/tuist/blob/main/server/data-export.md](https://github.com/tuist/tuist/blob/main/server/data-export.md):
+
+**(a) Specification of all categories of Exportable Data that can be transferred:**
+
+- Project manifests and configurations
+- Build artifacts and cache data
+- Team and organization settings
+- Build analytics and metrics
+- Cache contents
+
+**(b) Specification of all categories of Exportable Data specific to the internal functioning of Tuist's Data Processing Service, with risk of a breach of the provider's trade secrets, which are exempted from switching:**
+
+- Internal system performance metrics
+- Infrastructure configuration details
+- Proprietary caching algorithms
+- Internal service authentication keys
+- System optimization parameters
+
+**(c) Exportable Data protected by the intellectual property rights of Tuist or third parties, which are exempted from switching:**
+
+- Tuist source code
+- Licensed third-party components
+- Internal implementation details
+
+**(d) Information on procedures for switching and porting with the use of switching tools:**
+
+- Manual export process initiated by support ticket
+- Data provided in standard formats (JSON, YAML, binary artifacts)
+- Export coordinated with Tuist support team
+
+**(e) Estimate of the time needed to export and transfer the Exportable Data:**
+
+- All exports: Several days for data generation and preparation
+- Additional time for data transfer depending on size
+
+**(f) Known risks to continuity in the provision of the functions or Services of Tuist:**
+
+- None - services continue uninterrupted during export
+
+**(g) IT resources which will be ensured by the Provider for an effective switching:**
+
+- Dedicated support personnel for export coordination
+- Manual data preparation and validation
+- Secure data transfer methods
+- Support documentation
+
+## Appendix 3:Switching Notice
+
+Tuist GmbH,
+Jessnerstr. 27a,
+10247 Berlin,
+Germany
+
+[Date]
+
+**Switching notice**
+
+Name of Customer: [Name]
+
+Contract: [name and details of Contract, e.g. name of contract, its number, date of execution, as required by the contract]
+
+Switched Services: [All covered by the Contract] or [provide explicit Services or Digital Assets subject to switching if only part of the Services are to be covered by switching]
+
+[OPTION] On behalf of the Customer, I/we inform you that the Customer initiates switching of the Switched Services as of [specify starting date]. The notice period is as specified in the Addendum.
+
+[OPTION] On behalf of the Customer, I/we inform you that the Customer initiates switching of the following services, and/or Exportable Data: ...
+
+[OPTION] The Customer informs you that it intends to switch to [details of new provider/on premise infrastructure of Customer].
+
+[OPTION] (Applicable for automated switching) The Customer would like to switch in the following time window(s): [specify dates and details]. The Customer requests following IT Resources to be available in such time windows [to be completed by the Customer].
+
+Contact details of person responsible for switching: [details of Customers' representative responsible for Switching].
+
+________________________________________
+
+[signature of Customer's authorized representative]
+
+## Appendix 4:Exit Notice
+
+This form is applicable if Customer does not want to switch but only to erase its exportable Data or Digital Assets.
+
+Tuist GmbH,
+Jessnerstr. 27a,
+10247 Berlin,
+Germany
+
+[Date]
+
+**Exit notice**
+
+Name of Customer: [Name]
+
+Contract: [name and details of Contract, e.g. name of contract, its number, date of execution, as required by the contract]
+
+Erased Data/Digital Assets: [All covered by the Contract] or [provide explicit Data or Digital Assets subject to erasure]
+
+[OPTION] On behalf of the Customer, I/we inform you that the Customer initiates switching consisting solely of erasure of Erased Data/Digital Assets as of [starting date]. The notice period is as specified in the Addendum.
+
+[OPTION] Contact details of person responsible for switching: [details of Customers' representative responsible for Switching].
+
+________________________________________
+
+[signature of Customer's authorized representative]
+
+## Appendix 5:Notice for Alternative Transitional Period
+
+Tuist GmbH,
+Jessnerstr. 27a,
+10247 Berlin,
+Germany
+
+[Date]
+
+**Notice for alternative transitional period**
+
+Name of Customer: [Name]
+
+Contract: [name and details of contract, e.g. name of contract, its number, date of execution, as required by the contract]
+
+Erased Data/Digital Assets: [All covered by the Contract] or [provide explicit Data or Digital Assets subject to erasure]
+
+[OPTION] On behalf of the Customer, I/we inform you that the Customer wishes to extend the transitional period not longer than [date].
+
+[OPTION] Contact details of person responsible for Switching: [details of Customers' representative responsible for Switching].
+
+________________________________________
+
+[signature of Customer's authorized representative]
+
+*Last updated September 12, 2025*

--- a/server/priv/marketing/pages/data-processing-addendum.md
+++ b/server/priv/marketing/pages/data-processing-addendum.md
@@ -1,0 +1,721 @@
+---
+title: Data Processing Addendum
+description: This Data Processing Addendum regulates the data protection obligations of the Parties when processing Customer Personal Data under the Tuist Agreement.
+last_updated: 2026-02-10
+---
+
+## 1. Parties and Background
+
+1.1. Customer has entered into an agreement with Tuist GmbH ("Tuist") (each a "Party" and collectively the "Parties") under which Tuist has agreed to Tuist Services detailed in the Agreement with the Customer (together the "Services") to the Customer (as amended from time to time) (the "Agreement").
+
+1.2. In the course of providing the Services under the Agreement, Tuist will process Customer Personal Data. This Data Processing Addendum ("DPA") regulates the data protection obligations of the Parties when processing Customer Personal Data.
+
+1.3. Whether or not one of the following Exhibits of this DPA apply depends on where the Customer and Customer Affiliates reside. This DPA covers the following situations:
+
+(a) Where the Customer and Customer Affiliate (as defined below) reside in the European Economic Area, including the European Union ("**EU**", together the "**EEA**") the Data Processor Clauses (as defined below) laid down in **Exhibit A** of this DPA are intended to govern the processing.
+
+(b) Where the Customer and/or Customer Affiliate (as defined below) reside in the UK (as defined below) the UK Addendum (as defined below) included in **Exhibit B** of this DPA is intended to govern the processing.
+
+(c) Where the Customer and/or Customer Affiliate (as defined below) reside in a Restricted Country (as defined below) the Standard Contractual Clauses (as defined below) are laid down in **Exhibit C** of this DPA and are intended to govern the processing.
+
+1.4. The mandatory annexes of the Data Processor Clauses and the Standard Contractual Clauses are laid down in Exhibit D.
+
+## 2. Definitions
+
+2.1. Capitalized terms used but not defined within this DPA shall have the meaning set forth in the Agreement. The following capitalized terms used in this DPA shall be defined as follows.
+
+(a) "**Customer Affiliate**" means an affiliate of the Customer who is a beneficiary to the Agreement.
+
+(b) "**Customer Personal Data**" means Personal Data processed by Tuist on behalf of Customer or Customer Affiliate in connection with the provision of the Services, which may also include Personal Data of Customer and Customer Affiliate's customers and other third parties whose Personal Data is being processed by Customer or a Customer Affiliate.
+
+(c) "**Data Processor Clauses**" means standard contractual clauses set out in the annex of the Commission Implementing Decision (EU) 2021/915 of 4 June 2021 on standard contractual clauses between controllers and processors under Article 28(7) of Regulation (EU) 2016/679 of the European Parliament and of the Council and Article 29(7) of Regulation (EU) 2018/1725 of the European Parliament and of the Council.
+
+(d) "**GDPR**" means Regulation (EU) 2016/679 (the "**EU GDPR**") or, where applicable, the "**UK GDPR**" as it forms part of the law for England and Wales, Scotland and Northern Ireland by virtue of section 3 of the UK European Union (Withdrawal) Act 2018.
+
+(e) "**Personal Data**" means any information relating to an identified or identifiable individual or device, or is otherwise "personal data," "personal information," "personally identifiable information" and similar terms, and such terms shall have the same meaning as defined by applicable data protection laws.
+
+(f) "**Restricted Country**" means a country, territory or a specified sector within a country, or an international organisation outside the EEA not deemed to ensure an adequate level of protection by the European Commission.
+
+(g) "**SCC**" means the Standard Contractual Clauses and the Data Processor Clauses.
+
+(h) "**Standard Contractual Clauses**" means module 4 of the standard contractual clauses set out in the annex of the Commission Implementing Decision (EU) 2021/914 of 4 June 2021 on standard contractual clauses for the transfer of personal data to third countries pursuant to Regulation (EU) 2016/679 of the European Parliament and of the Council.
+
+(i) "**Sub-processor of Tuist**" means a processor appointed by Tuist to process Customer Personal Data; and
+
+(j) "**UK**" means the United Kingdom of Great Britain and Northern Ireland.
+
+2.2. The terms "controller", "processor", "data subject", "process", "personal data breach" and "supervisory authority" shall have the same meaning as set out in the GDPR.
+
+## 3. Interaction with the Agreement
+
+3.1. This DPA is incorporated into and forms an integral part of the Agreement and shall be effective and replace any previously applicable data processing and security terms as of the effective date of the Agreement ("Effective Date"). This DPA supplements and (in case of contradictions) supersedes the Agreement with respect to any processing of Customer Personal Data.
+
+3.2. Any processing operation as described in Section 6 and Annex II of Exhibit D to this DPA shall be subject to this DPA.
+
+3.3. Customer Affiliates shall be beneficiaries under this DPA and, through Customer (see Clauses 3.4 and 3.5), be entitled to enforce all rights in relation to the Customer Personal Data provided by the respective Affiliate. Customer will ensure that all obligations under this DPA will be passed on to the respective Customer Affiliate.
+
+3.4. Customer warrants that it is duly mandated by any Customer Affiliates on whose behalf Tuist processes Customer Personal Data in accordance with this DPA to (a) enforce the terms of this DPA on behalf of the Customer Affiliates, and to act on behalf of the Customer Affiliates in the administration and conduct of any claims arising in connection with this DPA; and (b) receive and respond to any notices or communications under this DPA on behalf of Customer Affiliates.
+
+3.5. Customer shall be the only point of contact for all communication between the Customer Affiliates and Tuist.
+
+## 4. Scope of Processing Clauses
+
+4.1. The Data Processor Clauses included in Section 1 of Exhibit A of this DPA shall by default apply where Customer Personal Data is provided by either Customer or a Customer Affiliate located in the EU and/or EEA, or to which the GDPR otherwise applies.
+
+4.2. In addition to the Clauses applicable under Clause 4.1, the UK Addendum included in Exhibit B shall apply where Customer Personal Data is provided by a Customer or a Customer Affiliate is located in the UK.
+
+4.3. The Standard Contractual Clauses included in Section 1 of Exhibit C of this DPA shall by default apply where Customer Personal Data is provided by a Customer or a Customer Affiliate located in a Restricted Country, or to which the GDPR otherwise does not apply.
+
+## 5. Roles of the Parties
+
+5.1. For the purposes of the GDPR, Tuist acts as "processor" or "sub-processor." Tuist's function as processor or sub-processor will be determined by the function of the Customer:
+
+(a) Where Customer acts as a controller, Tuist acts as a processor.
+
+(b) Where Customer acts as a processor on behalf of a controller, Tuist acts as a sub-processor.
+
+5.2. Where Tuist acts as a sub-processor, the terms provided in the Data Processor Clauses or the Standard Contractual Clauses shall apply mutatis mutandis. The Customer must inform Tuist if it acts as a processor under the instructions of a controller. Tuist shall process the personal data only on documented instructions from the Customer's controller, as communicated to Tuist by the Customer, and any additional documented instructions from the Customer. Such additional instructions shall not conflict with the instructions from the Customer's controller. The Customer's controller or the Customer may give further documented instructions regarding the data processing throughout the duration of the DPA.
+
+## 6. Subject, Duration, Purpose and Specification of Processing
+
+6.1. The details of data processing (such as subject matter, nature and purpose of the processing, categories of personal data and data subjects) are described by the Parties in the Agreement and in Exhibit D.
+
+6.2. The duration of the processing shall correspond to the duration of this DPA as set forth in Section 7.
+
+## 7. Contract Period
+
+The duration of this DPA coincides with the duration of the Agreement. It commences and terminates with the provision of the Services under the Agreement, unless otherwise stipulated in the provisions of this DPA.
+
+## 8. Miscellaneous
+
+8.1. In the event of any conflict between the SCC, the DPA or the Agreement the order of prevalence between the terms included therein shall be as follows:
+
+(a) where applicable, SCC,
+
+(b) the terms in **Exhibit D** of the DPA which are meant to fill in the required information for the SCC (where applicable) and, in particular, its Appendix,
+
+(c) the remaining provisions of this DPA, and
+
+(d) the Agreement and other contractual documents.
+
+8.2. In the event a clause under the Agreement has been found to violate the Applicable Laws, this shall not affect the validity of the remaining provisions, and the Parties will mutually agree on modifications to the Agreement to the extent necessary to ensure data privacy-law compliant processing.
+
+8.3. The DPA shall be governed by the laws stipulated in the Agreement.
+
+## Exhibit A: Data Processor Clauses
+
+The following outlines the Data Processor Clauses as implemented in the DPA, subject to the amendments in Section 2 of this Exhibit A:
+
+**Standard Contractual Clauses based on Commission Implementing Decision (EU) 2021/915**
+
+### Section I
+
+**Clause 1: Purpose and scope**
+
+(a) The purpose of these Standard Contractual Clauses (the Clauses) is to ensure compliance with Article 28(3) and (4) of Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation).
+
+(b) The controllers and processors listed in Annex I have agreed to these Clauses in order to ensure compliance with Article 28(3) and (4) of Regulation (EU) 2016/679 and/or Article 29(3) and (4) of Regulation (EU) 2018/1725.
+
+(c) These Clauses apply to the processing of personal data as specified in Annex II.
+
+(d) Annexes I to IV are an integral part of the Clauses.
+
+(e) These Clauses are without prejudice to obligations to which the controller is subject by virtue of Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725.
+
+(f) These Clauses do not by themselves ensure compliance with obligations related to international transfers in accordance with Chapter V of Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725.
+
+**Clause 2: Invariability of the Clauses**
+
+(a) The Parties undertake not to modify the Clauses, except for adding information to the Annexes or updating information in them.
+
+(b) This does not prevent the Parties from including the standard contractual clauses laid down in these Clauses in a broader contract, or from adding other clauses or additional safeguards provided that they do not directly or indirectly contradict the Clauses or detract from the fundamental rights or freedoms of data subjects.
+
+**Clause 3: Interpretation**
+
+(a) Where these Clauses use the terms defined in Regulation (EU) 2016/679 or Regulation (EU) 2018/1725 respectively, those terms shall have the same meaning as in that Regulation.
+
+(b) These Clauses shall be read and interpreted in the light of the provisions of Regulation (EU) 2016/679 or Regulation (EU) 2018/1725 respectively.
+
+(c) These Clauses shall not be interpreted in a way that runs counter to the rights and obligations provided for in Regulation (EU) 2016/679 / Regulation (EU) 2018/1725 or in a way that prejudices the fundamental rights or freedoms of the data subjects.
+
+**Clause 4: Hierarchy**
+
+In the event of a contradiction between these Clauses and the provisions of related agreements between the Parties existing at the time when these Clauses are agreed or entered into thereafter, these Clauses shall prevail.
+
+**Clause 5: Docking clause (Optional)**
+
+Clause 5 of the Data Processor Clauses (Docking Clause) does not apply.
+
+### Section II: Obligations of the Parties
+
+**Clause 6: Description of processing(s)**
+
+The details of the processing operations, in particular the categories of personal data and the purposes of processing for which the personal data is processed on behalf of the controller, are specified in Annex II.
+
+**Clause 7: Obligations of the Parties**
+
+7.1. Instructions
+
+(a) The processor shall process personal data only on documented instructions from the controller, unless required to do so by Union or Member State law to which the processor is subject. In this case, the processor shall inform the controller of that legal requirement before processing, unless the law prohibits this on important grounds of public interest. Subsequent instructions may also be given by the controller throughout the duration of the processing of personal data. These instructions shall always be documented.
+
+(b) The processor shall immediately inform the controller if, in the processor's opinion, instructions given by the controller infringe Regulation (EU) 2016/679 / Regulation (EU) 2018/1725 or the applicable Union or Member State data protection provisions.
+
+7.2. Purpose limitation
+
+The processor shall process the personal data only for the specific purpose(s) of the processing, as set out in Annex II, unless it receives further instructions from the controller.
+
+7.3. Duration of the processing of personal data
+
+Processing by the processor shall only take place for the duration specified in Annex II.
+
+7.4. Security of processing
+
+(a) The processor shall at least implement the technical and organisational measures specified in Annex III to ensure the security of the personal data. This includes protecting the data against a breach of security leading to accidental or unlawful destruction, loss, alteration, unauthorised disclosure or access to the data (personal data breach). In assessing the appropriate level of security, the Parties shall take due account of the state of the art, the costs of implementation, the nature, scope, context and purposes of processing and the risks involved for the data subjects.
+
+(b) The processor shall grant access to the personal data undergoing processing to members of its personnel only to the extent strictly necessary for implementing, managing and monitoring of the contract. The processor shall ensure that persons authorised to process the personal data received have committed themselves to confidentiality or are under an appropriate statutory obligation of confidentiality.
+
+7.5. Sensitive data
+
+If the processing involves personal data revealing racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade union membership, genetic data or biometric data for the purpose of uniquely identifying a natural person, data concerning health or a person's sex life or sexual orientation, or data relating to criminal convictions and offences ("sensitive data"), the processor shall apply specific restrictions and/or additional safeguards.
+
+7.6. Documentation and compliance
+
+(a) The Parties shall be able to demonstrate compliance with these Clauses.
+
+(b) The processor shall deal promptly and adequately with inquiries from the controller about the processing of data in accordance with these Clauses.
+
+(c) The processor shall make available to the controller all information necessary to demonstrate compliance with the obligations that are set out in these Clauses and stem directly from Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725. At the controller's request, the processor shall also permit and contribute to audits of the processing activities covered by these Clauses, at reasonable intervals or if there are indications of non-compliance. In deciding on a review or an audit, the controller may take into account relevant certifications held by the processor.
+
+(d) The controller may choose to conduct the audit by itself or mandate an independent auditor. Audits may also include inspections at the premises or physical facilities of the processor and shall, where appropriate, be carried out with reasonable notice.
+
+(e) The Parties shall make the information referred to in this Clause, including the results of any audits, available to the competent supervisory authority/ies on request.
+
+7.7. Use of sub-processors
+
+(a) GENERAL WRITTEN AUTHORISATION: The processor has the controller's general authorisation for the engagement of sub-processors from an agreed list. The processor shall specifically inform in writing the controller of any intended changes of that list through the addition or replacement of sub-processors at least 2 weeks in advance, thereby giving the controller sufficient time to be able to object to such changes prior to the engagement of the concerned sub-processor(s). The processor shall provide the controller with the information necessary to enable the controller to exercise the right to object.
+
+(b) Where the processor engages a sub-processor for carrying out specific processing activities (on behalf of the controller), it shall do so by way of a contract which imposes on the sub-processor, in substance, the same data protection obligations as the ones imposed on the data processor in accordance with these Clauses. The processor shall ensure that the sub-processor complies with the obligations to which the processor is subject pursuant to these Clauses and to Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725.
+
+(c) At the controller's request, the processor shall provide a copy of such a sub-processor agreement and any subsequent amendments to the controller. To the extent necessary to protect business secret or other confidential information, including personal data, the processor may redact the text of the agreement prior to sharing the copy.
+
+(d) The processor shall remain fully responsible to the controller for the performance of the sub-processor's obligations in accordance with its contract with the processor. The processor shall notify the controller of any failure by the sub-processor to fulfil its contractual obligations.
+
+(e) The processor shall agree a third party beneficiary clause with the sub-processor whereby, in the event the processor has factually disappeared, ceased to exist in law or has become insolvent, the controller shall have the right to terminate the sub-processor contract and to instruct the sub-processor to erase or return the personal data.
+
+7.8. International transfers
+
+(a) Any transfer of data to a third country or an international organisation by the processor shall be done only on the basis of documented instructions from the controller or in order to fulfil a specific requirement under Union or Member State law to which the processor is subject and shall take place in compliance with Chapter V of Regulation (EU) 2016/679 or Regulation (EU) 2018/1725.
+
+(b) The controller agrees that where the processor engages a sub-processor in accordance with Clause 7.7 for carrying out specific processing activities (on behalf of the controller) and those processing activities involve a transfer of personal data within the meaning of Chapter V of Regulation (EU) 2016/679, the processor and the sub-processor can ensure compliance with Chapter V of Regulation (EU) 2016/679 by using standard contractual clauses adopted by the Commission in accordance with Article 46(2) of Regulation (EU) 2016/679, provided the conditions for the use of those standard contractual clauses are met.
+
+**Clause 8: Assistance to the controller**
+
+(a) The processor shall promptly notify the controller of any request it has received from the data subject. It shall not respond to the request itself, unless authorised to do so by the controller.
+
+(b) The processor shall assist the controller in fulfilling its obligations to respond to data subjects' requests to exercise their rights, taking into account the nature of the processing. In fulfilling its obligations in accordance with (a) and (b), the processor shall comply with the controller's instructions.
+
+(c) In addition to the processor's obligation to assist the controller pursuant to Clause 8(b), the processor shall furthermore assist the controller in ensuring compliance with the following obligations, taking into account the nature of the data processing and the information available to the processor:
+
+(1) the obligation to carry out an assessment of the impact of the envisaged processing operations on the protection of personal data (a 'data protection impact assessment') where a type of processing is likely to result in a high risk to the rights and freedoms of natural persons;
+
+(2) the obligation to consult the competent supervisory authority/ies prior to processing where a data protection impact assessment indicates that the processing would result in a high risk in the absence of measures taken by the controller to mitigate the risk;
+
+(3) the obligation to ensure that personal data is accurate and up to date, by informing the controller without delay if the processor becomes aware that the personal data it is processing is inaccurate or has become outdated;
+
+(4) the obligations in Article 32 of Regulation (EU) 2016/679.
+
+(d) The Parties shall set out in Annex III the appropriate technical and organisational measures by which the processor is required to assist the controller in the application of this Clause as well as the scope and the extent of the assistance required.
+
+**Clause 9: Notification of personal data breach**
+
+In the event of a personal data breach, the processor shall cooperate with and assist the controller for the controller to comply with its obligations under Articles 33 and 34 of Regulation (EU) 2016/679 or under Articles 34 and 35 of Regulation (EU) 2018/1725, where applicable, taking into account the nature of processing and the information available to the processor.
+
+9.1 Data breach concerning data processed by the controller
+
+In the event of a personal data breach concerning data processed by the controller, the processor shall assist the controller:
+
+(a) in notifying the personal data breach to the competent supervisory authority/ies, without undue delay after the controller has become aware of it, where relevant (unless the personal data breach is unlikely to result in a risk to the rights and freedoms of natural persons);
+
+(b) in obtaining the following information which, pursuant to Article 33(3) of Regulation (EU) 2016/679, shall be stated in the controller's notification, and must at least include:
+
+(1) the nature of the personal data including where possible, the categories and approximate number of data subjects concerned and the categories and approximate number of personal data records concerned;
+
+(2) the likely consequences of the personal data breach;
+
+(3) the measures taken or proposed to be taken by the controller to address the personal data breach, including, where appropriate, measures to mitigate its possible adverse effects.
+
+Where, and insofar as, it is not possible to provide all this information at the same time, the initial notification shall contain the information then available and further information shall, as it becomes available, subsequently be provided without undue delay.
+
+(c) in complying, pursuant to Article 34 of Regulation (EU) 2016/679, with the obligation to communicate without undue delay the personal data breach to the data subject, when the personal data breach is likely to result in a high risk to the rights and freedoms of natural persons.
+
+9.2 Data breach concerning data processed by the processor
+
+In the event of a personal data breach concerning data processed by the processor, the processor shall notify the controller without undue delay after the processor having become aware of the breach. Such notification shall contain, at least:
+
+(a) a description of the nature of the breach (including, where possible, the categories and approximate number of data subjects and data records concerned);
+
+(b) the details of a contact point where more information concerning the personal data breach can be obtained;
+
+(c) its likely consequences and the measures taken or proposed to be taken to address the breach, including to mitigate its possible adverse effects.
+
+Where, and insofar as, it is not possible to provide all this information at the same time, the initial notification shall contain the information then available and further information shall, as it becomes available, subsequently be provided without undue delay.
+
+The Parties shall set out in Annex III all other elements to be provided by the processor when assisting the controller in the compliance with the controller's obligations under Articles 33 and 34 of Regulation (EU) 2016/679.
+
+### Section III: Final Provisions
+
+**Clause 10: Non-compliance with the Clauses and termination**
+
+(a) Without prejudice to any provisions of Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725, in the event that the processor is in breach of its obligations under these Clauses, the controller may instruct the processor to suspend the processing of personal data until the latter complies with these Clauses or the contract is terminated. The processor shall promptly inform the controller in case it is unable to comply with these Clauses, for whatever reason.
+
+(b) The controller shall be entitled to terminate the contract insofar as it concerns processing of personal data in accordance with these Clauses if:
+
+(1) the processing of personal data by the processor has been suspended by the controller pursuant to point (a) and if compliance with these Clauses is not restored within a reasonable time and in any event within one month following suspension;
+
+(2) the processor is in substantial or persistent breach of these Clauses or its obligations under Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725;
+
+(3) the processor fails to comply with a binding decision of a competent court or the competent supervisory authority/ies regarding its obligations pursuant to these Clauses or to Regulation (EU) 2016/679 and/or Regulation (EU) 2018/1725.
+
+(c) The processor shall be entitled to terminate the contract insofar as it concerns processing of personal data under these Clauses where, after having informed the controller that its instructions infringe applicable legal requirements in accordance with Clause 7.1 (b), the controller insists on compliance with the instructions.
+
+(d) Following termination of the contract, the processor shall, at the choice of the controller, delete all personal data processed on behalf of the controller and certify to the controller that it has done so, or, return all the personal data to the controller and delete existing copies unless Union or Member State law requires storage of the personal data. Until the data is deleted or returned, the processor shall continue to ensure compliance with these Clauses.
+
+**Amendments to the Data Processor Clauses**
+
+For the purposes of the Data Processor Clauses:
+
+1. For the purposes of Clause 7.7 of the Data Processor Clauses the agreed list of Sub-processors of Tuist for the purpose of Clause 7.7(a) of the Data Processor Clauses is set out in Annex IV of Exhibit D to this DPA (the "**Approved List**").
+
+2. Clause 7.7 lit. e) of the Data Processor Clauses shall not apply.
+
+3. If Customer objects to Tuist's use of a new Sub-processor of Tuist (including when exercising its right to object under Option 2 of Clause 7.7(a) of the Data Processor Clauses) on reasonable grounds, it shall provide Tuist with written notice of the objection within 2 weeks after Tuist has provided notice to the Customer described in Clause 7.7(a) of the Data Processor Clauses in Section 1 of this Exhibit A to the DPA of such proposed change ("**Objection**"). If Customer does not object to the engagement within the objection period, consent regarding the engagement shall be assumed. In the event Customer objects to Tuist's use of a new Sub-processor of Tuist, Customer and Tuist will work together in good faith to find a mutually acceptable resolution to address such Objection. If the Parties are unable to reach a mutually acceptable resolution within a reasonable timeframe, either Party may, as its sole and exclusive remedy, terminate the portion of the Agreement relating to the Services affected by such change by providing written notice to the other Party. During any such Objection period, Tuist may suspend the affected portion of the Services. Customer may only request a pro-rata refund if Customer can prove that the Objection is based on justified reasons of incompliance with Applicable Laws.
+
+4. Annex I (List of Parties) of the Data Processor Clauses shall be deemed to incorporate the information in Annex I of **Exhibit D** to this DPA.
+
+5. Annex II (Description of Transfer) of the Data Processor Clauses shall be deemed to incorporate the information in Annex II of **Exhibit D** to this DPA.
+
+6. Annex III (Technical and Organisational Measures) of the Data Processor Clauses shall be deemed to incorporate the information in Annex III of **Exhibit D** to this DPA.
+
+7. Annex IV (Subprocessor) of the Data Processor Clauses shall be deemed to incorporate the information in Annex IV of **Exhibit D** to this DPA.
+
+## Exhibit B: UK Addendum
+
+**1. Definitions and Interpretation**
+
+1.1. Terms used in this UK Addendum but not defined in the DPA have the following meaning:
+
+"**UK Data Protection Laws**" means all laws relating to data protection, the processing of personal data, privacy and/or electronic communications in force from time to time in the UK, including the UK GDPR and the Data Protection Act 2018.
+
+1.2. This UK Addendum must always be interpreted in a manner that is consistent with UK Data Protection Laws and so that it fulfils the Parties' obligation under the UK Data Protection Laws.
+
+1.3. Where there is any inconsistency or conflict between the UK Addendum and Data Processor Clauses, the UK Addendum overrides the Data Processor Clauses, except where (and in so far as) the inconsistent or conflicting terms of the Data Processor Clauses provides greater protection for data subjects, in which case those terms will override the UK Addendum.
+
+**2. Incorporation of and changes to the Data Processor Clauses**
+
+2.1. This UK Addendum incorporates the Data Processor Clauses which are amended to the extent necessary so that they ensure compliance with the requirements under Art. 28 UK GDPR.
+
+2.2. The Data Processor Clauses in Exhibit A including all amendments in Section 2 of Exhibit A shall be read and interpreted in a manner that is consistent with UK Data Protection Laws and so that it fulfils the parties' obligation to enter into an agreement that complies with Articles 28(3) and (4) of the UK GDPR.
+
+2.3. The Data Processor Clauses are deemed amended to the extent necessary, so they operate:
+
+(a) for processing by Tuist on behalf of the Customer, to the extent that UK Data Protection Laws apply to such processing; and
+
+(b) to ensure compliance with Article 28(3) and (4) of the UK GDPR.
+
+2.4. The amendments referred to in Section 2.2 include (without limitation) the following:
+
+(a) references to 'Regulation (EU) 2016/679', 'Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data (General Data Protection Regulation)' and 'that Regulation' are all replaced by 'UK GDPR';
+
+(b) references to specific Article(s) of 'Regulation (EU) 2016/679' are replaced with the equivalent Article or Section of UK GDPR;
+
+(c) references to Regulation (EU) 2018/1725 are removed;
+
+(d) references to the "Union", "EU" and "EU Member State" are all replaced with the "UK"; and
+
+(e) references to the "competent supervisory authority" shall be replaced with the Information Commissioner.
+
+2.5. References to the 'Clauses' means this UK Addendum, incorporating the Data Processor Clauses.
+
+## Exhibit C: Standard Contractual Clauses
+
+The following outlines the Standard Contractual Clauses as implemented in the DPA, subject to the amendments in Section 2 of this Exhibit C:
+
+**Standard Contractual Clauses based on Commission Implementing Decision (EU) 2021/914**
+
+### Section I
+
+**Clause 1: Purpose and scope**
+
+(a) The purpose of these standard contractual clauses is to ensure compliance with the requirements of Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data (General Data Protection Regulation) for the transfer of personal data to a third country.
+
+(b) The Parties:
+
+(i) the natural or legal person(s), public authority/ies, agency/ies or other body/ies (hereinafter 'entity/ies') transferring the personal data, as listed in Annex I.A (hereinafter each 'data exporter'), and
+
+(ii) the entity/ies in a third country receiving the personal data from the data exporter, directly or indirectly via another entity also Party to these Clauses, as listed in Annex I.A (hereinafter each 'data importer')
+
+have agreed to these standard contractual clauses (hereinafter: 'Clauses').
+
+(c) These Clauses apply with respect to the transfer of personal data as specified in Annex I.B.
+
+(d) The Appendix to these Clauses containing the Annexes referred to therein forms an integral part of these Clauses.
+
+**Clause 2: Effect and invariability of the Clauses**
+
+(a) These Clauses set out appropriate safeguards, including enforceable data subject rights and effective legal remedies, pursuant to Article 46(1) and Article 46(2)(c) of Regulation (EU) 2016/679 and, with respect to data transfers from controllers to processors and/or processors to processors, standard contractual clauses pursuant to Article 28(7) of Regulation (EU) 2016/679, provided they are not modified, except to select the appropriate Module(s) or to add or update information in the Appendix. This does not prevent the Parties from including the standard contractual clauses laid down in these Clauses in a wider contract and/or to add other clauses or additional safeguards, provided that they do not contradict, directly or indirectly, these Clauses or prejudice the fundamental rights or freedoms of data subjects.
+
+(b) These Clauses are without prejudice to obligations to which the data exporter is subject by virtue of Regulation (EU) 2016/679.
+
+**Clause 3: Third-party beneficiaries**
+
+(a) Data subjects may invoke and enforce these Clauses, as third-party beneficiaries, against the data exporter and/or data importer, with the following exceptions:
+
+(i) Clause 1, Clause 2, Clause 3, Clause 6, Clause 7;
+
+(ii) Clause 8.1 (b) and Clause 8.3(b);
+
+(iii) [Intentionally left blank]
+
+(iv) [Intentionally left blank]
+
+(v) Clause 13;
+
+(vi) Clause 15.1(c), (d) and (e);
+
+(vii) Clause 16(e);
+
+(viii) Clause 18.
+
+(b) Paragraph (a) is without prejudice to rights of data subjects under Regulation (EU) 2016/679.
+
+**Clause 4: Interpretation**
+
+(a) Where these Clauses use terms that are defined in Regulation (EU) 2016/679, those terms shall have the same meaning as in that Regulation.
+
+(b) These Clauses shall be read and interpreted in the light of the provisions of Regulation (EU) 2016/679.
+
+(c) These Clauses shall not be interpreted in a way that conflicts with rights and obligations provided for in Regulation (EU) 2016/679.
+
+**Clause 5: Hierarchy**
+
+In the event of a contradiction between these Clauses and the provisions of related agreements between the Parties, existing at the time these Clauses are agreed or entered into thereafter, these Clauses shall prevail.
+
+**Clause 6: Description of the transfer(s)**
+
+The details of the transfer(s), and in particular the categories of personal data that are transferred and the purpose(s) for which they are transferred, are specified in Annex I.B.
+
+**Clause 7: Docking clause (Optional)**
+
+[Intentionally left blank]
+
+### Section II: Obligations of the Parties
+
+**Clause 8: Data protection safeguards**
+
+The data exporter warrants that it has used reasonable efforts to determine that the data importer is able, through the implementation of appropriate technical and organisational measures, to satisfy its obligations under these Clauses.
+
+8.1 Instructions
+
+(a) The data exporter shall process the personal data only on documented instructions from the data importer acting as its controller.
+
+(b) The data exporter shall immediately inform the data importer if it is unable to follow those instructions, including if such instructions infringe Regulation (EU) 2016/679 or other Union or Member State data protection law.
+
+(c) The data importer shall refrain from any action that would prevent the data exporter from fulfilling its obligations under Regulation (EU) 2016/679, including in the context of sub-processing or as regards cooperation with competent supervisory authorities.
+
+(d) After the end of the provision of the processing services, the data exporter shall, at the choice of the data importer, delete all personal data processed on behalf of the data importer and certify to the data importer that it has done so, or return to the data importer all personal data processed on its behalf and delete existing copies.
+
+8.2 Security of processing
+
+(a) The Parties shall implement appropriate technical and organisational measures to ensure the security of the data, including during transmission, and protection against a breach of security leading to accidental or unlawful destruction, loss, alteration, unauthorised disclosure or access (hereinafter 'personal data breach'). In assessing the appropriate level of security, they shall take due account of the state of the art, the costs of implementation, the nature of the personal data, the nature, scope, context and purpose(s) of processing and the risks involved in the processing for the data subjects, and in particular consider having recourse to encryption or pseudonymisation, including during transmission, where the purpose of processing can be fulfilled in that manner.
+
+(b) The data exporter shall assist the data importer in ensuring appropriate security of the data in accordance with paragraph (a). In case of a personal data breach concerning the personal data processed by the data exporter under these Clauses, the data exporter shall notify the data importer without undue delay after becoming aware of it and assist the data importer in addressing the breach.
+
+(c) The data exporter shall ensure that persons authorised to process the personal data have committed themselves to confidentiality or are under an appropriate statutory obligation of confidentiality.
+
+8.3 Documentation and compliance
+
+(a) The Parties shall be able to demonstrate compliance with these Clauses.
+
+(b) The data exporter shall make available to the data importer all information necessary to demonstrate compliance with its obligations under these Clauses and allow for and contribute to audits.
+
+**Clause 9: Use of sub-processors**
+
+[Intentionally left blank]
+
+**Clause 10: Data subject rights**
+
+The Parties shall assist each other in responding to enquiries and requests made by data subjects under the local law applicable to the data importer or, for data processing by the data exporter in the EU, under Regulation (EU) 2016/679.
+
+**Clause 11: Redress**
+
+(a) The data importer shall inform data subjects in a transparent and easily accessible format, through individual notice or on its website, of a contact point authorised to handle complaints. It shall deal promptly with any complaints it receives from a data subject.
+
+The data importer agrees that data subjects may also lodge a complaint with an independent dispute resolution body at no cost to the data subject. It shall inform the data subjects, in the manner set out in paragraph (a), of such redress mechanism and that they are not required to use it, or follow a particular sequence in seeking redress.
+
+**Clause 12: Liability**
+
+(a) Each Party shall be liable to the other Party/ies for any damages it causes the other Party/ies by any breach of these Clauses.
+
+(b) Each Party shall be liable to the data subject, and the data subject shall be entitled to receive compensation, for any material or non-material damages that the Party causes the data subject by breaching the third-party beneficiary rights under these Clauses. This is without prejudice to the liability of the data exporter under Regulation (EU) 2016/679.
+
+(c) Where more than one Party is responsible for any damage caused to the data subject as a result of a breach of these Clauses, all responsible Parties shall be jointly and severally liable and the data subject is entitled to bring an action in court against any of these Parties.
+
+(d) The Parties agree that if one Party is held liable under paragraph (c), it shall be entitled to claim back from the other Party/ies that part of the compensation corresponding to its/their responsibility for the damage.
+
+(e) The data importer may not invoke the conduct of a processor or sub-processor to avoid its own liability.
+
+**Clause 13: Supervision**
+
+[Intentionally left blank]
+
+### Section III: Local Laws and Obligations in Case of Access by Public Authorities
+
+**Clause 14: Local laws and practices affecting compliance with the Clauses**
+
+The following applies where the EU processor combines the personal data received from the third country-controller with personal data collected by the processor in the EU.
+
+(a) The Parties warrant that they have no reason to believe that the laws and practices in the third country of destination applicable to the processing of the personal data by the data importer, including any requirements to disclose personal data or measures authorising access by public authorities, prevent the data importer from fulfilling its obligations under these Clauses. This is based on the understanding that laws and practices that respect the essence of the fundamental rights and freedoms and do not exceed what is necessary and proportionate in a democratic society to safeguard one of the objectives listed in Article 23(1) of Regulation (EU) 2016/679, are not in contradiction with these Clauses.
+
+(b) The Parties declare that in providing the warranty in paragraph (a), they have taken due account in particular of the following elements:
+
+(i) the specific circumstances of the transfer, including the length of the processing chain, the number of actors involved and the transmission channels used; intended onward transfers; the type of recipient; the purpose of processing; the categories and format of the transferred personal data; the economic sector in which the transfer occurs; the storage location of the data transferred;
+
+(ii) the laws and practices of the third country of destination, including those requiring the disclosure of data to public authorities or authorising access by such authorities, relevant in light of the specific circumstances of the transfer, and the applicable limitations and safeguards;
+
+(iii) any relevant contractual, technical or organisational safeguards put in place to supplement the safeguards under these Clauses, including measures applied during transmission and to the processing of the personal data in the country of destination.
+
+(c) The data importer warrants that, in carrying out the assessment under paragraph (b), it has made its best efforts to provide the data exporter with relevant information and agrees that it will continue to cooperate with the data exporter in ensuring compliance with these Clauses.
+
+(d) The Parties agree to document the assessment under paragraph (b) and make it available to the competent supervisory authority on request.
+
+(e) The data importer agrees to notify the data exporter promptly if, after having agreed to these Clauses and for the duration of the contract, it has reason to believe that it is or has become subject to laws or practices not in line with the requirements under paragraph (a), including following a change in the laws of the third country or a measure (such as a disclosure request) indicating an application of such laws in practice that is not in line with the requirements in paragraph (a).
+
+(f) Following a notification pursuant to paragraph (e), or if the data exporter otherwise has reason to believe that the data importer can no longer fulfil its obligations under these Clauses, the data exporter shall promptly identify appropriate measures (e.g. technical or organisational measures to ensure security and confidentiality) to be adopted by the data exporter and/or data importer to address the situation. The data exporter shall suspend the data transfer if it considers that no appropriate safeguards for such transfer can be ensured, or if instructed by the competent supervisory authority to do so. In this case, the data exporter shall be entitled to terminate the contract, insofar as it concerns the processing of personal data under these Clauses. If the contract involves more than two Parties, the data exporter may exercise this right to termination only with respect to the relevant Party, unless the Parties have agreed otherwise. Where the contract is terminated pursuant to this Clause, Clause 16(d) and (e) shall apply.
+
+**Clause 15: Obligations of the data importer in case of access by public authorities**
+
+The following applies where the EU processor combines the personal data received from the third country-controller with personal data collected by the processor in the EU.
+
+15.1 Notification
+
+(a) The data importer agrees to notify the data exporter and, where possible, the data subject promptly (if necessary with the help of the data exporter) if it:
+
+(i) receives a legally binding request from a public authority, including judicial authorities, under the laws of the country of destination for the disclosure of personal data transferred pursuant to these Clauses; such notification shall include information about the personal data requested, the requesting authority, the legal basis for the request and the response provided; or
+
+(ii) becomes aware of any direct access by public authorities to personal data transferred pursuant to these Clauses in accordance with the laws of the country of destination; such notification shall include all information available to the importer.
+
+(b) If the data importer is prohibited from notifying the data exporter and/or the data subject under the laws of the country of destination, the data importer agrees to use its best efforts to obtain a waiver of the prohibition, with a view to communicating as much information as possible, as soon as possible. The data importer agrees to document its best efforts in order to be able to demonstrate them on request of the data exporter.
+
+(c) Where permissible under the laws of the country of destination, the data importer agrees to provide the data exporter, at regular intervals for the duration of the contract, with as much relevant information as possible on the requests received (in particular, number of requests, type of data requested, requesting authority/ies, whether requests have been challenged and the outcome of such challenges, etc.).
+
+(d) The data importer agrees to preserve the information pursuant to paragraphs (a) to (c) for the duration of the contract and make it available to the competent supervisory authority on request.
+
+(e) Paragraphs (a) to (c) are without prejudice to the obligation of the data importer pursuant to Clause 14(e) and Clause 16 to inform the data exporter promptly where it is unable to comply with these Clauses.
+
+15.2 Review of legality and data minimisation
+
+(a) The data importer agrees to review the legality of the request for disclosure, in particular whether it remains within the powers granted to the requesting public authority, and to challenge the request if, after careful assessment, it concludes that there are reasonable grounds to consider that the request is unlawful under the laws of the country of destination, applicable obligations under international law and principles of international comity. The data importer shall, under the same conditions, pursue possibilities of appeal. When challenging a request, the data importer shall seek interim measures with a view to suspending the effects of the request until the competent judicial authority has decided on its merits. It shall not disclose the personal data requested until required to do so under the applicable procedural rules. These requirements are without prejudice to the obligations of the data importer under Clause 14(e).
+
+(b) The data importer agrees to document its legal assessment and any challenge to the request for disclosure and, to the extent permissible under the laws of the country of destination, make the documentation available to the data exporter. It shall also make it available to the competent supervisory authority on request.
+
+(c) The data importer agrees to provide the minimum amount of information permissible when responding to a request for disclosure, based on a reasonable interpretation of the request.
+
+### Section IV: Final Provisions
+
+**Clause 16: Non-compliance with the Clauses and termination**
+
+(a) The data importer shall promptly inform the data exporter if it is unable to comply with these Clauses, for whatever reason.
+
+(b) In the event that the data importer is in breach of these Clauses or unable to comply with these Clauses, the data exporter shall suspend the transfer of personal data to the data importer until compliance is again ensured or the contract is terminated. This is without prejudice to Clause 14(f).
+
+(c) The data exporter shall be entitled to terminate the contract, insofar as it concerns the processing of personal data under these Clauses, where:
+
+(i) the data exporter has suspended the transfer of personal data to the data importer pursuant to paragraph (b) and compliance with these Clauses is not restored within a reasonable time and in any event within one month of suspension;
+
+(ii) the data importer is in substantial or persistent breach of these Clauses; or
+
+(iii) the data importer fails to comply with a binding decision of a competent court or supervisory authority regarding its obligations under these Clauses.
+
+In these cases, it shall inform the competent supervisory authority of such non-compliance. Where the contract involves more than two Parties, the data exporter may exercise this right to termination only with respect to the relevant Party, unless the Parties have agreed otherwise.
+
+(d) Personal data collected by the data exporter in the EU that has been transferred prior to the termination of the contract pursuant to paragraph (c) shall immediately be deleted in its entirety, including any copy thereof. The data importer shall certify the deletion of the data to the data exporter. Until the data is deleted or returned, the data importer shall continue to ensure compliance with these Clauses. In case of local laws applicable to the data importer that prohibit the return or deletion of the transferred personal data, the data importer warrants that it will continue to ensure compliance with these Clauses and will only process the data to the extent and for as long as required under that local law.
+
+(e) Either Party may revoke its agreement to be bound by these Clauses where (i) the European Commission adopts a decision pursuant to Article 45(3) of Regulation (EU) 2016/679 that covers the transfer of personal data to which these Clauses apply; or (ii) Regulation (EU) 2016/679 becomes part of the legal framework of the country to which the personal data is transferred. This is without prejudice to other obligations applying to the processing in question under Regulation (EU) 2016/679.
+
+**Clause 17: Governing law**
+
+These Clauses shall be governed by the law of a country allowing for third-party beneficiary rights. The Parties agree that this shall be the law of Germany.
+
+**Clause 18: Choice of forum and jurisdiction**
+
+Any dispute arising from these Clauses shall be resolved by the courts of Berlin, Germany.
+
+**Amendments to the Standard Contractual Clauses**
+
+For the purposes of the Standard Contractual Clauses:
+
+1. Annex I.A (List of Parties) of the Standard Contractual Clauses shall be deemed to incorporate the information in Annex I of Exhibit D to this DPA.
+
+2. Annex I.B (Description of Transfer) of the Standard Contractual Clauses shall be deemed to incorporate the information in Annex II of Exhibit D to this DPA.
+
+## Exhibit D: Annexes
+
+### Annex I: List of Parties
+
+**Customer** referred to as the controller(s) in the Data Processing Clauses and data importer with respect to the Standard Contractual Clauses:
+
+- **Name**: The Customer is the party who has concluded the Agreement with Tuist
+- **Address**: is provided by the Customer in the Agreement
+- **Contact person's name, position, and contact details**: are provided by the Customer in the Agreement
+- **Contact details of the data processing officer**: if applicable, are provided by the Customer in the Agreement
+- **Activities relevant to the data transferred under the Standard Contractual Clauses**: as described in the Agreement and any applicable Order
+- **Role under Applicable Law**: controller or processor on behalf of a third party
+
+**Tuist** referred to as the processor with respect to the Data Processing Clauses and data exporter with respect to the Standard Contractual Clauses:
+
+- **Name**: Tuist GmbH
+- **Address**: Jessnerstr. 27a, 10247 Berlin, Germany
+- **Contact person**: Pedro Pinera Buendia, email: pedro@tuist.dev
+- **Contact details of the data processing officer**: not yet appointed, as there is no legal requirement to do so. This will be checked on a regular basis in the future.
+- **Activities relevant to the data transferred under the Standard Contractual Clauses**: as described in the Agreement
+- **Role under Applicable Law**: processor on behalf of Customer as a controller or sub-processor on behalf of Customer as a processor
+
+As an integral part of the Agreement, the DPA is effective without signature starting from the Effective Date of the Agreement.
+
+### Annex II: Description of Processing
+
+**Categories of data subjects whose personal data is processed:**
+
+- Employees of Customers, employees of Customers' customers and other third parties or partners.
+
+**Categories of personal data transferred (for purposes of Standard Contractual Clauses) and personal data processed (for purposes of Data Processing Clauses):**
+
+- Contact details; data that could be made available or accessible to Tuist in course of providing remote access.
+
+**For purposes of the Standard Contractual Clauses, the frequency of the transfer (e.g., whether the data is transferred on a one-off or continuous basis):**
+
+- Not on a regular basis, only upon Customer's request.
+
+**Nature of the processing:**
+
+- Tuist offers access to its Services including consulting services and software development services with respect to its open-source software. In course of providing the Services, Customer may grant access to Tuist into their IT or share certain personal data. Tuist only processes personal data in course of such Services.
+
+**Purpose(s) for which the personal data is processed, and for purposes of the Standard Contractual Clauses transferred, on behalf of the Customer:**
+
+- The purpose of the processing and transfer is to ensure the delivery and performance of the Services agreed in the Agreement.
+
+**For purposes of the Data Processing Clauses, the duration of the processing and for purposes of the Standard Contractual Clauses, the period for which the personal data will be retained, or, if that is not possible, the criteria used to determine that period:**
+
+- The personal data is processed for the duration of the contractual relationship. In the meantime, the personal data will be deleted upon request or if the purpose ceases to exist. After termination of the contractual relationship, the personal data is deleted in accordance with the internal deletion concept of Tuist.
+
+**For processing by (sub-) processors for purposes of the Data Processing Clauses, and for transfer to Sub-processors of Tuist, also specify subject matter, nature and duration of the processing:**
+
+- Sub-processors of Tuist are used solely for the purpose of hosting the software solution provided by Tuist. Such transfer and/or processing serves the purpose of providing the Services and occurs for the duration of the contractual relationship. The nature of the processing includes activities such as storing, transmitting, deleting, structuring, organisation.
+
+### Annex III: Technical and Organisational Measures
+
+**1. Pseudonymisation and Encryption (Art. 32 para 1 point a GDPR)**
+
+Pseudonymisation contains measures that enable one to process personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that this additional information is stored separately, and is subject to appropriate technical and organisational measures. Encryption contains measures that enable one to convert clearly legible information into an illegible string by means of a cryptographic process.
+
+- Stored data is encrypted where appropriate, including any backup copies of the data.
+
+**2. The ability to ensure the ongoing confidentiality, integrity, availability and resilience of processing systems and services (Art. 32 para 1 point b GDPR)**
+
+Confidentiality and integrity are ensured by the secure processing of personal data, including protection against unauthorized or unlawful processing and integrity and availability by measures to protect against accidental loss, destruction or damage.
+
+**2.1 Confidentiality**
+
+**2.1.1 Physical access control**
+
+Measures that prevent unauthorized persons from gaining access to data processing systems with which personal data are processed or used.
+
+- Physical access control systems
+- Definition of authorized persons; management and documentation of individual authorizations
+- Monitoring of all facilities housing IT systems
+
+**2.1.2 System/Electronic access control**
+
+Measures that prevent data processing systems from being used without authorization.
+
+- User Authentication by simple authentication methods (using username/password), including two-factor authentication where adequate
+- Secure transmission of credentials (using TLS)
+- Automatic account locking
+- Suspending inactive sessions
+- Guidelines for handling passwords and certificates
+- Definition of authorized persons
+- Managing means of authentication
+- Access control to infrastructure that is hosted by cloud service provider
+- In-time revocation of access for people who no longer need access / leave the company
+- Automated alerting on illegal attempts of logging systems directly or indirectly connected to personal data
+- Unique credentials per user
+- Use of jump server to restrict access where adequate
+
+**2.1.3 Internal Access Control**
+
+Measures that ensure that persons entitled to use a data processing system have access only to the data to which they have a right of access, and that personal data cannot be read, copied, modified or removed without authorization in the course of processing or use and after storage.
+
+- Automatic and manual locking
+- Access right management
+- Access right management including authorization concept, implementation of access restrictions, implementation of the "need-to-know" principle, managing of individual access rights
+
+**2.1.4 Isolation/Separation Control**
+
+Measures to ensure that data collected for different purposes can be processed (storage, amendment, deletion, transmission) separately.
+
+- Network separation
+- Segregation of responsibilities and duties
+- Document procedures and applications for the separation
+
+**2.1.5 Job Control**
+
+Measures that ensure that, in the case of commissioned processing of personal data, the data are processed strictly corresponding to the instructions of the principal.
+
+- Training and confidentiality agreements for internal staff and external staff
+- Information security assessment for vendors/partners
+
+**2.2 Integrity**
+
+**2.2.1 Data transmission control**
+
+Measures ensure that personal data cannot be read, copied, modified or removed without authorization during electronic transmission or transport, and that it is possible to check and establish to which bodies the transfer of personal data by means of data transmission facilities is envisaged.
+
+- Secure transmission between client and server and to external systems by using industry-standard encryption
+- Secure network interconnections ensured by Firewalls, anti-virus programs, routinely patching software etc.
+- Logging of transmissions of data from IT system that stores or processes personal data
+
+**2.2.2 Data input control**
+
+Measures that ensure that it is possible to check and establish whether and by whom personal data have been input into data processing systems, modified or removed.
+
+- Logging authentication and monitored logical system access
+- Logging of data access including, but not limited to access, modification, entry and deletion of data
+- Documentation of data entry rights and partially logging security related entries
+
+**2.3 Availability and Resilience of Processing Systems and Services**
+
+Availability includes measures that ensure that personal data is protected from accidental destruction or loss due to internal or external influences. Resilience of processing systems and services includes measures that ensure the ability to withstand attacks or to quickly restore systems to working order after an attack.
+
+- Backup Concept
+- Implementation of transport policies
+- Protection of stored backup media
+
+**3. The ability to restore the availability and access to personal data in a timely manner in the event of a physical or technical incident (Art. 32 para 1 point c GDPR)**
+
+Organisational measures that ensure the possibility to quickly restore the system or data in the event of a physical or technical incident.
+
+- Continuity planning (Recovery Time Objective)
+
+**4. A process for regularly testing, assessing and evaluating the effectiveness of technical and organisational measures for ensuring the security of the processing (Art. 32 para 1 point d GDPR)**
+
+Organisational measures that ensure the regular review and assessment of technical and organisational measures.
+
+- Testing of emergency equipment
+- Documentation of interfaces and personal data fields
+- Internal assessments
+
+### Annex IV: Sub-processors
+
+The Customer has authorized the use of the Sub-processor(s) of Tuist listed at [https://security.tuist.dev/subprocessors](https://security.tuist.dev/subprocessors).
+
+*Last updated February 10, 2026*

--- a/server/priv/marketing/pages/service-level-addendum.md
+++ b/server/priv/marketing/pages/service-level-addendum.md
@@ -1,0 +1,154 @@
+---
+title: Service Level Addendum
+description: This Service Level Addendum defines the availability, error classes, response and recovery times, and service level credits for the Tuist platform.
+last_updated: 2025-08-08
+---
+
+## 1. General
+
+1.1. This SLA is entered into between Tuist GmbH ("**Tuist**") and the Customer (as defined in the Agreement), and will be subject to, and governed by, the terms of the Terms of Service - Online (the "**Agreement**").
+
+1.2. In the event of a conflict between this SLA, the Agreement or any Addenda or other schedule to the Agreement (other than the Data Processing Addendum), this Addendum will prevail.
+
+1.3. Unless otherwise defined in this SLA, capitalized terms shall have the meaning assigned to them in the Agreement.
+
+## 2. Definitions
+
+**"Availability"** means the ratio of actual uptime (i.e., uptime less downtime) to the uptime during which the Software as a Service can be used (including in cases of occurrence of Error Classes 3 and 4 but excluding Error Classes 1 and 2). Availability shall be measured in each case on a monthly basis. Coordinated Maintenance Windows are not taken into account when determining availability, i.e., they have no influence on availability. The following formula applies:
+
+> Availability in % = (Operating Hours minus Downtime) / Operating Hours
+
+**"Downtime"** means the periods of time during which the Software as a Service cannot be used or cannot be used completely due to a failure of Error Class 1 or 2. The respective downtime is calculated as the sum of actual response time and actual recovery time. Downtime in the sense of availability does not include downtime due to (i) Maintenance Windows during which access to the Software as a Service is not possible, (ii) unforeseen maintenance work that becomes necessary, if such work was not caused by a breach of Tuist's obligations to provide the Software as a Service (e.g., force majeure, in particular unforeseeable hardware failures, strikes, natural events), (iii) from virus or hacker attacks, insofar as Tuist has taken the agreed protective measures or, in the absence of an agreement, the usual protective measures, (iv) of the Customer's specifications, due to unavailability of the Customer's equipment or due to other interruptions caused by the Customer (e.g., failure of the Customer to cooperate), (v) unavailable or defective third-party services attributable to the Customer (in particular the interfaces (APIs) to connected third-party systems), (vi) the application of urgently needed security patches, and (vii) of errors in Customer applications or due to errors in the Software as a Service triggered by Customer applications or data.
+
+**"Error Classes"** means the categorization of the significance of various errors or faults in the Software as a Service into four Error Classes, in which the errors or faults are classified according to their impact on Customer's business processes.
+
+- **Error Class 1** (critical malfunction): refers to errors that preclude or make it impossible to use the Software, e.g., the Software as a Service cannot be started.
+- **Error Class 2** (serious malfunction): refers to errors that significantly impede or severely restrict the use of the software in essential parts, e.g., the complete failure of the communication function of the Software.
+- **Error Class 3** (moderate malfunction): refers to errors that restrict the functionality of the Software only in partial areas so that use is still possible, e.g., real-time functions do not ensure real-time transmission.
+- **Error Class 4** (minimal malfunction): refers to errors that do not fundamentally restrict use but rather involve losses in convenience, e.g., speed impairments or display errors.
+
+**"Maintenance Window"** means the period of time during which Software as a Service may be taken out of service for maintenance or updates.
+
+**"Operating Hours"** means the scheduled times (target time) during which the Software as a Service ordered by Customer can be used. Regular business hours (as specified herein) and Maintenance Windows are within the Operating Hours.
+
+**"Response Time"** means the effective period of time between the detection of a malfunction/error report within the scope of the self-test and the start of the work of the body and/or person commissioned by Tuist to rectify the error, or the receipt of a fault/error report from the Customer by Tuist on the one hand and the first contact between the office and/or person charged with troubleshooting by Tuist and the Customer on the other hand.
+
+**"Recovery Time"** shall mean the start of the error elimination immediately following the Response Time. The recovery time ends with the successful elimination of the error or, in individual cases, with an objectively reasonable workaround solution.
+
+**"Service Level Credits"** means a credit, determined by Tuist, to be applied against the agreed compensation if Tuist fails to perform the Software as a Service as agreed in this SLA.
+
+**"Times"** refers in each case to the time zone of Berlin.
+
+**"Updates"** means any modification, enhancement, or improvement made to the Software that is intended to maintain, improve, or expand its functionality, performance, or security. Updates may include bug fixes, patches, minor feature additions, or performance optimizations. Updates are typically provided to ensure the Software remains current with technological advancements and continues to meet the agreed-upon service levels.
+
+## 3. Ticket System
+
+For each request of Customer, Tuist shall assign a processing number ("**Ticket**"). At its own discretion, Tuist will implement an electronic ticket system for this purpose, which will enable traceability of the status of the processing of the Tickets.
+
+## 4. Business Hours
+
+Regular business hours are 8:00 a.m. to 5:00 p.m. from Monday to Friday, except for public holidays in Berlin, Germany.
+
+## 5. Availability
+
+The Software as a Service is provided with an Availability of 95% per month.
+
+## 6. Error Reporting
+
+Customer shall report to Tuist any impairments of Availability, errors or other disruptions of which Customer becomes aware. Tuist will endeavor to eliminate the disruptions without undue delay.
+
+## 7. Maintenance Windows
+
+Scheduled maintenance window for maintenance work and data backups of the Software as a Service is daily in the time from 0:00 to 2:00. During this time, operation of the Software as a Service may not be possible. Additional Maintenance Windows will be communicated by Tuist to Customer regarding the intended date (date, start time and scheduled duration) in a timely manner and in any case at least three (3) days in advance.
+
+## 8. Error Classification and Response Times
+
+The classification of the errors shall be made by Tuist in its reasonable discretion with due regard to the impact that the relevant error has on Customer's business operations and the interests of Tuist. Upon becoming aware of an error through Tuist's routine self-inspection or notification by the Customer, Tuist will begin problem analysis and respond to Customer, and if already available, provide information about possible solutions, as follows:
+
+**Discovery within regular business hours (Error Classes 1 and 2):**
+
+| Error Class | Response Time |
+|---|---|
+| Error Class 1 | Max. 2 hours from error detection/reporting |
+| Error Class 2 | Max. 4 hours from fault detection/notification |
+
+**Discovery between 6 a.m. and 9 p.m. but outside regular business hours (Error Classes 1 and 2):**
+
+| Error Class | Response Time |
+|---|---|
+| Error Class 1 | Max. 4 hours from error detection/reporting |
+| Error Class 2 | Max. 8 hours from error detection/reporting |
+
+**Discovery between 9 p.m. and 6 a.m. (Error Classes 1 and 2):**
+
+| Error Class | Response Time |
+|---|---|
+| Error Class 1 | Max. 4 hours, starting at 6 a.m. |
+| Error Class 2 | Max. 8 hours, starting at 6 a.m. |
+
+**Error Classes 3 and 4:**
+
+| Error Class | Response Time |
+|---|---|
+| Error Class 3 | Max. 2 hours from start of regular business hours |
+| Error Class 4 | Max. 4 hours from start of regular business hours |
+
+## 9. Recovery Times for Software as a Service
+
+The following recovery times are deemed agreed for Software as a Service:
+
+| Error Class | Recovery Time |
+|---|---|
+| Error Class 1 | 12 hours |
+| Error Class 2 | 1 working day |
+| Error Class 3 | 20 working days |
+| Error Class 4 | With the next update |
+
+## 10. Recovery Times for On-Premise Software
+
+The following recovery times are deemed agreed for On-Premise Software. Recovery in terms of On-Premise Software means the provision of an updated version of the Software:
+
+| Error Class | Recovery Time |
+|---|---|
+| Error Class 1 | 1 working day |
+| Error Class 2 | 3 working days |
+| Error Class 3 | 20 working days |
+| Error Class 4 | With the next update |
+
+## 11. Error Report Requirements
+
+All error and fault reports from Customer must be adequately described and contain the following information in particular: (i) comprehensible description of the error or fault, (ii) time of the fault or malfunction, (iii) information on the IT system used by Customer, (iv) non-binding proposal for the classification of the fault or malfunction, and (v) designation of a qualified contact person of Customer, including contact possibility.
+
+## 12. Error Reporting Channels
+
+All error and fault reports detected by Customer shall be submitted immediately to Tuist via one of the following means of communication:
+
+- Email: contact@tuist.dev
+
+## 13. Update Frequency
+
+Tuist shall deliver Updates to the Software on a regular basis to ensure optimal functionality, performance, and security. Updates shall be provided at least 12 times per year ("**Update Frequency**"), or as necessary to address critical issues, vulnerabilities, or compliance requirements. The Provider will notify the Customer in advance of any scheduled Updates, including details of the changes and potential impacts on service availability. The Provider will make reasonable efforts to minimize disruption during the implementation of Updates. Emergency Updates may be deployed without prior notice to address urgent security or operational issues.
+
+## 14. Customer Obligations
+
+Customer will create all technical conditions and grant access necessary for the provision of services by Tuist.
+
+## 15. Service Level Credits
+
+To the extent Tuist fails to provide the services under this SLA as agreed, Tuist will provide Service Level Credits to Customer in accordance with the following.
+
+15.1. In order to receive Service Level Credits, Customer must submit a notice of noncompliance to Tuist within 24 hours using the contact options provided in Section 12. Tuist will issue Service Level Credits only if Tuist can verify the notice of noncompliance.
+
+15.2. Service-Level Credits are charged as part of the billing for the following billing period. Service Level Credits cannot be paid out.
+
+15.3. The maximum amount of eligible Service-Level Credits is limited to 25% of each billing period.
+
+15.4. Service-Level Credits granted by Tuist shall be credited against any further claims of the Customer.
+
+15.5. If the Software as a Service fails to meet the agreed Availability, Tuist shall grant Service Level Credits for each 0.1% deviation from the agreed availability for that period in the amount of 0.1% of the agreed remuneration for that period, but in total not more than 20% of the agreed remuneration for that period.
+
+15.6. If Tuist exceeds the agreed upon response time, Tuist will grant Service-Level Credits for each 1 hour(s) overrun equal to 0.1% of the agreed upon compensation for that period, but not to exceed a total of 5% of the agreed upon compensation for that period.
+
+15.7. If Tuist exceeds the agreed upon recovery time, Tuist will grant Service-Level Credits for each 2 hour(s) overrun equal to 0.1% of the agreed upon compensation for that period, but not to exceed a total of 5% of the agreed upon compensation for that period.
+
+*Last updated August 8, 2025*

--- a/server/priv/marketing/pages/terms.md
+++ b/server/priv/marketing/pages/terms.md
@@ -1,63 +1,351 @@
 ---
 title: Terms of service
-description: These terms of service govern your use of the application located at https://tuist.dev and any related services provided by Tuist.
-last_updated: 2023-10-23
+description: These Terms of Service outline the terms and conditions for the provision of services offered by Tuist GmbH.
+last_updated: 2025-08-08
 ---
 
-These Terms of Service govern your use of the application located at [https://tuist.dev](https://tuist.dev) and any related services provided by Tuist.
+## Section 1: Welcome and Scope of the ToS
 
-By accessing [https://tuist.dev](https://tuist.dev), you agree to abide by these Terms of Service and to comply with all applicable laws and regulations. If you do not agree with these Terms of Service, you are prohibited from using or accessing this application or using any other services provided by Tuist.
+1.1. Tuist GmbH, Jessnerstr. 27a, 10247 Berlin, Germany ("**Tuist**", "**we**", "**our**", or "**us**"), is an integrated and open-core toolchain provider for app development. Our developer-centric platform extends Apple's native development tools, offering automation, insights, and optimized workflows to streamline the app development life cycle for Swift and iOS projects. We provide a suite of services and software solutions, including, but not limited to, project generation, caching, selective testing, app previews, build, test, and bundle insights, and package registry, all designed to improve productivity, scalability, and collaboration for development teams. Our offerings are available through a combination of free and paid plans, with support for enterprise features, priority support, and custom terms as required by business customers.
 
-We, Tuist, reserve the right to review and amend any of these Terms of Service at our sole discretion. Upon doing so, we will update this page. Any changes to these Terms of Service will take effect immediately from the date of publication.
+1.2. These ToS outline the terms and conditions for the provision of services offered by Tuist. The functionalities and capabilities of the Platform are outlined in detail in our documentation to be found under [https://docs.tuist.dev](https://docs.tuist.dev).
 
-These Terms of Service were last updated on 26 August 2023.
+1.3. Capitalized terms used but not defined within this Agreement will have the meaning set forth in Section 2.
 
-### Limitations of Use
+1.4. These ToS form a legal contract between you, either (a) an individual user or (b) a business organization (in either case, the "**Customer**", "**You**", or "**Your**"; Tuist and Customer each, a "**Party**" and together, the "**Parties**"), and Tuist with respect to the provision of the Services by Tuist.
 
-By using this application, you warrant on behalf of yourself, your users, and other parties you represent that you will not:
+1.5. If You subscribe to the Services through our website, by clicking on the 'ACCEPT TERMS' and 'Subscribe with the obligation to pay' button or by using them, You agree to be bound by the terms of these ToS. If You are an individual entering into these ToS on behalf of a company or other legal entity, You represent that You have the authority to bind such entity and its Affiliates to these terms and conditions; if You do not have such authority, or if You do not wish to be bound by the terms of these ToS, You must not click the buttons, and You must not access or use the Services.
 
-- Modify, copy, prepare derivative works of, decompile, or reverse engineer any materials and software contained on this application.
-- Remove any copyright or other proprietary notations from any materials and software on this application.
-- Transfer the materials to another person or "mirror" the materials on any other server.
-- Knowingly or negligently use this application or any of its associated services in a way that abuses or disrupts our networks or any other service Tuist provides.
-- Use this application or its associated services to transmit or publish any harassing, indecent, obscene, fraudulent, or unlawful material.
-- Use this application or its associated services in violation of any applicable laws or regulations.
-- Use this application in conjunction with sending unauthorized advertising or spam.
-- Harvest, collect, or gather user data without the user’s consent.
-- Use this application or its associated services in such a way that may infringe the privacy, intellectual property rights, or other rights of third parties.
+1.6. Please read these ToS carefully to ensure that You understand the terms before You use the Platform.
 
-### Intellectual Property
+1.7. If You would like to get in contact with us and with respect to any notice required or permitted under these ToS, You can write to us by email to legal@tuist.dev.
 
-The intellectual property in the materials contained in this application is owned by or licensed to Tuist and is protected by applicable copyright and trademark law. We grant our users permission to download one copy of the materials for personal, non-commercial transitory use.
+1.8. The Annexes form an integral part of the Agreement.
 
-This constitutes the grant of a license, not a transfer of title. This license shall automatically terminate if you violate any of these restrictions or the Terms of Service, and may be terminated by Tuist at any time.
+1.9. In the event of a conflict between the terms of these ToS and the Annexes, the terms of the Annexes shall take precedence.
 
-### Liability
+## Section 2: Definitions and Interpretation
 
-Our application and the materials on our application are provided on an "as is" basis. To the extent permitted by law, Tuist makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property, or other violation of rights.
+2.1. "**Acceptable Use Policy**" means the policy located at [https://tuist.dev/acceptable-use-policy](https://tuist.dev/acceptable-use-policy) and as may be updated by us from time to time.
 
-In no event shall Tuist or its suppliers be liable for any consequential loss suffered or incurred by you or any third party arising from the use or inability to use this application or the materials on this application, even if Tuist or an authorized representative has been notified, orally or in writing, of the possibility of such damage.
+2.2. "**Affiliate**" means any entity that, directly or indirectly, through one or more intermediaries, controls, is controlled by, or is under common control with a Party within the meaning of Section 15 et seq. German Stock Corporation Act (AktG).
 
-In the context of this agreement, "consequential loss" includes any consequential loss, indirect loss, real or anticipated loss of profit, loss of benefit, loss of revenue, loss of business, loss of goodwill, loss of opportunity, loss of savings, loss of reputation, loss of use and/or loss or corruption of data, whether under statute, contract, equity, tort (including negligence), indemnity or otherwise.
+2.3. "**Agreement**" means these ToS and its Annexes.
 
-Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.
+2.4. "**AI**" means artificial intelligence.
 
-### Accuracy of Materials
+2.5. "**AI Functionality**" means those certain artificial intelligence features and functionalities powered by an AI Subprocessor and enabled for use by You in the Platform, if any.
 
-The materials appearing on our application are not comprehensive and are for general information purposes only. Tuist does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on this application, or otherwise relating to such materials or on any resources linked to this application.
+2.6. "**AI Subprocessor**" means those certain third-party providers currently used by Tuist to provide a certain AI Functionality.
 
-### Links
+2.7. "**Annexes**" means the [Data Processing Addendum](/data-processing-addendum), the [Data Act Addendum](/data-act-addendum), the [Service Level Addendum](/service-level-addendum), and any other referenced document in these ToS or referenced during the subscription process.
 
-Tuist has not reviewed all of the sites linked to its application and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement, approval, or control by Tuist of the site. Use of any such linked site is at your own risk and we strongly advise you make your own investigations with respect to the suitability of those sites.
+2.8. "**Applicable Law**" means all laws, rules, and regulations applicable to either Party's performance under this Agreement, including, but not limited to, those applicable to the processing of personal data, in particular, the European General Data Protection Regulation 2016/679 ('GDPR') and all national laws validly amending the applicable rules for the processing of personal data.
 
-### Right to Terminate
+2.9. "**Beta Services**" means new services or new features available to You from time to time for evaluation and testing as part of the Platform.
 
-We may suspend or terminate your right to use our application and terminate these Terms of Service immediately upon written notice to you for any breach of these Terms of Service.
+2.10. "**Confidential Information**" is information of a business, financial, operational, technical, or other nature, as well as all information that is not generally known or readily accessible, either as a whole or in the exact arrangement and composition of its components, and is therefore of economic value, which is protected by appropriate confidentiality measures on the part of Tuist ("**Disclosing Party**") or an Affiliate of Tuist and in which there is a legitimate interest in confidentiality ("**Trade Secret**"), which the Customer ("**Receiving Party**") receives from the Disclosing Party and which:
 
-### Severance
+(a) is available in written, recorded, graphic, or other tangible form and is marked as "confidential", "trade secret", or with a similar designation;
 
-Any term of these Terms of Service which is wholly or partially void or unenforceable is severed to the extent that it is void or unenforceable. The validity of the remainder of these Terms of Service is not affected.
+(b) is communicated orally and is classified as "confidential" or "trade secret" or a similar designation by the Disclosing Party at the time of disclosure and such classification is confirmed in writing within thirty (30) days of disclosure; or
 
-### Governing Law
+(c) to the extent that it concerns information as referred to in Section 2.10(a) or 2.10(b), is received without appropriate marking under such circumstances that could reasonably be interpreted as an obligation of confidentiality or the Receiving Party could reasonably assume that the information is secret.
 
-These Terms of Service are governed by and construed in accordance with the laws of Germany. You irrevocably submit to the exclusive jurisdiction of the courts in that State or location.
+Confidential Information also includes all summaries and abstracts of the Confidential Information. For the avoidance of doubt, Your Confidential Information includes Your Data.
+
+2.11. "**Customer AI Data**" means (a) any input you provide to be processed through the AI Functionality ("**AI Input**") and (b) any received output generated and returned by the AI Functionality based on your AI Input ("**AI Output**"). Customer AI Data is a subset of Customer Data.
+
+2.12. "**Customer Data**" means any and all data supplied, submitted, ingested, processed, stored, posted, displayed, or otherwise made available by or on behalf of You for processing by or use with the Platform.
+
+2.13. "**Data Processing Services**" means any digital service that is provided to You that enables ubiquitous and on-demand network access to a shared pool of configurable, scalable, and elastic computing resources of a centralized, distributed, or highly distributed nature that can be rapidly provisioned and released with minimal management effort or service provider interaction.
+
+2.14. "**Documentation**" means the technical specification documentation generally made available by Tuist to its customers with regard to the then-current version of the Platform from time to time. You can access the Documentation at any time at [https://docs.tuist.dev](https://docs.tuist.dev).
+
+2.15. "**Effective Date**" means the date on which You have subscribed to the Services.
+
+2.16. "**FCL Software**" means the software functionality that Tuist provides to You as Software as a Service or On-Premises Software under the FCL Terms including, but not limited to, the Tuist server and as described in the applicable Order.
+
+2.17. "**FCL Terms**" means the license terms Faire Core License, Version 1.0, available under the URL [https://github.com/keygen-sh/fcl.dev/blob/master/FCL-1.0-MIT.md](https://github.com/keygen-sh/fcl.dev/blob/master/FCL-1.0-MIT.md).
+
+2.18. "**Fees**" means the remuneration to be paid by You as further specified during the order process, or any applicable price list.
+
+2.19. "**Free Services**" means Beta Services and Trial Services.
+
+2.20. "**Initial Term**" means the period commencing on the Start Date and continuing for the duration specified in the applicable Order.
+
+2.21. "**Intellectual Property**" means any property that is protected in any manner by Intellectual Property Rights.
+
+2.22. "**Intellectual Property Rights**" means any and all intellectual property rights or similar proprietary rights, including (a) patent rights and utility models, (b) copyrights and database rights, (c) trademarks, trade names, domain names, and trade dress and the goodwill associated therewith, (d) trade secrets, (e) mask works, and (f) industrial design rights, in each case, including any registrations of, applications to register, and renewals and extensions of any of the foregoing in any jurisdiction in the world.
+
+2.23. "**Internal Purposes**" means the use of the Platform for which You are the primary beneficiary, and which is specified in the respective Order.
+
+2.24. "**Platform**" means the software functionality that Tuist provides to You as Software as a Service but does not include FCL Software.
+
+2.25. "**Professional Services**" means the implementation, data onboarding, commissioning support, consulting, development, and other professional services that Tuist may perform as described in the applicable Order.
+
+2.26. "**Renewal Term**" means each successive period following the initial Subscription Term during which an Order is automatically renewed.
+
+2.27. "**Services**" means the Platform and any Professional Services.
+
+2.28. "**Software as a Service**" means the provision of a computer program under a subscription or managed service model where the computer program is hosted in a multi-tenant cloud environment and maintained remotely either by Tuist or a third party.
+
+2.29. "**Start Date**" means the date specified as the start date in the applicable Order. If no such date is specified in the Order, the Start Date shall be the date on which both Parties have executed this Agreement.
+
+2.30. "**Taxes**" means taxes (e.g., value-added tax), levies, duties, or similar governmental assessments of any nature (collectively).
+
+2.31. "**Term**" means the Initial Term and each following Renewal Term.
+
+2.32. "**Third-Party Software**" means any software contained in the Platform that is licensed to Tuist by a third party, including, but not limited to, open-source software.
+
+2.33. "**Trial Period**" means the period for which Trial Services are made available to You.
+
+2.34. "**Trial Services**" means services or features available to You on a trial basis.
+
+2.35. "**User**" means any authorized person or entity who accesses or uses the Platform.
+
+2.36. "**Withholding Tax**" means any withholding Taxes imposed or levied by any governmental authority.
+
+2.37. "**Work Results**" refers to all deliverables, materials, documents, data, reports, inventions, discoveries, processes, designs, software, code, analyses, drawings, specifications, and any other tangible or intangible items or outcomes that are conceived, created, developed, written, or otherwise produced by Tuist (either solely or jointly with others) in the course of performing the Professional Services. Work Results include all modifications, enhancements, and derivative works thereof, regardless of the form or medium in which they are embodied.
+
+## Section 3: Using the Platform and Creating an Account
+
+3.1. You can register for an account to access the Platform via the website: [https://tuist.dev](https://tuist.dev). Registration requires providing a full name, valid email address, and password.
+
+3.2. You are required to provide truthful information both during registration as well as in the context of using the Platform. You are solely responsible for the completeness and accuracy of the information provided. You agree that any content submitted to the Platform does not and will not violate third-party rights of any kind, including, without limitation, any intellectual property rights.
+
+3.3. We may update and further develop the Platform at any time and adapt it due to a changed legal situation, technical developments, or to improve IT security. In doing so, we will give due consideration to Your legitimate interests and inform You of any necessary updates in a timely manner. However, sometimes changes will need to be made immediately and if this happens, we will not be able to provide You with notice.
+
+3.4. Subject to the terms and conditions of this Agreement, You may permit Users, provided they are not a competitor of Tuist, to use the Platform for Your Internal Purposes and benefit in accordance with Section 4. You agree to keep confidential the login names and passwords required for the use of the Platform, to keep them in a safe place, and to protect them against unauthorized access by third parties with appropriate precautions, and to instruct Your Users to do the same. You control access to and use of the Services by Users. You are responsible and fully liable for the breach of this Agreement by the acts and omissions of Users (including any usage charges or overage charges) under the Agreement.
+
+## Section 4: Platform License
+
+4.1. With respect to the Platform, subject to the terms and conditions of the Agreement, compliance with our Acceptable Use Policy, and Your payment of the Fees, Tuist grants to You a nonexclusive, nontransferable, and non-sublicensable right during the Term to access and use the Platform solely for Your Internal Purposes as permitted by their features and functionality and in accordance with the Documentation. Except as expressly granted, there are no other rights of access or licenses granted to You, express or implied. All rights not granted are reserved by Tuist.
+
+4.2. You may designate Users to use the Platform on Your behalf in accordance with the Documentation. Use of the Platform by You and the Users in the aggregate must be within the restrictions set forth (if any). You shall require that all Users keep their user ID and password information confidential and not share such information with any unauthorized person. You shall be responsible for all actions taken using Your accounts and passwords.
+
+4.3. For any FCL Software, You acknowledge that the FCL Terms shall take precedence over the terms of this ToS with respect to those FCL Software and that the ToS only governs those aspects that are not covered by the FCL Terms, including, but not limited to, support, payment, and service levels. In case of a conflict between the terms of the ToS and the FCL Terms, the FCL Terms shall prevail.
+
+4.4. If You or Your Users contribute code, documentation, or other materials to any Tuist project licensed under the FCL Terms or any other license, such contributions shall be governed by the Contributor License Agreement ("**CLA**") as made available by Tuist. You shall ensure that any such contributors execute the CLA prior to making contributions.
+
+4.5. Subject to the terms and conditions of this Agreement, You may permit Users, provided they are not a competitor of Tuist, to use the Platform for Your Internal Purposes and benefit in accordance with this section. You agree to keep confidential the credentials (login names and passwords) required for the use of the Platform, to keep them in a safe place, and to protect them against unauthorized access by third parties with appropriate precautions, and to instruct Your Users to do the same. You control access to and use of the Services by Users. You are responsible and fully liable for the breach of this Agreement by the acts and omissions of Users (including any usage charges or overage charges) under the Agreement.
+
+4.6. Unless the intended use of the Platform is explicitly described in the Order, use of the Platform in high-risk areas is excluded (operation of nuclear power plants, air traffic control systems, weapons of war, life-support equipment, or comparable high-risk applications in which malfunctions typically lead directly to the death of people or to major emergencies).
+
+4.7. The Platform may contain software, including any open-source software that is used as a dependency and not incorporated into the Platform ("**Third-Party Software**"), in which intellectual property rights are owned by a third party. The terms of the Agreement do not apply to Third-Party Software as Third-Party Software is subject to their own terms and are deemed licensed directly to You by the respective third party under those terms.
+
+4.8. The Platform is a general tool designed for the purposes described in the Documentation. Unless otherwise agreed in the Order, it has not been customized, and will not be customized, to Your requirements.
+
+4.9. Tuist will grant You access to the Platform and the Documentation in English by electronic means within a reasonable period following the Effective Date.
+
+4.10. You shall not, directly or indirectly, and You shall not permit any User or third party to (i) distribute (except as expressly permitted herein), sell, sublicense, rent, lease, or use the Platform on a temporary basis, in a service bureau, hosting, or for service provider or similar purpose; (ii) perform vulnerability scanning, penetration testing, or other security testing, including network discovery, port and service identification, password cracking, and remote access testing, of Tuist's systems or the Platform; (iii) modify, edit or alter, disassemble, decompile, or reverse engineer any part of the Platform (this prohibition includes, but is not limited to, examining data structures or similar program-generated materials) or access and use the Platform to create or support Tuist's competing software or services and/or assist any third party in such creation and support; (iv) access libraries, data, or databases that are integrated into the Platform or which are made available by means other than through the Platform itself; (v) change the Documentation (in whole or in part) or create a work derived from the Documentation (or a part thereof), except for Internal Purposes of Yours or if Tuist has expressly agreed to this in writing; (vi) remove any product labeling, proprietary notices, copyright notices, or other notices in the Platform or Documentation; or (vii) publicly disseminate any performance data or analysis (including, but not limited to, benchmarks) related to the Platform or Documentation, regardless of its origin.
+
+4.11. The restrictions pursuant to Section 4.10 shall not limit Your statutory rights in accordance with Applicable Law implementing Articles 3, 6, 10, and 12 of Directive (EU) 2019/790 and Articles 4, 5, and 6 of Directive 2009/24/EC.
+
+4.12. To the extent AI Functionality is included in the Platform by Tuist, the following terms shall apply to the use of such AI Functionality. This Section 4.12 shall not apply, to the extent You have combined your own AI model or a third-party AI model on your own behalf in an on-premise environment.
+
+(a) As between the AI Subprocessor, Tuist, and You, and to the extent permitted by law, You own all Customer AI Data. However, You understand and acknowledge that the AI Functionality may produce similar responses to similar prompts by other Tuist customers and/or third parties using similar AI Functionality and Your rights in the content of such responses may not be enforceable. Tuist will only use Your AI Data as necessary to provide the Services. Subject to Section 4.12(b), the AI Subprocessor will only use Your AI Data to provide and maintain the AI Functionality, comply with applicable law, and enforce License Restrictions, in accordance with its usage policies and published documentation. You are solely responsible for ensuring that Your AI Data complies with applicable laws.
+
+(b) Any AI Input may, depending on the type of AI Functionality, be used by an AI Subprocessor for model training and improvement, subject to applicable opt-out rights provided by such AI Subprocessor. You acknowledge that Tuist has no control over the use of the AI Input and any use of such is at Your own risk.
+
+(c) You have the right to use the AI Output for your internal business purposes. Tuist may use AI Output for its own internal business purposes.
+
+(d) The rights granted herein are subject to the restrictions ("**License Restrictions**") of each AI Subprocessor from time to time in place, including, without limitation, those set forth below, and You agree that You will comply with and not violate, or allow any user to violate, the following AI Subprocessor safety and usage policies (as may be updated from time to time):
+
+- OpenAI Ireland Ltd., the usage policy is available under the following URL: [https://openai.com/policies/usage-policies/](https://openai.com/policies/usage-policies/).
+
+4.13. All Intellectual Property Rights in and to Your Data belong to and shall remain vested in You or the relevant third-party owner.
+
+4.14. Unless you are a consumer, You hereby grant Tuist a limited, revocable, nonexclusive, nontransferable, worldwide and royalty-free license to use Your company name and logo (whether or not trademark-protected) on Tuist's website and in the Tuist's sales and promotion material to identify You as a customer of Tuist. You have the right to waive this license in written form at any point in time.
+
+## Section 5: Free Services
+
+5.1. In connection with the Platform, Tuist may from time to time make new services or new features available to You for evaluation and testing as part of the Platform (each, a "**Beta Service**"). Beta Services will be identified as "beta", "pre-release", "early-release", or "development" (or words or phrases with similar meanings). Whether You choose to use the Beta Services is completely optional and within Your control. Tuist makes no commitment that future versions of a Beta Service will be released. If You choose to use a Beta Service, You expressly acknowledge and agree to the provisions of Section 4.3.
+
+5.2. Tuist may make new services or features available to You on a trial basis ("**Trial Services**") free of charge and for a limited period under or in connection with an Order ("**Trial Period**"). Trial Periods shall terminate on the earlier to occur of:
+
+(a) the end of any applicable Trial Period; or
+
+(b) termination by Tuist of the Trial Period in its sole discretion.
+
+5.3. Additional terms and conditions regarding the Trial Services may appear on a trial registration or other web page. You must accept and agree to those additional terms and conditions prior to using the Trial Services.
+
+5.4. Unless otherwise agreed between the Parties in writing, use of Beta Services and Trial Services ("**Free Services**") is subject to the terms and conditions of this ToS and the applicable Order. Free Services may be provided to You up to certain limits as provided by Tuist in connection with the applicable Free Services ("**Free Service Limits**"). Usage over the Free Service Limits is not authorized by Tuist. You agree that Tuist, in its sole discretion and for any or no reason, may terminate Your access to the Free Services or any part thereof at any time. You agree that any termination of Your access to the Free Services may be without prior notice. You are solely responsible for exporting Your Data from the Free Services prior to termination of Your access to the Free Services for any reason. Notwithstanding anything to the contrary contained in this ToS, the relevant Order, or elsewhere, all Free Services are provided "as is", and Tuist does not provide any warranty, support, or indemnification of any kind with respect to the Free Services or any products, results, or use thereof. You are solely responsible for Your use and reliance on any such results. You further agree that the provision of the results obtained through the Free Services is not a substitute to Your considered and informed decision-making, and that You remain solely responsible for any use of such results and for any decisions made in relation to such results. Warranty as provided under Section 9.2 below shall be expressly excluded.
+
+## Section 6: Your Obligations
+
+6.1. You may engage with the Platform via an authentication method provided by Tuist or a third-party authentication provider. Your use of a third-party authentication method is governed by the terms and conditions of the respective third-party authentication method provider. Tuist will not be responsible for Your use of the authentication method or any act or omission of any third-party authentication method provider, including (a) failure of the authentication method, (b) presence of bugs or errors in the authentication method, or (c) provision by the authentication method of inaccurate identities at login. To the extent that authentication methods are made available by Tuist, all authentication methods are provided without any representation or warranty unless explicitly stated otherwise.
+
+6.2. You are responsible for:
+
+(a) obtaining, deploying, and maintaining all computer hardware, software, modems, routers, and other communications equipment necessary for You and Your Users to access and use the Platform via the Internet;
+
+(b) contracting with third-party internet service provider, telecommunications, and other similar service providers to access and use the Platform via the Internet; and
+
+(c) paying all third-party fees and access charges incurred in connection with the foregoing.
+
+6.3. Tuist shall not be responsible for supplying any hardware, software (other than provided as part of the Platform) or equipment to You under these ToS. You shall inform yourselves about the substantial functionalities of the Platform before the start of Agreement in an exhaustive manner and you bear the risk that the Platform satisfies Your factual needs and is compatible with Your computer systems. You are responsible for managing your own computing resources effectively, including monitoring and making any necessary adjustments to drive capacity to ensure that Tuist can provide the Services effectively and efficiently. Tuist will retain your data for thirty (30) days post-termination to allow for migration, after which it will be deleted unless otherwise required by law.
+
+6.4. You acknowledge and agree that Tuist neither endorses the contents of any of Your communications or Customer Data, nor assumes any responsibility for any material contained therein, any infringement of third-party Intellectual Property Rights arising therefrom, or any crime facilitated thereby. You shall be solely responsible and liable for the completeness, integrity, quality, and accuracy of Customer Data. You warrant that none of your Customer Data or User's use of Your Customer Data will violate the Acceptable Use Policy.
+
+6.5. You shall use the storage capacities provided as part of the Platform only for purposes related to the use of the Platform, including project management files. You shall not store any other data not related to the purposes of the usage of the Platform. In case of a breach, Tuist may terminate the respective Order in accordance with Section 13.3.
+
+6.6. You shall be solely responsible to create backups of the files and data stored within the Platform.
+
+6.7. Each Party shall provide accurate, current, and complete information as is necessary for proper communication from time to time regarding the Services, issuing invoices or accepting payments, or contacting the other party for other account-related purposes. Tuist and You each shall keep any online account information current and promptly inform the respective other party of any changes in such party's legal business name, address, email address, and phone number.
+
+6.8. During the entire term of the Agreement, You cooperate with Tuist closely and faithfully and shall contribute reasonably to the fulfilment of the Agreement. You shall actively contribute to the provision of Services to the extent necessary, e.g., by providing, if necessary, employees, workspace, hardware and software, data, and telecommunication facilities, by answering questions and by controlling work results of Tuist. You shall provide accurate, current, and complete information as reasonably required for the provision and management of the Services. You shall promptly update any such information as necessary to maintain its accuracy and completeness.
+
+6.9. You name a qualified contact person and/or project manager and notify his contact details that allow contact with the contact person and his designated proxy at any time. The contact person must be able to make the necessary decisions by himself or to procure them immediately on your behalf. You shall immediately notify Tuist regarding all modifications of the contact's details in writing. You shall provide your employees, who have specific know-how necessary for the execution of the Agreement and to the provision of the contractual services by Tuist, at no cost.
+
+6.10. You must comply with all applicable legal and regulatory requirements related to the use of the Services. You shall ensure that its use of the Services do not violate any confidentiality obligations or other obligations under applicable law. If it is required that Tuist needs to process personal data on behalf of You, You comply with the respective data protection obligations.
+
+6.11. Any prejudice and additional costs resulting from a breach of this Section 6, and other contribution obligations of You set out in the Agreement, are at Your expense. In particular, You are not dispensed from Your obligation to pay the Fees if Tuist cannot provide Services due to deficient or default contributions of You, Your contact persons, or other employees of You.
+
+6.12. If You become aware of any inability to comply with the obligations outlined herein, You must promptly notify Tuist of such noncompliance and take reasonable steps to rectify the situation in a timely manner.
+
+## Section 7: Invoicing and Payment
+
+7.1. As the sole and complete consideration for Tuist's performance under this Agreement, the Customer shall pay to Tuist the Fees.
+
+7.1.1. The Fees and any other charges incurred, such as taxes and transaction fees, will be charged to Your payment method on the specific payment date indicated on Your 'Account' page. The billing cycle length depends on the subscription plan chosen at sign up, as detailed on our pricing page at [https://tuist.dev/pricing](https://tuist.dev/pricing). Payment dates may change if Your payment method fails, You change Your subscription plan, or if Your subscription began on a day not contained in a given month. You can view Your current month's usage and see Your next payment date by visiting the dashboard and clicking on the 'Billing Details' link on the 'Account' page. We may authorize Your payment method in anticipation of subscription charges through various methods, including authorizing it for up to approximately one month of service upon registration.
+
+7.1.2. To use the Services, You must provide one or more payment methods. You authorize us to charge any payment method associated with Your account if Your primary payment method is declined or unavailable. You remain responsible for any uncollected amounts. If a payment is not successfully settled due to expiration, insufficient funds, or otherwise, and You do not cancel Your account, we may suspend Your access to the Platform and our Services until we successfully charge a valid payment method. For some payment methods, the issuer may charge fees, such as foreign transaction fees. Local tax charges may vary depending on the payment method used. Check with Your payment method service provider for details.
+
+7.1.3. If the payment method credit card via Stripe is selected, the invoice amount is due immediately upon conclusion of the Agreement. Payment is processed by the payment service provider, Stripe Payments Europe Ltd., 1 Grand Canal Street Lower, Grand Canal Dock, Dublin, Ireland (hereinafter, "**Stripe**"). Stripe reserves the right to carry out a credit check and to reject this payment method if the credit check is negative.
+
+7.1.4. You can update Your payment method by visiting the 'Account' page. We may also update Your payment methods using information provided by payment service providers. Following any update, You authorize us to continue charging the applicable payment method.
+
+7.1.5. You can cancel Your subscription at any time, and You will continue to have access through the end of Your billing period. Payments are nonrefundable, and we do not provide refunds or credits for partial periods. To cancel, go to the 'Account' page and follow the cancellation instructions. If You cancel, Your account will close at the end of Your current billing period.
+
+7.1.6. We may change our subscription plans and prices from time to time. We will notify You at least one (1) month before any changes take effect. If You do not wish to accept the changes, You can cancel Your subscription before they become effective or reject acceptance. If You do not accept such change within the given acceptance period, we may terminate the subscription at the end of the then-current billing period.
+
+7.1.7. Fees stated are net amounts exclusive of any Taxes and such Taxes shall be borne by You. If Tuist is responsible for paying any Taxes in respect of any Fees pursuant to Applicable Law, the corresponding amounts shall be added to the applicable invoice issued by Tuist and paid by You together with the relevant Fees.
+
+7.1.8. For customers that reside outside of Germany, any amount payable shall be paid without deduction, withholding, or other consideration of any Withholding Tax, unless such deduction, withholding, or other consideration is required by law. If You are required by law to withhold and pay Withholding Tax on any amount payable to Tuist, You shall make all payments required in connection with such withholding in a timely manner and in the minimum amount required by law and/or administrative regulation, file with the taxing authorities, document, and provide Tuist with evidence of such withholding by submitting the original tax receipt. In this case, the remuneration to be paid by the Customer shall be increased by an amount necessary for Tuist receiving a net amount equal to the amount it would have received if the tax deduction had not been made. You and Tuist will take reasonable steps to obtain a refund of the Withholding Tax from the applicable taxing authority. If Tuist ultimately receives a tax refund claim or tax credit, Tuist will refund to You an amount that Tuist calculates to be equal to the tax refund or tax credit received. You shall indemnify Tuist against all costs and expenses incurred as a result of applying for a refund of the Withholding Tax. Any claims by You under this Section 7.1 shall become time-barred six (6) months from the end of term during which the relevant Withholding Tax can be assessed or its assessment can be altered pursuant to Applicable Law.
+
+7.2. If Tuist does not receive Fees by the due date, then at Tuist's discretion, without limiting Tuist's other rights and remedies, such charges may accrue late interest, calculated in accordance with Applicable Law (plus the costs of collection).
+
+7.3. If You do not pay any overdue amounts owed by You for the Platform within five (5) days from having received notice from Tuist of such overdue amounts, Tuist may, without limiting Tuist's other rights and remedies, suspend Your (including, for clarity, its Users') access to the Platform until such amounts are paid in full.
+
+7.4. You may offset Tuist's remuneration claims under this Agreement only against claims that have been legally established by final judgment or accepted by Tuist.
+
+## Section 8: Data Protection, Data Act Compliance, and Service Level
+
+8.1. By accessing and using the Platform, we may process Your personal data. Please read our [Privacy Notice](/privacy) to find more information about how we collect, use, disclose, and otherwise process Your personal data.
+
+8.2. The Parties agree that the [Data Processing Addendum](/data-processing-addendum) ("**DPA**") forms an integral part of the Agreement to the extent Tuist is processing personal data on your behalf. The Parties agree to amend the DPA in good faith to the extent that this is required to comply with the applicable data protection laws.
+
+8.3. The terms and conditions set forth in the [Data Act Addendum](/data-act-addendum) ("**DAA**") shall apply to the extent Services constitute Data Processing Services.
+
+8.4. The Parties agree on the service level with respect to Availability (as defined in the SLA) of the Platform, the response and resolution times in case of any errors of the Platform, and the Update Frequency (as defined in the SLA) as outlined in the [Service Level Addendum](/service-level-addendum) ("**SLA**").
+
+## Section 9: Warranties
+
+9.1. The parties represent and warrant to each other that (i) each party is duly organized, validly existing, and in good standing as a corporation or other entity under Applicable Law of the jurisdiction of its incorporation or other organization; (ii) each party has the full right, power, and authority to enter into and perform the obligations and grant the rights, licenses, consents, and authorizations it grants or is required to grant under this Agreement; and (iii) the execution of this Agreement by its representative has been duly authorized by all necessary corporate or organizational action of such party.
+
+9.2. Tuist's sole representations and warranties in respect of the Platform are as follows: (i) the Platform as delivered by Tuist does not infringe third-party intellectual property rights and is free from third-party rights that would prevent the use of the Software in accordance with the Agreement; and (ii) the Platform as delivered by Tuist complies with the specifications set forth in the Documentation and operates substantially in accordance with the Documentation.
+
+9.3. You represent and warrant to Tuist that (i) You own or otherwise have and will have necessary and sufficient rights and consents in and relating to Your Customer Data as received by Tuist; (ii) Your Customer Data does not and will not infringe, misappropriate, or otherwise violate any Intellectual Property Rights, or any privacy or other rights of any third party or violate any Applicable Laws; and (iii) Your use of the Platform and all Customer Data is and will be at all times compliant with Your privacy policies and Applicable Laws.
+
+9.4. In the event of a breach of a Tuist warranty regarding the Software, the procedure set forth in the SLA shall apply. In the event of any other breaches of warranty with respect to the Software, You shall promptly inform Tuist in reasonable detail and give Tuist reasonable opportunity to correct the nonconformity or to re-perform the relevant service at no additional charge to You. Only if correction or re-performance fails, You may terminate the subscription and receive a refund of any Fees You have prepaid with respect to the affected work or service. For the avoidance of doubt, You shall not be entitled to any refund of Fees to the extent they relate to unaffected work or services actually received by You. Correction or reperformance are deemed failed if (a) correction or re-performance is impossible, (b) correction or re-performance cannot reasonably be expected to succeed, (c) Tuist refuses or unreasonably delays correction or re-performance, (d) Tuist had sufficient opportunity to correct the nonconformity or properly re-perform the service but failed to do so within reasonable time, or (e) You cannot reasonably be expected to accept correction or re-performance under the specific circumstances taking into account both Parties' legitimate interests. You shall not be entitled to any warranty claims (a) to the extent the relevant error or other nonconformance was caused by misuse, unauthorized modifications, or third-party hardware, software, or services, (b) the relevant work or service was provided on a no-charge or evaluation basis, or (c) You culpably failed to notify Tuist of the error or other nonconformance within one (1) week from the error or other nonconformance becoming apparent to You.
+
+9.5. If and to the extent that the Software infringes any third-party right, Tuist may, at its option (i) secure sufficient licenses or other rights to use the relevant third-party right; or (ii) remedy the enforcement of any claims based on the relevant third-party right against You in accordance with Section 10; or (iii) change or replace the Software in such a manner that it no longer infringes the relevant third-party right while substantially maintaining the warranted functionality of the Software.
+
+9.6. Your right of termination for failure to provide the use of the Platform pursuant to Section 543 (2) sentence 1 no. 1 German Civil Code (BGB) shall be excluded unless the provision of the contractual use of the Platform is deemed to have failed.
+
+9.7. Any claims for damages due to any breach of warranty and claims for compensation of wasted efforts due to defects are subject to Section 11. Together with Section 10 (Intellectual Property Indemnification) and Section 11 (Liability), this Section 9 sets out Your sole remedies for any breach of warranty.
+
+## Section 10: Intellectual Property Indemnification
+
+10.1. If a third party asserts claims against You and your employees, officers, and directors which are based on the infringement of any third party's intellectual property rights through the use of the Platform, and if Tuist is obliged to remedy such defect of title within the scope of its warranty obligations, Tuist shall also defend You against the claims of the third party as follows and shall indemnify You against these claims within the scope of the agreed limitation of liability in Section 11. Intellectual property rights in this sense are only those to which the third party is entitled in the Federal Republic of Germany.
+
+10.2. The foregoing indemnification obligation shall not apply to the extent the infringement claim arises as a result of (i) the combination of the Platform with other non-Tuist products or software not specifically permitted in the Documentation, and (ii) unauthorized use of the Platform or use of the Platform in breach of the Agreement by the Customer.
+
+10.3. You will defend Tuist and its affiliates, and their respective employees, officers, and directors against any third-party claim alleging that Your Customer Data infringes or misappropriates that third party's intellectual property rights.
+
+10.4. The Party responsible for the infringement shall undertake the legal defense against such third-party claims at its own expense. The responsible Party shall reimburse the other Party only for expenses incurred as a result of a final judgment.
+
+10.5. The foregoing indemnity obligations are conditioned upon the indemnified Party providing to the indemnifying Party (i) prompt written notice of the assertion of any claim by the third party (but in any event notice given in sufficient time for the indemnifying Party to respond without prejudice), (ii) the right to control and direct the investigation, defense, and any settlement of such claim; to the extent that the indemnified Party is unable to fully transfer the legal defense to the indemnifying Party, the indemnifying Party shall instead grant control over the legal defense and shall only and at all times act in agreement with the indemnified Party in the context of the legal defense or in settlement negotiations, and (iii) all reasonable and necessary cooperation.
+
+10.6. Neither Party shall agree to any settlement that admits fault or attributes liability or otherwise imposes any affirmative obligation on the other Party without first obtaining prior consent from the other Party.
+
+10.7. The limitation period for the claim for indemnification corresponds to the limitation period for Your warranty claims for defects in title.
+
+## Section 11: Liability
+
+11.1. Tuist will be liable in accordance with the applicable law: (i) for willfulness and gross negligence; (ii) for damage to life, limb, or health; (iii) for breach of a specific guarantee; (iv) for fraudulent misrepresentation and fraudulent concealment of a defect; and (v) in accordance with the German Product Liability Act (Produkthaftungsgesetz).
+
+11.2. Tuist will also be liable in the event of a breach of an essential obligation under the Agreement due to ordinary negligence on the part of Tuist or any of its representatives, or vicarious or surrogate agents, but limited to the foreseeable, typical damage. Essential obligations are obligations that necessarily need to be fulfilled to enable performance of the Agreement and on which You regularly rely and may reasonably rely.
+
+11.3. Except as set forth in Sections 11.1 and 11.2, Tuist's liability is hereby excluded.
+
+11.4. The exclusions and limitations of liability set forth in this Section 11 (Liability) equally apply to Tuist's legal representatives, or vicarious and surrogate agents.
+
+11.5. Liability in accordance with Section 11.4 is limited to EUR 50.00 if Services are provided by Tuist to You free of charge.
+
+## Section 12: Confidentiality
+
+12.1. Each Party acknowledges that during the performance of the Agreement, it may obtain the Confidential Information of the other Party. The Receiving Party shall, both during the term of the Agreement and a period of five (5) years thereafter, keep in confidence and trust all of the Disclosing Party's Confidential Information received by it, and the Receiving Party shall not use the Confidential Information of the Disclosing Party other than as necessary to fulfill the Receiving Party's obligations or to exercise the Receiving Party's rights under the Agreement. Each Party agrees to secure and protect the other Party's Confidential Information with the same degree of care and in a manner consistent with the maintenance of such Party's own Confidential Information (but in no event less than reasonable care), and to take appropriate action by instruction or agreement with its employees or other agents who are permitted access to the other Party's Confidential Information to satisfy its obligations under this Section. The Receiving Party shall not disclose Confidential Information of the Disclosing Party to any person or entity other than its officers, employees, and agents who need to know it to exercise the Receiving Party's rights and fulfill its obligations under the Agreement, and who are subject to confidentiality obligations at least as stringent as the obligations set forth in the Agreement. The Receiving Party shall be liable for any breach of this Section 12.1 by such persons.
+
+12.2. The obligations set forth in Section 12.1 shall not apply to information that the Receiving Party can document: (i) was known by the Receiving Party prior to receipt from the Disclosing Party, either by obtaining the information itself or through receipt directly or indirectly from a source other than one having an obligation of confidentiality to the Disclosing Party; (ii) was independently developed by the Receiving Party without use of or reference to the Disclosing Party's Confidential Information; or (iii) becomes publicly known or otherwise ceases to be secret or confidential, except as a result of a breach of the Agreement or any obligation of confidentiality by the Receiving Party.
+
+12.3. Nothing in the Agreement shall prevent the Receiving Party from disclosing Confidential Information to the extent the Receiving Party is legally compelled to do so by (i) any governmental investigative or judicial agency pursuant to proceedings over which such agency has jurisdiction or (ii) Applicable Law; provided, however, that prior to any such disclosure, the Receiving Party shall (x) assert the confidential nature of the Confidential Information to the relevant authority and disclose only so much Confidential Information as is required; (y) immediately notify the Disclosing Party in writing of the request for disclosure and provide the Disclosing Party with sufficient opportunity to challenge the request; and (z) cooperate fully with the Disclosing Party in protecting against any such disclosure and in obtaining a protective order narrowing the scope of the compelled disclosure and protecting its confidentiality.
+
+## Section 13: Term and Termination
+
+13.1. This Agreement commences on the date You signed up for the Services online and continues until terminated pursuant to Section 13.2. Each individual subscription shall continue for the Term.
+
+13.2. Each Party can terminate this Agreement with effect from the end of the next billing period.
+
+13.3. Either Party may terminate the Agreement by notice to the other Party for cause:
+
+(a) if the other Party is in material breach of this Agreement and either the breach cannot be cured or, if the breach can be cured, it is not cured within thirty (30) days following that Party's receipt of notice of such breach. The Parties agree that any breach of Section 4, Section 12, and our Acceptable Use Policy in particular, shall constitute a material breach; or
+
+(b) to the extent possible under Applicable Laws, if the other Party: (i) becomes insolvent or files, or has filed against it, a petition for voluntary or involuntary bankruptcy or under any other insolvency law; (ii) makes or seeks to make a general assignment for the benefit of its creditors, seeks reorganization, winding-up, liquidation, dissolution, or other similar relief with respect to it or its debts; (iii) applies for, or consents to, the appointment of a trustee, receiver, or custodian for a substantial part of its property; or (iv) is generally unable to pay its debts as they become due.
+
+For the avoidance of doubt, termination pursuant to this Section 13.3 does not affect any other rights or remedies to which the terminating Party may be entitled under this Agreement or Applicable Law and is effective on the nonterminating Party's receipt of notice of termination or any later date set out in such notice.
+
+13.4. Any notice of termination will only be effective if sent to, and received by, the other Party by letter, facsimile, or email. A termination notice is not required provided You terminate by unsubscribing within Your 'Account' page.
+
+13.5. Termination of the Agreement will terminate related licenses granted, unless granted for an indefinite period. In addition, within ten (10) Business Days of the effective date of termination of the Agreement, each Receiving Party shall (i) return to the Disclosing Party, or at the Disclosing Party's option, the Receiving Party shall destroy all items of Confidential Information that relate to the Agreement and is in the Receiving Party's possession or control, including any copies, extracts, or portions thereof, and (ii) upon request, certify in writing to the Disclosing Party that it has complied with the foregoing.
+
+13.6. The termination or expiration of this Agreement for any reason shall not affect a party's rights or obligations that expressly or by their nature continue and survive (including the payment terms and the provisions concerning ownership, proprietary rights, confidentiality, and limitation of liability).
+
+13.7. Any notice of termination will only be effective if sent to, and received by, the other Party by letter, facsimile, or email.
+
+13.8. To the extent that Customer Data includes personal data, it shall be returned to the Customer or deleted in accordance with the terms of the DPA.
+
+## Section 14: Modifications
+
+14.1. Tuist reserves the right to amend this Agreement, provided that the amendment is reasonable for the Customer and that Tuist takes the Customer's legitimate interests into account within the scope of the amendment. Changes to the subject matter of the Agreement and the main performance obligations that would lead to a change in the nature of the Agreement as a whole are excluded from the right to amend.
+
+14.2. An amendment to the Agreement by Tuist shall be justified, in particular, if Tuist is obliged to ensure that Services comply with Applicable Law, especially if the applicable legal situation changes, or if Tuist is complying with a court order or an official decision through the amendment.
+
+14.3. An amendment to the Agreement initiated by Tuist requires that Tuist notify the Customer of the intended amendment via email, in-app notification, or website posting at least four (4) weeks before the proposed date of entry into force. The Customer shall be deemed to have given consent if the Customer has not notified Tuist of its rejection prior to the proposed date of entry into force of the amendment. Tuist shall be obliged to expressly draw the Customer's attention to the effect of consent by its conduct within the scope of a change request and to separately inform the Customer of the changes in a highlighted manner, e.g., by means of a synoptic comparison, by highlighting the changes in bold, or by means of an addendum to this Agreement.
+
+14.4. If the Customer objects to the new provisions of the Agreement, Tuist shall be entitled to terminate the Agreement or the respective Order without notice.
+
+14.5. If the term of an Agreement automatically renews, or if the Parties enter a new Order referencing the terms of this Agreement, the Customer agrees that the latest version of the Agreement will apply to the respective Orders. If the Customer does not agree to the terms of this Agreement or any renewed version, the Customer may terminate the respective Order.
+
+## Section 15: Miscellaneous
+
+15.1. Tuist may publicly use the Customer's company name (including any related company trademark) solely to identify the Customer as a customer of Tuist. Any other use of one Party's names, logos, or trademarks by the other Party is subject to the one Party's prior written consent.
+
+15.2. Any notice or communication required or permitted under this Agreement shall be in writing and may be delivered by electronic means, including, but not limited to, email, in-app notifications, or electronic signature platforms such as DocuSign. Such electronic communications shall be deemed to be in writing. Notices sent by electronic means shall be considered received upon confirmation of successful transmission or, in the case of electronic signature platforms, upon confirmation of completion of the signing process. All notices to Tuist must be delivered to the email address legal@tuist.dev or to the postal address specified in the Parties Section, unless otherwise specified in this Agreement. All communications and notices under this Agreement shall be in the English language. Notices will be treated as delivered on the date received at the specified address, the date shown on the return receipt, the date of email transmission, or the date on the courier confirmation of delivery, as applicable.
+
+15.3. The Agreement shall be governed by the laws of Germany without regard to conflicts of law provisions thereof. The Parties agree that the United Nations Convention on Contracts for the International Sale of Goods shall not apply. In the event of a dispute that may arise between the Parties regarding the validity, implementation, interpretation, or termination of the Agreement, to the extent legally permissible, sole jurisdiction is allocated to the competent courts of Berlin, Germany.
+
+15.4. This Agreement does not create any third-party beneficiary rights in any individual or entity that is not a party to this Agreement.
+
+15.5. The Agreement constitutes the sole and entire agreement of the Parties with respect to the subject matter contained herein and therein and supersedes all prior and contemporaneous understandings, agreements, representations, and warranties, both written and oral, regarding such subject matter.
+
+15.6. No term or provision of the ToS or any Order shall be considered waived by a Party, and no breach excused by a Party, unless such waiver or consent is in writing and signed on behalf of the party against whom the waiver is asserted. No consent by a Party to, or waiver of, a breach by a Party, whether express or implied, shall constitute consent to, waiver of, or excuse of any other, different, or subsequent breach by a Party.
+
+15.7. No Party may assign the ToS or any Order except upon the prior written consent of the respective other Party. Notwithstanding the foregoing, Tuist may assign the ToS and any Order without such consent in connection with a merger, reorganization, acquisition, or other transfer of all or substantially all of Tuist's assets or voting securities. Any attempt to transfer or assign the ToS or any Order except as expressly authorized under this Section 15.7 will be null and void.
+
+15.8. Neither Party will be liable to the other for any delay or failure to perform any obligation under this Agreement (except for a failure to pay fees) if the delay or failure is due to events that are beyond the reasonable control of such Party and could not be avoided through the exercise of reasonable care and diligence, including, but not limited to, any strike, blockade, war, act of terrorism, riot, natural disaster, or failure or diminishment of power or of telecommunications or data networks or services ("**Force Majeure**"). In the event that Force Majeure occurs and persists for a period of thirty (30) days, the Customer may terminate this Agreement by providing written notice to Tuist. In the event Tuist's performance hereunder is affected by Force Majeure, the fees to be paid by Customer will be equitably adjusted to reflect the period of nonperformance.
+
+15.9. This ToS and any Order shall be signed by duly authorized representatives of the Parties and may also be executed in digital form by means of a simple electronic signature. This ToS and any Order may be executed by the exchange of signed copies by facsimile, DocuSign, Adobe Sign, or by the exchange of PDF copies of the Order by email, each such copy constituting an original for each Party whose signature appears thereon, but all copies together constituting one and the same document. An executed DocuSign or PDF copy or scanned electronic copy of the ToS or any Order shall have the same validity and effect as delivery of an original signed copy of the Agreement, and the electronic signature of a Party is to be considered as an original signature.
+
+*Last updated August 8, 2025*


### PR DESCRIPTION
## Summary

Replaces the outdated 2023 Terms of Service with a comprehensive new version prepared by our lawyers, and adds three legal addendums as new marketing pages:

- **Service Level Addendum** (`/service-level-addendum`): defines availability (95% monthly), error classes, response/recovery times, and service level credits
- **Data Act Addendum** (`/data-act-addendum`): implements the EU Data Act (Regulation 2023/2854) for switching and porting between data processing services
- **Data Processing Addendum** (`/data-processing-addendum`): GDPR compliance with EU/UK/international data transfer clauses, sub-processor list linked from security.tuist.dev

Also adds a terms of service reference to the `organization create` CLI command's help text so users are aware of the ToS when creating organizations from the terminal. No code changes needed for routing since NimblePublisher auto-discovers the new markdown files.

> [!NOTE]
> With this work and [this other one](https://github.com/tuist/tuist/pull/9261) every person creating a personal or an organization account agrees with our _online_ terms of service. In a follow-up PR I'll implement a workflow to get the current users and organizations to agree with these terms.