### PR TITLE
fix(server): drop has_many association fields in insert_all

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1333,7 +1333,7 @@ defmodule Tuist.Tests do
       Enum.map(existing_runs, fn run ->
         run
         |> Map.from_struct()
-        |> Map.drop([:__meta__, :ran_by_account])
+        |> Map.drop([:__meta__, :ran_by_account, :failures, :repetitions])
         |> Map.merge(%{is_flaky: true, inserted_at: NaiveDateTime.utc_now()})
       end)
 


### PR DESCRIPTION
## Summary
- Fixes `insert_all` crash in `mark_as_flaky_and_duplicate` caused by `has_many :failures` and `has_many :repetitions` associations added to `TestCaseRun` schema in #9379
- When `Map.from_struct()` converts a `TestCaseRun` struct to a map, the association keys (`:failures`, `:repetitions`) are included with `NotLoaded` values, which `insert_all` rejects
- Adds these keys to the existing `Map.drop` call alongside `:__meta__` and `:ran_by_account`

## Test plan
- [x] `mix test test/tuist/tests_test.exs` — all 125 tests pass
- [x] `mix test test/tuist/tests/analytics_test.exs` — pre-existing failures only (same as main)
- [x] `mix test test/tuist_web/controllers/api/test_case_runs_controller_test.exs` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)