### PR TITLE
fix(server): format test controller files

### DIFF
--- a/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
@@ -3,6 +3,7 @@ defmodule TuistWeb.API.TestCaseRunsControllerTest do
   use Mimic
 
   alias Tuist.Tests
+  alias Tuist.Tests.TestCaseRun
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
@@ -32,7 +33,7 @@ defmodule TuistWeb.API.TestCaseRunsControllerTest do
         )
 
       stub(Tests, :list_test_case_runs_by_test_case_id, fn _test_case_id, _options ->
-        {[%{struct(Tuist.Tests.TestCaseRun, test_case_run) | status: :success}],
+        {[%{struct(TestCaseRun, test_case_run) | status: :success}],
          %{
            has_next_page?: false,
            has_previous_page?: false,
@@ -184,7 +185,7 @@ defmodule TuistWeb.API.TestCaseRunsControllerTest do
         )
 
       run_struct = %{
-        struct(Tuist.Tests.TestCaseRun, test_case_run)
+        struct(TestCaseRun, test_case_run)
         | status: :failure,
           git_commit_sha: "abc1234"
       }
@@ -252,11 +253,9 @@ defmodule TuistWeb.API.TestCaseRunsControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
 
       test_case_run =
-        RunsFixtures.test_case_run_fixture(
-          project_id: other_project.id
-        )
+        RunsFixtures.test_case_run_fixture(project_id: other_project.id)
 
-      run_struct = %{struct(Tuist.Tests.TestCaseRun, test_case_run) | status: :success, failures: [], repetitions: []}
+      run_struct = %{struct(TestCaseRun, test_case_run) | status: :success, failures: [], repetitions: []}
 
       stub(Tests, :get_test_case_run_by_id, fn _id, _opts -> {:ok, run_struct} end)
 

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -268,7 +268,11 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       end)
 
       # When
-      conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases?name=testSpecific&suite_name=MySuite")
+      conn =
+        get(
+          conn,
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases?name=testSpecific&suite_name=MySuite"
+        )
 
       # Then
       response = json_response(conn, :ok)


### PR DESCRIPTION
## Summary
- Fixes Elixir formatting in test files introduced by #9379
- `test_case_runs_controller_test.exs`: adds `TestCaseRun` alias, simplifies struct calls, collapses single-arg fixture call
- `test_cases_controller_test.exs`: wraps long `get` URL across multiple lines

## Test plan
- [x] `mix format --check-formatted` passes for both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)