### PR TITLE
fix(server,cache): fix Loki logger handler crash from incorrect structured_metadata format

### DIFF
--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -77,10 +77,7 @@ defmodule Cache.Application do
           env: {:static, System.get_env("DEPLOY_ENV") || "production"},
           level: :level
         },
-        structured_metadata: [
-          traceID: {:metadata, :trace_id},
-          spanID: {:metadata, :span_id}
-        ]
+        structured_metadata: [:trace_id, :span_id]
       )
     end
   end

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -89,10 +89,7 @@ defmodule Tuist.Application do
           env: {:static, to_string(Environment.env())},
           level: :level
         },
-        structured_metadata: [
-          traceID: {:metadata, :trace_id},
-          spanID: {:metadata, :span_id}
-        ]
+        structured_metadata: [:trace_id, :span_id]
       )
     end
   end


### PR DESCRIPTION
## Summary

- The `structured_metadata` option for `loki_logger_handler` was incorrectly passed as a keyword list with `{:metadata, key}` tuples (matching the labels syntax), but the library expects a flat list of atom keys. This caused the handler to crash during log event processing and get auto-removed by the Erlang logger, silently breaking all log forwarding to Loki while traces continued to work fine.
- Fixes both the server and cache services.