### PR TITLE
revert(cache): remove S3.exists? from module download hot path

### DIFF
--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -107,12 +107,6 @@ http {
             proxy_buffering off;
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_remote_redirect;
-            error_page 403 404 = @handle_remote_not_found;
-        }
-
-        location @handle_remote_not_found {
-            default_type application/json;
-            return 404 '{"message":"Not found"}';
         }
 
         location @handle_remote_redirect {

--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -25,7 +25,6 @@ defmodule Cache.Application do
       Cache.S3TransfersBuffer,
       {Phoenix.PubSub, name: Cache.PubSub},
       Cache.Authentication,
-      Cache.S3,
       Cache.KeyValueStore,
       Cache.MultipartUploads,
       Cache.Registry.Metadata,

--- a/cache/lib/cache/module/prom_ex_plugin.ex
+++ b/cache/lib/cache/module/prom_ex_plugin.ex
@@ -14,23 +14,23 @@ defmodule Cache.Module.PromExPlugin do
       # Downloads
       counter(
         [:tuist_cache, :module, :download, :hits, :total],
-        event_name: [:cache, :xcode_module, :download, :hit],
+        event_name: [:cache, :module, :download, :hit],
         description: "Total module cache download requests received."
       ),
       counter(
         [:tuist_cache, :module, :download, :disk_hits, :total],
-        event_name: [:cache, :xcode_module, :download, :disk_hit],
+        event_name: [:cache, :module, :download, :disk_hit],
         description: "Module cache downloads served from local disk."
       ),
       sum(
         [:tuist_cache, :module, :download, :disk_bytes],
-        event_name: [:cache, :xcode_module, :download, :disk_hit],
+        event_name: [:cache, :module, :download, :disk_hit],
         measurement: :size,
         description: "Total bytes served from local disk for module cache."
       ),
       distribution(
         [:tuist_cache, :module, :download, :artifact_size, :bytes],
-        event_name: [:cache, :xcode_module, :download, :disk_hit],
+        event_name: [:cache, :module, :download, :disk_hit],
         measurement: :size,
         unit: :byte,
         description: "Distribution of module cache artifact sizes downloaded from disk.",
@@ -38,28 +38,28 @@ defmodule Cache.Module.PromExPlugin do
       ),
       counter(
         [:tuist_cache, :module, :download, :disk_misses, :total],
-        event_name: [:cache, :xcode_module, :download, :disk_miss],
+        event_name: [:cache, :module, :download, :disk_miss],
         description: "Module cache downloads not found on disk (redirected to S3)."
       ),
       counter(
         [:tuist_cache, :module, :download, :s3_hits, :total],
-        event_name: [:cache, :xcode_module, :download, :s3_hit],
+        event_name: [:cache, :module, :download, :s3_hit],
         description: "Module cache downloads served from S3."
       ),
       sum(
         [:tuist_cache, :module, :download, :s3_bytes],
-        event_name: [:cache, :xcode_module, :download, :s3_hit],
+        event_name: [:cache, :module, :download, :s3_hit],
         measurement: :size,
         description: "Total bytes downloaded from S3 for module cache."
       ),
       counter(
         [:tuist_cache, :module, :download, :s3_misses, :total],
-        event_name: [:cache, :xcode_module, :download, :s3_miss],
+        event_name: [:cache, :module, :download, :s3_miss],
         description: "Module cache downloads not found in S3 (404)."
       ),
       counter(
         [:tuist_cache, :module, :download, :errors, :total],
-        event_name: [:cache, :xcode_module, :download, :error],
+        event_name: [:cache, :module, :download, :error],
         description: "Module cache download errors.",
         tags: [:reason],
         tag_values: fn metadata -> %{reason: to_string(Map.get(metadata, :reason, :unknown))} end
@@ -68,23 +68,23 @@ defmodule Cache.Module.PromExPlugin do
       # Multipart uploads
       counter(
         [:tuist_cache, :module, :multipart, :starts, :total],
-        event_name: [:cache, :xcode_module, :multipart, :start],
+        event_name: [:cache, :module, :multipart, :start],
         description: "Total multipart module cache uploads started."
       ),
       counter(
         [:tuist_cache, :module, :multipart, :parts, :total],
-        event_name: [:cache, :xcode_module, :multipart, :part],
+        event_name: [:cache, :module, :multipart, :part],
         description: "Total multipart upload parts received."
       ),
       sum(
         [:tuist_cache, :module, :multipart, :parts, :bytes],
-        event_name: [:cache, :xcode_module, :multipart, :part],
+        event_name: [:cache, :module, :multipart, :part],
         measurement: :size,
         description: "Total bytes received via multipart upload parts."
       ),
       distribution(
         [:tuist_cache, :module, :multipart, :part_size, :bytes],
-        event_name: [:cache, :xcode_module, :multipart, :part],
+        event_name: [:cache, :module, :multipart, :part],
         measurement: :size,
         unit: :byte,
         description: "Distribution of multipart upload part sizes.",
@@ -92,18 +92,18 @@ defmodule Cache.Module.PromExPlugin do
       ),
       counter(
         [:tuist_cache, :module, :multipart, :completions, :total],
-        event_name: [:cache, :xcode_module, :multipart, :complete],
+        event_name: [:cache, :module, :multipart, :complete],
         description: "Total multipart module cache uploads completed."
       ),
       sum(
         [:tuist_cache, :module, :multipart, :completed, :bytes],
-        event_name: [:cache, :xcode_module, :multipart, :complete],
+        event_name: [:cache, :module, :multipart, :complete],
         measurement: :size,
         description: "Total bytes uploaded via completed multipart uploads."
       ),
       distribution(
         [:tuist_cache, :module, :multipart, :artifact_size, :bytes],
-        event_name: [:cache, :xcode_module, :multipart, :complete],
+        event_name: [:cache, :module, :multipart, :complete],
         measurement: :size,
         unit: :byte,
         description: "Distribution of completed multipart upload artifact sizes.",
@@ -111,7 +111,7 @@ defmodule Cache.Module.PromExPlugin do
       ),
       distribution(
         [:tuist_cache, :module, :multipart, :parts_count, :distribution],
-        event_name: [:cache, :xcode_module, :multipart, :complete],
+        event_name: [:cache, :module, :multipart, :complete],
         measurement: :parts_count,
         description: "Distribution of parts per completed multipart upload.",
         reporter_options: [buckets: [1, 2, 4, 8, 16, 32, 64, 128]]

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -161,14 +161,6 @@
             proxy_buffering off;
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_remote_redirect;
-            error_page 403 404 = @handle_remote_not_found;
-          '';
-        };
-
-        locations."@handle_remote_not_found" = {
-          extraConfig = ''
-            default_type application/json;
-            return 404 '{"message":"Not found"}';
           '';
         };
 

--- a/cache/test/cache_web/controllers/module_cache_controller_test.exs
+++ b/cache/test/cache_web/controllers/module_cache_controller_test.exs
@@ -76,6 +76,11 @@ defmodule CacheWeb.ModuleCacheControllerTest do
         :ok
       end)
 
+      expect(S3, :exists?, fn key ->
+        assert key == "test-account/test-project/module/builds/ab/c1/#{hash}/#{name}"
+        true
+      end)
+
       expect(S3, :presign_download_url, fn key ->
         assert key == "test-account/test-project/module/builds/ab/c1/#{hash}/#{name}"
         {:ok, "https://example.com/bucket/#{key}?token=abc"}
@@ -121,6 +126,10 @@ defmodule CacheWeb.ModuleCacheControllerTest do
 
       expect(CacheArtifacts, :track_artifact_access, fn _key ->
         :ok
+      end)
+
+      expect(S3, :exists?, fn _key ->
+        true
       end)
 
       expect(S3, :presign_download_url, fn _key ->


### PR DESCRIPTION
## Summary

- Reverts ea66b14e97d3df968af367cf941876127f6f4de6 (#9387) which removed `S3.exists?` from the module download hot path
- Restores the previous behavior including the S3 existence check before serving cached modules