### PR TITLE
fix(docs): remove malformed redirect rule causing root path 404

### DIFF
--- a/docs/.vitepress/locale-redirects.txt
+++ b/docs/.vitepress/locale-redirects.txt
@@ -292,4 +292,3 @@
 /references/project-description/typealiases/settingsdictionary /en/references/project-description/typealiases/settingsdictionary 301
 /:locale/guides/quick-start/create-a-project /:locale/tutorials/xcode/create-a-generated-project 301
 /:locale/guides/quick-start/optimize-workflows /:locale/tutorials/xcode/create-a-generated-project 301
-/en 301


### PR DESCRIPTION
The `_redirects` file generated for Cloudflare Pages had a malformed rule `/en 301` at the end (missing the destination path). This was coming from the last line of `locale-redirects.txt`. Cloudflare Pages may reject the entire redirects file when it encounters an invalid rule, which would explain why `docs.tuist.dev/` was returning a 404 instead of redirecting to `docs.tuist.dev/en`.