### PR TITLE
refactor(cache): make nginx configuration more consistent

### DIFF
--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -87,6 +87,7 @@ http {
         location /internal/local/ {
             internal;
             alias /storage/;
+            types { }
             default_type application/octet-stream;
             gzip off;
             add_header Cache-Control "public, max-age=31536000, immutable";

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -139,6 +139,7 @@
           extraConfig = ''
             internal;
             alias /cas/;
+            types { }
             default_type application/octet-stream;
             gzip off;
             add_header Cache-Control "public, max-age=31536000, immutable";


### PR DESCRIPTION
Follow-up to #9401 
Not a fix, everything works as-is, but makes the whole "we don't guess mime types but explicitly set them according to the API contract" bit consistent across all download routes.
