### PR TITLE
fix(docs): fix root path redirect to /en/

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -380,6 +380,8 @@ export default withMermaid(
         )
         .join("\n");
       const redirects = `
+/ /en/ 301
+/index /en/index 301
 /documentation/tuist/installation /guide/introduction/installation 301
 /documentation/tuist/project-structure /guide/project/directory-structure 301
 /documentation/tuist/command-line-interface /guide/automation/generate 301
@@ -499,7 +501,7 @@ ${await fs.readFile(path.join(import.meta.dirname, "locale-redirects.txt"), {
   encoding: "utf-8",
 })}
     `;
-      fs.writeFile(redirectsPath, redirects);
+      await fs.writeFile(redirectsPath, redirects);
     },
     themeConfig: {
       logo: "/logo.png",

--- a/docs/.vitepress/locale-redirects.txt
+++ b/docs/.vitepress/locale-redirects.txt
@@ -40,8 +40,6 @@
 /guides/start/new-project /en/guides/start/new-project 301
 /guides/start/migrate/swift-package /en/guides/start/migrate/swift-package 301
 /guides/start/swift-package /en/guides/start/swift-package 301
-/ /en/ 301
-/index /en/index 301
 /references/migrations/from-v3-to-v4 /en/references/migrations/from-v3-to-v4 301
 /server/on-premise/metrics /en/server/on-premise/metrics 301
 /server/introduction/authentication /en/server/introduction/authentication 301


### PR DESCRIPTION
The Diataxis PR (#9366) broke the `/ -> /en/` redirect on docs.tuist.dev, causing a 404 when visiting the root URL. The previous fix (#9414) removed a malformed redirect rule but didn't resolve the issue.

This moves the `/ /en/ 301` and `/index /en/index 301` rules from `locale-redirects.txt` (which gets appended at the end of the `_redirects` file) to the very top of the generated `_redirects` in `config.mjs`, ensuring they are processed first. It also adds a missing `await` on `fs.writeFile` to prevent potential race conditions during the build.