### PR TITLE
fix(server,cache): add service_namespace label to Loki log handler

### DIFF
--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -75,6 +75,7 @@ defmodule Cache.Application do
         labels: %{
           app: {:static, "tuist-cache"},
           service_name: {:static, "tuist-cache"},
+          service_namespace: {:static, "tuist"},
           env: {:static, System.get_env("DEPLOY_ENV") || "production"},
           level: :level
         },

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -88,6 +88,7 @@ defmodule Tuist.Application do
         labels: %{
           app: {:static, "tuist-server"},
           service_name: {:static, "tuist-server"},
+          service_namespace: {:static, "tuist"},
           env: {:static, to_string(Environment.env())},
           level: :level
         },


### PR DESCRIPTION
## Summary
- Adds the missing `service_namespace` label to the Loki log handler in both the server and cache applications
- Grafana's trace-to-logs navigation filters by `service_namespace=tuist` (from OTel resource attributes on traces), but the Loki handler wasn't sending that label with logs, so clicking "Logs for this span" returned zero results

## Test plan
- Deploy and verify that clicking "Logs for this span" in Grafana now shows the matching logs