### PR TITLE
fix(cli): add missing tree-shake after focus targets in automation mapper chain

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -157,6 +157,7 @@ public final class GraphMapperFactory: GraphMapperFactorying {
                     excludedTargets: excludedTargets
                 )
             )
+            mappers.append(TreeShakePrunedTargetsGraphMapper())
 
             if !ignoreBinaryCache {
                 let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(


### PR DESCRIPTION
## Summary

When using `tuist test --test-targets TargetA TargetB --build-only --no-selective-testing`, xcodebuild could fail with errors about test bundles that shouldn't be part of the build. The issue was that `FocusTargetsGraphMappers` correctly marked non-included targets as prunable, but `TreeShakePrunedTargetsGraphMapper` only ran inside the `!ignoreBinaryCache` block. This meant that when binary cache was disabled, pruned targets stayed in the graph and their test bundles were still referenced in schemes.

This adds a `TreeShakePrunedTargetsGraphMapper` right after `FocusTargetsGraphMappers` in the automation mapper chain, matching the pattern already used in the OSS `GraphMapperFactory.automation()` and the `default()` mapper chain.

## Test plan

- Verify that `tuist test --test-targets CoreLibTests FeatureATests --build-only --no-selective-testing` only builds the specified test targets and their dependencies, without referencing unrelated test bundles.