### PR TITLE
fix(cli): only cache dependency checkouts in Linux CI jobs

### DIFF
--- a/cli/Sources/TuistServer/Services/ListOrganizationsService.swift
+++ b/cli/Sources/TuistServer/Services/ListOrganizationsService.swift
@@ -37,6 +37,7 @@ public struct ListOrganizationsService: ListOrganizationsServicing {
         case let .ok(okResponse):
             switch okResponse.body {
             case let .json(data):
+                // swiftformat:disable:next preferKeyPath
                 return data.organizations.map { $0.name }
             }
         case let .forbidden(forbiddenResponse):


### PR DESCRIPTION
## Summary
- Fixed Linux Unit Tests linker failure by replacing `map(\.name)` with `map { $0.name }` in `ListOrganizationsService.swift`
- Changed Linux CI jobs to only cache `.build/checkouts` and `.build/registry` instead of the entire `.build` directory

## Context

The Linux Unit Tests job consistently fails with:

```
ListOrganizationsService.swift:40: error: undefined reference to '$sST12TuistSupportE3mapySayqd__Gs7KeyPathCy7ElementQzqd__GlF'
```

Example failing run: https://github.com/tuist/tuist/actions/runs/21982909964/job/63509757864?pr=9445#step:5:6435

**Root cause:** `TuistSupport` is only a dependency of `TuistServer` on macOS (`#if os(macOS)` in Package.swift). However, when `swift test` runs, it builds **all** targets — including `TuistSupport` — making `canImport(TuistSupport)` true even on Linux. Several TuistServer files conditionally import TuistSupport via `#if canImport(TuistSupport)`, which causes the compiler to resolve `map(\.name)` to TuistSupport's `Sequence.map(_ keyPath:)` extension instead of stdlib's implicit KeyPath-to-closure conversion. Since TuistSupport isn't linked into the `tuist` executable on Linux, the linker can't find the symbol.

Note: `swift build --target tuist` (Linux Build job) passes because it doesn't build TuistSupport, so `canImport` is false and the stdlib path is taken.

**Fix:** Use explicit closure syntax `map { $0.name }` which always resolves to stdlib's `map`, avoiding the ambiguous overload.

## Test plan
- [ ] Verify Linux Build job still passes
- [ ] Verify Linux Unit Tests job passes (previously always failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)