### PR TITLE
fix(cli): use Swift Static Linux SDK for fully static binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,6 +511,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
 
+      - name: Cache Static Linux SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.swiftpm/swift-sdks
+          key: static-linux-sdk-swift-6.1.2-${{ matrix.arch }}
+
       - name: Restore cache
         id: cache-restore
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Problem

The tuist Linux binary is built in an Ubuntu-based `swift:6.1` container where `libcurl4-openssl-dev` exports `CURL_OPENSSL_4` versioned symbols. When the binary runs on other distributions like Fedora CoreOS (which ships `libcurl-minimal` without that versioned symbol), the dynamic linker warns:

```
tuist: /lib64/libcurl.so.4: no version information available (required by tuist)
```

The previous fix attempted to statically link just libcurl by removing the `.so` symlink and falling back to `libcurl.a`. While this worked, it was a fragile hack — and the same class of problem could reappear with any other dynamically linked system library.

## Solution

Instead of playing whack-a-mole with individual libraries, switch to Swift's [Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) which produces **fully static musl-based binaries** with zero shared library dependencies. This means:

- No dynamic linker needed at runtime
- No dependency on host system's glibc, libcurl, or any other shared library
- Binary runs identically on Ubuntu, Fedora, Alpine, or any Linux distribution

The build changes from `--static-swift-stdlib` (which only statically links Swift's own stdlib, not system libs) to `--swift-sdk <target>` which cross-compiles against musl libc for a completely self-contained binary.

### Risk

URLSession has an [open runtime crash bug](https://github.com/swiftlang/swift-corelibs-foundation/issues/5092) with the Static Linux SDK (reported against Swift 6.0.1). It may be fixed in 6.1.2. If URLSession crashes at runtime, we'll fall back to the simpler libcurl-only static linking approach.

## Changes

- **`mise/tasks/cli/bundle-linux.sh`**: Replace the libcurl symlink hack and `--static-swift-stdlib` with Static Linux SDK installation + `--swift-sdk` build flag
- **`.github/workflows/release.yml`**: Cache the ~500MB SDK artifact bundle per architecture to avoid re-downloading on every release

## Test plan
- [ ] Build locally with `mise run cli:bundle-linux -- -v`
- [ ] Verify binary is fully static: `ldd build/tuist` → `not a dynamic executable`
- [ ] Run the binary and verify URLSession-based operations work (e.g. `tuist auth` or any server-hitting command)
- [ ] If URLSession crashes at runtime, fall back to the simpler libcurl-only static linking approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)