### PR TITLE
fix(cli): restore cache run analytics on dashboard

### DIFF
--- a/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
@@ -12,6 +12,7 @@
         public static var configuration: CommandConfiguration {
             CommandConfiguration(
                 commandName: "warm",
+                _superCommandName: "cache",
                 abstract: "Warms the local and remote cache."
             )
         }


### PR DESCRIPTION
## Summary
- When `CacheCommand` was refactored from a single command into a parent with subcommands in #9277 (4.137.0), the event name sent to the server changed from `"cache"` to `"warm"` because `CacheWarmCommand` was missing `_superCommandName`
- The server filters cache runs by `name == "cache"`, so they stopped appearing on the dashboard
- Adds `_superCommandName: "cache"` to `CacheWarmCommand`, matching the pattern used by other subcommands like `HashCacheCommand`

## Test plan
- [ ] Run `tuist cache` and verify the command event is sent with `name: "cache"` (not `"warm"`)
- [ ] Verify cache runs appear on the dashboard after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)