### PR TITLE
fix(cli): use BundleToken for Bundle(for:) in TemplatesDirectoryLocator

### DIFF
--- a/cli/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/cli/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -26,6 +26,8 @@ public protocol TemplatesDirectoryLocating {
 }
 
 public struct TemplatesDirectoryLocator: TemplatesDirectoryLocating {
+    private final class BundleToken {}
+
     private let rootDirectoryLocator: RootDirectoryLocating
     private let fileSystem: FileSysteming
 
@@ -54,7 +56,7 @@ public struct TemplatesDirectoryLocator: TemplatesDirectoryLocating {
                     .removingLastComponent()
             }
         #else
-            let maybeBundlePath = try? AbsolutePath(validating: Bundle(for: TemplatesDirectoryLocator.self).bundleURL.path)
+            let maybeBundlePath = try? AbsolutePath(validating: Bundle(for: BundleToken.self).bundleURL.path)
         #endif
         guard let bundlePath = maybeBundlePath else { return nil }
         let paths = [


### PR DESCRIPTION
## Summary
- `TemplatesDirectoryLocator` was converted from a `class` to a `struct` in #9445, but the Release-only code path (`#else` block) uses `Bundle(for:)` which requires `AnyClass`
- This caused the CLI release build to fail with exit code 65: `cannot convert value of type 'TemplatesDirectoryLocator.Type' to expected argument type 'AnyClass'`
- Fix: add a private `BundleToken` class (same pattern used elsewhere in the codebase) and use it for the `Bundle(for:)` call

## Test plan
- [ ] Verify the release workflow succeeds after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)