### PR TITLE
fix(cli): remove OpenAPIURLSession from cross-platform targets for Linux static SDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,6 @@ var tuistServerDependencies: [Target.Dependency] = [
     swiftToolsSupportDependency,
     .product(name: "OpenAPIRuntime", package: "apple.swift-openapi-runtime"),
     .product(name: "HTTPTypes", package: "apple.swift-http-types"),
-    .product(name: "OpenAPIURLSession", package: "apple.swift-openapi-urlsession"),
     .product(name: "KeychainAccess", package: "kishikawakatsumi.KeychainAccess", condition: .when(platforms: [.macOS])),
     .product(name: "Rosalind", package: "tuist.Rosalind", condition: .when(platforms: [.macOS])),
 ]
@@ -192,7 +191,7 @@ var tuistBundleCommandDependencies: [Target.Dependency] = [
     "TuistNooraExtension",
     "TuistConfigLoader",
     .product(name: "Noora", package: "tuist.Noora"),
-    .product(name: "OpenAPIURLSession", package: "apple.swift-openapi-urlsession"),
+    .product(name: "OpenAPIRuntime", package: "apple.swift-openapi-runtime"),
 ]
 var tuistRegistryCommandDependencies: [Target.Dependency] = [
     pathDependency,

--- a/cli/Sources/TuistBundleCommand/Services/BundleListCommandService.swift
+++ b/cli/Sources/TuistBundleCommand/Services/BundleListCommandService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Noora
-import OpenAPIURLSession
+import OpenAPIRuntime
 import Path
 import TuistConfigLoader
 import TuistEnvironment

--- a/cli/Sources/TuistBundleCommand/Services/BundleShowCommandService.swift
+++ b/cli/Sources/TuistBundleCommand/Services/BundleShowCommandService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Mockable
 import Noora
-import OpenAPIURLSession
+import OpenAPIRuntime
 import Path
 import TuistConfigLoader
 import TuistEnvironment

--- a/cli/Sources/TuistServer/Services/AuthenticateService.swift
+++ b/cli/Sources/TuistServer/Services/AuthenticateService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol AuthenticateServicing {

--- a/cli/Sources/TuistServer/Services/CancelOrganizationInviteService.swift
+++ b/cli/Sources/TuistServer/Services/CancelOrganizationInviteService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 public protocol CancelOrganizationInviteServicing {
     func cancelOrganizationInvite(

--- a/cli/Sources/TuistServer/Services/CreateAccountTokenService.swift
+++ b/cli/Sources/TuistServer/Services/CreateAccountTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol CreateAccountTokenServicing {

--- a/cli/Sources/TuistServer/Services/CreateBuildService.swift
+++ b/cli/Sources/TuistServer/Services/CreateBuildService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 #if canImport(TuistXCActivityLog)

--- a/cli/Sources/TuistServer/Services/CreateBundleService.swift
+++ b/cli/Sources/TuistServer/Services/CreateBundleService.swift
@@ -2,7 +2,7 @@ import TuistHTTP
 #if os(macOS)
     import Foundation
     import Mockable
-    import OpenAPIURLSession
+    import OpenAPIRuntime
     import Path
     import Rosalind
 

--- a/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
+++ b/cli/Sources/TuistServer/Services/CreateCommandEventService.swift
@@ -1,7 +1,7 @@
 #if canImport(TuistCore)
     import Foundation
     import Mockable
-    import OpenAPIURLSession
+    import OpenAPIRuntime
     import TuistCore
     import XcodeGraph
 

--- a/cli/Sources/TuistServer/Services/CreateOrganizationInviteService.swift
+++ b/cli/Sources/TuistServer/Services/CreateOrganizationInviteService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol CreateOrganizationInviteServicing {

--- a/cli/Sources/TuistServer/Services/CreateOrganizationService.swift
+++ b/cli/Sources/TuistServer/Services/CreateOrganizationService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol CreateOrganizationServicing {

--- a/cli/Sources/TuistServer/Services/CreateProjectService.swift
+++ b/cli/Sources/TuistServer/Services/CreateProjectService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol CreateProjectServicing {

--- a/cli/Sources/TuistServer/Services/CreateProjectTokenService.swift
+++ b/cli/Sources/TuistServer/Services/CreateProjectTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/CreateTestService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 #if canImport(TuistXCResultService)

--- a/cli/Sources/TuistServer/Services/DeleteAccountService.swift
+++ b/cli/Sources/TuistServer/Services/DeleteAccountService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 public protocol DeleteAccountServicing: Sendable {
     func deleteAccount(

--- a/cli/Sources/TuistServer/Services/DeletePreviewService.swift
+++ b/cli/Sources/TuistServer/Services/DeletePreviewService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public protocol DeletePreviewServicing: Sendable {

--- a/cli/Sources/TuistServer/Services/DeleteProjectService.swift
+++ b/cli/Sources/TuistServer/Services/DeleteProjectService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol DeleteProjectServicing {

--- a/cli/Sources/TuistServer/Services/ExchangeOIDCTokenService.swift
+++ b/cli/Sources/TuistServer/Services/ExchangeOIDCTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol ExchangeOIDCTokenServicing {

--- a/cli/Sources/TuistServer/Services/GetAuthTokenService.swift
+++ b/cli/Sources/TuistServer/Services/GetAuthTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol GetAuthTokenServicing {

--- a/cli/Sources/TuistServer/Services/GetBuildService.swift
+++ b/cli/Sources/TuistServer/Services/GetBuildService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public typealias Build = Operations.getBuild.Output.Ok.Body.jsonPayload

--- a/cli/Sources/TuistServer/Services/GetBundleService.swift
+++ b/cli/Sources/TuistServer/Services/GetBundleService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/GetCacheEndpointsService.swift
+++ b/cli/Sources/TuistServer/Services/GetCacheEndpointsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol GetCacheEndpointsServicing: Sendable {

--- a/cli/Sources/TuistServer/Services/GetCacheRunService.swift
+++ b/cli/Sources/TuistServer/Services/GetCacheRunService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public typealias CacheRun = Operations.getCacheRun.Output.Ok.Body.jsonPayload

--- a/cli/Sources/TuistServer/Services/GetGenerationService.swift
+++ b/cli/Sources/TuistServer/Services/GetGenerationService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public typealias Generation = Operations.getGeneration.Output.Ok.Body.jsonPayload

--- a/cli/Sources/TuistServer/Services/GetOrganizationService.swift
+++ b/cli/Sources/TuistServer/Services/GetOrganizationService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol GetOrganizationServicing {

--- a/cli/Sources/TuistServer/Services/GetOrganizationUsage.swift
+++ b/cli/Sources/TuistServer/Services/GetOrganizationUsage.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol GetOrganizationUsageServicing {

--- a/cli/Sources/TuistServer/Services/GetProjectService.swift
+++ b/cli/Sources/TuistServer/Services/GetProjectService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/GetTestCaseRunService.swift
+++ b/cli/Sources/TuistServer/Services/GetTestCaseRunService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public typealias ServerTestCaseRun = Operations.getTestCaseRun.Output.Ok.Body.jsonPayload

--- a/cli/Sources/TuistServer/Services/GetTestCaseService.swift
+++ b/cli/Sources/TuistServer/Services/GetTestCaseService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 public typealias ServerTestCase = Operations.getTestCase.Output.Ok.Body.jsonPayload

--- a/cli/Sources/TuistServer/Services/ListAccountTokensService.swift
+++ b/cli/Sources/TuistServer/Services/ListAccountTokensService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol ListAccountTokensServicing {

--- a/cli/Sources/TuistServer/Services/ListBuildsService.swift
+++ b/cli/Sources/TuistServer/Services/ListBuildsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListBundlesService.swift
+++ b/cli/Sources/TuistServer/Services/ListBundlesService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListCacheRunsService.swift
+++ b/cli/Sources/TuistServer/Services/ListCacheRunsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListGenerationsService.swift
+++ b/cli/Sources/TuistServer/Services/ListGenerationsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListOrganizationsService.swift
+++ b/cli/Sources/TuistServer/Services/ListOrganizationsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol ListOrganizationsServicing {

--- a/cli/Sources/TuistServer/Services/ListProjectTokensService.swift
+++ b/cli/Sources/TuistServer/Services/ListProjectTokensService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListProjectsService.swift
+++ b/cli/Sources/TuistServer/Services/ListProjectsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol ListProjectsServicing: Sendable {

--- a/cli/Sources/TuistServer/Services/ListTestCaseRunsService.swift
+++ b/cli/Sources/TuistServer/Services/ListTestCaseRunsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/ListTestCasesService.swift
+++ b/cli/Sources/TuistServer/Services/ListTestCasesService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/RefreshAuthTokenService.swift
+++ b/cli/Sources/TuistServer/Services/RefreshAuthTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol RefreshAuthTokenServicing: Sendable {

--- a/cli/Sources/TuistServer/Services/RemoveOrganizationMemberService.swift
+++ b/cli/Sources/TuistServer/Services/RemoveOrganizationMemberService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 public protocol RemoveOrganizationMemberServicing {
     func removeOrganizationMember(

--- a/cli/Sources/TuistServer/Services/RevokeAccountTokenService.swift
+++ b/cli/Sources/TuistServer/Services/RevokeAccountTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol RevokeAccountTokenServicing {

--- a/cli/Sources/TuistServer/Services/RevokeProjectTokenService.swift
+++ b/cli/Sources/TuistServer/Services/RevokeProjectTokenService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/UpdateAccountService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateAccountService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol UpdateAccountServicing {

--- a/cli/Sources/TuistServer/Services/UpdateOrganizationMemberService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateOrganizationMemberService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 public protocol UpdateOrganizationMemberServicing {
     func updateOrganizationMember(

--- a/cli/Sources/TuistServer/Services/UpdateOrganizationService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateOrganizationService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 
 @Mockable
 public protocol UpdateOrganizationServicing {

--- a/cli/Sources/TuistServer/Services/UpdateProjectService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateProjectService.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import OpenAPIURLSession
+import OpenAPIRuntime
 import TuistHTTP
 
 @Mockable

--- a/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
+++ b/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
@@ -2,7 +2,7 @@
     import FileSystem
     import Foundation
     import Mockable
-    import OpenAPIURLSession
+    import OpenAPIRuntime
     import Path
     import TuistHTTP
 


### PR DESCRIPTION
## Summary
- Remove `OpenAPIURLSession` dependency from cross-platform `TuistServer` and `TuistBundleCommand` targets that are compiled for Linux
- Replace `import OpenAPIURLSession` with `import OpenAPIRuntime` in 47 service files that only use types from `OpenAPIRuntime`
- macOS-only targets (`TuistCache`, `TuistCacheEE`) retain `OpenAPIURLSession` as they are never compiled for Linux

## Problem
The Linux CLI release fails because `swift-openapi-urlsession` v1.2.0 uses `pthread_mutex_t` which is unavailable when building with the Swift Static Linux SDK (musl libc). See [failed job](https://github.com/tuist/tuist/actions/runs/21990518414/job/63536420474).

## Test plan
- [ ] Linux CLI release CI builds successfully for both x86_64 and aarch64
- [ ] macOS CI builds and tests pass (no regressions from import changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)