### PR TITLE
fix(cli): use canImport(Musl) for Static Linux SDK compatibility

### DIFF
--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -5,9 +5,11 @@ import Mockable
 import NIOCore
 import Path
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 

--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -1,8 +1,12 @@
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
 
     let systemGlob = Glibc.glob
-#else
+#elseif canImport(Musl)
+    import Musl
+
+    let systemGlob = Musl.glob
+#elseif canImport(Darwin)
     import Darwin
 
     let systemGlob = Darwin.glob

--- a/cli/Sources/TuistSupport/Utils/TemporaryDirectory.swift
+++ b/cli/Sources/TuistSupport/Utils/TemporaryDirectory.swift
@@ -1,6 +1,8 @@
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin.C
 #endif
 import Foundation

--- a/cli/Sources/TuistSupport/Utils/ThreadDumpSignalHandler.swift
+++ b/cli/Sources/TuistSupport/Utils/ThreadDumpSignalHandler.swift
@@ -2,9 +2,11 @@ import Dispatch
 import Foundation
 import TuistEnvironment
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 


### PR DESCRIPTION
## Summary
- Replace `#if os(Linux) import Glibc` with `#if canImport(Glibc)` / `#elseif canImport(Musl)` in cross-platform targets
- The Swift Static Linux SDK uses musl libc where the C library module is named `Musl` instead of `Glibc`
- Follows up on #9456 which removed `OpenAPIURLSession` from cross-platform targets

## Test plan
- [ ] Linux CLI release CI builds successfully for both x86_64 and aarch64
- [ ] macOS CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)