### PR TITLE
fix(cli): fix Linux static SDK build (Musl imports + static linking)

### DIFF
--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -5,9 +5,11 @@ import Mockable
 import NIOCore
 import Path
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 

--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -1,8 +1,12 @@
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
 
     let systemGlob = Glibc.glob
-#else
+#elseif canImport(Musl)
+    import Musl
+
+    let systemGlob = Musl.glob
+#elseif canImport(Darwin)
     import Darwin
 
     let systemGlob = Darwin.glob

--- a/cli/Sources/TuistSupport/Utils/TemporaryDirectory.swift
+++ b/cli/Sources/TuistSupport/Utils/TemporaryDirectory.swift
@@ -1,6 +1,8 @@
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin.C
 #endif
 import Foundation

--- a/cli/Sources/TuistSupport/Utils/ThreadDumpSignalHandler.swift
+++ b/cli/Sources/TuistSupport/Utils/ThreadDumpSignalHandler.swift
@@ -2,9 +2,11 @@ import Dispatch
 import Foundation
 import TuistEnvironment
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
-#else
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(Darwin)
     import Darwin
 #endif
 

--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -50,9 +50,9 @@ else
 fi
 
 echo "==> Building tuist executable (static musl, $SDK_TARGET)"
-swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry --swift-sdk "$SDK_TARGET"
+swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry --swift-sdk "$SDK_TARGET" -Xlinker -static
 
-BIN_PATH=$(swift build --product tuist --configuration release --build-path "$BUILD_PATH" --swift-sdk "$SDK_TARGET" --show-bin-path)
+BIN_PATH=$(swift build --product tuist --configuration release --build-path "$BUILD_PATH" --swift-sdk "$SDK_TARGET" -Xlinker -static --show-bin-path)
 echo "==> Copying binary from $BIN_PATH"
 cp "$BIN_PATH/tuist" $BUILD_DIRECTORY/tuist
 


### PR DESCRIPTION
## Summary
- Replace `#if os(Linux) import Glibc` with `#if canImport(Glibc)` / `#elseif canImport(Musl)` in cross-platform targets — the Swift Static Linux SDK uses musl libc where the C library module is `Musl`, not `Glibc`
- Add `-Xlinker -static` to the build command in `bundle-linux.sh` to force fully static linking, preventing the linker from pulling in system `libcurl` dependencies (`libidn2`, `libldap`) that aren't available as static libraries

## Test plan
- [ ] Linux CLI release CI builds successfully for both x86_64 and aarch64
- [ ] macOS CI builds and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)