### PR TITLE
fix(cache): use non-recursive tmpfiles rule for /cas mount point

### DIFF
--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -103,7 +103,7 @@
   ];
 
   systemd.tmpfiles.rules = [
-    "Z /cas 0755 cache cache - -"
+    "d /cas 0755 cache cache - -"
     "d /cas/tmp 1777 cache cache - -"
     "d /var/lib/cache 0755 cache cache - -"
     "d /run/cache 0777 root root - -"


### PR DESCRIPTION
## Summary

- Fixes `systemd-tmpfiles-setup.service` hanging indefinitely during NixOS boot on cache servers

## Problem

The tmpfiles rule for `/cas` used the `Z` directive, which recursively applies ownership and permissions to the directory **and all files underneath it**. With millions of small CAS artifacts on the `/cas` volume, this caused `systemd-tmpfiles-setup.service` to walk the entire tree at every boot — hanging at "A start job is running for Create System Files and Directories" indefinitely.

## Fix

Changed `Z /cas 0755 cache cache - -` to `d /cas 0755 cache cache - -`.

- `Z` = recursive chmod/chown on the directory and all contents
- `d` = ensure the directory exists with the specified ownership/permissions, without recursing

The files underneath `/cas` are created by the cache application (running as the `cache` user inside Docker), so recursive permission enforcement at boot is unnecessary.

## Test Plan

Deploy to a cache server and verify it boots without hanging on `systemd-tmpfiles-setup.service`.