### PR TITLE
Fix frontmatter syntax error in the generated projects skill

### DIFF
--- a/skills/skills/generated-projects/SKILL.md
+++ b/skills/skills/generated-projects/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-tuist-generated-projects
-description: Guides day-to-day work in Tuist-generated Xcode workspaces: generation, build and test commands, and buildable folders. Use when working in a Tuist-generated project or when users mention `tuist generate`, `xcodebuild test`, or generated workspaces.
+description: Guides day-to-day work in Tuist-generated Xcode workspaces, including generation, build and test commands, and buildable folders. Use when working in a Tuist-generated project or when users mention `tuist generate`, `xcodebuild test`, or generated workspaces.
 ---
 
 # Using Tuist Generated Projects


### PR DESCRIPTION
There's a syntax error in the frontmatter of the [generated projects skill](https://github.com/tuist/agent-skills/pull/2). I'm fixing it here since this is the soure of truth, and they'll get released and pushed to that other repository.