### PR TITLE
fix(app): make TuistSimulator and XcodeGraph available on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,6 +102,8 @@ var tuistServerDependencies: [Target.Dependency] = [
     .product(name: "HTTPTypes", package: "apple.swift-http-types"),
     .product(name: "KeychainAccess", package: "kishikawakatsumi.KeychainAccess", condition: .when(platforms: [.macOS])),
     .product(name: "Rosalind", package: "tuist.Rosalind", condition: .when(platforms: [.macOS])),
+    "TuistSimulator",
+    xcodeGraphDependency,
 ]
 var tuistHTTPDependencies: [Target.Dependency] = [
     "TuistConstants",
@@ -305,8 +307,7 @@ tuistAuthCommandDependencies.append(contentsOf: ["TuistLoader", "TuistSupport"])
 tuistServerDependencies.append(contentsOf: [
     "TuistSupport", "TuistCore", "TuistProcess", "TuistCI",
     "TuistAutomation", "TuistGit", "TuistXCActivityLog",
-    "TuistXCResultService", "TuistSimulator",
-    xcodeGraphDependency,
+    "TuistXCResultService",
 ])
 tuistHTTPDependencies.append(contentsOf: ["TuistSupport", "TuistHAR"])
 tuistCASDependencies.append(contentsOf: ["TuistCache", "TuistCASAnalytics"])

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -831,7 +831,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.uniqueIDGenerator.targetName),
                     .target(name: Module.xcActivityLog.targetName, condition: .when([.macos])),
                     .target(name: Module.xcResultService.targetName, condition: .when([.macos])),
-                    .target(name: Module.simulator.targetName, condition: .when([.macos])),
+                    .target(name: Module.simulator.targetName),
                     .target(name: Module.automation.targetName, condition: .when([.macos])),
                     .target(name: Module.ci.targetName, condition: .when([.macos])),
                     .target(name: Module.process.targetName, condition: .when([.macos])),
@@ -841,7 +841,7 @@ public enum Module: String, CaseIterable {
                     .external(name: "OpenAPIURLSession"),
                     .external(name: "HTTPTypes"),
                     .external(name: "SwiftToolsSupport"),
-                    .external(name: "XcodeGraph", condition: .when([.macos])),
+                    .external(name: "XcodeGraph"),
                     .external(name: "Rosalind", condition: .when([.macos])),
                     .external(name: "KeychainAccess"),
                 ]


### PR DESCRIPTION
## Summary
- Removes the macOS-only platform condition from `TuistSimulator` and `XcodeGraph` dependencies in the `TuistServer` module
- Makes these dependencies available on all platforms, fixing builds that target iOS (e.g. tuist previews)

## Test plan
- [ ] Verify the project generates successfully with `tuist generate --no-open`
- [ ] Verify the workspace builds for macOS
- [ ] Verify tuist previews works on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)