### PR TITLE
fix(cli): increase inspect build activity log timeout and make it configurable

### DIFF
--- a/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Inspect/InspectBuildCommandService.swift
@@ -146,8 +146,9 @@ struct InspectBuildCommandService {
         referenceDate: Date
     ) async throws -> AbsolutePath {
         var mostRecentActivityLogPath: AbsolutePath!
+        let timeoutSeconds = Int(Environment.current.variables["TUIST_INSPECT_BUILD_TIMEOUT"] ?? "") ?? 10
         try await withTimeout(
-            .seconds(5),
+            .seconds(timeoutSeconds),
             onTimeout: {
                 throw InspectBuildCommandServiceError.mostRecentActivityLogNotFound(projectPath)
             }


### PR DESCRIPTION
## Summary
- Bumps the timeout for finding the most recent activity log during `inspect build` from 5s to 10s
- Makes the timeout configurable via the `TUIST_INSPECT_BUILD_TIMEOUT` environment variable (in seconds)

## Test plan
- [ ] Verify `inspect build` uses the new 10s default timeout
- [ ] Set `TUIST_INSPECT_BUILD_TIMEOUT=3` and verify a shorter timeout is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)