### PR TITLE
fix(cli): restore TuistSimulator to macOS-only block in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,8 +102,6 @@ var tuistServerDependencies: [Target.Dependency] = [
     .product(name: "HTTPTypes", package: "apple.swift-http-types"),
     .product(name: "KeychainAccess", package: "kishikawakatsumi.KeychainAccess", condition: .when(platforms: [.macOS])),
     .product(name: "Rosalind", package: "tuist.Rosalind", condition: .when(platforms: [.macOS])),
-    "TuistSimulator",
-    xcodeGraphDependency,
 ]
 var tuistHTTPDependencies: [Target.Dependency] = [
     "TuistConstants",
@@ -307,7 +305,8 @@ tuistAuthCommandDependencies.append(contentsOf: ["TuistLoader", "TuistSupport"])
 tuistServerDependencies.append(contentsOf: [
     "TuistSupport", "TuistCore", "TuistProcess", "TuistCI",
     "TuistAutomation", "TuistGit", "TuistXCActivityLog",
-    "TuistXCResultService",
+    "TuistXCResultService", "TuistSimulator",
+    xcodeGraphDependency,
 ])
 tuistHTTPDependencies.append(contentsOf: ["TuistSupport", "TuistHAR"])
 tuistCASDependencies.append(contentsOf: ["TuistCache", "TuistCASAnalytics"])


### PR DESCRIPTION
## Summary
- Fixes the Linux CLI release build broken by #9464
- Moves `TuistSimulator` and `xcodeGraphDependency` back into the `#if os(macOS)` block in `Package.swift`, since `TuistSimulator` is only defined as a target inside that block
- The `Module.swift` changes from #9464 (removing `.when([.macos])` conditions) are preserved, so TuistSimulator and XcodeGraph remain available on iOS via Tuist project generation

## Test plan
- [ ] Verify Linux CLI release build passes in CI
- [ ] Verify macOS build still compiles TuistServer with TuistSimulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)