### PR TITLE
refactor(cli): move file element validation from mappers to linter

### DIFF
--- a/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -156,8 +156,10 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
         )
 
         // Lint Manifests
-        let workspaceLintingIssues = manifestLinter.lint(workspace: allManifests.workspace)
-        let projectLintingIssues = manifestProjects.flatMap { manifestLinter.lint(project: $0.value) }
+        let workspaceLintingIssues = try await manifestLinter.lint(workspace: allManifests.workspace, path: allManifests.path)
+        let projectLintingIssues = try await manifestProjects.concurrentFlatMap {
+            try await manifestLinter.lint(project: $0.value, path: $0.key)
+        }
         let lintingIssues = workspaceLintingIssues + projectLintingIssues
         try lintingIssues.printAndThrowErrorsIfNeeded()
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
-import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -36,30 +35,15 @@ extension XcodeGraph.CopyFileElement {
                 files = []
             }
 
-            if files.isEmpty {
-                if FileHandler.shared.isFolder(path) {
-                    Logger.current
-                        .warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
-                } else {
-                    // FIXME: This should be done in a linter.
-                    Logger.current.warning("No files found at: \(path.pathString)")
-                }
-            }
-
             return files
         }
 
         func folderReferences(_ path: AbsolutePath) async throws -> [AbsolutePath] {
             guard try await fileSystem.exists(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current.warning("\(path.pathString) does not exist")
                 return []
             }
 
             guard FileHandler.shared.isFolder(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current
-                    .warning("\(path.pathString) is not a directory - folder reference paths need to point to directories")
                 return []
             }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
-import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -47,30 +46,15 @@ extension XcodeGraph.FileElement {
                 files = []
             }
 
-            if files.isEmpty {
-                if FileHandler.shared.isFolder(path) {
-                    Logger.current
-                        .warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
-                } else if !path.isGlobPath {
-                    // FIXME: This should be done in a linter.
-                    Logger.current.warning("No files found at: \(path.pathString)")
-                }
-            }
-
             return files
         }
 
         func folderReferences(_ path: AbsolutePath) async throws -> [AbsolutePath] {
             guard try await fileSystem.exists(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current.warning("\(path.pathString) does not exist")
                 return []
             }
 
             guard FileHandler.shared.isFolder(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current
-                    .warning("\(path.pathString) is not a directory - folder reference paths need to point to directories")
                 return []
             }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
-import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -43,16 +42,6 @@ extension XcodeGraph.ResourceFileElement {
                 files = []
             }
 
-            if files.isEmpty {
-                if FileHandler.shared.isFolder(path) {
-                    Logger.current
-                        .warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
-                } else if !path.isGlobPath {
-                    // FIXME: This should be done in a linter.
-                    Logger.current.warning("No files found at: \(path.pathString)")
-                }
-            }
-
             return files
                 .compactMap { $0.opaqueParentDirectory() ?? $0 }
                 .uniqued()
@@ -60,15 +49,10 @@ extension XcodeGraph.ResourceFileElement {
 
         func folderReferences(_ path: AbsolutePath) async throws -> [AbsolutePath] {
             guard try await fileSystem.exists(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current.warning("\(path.pathString) does not exist")
                 return []
             }
 
             guard FileHandler.shared.isFolder(path) else {
-                // FIXME: This should be done in a linter.
-                Logger.current
-                    .warning("\(path.pathString) is not a directory - folder reference paths need to point to directories")
                 return []
             }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
@@ -4,7 +4,6 @@ import Path
 import ProjectDescription
 import TuistConstants
 import TuistCore
-import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -33,13 +32,6 @@ extension XcodeGraph.Workspace {
             .map(\.parentDirectory)
             .filter { $0.basename != Constants.tuistDirectoryName && !$0.pathString.contains(".build/checkouts") }
             .uniqued()
-
-            if projects.isEmpty {
-                // FIXME: This should be done in a linter.
-                // Before we can do that we have to change the linters to run with the TuistCore models and not the
-                // ProjectDescription ones.
-                Logger.current.warning("No projects found at: \(path.pathString)")
-            }
 
             return Array(projects)
         }

--- a/cli/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/cli/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -1,11 +1,14 @@
+import FileSystem
+import Path
 import ProjectDescription
 import TuistCore
 import TuistSupport
 import XCTest
 
 @testable import TuistLoader
+@testable import TuistTesting
 
-class ManifestLinterTests: XCTestCase {
+final class ManifestLinterTests: TuistUnitTestCase {
     var subject: ManifestLinter!
 
     override func setUp() {
@@ -20,7 +23,7 @@ class ManifestLinterTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_lint_project_duplicateConfigurationNames() {
+    func test_lint_project_duplicateConfigurationNames() async throws {
         // Given
         let settings: Settings = .settings(configurations: [
             .debug(name: "A"),
@@ -31,9 +34,10 @@ class ManifestLinterTests: XCTestCase {
         ])
 
         let project = Project.test(name: "MyProject", settings: settings)
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(project: project)
+        let results = try await subject.lint(project: project, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -46,7 +50,7 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_target_duplicateConfigurationNames() {
+    func test_lint_target_duplicateConfigurationNames() async throws {
         // Given
         let settings: Settings = .settings(configurations: [
             .debug(name: "A"),
@@ -57,9 +61,10 @@ class ManifestLinterTests: XCTestCase {
         ])
 
         let project = Project.test(targets: [.test(name: "MyFramework", settings: settings)])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(project: project)
+        let results = try await subject.lint(project: project, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -72,15 +77,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_project_duplicateTargetNames() throws {
+    func test_lint_project_duplicateTargetNames() async throws {
         // Given
         let targetA = Target.test(name: "A")
         let targetADuplicated = Target.test(name: "A")
         let targetB = Target.test(name: "B")
         let project = Project.test(targets: [targetA, targetADuplicated, targetB])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(project: project)
+        let results = try await subject.lint(project: project, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -89,15 +95,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInBuildAction() {
+    func test_lint_workspace_scheme_missingProjectPathInBuildAction() async throws {
         // Given
 
         let buildAction = BuildAction.buildAction(targets: [.target("TargetA")])
         let scheme = Scheme.scheme(name: "MyScheme", buildAction: buildAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -109,14 +116,15 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInRunAction() {
+    func test_lint_workspace_scheme_missingProjectPathInRunAction() async throws {
         // Given
         let runAction = RunAction.runAction(expandVariableFromTarget: .target("TargetA"))
         let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -128,14 +136,15 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInProfileAction() {
+    func test_lint_workspace_scheme_missingProjectPathInProfileAction() async throws {
         // Given
         let profileAction = ProfileAction.profileAction(executable: .target("TargetA"))
         let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -147,14 +156,15 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInTestAction() {
+    func test_lint_workspace_scheme_missingProjectPathInTestAction() async throws {
         // Given
         let testAction = TestAction.test(targets: [.testableTarget(target: .target("TargetA"))])
         let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -166,15 +176,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInBuildActionPreActions() {
+    func test_lint_workspace_scheme_missingProjectPathInBuildActionPreActions() async throws {
         // Given
         let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let buildAction = BuildAction.buildAction(targets: [], preActions: preActions)
         let scheme = Scheme.scheme(name: "MyScheme", buildAction: buildAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -186,15 +197,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInRunActionPreActions() {
+    func test_lint_workspace_scheme_missingProjectPathInRunActionPreActions() async throws {
         // Given
         let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let runAction = RunAction.runAction(preActions: preActions)
         let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -206,15 +218,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInProfileActionPreActions() {
+    func test_lint_workspace_scheme_missingProjectPathInProfileActionPreActions() async throws {
         // Given
         let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let profileAction = ProfileAction.profileAction(preActions: preActions)
         let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -226,15 +239,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInTestActionPreActions() {
+    func test_lint_workspace_scheme_missingProjectPathInTestActionPreActions() async throws {
         // Given
         let preActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let testAction = TestAction.targets([], preActions: preActions)
         let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -246,15 +260,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInRunActionPostActions() {
+    func test_lint_workspace_scheme_missingProjectPathInRunActionPostActions() async throws {
         // Given
         let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let runAction = RunAction.runAction(postActions: postActions)
         let scheme = Scheme.scheme(name: "MyScheme", runAction: runAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -266,15 +281,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInProfileActionPostActions() {
+    func test_lint_workspace_scheme_missingProjectPathInProfileActionPostActions() async throws {
         // Given
         let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let profileAction = ProfileAction.profileAction(postActions: postActions)
         let scheme = Scheme.scheme(name: "MyScheme", profileAction: profileAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -286,15 +302,16 @@ class ManifestLinterTests: XCTestCase {
         )))
     }
 
-    func test_lint_workspace_scheme_missingProjectPathInTestActionPostActions() {
+    func test_lint_workspace_scheme_missingProjectPathInTestActionPostActions() async throws {
         // Given
         let postActions = [ExecutionAction.executionAction(scriptText: "", target: .target("TargetA"))]
         let testAction = TestAction.targets([], preActions: postActions)
         let scheme = Scheme.scheme(name: "MyScheme", testAction: testAction)
         let workspace = Workspace.test(schemes: [scheme])
+        let path = try temporaryPath()
 
         // When
-        let results = subject.lint(workspace: workspace)
+        let results = try await subject.lint(workspace: workspace, path: path)
 
         // Then
         XCTAssertTrue(results.contains(LintingIssue(
@@ -304,5 +321,125 @@ class ManifestLinterTests: XCTestCase {
             """,
             severity: .error
         )))
+    }
+
+    // MARK: - File Element Linting Tests
+
+    func test_lint_project_fileElementNotFound() async throws {
+        // Given
+        let path = try temporaryPath()
+        let nonExistentPath = path.appending(component: "NonExistent.swift")
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.glob(pattern: .path(nonExistentPath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: "No files found at: \(nonExistentPath.pathString)",
+            severity: .warning
+        )))
+    }
+
+    func test_lint_project_folderReferenceNotFound() async throws {
+        // Given
+        let path = try temporaryPath()
+        let nonExistentPath = path.appending(component: "NonExistentFolder")
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.folderReference(path: .path(nonExistentPath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: "\(nonExistentPath.pathString) does not exist",
+            severity: .warning
+        )))
+    }
+
+    func test_lint_project_folderReferenceIsNotDirectory() async throws {
+        // Given
+        let path = try temporaryPath()
+        let filePath = path.appending(component: "File.txt")
+        try FileHandler.shared.touch(filePath)
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.folderReference(path: .path(filePath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: "\(filePath.pathString) is not a directory - folder reference paths need to point to directories",
+            severity: .warning
+        )))
+    }
+
+    func test_lint_project_directoryUsedAsGlob() async throws {
+        // Given
+        let path = try temporaryPath()
+        let folderPath = path.appending(component: "Folder")
+        try FileHandler.shared.createFolder(folderPath)
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.glob(pattern: .path(folderPath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertTrue(results.contains(LintingIssue(
+            reason: "'\(folderPath.pathString)' is a directory, try using: '\(folderPath.pathString)/**' to list its files",
+            severity: .warning
+        )))
+    }
+
+    func test_lint_project_validFileElement() async throws {
+        // Given
+        let path = try temporaryPath()
+        let filePath = path.appending(component: "File.swift")
+        try FileHandler.shared.touch(filePath)
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.glob(pattern: .path(filePath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertFalse(results.contains { $0.reason.contains(filePath.pathString) })
+    }
+
+    func test_lint_project_validFolderReference() async throws {
+        // Given
+        let path = try temporaryPath()
+        let folderPath = path.appending(component: "Folder")
+        try FileHandler.shared.createFolder(folderPath)
+        let project = Project.test(
+            targets: [
+                .test(additionalFiles: [.folderReference(path: .path(folderPath.pathString))]),
+            ]
+        )
+
+        // When
+        let results = try await subject.lint(project: project, path: path)
+
+        // Then
+        XCTAssertFalse(results.contains { $0.reason.contains(folderPath.pathString) })
     }
 }


### PR DESCRIPTION
## Why

Several manifest mappers (FileElement, ResourceFileElement, CopyFileElement, Workspace) contained file validation logic with FIXME comments stating "This should be done in a linter." The validation was happening during model conversion, logging warnings directly via `Logger.current.warning()` instead of going through the proper linting system.

This made the validation:
- Inconsistent with other validations that use `LintingIssue`
- Harder to test in isolation
- Mixed concerns between mapping (conversion) and validation (linting)

## What

**ManifestLinter changes:**
- Convert `ManifestLinting` protocol to async to support file system operations
- Add `FileSysteming` and `RootDirectoryLocating` dependencies
- Implement file element validation methods:
  - `lintFileElement()` - validates glob patterns and folder references
  - `lintResourceFileElement()` - validates resource file elements  
  - `lintCopyFileElement()` - validates copy file elements
  - `lintGlobPattern()` - checks if glob matches any files, warns about directories used as globs
  - `lintFolderReference()` - checks folder existence and type
  - `lintWorkspaceProjects()` - validates workspace project paths exist

**Mapper changes:**
- Remove `TuistLogging` imports from FileElement, ResourceFileElement, CopyFileElement, and Workspace mappers
- Remove `Logger.current.warning()` calls and FIXME comments
- Mappers now silently return empty arrays for missing files (linter handles warnings)

**ManifestGraphLoader changes:**
- Update to call async linter methods with path parameter

## Test plan

- [x] Add new tests for file element validation in `ManifestLinterTests`:
  - `test_lint_project_fileElementNotFound`
  - `test_lint_project_folderReferenceNotFound`
  - `test_lint_project_folderReferenceIsNotDirectory`
  - `test_lint_project_directoryUsedAsGlob`
  - `test_lint_project_validFileElement`
  - `test_lint_project_validFolderReference`
- [x] Convert existing tests to async
- [ ] Run `tuist generate` on a project with missing file paths and verify warnings appear