### PR TITLE
fix(cli): enable HTTP logging and server warnings on Linux

### DIFF
--- a/cli/Sources/TuistHTTP/OutputWarningsMiddleware.swift
+++ b/cli/Sources/TuistHTTP/OutputWarningsMiddleware.swift
@@ -2,10 +2,7 @@ import Foundation
 import HTTPTypes
 import OpenAPIRuntime
 
-#if os(macOS)
-    import TuistAlert
-    import TuistSupport
-#endif
+import TuistAlert
 
 public enum OutputWarningsMiddlewareError: LocalizedError {
     case couldntConvertToData
@@ -52,9 +49,7 @@ public struct OutputWarningsMiddleware: ClientMiddleware {
             throw OutputWarningsMiddlewareError.invalidSchema
         }
 
-        #if os(macOS)
-            json.forEach { AlertController.current.warning(.alert("\($0)")) }
-        #endif
+        json.forEach { AlertController.current.warning(.alert("\($0)")) }
 
         return (response, body)
     }

--- a/cli/Sources/TuistHTTP/VerboseLoggingMiddleware.swift
+++ b/cli/Sources/TuistHTTP/VerboseLoggingMiddleware.swift
@@ -2,10 +2,7 @@ import Foundation
 import HTTPTypes
 import OpenAPIRuntime
 
-#if os(macOS)
-    import TuistLogging
-    import TuistSupport
-#endif
+import TuistLogging
 
 /// A middleware that outputs in debug mode the request and responses sent and received from the server
 public struct VerboseLoggingMiddleware: ClientMiddleware {
@@ -23,30 +20,26 @@ public struct VerboseLoggingMiddleware: ClientMiddleware {
         next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
     ) async throws -> (HTTPResponse, HTTPBody?) {
         let (requestBodyToLog, requestBodyForNext) = try await process(body)
-        #if os(macOS)
-            Logger.current.debug("""
-            Sending HTTP request to \(serviceName):
-              - Method: \(request.method.rawValue)
-              - URL: \(baseURL.absoluteString)
-              - Path: \(request.path ?? "")
-              - Body: \(requestBodyToLog)
-              - Headers: \(request.headerFields)
-            """)
-        #endif
+        Logger.current.debug("""
+        Sending HTTP request to \(serviceName):
+          - Method: \(request.method.rawValue)
+          - URL: \(baseURL.absoluteString)
+          - Path: \(request.path ?? "")
+          - Body: \(requestBodyToLog)
+          - Headers: \(request.headerFields)
+        """)
 
         let (response, responseBody) = try await next(request, requestBodyForNext, baseURL)
         let (responseBodyToLog, responseBodyForNext) = try await process(responseBody)
 
-        #if os(macOS)
-            Logger.current.debug("""
-            Received HTTP response from \(serviceName):
-              - URL: \(baseURL.absoluteString)
-              - Path: \(request.path ?? "")
-              - Status: \(response.status.code)
-              - Body: \(responseBodyToLog)
-              - Headers: \(response.headerFields)
-            """)
-        #endif
+        Logger.current.debug("""
+        Received HTTP response from \(serviceName):
+          - URL: \(baseURL.absoluteString)
+          - Path: \(request.path ?? "")
+          - Status: \(response.status.code)
+          - Body: \(responseBodyToLog)
+          - Headers: \(response.headerFields)
+        """)
 
         return (response, responseBodyForNext)
     }


### PR DESCRIPTION
## Summary
- Removed overly broad `#if os(macOS)` guards from `VerboseLoggingMiddleware` and `OutputWarningsMiddleware` in `TuistHTTP`
- `TuistLogging` and `TuistAlert` are already cross-platform dependencies of `TuistHTTP`, so the guards were unnecessarily disabling verbose HTTP logging and server warning output on Linux
- The unused `import TuistSupport` (macOS-only) was also removed from both files

## Test plan
- [x] macOS workspace build passes (`Tuist-Workspace` scheme, 0 errors)
- [ ] Linux CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)