### PR TITLE
fix(server): ignore Bandit.HTTPError in Sentry and handle it in cache body reader

### DIFF
--- a/cache/lib/cache/body_reader.ex
+++ b/cache/lib/cache/body_reader.ex
@@ -35,6 +35,9 @@ defmodule Cache.BodyReader do
     |> Plug.Conn.read_body(merged_opts)
     |> handle_read_result(conn, merged_opts, :store, max_bytes)
   rescue
+    Bandit.HTTPError ->
+      {:error, :cancelled, conn}
+
     Bandit.TransportError ->
       {:error, :cancelled, conn}
   end
@@ -54,6 +57,9 @@ defmodule Cache.BodyReader do
     |> Plug.Conn.read_body(merged_opts)
     |> handle_device_result(conn, merged_opts, writer, max_bytes)
   rescue
+    Bandit.HTTPError ->
+      {:error, :cancelled, conn}
+
     Bandit.TransportError ->
       {:error, :cancelled, conn}
   end
@@ -107,6 +113,9 @@ defmodule Cache.BodyReader do
       {:ok, _, conn_after} -> {:ok, conn_after}
       {:error, _reason, conn_after} -> {:error, conn_after}
     end
+  rescue
+    Bandit.HTTPError -> {:error, conn}
+    Bandit.TransportError -> {:error, conn}
   end
 
   defp handle_read_result(result, conn, opts, mode, max_bytes) do
@@ -174,6 +183,9 @@ defmodule Cache.BodyReader do
     |> Plug.Conn.read_body(chunk_opts)
     |> handle_loop_result(conn, opts, bytes_read, writer, max_bytes)
   rescue
+    Bandit.HTTPError ->
+      {:error, :cancelled, conn}
+
     Bandit.TransportError ->
       {:error, :cancelled, conn}
   end

--- a/tuist_common/lib/tuist_common/sentry_event_filter.ex
+++ b/tuist_common/lib/tuist_common/sentry_event_filter.ex
@@ -20,6 +20,7 @@ defmodule TuistCommon.SentryEventFilter do
   """
 
   @default_ignored_exceptions [
+    Bandit.HTTPError,
     Bandit.TransportError,
     Phoenix.Router.NoRouteError
   ]

--- a/tuist_common/test/tuist_common/sentry_event_filter_test.exs
+++ b/tuist_common/test/tuist_common/sentry_event_filter_test.exs
@@ -13,6 +13,11 @@ defmodule TuistCommon.SentryEventFilterTest do
   end
 
   describe "before_send/1" do
+    test "excludes Bandit.HTTPError" do
+      event = event(%{original_exception: %Bandit.HTTPError{message: "Body read timeout"}})
+      assert SentryEventFilter.before_send(event) == false
+    end
+
     test "excludes Bandit.TransportError" do
       event = event(%{original_exception: %Bandit.TransportError{message: "test"}})
       assert SentryEventFilter.before_send(event) == false


### PR DESCRIPTION
## Summary

- Adds `Bandit.HTTPError` to the shared Sentry event filter so body read timeouts stop consuming our Sentry quota (~55K events across server and cache)
- Rescues `Bandit.HTTPError` in the cache `BodyReader` functions (`read`, `read_to_device`, `drain`, `read_loop`) alongside the existing `Bandit.TransportError` handling, so client disconnects during uploads are handled gracefully instead of bubbling up as unhandled exceptions

## Test plan

- [x] `tuist_common` Sentry filter tests pass (9 tests, including new `Bandit.HTTPError` test)
- [x] `cache` body reader tests pass