### PR TITLE
chore(cli): pass --build-system to ProjectCreateCommand in acceptance test fixture

### DIFF
--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
@@ -79,7 +79,7 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
                                 )
                                 try await TuistTest.run(
                                     ProjectCreateCommand.self,
-                                    [fullHandle, "--path", fixtureTemporaryDirectory.pathString]
+                                    [fullHandle, "--path", fixtureTemporaryDirectory.pathString, "--build-system", "xcode"]
                                 )
                                 resetUI()
 


### PR DESCRIPTION
## Summary
- The `ProjectCreateCommand` now prompts for a build system via `singleChoicePrompt` when none is specified (added with Gradle support)
- `NooraMock` delegates prompt calls to the real `Noora` instance, which crashes in non-interactive test terminals at `SingleChoicePrompt.run(options:)`
- All 8 `TuistCacheEECanaryAcceptanceTests` were failing with: `Crash: xctest at SingleChoicePrompt.run<A>(options:)`
- Passing `--build-system xcode` explicitly in the fixture trait avoids the interactive prompt

## Test plan
- [ ] Verify `TuistCacheEECanaryAcceptanceTests` pass (all 8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)