### PR TITLE
fix(server): filter github webhook body read timeouts in Sentry

### DIFF
--- a/server/lib/tuist/sentry_event_filter.ex
+++ b/server/lib/tuist/sentry_event_filter.ex
@@ -11,7 +11,67 @@ defmodule Tuist.SentryEventFilter do
     TuistWeb.Errors.UnauthorizedError
   ]
 
+  def before_send(%Sentry.Event{} = event) do
+    if github_webhook_body_read_timeout?(event) do
+      false
+    else
+      TuistCommon.SentryEventFilter.before_send(event, @additional_ignored_exceptions)
+    end
+  end
+
   def before_send(event) do
     TuistCommon.SentryEventFilter.before_send(event, @additional_ignored_exceptions)
   end
+
+  defp github_webhook_body_read_timeout?(event) do
+    body_read_timeout?(event) and github_webhook_url?(event)
+  end
+
+  defp body_read_timeout?(%Sentry.Event{original_exception: %Bandit.HTTPError{message: "Body read timeout"}}), do: true
+
+  defp body_read_timeout?(%Sentry.Event{exception: exceptions}) when is_list(exceptions) do
+    Enum.any?(exceptions, fn
+      %Sentry.Interfaces.Exception{type: "Bandit.HTTPError", value: "Body read timeout"} -> true
+      %{type: "Bandit.HTTPError", value: "Body read timeout"} -> true
+      _ -> false
+    end)
+  end
+
+  defp body_read_timeout?(_event), do: false
+
+  defp github_webhook_url?(event) do
+    case event_url(event) do
+      nil ->
+        false
+
+      url ->
+        case URI.parse(url) do
+          %URI{path: "/webhooks/github"} -> true
+          _ -> false
+        end
+    end
+  end
+
+  defp event_url(%Sentry.Event{request: %Sentry.Interfaces.Request{url: url}}) when is_binary(url), do: url
+
+  defp event_url(%Sentry.Event{request: %{url: url}}) when is_binary(url), do: url
+  defp event_url(%Sentry.Event{tags: tags}), do: tag_value(tags, "url")
+  defp event_url(_event), do: nil
+
+  defp tag_value(tags, key) when is_map(tags), do: tag_value(Map.to_list(tags), key)
+
+  defp tag_value(tags, key) when is_list(tags) do
+    Enum.find_value(tags, fn
+      {tag_key, tag_value} when is_binary(tag_value) ->
+        if to_string(tag_key) == key, do: tag_value
+
+      %{key: tag_key, value: tag_value} when is_binary(tag_value) ->
+        if to_string(tag_key) == key, do: tag_value
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp tag_value(_tags, _key), do: nil
 end

--- a/server/test/tuist/sentry_event_filter_test.exs
+++ b/server/test/tuist/sentry_event_filter_test.exs
@@ -1,0 +1,45 @@
+defmodule Tuist.SentryEventFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.SentryEventFilter
+
+  defp event(overrides) do
+    defaults = %{
+      event_id: String.duplicate("a", 32),
+      timestamp: "2020-01-01T00:00:00Z"
+    }
+
+    struct!(Sentry.Event, Map.merge(defaults, overrides))
+  end
+
+  describe "before_send/1" do
+    test "excludes webhook body read timeout errors" do
+      event =
+        event(%{
+          exception: [
+            %Sentry.Interfaces.Exception{type: "Bandit.HTTPError", value: "Body read timeout"}
+          ],
+          tags: [{"url", "http://tuist.dev/webhooks/github"}]
+        })
+
+      assert SentryEventFilter.before_send(event) == false
+    end
+
+    test "allows body read timeout errors on non-webhook URLs" do
+      event =
+        event(%{
+          exception: [
+            %Sentry.Interfaces.Exception{type: "Bandit.HTTPError", value: "Body read timeout"}
+          ],
+          tags: [{"url", "http://tuist.dev/api/v1/builds"}]
+        })
+
+      assert SentryEventFilter.before_send(event) == event
+    end
+
+    test "still applies shared sentry event filters" do
+      event = event(%{original_exception: %Bandit.TransportError{message: "test"}})
+      assert SentryEventFilter.before_send(event) == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
**Problem:** Sentry issue [TUIST-7](https://tuist.sentry.io/issues/91210208/?query=is%3Aunresolved&referrer=issue-stream) keeps receiving `Bandit.HTTPError: Body read timeout` for `POST /webhooks/github` even after webhook timeout handling was added in [#9327](https://github.com/tuist/tuist/pull/9327).

**Why this still happened:** The webhook plug now rescues request timeouts and returns `408`, but the server also runs `Sentry.LoggerHandler`, and Bandit still logs these timeouts at error level. Those log events were not filtered by the existing `before_send` rules.

## What Changed
- Added a targeted filter in `Tuist.SentryEventFilter` to drop events only when all conditions match:
  - Exception is `Bandit.HTTPError` with value/message `Body read timeout`
  - Request/tag URL path is exactly `/webhooks/github`
- Added tests in `server/test/tuist/sentry_event_filter_test.exs` to verify:
  - Matching webhook timeout events are dropped
  - Non-webhook timeout events are preserved
  - Shared default filter behavior still works

## Rationale
**Keep useful signal, remove known noise.**

This keeps Sentry visibility for other `Bandit.HTTPError` failures and other routes, while removing a high-volume, expected timeout pattern from GitHub webhook delivery.

## Alternatives Considered
- **Ignore `Bandit.HTTPError` globally:** too broad; risks hiding real transport/runtime issues.
- **Disable Sentry logger handler:** too broad; would reduce observability for unrelated logger-emitted failures.
- **Rely only on read timeout tweaks / request handling:** already done, but logger-emitted events still reached Sentry.

## Testing
- Ran targeted tests locally:
  - `mix test test/tuist/sentry_event_filter_test.exs test/tuist_web/plugs/webhook_plug_test.exs`
- Result: `13 tests, 0 failures`
