### PR TITLE
chore(server): move erlang and elixir tool definitions to root mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
     tuist = "4.146.2"
     swiftlint = "0.59.1"
+    "elixir" = "1.19.1"
+    "erlang" = "28.1"
     swiftformat = "0.58.7"
     git-cliff = "2.6.0"
     sops = "3.9.3"

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -9,7 +9,5 @@ TUIST_SECRET_KEY_BASE = "rpux4+W/oBey0drSFOctyIbppOG2A9VUUuTMC1WaM8xZgYxA6gg4yry
   "ubi:aquasecurity/trivy" = "0.63.0"
   "clickhouse" = "26.1.2"
   "npm:prettier" = "3.4.2"
-  "elixir" = "1.19.1"
-  "erlang" = "28.1"
   "asdf:aeons/asdf-minio" = "latest"
   "npm:appium" = "3.0.1"


### PR DESCRIPTION
## Summary
- Moved `erlang` and `elixir` tool definitions from `server/mise.toml` to the root `mise.toml`
- When these tools are only in `server/mise.toml`, shells started from the root directory resolve different binary paths than shells started from `server/`, causing full BEAM recompilation every time you switch between the two

## Test plan
- [ ] Run `mix compile` from `server/` directory
- [ ] Run `mix compile` from root directory (via `cd server && mix compile`)
- [ ] Verify no recompilation occurs when switching between the two

🤖 Generated with [Claude Code](https://claude.com/claude-code)