### PR TITLE
fix(cache): re-inject Content-Version header for registry requests served via nginx

### DIFF
--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -12,6 +12,14 @@ http {
 
     keepalive_requests 10000;
 
+    # Swift Package Registry requires a Content-Version response header.
+    # X-Accel-Redirect to proxy_pass locations replaces upstream headers,
+    # so we re-inject it only for registry requests.
+    map $request_uri $registry_content_version {
+        "~^/api/registry/swift/" "1";
+        default "";
+    }
+
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
@@ -91,6 +99,7 @@ http {
             default_type application/octet-stream;
             gzip off;
             add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Content-Version $registry_content_version;
         }
 
         location ~ ^/internal/remote/(.*?)/(.*?)/(.*) {
@@ -104,6 +113,7 @@ http {
             set $download_url $1://$2/$3;
             proxy_set_header Host $2;
             proxy_pass $download_url$is_args$args;
+            add_header Content-Version $registry_content_version;
             proxy_request_buffering off;
             proxy_buffering off;
             proxy_intercept_errors on;
@@ -125,6 +135,7 @@ http {
             proxy_hide_header Content-Type;
             default_type application/octet-stream;
             proxy_pass $saved_redirect_location;
+            add_header Content-Version $registry_content_version;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Re-injects the `Content-Version: 1` response header at the nginx layer for Swift Package Registry requests. The Elixir controller sets this header, but nginx's X-Accel-Redirect mechanism strips upstream headers when serving files from internal locations (`/internal/local/`, `/internal/remote/`, `@handle_remote_redirect`).
- Uses an nginx `map` directive on `$request_uri` to conditionally set the header only for `/api/registry/swift/` requests, leaving non-registry traffic (CAS, gradle, module cache) unaffected.
- Updates both `cache/docker/nginx.conf` (Docker/Kamal deployment) and `cache/platform/nginx.nix` (NixOS deployment).