### PR TITLE
refactor(cache): rename cas_artifacts table to cache_artifacts

### DIFF
--- a/cache/lib/cache/cache_artifact.ex
+++ b/cache/lib/cache/cache_artifact.ex
@@ -5,7 +5,7 @@ defmodule Cache.CacheArtifact do
 
   import Ecto.Changeset
 
-  schema "cas_artifacts" do
+  schema "cache_artifacts" do
     field :key, :string
     field :size_bytes, :integer
     field :last_accessed_at, :utc_datetime_usec

--- a/cache/lib/cache/cache_artifacts_buffer.ex
+++ b/cache/lib/cache/cache_artifacts_buffer.ex
@@ -42,7 +42,7 @@ defmodule Cache.CacheArtifactsBuffer do
   end
 
   @impl true
-  def buffer_name, do: :cas_artifacts
+  def buffer_name, do: :cache_artifacts
 
   @impl true
   def flush_entries(table, max_batch_size) do
@@ -84,7 +84,7 @@ defmodule Cache.CacheArtifactsBuffer do
   @impl true
   def queue_stats(table) do
     count = SQLiteBuffer.table_size(table)
-    %{cas_artifacts: count, total: count}
+    %{cache_artifacts: count, total: count}
   end
 
   @impl true

--- a/cache/lib/cache/sqlite_buffer/prom_ex_plugin.ex
+++ b/cache/lib/cache/sqlite_buffer/prom_ex_plugin.ex
@@ -56,10 +56,10 @@ defmodule Cache.SQLiteBuffer.PromExPlugin do
           measurement: :key_values,
           description: "Queued key-value upserts."
         ),
-        last_value([:tuist_cache, :sqlite_buffer, :pending, :cas_artifacts],
+        last_value([:tuist_cache, :sqlite_buffer, :pending, :cache_artifacts],
           event_name: [:cache, :prom_ex, :sqlite_buffer, :queue],
-          measurement: :cas_artifacts,
-          description: "Queued CAS artifact updates and deletes."
+          measurement: :cache_artifacts,
+          description: "Queued cache artifact updates and deletes."
         ),
         last_value([:tuist_cache, :sqlite_buffer, :pending, :s3_transfers],
           event_name: [:cache, :prom_ex, :sqlite_buffer, :queue],
@@ -86,15 +86,15 @@ defmodule Cache.SQLiteBuffer.PromExPlugin do
       :ok
     else
       key_values = Map.get(stats_by_buffer[Cache.KeyValueBuffer] || %{}, :key_values, 0)
-      cas_artifacts = Map.get(stats_by_buffer[Cache.CacheArtifactsBuffer] || %{}, :cas_artifacts, 0)
+      cache_artifacts = Map.get(stats_by_buffer[Cache.CacheArtifactsBuffer] || %{}, :cache_artifacts, 0)
       s3_transfers = Map.get(stats_by_buffer[Cache.S3TransfersBuffer] || %{}, :s3_transfers, 0)
 
       :telemetry.execute(
         [:cache, :prom_ex, :sqlite_buffer, :queue],
         %{
-          total: key_values + cas_artifacts + s3_transfers,
+          total: key_values + cache_artifacts + s3_transfers,
           key_values: key_values,
-          cas_artifacts: cas_artifacts,
+          cache_artifacts: cache_artifacts,
           s3_transfers: s3_transfers
         },
         %{}

--- a/cache/priv/repo/migrations/20260217191700_rename_cas_artifacts_to_cache_artifacts.exs
+++ b/cache/priv/repo/migrations/20260217191700_rename_cas_artifacts_to_cache_artifacts.exs
@@ -1,0 +1,7 @@
+defmodule Cache.Repo.Migrations.RenameCasArtifactsToCacheArtifacts do
+  use Ecto.Migration
+
+  def change do
+    rename table(:cas_artifacts), to: table(:cache_artifacts)
+  end
+end

--- a/cache/test/cache/sqlite_buffer_test.exs
+++ b/cache/test/cache/sqlite_buffer_test.exs
@@ -132,7 +132,7 @@ defmodule Cache.SQLiteBufferTest do
 
     Task.await_many(tasks)
 
-    assert %{cas_artifacts: 1} = CacheArtifactsBuffer.queue_stats()
+    assert %{cache_artifacts: 1} = CacheArtifactsBuffer.queue_stats()
 
     :ok = CacheArtifactsBuffer.flush()
 


### PR DESCRIPTION
## Summary

- Renames the `cas_artifacts` SQLite table to `cache_artifacts` to match the `Cache.CacheArtifact` module name
- Uses `ALTER TABLE RENAME TO` which is a metadata-only operation in SQLite — instant, no data copy, no write blocking
- Updates all `:cas_artifacts` atom references in buffer, telemetry/prom_ex, and tests to `:cache_artifacts`