### PR TITLE
fix(cli): bump Swift to 6.2 for Linux static builds to fix SSL certificates

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -354,7 +354,7 @@ jobs:
     name: Linux Build
     runs-on: ubuntu-latest
     container:
-      image: swift:6.1
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
@@ -378,7 +378,7 @@ jobs:
     name: Linux Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: swift:6.1
+      image: swift:6.2
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,7 +496,7 @@ jobs:
     if: needs.check-releases.outputs.cli-should-release == 'true'
     runs-on: ${{ matrix.runner }}
     container:
-      image: swift:6.1
+      image: swift:6.2
     timeout-minutes: 30
     strategy:
       matrix:
@@ -515,7 +515,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.swiftpm/swift-sdks
-          key: static-linux-sdk-swift-6.1.2-${{ matrix.arch }}
+          key: static-linux-sdk-swift-6.2.3-${{ matrix.arch }}
 
       - name: Restore cache
         id: cache-restore

--- a/mise/tasks/cli/build-cross-platform.sh
+++ b/mise/tasks/cli/build-cross-platform.sh
@@ -13,7 +13,7 @@ if [ "$usage_linux_vm" = "true" ]; then
     $CONTAINER_ENGINE run --rm \
             --volume "$MISE_PROJECT_ROOT:/package" \
             --workdir "/package" \
-            swift:6.1 \
+            swift:6.2 \
             swift build --target tuist --build-path .build-linux --replace-scm-with-registry
 else
     swift build --target tuist --replace-scm-with-registry

--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -19,7 +19,7 @@ if [ "$usage_linux_vm" = "true" ]; then
         --volume "$PROJECT_ROOT:/package" \
         --workdir "/package" \
         --env MISE_PROJECT_ROOT=/package \
-        swift:6.1 \
+        swift:6.2 \
         ./mise/tasks/cli/bundle-linux.sh
 fi
 
@@ -36,8 +36,8 @@ mkdir -p $BUILD_DIRECTORY
 # This eliminates all shared library dependencies and cross-distro compatibility issues
 # (e.g. Ubuntu's CURL_OPENSSL_4 vs Fedora's libcurl-minimal).
 echo "==> Installing Swift Static Linux SDK"
-swift sdk install https://download.swift.org/swift-6.1.2-release/static-sdk/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-    --checksum df0b40b9b582598e7e3d70c82ab503fd6fbfdff71fd17e7f1ab37115a0665b3b
+swift sdk install https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+    --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c
 
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then


### PR DESCRIPTION
## Summary
- The static musl binary built with Swift 6.1.2's static Linux SDK cannot verify SSL certificates, causing `SSL certificate problem: unable to get local issuer certificate` errors for all HTTPS requests (including OIDC auth in CI)
- Root cause: a bug in swift-corelibs-foundation where libcurl version checks fail because curl headers aren't included ([swiftlang/swift-corelibs-foundation#5157](https://github.com/swiftlang/swift-corelibs-foundation/issues/5157))
- The fix ([#5159](https://github.com/swiftlang/swift-corelibs-foundation/pull/5159)) was merged to `main` but not backported to `release/6.1`, so it's only available in Swift 6.2+
- Bumps Swift toolchain and static Linux SDK from 6.1.2 to 6.2.3 for all Linux builds and scripts
- `swift-tools-version` in `Package.swift` stays at 6.1 since macOS builds don't need 6.2

## Test plan
- [ ] Linux Build CI job passes with `swift:6.2` container
- [ ] Linux Unit Tests CI job passes
- [ ] Build static musl binary locally with `mise run cli:bundle --linux-vm` and verify HTTPS works

🤖 Generated with [Claude Code](https://claude.com/claude-code)