### PR TITLE
fix(gradle): resolve tuist executable path before running from temp directory

### DIFF
--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
@@ -163,6 +163,16 @@ class TuistCommandConfigurationProvider(
         // When a project handle is provided explicitly, run in a temp directory to
         // avoid tuist detecting any project context. When relying on tuist.toml,
         // run in the project directory so the CLI can find the config file.
+        // Resolve the executable to an absolute path before switching to the temp
+        // directory so that version-manager shims (e.g. mise) that rely on the
+        // working directory to locate their config still resolve correctly.
+        val resolvedCommand = if (!project.isNullOrBlank()) {
+            fullCommand.mapIndexed { index, arg ->
+                if (index == 0) resolveExecutablePath(arg) else arg
+            }
+        } else {
+            fullCommand
+        }
         val workDir = if (!project.isNullOrBlank()) {
             java.nio.file.Files.createTempDirectory("tuist-gradle-").toFile()
         } else {
@@ -170,7 +180,7 @@ class TuistCommandConfigurationProvider(
         }
         val cleanupTempDir = !project.isNullOrBlank()
         try {
-            val processBuilder = ProcessBuilder(fullCommand)
+            val processBuilder = ProcessBuilder(resolvedCommand)
                 .apply { workDir?.let { directory(it) } }
                 .redirectErrorStream(false)
 
@@ -209,6 +219,20 @@ class TuistCommandConfigurationProvider(
             if (cleanupTempDir) {
                 workDir?.deleteRecursively()
             }
+        }
+    }
+
+    private fun resolveExecutablePath(executable: String): String {
+        if (java.io.File(executable).isAbsolute) return executable
+        return try {
+            val process = ProcessBuilder("which", executable)
+                .apply { projectDir?.let { directory(it) } }
+                .redirectErrorStream(true)
+                .start()
+            val path = BufferedReader(InputStreamReader(process.inputStream)).use { it.readLine()?.trim() }
+            if (process.waitFor() == 0 && !path.isNullOrBlank()) path else executable
+        } catch (e: Exception) {
+            executable
         }
     }
 }


### PR DESCRIPTION
## Summary
- When a project handle is provided, the Gradle plugin runs `tuist cache config` from a temp directory. Version-manager shims (e.g. mise) rely on the working directory to locate their config and fail when invoked from a temp directory.
- Resolves the executable to an absolute path via `which` while still in the project directory before switching to the temp directory.

## Test plan
- [ ] Verify that `./gradlew build` works with mise-managed tuist when `project` is configured in `settings.gradle.kts`
- [ ] Verify that explicit `executablePath` configuration still works
- [ ] Verify that the fallback (when `which` fails) still uses the bare command name

🤖 Generated with [Claude Code](https://claude.com/claude-code)