### PR TITLE
chore(cli): add .swiftpm/** to CI workflow path filters

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/app.yml"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
       - "Package.swift"
       - "Package.resolved"
   pull_request:
@@ -18,6 +19,7 @@ on:
       - ".github/workflows/app.yml"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
       - "Package.swift"
       - "Package.resolved"
 

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -18,6 +18,7 @@ on:
       - "examples/xcode/**"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -34,6 +35,7 @@ on:
       - "examples/xcode/**"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,6 +17,7 @@ on:
       - "examples/xcode/**"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
       - "Package.swift"
       - "Package.resolved"
   pull_request:
@@ -34,6 +35,7 @@ on:
       - "examples/xcode/**"
       - "Tuist/**"
       - ".xcode-version"
+      - ".swiftpm/**"
       - "Package.swift"
       - "Package.resolved"
 


### PR DESCRIPTION
## Summary
- Added `.swiftpm/**` to the path filters of the CLI, CLI Cache EE, and App GitHub Actions workflows
- Without this, PRs that only change `.swiftpm/configuration/registries.json` (like #9498) don't trigger CI checks, even though registry configuration directly affects Swift package resolution and builds

## Test plan
- [x] Verify that future PRs touching `.swiftpm/` files trigger the CLI, CLI Cache EE, and App workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)