### PR TITLE
fix(server): add Docker Buildx setup for GHA cache to work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -724,6 +724,9 @@ jobs:
             git cliff --include-path "server/**/*" --config cliff.toml --repository "../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -810,6 +813,9 @@ jobs:
           else
             git cliff --include-path "cache/**/*" --config cliff.toml --repository "../" --bump -o CHANGELOG.md 2>/dev/null
           fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -456,6 +456,8 @@ jobs:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: server
       - run: mise run install
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # We move it so that we can copy it inside the Docker image for
       # reproducibility of dependency resolution.
       - name: Docker build


### PR DESCRIPTION
## Summary
- The `cache-from: type=gha` / `cache-to: type=gha,mode=max` Docker cache options require a buildx builder with the `docker-container` driver
- Without `docker/setup-buildx-action`, the default docker driver silently ignores the cache config, so every build rebuilds all layers from scratch
- Added `docker/setup-buildx-action@v3` to `release.yml` (server + cache jobs) and `server.yml` (docker_build job)

## Test plan
- [ ] Verify the server CI `docker_build` job uses cache on next PR build
- [ ] Verify the next server/cache release builds are faster with cached layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)