### PR TITLE
fix(cli): pass jsonThroughNoora to Noora on Linux

### DIFF
--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -132,6 +132,7 @@ public struct TuistCommand: AsyncParsableCommand {
         #endif
     }
 
+    // swiftlint:disable:next function_body_length
     public static func main(
         logFilePath: AbsolutePath,
         _ arguments: [String]? = nil,


### PR DESCRIPTION
## Summary
- On Linux, `initNoora()` was always called without the `jsonThroughNoora` parameter, defaulting to `false`
- When `--json` is present and `jsonThroughNoora` is `false`, Noora uses `IgnoreOutputPipeline` which discards all output
- This caused `tuist cache config --json` to produce no output on Linux even though the command succeeded (exit code 0)
- The fix mirrors the macOS path by checking if the parsed command conforms to `NooraReadyCommand` and forwarding its `jsonThroughNoora` value to `initNoora()`

## Test plan
- [ ] Run `tuist cache config --json` on Linux and verify JSON output is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)