### PR TITLE
fix(server): upgrade ajv to 8.18.0 to fix CVE-2025-69873

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,8 @@
       "vue-demi"
     ],
     "overrides": {
-      "mdast-util-to-hast": "13.2.1"
+      "mdast-util-to-hast": "13.2.1",
+      "ajv": "8.18.0"
     }
   }
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   mdast-util-to-hast: 13.2.1
+  ajv: 8.18.0
 
 importers:
 
@@ -432,7 +433,7 @@ packages:
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
-      ajv: ^8.5.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -440,13 +441,13 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -1502,9 +1503,9 @@ snapshots:
       '@scalar/json-magic': 0.8.3
       '@scalar/openapi-types': 0.5.2
       '@scalar/openapi-upgrader': 0.1.5
-      ajv: 8.17.1
-      ajv-draft-04: 1.0.0(ajv@8.17.1)
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
       jsonpointer: 5.0.1
       leven: 4.0.0
       yaml: 2.8.0
@@ -1811,15 +1812,15 @@ snapshots:
     dependencies:
       vue: 3.5.25
 
-  ajv-draft-04@1.0.0(ajv@8.17.1):
+  ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.6


### PR DESCRIPTION
## Summary
- Upgrades `ajv` from 8.17.1 to 8.18.0 via pnpm override to fix CVE-2025-69873 (ReDoS via `$data` reference)
- `ajv` is a transitive dependency of `@scalar/openapi-parser` (via `@scalar/api-reference`)

## Test plan
- [ ] Security check (Trivy) passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)