### PR TITLE
chore(server): optimize all server CI jobs

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -330,8 +330,6 @@ jobs:
           key: mix-${{ hashFiles('server/mix.lock') }}
           restore-keys: |
             mix-
-      - name: Touch cached build artifacts
-        run: if [ -d _build ]; then find _build -type f -exec touch {} +; fi
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         with:
@@ -366,8 +364,6 @@ jobs:
           key: mix-${{ hashFiles('server/mix.lock') }}
           restore-keys: |
             mix-
-      - name: Touch cached build artifacts
-        run: if [ -d _build ]; then find _build -type f -exec touch {} +; fi
       - name: Restore PNPM Cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

Optimizes all server CI jobs by reducing unnecessary tool installation and improving caching.

### Changes
- **Selective tool installation**: Use `jdx/mise-action` `install_args` to only install tools each job needs (instead of all 20+ tools from mise.toml)
- **NVMe mise cache**: Use `namespacelabs/nscloud-cache-action` with `cache: mise` for fast mise tool caching (~1s restore vs ~38s)
- **Skip auto-install in tasks**: Use `mise run --no-prepare` for all mise tasks to prevent re-installing all tools
- **Compiled artifact caching**: Use `actions/cache@v4` for `deps/` and `_build/` with `mix.lock` hash key
- **Consistent mise config**: All jobs use `working_directory: server` on mise-action for consistent environment
- Run on `namespace-profile-default-with-volume` runner

### Timing improvements

Compared against latest `main` run ([baseline](https://github.com/tuist/tuist/actions/runs/22179950170)) vs [this PR](https://github.com/tuist/tuist/actions/runs/22184012160):

| Job | Before | After | Improvement |
|---|---|---|---|
| **Credo** | 2m08s | 0m47s | **-63%** |
| **Security** | 2m11s | 0m39s | **-70%** |
| **esbuild** | 1m29s | 0m37s | **-58%** |
| **Gettext (Dashboard)** | 2m39s | 1m24s | **-47%** |
| **Seed** | 3m03s | 1m52s | **-39%** |
| **Format** | 2m06s | 1m23s | **-34%** |
| **Gettext (Marketing)** | 2m20s | 1m44s | **-26%** |
| Docker build | 0m34s | 0m27s | -21% |
| Gradle Cache Acceptance | 7m37s | 6m31s | -14% |
| Test | 4m53s | 4m17s | -12% |

### Known limitation

Jobs that run `mix compile` / `mix ecto.create` (Test, Seed) always recompile ~490 files (~40s) because `tuist_common` is a path dependency. Elixir detects source changes in path deps on every fresh checkout, which cascades to a full project recompile. This is an Elixir compiler behavior that can't be worked around with timestamp manipulation or caching alone. The `mix credo` command avoids this cascade through its own compilation strategy, which is why Credo is fast.

## Test plan
- [x] All CI jobs pass
- [x] Verified timing improvements across all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)