### PR TITLE
fix(cli): restore SRCROOT path resolution for cached target settings

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -210,8 +210,19 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
             let targetDependency: GraphDependency = .target(name: target.target.name, path: target.path)
             settings[targetDependency] = try await targetSettings(target)
             for dependency in dependencies {
+                var dependencySettings = settings[dependency] ?? [:]
+
+                if case let GraphDependency.target(_, dependencyPath, _) = dependency,
+                   dependencyPath != target.path
+                {
+                    dependencySettings = dependencySettings.resolvingSrcRootPaths(
+                        from: dependencyPath,
+                        to: target.path
+                    )
+                }
+
                 settings[targetDependency] = (settings[targetDependency] ?? [:])
-                    .combine(with: settings[dependency] ?? [:])
+                    .combine(with: dependencySettings)
                     .removeDuplicates()
             }
         }
@@ -238,6 +249,20 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
 }
 
 extension SettingsDictionary {
+    func resolvingSrcRootPaths(
+        from sourcePath: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) -> SettingsDictionary {
+        mapValues { value in
+            switch value {
+            case let .string(stringValue):
+                return .string(stringValue.resolvingSrcRootPath(from: sourcePath, to: destinationPath))
+            case let .array(arrayValue):
+                return .array(arrayValue.map { $0.resolvingSrcRootPath(from: sourcePath, to: destinationPath) })
+            }
+        }
+    }
+
     /// There are scenarios when the combined settings introduce duplicates for these setting keys.
     /// We don't know how to reproduce – either in a reproducible sample or via unit tests.
     /// This is also why the `removeOtherSwiftFlagsDuplicates` is `internal` instead of `fileprivate`, so we can at least test the
@@ -325,5 +350,32 @@ extension String {
             self == "-I" ||
             self == "-enable-upcoming-feature" ||
             self == "-enable-experimental-feature"
+    }
+
+    fileprivate func resolvingSrcRootPath(
+        from sourcePath: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) -> String {
+        let srcRootMarker = "$(SRCROOT)"
+        guard contains(srcRootMarker) else { return self }
+
+        var pathComponents = split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard let srcRootIndex = pathComponents.firstIndex(where: { $0.contains(srcRootMarker) }) else { return self }
+
+        let prefix = String(pathComponents[srcRootIndex].prefix(while: { $0 != "$" }))
+        let suffix = pathComponents.last?.hasSuffix("\"") == true ? "\"" : ""
+
+        pathComponents[srcRootIndex] = srcRootMarker
+
+        let relativePathString = pathComponents[(srcRootIndex + 1)...]
+            .joined(separator: "/")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+
+        guard let relativePath = try? RelativePath(validating: relativePathString) else { return self }
+
+        let absolutePath = sourcePath.appending(relativePath)
+        let resolvedComponents = absolutePath.relative(to: destinationPath).components
+
+        return prefix + (pathComponents[...srcRootIndex] + resolvedComponents).joined(separator: "/") + suffix
     }
 }

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -1036,20 +1036,14 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         )
 
         // App gets CachedFramework's settings via combination.
-        // Ideally, the paths would be recalculated relative to App's project path,
-        // but the current implementation propagates $(SRCROOT)-relative paths as-is
-        // from the dependency's project. This means App gets CachedFramework's paths
-        // which are relative to .cache/.../HASH/ rather than Project/.
-        //
-        // TODO: In the future, the mapper should recalculate $(SRCROOT) paths when
-        // propagating settings across target boundaries with different project paths.
+        // The paths should be recalculated relative to App's project path.
         let appSettings = gotGraph.projects[appProjectPath]?.targets["App"]?.settings?.base
         let appHeaderSearchPaths = appSettings?["HEADER_SEARCH_PATHS"]
 
-        // App currently inherits CachedFramework's path (relative to .cache/.../HASH/)
+        // App's path should be relative to its own project (Project/), not to CachedFramework's project
         XCTAssertEqual(
             appHeaderSearchPaths,
-            .array(["\"$(SRCROOT)/../../../../BuiltFrameworks/GoogleMaps.xcframework/ios-arm64/Headers\""])
+            .array(["\"$(SRCROOT)/../BuiltFrameworks/GoogleMaps.xcframework/ios-arm64/Headers\""])
         )
     }
 


### PR DESCRIPTION
## Summary

- Restores the `resolvingSrcRootPaths` logic from PR #9203 that was accidentally removed by PR #9446 ("revert static framework resource embedding")
- Fixes incorrect `FRAMEWORK_SEARCH_PATHS` and `HEADER_SEARCH_PATHS` for external static xcframeworks when some targets are cached
- Restores correct test assertions that were changed to accept the broken behavior

### Root cause

PR #9446 was a large revert (45 files) that intended to revert PRs #9081, #9141, #9210, #9240, #9317, #9382, #9419. However, because changes from those PRs and the unrelated PR #9203 overlapped in `StaticXCFrameworkModuleMapGraphMapper.swift`, the revert accidentally swept up the #9203 fix as well.

### What was lost

Three pieces of code from PR #9203:
1. `resolvingSrcRootPaths(from:to:)` on `SettingsDictionary` — transforms all `$(SRCROOT)`-relative paths when propagating settings between targets at different project paths
2. `resolvingSrcRootPath(from:to:)` on `String` — resolves a `$(SRCROOT)/relative/path` from one project directory to another
3. Path resolution guard in `mapGraph` — when combining settings from a dependency at a different project path, calls `resolvingSrcRootPaths` to correct the paths

### Impact

Without this fix, when targets are cached to `.cache/tuist/Binaries/HASH/`, any `$(SRCROOT)`-relative paths in their settings are propagated as-is to consuming targets. Since the cached target's project is at a different path than the consuming app, the resulting paths are incorrect:
```
"$(SRCROOT)/../BuiltFrameworks/GoogleMaps.xcframework    (correct)
"$(SRCROOT)/../../../BuiltFrameworks/GoogleMaps.xcframework  (incorrect — relative to cache path)
```

## Test plan

- [x] Existing regression tests from PR #9203 now assert correct behavior again
- [ ] Verify with reproduction project from https://github.com/Alex-Ozun/TuistTestCaching


🤖 Generated with [Claude Code](https://claude.com/claude-code)