### PR TITLE
feat(infra): route tuist.dev registry paths through cache nodes

### DIFF
--- a/infra/registry-router/wrangler.toml
+++ b/infra/registry-router/wrangler.toml
@@ -3,7 +3,8 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
 routes = [
-  { pattern = "registry.tuist.dev/*", zone_name = "tuist.dev" }
+  { pattern = "registry.tuist.dev/*", zone_name = "tuist.dev" },
+  { pattern = "tuist.dev/api/registry/*", zone_name = "tuist.dev" }
 ]
 
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary

- Adds a `tuist.dev/api/registry/*` route to the registry-router Cloudflare Worker, so Swift package registry requests on `tuist.dev` are geo-routed to the nearest cache node instead of hitting the old server.
- Existing `registry.tuist.dev/*` route is unchanged.
