### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Check if author is team member
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.TUIST_GITHUB_TOKEN || github.token }}
           script: |
@@ -85,7 +85,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Skip Xcode Macro Fingerprint Validation
@@ -98,7 +98,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -139,7 +139,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Skip Xcode Macro Fingerprint Validation
@@ -152,7 +152,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -184,7 +184,7 @@ jobs:
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Skip Xcode Macro Fingerprint Validation
@@ -197,7 +197,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login

--- a/.github/workflows/cache-deploy.yml
+++ b/.github/workflows/cache-deploy.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     environment: cache-canary
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: 1password/install-cli-action@v2
       - uses: jdx/mise-action@v3.2.0
         with:
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.deploy-canary.result == 'success' }}
     environment: cache-production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: 1password/install-cli-action@v2
       - uses: jdx/mise-action@v3.2.0
         with:

--- a/.github/workflows/cache-staging-deploy.yml
+++ b/.github/workflows/cache-staging-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     environment: cache-staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: 1password/install-cli-action@v2
       - uses: jdx/mise-action@v3.2.0
         with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: namespace-profile-default
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             cache/deps
@@ -59,9 +59,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             cache/deps
@@ -82,9 +82,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             cache/deps
@@ -105,9 +105,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             cache/deps
@@ -127,6 +127,6 @@ jobs:
     runs-on: namespace-profile-default
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Validate docker-compose.yml
         run: docker compose config --quiet

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Check CLA Status
         id: cla_check
@@ -55,7 +55,7 @@ jobs:
 
       - name: Comment on PR if CLA required
         if: steps.cla_check.outputs.cla_required == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const marker = '<!-- cla-check -->';
@@ -120,7 +120,7 @@ jobs:
 
       - name: Update comment if CLA passed
         if: steps.cla_check.outputs.cla_required == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const marker = '<!-- cla-check -->';

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Check if author is team member
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.TUIST_GITHUB_TOKEN || github.token }}
           script: |
@@ -104,12 +104,12 @@ jobs:
        github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' && needs.check-team-membership.outputs.is-team-member == 'true' && github.event.pull_request.draft == false))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
         with:
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
@@ -123,7 +123,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -154,12 +154,12 @@ jobs:
        github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' && needs.check-team-membership.outputs.is-team-member == 'true' && github.event.pull_request.draft == false))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
         with:
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
@@ -173,7 +173,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -204,12 +204,12 @@ jobs:
        github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' && needs.check-team-membership.outputs.is-team-member == 'true' && github.event.pull_request.draft == false))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
         with:
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
@@ -223,7 +223,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: namespace-profile-default-macos
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -66,7 +66,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -100,7 +100,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -125,7 +125,7 @@ jobs:
     timeout-minutes: 60
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -134,7 +134,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -168,7 +168,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 60
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -202,7 +202,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -233,7 +233,7 @@ jobs:
     timeout-minutes: 60
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -242,7 +242,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -280,7 +280,7 @@ jobs:
     timeout-minutes: 60
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -289,7 +289,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -320,7 +320,7 @@ jobs:
     timeout-minutes: 60
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Restore cache
@@ -329,7 +329,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore cache
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -384,7 +384,7 @@ jobs:
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore cache
         id: cache-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 #v5
         with:
           requireScope: true
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Test docker-compose configuration
         run: ./docs/test-docker-compose.sh
 
@@ -54,9 +54,9 @@ jobs:
     timeout-minutes: 80
     if: github.event.pull_request.head.repo.fork != true && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
         id: pnpm-cache
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
           path: .build
           key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-docs-${{ hashFiles('./Package.resolved') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-docs-
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           working_directory: docs
       - name: Authenticate with Tuist
@@ -94,7 +94,7 @@ jobs:
         working-directory: docs
         run: mise run generate-manifests-docs
       - name: Upload generated docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: docs-generated
           path: docs/docs/generated
@@ -112,14 +112,14 @@ jobs:
     needs: [generate-cli-docs]
     if: github.event.pull_request.head.repo.fork != true && (github.event.pull_request.draft == false || github.event_name != 'pull_request')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Download generated docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: docs-generated
           path: docs/docs/generated
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
         id: pnpm-cache
         with:
           path: |
@@ -138,7 +138,7 @@ jobs:
           path: docs/.vitepress/cache
           key: vitepress-cache-${{ hashFiles('docs/package.json') }}
           restore-keys: vitepress-cache-
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           working_directory: docs
       - name: Lint localization

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -37,13 +37,13 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Restore PNPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
         id: pnpm-cache
         with:
           path: |
             ~/.pnpm/store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           working_directory: handbook
       - name: Build handbook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
       skills-next-version-number: ${{ steps.skills-check.outputs.next-version-number }}
       should-release-any: ${{ steps.check-any.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Check CLI for releasable changes
         id: cli-check
@@ -417,7 +417,7 @@ jobs:
       artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -429,7 +429,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -477,7 +477,7 @@ jobs:
 
       - name: Upload CLI artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: cli-artifacts
           path: |
@@ -506,7 +506,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -539,7 +539,7 @@ jobs:
 
       - name: Upload CLI Linux artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: cli-linux-${{ matrix.arch }}-artifacts
           path: |
@@ -561,7 +561,7 @@ jobs:
       artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -569,7 +569,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Install create-dmg
         run: brew install create-dmg
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -622,7 +622,7 @@ jobs:
 
       - name: Upload App artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: app-artifacts
           path: |
@@ -642,7 +642,7 @@ jobs:
     runs-on: namespace-profile-default-macos
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -652,7 +652,7 @@ jobs:
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -692,10 +692,10 @@ jobs:
       artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Get release notes
         id: release-notes
@@ -761,7 +761,7 @@ jobs:
 
       - name: Upload Server artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: server-artifacts
           path: |
@@ -780,10 +780,10 @@ jobs:
       artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Get release notes
         id: release-notes
@@ -848,7 +848,7 @@ jobs:
 
       - name: Upload Cache artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: cache-artifacts
           path: |
@@ -867,11 +867,11 @@ jobs:
       artifacts-uploaded: ${{ steps.upload.outputs.uploaded }}
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -959,7 +959,7 @@ jobs:
 
       - name: Upload Gradle artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: gradle-artifacts
           path: |
@@ -979,10 +979,10 @@ jobs:
     outputs:
       release-notes: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Get release notes
         id: release-notes
@@ -1029,7 +1029,7 @@ jobs:
           fi
 
       - name: Upload Skills artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: skills-artifacts
           path: |
@@ -1061,29 +1061,29 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
 
       - name: Download CLI artifacts
         if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: cli-artifacts
 
       - name: Download CLI Linux x86_64 artifacts
         if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli-linux.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: cli-linux-x86_64-artifacts
           path: build-linux-x86_64
 
       - name: Download CLI Linux aarch64 artifacts
         if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli-linux.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: cli-linux-aarch64-artifacts
           path: build-linux-aarch64
@@ -1102,33 +1102,33 @@ jobs:
 
       - name: Download App artifacts
         if: needs.check-releases.outputs.app-should-release == 'true' && needs.release-app.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: app-artifacts
           path: app
 
       - name: Download Server artifacts
         if: needs.check-releases.outputs.server-should-release == 'true' && needs.release-server.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: server-artifacts
 
       - name: Download Cache artifacts
         if: needs.check-releases.outputs.cache-should-release == 'true' && needs.release-cache.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: cache-artifacts
 
       - name: Download Gradle artifacts
         if: needs.check-releases.outputs.gradle-should-release == 'true' && needs.release-gradle.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: gradle-artifacts
           path: gradle
 
       - name: Download Skills artifacts
         if: needs.check-releases.outputs.skills-should-release == 'true' && needs.release-skills.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4
         with:
           name: skills-artifacts
           path: skills

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
       - name: TruffleHog Secret Scan
@@ -33,7 +33,7 @@ jobs:
           extra_args: --results=verified --json
       - name: Comment on PR
         if: steps.trufflehog.outcome == 'failure' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const marker = '<!-- trufflehog-secret-scan-comment -->';

--- a/.github/workflows/server-canary-deployment.yml
+++ b/.github/workflows/server-canary-deployment.yml
@@ -33,16 +33,16 @@ jobs:
     runs-on: namespace-profile-default
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           install: false
       - name: "Get version"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -42,13 +42,13 @@ jobs:
         working-directory: server
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           install: false
       - name: "Get version"
@@ -70,7 +70,7 @@ jobs:
     needs: canary
     environment: server-canary
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           token: ${{ secrets.TUIST_GITHUB_TOKEN }}
           submodules: recursive
@@ -82,7 +82,7 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-cache-ee-${{ hashFiles('Package.resolved') }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       - name: Authenticate with Tuist
         run: tuist auth login
       - name: Setup Tuist cache
@@ -111,13 +111,13 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           install: false
       - name: "Get version"
@@ -144,13 +144,13 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha == '' }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         if: ${{ github.event.inputs.commit_sha != '' }}
         with:
           ref: ${{ github.event.inputs.commit_sha }}
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           install: false
       - name: "Get version"

--- a/.github/workflows/server-staging-deployment.yml
+++ b/.github/workflows/server-staging-deployment.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: namespace-profile-default
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           install: false
       - name: "Get version"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -42,9 +42,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -106,9 +106,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -118,7 +118,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
       - name: Check for .po file modifications by non-bot users
@@ -259,9 +259,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -271,7 +271,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -292,9 +292,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -304,7 +304,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -322,9 +322,9 @@ jobs:
     runs-on: namespace-profile-default
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -334,7 +334,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -353,9 +353,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4 # v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -365,7 +365,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -400,9 +400,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -412,7 +412,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -431,7 +431,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           submodules: false
       - name: Set up Docker Buildx
@@ -466,9 +466,9 @@ jobs:
   #         --health-timeout 5s
   #         --health-retries 5
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
   #     - name: Restore Mix Cache
-  #       uses: actions/cache@v4
+  #       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
   #       id: mix-cache
   #       with:
   #         path: |
@@ -477,7 +477,7 @@ jobs:
   #           _site
   #         key: mix-${{ hashFiles('mix.lock') }}
   #     - name: Restore PNPM Cache
-  #       uses: actions/cache@v4
+  #       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
   #       id: pnpm-cache
   #       with:
   #         path: |
@@ -522,9 +522,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Restore Mix Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: mix-cache
         with:
           path: |
@@ -534,7 +534,7 @@ jobs:
           restore-keys: |
             mix-
       - name: Restore PNPM Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         id: pnpm-cache
         with:
           path: |
@@ -580,7 +580,7 @@ jobs:
       TUIST_SECRET_KEY_ENCRYPTION: ci-test-encryption-key-32-bytes!
       TUIST_CACHE_API_KEY: 7a3de63bb6136d94539e9976b1c54bfd553467c2c4775f84b7b2baf27f8b38c6
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: jdx/mise-action@v3.2.0
         with:
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
@@ -595,7 +595,7 @@ jobs:
           java-version: '21'
       - uses: android-actions/setup-android@v3
       - name: Restore server deps
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             server/deps
@@ -621,7 +621,7 @@ jobs:
           mix ecto.migrate
           mix run priv/repo/seeds.exs
       - name: Restore cache deps
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             cache/deps

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 #v8
         with:
           stale-issue-message: |
             Hola 👋,


### PR DESCRIPTION
### 📝 Resolves
<https://github.com/tuist/tuist/issues/YYY>

---

### ✅ Purpose
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds. By specifying the exact commit SHA, the workflow uses the same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

---

### 🔍 Learn More
Learn more:  
[https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

---

### 📝 Changes
- Pinned `actions/download-artifact` from `v4` to `d3f86a1` in `.github/workflows/release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/secret-scanning.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/server-staging-deployment.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/cli-cache-ee.yml`
- Pinned `actions/github-script` from `v7` to `f28e40c` in `.github/workflows/cli-cache-ee.yml`
- Pinned `actions/github-script` from `v7` to `f28e40c` in `.github/workflows/secret-scanning.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/server-production-deployment.yml`
- Pinned `actions/download-artifact` from `v4` to `d3f86a1` in `.github/workflows/docs.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/cache-deploy.yml`
- Pinned `actions/cache` from `v4` to `0057852` in `.github/workflows/server.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/cache-staging-deploy.yml`
- Pinned `actions/github-script` from `v7` to `f28e40c` in `.github/workflows/app.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/cache.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `amannn/action-semantic-pull-request` from `v5` to `e32d7e6` in `.github/workflows/conventional-pr.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/server.yml`
- Pinned `actions/cache` from `v3` to `6f8efc2` in `.github/workflows/handbook.yml`
- Pinned `actions/github-script` from `v7` to `f28e40c` in `.github/workflows/cla.yml`
- Pinned `actions/checkout` from `v2` to `ee0669b` in `.github/workflows/conventional-pr.yml`
- Pinned `actions/cache` from `v4` to `0057852` in `.github/workflows/cache.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/docs.yml`
- Pinned `actions/stale` from `v8` to `1160a22` in `.github/workflows/stale.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/app.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/cache.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/server.yml`

---

### 🧪 Testing
The changes will be (mostly) tested in the CI pipeline of the pull request but there shouldn't be any changes as the downloaded actions remain the same.
