### PR TITLE
chore(platform): nginx and kernel tuning

### DIFF
--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -35,14 +35,24 @@
       "net.core.wmem_max" = 67108864;
       "net.ipv4.tcp_rmem" = "4096 131072 67108864";
       "net.ipv4.tcp_wmem" = "4096 65536 67108864";
+      # System-wide FD ceiling. Each connection, open CAS file, and
+      # cached FD (open_file_cache) consumes one. 1 M gives headroom
+      # for thousands of concurrent downloads + the file cache.
       "fs.file-max" = 1048576;
       "fs.nr_open" = 1048576;
+      # Max outstanding AIO operations system-wide. The cacheio thread
+      # pool submits AIO reads for every large-file download chunk.
       "fs.aio-max-nr" = 1048576;
+      # Per-socket ancillary buffer (cmsg). 64 KB covers the overhead
+      # for SO_TIMESTAMP / IP_PKTINFO used by the network stack.
       "net.core.optmem_max" = 65536;
 
       # BBR congestion control — bandwidth-based instead of loss-based (cubic).
-      # Ramps up faster on WAN links and sustains higher throughput.
+      # Ramps up faster on WAN links and sustains higher throughput for
+      # both large module downloads and bursty Xcode fetches.
       "net.ipv4.tcp_congestion_control" = "bbr";
+      # Fair Queue qdisc — required companion for BBR. Provides per-flow
+      # pacing so concurrent downloads get fair bandwidth allocation.
       "net.core.default_qdisc" = "fq";
 
       # Keep the congestion window warm between HTTP/2 stream bursts instead
@@ -87,8 +97,11 @@
       "net.ipv4.tcp_keepalive_intvl" = 15;
       "net.ipv4.tcp_keepalive_probes" = 5;
 
-      # Process more packets per NAPI cycle before yielding to the
-      # network stack. Helps absorb download bursts at the NIC.
+      # Process more packets (600, default 300) and spend more time
+      # (16 ms, default 8 ms) per NAPI poll cycle before yielding.
+      # Prevents packet drops when many concurrent downloads burst
+      # at the NIC simultaneously. Tradeoff: slightly higher per-cycle
+      # CPU cost, but avoids softnet backlog overflows.
       "net.core.netdev_budget" = 600;
       "net.core.netdev_budget_usecs" = 16000;
     };

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -2,34 +2,60 @@
   services.nginx = {
     enable = true;
 
+    # Disable NixOS convenience presets — we set every directive
+    # explicitly to control the sendfile / kTLS / proxy pipeline.
     recommendedGzipSettings = false;
     recommendedOptimisation = false;
     recommendedProxySettings = false;
     recommendedTlsSettings = false;
 
     appendConfig = ''
+      # One worker per vCPU; each runs its own event loop.
       worker_processes auto;
+      # Let workers open enough FDs for connections + open_file_cache +
+      # CAS files. Must match or exceed the systemd LimitNOFILE below.
       worker_rlimit_nofile 1048576;
+      # Shared thread pool for AIO reads of large CAS files (directio path).
+      # 32 threads cover ~16 concurrent large-file downloads with double-
+      # buffered output_buffers. Queue depth absorbs download bursts.
       thread_pool cacheio threads=32 max_queue=65536;
     '';
 
     eventsConfig = ''
+      # Max simultaneous connections per worker. With auto workers on an
+      # 8-vCPU node this allows 32 K total connections.
       worker_connections 4096;
+      # Accept all pending connections at once instead of one per epoll
+      # wake — reduces event-loop iterations during connection bursts.
       multi_accept on;
     '';
 
     appendHttpConfig = ''
+      # Multiplex downloads over a single TCP connection per client,
+      # avoiding per-request TLS handshakes and connection overhead.
       http2 on;
 
+      # Zero-copy file transfer — the kernel moves data straight from
+      # the page cache to the NIC via kTLS, bypassing user-space copies.
       sendfile on;
+      # Cork the socket until a full frame is ready (combines headers +
+      # body into fewer packets), then uncork immediately with nodelay
+      # so the last partial frame isn't held back by Nagle's algorithm.
       tcp_nopush on;
       tcp_nodelay on;
 
+      # Long-lived connections for HTTP/2 clients that download many
+      # artifacts in sequence. 50 K requests per connection avoids
+      # renegotiation overhead during large CI fetches.
       keepalive_timeout 120s;
       keepalive_requests 50000;
 
-      # ssl_protocols and server_tokens are set by the NixOS nginx module.
+      # Cap concurrent streams so one HTTP/2 connection cannot monopolise
+      # a worker. 256 covers the CLI's 100-module concurrency with room
+      # for registry and Xcode requests on the same connection.
       http2_max_concurrent_streams 256;
+      # 16 KB is the default HTTP/2 max frame size; values above this
+      # are silently split by most clients. Matches the spec ceiling.
       http2_chunk_size 16k;
 
       # Cap each sendfile() call so one large transfer cannot monopolise
@@ -63,6 +89,8 @@
 
       upstream cache_upstream {
         server unix:/run/cache/current.sock;
+        # Idle upstream connections held open per worker. Unix sockets
+        # have near-zero setup cost, so 64 is plenty even under burst.
         keepalive 64;
         keepalive_timeout 120s;
         keepalive_requests 50000;
@@ -101,10 +129,15 @@
       "${config.networking.hostName}.tuist.dev" = {
         forceSSL = true;
         enableACME = true;
+        # Offload TLS record encryption to the kernel. Combined with
+        # sendfile this gives true zero-copy: data goes page-cache → NIC
+        # without entering user-space. ~15-30 % throughput gain on downloads.
         kTLS = true;
 
         extraConfig = ''
+          # No upload size limit — large cache artifacts can be hundreds of MB.
           client_max_body_size 0;
+          # Generous body timeout for slow upload connections.
           client_body_timeout 30m;
         '';
 
@@ -122,6 +155,8 @@
 
             proxy_pass http://cache_upstream;
 
+            # HTTP/1.1 + empty Connection header enables upstream keepalive
+            # pooling, avoiding a new unix-socket connect per request.
             proxy_http_version 1.1;
             proxy_set_header Connection "";
 
@@ -131,11 +166,15 @@
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Port $server_port;
 
+            # Long timeouts for large artifact uploads (up to 300 MB).
             proxy_connect_timeout 30m;
             proxy_send_timeout 30m;
             proxy_read_timeout 30m;
             send_timeout 30m;
 
+            # Stream uploads/downloads through without buffering to disk.
+            # Phoenix responds fast (<200 ms); buffering would only add
+            # latency and disk I/O contention with CAS reads.
             proxy_buffering off;
             proxy_request_buffering off;
           '';
@@ -168,6 +207,8 @@
             types { }
             default_type application/octet-stream;
             sendfile on;
+            # Binary artifacts — compression wastes CPU and most are
+            # already compressed (zips, frameworks).
             gzip off;
 
             # Files ≥ 8 MB bypass the page cache (O_DIRECT) and are read
@@ -183,6 +224,8 @@
             # is filled by the thread pool, smoothing large-file throughput.
             output_buffers 2 512k;
 
+            # CAS keys are content-addressed — once written, never changed.
+            # Immutable lets clients skip conditional requests entirely.
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header Content-Version $registry_content_version;
 
@@ -204,13 +247,19 @@
             # object metadata (often application/zip), which breaks strict clients.
             proxy_hide_header Content-Type;
             default_type application/octet-stream;
+            # Resolve S3 hostnames via Cloudflare; cache DNS for 5 min to
+            # avoid a lookup per download. IPv6 off avoids dual-stack delays.
             resolver 1.1.1.1 ipv6=off valid=300s;
             resolver_timeout 5s;
             set $download_url $1://$2/$3;
+            # Keepalive to S3: HTTP/1.1 + empty Connection reuses TCP
+            # connections across consecutive downloads from the same bucket.
             proxy_http_version 1.1;
             proxy_set_header Connection "";
             proxy_set_header Host $2;
             proxy_socket_keepalive on;
+            # SNI required — S3 virtual-hosted buckets need the correct
+            # hostname in the TLS ClientHello to route to the right bucket.
             proxy_ssl_server_name on;
             proxy_pass $download_url$is_args$args;
             add_header Content-Version $registry_content_version;
@@ -225,6 +274,8 @@
             proxy_buffers 4 16k;
             proxy_busy_buffers_size 16k;
 
+            # Intercept S3 error/redirect responses so we can return clean
+            # JSON errors or follow redirects with the correct Content-Type.
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_remote_redirect;
             error_page 403 404 = @handle_remote_not_found;
@@ -244,6 +295,8 @@
 
         locations."@handle_remote_redirect" = {
           extraConfig = ''
+            # S3 presigned URLs may 307-redirect (e.g. region redirects).
+            # Follow the redirect server-side so clients see a single hop.
             set $saved_redirect_location $upstream_http_location;
             proxy_hide_header Content-Type;
             default_type application/octet-stream;
@@ -264,7 +317,10 @@
   };
 
   systemd.services.nginx.serviceConfig = {
+    # Prevent nginx from writing to the CAS volume — all writes go
+    # through the Phoenix app which manages content-addressing.
     ReadOnlyPaths = ["/cas"];
+    # Match worker_rlimit_nofile so the systemd limit doesn't cap it.
     LimitNOFILE = 1048576;
   };
 }


### PR DESCRIPTION
Tweaks settings of our cache nodes on both nginx and kernel side.

_A lot_ of these are just the `recommendedProxySettings` from nix spelled out and slightly tweaked; decided to get rid of them since they're opaque and it wasn't clear when tweaking things what was implicitly set through them.

Also added configuration commands that explain what everything does. Used to do these inside PRs but kernel parameters aren't exactly named self-descriptively, so think this is one of the bits where comments are valuable.

The main changes that isn't just a number tweak are `"net.ipv4.tcp_congestion_control" = "bbr";` which sets [BBR](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-01.html) as congestion control, which should make downloads much fairer among each other and especially create fairness between thousands of small CAS downloads and one bigger module cache download; and kTLS, which offloads TLS to the kernel instead of running it in userspace, which should make `sendfile` truely zero-copy.