### PR TITLE
fix(cache): handle null last_accessed_at in eviction and cap batch size

### DIFF
--- a/cache/lib/cache/key_value_entries.ex
+++ b/cache/lib/cache/key_value_entries.ex
@@ -10,6 +10,14 @@ defmodule Cache.KeyValueEntries do
 
   def delete_expired(max_age_days \\ 30) do
     cutoff = DateTime.add(DateTime.utc_now(), -max_age_days, :day)
-    Repo.delete_all(from(e in KeyValueEntry, where: e.last_accessed_at < ^cutoff))
+
+    ids_to_delete =
+      from(e in KeyValueEntry,
+        where: is_nil(e.last_accessed_at) or e.last_accessed_at < ^cutoff,
+        limit: 10_000,
+        select: e.id
+      )
+
+    Repo.delete_all(from(e in KeyValueEntry, where: e.id in subquery(ids_to_delete)))
   end
 end

--- a/cache/priv/repo/migrations/20260217120000_add_last_accessed_at_to_key_value_entries.exs
+++ b/cache/priv/repo/migrations/20260217120000_add_last_accessed_at_to_key_value_entries.exs
@@ -6,11 +6,6 @@ defmodule Cache.Repo.Migrations.AddLastAccessedAtToKeyValueEntries do
       add :last_accessed_at, :utc_datetime_usec
     end
 
-    execute(
-      "UPDATE key_value_entries SET last_accessed_at = strftime('%Y-%m-%dT%H:%M:%f', 'now') WHERE last_accessed_at IS NULL",
-      ""
-    )
-
     create index(:key_value_entries, [:last_accessed_at])
   end
 end


### PR DESCRIPTION
## Summary

- Remove the backfill `UPDATE` from the `last_accessed_at` migration, allowing the column to be nullable for existing rows because backfilling was way too slow
- Update the eviction query in `KeyValueEntries.delete_expired/1` to also delete entries where `last_accessed_at IS NULL`
- Cap eviction batches to 10,000 rows per execution to bound query cost