### PR TITLE
fix(cli): Prioritize local packages over registry versions

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -172,7 +172,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                 return $0.name
             }
         })
-        .map { _, groupedPackageInfos in
+        .compactMap { _, groupedPackageInfos in
             if let localPackage = groupedPackageInfos.first(where: {
                 ["local", "fileSystem", "localSourceControl"].contains($0.kind)
             }) {
@@ -180,9 +180,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             } else if let registryPackage = groupedPackageInfos.first(where: { $0.kind == "registry" }) {
                 return registryPackage
             } else {
-                /// `group` is guaranteed to be non-empty because `Dictionary(grouping:by:)` only creates buckets that contain
-                /// at least one element. If `packageInfos` is empty, the `map` body is never executed.
-                return groupedPackageInfos.first!
+                return groupedPackageInfos.first
             }
         }
 

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -5,7 +5,6 @@ import Testing
 import TuistCore
 import TuistSupport
 import TuistTesting
-
 @testable import TuistLoader
 
 struct SwiftPackageManagerGraphLoaderTests {
@@ -220,116 +219,112 @@ struct SwiftPackageManagerGraphLoaderTests {
         }
     }
 
-    @Test
-    func test_load_when_dependency_via_local_registry_and_scm() async throws {
-        try await withMockedDependencies {
-            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) {
-                temporaryDirectory in
-                // Given
-                let packageSettings = PackageSettings.test()
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_when_dependency_via_local_registry_and_scm() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 
-                let workspacePath = temporaryDirectory.appending(components: [
-                    ".build", "workspace-state.json",
-                ])
-                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
-                
-                let localPackagePath = temporaryDirectory.appending(component: "Alamofire")
-                try await fileSystem.makeDirectory(at: localPackagePath)
-                
-                try await fileSystem.writeText(
-                    """
-                    {
-                      "object" : {
-                        "artifacts" : [],
-                        "dependencies" : [
-                          {
-                            "basedOn" : null,
-                            "packageRef" : {
-                              "identity" : "Alamofire.Alamofire",
-                              "kind" : "registry",
-                              "location" : "Alamofire.Alamofire",
-                              "name" : "Alamofire.Alamofire"
-                            },
-                            "state" : {
-                              "name" : "registryDownload",
-                              "version" : "5.10.2"
-                            },
-                            "subpath" : "Alamofire/Alamofire/5.10.2"
-                          },
-                          {
-                            "basedOn" : null,
-                            "packageRef" : {
-                              "identity" : "Alamofire",
-                              "kind" : "remoteSourceControl",
-                              "location" : "https://github.com/Alamofire/Alamofire.git",
-                              "name" : "Alamofire"
-                            },
-                            "state" : {
-                              "checkoutState" : {
-                                "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-                                "version" : "2.4.0"
-                              },
-                              "name" : "sourceControlCheckout"
-                            },
-                            "subpath" : "alamofire"
-                          },
-                          {
-                            "basedOn" : null,
-                            "packageRef" : {
-                              "identity" : "Alamofire",
-                              "kind" : "fileSystem",
-                              "path" : "\(localPackagePath.pathString)",
-                              "name" : "Alamofire"
-                            },
-                            "state" : {
-                              "name" : "fileSystem",
-                              "path" : "\(localPackagePath.pathString)"
-                            },
-                            "subpath" : "Alamofire"
-                          },
-                        ],
-                      }
-                    }
-                    """,
-                    at: workspacePath
-                )
+        // Given
+        let packageSettings = PackageSettings.test()
 
-                try await fileSystem.makeDirectory(
-                    at: temporaryDirectory.appending(components: [".build", "Derived"])
-                )
-                try await fileSystem.touch(
-                    temporaryDirectory.appending(components: [
-                        ".build", "Derived", "Package.resolved",
-                    ])
-                )
-                try await fileSystem.touch(
-                    temporaryDirectory.appending(component: "Package.resolved")
-                )
+        let workspacePath = temporaryDirectory.appending(components: [
+            ".build", "workspace-state.json",
+        ])
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
 
-                given(packageInfoMapper)
-                    .resolveExternalDependencies(
-                        path: .any,
-                        packageInfos: .any,
-                        packageToFolder: .any,
-                        packageToTargetsToArtifactPaths: .any,
-                        packageModuleAliases: .any
-                    )
-                    .willReturn([:])
+        let localPackagePath = temporaryDirectory.appending(component: "Alamofire")
+        try await fileSystem.makeDirectory(at: localPackagePath)
 
-                // When
-                let got = try await subject.load(
-                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
-                    packageSettings: packageSettings,
-                    disableSandbox: true
-                )
-
-                // Then
-                // Expect local package to be picked (hash is nil for local)
-                #expect(
-                    got.externalProjects.values.map(\.hash) == [nil]
-                )
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "Alamofire.Alamofire",
+                      "kind" : "registry",
+                      "location" : "Alamofire.Alamofire",
+                      "name" : "Alamofire.Alamofire"
+                    },
+                    "state" : {
+                      "name" : "registryDownload",
+                      "version" : "5.10.2"
+                    },
+                    "subpath" : "Alamofire/Alamofire/5.10.2"
+                  },
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "Alamofire",
+                      "kind" : "remoteSourceControl",
+                      "location" : "https://github.com/Alamofire/Alamofire.git",
+                      "name" : "Alamofire"
+                    },
+                    "state" : {
+                      "checkoutState" : {
+                        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+                        "version" : "2.4.0"
+                      },
+                      "name" : "sourceControlCheckout"
+                    },
+                    "subpath" : "alamofire"
+                  },
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "Alamofire",
+                      "kind" : "fileSystem",
+                      "path" : "\(localPackagePath.pathString)",
+                      "name" : "Alamofire"
+                    },
+                    "state" : {
+                      "name" : "fileSystem",
+                      "path" : "\(localPackagePath.pathString)"
+                    },
+                    "subpath" : "Alamofire"
+                  },
+                ],
+              }
             }
-        }
+            """,
+            at: workspacePath
+        )
+
+        try await fileSystem.makeDirectory(
+            at: temporaryDirectory.appending(components: [".build", "Derived"])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(components: [
+                ".build", "Derived", "Package.resolved",
+            ])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(component: "Package.resolved")
+        )
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any
+            )
+            .willReturn([:])
+
+        // When
+        let got = try await subject.load(
+            packagePath: temporaryDirectory.appending(component: "Package.swift"),
+            packageSettings: packageSettings,
+            disableSandbox: true
+        )
+
+        // Then
+        #expect(
+            got.externalProjects.values.map(\.hash) == [nil]
+        )
     }
 
     @Test


### PR DESCRIPTION
Resolves [this issue](https://community.tuist.dev/t/swift-package-registry-overriding-local-dependency-in-tuist-generated-project/902)￼

## Summary

This PR fixes an issue in Tuist’s SwiftPM graph loading where a registry package could take precedence over a local/path dependency when the same package is present from multiple sources (local, registry, and/or SCM). In practice, this could cause the generated Xcode project to link against the registry version even when a local dependency was explicitly declared.

Tuist now selects a single package per "identity group" using the following precedence:

1. Local (path / fileSystem / local source control)
2. Registry
3. Source Control (SCM)

This matches SwiftPM’s expected behavior:

> “A local package dependency will override any regular dependency in the package graph that has the same package name.”
> — [Package Manager Local Dependencies](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0201-package-manager-local-dependencies.md)￼

and the behavior introduced on https://github.com/tuist/tuist/pull/7518

How I tested
- Added a unit test (currently asserting via a nil hash — open to suggestions if there’s a better assertion to use here).
- Verified manually by running `tuist run generate --path ...` on a project reproducing the scenario described in the forum link above, and confirmed the generated project uses the local package rather than the registry one after the fix.