### PR TITLE
feat(cache): report registry download events to server

### DIFF
--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -40,7 +40,8 @@ defmodule Cache.Application do
 
     children =
       if Cache.Config.analytics_enabled?() do
-        base_children ++ [Cache.CASEventsPipeline, Cache.GradleCacheEventsPipeline]
+        base_children ++
+          [Cache.CASEventsPipeline, Cache.GradleCacheEventsPipeline, Cache.RegistryDownloadEventsPipeline]
       else
         base_children
       end

--- a/cache/lib/cache/registry_download_events_pipeline.ex
+++ b/cache/lib/cache/registry_download_events_pipeline.ex
@@ -1,0 +1,119 @@
+defmodule Cache.RegistryDownloadEventsPipeline do
+  @moduledoc """
+  Broadway pipeline for batching and sending registry download events to the server.
+
+  Events are sent to the registry webhook endpoint.
+  """
+  use Broadway
+
+  alias Broadway.Message
+
+  require Logger
+
+  def start_link(_opts) do
+    batch_size = Application.get_env(:cache, :events_batch_size, 100)
+    batch_timeout = Application.get_env(:cache, :events_batch_timeout, 5_000)
+
+    Broadway.start_link(__MODULE__,
+      name: __MODULE__,
+      producer: [
+        module: {OffBroadwayMemory.Producer, buffer: :registry_download_events_buffer},
+        concurrency: 1
+      ],
+      processors: [
+        default: [concurrency: 2]
+      ],
+      batchers: [
+        http: [
+          concurrency: 2,
+          batch_size: batch_size,
+          batch_timeout: batch_timeout
+        ]
+      ]
+    )
+  end
+
+  @doc """
+  Pushes a registry download event to the pipeline asynchronously.
+  """
+  def async_push(event) do
+    OffBroadwayMemory.Buffer.async_push(:registry_download_events_buffer, event)
+  end
+
+  @impl true
+  def handle_message(_processor, message, _context) do
+    message
+    |> Message.put_batch_key(:default)
+    |> Message.put_batcher(:http)
+  end
+
+  @impl true
+  def handle_batch(:http, messages, _batch_info, _context) do
+    events = Enum.map(messages, & &1.data)
+    send_batch(events)
+    messages
+  end
+
+  defp send_batch(events) do
+    case Cache.Config.api_key() do
+      nil -> :ok
+      secret -> do_send_batch(secret, events)
+    end
+  end
+
+  defp do_send_batch(secret, events) do
+    server_url = Cache.Authentication.server_url()
+    url = "#{server_url}/webhooks/registry"
+
+    api_events =
+      Enum.map(events, fn event ->
+        %{
+          scope: event.scope,
+          name: event.name,
+          version: event.version
+        }
+      end)
+
+    body = Jason.encode!(%{events: api_events})
+
+    signature =
+      :hmac
+      |> :crypto.mac(:sha256, secret, body)
+      |> Base.encode16(case: :lower)
+
+    headers = [
+      {"x-cache-signature", signature},
+      {"content-type", "application/json"}
+    ]
+
+    req_options = Application.get_env(:cache, :req_options, [])
+
+    options =
+      Keyword.merge(
+        [
+          url: url,
+          method: :post,
+          headers: headers,
+          body: body,
+          finch: Cache.Finch,
+          retry: false,
+          cache: false
+        ],
+        req_options
+      )
+
+    case Req.request(options) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.error("Failed to send registry download events (status #{status}): #{inspect(body)}")
+
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to send registry download events: #{inspect(reason)}")
+        :ok
+    end
+  end
+end

--- a/cache/test/cache/registry_download_events_pipeline_test.exs
+++ b/cache/test/cache/registry_download_events_pipeline_test.exs
@@ -1,0 +1,163 @@
+defmodule Cache.RegistryDownloadEventsPipelineTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Cache.RegistryDownloadEventsPipeline
+
+  setup do
+    stub(Cache.Authentication, :server_url, fn -> "http://localhost:4000" end)
+    :ok
+  end
+
+  describe "async_push/1" do
+    test "does not crash when pushing a valid event" do
+      event = %{
+        scope: "apple",
+        name: "swift-argument-parser",
+        version: "1.0.0"
+      }
+
+      assert :ok = RegistryDownloadEventsPipeline.async_push(event)
+    end
+  end
+
+  describe "handle_message/3" do
+    test "sends events to http batcher with default batch key" do
+      event = %{
+        scope: "apple",
+        name: "swift-argument-parser",
+        version: "1.0.0"
+      }
+
+      message = %Broadway.Message{
+        data: event,
+        acknowledger: {Broadway.CallerAcknowledger, {self(), make_ref()}, :ok}
+      }
+
+      result = RegistryDownloadEventsPipeline.handle_message(:default, message, %{})
+
+      assert result.batch_key == :default
+      assert result.batcher == :http
+      assert result.data == event
+    end
+  end
+
+  describe "handle_batch/4" do
+    test "skips sending events when API key is not configured" do
+      stub(Cache.Config, :api_key, fn -> nil end)
+
+      events = [
+        %{scope: "apple", name: "swift-argument-parser", version: "1.0.0"}
+      ]
+
+      messages =
+        Enum.map(events, fn event ->
+          %Broadway.Message{
+            data: event,
+            acknowledger: {Broadway.CallerAcknowledger, {self(), make_ref()}, :ok}
+          }
+        end)
+
+      reject(&Req.request/1)
+
+      result =
+        RegistryDownloadEventsPipeline.handle_batch(
+          :http,
+          messages,
+          %{batch_key: :default},
+          %{}
+        )
+
+      assert result == messages
+    end
+
+    test "sends batch of events to the registry webhook with correct payload shape" do
+      events = [
+        %{scope: "apple", name: "swift-argument-parser", version: "1.0.0"},
+        %{scope: "pointfreeco", name: "swift-composable-architecture", version: "0.52.0"}
+      ]
+
+      messages =
+        Enum.map(events, fn event ->
+          %Broadway.Message{
+            data: event,
+            acknowledger: {Broadway.CallerAcknowledger, {self(), make_ref()}, :ok}
+          }
+        end)
+
+      expect(Req, :request, fn options ->
+        assert options[:url] == "http://localhost:4000/webhooks/registry"
+        assert options[:method] == :post
+
+        body = options[:body]
+        decoded_body = Jason.decode!(body)
+        assert length(decoded_body["events"]) == 2
+
+        first = Enum.at(decoded_body["events"], 0)
+        assert first["scope"] == "apple"
+        assert first["name"] == "swift-argument-parser"
+        assert first["version"] == "1.0.0"
+
+        second = Enum.at(decoded_body["events"], 1)
+        assert second["scope"] == "pointfreeco"
+        assert second["name"] == "swift-composable-architecture"
+        assert second["version"] == "0.52.0"
+
+        headers = options[:headers]
+        assert {"content-type", "application/json"} in headers
+        assert Enum.any?(headers, fn {key, _value} -> key == "x-cache-signature" end)
+
+        {:ok, %{status: 202, body: ""}}
+      end)
+
+      result =
+        RegistryDownloadEventsPipeline.handle_batch(
+          :http,
+          messages,
+          %{batch_key: :default},
+          %{}
+        )
+
+      assert result == messages
+    end
+
+    test "computes correct HMAC-SHA256 signature" do
+      secret = "test-api-key-secret"
+      stub(Cache.Config, :api_key, fn -> secret end)
+
+      events = [
+        %{scope: "apple", name: "swift-argument-parser", version: "1.0.0"}
+      ]
+
+      messages =
+        Enum.map(events, fn event ->
+          %Broadway.Message{
+            data: event,
+            acknowledger: {Broadway.CallerAcknowledger, {self(), make_ref()}, :ok}
+          }
+        end)
+
+      expect(Req, :request, fn options ->
+        body = options[:body]
+
+        expected_signature =
+          :hmac
+          |> :crypto.mac(:sha256, secret, body)
+          |> Base.encode16(case: :lower)
+
+        headers = options[:headers]
+        {_, actual_signature} = Enum.find(headers, fn {key, _} -> key == "x-cache-signature" end)
+        assert actual_signature == expected_signature
+
+        {:ok, %{status: 200, body: ""}}
+      end)
+
+      RegistryDownloadEventsPipeline.handle_batch(
+        :http,
+        messages,
+        %{batch_key: :default},
+        %{}
+      )
+    end
+  end
+end

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -38,6 +38,7 @@ defmodule Tuist do
       CacheActionItems,
       CommandEvents,
       CommandEvents.Event,
+      Registry,
       Registry.Swift.Packages,
       Registry.Swift.Packages.Package,
       Registry.Swift.Packages.PackageManifest,

--- a/server/lib/tuist/registry.ex
+++ b/server/lib/tuist/registry.ex
@@ -1,0 +1,22 @@
+defmodule Tuist.Registry do
+  @moduledoc false
+  alias Tuist.IngestRepo
+  alias Tuist.Registry.DownloadEvent
+
+  def create_download_events(events) when is_list(events) do
+    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+
+    entries =
+      Enum.map(events, fn event ->
+        %{
+          id: UUIDv7.generate(),
+          scope: event.scope,
+          name: event.name,
+          version: event.version,
+          inserted_at: now
+        }
+      end)
+
+    IngestRepo.insert_all(DownloadEvent, entries)
+  end
+end

--- a/server/lib/tuist/registry/download_event.ex
+++ b/server/lib/tuist/registry/download_event.ex
@@ -1,0 +1,15 @@
+defmodule Tuist.Registry.DownloadEvent do
+  @moduledoc """
+  Ecto schema for registry download events stored in ClickHouse.
+  """
+  use Ecto.Schema
+
+  @primary_key false
+  schema "registry_download_events" do
+    field :id, Ch, type: "UUID"
+    field :scope, Ch, type: "String"
+    field :name, Ch, type: "String"
+    field :version, Ch, type: "String"
+    field :inserted_at, Ch, type: "DateTime"
+  end
+end

--- a/server/lib/tuist_web/controllers/webhooks/registry_controller.ex
+++ b/server/lib/tuist_web/controllers/webhooks/registry_controller.ex
@@ -1,0 +1,30 @@
+defmodule TuistWeb.Webhooks.RegistryController do
+  use TuistWeb, :controller
+
+  alias Tuist.Registry
+
+  def handle(conn, %{"events" => events}) when is_list(events) do
+    download_events =
+      Enum.map(events, fn event ->
+        %{
+          scope: event["scope"],
+          name: event["name"],
+          version: event["version"]
+        }
+      end)
+
+    Registry.create_download_events(download_events)
+
+    conn
+    |> put_status(:accepted)
+    |> json(%{})
+    |> halt()
+  end
+
+  def handle(conn, _params) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: "Invalid payload"})
+    |> halt()
+  end
+end

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -83,6 +83,12 @@ defmodule TuistWeb.Endpoint do
     secret: {Tuist.Environment, :cache_api_key, []},
     signature_header: "x-cache-signature"
 
+  plug WebhookPlug,
+    at: "/webhooks/registry",
+    handler: TuistWeb.Webhooks.RegistryController,
+    secret: {Tuist.Environment, :cache_api_key, []},
+    signature_header: "x-cache-signature"
+
   # The /api/runs endpoint can receive large payloads (files, cacheable_tasks, cas_outputs)
   # for projects with thousands of files. 50MB should accommodate most projects.
   # TODO: Consider streaming large arrays instead of loading everything into memory.

--- a/server/priv/ingest_repo/migrations/20260219194813_create_registry_download_events_table.exs
+++ b/server/priv/ingest_repo/migrations/20260219194813_create_registry_download_events_table.exs
@@ -1,0 +1,27 @@
+defmodule Tuist.IngestRepo.Migrations.CreateRegistryDownloadEventsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:registry_download_events,
+             primary_key: false,
+             engine: "MergeTree",
+             options: "PARTITION BY toYYYYMM(inserted_at) ORDER BY (scope, name, inserted_at)"
+           ) do
+      add :id, :uuid, null: false
+      add :scope, :string, null: false
+      add :name, :string, null: false
+      add :version, :string, null: false
+      add :inserted_at, :naive_datetime, null: false, default: fragment("now()")
+    end
+
+    execute(
+      "ALTER TABLE registry_download_events ADD INDEX registry_download_events_scope_name_index (scope, name) TYPE bloom_filter(0.01) GRANULARITY 4",
+      "ALTER TABLE registry_download_events DROP INDEX IF EXISTS registry_download_events_scope_name_index"
+    )
+
+    execute(
+      "ALTER TABLE registry_download_events ADD INDEX registry_download_events_inserted_at_index (inserted_at) TYPE minmax GRANULARITY 4",
+      "ALTER TABLE registry_download_events DROP INDEX IF EXISTS registry_download_events_inserted_at_index"
+    )
+  end
+end

--- a/server/test/tuist_web/controllers/webhooks/registry_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/registry_controller_test.exs
@@ -1,0 +1,128 @@
+defmodule TuistWeb.Webhooks.RegistryControllerTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use Mimic
+
+  import Ecto.Query
+
+  alias Tuist.ClickHouseRepo
+  alias Tuist.Registry.DownloadEvent
+
+  @cache_api_key "test-registry-api-key"
+
+  setup %{conn: conn} do
+    stub(Tuist.Environment, :cache_api_key, fn -> @cache_api_key end)
+
+    %{conn: conn}
+  end
+
+  defp sign_request(body) do
+    json_body = Jason.encode!(body)
+
+    signature =
+      :hmac
+      |> :crypto.mac(:sha256, @cache_api_key, json_body)
+      |> Base.encode16(case: :lower)
+
+    {json_body, signature}
+  end
+
+  describe "POST /webhooks/registry" do
+    test "creates download events with valid payload and verifies in ClickHouse", %{conn: conn} do
+      unique_scope = "valid-test-#{System.unique_integer([:positive])}"
+
+      params = %{
+        "events" => [
+          %{"scope" => unique_scope, "name" => "swift-nio", "version" => "2.0.0"}
+        ]
+      }
+
+      {body, signature} = sign_request(params)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-cache-signature", signature)
+        |> post(~p"/webhooks/registry", body)
+
+      assert json_response(conn, 202) == %{}
+
+      events =
+        ClickHouseRepo.all(from(e in DownloadEvent, where: e.scope == ^unique_scope))
+
+      assert length(events) == 1
+      [event] = events
+      assert event.scope == unique_scope
+      assert event.name == "swift-nio"
+      assert event.version == "2.0.0"
+    end
+
+    test "returns 400 for invalid payload without events key", %{conn: conn} do
+      params = %{"invalid" => "data"}
+
+      {body, signature} = sign_request(params)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-cache-signature", signature)
+        |> post(~p"/webhooks/registry", body)
+
+      assert json_response(conn, 400) == %{"error" => "Invalid payload"}
+    end
+
+    test "handles batch of multiple events and all are inserted", %{conn: conn} do
+      unique_scope = "batch-test-#{System.unique_integer([:positive])}"
+
+      params = %{
+        "events" => [
+          %{"scope" => unique_scope, "name" => "swift-nio", "version" => "2.0.0"},
+          %{"scope" => unique_scope, "name" => "swift-log", "version" => "1.5.0"},
+          %{"scope" => unique_scope, "name" => "xcodeproj", "version" => "3.0.0"}
+        ]
+      }
+
+      {body, signature} = sign_request(params)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-cache-signature", signature)
+        |> post(~p"/webhooks/registry", body)
+
+      assert json_response(conn, 202) == %{}
+
+      events =
+        ClickHouseRepo.all(
+          from(e in DownloadEvent,
+            where: e.scope == ^unique_scope,
+            order_by: e.name
+          )
+        )
+
+      assert length(events) == 3
+      names = Enum.map(events, & &1.name)
+      assert "swift-log" in names
+      assert "swift-nio" in names
+      assert "xcodeproj" in names
+    end
+
+    test "rejects requests with invalid signature", %{conn: conn} do
+      params = %{
+        "events" => [
+          %{"scope" => "apple", "name" => "swift-nio", "version" => "2.0.0"}
+        ]
+      }
+
+      json_body = Jason.encode!(params)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-cache-signature", "invalid_signature")
+        |> post(~p"/webhooks/registry", json_body)
+
+      assert conn.status == 403
+      assert conn.resp_body == "Invalid signature"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Cache nodes collect registry package download events via a Broadway pipeline and batch-send them to the server through a signed webhook
- Server ingests download events into a ClickHouse `registry_download_events` table for tracking