### PR TITLE
fix(cache): fix incorrect S3 url composition when S3_ENDPOINT is set

### DIFF
--- a/cache/lib/cache/finch/pools.ex
+++ b/cache/lib/cache/finch/pools.ex
@@ -25,7 +25,11 @@ defmodule Cache.Finch.Pools do
 
     case Application.fetch_env(:ex_aws, :s3) do
       {:ok, s3_config} ->
-        s3_url = "#{s3_config[:scheme]}#{s3_config[:host]}"
+        s3_url =
+          case s3_config[:port] do
+            nil -> "#{s3_config[:scheme]}#{s3_config[:host]}"
+            port -> "#{s3_config[:scheme]}#{s3_config[:host]}:#{port}"
+          end
 
         Map.put(pools, s3_url,
           conn_opts: [


### PR DESCRIPTION
When `S3_ENDPOINT` was set, `runtime.exs` would incorrectly concatenate parsed `host` and `port` instead of keeping them two separate configuration items for ex_aws.
