### PR TITLE
fix(cli): place precompiled dependencies from SPM build directory in frameworks group

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Path
+import TuistConstants
 import TuistCore
 import TuistLogging
 import TuistSupport
@@ -354,6 +355,21 @@ class ProjectFileElements {
                 name: path.basename,
                 expectedSignature: expectedSignature,
                 toGroup: groups.cachedFrameworks,
+                pbxproj: pbxproj
+            )
+            compiled[path] = fileElement
+        } else if path.pathString
+            .contains("/\(Constants.SwiftPackageManager.packageBuildDirectoryName)/")
+        {
+            guard compiled[path] == nil else {
+                return
+            }
+            let fileElement = addFileElementWithAbsolutePath(
+                from: sourceRootPath,
+                fileAbsolutePath: path,
+                name: path.basename,
+                expectedSignature: expectedSignature,
+                toGroup: groups.frameworks,
                 pbxproj: pbxproj
             )
             compiled[path] = fileElement


### PR DESCRIPTION
## Summary

fixes https://github.com/tuist/tuist/issues/9461

Precompiled dependencies (e.g. xcframeworks) resolved from the SPM `.build/` directory were incorrectly placed in the project source group instead of the Frameworks group. This adds a check for paths containing the SPM package build directory name and routes them to the frameworks group, consistent with how other precompiled dependencies are handled.

Expected beahviour verified:

The sample project from https://github.com/tuist/tuist/issues/9461 now **does not** contain the `Tuist` group 

<img width="295" height="324" alt="Screenshot 2026-02-22 at 11 15 43" src="https://github.com/user-attachments/assets/1121608a-42c0-4715-a743-71df17580dd2" />


[TUI-494](https://linear.app/tuist/issue/TUI-494/generated-project-contains-references-to-3rd-party-libraries)
