### PR TITLE
fix(cli): replace deprecated tuist build recommendation in previews

### DIFF
--- a/cli/Sources/TuistShareCommand/Services/ShareCommandService.swift
+++ b/cli/Sources/TuistShareCommand/Services/ShareCommandService.swift
@@ -44,7 +44,7 @@ enum ShareCommandServiceError: Equatable, LocalizedError {
             case let .projectOrWorkspaceNotFound(path):
                 return "Workspace or project not found at \(path)"
             case let .noAppsFound(app: app, configuration: configuration):
-                return "\(app) for the \(configuration) configuration was not found. You can build it by running `tuist build \(app)`"
+                return "\(app) for the \(configuration) configuration was not found. You can build it by running `xcodebuild build -scheme \(app) -configuration \(configuration)`"
             case .appNotSpecified:
                 return "If you're not using Tuist projects, you must specify the app name when sharing an app, such as `tuist share App --platforms ios`."
             case .platformsNotSpecified:

--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -28,16 +28,28 @@ When building for device, it is currently your responsibility to ensure the app 
 :::
 
 ::: code-group
-```bash [Tuist Project]
+```bash [Tuist Project (Debug)]
 tuist generate App
 xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -sdk iphonesimulator # Build the app for the simulator
 xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App
 ```
-```bash [Xcode Project]
+```bash [Tuist Project (Release)]
+tuist generate App
+xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -sdk iphonesimulator # Build the app for the simulator
+xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
+tuist share App --configuration Release
+```
+```bash [Xcode Project (Debug)]
 xcodebuild -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
 xcodebuild -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Debug --platforms iOS
+tuist share App.ipa # Share an existing .ipa file
+```
+```bash [Xcode Project (Release)]
+xcodebuild -scheme App -project App.xcodeproj -configuration Release # Build the app for the simulator
+xcodebuild -scheme App -project App.xcodeproj -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
+tuist share App --configuration Release --platforms iOS
 tuist share App.ipa # Share an existing .ipa file
 ```
 <!-- -->


### PR DESCRIPTION
## Summary
- Updated the error message in `tuist share` to recommend `xcodebuild build` instead of the deprecated `tuist build` when an app bundle is not found
- Added Release configuration examples to the previews documentation alongside the existing Debug examples

## Test plan
- [ ] Verify the error message shows the correct `xcodebuild` command when running `tuist share` without a built app
- [ ] Verify the docs render correctly with the four tab variants (Tuist Project Debug/Release, Xcode Project Debug/Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)