### PR TITLE
fix(server): deduplicate first_run test case events

### DIFF
--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -747,7 +747,8 @@ test_case_definitions =
     }
   end
 
-{test_case_id_map, _test_cases_with_flaky_run} = Tuist.Tests.create_test_cases(tuist_project.id, test_case_definitions)
+{test_case_id_map, _test_cases_with_flaky_run, _new_test_case_ids} =
+  Tuist.Tests.create_test_cases(tuist_project.id, test_case_definitions)
 
 # Update flaky test cases to be marked as is_flaky
 # ~70% stay quarantined, ~30% get unquarantined (to show chart going down)


### PR DESCRIPTION
## Summary
- When a test case not yet seen on the default branch was run multiple times on a feature branch, a `first_run` event was created each time in ClickHouse
- `create_test_cases` already knows which test case IDs are truly new (not yet in the `test_cases` table), so we pass that set to `create_first_run_events` and only create events for those
- The `is_new` flag on `test_case_runs` is unaffected — it continues to be `true` on every run until the test case appears on the default branch

## Test plan
- [x] Added test: "creates only one first_run event even when test case is run multiple times"
- [x] Existing `is_new` detection tests still pass
- [x] Existing `list_test_case_events` and event creation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)