### PR TITLE
fix(app): use App Store export method for iOS upload

### DIFF
--- a/mise/tasks/app/bundle-ios.sh
+++ b/mise/tasks/app/bundle-ios.sh
@@ -20,7 +20,7 @@ op read "op://tuist/Distribution Certificate/distribution.p12" --out-file $TMP_D
 security import $TMP_DIR/certificate.p12 -P $(op read "op://tuist/Distribution Certificate/password") -A
 
 mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-op read "op://tuist/Tuist App Ad Hoc/Tuist_App_Ad_Hoc.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist.mobileprovision"
+op read "op://tuist/Tuist App Store Connect Provisioning Profile/Tuist_App_Store_Connect.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist.mobileprovision"
 
 EXPORT_OPTIONS_PLIST_PATH=$TMP_DIR/ExportOptions.plist
 
@@ -32,11 +32,11 @@ cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
 	<key>destination</key>
 	<string>export</string>
 	<key>method</key>
-	<string>release-testing</string>
+	<string>app-store</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>dev.tuist.app</key>
-		<string>Tuist App Ad Hoc</string>
+		<string>Tuist App Store Connect</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution: Tuist GmbH (U6LC622NKF)</string>


### PR DESCRIPTION
## Summary
- Switched iOS bundle export method from `release-testing` (Ad Hoc) to `app-store`, which includes the SwiftSupport folder required by App Store Connect
- Updated provisioning profile from Ad Hoc to App Store distribution profile
- Fixes ITMS-90426: "The SwiftSupport folder is missing"

## Test plan
- [ ] Verify the App Store provisioning profile exists in 1Password at `op://tuist/Tuist App Store Connect Provisioning Profile`
- [ ] Trigger an iOS app release and confirm App Store Connect accepts the upload without ITMS-90426

🤖 Generated with [Claude Code](https://claude.com/claude-code)