### PR TITLE
fix(server): optimize slow test case runs listing query

### DIFF
--- a/server/priv/ingest_repo/migrations/20260224100000_add_project_ran_at_projection_to_test_case_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260224100000_add_project_ran_at_projection_to_test_case_runs.exs
@@ -1,0 +1,42 @@
+defmodule Tuist.IngestRepo.Migrations.AddProjectRanAtProjectionToTestCaseRuns do
+  @moduledoc """
+  Replaces `proj_by_project_analytics` with a new `proj_test_case_runs_by_project_ran_at` projection
+  that includes all columns, ordered by `(project_id, ran_at)`.
+
+  This optimizes the most common test case runs query:
+
+      SELECT * FROM test_case_runs
+      WHERE project_id = ?
+      ORDER BY ran_at DESC
+      LIMIT 20
+
+  Without this projection, ClickHouse must scan all rows (100M+) because the table's
+  ordering key `(test_run_id, test_module_run_id, inserted_at, id)` doesn't start
+  with `project_id`. The old `proj_by_project_analytics` had the right ordering prefix
+  but only included 6 columns, so ClickHouse couldn't use it for `SELECT *` queries.
+  Since the new projection is a superset, the old one is no longer needed.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_analytics"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_case_runs
+    ADD PROJECTION proj_test_case_runs_by_project_ran_at (
+      SELECT *
+      ORDER BY project_id, ran_at
+    )
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_test_case_runs_by_project_ran_at"
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260224100001_materialize_project_ran_at_projection.exs
+++ b/server/priv/ingest_repo/migrations/20260224100001_materialize_project_ran_at_projection.exs
@@ -1,0 +1,23 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeProjectRanAtProjection do
+  @moduledoc """
+  Materializes the `proj_test_case_runs_by_project_ran_at` projection for existing data parts.
+  This is a separate migration so that the DDL change is applied first and new
+  data immediately benefits from the projection.
+
+  Materialization rebuilds the projection for all existing data parts and may
+  take time on large tables.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_test_case_runs_by_project_ran_at"
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new ClickHouse projection `proj_test_case_runs_by_project_ran_at` (`SELECT * ORDER BY project_id, ran_at`) to optimize the most common test case runs listing query
- Drops the now-redundant `proj_by_project_analytics` projection (same ordering prefix but only 6 columns, so ClickHouse couldn't use it for `SELECT *` queries)
- Without this projection, ClickHouse scans all 100M+ rows; with it, it jumps directly to the project and reads only the needed rows

### Query being optimized

```sql
SELECT
    t0.id,
    t0.name,
    t0.test_run_id,
    t0.test_module_run_id,
    t0.test_suite_run_id,
    t0.test_case_id,
    t0.project_id,
    t0.is_ci,
    t0.scheme,
    t0.account_id,
    t0.ran_at,
    t0.git_branch,
    t0.git_commit_sha,
    t0.status,
    t0.is_flaky,
    t0.is_new,
    t0.duration,
    t0.inserted_at,
    t0.module_name,
    t0.suite_name
FROM test_case_runs AS t0
WHERE t0.project_id = _CAST(1227, 'Int64')
ORDER BY t0.ran_at DESC
LIMIT _CAST(0, 'Int64'), _CAST(20, 'Int64')
```

This query was reading **101M rows** and timing out after 15 seconds (`QUERY_WAS_CANCELLED`).

## Test plan
- [ ] Deploy and run `mix ecto.migrate` against ClickHouse
- [ ] Wait for materialization to complete on existing data parts
- [ ] Verify the slow query uses the new projection via `EXPLAIN` or query log
- [ ] Confirm test case runs listing page loads in under 1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)