### PR TITLE
fix(app): fix build commands in AGENTS.md to use workspace

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -15,8 +15,8 @@ This node covers the Tuist companion app under `app/`. The app provides a menu b
 
 ## Building and Testing
 - Generate the project: `tuist generate --no-open` (from `app/` directory)
-- Build: `xcodebuild build -project TuistApp.xcodeproj -scheme TuistApp`
-- Test: `xcodebuild test -project TuistApp.xcodeproj -scheme TuistApp`
+- Build: `xcodebuild build -workspace TuistApp.xcworkspace -scheme TuistApp`
+- Test: `xcodebuild test -workspace TuistApp.xcworkspace -scheme TuistApp`
 
 ## Dependencies
 The app depends on several CLI modules:


### PR DESCRIPTION
## Summary
- Fixes build/test commands in `app/AGENTS.md` to reference the workspace (`TuistApp.xcworkspace`) instead of the project (`TuistApp.xcodeproj`)
- Triggers app release to pick up the App Store export method fix from #9565

## Test plan
- [ ] Verify app release is triggered after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)