### PR TITLE
fix(app): install both profiles, let export re-sign for App Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -674,7 +674,7 @@ jobs:
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
       - name: Generate TuistApp
-        run: TUIST_APP_STORE_BUILD=1 tuist generate TuistApp --no-binary-cache
+        run: tuist generate TuistApp --no-binary-cache
       - name: Upload iOS App to App Store Connect
         run: mise run app:upload-ios
         env:

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -150,7 +150,7 @@ let project = Project(
                     // Needed for the app notarization
                     "OTHER_CODE_SIGN_FLAGS": "--timestamp --deep",
                     "ENABLE_HARDENED_RUNTIME": true,
-                    "PROVISIONING_PROFILE_SPECIFIER[sdk=iphone*]": Environment.appStoreBuild.getBoolean(default: false) ? "Tuist App Store Connect" : "Tuist App Ad Hoc",
+                    "PROVISIONING_PROFILE_SPECIFIER[sdk=iphone*]": "Tuist App Ad Hoc",
                     "PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]": "Tuist macOS Distribution",
                 ]
             )

--- a/mise/tasks/app/bundle-ios.sh
+++ b/mise/tasks/app/bundle-ios.sh
@@ -20,7 +20,8 @@ op read "op://tuist/Distribution Certificate/distribution.p12" --out-file $TMP_D
 security import $TMP_DIR/certificate.p12 -P $(op read "op://tuist/Distribution Certificate/password") -A
 
 mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-op read "op://tuist/Tuist App Store Connect Provisioning Profile/Tuist_App_Store_Connect.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist.mobileprovision"
+op read "op://tuist/Tuist App Ad Hoc/Tuist_App_Ad_Hoc.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_ad_hoc.mobileprovision"
+op read "op://tuist/Tuist App Store Connect Provisioning Profile/Tuist_App_Store_Connect.mobileprovision" --out-file "$HOME/Library/MobileDevice/Provisioning Profiles/tuist_app_store.mobileprovision"
 
 EXPORT_OPTIONS_PLIST_PATH=$TMP_DIR/ExportOptions.plist
 
@@ -32,7 +33,7 @@ cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
 	<key>destination</key>
 	<string>export</string>
 	<key>method</key>
-	<string>app-store</string>
+	<string>app-store-connect</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>dev.tuist.app</key>
@@ -52,7 +53,7 @@ cat << EOF > "$EXPORT_OPTIONS_PLIST_PATH"
 </plist>
 EOF
 
-tuist xcodebuild archive clean -archivePath $TMP_DIR/Tuist.xcarchive -workspace Tuist.xcworkspace -scheme TuistApp -configuration Release -destination "generic/platform=iOS" CODE_SIGN_IDENTITY="Apple Distribution: Tuist GmbH (U6LC622NKF)" CODE_SIGN_STYLE="Manual" CODE_SIGN_INJECT_BASE_ENTITLEMENTS="NO" PROVISIONING_PROFILE_SPECIFIER="Tuist App Store Connect"
+tuist xcodebuild archive clean -archivePath $TMP_DIR/Tuist.xcarchive -workspace Tuist.xcworkspace -scheme TuistApp -configuration Release -destination "generic/platform=iOS" CODE_SIGN_IDENTITY="Apple Distribution: Tuist GmbH (U6LC622NKF)" CODE_SIGN_STYLE="Manual" CODE_SIGN_INJECT_BASE_ENTITLEMENTS="NO"
 xcodebuild -exportArchive -archivePath $TMP_DIR/Tuist.xcarchive -exportOptionsPlist $EXPORT_OPTIONS_PLIST_PATH -exportPath $TMP_DIR
 mkdir -p build
 cp $TMP_DIR/Tuist.ipa build/Tuist.ipa


### PR DESCRIPTION
## Summary
- Install both Ad Hoc and App Store provisioning profiles in `bundle-ios.sh`
- Archive uses Ad Hoc (from `Project.swift` settings, only on TuistApp target) — avoids propagation to dependency targets
- Export re-signs with App Store profile (via `ExportOptions.plist`) and uses `app-store` method, which includes the SwiftSupport folder
- Reverts the dynamic config approach from #9569 which caused provisioning profile errors on all dependency targets
- Fixes ITMS-90426: "The SwiftSupport folder is missing"

## Test plan
- [ ] Verify the iOS release job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)