### PR TITLE
fix(server): make MATERIALIZE mutations synchronous to prevent migration failures

### DIFF
--- a/server/priv/ingest_repo/migrations/20260223100001_materialize_id_index_and_flaky_projection.exs
+++ b/server/priv/ingest_repo/migrations/20260223100001_materialize_id_index_and_flaky_projection.exs
@@ -14,10 +14,10 @@ defmodule Tuist.IngestRepo.Migrations.MaterializeIdIndexAndFlakyProjection do
 
   def up do
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs MATERIALIZE INDEX idx_id"
+    execute "ALTER TABLE test_case_runs MATERIALIZE INDEX idx_id SETTINGS mutations_sync = 1"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_by_project_flaky"
+    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_by_project_flaky SETTINGS mutations_sync = 1"
   end
 
   def down do

--- a/server/priv/ingest_repo/migrations/20260224100001_materialize_project_ran_at_projection.exs
+++ b/server/priv/ingest_repo/migrations/20260224100001_materialize_project_ran_at_projection.exs
@@ -14,7 +14,7 @@ defmodule Tuist.IngestRepo.Migrations.MaterializeProjectRanAtProjection do
 
   def up do
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_test_case_runs_by_project_ran_at"
+    execute "ALTER TABLE test_case_runs MATERIALIZE PROJECTION proj_test_case_runs_by_project_ran_at SETTINGS mutations_sync = 1"
   end
 
   def down do


### PR DESCRIPTION
## Summary
- Adds `SETTINGS mutations_sync = 1` to `MATERIALIZE INDEX` and `MATERIALIZE PROJECTION` statements in ClickHouse migrations for `test_case_runs`
- ClickHouse MATERIALIZE operations are asynchronous by default, queuing background mutations. Subsequent migrations that modify the same table fail because ClickHouse refuses to alter a table with pending mutations.
- This fixes the migration failure: `Cannot drop projection proj_by_project_analytics because it's affected by mutation which is not finished yet`

## Test plan
- [ ] Run `mix ecto.migrate` on the IngestRepo and verify all migrations pass without errors
- [ ] Verify the `proj_test_case_runs_by_project_ran_at` projection is created and materialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)