### PR TITLE
fix(server): hide Operations button from non-ops users in account dropdown

### DIFF
--- a/server/lib/tuist_web/components/account_dropdown.ex
+++ b/server/lib/tuist_web/components/account_dropdown.ex
@@ -63,7 +63,7 @@ defmodule TuistWeb.AccountDropdown do
                 <:icon_left><.settings /></:icon_left>
               </.button>
               <.button
-                :if={Authorization.authorize(:ops_read, @current_user)}
+                :if={Authorization.authorize(:ops_read, @current_user) == :ok}
                 navigate={~p"/ops/qa"}
                 label={dgettext("dashboard", "Operations")}
                 variant="secondary"

--- a/server/test/tuist_web/live/account_dropdown_test.exs
+++ b/server/test/tuist_web/live/account_dropdown_test.exs
@@ -1,0 +1,29 @@
+defmodule TuistWeb.AccountDropdownTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.LiveCase
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  alias Tuist.Environment
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = AccountsFixtures.user_fixture(preload: [:account])
+
+    Mimic.stub(Environment, :ops_user_handles, fn -> [] end)
+
+    conn = log_in_user(conn, user)
+
+    %{conn: conn, user: user}
+  end
+
+  test "does not show the Operations button for non-ops users", %{conn: conn, user: user} do
+    # When
+    {:ok, _lv, html} = live(conn, ~p"/#{user.account.name}/settings")
+
+    # Then
+    refute html =~ "/ops/qa"
+    refute html =~ "Operations"
+  end
+end


### PR DESCRIPTION
## Summary

- **Bug**: The "Operations" button in the account dropdown was visible to all authenticated users, not just ops users.
- **Root cause**: `Authorization.authorize(:ops_read, @current_user)` returns `:ok` or `{:error, :forbidden}`. Since `{:error, :forbidden}` is truthy in Elixir (only `nil` and `false` are falsy), the `:if` condition always evaluated to true.
- **Fix**: Changed the condition to `Authorization.authorize(:ops_read, @current_user) == :ok` so it properly checks for the success value.

## Test Plan

Added `AccountDropdownTest` LiveView test that renders the account settings page as a non-ops user (stubbing `Environment.ops_user_handles` to return `[]`) and asserts the Operations button/link is not present.