### PR TITLE
fix(cli): move macOS pipelines back to GitHub runners

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -76,7 +76,7 @@ jobs:
             }
   app-build:
     name: Build
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     needs: [check-team-membership]
     if: |

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -95,7 +95,7 @@ jobs:
             }
   inspect-implicit-imports:
     name: Inspect Implicit Imports
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 60
     needs: [check-team-membership]
     if: |
@@ -117,9 +117,6 @@ jobs:
           submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: actions/cache/restore@v4
         id: cache
         with:
@@ -144,7 +141,7 @@ jobs:
           TUIST_EE: 1
   acceptance-tests:
     name: Acceptance Tests
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 40
     needs: [check-team-membership]
     if: |
@@ -166,9 +163,6 @@ jobs:
           submodules: recursive
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: actions/cache/restore@v4
         id: cache
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -54,15 +54,12 @@ concurrency:
 jobs:
   cli-lint:
     name: Lint
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: actions/cache/restore@v4
         id: cache
         with:
@@ -89,16 +86,13 @@ jobs:
 
   cli-spm-build:
     name: SwiftPM Build
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: actions/cache/restore@v4
         id: cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,7 +415,7 @@ jobs:
     name: Release CLI
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -435,9 +435,6 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.resolved') }}
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v3.2.0
         with:
           install_args: "tuist git-cliff 1password-cli"
@@ -564,7 +561,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -581,9 +578,6 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Install create-dmg
         run: brew install create-dmg
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v3.2.0
         with:
           install_args: "tuist git-cliff 1password-cli"
@@ -657,7 +651,7 @@ jobs:
     name: Release iOS App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -670,9 +664,6 @@ jobs:
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
-      - uses: namespacelabs/nscloud-cache-action@v1
-        with:
-          cache: mise
       - uses: jdx/mise-action@v3.2.0
         with:
           install_args: "tuist 1password-cli"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -65,7 +65,7 @@ jobs:
           mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"
   acceptance-tests:
     name: Acceptance Tests
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-26
     timeout-minutes: 30
     needs: canary
     environment: server-canary


### PR DESCRIPTION
## Summary
This PR moves most macOS GitHub Actions jobs back from Namespace runners to GitHub-hosted runners (`macos-26`) to reduce Namespace spend.

## Context
**Namespace costs increased significantly**, and these pipelines were a major contributor after the previous migration to `namespace-profile-default-macos`.

## What Changed
- Switched macOS jobs from `namespace-profile-default-macos` to `macos-26` in:
  - `.github/workflows/app.yml`
  - `.github/workflows/cli.yml`
  - `.github/workflows/cli-cache-ee.yml`
  - `.github/workflows/release.yml`
  - `.github/workflows/server-production-deployment.yml`
- Removed `namespacelabs/nscloud-cache-action@v1` from the jobs moved to GitHub-hosted macOS runners.
- **Kept Unit Tests jobs on Namespace** as requested:
  - `cli.yml` → `cli-unit-tests`
  - `cli-cache-ee.yml` → `unit-tests`

## Alternatives Considered
- **Move all macOS jobs to GitHub-hosted runners**:
  - Rejected to preserve the existing Unit Tests behavior/performance profile.
- **Keep current Namespace setup and optimize elsewhere**:
  - Rejected because runner migration is the fastest direct lever to reduce Namespace costs.

## Testing Notes
- Validated YAML parsing locally for all modified workflows using Ruby YAML loader.
- Verified there are no unintended `namespace-profile-default-macos` entries beyond the two Unit Tests jobs.
- **Not run**: full CI workflow execution in GitHub Actions (will be validated by this PR checks).
