### PR TITLE
fix(server): remove synchronous DELETE from ClickHouse migration to avoid deploy timeout

### DIFF
--- a/server/priv/ingest_repo/migrations/20260225100001_make_project_id_and_ran_at_non_nullable_in_test_case_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260225100001_make_project_id_and_ran_at_non_nullable_in_test_case_runs.exs
@@ -20,12 +20,6 @@ defmodule Tuist.IngestRepo.Migrations.MakeProjectIdAndRanAtNonNullableInTestCase
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky"
 
-    # The backfill migration (100000) used INSERT to create new rows with non-null
-    # values, but in MergeTree the old rows with NULLs still exist. Delete them
-    # so MODIFY COLUMN can convert to non-nullable without hitting NULLs.
-    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs DELETE WHERE project_id IS NULL OR ran_at IS NULL SETTINGS mutations_sync = 1"
-
     # ClickHouse requires a DEFAULT when converting from Nullable to non-nullable,
     # even when no NULLs exist. We remove it immediately after so the column
     # ends up non-nullable with no default.


### PR DESCRIPTION
## Summary

- Removes the `DELETE WHERE project_id IS NULL OR ran_at IS NULL SETTINGS mutations_sync = 1` from the migration — it scans ~47M rows on S3 storage and times out Render's port binding check

## Before deploying

Run these in the ClickHouse console and wait for each to complete:

```sql
-- Kill any stuck mutations from previous failed attempts
KILL MUTATION WHERE table = 'test_case_runs' AND is_done = 0;

-- Delete old rows with NULLs (the INSERT backfill left them behind)
ALTER TABLE test_case_runs DELETE WHERE project_id IS NULL OR ran_at IS NULL SETTINGS mutations_sync = 1;
```

Verify no pending mutations remain before deploying:
```sql
SELECT * FROM system.mutations WHERE table = 'test_case_runs' AND is_done = 0;
```

## Test plan

- [ ] Run manual steps in ClickHouse console
- [ ] Deploy and verify migration completes successfully
- [ ] Verify projections are recreated and materialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)