### PR TITLE
fix(server): add mutations_sync to DROP PROJECTION in ClickHouse migration

### DIFF
--- a/server/priv/ingest_repo/migrations/20260225100001_make_project_id_and_ran_at_non_nullable_in_test_case_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260225100001_make_project_id_and_ran_at_non_nullable_in_test_case_runs.exs
@@ -15,10 +15,10 @@ defmodule Tuist.IngestRepo.Migrations.MakeProjectIdAndRanAtNonNullableInTestCase
 
   def up do
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_test_case_runs_by_project_ran_at"
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_test_case_runs_by_project_ran_at SETTINGS mutations_sync = 1"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky"
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky SETTINGS mutations_sync = 1"
 
     # ClickHouse requires a DEFAULT when converting from Nullable to non-nullable,
     # even when no NULLs exist. We remove it immediately after so the column


### PR DESCRIPTION
## Summary

- Adds `SETTINGS mutations_sync = 1` to the two `DROP PROJECTION IF EXISTS` statements in migration `20260225100001`

## Context

Each failed deploy attempt queues duplicate `DROP PROJECTION` mutations. On retry, ClickHouse rejects new ALTERs with error 517 because the previous mutations haven't finished. Adding `mutations_sync = 1` makes each statement wait for completion before proceeding.

### Before deploying

Kill pending mutations from previous failed attempts in the ClickHouse console:

```sql
KILL MUTATION WHERE table = 'test_case_runs';
```

## Test plan

- [ ] Kill pending mutations via ClickHouse console
- [ ] Deploy and verify migration completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)