### PR TITLE
fix(server): Fix login slowness on Safari iOS

### DIFF
--- a/server/assets/app/css/pages/auth.css
+++ b/server/assets/app/css/pages/auth.css
@@ -160,7 +160,10 @@
   }
 
   & [data-part="background"] {
-    @media (max-width: 768px) {
+    /* This is necessary because in Safari iOS, "filter: blur()" makes the main thread hang;
+       causing the rendering to be slow, and other cascading issues, like the websocket connection
+       timing out */
+    @supports (-webkit-touch-callout: none) {
       display: none;
     }
 
@@ -215,9 +218,7 @@
       left: 0px;
       translate: -50% 20%;
       z-index: var(--noora-z-index-2);
-      @media (min-width: 768px) {
-        filter: blur(150px);
-      }
+      filter: blur(150px);
       border-radius: 1000px;
       background: light-dark(oklch(54.2% 0.27 286.9 / 0.1), oklch(54.2% 0.27 286.9 / 0.15));
       width: 90%;


### PR DESCRIPTION
Turns out 😬 that the slowness on Safari iOS, which only happens on the login page, is caused by the CSS attribute `filter: blur(150px);` that we use for the background, which takes ages to render on Safari iOS, causing the main thread to freeze and other pieces, like the websocket connection to timeout falling back to longpolls. 

I'm hiding it on Safari iOS and took the opportunity to align the login content horizontally and reduce some top and bottom padding that made the page scrollable unnecessarily.