### PR TITLE
fix(cli): Fix buildable-folder header visibility and generation crash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ Examples:
 
 ## Workflow
 - The Xcode project is generated with Tuist running `tuist generate --no-open`
-- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace` instead of `swift build`
-- When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests` instead of `swift test`.
+- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift build`
+- When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift test`.
 - Prefer running test suites or individual test cases, and not the whole test target, for performance
 - When using `swift build`, `swift test`, or `swift package resolve` always include `--replace-scm-with-registry` to avoid switching packages from registry to source control resolution
 

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -70,6 +70,7 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         if shouldAddHeadersBuildPhase(target) {
             try generateHeadersBuildPhase(
                 headers: target.headers,
+                buildableFolders: target.buildableFolders,
                 pbxTarget: pbxTarget,
                 fileElements: fileElements,
                 pbxproj: pbxproj
@@ -345,6 +346,7 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
 
     func generateHeadersBuildPhase(
         headers: Headers?,
+        buildableFolders: [BuildableFolder],
         pbxTarget: PBXTarget,
         fileElements: ProjectFileElements,
         pbxproj: PBXProj
@@ -352,6 +354,10 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         let headersBuildPhase = PBXHeadersBuildPhase()
         pbxproj.add(object: headersBuildPhase)
         pbxTarget.buildPhases.append(headersBuildPhase)
+
+        let isPartOfSynchronizedGroup: (AbsolutePath) -> Bool = { path in
+            buildableFolders.contains { path.isDescendant(of: $0.path) }
+        }
 
         let addHeader: (AbsolutePath, String?) throws -> PBXBuildFile = { path, accessLevel in
             guard let fileReference = fileElements.file(path: path) else {
@@ -363,9 +369,18 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             return PBXBuildFile(file: fileReference, settings: settings)
         }
         if let headers {
-            let pbxBuildFiles = try headers.private.sorted().map { try addHeader($0, "private") } +
-                headers.public.sorted().map { try addHeader($0, "public") } +
-                headers.project.sorted().map { try addHeader($0, nil) }
+            let pbxBuildFiles = try headers.private
+                .filter { !isPartOfSynchronizedGroup($0) }
+                .sorted()
+                .map { try addHeader($0, "private") } +
+                headers.public
+                .filter { !isPartOfSynchronizedGroup($0) }
+                .sorted()
+                .map { try addHeader($0, "public") } +
+                headers.project
+                .filter { !isPartOfSynchronizedGroup($0) }
+                .sorted()
+                .map { try addHeader($0, nil) }
 
             pbxBuildFiles.forEach { pbxproj.add(object: $0) }
             headersBuildPhase.files = pbxBuildFiles

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -227,10 +227,66 @@ struct TargetGenerator: TargetGenerating {
                 synchronizedGroup.exceptions?.append(exceptionSet)
             }
 
+            let targetHeadersInSynchronizedGroup = synchronizedHeaders(
+                buildableFolderPath: buildableFolder.path,
+                targetHeaders: target.headers,
+                buildableFolderExceptions: buildableFolder.exceptions
+            )
+            if !targetHeadersInSynchronizedGroup.public.isEmpty || !targetHeadersInSynchronizedGroup.private.isEmpty {
+                let exceptionSet = PBXFileSystemSynchronizedBuildFileExceptionSet(
+                    target: pbxTarget,
+                    membershipExceptions: [],
+                    publicHeaders: targetHeadersInSynchronizedGroup.public,
+                    privateHeaders: targetHeadersInSynchronizedGroup.private,
+                    additionalCompilerFlagsByRelativePath: [:],
+                    attributesByRelativePath: nil,
+                    platformFiltersByRelativePath: nil
+                )
+                pbxproj.add(object: exceptionSet)
+                synchronizedGroup.exceptions?.append(exceptionSet)
+            }
+
             if !explicitFolders.isEmpty {
                 synchronizedGroup.explicitFolders = explicitFolders
             }
         }
+    }
+
+    private func synchronizedHeaders(
+        buildableFolderPath: AbsolutePath,
+        targetHeaders: Headers?,
+        buildableFolderExceptions: BuildableFolderExceptions
+    ) -> (public: [String], private: [String]) {
+        guard let targetHeaders else { return (public: [], private: []) }
+
+        let existingPublicHeaders = Set(
+            buildableFolderExceptions
+                .flatMap(\.publicHeaders)
+                .filter { $0.isDescendant(of: buildableFolderPath) }
+                .map { $0.relative(to: buildableFolderPath).pathString }
+        )
+        let existingPrivateHeaders = Set(
+            buildableFolderExceptions
+                .flatMap(\.privateHeaders)
+                .filter { $0.isDescendant(of: buildableFolderPath) }
+                .map { $0.relative(to: buildableFolderPath).pathString }
+        )
+
+        let publicHeaders = Set(
+            targetHeaders.public
+                .filter { $0.isDescendant(of: buildableFolderPath) }
+                .map { $0.relative(to: buildableFolderPath).pathString }
+        )
+        let privateHeaders = Set(
+            targetHeaders.private
+                .filter { $0.isDescendant(of: buildableFolderPath) }
+                .map { $0.relative(to: buildableFolderPath).pathString }
+        )
+
+        return (
+            public: Array(publicHeaders.subtracting(existingPublicHeaders)).sorted(),
+            private: Array(privateHeaders.subtracting(existingPrivateHeaders)).sorted()
+        )
     }
 
     func generateTargetDependencies(

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -507,6 +507,7 @@ struct BuildPhaseGeneratorTests {
         // When
         try subject.generateHeadersBuildPhase(
             headers: headers,
+            buildableFolders: [],
             pbxTarget: target,
             fileElements: fileElements,
             pbxproj: pbxproj
@@ -533,6 +534,43 @@ struct BuildPhaseGeneratorTests {
             FileWithSettings(name: "Public1.h", attributes: ["Public"]),
             FileWithSettings(name: "Project1.h", attributes: nil),
         ])
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateHeadersBuildPhase_skipsHeadersFromBuildableFolders() throws {
+        // Given
+        let target = PBXNativeTarget(name: "Test")
+        let pbxproj = PBXProj()
+        pbxproj.add(object: target)
+
+        let headers = Headers(
+            public: ["/test/Sources/Public1.h"],
+            private: ["/test/Sources/Private1.h"],
+            project: ["/test/Sources/Project1.h"]
+        )
+        let buildableFolders = [
+            BuildableFolder(
+                path: "/test/Sources",
+                exceptions: BuildableFolderExceptions(exceptions: []),
+                resolvedFiles: []
+            ),
+        ]
+
+        // When
+        try subject.generateHeadersBuildPhase(
+            headers: headers,
+            buildableFolders: buildableFolders,
+            pbxTarget: target,
+            fileElements: .init(),
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try #require(target.buildPhases.first as? PBXHeadersBuildPhase)
+        #expect(buildPhase.files?.isEmpty == true)
     }
 
     @Test(

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -101,6 +101,70 @@ struct TargetGeneratorTests {
         #expect(exception.platformFiltersByRelativePath == ["Resources/ios_only.mp4": ["ios"]])
     }
 
+    @Test func generateTarget_synchronizedGroups_mapsTargetHeadersIntoSynchronizedExceptions() async throws {
+        // Given
+        let buildableFolderPath = path.appending(component: "Sources")
+        let publicHeaderPath = path.appending(components: ["Sources", "Headers", "Public.h"])
+        let privateHeaderPath = path.appending(components: ["Sources", "Headers", "Private.h"])
+        let projectHeaderPath = path.appending(components: ["Sources", "Headers", "Project.h"])
+        let target = Target.test(
+            name: "MyFramework",
+            product: .framework,
+            headers: Headers(
+                public: [publicHeaderPath],
+                private: [privateHeaderPath],
+                project: [projectHeaderPath]
+            ),
+            scripts: [],
+            buildableFolders: [
+                BuildableFolder(path: buildableFolderPath, exceptions: BuildableFolderExceptions(exceptions: []), resolvedFiles: [
+                    BuildableFolderFile(path: path.appending(components: ["Sources", "Included.swift"]), compilerFlags: nil),
+                    BuildableFolderFile(path: publicHeaderPath, compilerFlags: nil),
+                    BuildableFolderFile(path: privateHeaderPath, compilerFlags: nil),
+                    BuildableFolderFile(path: projectHeaderPath, compilerFlags: nil),
+                ]),
+            ]
+        )
+        let project = Project.test(
+            path: path,
+            sourceRootPath: path,
+            xcodeProjPath: path.appending(component: "Test.xcodeproj"),
+            targets: [target]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(
+            project: project,
+            pbxproj: pbxproj
+        )
+        try fileElements.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // When
+        let generatedTarget = try await subject.generateTarget(
+            target: target,
+            project: project,
+            pbxproj: pbxproj,
+            pbxProject: pbxProject,
+            projectSettings: Settings.test(),
+            fileElements: fileElements,
+            path: path,
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+        let group = try #require(generatedTarget.fileSystemSynchronizedGroups?.first)
+        #expect(group.exceptions?.count == 1)
+        let exception = try #require(group.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
+        #expect(exception.membershipExceptions == nil || exception.membershipExceptions == [])
+        #expect(exception.publicHeaders == ["Headers/Public.h"])
+        #expect(exception.privateHeaders == ["Headers/Private.h"])
+    }
+
     @Test(.inTemporaryDirectory) func generateTarget_synchronizedGroups_withExcludedFolders() async throws {
         // Given
         let temporaryPath = try #require(FileSystem.temporaryTestDirectory)


### PR DESCRIPTION
## Summary
- **Avoid header phase generation crashes** by skipping header build file entries that belong to synchronized buildable folders (those files do not have standalone file references).
- **Preserve header visibility for synchronized folders** by mapping target-level public/private headers into `PBXFileSystemSynchronizedBuildFileExceptionSet` entries.
- **Add regression coverage** for both behaviors in `BuildPhaseGeneratorTests` and `TargetGeneratorTests`.
- **Document Xcode test/build invocation** in `AGENTS.md` with explicit signing-disable flags (`CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`).

## Context
Issue: https://github.com/tuist/tuist/issues/9601

With buildable folders enabled, Objective-C header visibility could be lost or generation could fail when headers were declared in target headers while sources were represented through synchronized groups.

## Rationale
The generated project represents buildable-folder contents through synchronized groups, not per-file references. Adding those headers to the standard headers build phase can therefore fail. Visibility must be expressed through synchronized exception sets instead.

## Alternatives Considered
- **Require users to always declare folder exceptions manually** (`publicHeaders` / `privateHeaders`).
  Rejected because it is error-prone and duplicates data already expressed in target headers.
- **Create synthetic file references for synchronized-folder headers**.
  Rejected because it fights the synchronized-group model and increases project complexity.

## Testing
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistGeneratorTests/BuildPhaseGeneratorTests -only-testing TuistGeneratorTests/TargetGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` ✅
