### PR TITLE
chore(cache): adjust socket backlog

### DIFF
--- a/cache/config/runtime.exs
+++ b/cache/config/runtime.exs
@@ -17,7 +17,10 @@ if config_env() == :prod do
       nil ->
         [
           ip: {0, 0, 0, 0, 0, 0, 0, 0},
-          port: port
+          port: port,
+          thousand_island_options: [
+            transport_options: [backlog: 16_384]
+          ]
         ]
 
       path ->
@@ -26,7 +29,10 @@ if config_env() == :prod do
 
         [
           ip: {:local, path},
-          port: 0
+          port: 0,
+          thousand_island_options: [
+            transport_options: [backlog: 16_384]
+          ]
         ]
     end
 

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -89,9 +89,11 @@
 
       upstream cache_upstream {
         server unix:/run/cache/current.sock;
-        # Idle upstream connections held open per worker. Unix sockets
-        # have near-zero setup cost, so 64 is plenty even under burst.
-        keepalive 64;
+        # Idle upstream connections held open per worker. Sized to
+        # absorb 10 K+ req/s bursts so most requests reuse a warm
+        # connection instead of opening a new one (which would hit
+        # the listen backlog).
+        keepalive 256;
         keepalive_timeout 120s;
         keepalive_requests 50000;
       }


### PR DESCRIPTION
Adjusts Bandit's socket backlog to handle bursty requests a little better instead of 502ing.