### PR TITLE
feat(docs): add network page with outbound IP addresses

### DIFF
--- a/docs/.vitepress/bars.mjs
+++ b/docs/.vitepress/bars.mjs
@@ -21,6 +21,7 @@ import {
   slackIcon,
   testInsightsIcon,
   flakyTestsIcon,
+  networkIcon,
 } from "./icons.mjs";
 import { loadData as loadExamplesData } from "./data/examples";
 import { loadData as loadProjectDescriptionData } from "./data/project-description";
@@ -756,6 +757,13 @@ export async function guidesSidebar(locale) {
             "sidebars.guides.items.server.items.authentication.text",
           )}</span>`,
           link: `/${locale}/guides/server/authentication`,
+        },
+        {
+          text: `<span style="display: flex; flex-direction: row; align-items: center; gap: 7px;">${networkIcon()} ${localizedString(
+            locale,
+            "sidebars.guides.items.server.items.network.text",
+          )}</span>`,
+          link: `/${locale}/guides/server/network`,
         },
         {
           text: `<span style="display: flex; flex-direction: row; align-items: center; gap: 7px;">${selfHostingIcon()} ${localizedString(

--- a/docs/.vitepress/icons.mjs
+++ b/docs/.vitepress/icons.mjs
@@ -228,6 +228,11 @@ export function testInsightsIcon() {
   return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-flask-conical"><path d="M10 2v7.527a2 2 0 0 1-.211.896L4.72 20.55a1 1 0 0 0 .9 1.45h12.76a1 1 0 0 0 .9-1.45l-5.069-10.127A2 2 0 0 1 14 9.527V2"/><path d="M8.5 2h7"/><path d="M7 16h10"/></svg>`;
 }
 
+// Network icon - globe/network for IP addresses
+export function networkIcon() {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-globe"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`;
+}
+
 // Flaky tests icon - alert triangle for unstable tests
 export function flakyTestsIcon() {
   return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-triangle-alert"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>`;

--- a/docs/.vitepress/strings/en.json
+++ b/docs/.vitepress/strings/en.json
@@ -465,6 +465,9 @@
             "authentication": {
               "text": "Authentication"
             },
+            "network": {
+              "text": "Network"
+            },
             "self-hosting": {
               "text": "Self-hosting",
               "items": {

--- a/docs/docs/en/guides/integrations/gitforge/github.md
+++ b/docs/docs/en/guides/integrations/gitforge/github.md
@@ -18,6 +18,12 @@ After that, you can add a project connection between your GitHub repository and 
 
 ![An image that shows adding the project connection](/images/guides/integrations/gitforge/github/add-project-connection.png)
 
+::: tip IP ALLOWLISTING
+<!-- -->
+If your GitHub organization uses [IP allow lists](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization) or your GitHub instance is behind a firewall, make sure to allowlist Tuist's <LocalizedLink href="/guides/server/network#outbound-ip-addresses">outbound IP addresses</LocalizedLink> so that the integration can communicate with your repository.
+<!-- -->
+:::
+
 ## Pull/merge request comments {#pull-merge-request-comments}
 
 The GitHub app posts a Tuist run report, which includes a summary of the PR, including links to the latest <LocalizedLink href="/guides/features/previews#pullmerge-request-comments">previews</LocalizedLink> or <LocalizedLink href="/guides/features/selective-testing#pullmerge-request-comments">tests</LocalizedLink>:

--- a/docs/docs/en/guides/server/network.md
+++ b/docs/docs/en/guides/server/network.md
@@ -1,0 +1,25 @@
+---
+{
+  "title": "Network",
+  "titleTemplate": ":title | Server | Guides | Tuist",
+  "description": "Network configuration for Tuist, including outbound IP address ranges."
+}
+---
+# Network {#network}
+
+This page covers network-related configuration that may be needed when integrating Tuist with your infrastructure.
+
+## Outbound IP addresses {#outbound-ip-addresses}
+
+If your infrastructure restricts inbound traffic by IP address, you may need to allowlist the IP ranges used by Tuist. This is common when Tuist needs to communicate with services behind a firewall or VPN, such as self-hosted Git providers or artifact storage, or when your GitHub organization uses [IP allow lists](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization).
+
+Tuist outbound network traffic can originate from one of the following IP address ranges:
+
+| IP range | CIDR notation |
+|---|---|
+| 74.220.51.0 – 74.220.51.255 | `74.220.51.0/24` |
+| 74.220.59.0 – 74.220.59.255 | `74.220.59.0/24` |
+
+::: tip
+Add both ranges to your allowlist to ensure uninterrupted connectivity with Tuist services.
+:::


### PR DESCRIPTION

<img width="1694" height="1044" alt="image" src="https://github.com/user-attachments/assets/a6579bbb-9a5c-4a9e-85c2-e768d0827c18" />


## Summary
- Adds a new **Network** page under Server docs (`/guides/server/network`) documenting Tuist's outbound IP address ranges (`74.220.51.0/24` and `74.220.59.0/24`)
- Adds an IP allowlisting tip to the GitHub integration guide, linking to the new page
- Adds a globe icon and sidebar entry for the Network page

## Context
Customers with IP allowlisting (e.g. GitHub organization IP allow lists or firewalls) need to know Tuist's outbound IP ranges to configure access.

## Test plan
- [ ] Verify docs build succeeds
- [ ] Verify the Network page renders correctly with the IP table
- [ ] Verify the GitHub integration page shows the IP allowlisting tip with working link

🤖 Generated with [Claude Code](https://claude.com/claude-code)