### PR TITLE
fix(server): improve command_events delete performance and correctness

### DIFF
--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -7,7 +7,6 @@ defmodule Tuist.ProjectsTest do
   alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.Accounts.ProjectAccount
   alias Tuist.Base64
-  alias Tuist.CommandEvents
   alias Tuist.Projects
   alias Tuist.Projects.ProjectToken
   alias Tuist.VCS
@@ -181,18 +180,16 @@ defmodule Tuist.ProjectsTest do
       account = Accounts.get_account_from_organization(organization)
       project = ProjectsFixtures.project_fixture(account_id: account.id)
 
-      command_event =
-        CommandEventsFixtures.command_event_fixture(
-          name: "generate",
-          project_id: project.id
-        )
+      CommandEventsFixtures.command_event_fixture(
+        name: "generate",
+        project_id: project.id
+      )
 
       # When
       Projects.delete_project(project)
 
       # Then
       assert nil == Projects.get_project_by_id(project.id)
-      assert {:error, :not_found} == CommandEvents.get_command_event_by_id(command_event.id)
     end
   end
 


### PR DESCRIPTION
## Summary
- **Performance**: Use `mutations_sync = 0` to make ClickHouse deletions fully async — the `ALTER TABLE DELETE` returns immediately instead of blocking for ~4 seconds while mutations are processed across all monthly partitions. This is safe because once the project/account is deleted from Postgres, no code path will query ClickHouse for that project's events anymore.
- **Correctness**: Delete data from materialized views (`command_events_by_duration`, `command_events_by_hit_rate`) in addition to the source table — previously only `command_events` was cleaned, leaving stale data in the MVs.
- Dynamically discover materialized views via `system.tables` so any future MVs are automatically included without code changes.
- Consolidate delete logic into a shared `delete_events_for_project_ids/1` helper that issues a single `WHERE project_id IN (...)` query per table.

## Test plan
- [ ] Verify `delete_project_events/1` fires async mutations on all three tables (source + 2 MVs) in a dev/staging environment
- [ ] Verify `delete_account_events/1` cleans up all projects for the account in a single query per table
- [ ] Existing test `Tuist.ProjectsTest` "deletes a project" validates Postgres cleanup; ClickHouse assertion removed since deletion is now async

🤖 Generated with [Claude Code](https://claude.com/claude-code)