### PR TITLE
fix(docs): add HTML comments to VitePress tip block for translation segmentation

### DIFF
--- a/docs/docs/en/guides/server/network.md
+++ b/docs/docs/en/guides/server/network.md
@@ -21,5 +21,7 @@ Tuist outbound network traffic can originate from one of the following IP addres
 | 74.220.59.0 – 74.220.59.255 | `74.220.59.0/24` |
 
 ::: tip
+<!-- -->
 Add both ranges to your allowlist to ensure uninterrupted connectivity with Tuist services.
+<!-- -->
 :::


### PR DESCRIPTION
## Summary
- The `lint-localization` CI check on `main` is failing because the tip block in `docs/docs/en/guides/server/network.md` is missing the required `<!-- -->` HTML comments needed for proper translation segmentation
- Adds the opening and closing `<!-- -->` comments around the tip block content

## Test plan
- [ ] Verify `lint-localization` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)