### PR TITLE
fix(server): use deep link for Android preview Run button

### DIFF
--- a/server/lib/tuist_web/live/preview_live.html.heex
+++ b/server/lib/tuist_web/live/preview_live.html.heex
@@ -1,6 +1,6 @@
 <div id="preview">
   <.alert
-    :if={@user_agent.os.family != "iOS" and not (@preview.supported_platforms == [:android])}
+    :if={@user_agent.os.family != "iOS"}
     id="download-tuist-app-alert"
     phx-hook="DeeplinkValidation"
     data-deeplink-element-id="preview-run-button"

--- a/server/test/tuist_web/live/preview_live_test.exs
+++ b/server/test/tuist_web/live/preview_live_test.exs
@@ -102,6 +102,35 @@ defmodule TuistWeb.PreviewLiveTest do
     assert has_element?(lv, "#preview-run-button span", "Run")
   end
 
+  test "it shows run button for android preview on macOS", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    # Given
+    preview = AppBuildsFixtures.preview_fixture(project: project, supported_platforms: [:android])
+
+    app_build =
+      AppBuildsFixtures.app_build_fixture(
+        preview: preview,
+        type: :apk,
+        supported_platforms: [:android]
+      )
+
+    AppBuilds.update_preview_with_app_build(preview.id, app_build)
+
+    stub(UAParser, :parse, fn _ ->
+      %UAParser.UA{os: %UAParser.OperatingSystem{family: "macOS"}}
+    end)
+
+    # When
+    {:ok, lv, _html} =
+      live(conn, ~p"/#{organization.account.name}/#{project.name}/previews/#{preview.id}")
+
+    # Then
+    assert has_element?(lv, "#preview-run-button span", "Run")
+  end
+
   test "it requires authenticated user when the preview is :app_bundle", %{
     conn: conn,
     organization: organization,


### PR DESCRIPTION
## Summary
- Removed the Android-only branch in `run_button_href/2` that was causing the Run button to directly download the APK
- Android previews now use the `tuist://open-preview?...` deep link, matching the iOS preview behavior on non-iOS platforms — the Tuist macOS menu bar app handles APK download, ADB install, and launch
- The "Tuist app not installed?" alert now shows for Android previews too, since they require the desktop app
- Added a test verifying the Run button renders for Android previews on macOS

## Test plan
- [x] Existing preview live tests pass (13/13)
- [ ] Verify on an Android preview page that the Run button opens the Tuist macOS app via deep link instead of downloading the APK

🤖 Generated with [Claude Code](https://claude.com/claude-code)