### PR TITLE
fix(server): add command_events_by_ran_at materialized view for fast pagination

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -957,5 +957,7 @@ defmodule Tuist.CommandEvents do
   defp sort_optimized_table(%{order_by: [field | _]}) when field in [:hit_rate, "hit_rate"],
     do: "command_events_by_hit_rate"
 
+  defp sort_optimized_table(%{order_by: [field | _]}) when field in [:ran_at, "ran_at"], do: "command_events_by_ran_at"
+
   defp sort_optimized_table(_), do: nil
 end

--- a/server/priv/ingest_repo/migrations/20260226130000_create_command_events_by_ran_at_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260226130000_create_command_events_by_ran_at_mv.exs
@@ -1,0 +1,42 @@
+defmodule Tuist.IngestRepo.Migrations.CreateCommandEventsByRanAtMv do
+  @moduledoc """
+  Creates a materialized view for efficient ORDER BY ran_at DESC queries.
+
+  The main `command_events` table is PARTITION BY toYYYYMM(ran_at) with
+  ORDER BY (project_id, name, ran_at). Without a date range filter in the
+  query, ClickHouse must read from every monthly partition and merge-sort
+  across them to satisfy ORDER BY ran_at DESC LIMIT N — even though ran_at
+  is already the third column of the sorting key.
+
+  This materialized view stores the same data WITHOUT partitioning, so all
+  rows for a given (project_id, name) are physically contiguous and sorted
+  by ran_at. ClickHouse can then use optimize_read_in_order to read only
+  the last N granules for the specific (project_id, name), instead of
+  scanning each partition independently and merging.
+
+  The Elixir query layer routes ORDER BY ran_at queries to this view via
+  sort_optimized_table/1, matching the same pattern used for
+  command_events_by_duration and command_events_by_hit_rate.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
+    ENGINE = MergeTree
+    ORDER BY (project_id, name, ran_at)
+    POPULATE
+    AS SELECT * FROM command_events
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS command_events_by_ran_at"
+  end
+end


### PR DESCRIPTION
## Problem

The cache/generate runs list query was slow:

```sql
SELECT ... FROM command_events
WHERE project_id = ? AND name IN (?)
ORDER BY ran_at DESC
LIMIT ?
```

Observed production performance:
- **Avg. read rows**: 571,415
- **Avg. memory**: 544 MiB
- **p50 latency**: 7,087 ms
- **p90 latency**: 10,691 ms

The root cause: the main `command_events` table has `ORDER BY (project_id, name, ran_at)` — which looks right — but is also `PARTITION BY toYYYYMM(ran_at)`. Without a date range filter in the query, ClickHouse reads from **every monthly partition** and merge-sorts candidates across all of them. The EXPLAIN confirms this: **40 parts / 40 ranges** read on the base table.

## Fix

A materialized view `command_events_by_ran_at` with `ORDER BY (project_id, name, ran_at)` and **no `PARTITION BY`**. Without partitioning, all rows for a given `(project_id, name)` pair are physically contiguous. The primary key index then prunes the scan to only the granules covering that bucket. The EXPLAIN on the MV shows **1 part / 9 granules** for the same query.

This mirrors the existing pattern for `duration`/`hit_rate` sorts (`command_events_by_duration`, `command_events_by_hit_rate`). The `sort_optimized_table/1` function in `command_events.ex` routes `ORDER BY ran_at` queries to the new view, matching how those cases are handled.

## Local benchmark (208k rows, 14 monthly partitions)

| | Read rows | Granules | Elapsed |
|---|---|---|---|
| Base table | 210,897 | 40 / 41 | ~17 ms |
| MV | 81,859 | 9 / 27 | ~4 ms |
| **Improvement** | **2.6×** | **4.4×** | **4×** |

On production the gap is larger: more months of data means more partitions to merge.

## Test plan

- [ ] Run `mix ecto.migrate` (ingest_repo) locally and verify the MV is created
- [ ] Confirm latency drop on cache/generate runs pages after staging deploy