### PR TITLE
fix(android): set Google Play release status to draft

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -82,6 +82,7 @@ play {
         serviceAccountCredentials.set(file(serviceAccountJsonPath))
     }
     track.set("internal")
+    releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.DRAFT)
     defaultToAppBundles.set(true)
 }
 


### PR DESCRIPTION
## Summary
- Google Play rejects completed releases for apps that haven't had their first production release, returning: *"Only releases with status draft may be created on draft app."*
- Sets `releaseStatus` to `DRAFT` in the gradle-play-publisher config so the internal track upload succeeds
- Once the app completes its first production review, this can be changed back to `COMPLETED`

Fixes: https://github.com/tuist/tuist/actions/runs/22455556773/job/65036230529

## Test plan
- [ ] Verify the next release workflow run succeeds for the "Release Android App" job

🤖 Generated with [Claude Code](https://claude.com/claude-code)