### PR TITLE
fix(cli): add --no-prepare to mise run in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,7 +449,7 @@ jobs:
       - name: Initialize TuistCacheEE submodule
         env:
           TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
-        run: mise run cli:ee
+        run: mise run --no-prepare cli:ee
       - name: Get release notes
         id: release-notes
         working-directory: cli
@@ -469,7 +469,7 @@ jobs:
         run: git cliff --include-path "cli/**/*" --include-path ".xcode-version-releases" --config cliff.toml --repository "../" --bump -o CHANGELOG.md 2>/dev/null
 
       - name: Bundle CLI
-        run: mise run cli:bundle
+        run: mise run --no-prepare cli:bundle
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -629,7 +629,7 @@ jobs:
           fi
 
       - name: Bundle macOS app
-        run: mise run app:bundle
+        run: mise run --no-prepare app:bundle
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -695,7 +695,7 @@ jobs:
       - name: Generate TuistApp
         run: tuist generate TuistApp --no-binary-cache
       - name: Upload iOS App to App Store Connect
-        run: mise run app:upload-ios
+        run: mise run --no-prepare app:upload-ios
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
@@ -1324,13 +1324,13 @@ jobs:
         if: needs.check-releases.outputs.cli-should-release == 'true' && needs.release-cli.result == 'success'
         run: |
           SHA256=$(cat build/SHASUMS256.txt | grep tuist.zip | awk '{print $1}')
-          mise run cli:release:homebrew-formula --version "${{ needs.check-releases.outputs.cli-next-version }}" --github-token "${{ secrets.TUIST_GITHUB_TOKEN }}" --sha256 "$SHA256"
+          mise run --no-prepare cli:release:homebrew-formula --version "${{ needs.check-releases.outputs.cli-next-version }}" --github-token "${{ secrets.TUIST_GITHUB_TOKEN }}" --sha256 "$SHA256"
 
       - name: Trigger Homebrew Cask Update
         if: needs.check-releases.outputs.app-should-release == 'true' && needs.release-app.result == 'success'
         run: |
           SHA256=$(cat app/build/artifacts/SHASUMS256.txt | grep Tuist.dmg | awk '{print $1}')
-          mise run app:release:homebrew-cask --version "${{ needs.check-releases.outputs.app-next-version-number }}" --github-token "${{ secrets.TUIST_GITHUB_TOKEN }}" --sha256 "$SHA256"
+          mise run --no-prepare app:release:homebrew-cask --version "${{ needs.check-releases.outputs.app-next-version-number }}" --github-token "${{ secrets.TUIST_GITHUB_TOKEN }}" --sha256 "$SHA256"
 
       - name: Commit all changes and push
         run: |


### PR DESCRIPTION
## Summary
- Adds `--no-prepare` to all 6 `mise run` invocations in the release workflow
- Prevents mise from trying to install all tools from `.mise.toml` on every task run — each job already installs only the tools it needs via `jdx/mise-action` with `install_args`
- Fixes transient failures like [this run](https://github.com/tuist/tuist/actions/runs/22479916369/job/65115760204) where downloads for unrelated tools (age, bats, gradle, protoc, swiftlint) fail with "connection closed before message completed"

## Test plan
- [ ] Verify the next release workflow run completes without tool installation errors in `mise run` steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)