### PR TITLE
fix(cli): bump Release CLI job timeout from 30 to 50 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,7 +416,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
     outputs:


### PR DESCRIPTION
## Summary
- The Release CLI job has been timing out at the 30-minute limit ([failed run](https://github.com/tuist/tuist/actions/runs/22482193639/job/65134317826))
- Bumps the timeout from 30 to 50 minutes, matching the Linux release job

## Test plan
- [ ] Verify the next release workflow run completes within the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)