### PR TITLE
fix(cli): reduce CI GitHub API usage to avoid rate limits

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,10 @@ on:
       - "server/**"
       - ".github/workflows/cla.yml"
 
+concurrency:
+  group: cla-${{ github.head_ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,7 +1,11 @@
 name: conventional-pr
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
+
+concurrency:
+  group: conventional-pr-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-pr:
@@ -9,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
       - uses: amannn/action-semantic-pull-request@v5
         with:
           requireScope: true


### PR DESCRIPTION
## Summary

- **`conventional-pr.yml`**: Remove `synchronize` trigger — the action only validates the PR title, which doesn't change when new commits are pushed. Also remove the unnecessary `actions/checkout@v2` step (the action reads from the event payload, not source code). Add concurrency group.
- **`cla.yml`**: Add concurrency group to cancel redundant in-flight runs.

These were the only two PR-triggered workflows without concurrency groups. Together with unnecessary `synchronize` triggers, they contributed extra workflow runs and API calls that eat into the `GITHUB_TOKEN` [installation rate limit](https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api) (1,000 req/hour).

## Context

Multiple CI jobs are failing with `API rate limit exceeded for installation`:
- [Lint PR](https://github.com/tuist/tuist/actions/runs/22487887839/job/65142007873?pr=9635)
- [CodeQL Analyze](https://github.com/tuist/tuist/actions/runs/22487841289/job/65141845420?pr=9635)

The CodeQL Default Setup is managed via repo settings and can't be fixed via PR — but reducing the overall API pressure from other workflows helps all jobs stay within limits.

## Test plan

- [ ] Verify `conventional-pr` still runs on PR open and title edit
- [ ] Verify `conventional-pr` does NOT run on new commits pushed to a PR
- [ ] Verify concurrent runs of both workflows are properly cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)