### PR TITLE
fix(ci): prevent commit-and-release from being skipped when optional jobs are skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1135,6 +1135,7 @@ jobs:
         release-skills,
       ]
     if: |
+      always() &&
       needs.check-releases.outputs.should-release-any == 'true' &&
       (needs.release-cli.result == 'success' || needs.release-cli.result == 'skipped') &&
       (needs.release-cli-linux.result == 'success' || needs.release-cli-linux.result == 'skipped') &&


### PR DESCRIPTION
## Summary
- Adds `always()` to the `commit-and-release` job's `if` condition in the release workflow
- Without `always()`, GitHub Actions automatically skips the job when any upstream `needs` job is skipped (e.g. `release-gradle`, `release-skills`), without even evaluating the `if` expression
- The existing condition already handles skipped jobs correctly (`result == 'skipped'`), but it was never being evaluated

## Context
In [this release run](https://github.com/tuist/tuist/actions/runs/22525230990/job/65257664906), the `Commit and Release` job was skipped even though all release jobs succeeded — because `Release Gradle Plugin` and `Release Skills` were skipped (no releasable changes), which caused GitHub Actions to skip the dependent job automatically.

## Test plan
- [ ] Next release run should execute `Commit and Release` when all required jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)