### PR TITLE
fix(ci): use --autostash in release push retry loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1416,7 +1416,7 @@ jobs:
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts"
-            if git pull --rebase origin ${{ github.ref_name }}; then
+            if git pull --rebase --autostash origin ${{ github.ref_name }}; then
               if git push origin ${{ github.ref_name }} --tags; then
                 echo "Successfully pushed changes and tags"
                 break


### PR DESCRIPTION
## Summary
- Fixes the `commit-and-release` job failing with `error: cannot pull with rebase: You have unstaged changes` by adding `--autostash` to the `git pull --rebase` command in the push retry loop
- The `--autostash` flag automatically stashes any unstaged changes before the rebase and restores them after, preventing the failure

## Test plan
- [ ] Trigger a release workflow and verify the push retry loop succeeds even when there are unstaged changes in the working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)