### PR TITLE
fix(server): scope test_case_runs new-test query by project_id

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -633,8 +633,8 @@ defmodule Tuist.Tests do
     if is_nil(default_branch) do
       Enum.map(test_case_data, &Map.put(&1, :is_new, false))
     else
-      test_case_ids = Enum.map(test_case_data, & &1.test_case_id)
-      existing_on_default_branch = get_test_case_ids_with_ci_runs_on_branch(test_case_ids, default_branch)
+      existing_on_default_branch =
+        get_test_case_ids_with_ci_runs_on_branch(test.project_id, default_branch)
 
       Enum.map(test_case_data, fn data ->
         is_new = data.test_case_id not in existing_on_default_branch
@@ -643,24 +643,18 @@ defmodule Tuist.Tests do
     end
   end
 
-  defp get_test_case_ids_with_ci_runs_on_branch([], _branch), do: MapSet.new()
-
-  defp get_test_case_ids_with_ci_runs_on_branch(test_case_ids, branch) do
-    test_case_id_set = MapSet.new(test_case_ids)
+  defp get_test_case_ids_with_ci_runs_on_branch(project_id, branch) do
     ninety_days_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -90, :day)
 
-    query =
-      from(tcr in TestCaseRun,
-        where: tcr.git_branch == ^branch,
-        where: tcr.is_ci == true,
-        where: tcr.ran_at >= ^ninety_days_ago,
-        distinct: true,
-        select: tcr.test_case_id
-      )
-
-    query
+    from(tcr in TestCaseRun,
+      where: tcr.project_id == ^project_id,
+      where: tcr.git_branch == ^branch,
+      where: tcr.is_ci == true,
+      where: tcr.ran_at >= ^ninety_days_ago,
+      distinct: true,
+      select: tcr.test_case_id
+    )
     |> ClickHouseRepo.all()
-    |> Enum.filter(&(&1 in test_case_id_set))
     |> MapSet.new()
   end
 


### PR DESCRIPTION
## Summary

Optimizes the ClickHouse query in `get_test_case_ids_with_ci_runs_on_branch` that detects whether test cases are "new" (never seen on CI on the default branch).

**Before:** The query scanned all test_case_runs across **all projects** for a given branch, returned all distinct test_case_ids (~10K+), then filtered in Elixir to keep only the current project's IDs.

```sql
SELECT DISTINCT test_case_id FROM test_case_runs
WHERE git_branch = ? AND is_ci = ? AND ran_at >= ?
```

**After:** The query is scoped by `project_id`, allowing ClickHouse to use the `proj_test_case_runs_by_project_ran_at` projection (binary search on `project_id, ran_at`). Elixir-side filtering is removed since results are already project-scoped.

```sql
SELECT DISTINCT test_case_id FROM test_case_runs
WHERE project_id = ? AND git_branch = ? AND is_ci = ? AND ran_at >= ?
```

## Benchmark results (5M rows, 50 projects, 10K unique test cases)

| Metric | Before | After | Improvement |
|---|---|---|---|
| Avg latency | 62.2ms | 37.5ms | **1.7x faster (40% reduction)** |
| Rows read | 1,669,194 | 287,909 | **83% reduction** |
| Data read | 52.8 MiB | 10.3 MiB | **81% reduction** |
| IDs transferred | 10,000 | 200 | **50x less network** |

The improvement scales with the number of projects — production should see an even larger reduction. Query plan analysis confirmed:
- **Before:** Uses `proj_by_branch_ci` projection, scans 210/619 granules (all projects on branch)
- **After:** Uses `proj_test_case_runs_by_project_ran_at` projection, scans 34/619 granules (single project)

## Test plan

- [x] All 5 `is_new` detection tests pass locally
- [x] Correctness verified: new query returns a proper subset of old query results
- [x] Benchmarked with 5M seeded rows in local ClickHouse
- [ ] Monitor query stats in ClickHouse cloud after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)