### PR TITLE
feat(server): show public project CTA banner on tuist/android dashboard

### DIFF
--- a/server/lib/tuist_web/components/layouts/project.html.heex
+++ b/server/lib/tuist_web/components/layouts/project.html.heex
@@ -16,13 +16,17 @@
       current_user={@current_user}
     />
     <div class="layout__content">
-      <TuistWeb.Components.PublicProjectCTABanner.public_project_cta_banner :if={
-        TuistWeb.Components.PublicProjectCTABanner.show_banner?(
-          @selected_account.name,
-          @selected_project.name,
-          @current_user
-        )
-      } />
+      <TuistWeb.Components.PublicProjectCTABanner.public_project_cta_banner
+        :if={
+          TuistWeb.Components.PublicProjectCTABanner.show_banner?(
+            @selected_account.name,
+            @selected_project.name,
+            @current_user
+          )
+        }
+        account_name={@selected_account.name}
+        project_name={@selected_project.name}
+      />
       {@inner_content}
     </div>
   </section>

--- a/server/lib/tuist_web/components/public_project_cta_banner.ex
+++ b/server/lib/tuist_web/components/public_project_cta_banner.ex
@@ -1,6 +1,6 @@
 defmodule TuistWeb.Components.PublicProjectCTABanner do
   @moduledoc """
-  A CTA banner component shown to unauthenticated users viewing the tuist/tuist project dashboard.
+  A CTA banner component shown to unauthenticated users viewing a public project dashboard.
   """
   use TuistWeb, :html
   use Noora
@@ -25,7 +25,9 @@ defmodule TuistWeb.Components.PublicProjectCTABanner do
         <p>
           {dgettext(
             "dashboard",
-            "This is a public dashboard for the tuist/tuist project."
+            "This is a public dashboard for the %{account_name}/%{project_name} project.",
+            account_name: @account_name,
+            project_name: @project_name
           )}
           <br />
           {dgettext(
@@ -57,8 +59,10 @@ defmodule TuistWeb.Components.PublicProjectCTABanner do
     """
   end
 
+  @public_projects MapSet.new([{"tuist", "tuist"}, {"tuist", "android"}])
+
   def show_banner?(account_name, project_name, current_user) do
-    is_nil(current_user) and account_name == "tuist" and project_name == "tuist"
+    is_nil(current_user) and MapSet.member?(@public_projects, {account_name, project_name})
   end
 
   defp banner_shell(assigns) do

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -124,7 +124,7 @@ msgid "Flags"
 msgstr ""
 
 #: lib/tuist_web/components/empty_card_section.ex:29
-#: lib/tuist_web/components/public_project_cta_banner.ex:38
+#: lib/tuist_web/components/public_project_cta_banner.ex:40
 #, elixir-autogen, elixir-format
 msgid "Get started"
 msgstr ""
@@ -447,19 +447,19 @@ msgstr ""
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/components/public_project_cta_banner.ex:31
+#: lib/tuist_web/components/public_project_cta_banner.ex:33
 #, elixir-autogen, elixir-format
 msgid "Ready to speed up your builds and unlock insights for your app?"
 msgstr ""
 
-#: lib/tuist_web/components/public_project_cta_banner.ex:45
+#: lib/tuist_web/components/public_project_cta_banner.ex:47
 #, elixir-autogen, elixir-format
 msgid "Talk to us"
 msgstr ""
 
 #: lib/tuist_web/components/public_project_cta_banner.ex:26
 #, elixir-autogen, elixir-format
-msgid "This is a public dashboard for the tuist/tuist project."
+msgid "This is a public dashboard for the %{account_name}/%{project_name} project."
 msgstr ""
 
 #: lib/tuist_web/components/app_layout_components.ex:120


### PR DESCRIPTION
## Summary

The CTA banner that we show to unauthenticated users on the tuist/tuist public dashboard now also appears on the tuist/android dashboard. The banner text is dynamic, so it correctly displays the account/project name instead of being hardcoded to "tuist/tuist".

To support additional public projects in the future, the visibility logic uses a `MapSet` of allowed account/project pairs, making it easy to extend.