### PR TITLE
feat(cache): raise Gradle upload size limit to 100MB

### DIFF
--- a/cache/lib/cache_web/controllers/gradle_controller.ex
+++ b/cache/lib/cache_web/controllers/gradle_controller.ex
@@ -21,6 +21,8 @@ defmodule CacheWeb.GradleController do
 
   require Logger
 
+  @max_upload_bytes 100 * 1024 * 1024
+
   plug OpenApiSpex.Plug.CastAndValidate,
     json_render_error_v2: true
 
@@ -167,7 +169,7 @@ defmodule CacheWeb.GradleController do
   end
 
   defp save_new_artifact(conn, account_handle, project_handle, cache_key) do
-    case BodyReader.read(conn) do
+    case BodyReader.read(conn, max_bytes: @max_upload_bytes) do
       {:ok, data, conn_after} ->
         size = data_size(data)
         :telemetry.execute([:cache, :gradle, :upload, :attempt], %{size: size}, %{})


### PR DESCRIPTION
## Summary

- Raises the Gradle build cache upload size limit from the default 25MB to 100MB
- Adds a `@max_upload_bytes` module attribute to `GradleController` and passes it to `BodyReader.read/2`

## Test Plan

Existing Gradle upload tests cover the upload path. The change only affects the size threshold passed to the body reader.