### PR TITLE
fix(server): use x-forwarded-proto for MCP OAuth metadata URLs

### DIFF
--- a/server/lib/tuist_web/request_origin.ex
+++ b/server/lib/tuist_web/request_origin.ex
@@ -2,7 +2,12 @@ defmodule TuistWeb.RequestOrigin do
   @moduledoc false
 
   def from_conn(conn) do
-    scheme = Atom.to_string(conn.scheme)
+    scheme =
+      case Plug.Conn.get_req_header(conn, "x-forwarded-proto") do
+        [proto] -> proto
+        _ -> Atom.to_string(conn.scheme)
+      end
+
     default_port = if scheme == "https", do: 443, else: 80
     authority = if conn.port == default_port, do: conn.host, else: "#{conn.host}:#{conn.port}"
     "#{scheme}://#{authority}"


### PR DESCRIPTION
## Summary

The MCP OAuth protected resource metadata endpoint (`/.well-known/oauth-protected-resource/mcp`) and the `WWW-Authenticate` header on `/mcp` 401 responses were returning `http://` URLs instead of `https://`. This happened because `RequestOrigin.from_conn/1` used `conn.scheme`, which is `:http` behind Cloudflare/Render since they terminate TLS at the proxy layer.

This broke the MCP auth flow for clients like Claude Desktop, which follow the MCP spec requirement that all authorization server endpoints use HTTPS.

The fix checks the `x-forwarded-proto` header (set by Cloudflare/Render) before falling back to `conn.scheme`.

## Test plan

- Existing tests pass (they don't set `x-forwarded-proto`, so they fall back to `conn.scheme` as before)
- In production, `x-forwarded-proto: https` will produce the correct `https://` URLs