### PR TITLE
fix(cli): add xcassets and xcstrings to sources build phase for static targets

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -87,6 +87,14 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 buildableFolders: resourceBuildableFolders
             )
             modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
+            // Asset catalogs and string catalogs need to be included in the main target's sources
+            // build phase so Xcode generates typed asset symbols (mirroring SwiftPM's PIF builder).
+            let codeGeneratingResourceExtensions: Set<String> = ["xcassets", "xcstrings"]
+            for resource in target.resources.resources {
+                if let ext = resource.path.extension, codeGeneratingResourceExtensions.contains(ext) {
+                    modifiedTarget.sources.append(SourceFile(path: resource.path))
+                }
+            }
             modifiedTarget.resources.resources = []
             modifiedTarget.copyFiles = []
             modifiedTarget.buildableFolders = remainingBuildableFolders

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -953,6 +953,58 @@ struct ResourcesProjectMapperTests {
         #expect(gotProject.targets.count == 2)
     }
 
+    @Test
+    func mapWhenStaticTargetHasXcassetsAddsThemAsSources() async throws {
+        // Given
+        let resources: [ResourceFileElement] = [
+            .file(path: "/Resources/Assets.xcassets"),
+            .file(path: "/Resources/image.png"),
+        ]
+        let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: .init(resources))
+        let project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
+
+        // When
+        let (gotProject, _) = try await subject.map(project: project)
+
+        // Then
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        #expect(gotTarget.resources.resources.isEmpty)
+        let xcassetsSources = gotTarget.sources.filter { $0.path.extension == "xcassets" }
+        #expect(xcassetsSources.count == 1)
+        let expectedXcassetsPath = try AbsolutePath(validating: "/Resources/Assets.xcassets")
+        #expect(xcassetsSources.first?.path == expectedXcassetsPath)
+
+        let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
+        #expect(resourcesTarget.product == .bundle)
+        #expect(resourcesTarget.resources.resources == resources)
+    }
+
+    @Test
+    func mapWhenStaticTargetHasXcstringsAddsThemAsSources() async throws {
+        // Given
+        let resources: [ResourceFileElement] = [
+            .file(path: "/Resources/Localizable.xcstrings"),
+            .file(path: "/Resources/image.png"),
+        ]
+        let target = Target.test(product: .staticFramework, sources: ["/Absolute/File.swift"], resources: .init(resources))
+        let project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
+
+        // When
+        let (gotProject, _) = try await subject.map(project: project)
+
+        // Then
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        #expect(gotTarget.resources.resources.isEmpty)
+        let xcstringsSources = gotTarget.sources.filter { $0.path.extension == "xcstrings" }
+        #expect(xcstringsSources.count == 1)
+        let expectedXcstringsPath = try AbsolutePath(validating: "/Resources/Localizable.xcstrings")
+        #expect(xcstringsSources.first?.path == expectedXcstringsPath)
+    }
+
     // MARK: - Helpers
 
     private func verifySideEffects(


### PR DESCRIPTION
## Summary

When integrating SPM packages as static frameworks, Xcode's automatic asset symbol generation doesn't work because `ResourcesProjectMapper` moves all resources (including `.xcassets` and `.xcstrings`) entirely to a companion `.bundle` target. Xcode needs these files in the main target's sources build phase to run `actool` and generate typed symbols like `ColorResource` and `ImageResource`.

This fix adds `.xcassets` and `.xcstrings` files back as source entries on the main target after resources are moved to the bundle target, mirroring how SwiftPM's PIF builder handles it.

[**Community discussion**](https://community.tuist.dev/t/missing-resource-accessors-in-static-dependencies/918/4)

## Test plan

- [x] Added unit tests for xcassets and xcstrings being preserved as sources
- [x] All existing `ResourcesProjectMapperTests` pass with no regressions
- [ ] Verify end-to-end with a local SPM package containing xcassets integrated as a static framework