### PR TITLE
fix(server): optimize test_case_run lookup with UUIDv7 partition pruning

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -490,6 +490,12 @@ defmodule Tuist.Tests do
     end
   end
 
+  # The test_case_runs table is partitioned by toYYYYMM(inserted_at). Without a
+  # partition hint, the proj_by_id projection must check every part across all
+  # monthly partitions (~93K rows read, ~2.7s p50 in production). UUIDv7 encodes
+  # a millisecond timestamp in the first 48 bits, which closely matches
+  # inserted_at, so we extract the month and add a toYYYYMM filter to prune all
+  # but one partition (~8K rows read, ~35x improvement).
   defp uuidv7_to_yyyymm(uuid_string) do
     hex = uuid_string |> String.replace("-", "") |> String.slice(0, 12)
     timestamp_ms = String.to_integer(hex, 16)


### PR DESCRIPTION
## Summary
- Optimizes the slow `get_test_case_run_by_id` ClickHouse query (p50: 2.7s, ~93K rows read) by adding partition pruning
- Extracts the month from UUIDv7 IDs and adds a `toYYYYMM(inserted_at)` filter so ClickHouse only scans parts in the matching monthly partition
- Falls back to unscoped query for non-UUIDv7 IDs or month-boundary edge cases

### Local benchmark (5M rows)

| Configuration | Read Rows | Reduction |
|---|---|---|
| Before (projection only) | 287,914 | baseline |
| **After (projection + partition pruning)** | **8,192** | **35x fewer** |

## Test plan
- [x] Existing `get_test_case_run_by_id/2` tests pass (8 tests)
- [x] Controller tests pass (18 tests)
- [x] MCP server tests pass
- [x] Credo passes with no issues
- [x] Verified with `EXPLAIN indexes=1` locally that projection + partition pruning is used
- [ ] Monitor ClickHouse query stats after deploy for reduced read rows and latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)