### PR TITLE
fix(cli): Fix case-insensitive prioritize local packages over registry

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -169,9 +169,9 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         packageInfos = Dictionary(grouping: packageInfos, by: {
             if $0.kind == "registry" {
                 // A package is uniquely identified by a scoped identifier in the form scope.package-name.
-                return String($0.name.split(separator: ".").last ?? "")
+                return String($0.name.split(separator: ".").last ?? "").lowercased()
             } else {
-                return $0.name
+                return $0.name.lowercased()
             }
         })
         .compactMap { _, groupedPackageInfos in

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -327,6 +327,97 @@ struct SwiftPackageManagerGraphLoaderTests {
         )
     }
 
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_when_dependency_via_local_and_registry_case_insensitive() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        // Given
+        let packageSettings = PackageSettings.test()
+
+        let workspacePath = temporaryDirectory.appending(components: [
+            ".build", "workspace-state.json",
+        ])
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+
+        let localPackagePath = temporaryDirectory.appending(component: "Alamofire")
+        try await fileSystem.makeDirectory(at: localPackagePath)
+
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "alamofire.alamofire",
+                      "kind" : "registry",
+                      "location" : "alamofire.alamofire",
+                      "name" : "alamofire.alamofire"
+                    },
+                    "state" : {
+                      "name" : "registryDownload",
+                      "version" : "5.10.2"
+                    },
+                    "subpath" : "alamofire/alamofire/5.10.2"
+                  },
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "Alamofire",
+                      "kind" : "fileSystem",
+                      "path" : "\(localPackagePath.pathString)",
+                      "name" : "Alamofire"
+                    },
+                    "state" : {
+                      "name" : "fileSystem",
+                      "path" : "\(localPackagePath.pathString)"
+                    },
+                    "subpath" : "Alamofire"
+                  },
+                ],
+              }
+            }
+            """,
+            at: workspacePath
+        )
+
+        try await fileSystem.makeDirectory(
+            at: temporaryDirectory.appending(components: [".build", "Derived"])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(components: [
+                ".build", "Derived", "Package.resolved",
+            ])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(component: "Package.resolved")
+        )
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any
+            )
+            .willReturn([:])
+
+        // When
+        let (got, _) = try await subject.load(
+            packagePath: temporaryDirectory.appending(component: "Package.swift"),
+            packageSettings: packageSettings,
+            disableSandbox: true
+        )
+
+        // Then
+        #expect(
+            got.externalProjects.values.map(\.hash) == [nil]
+        )
+    }
+
     @Test
     func load_warnOutdatedDependencies() async throws {
         try await withMockedDependencies {


### PR DESCRIPTION
Adds additional resolution scenarios to address [this issue](https://community.tuist.dev/t/swift-package-registry-overriding-local-dependency-in-tuist-generated-project/902)￼, building on top of https://github.com/tuist/tuist/pull/9540.

## Swift Package Registry package names [are case-insensitive](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/registryserverspecification/#362-Package-name).
The same package can appear with different casing in workspace-state.json depending on how it was recorded/resolved. This caused our comparison logic to treat identical packages as different, leading to incorrect resolution behavior (e.g., a registry dependency being preferred over a local override).

This change updates package name comparisons to be case-insensitive, and adds coverage for the affected cases.

How to test locally
- Run the unit tests (includes a new test covering the casing mismatch).
- Validated in a real repo exhibiting the issue: local dependency override now wins as expected.
