### PR TITLE
fix(gradle): publish Gradle plugin before updating settings version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -992,10 +992,6 @@ jobs:
             git cliff --include-path "gradle/**/*" --config cliff.toml --repository "../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
-      - name: Update version in settings.gradle.kts
-        run: |
-          sed -i 's/id("dev.tuist") version ".*"/id("dev.tuist") version "${{ needs.check-releases.outputs.gradle-next-version-number }}"/' gradle/settings.gradle.kts
-
       - name: Publish to Gradle Plugin Portal
         working-directory: gradle
         run: |
@@ -1004,6 +1000,10 @@ jobs:
           ./gradlew publishPlugins -Pversion=${{ needs.check-releases.outputs.gradle-next-version-number }} -Pgradle.publish.key="$PUBLISH_KEY" -Pgradle.publish.secret="$PUBLISH_SECRET"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Update version in settings.gradle.kts
+        run: |
+          sed -i 's/id("dev.tuist") version ".*"/id("dev.tuist") version "${{ needs.check-releases.outputs.gradle-next-version-number }}"/' gradle/settings.gradle.kts
 
       - name: Tag Gradle release
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Gradle plugin release failure ([failed run](https://github.com/tuist/tuist/actions/runs/22587224474/job/65465362001))
- The release workflow was updating the `dev.tuist` plugin version in `settings.gradle.kts` **before** publishing to the Gradle Plugin Portal
- When Gradle evaluated `settings.gradle.kts` during `publishPlugins`, it tried to resolve the new version (0.2.2) which didn't exist yet on the portal, causing `BUILD FAILED`
- Fix: move the version update step to **after** the publish step

## Test plan
- [ ] Re-run the release workflow and verify the Gradle plugin publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)