### PR TITLE
fix(server): optimize command_events_by_ran_at sort key for faster pagination

### DIFF
--- a/server/priv/ingest_repo/migrations/20260302220000_optimize_command_events_by_ran_at_sort_key.exs
+++ b/server/priv/ingest_repo/migrations/20260302220000_optimize_command_events_by_ran_at_sort_key.exs
@@ -14,8 +14,10 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
   predicate. This reduces reads from ~180K to ~8K rows (one granule).
 
   Note: `command_events_by_hit_rate` is NOT changed because `hit_rate` is
-  Nullable, which prevents the read-in-order optimization. Keeping `name`
-  in its sort key is better since it at least narrows the scan range.
+  Float32 and ClickHouse does not use the read-in-order optimization for
+  float sort keys (EXPLAIN PLAN shows ReadType: Default instead of
+  InReverseOrder). Keeping `name` in its sort key is better since it at
+  least narrows the scan range.
   """
 
   use Ecto.Migration
@@ -29,7 +31,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
+    CREATE MATERIALIZED VIEW command_events_by_ran_at
     ENGINE = MergeTree
     ORDER BY (project_id, ran_at)
     POPULATE
@@ -41,7 +43,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_duration
+    CREATE MATERIALIZED VIEW command_events_by_duration
     ENGINE = MergeTree
     ORDER BY (project_id, duration)
     POPULATE
@@ -55,7 +57,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
+    CREATE MATERIALIZED VIEW command_events_by_ran_at
     ENGINE = MergeTree
     ORDER BY (project_id, name, ran_at)
     POPULATE
@@ -67,7 +69,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_duration
+    CREATE MATERIALIZED VIEW command_events_by_duration
     ENGINE = MergeTree
     ORDER BY (project_id, name, duration)
     POPULATE


### PR DESCRIPTION
## Summary

- Recreates `command_events_by_ran_at` and `command_events_by_duration` ClickHouse materialized views with `name` removed from the sort key
- Uses `DROP VIEW ... SYNC` to ensure drops fully propagate across replicas before recreating

## Problem

The materialized views used `ORDER BY (project_id, name, <sort_column>)`. When queries filter with `name IN (...)` and sort by the target column with `LIMIT N`, ClickHouse cannot use its read-in-order optimization because `name` sits between `project_id` and the sort column. It reads ALL matching rows and then merge-sorts them.

Production stats for `command_events_by_ran_at`:
- **Avg read rows**: 432,375
- **p50 latency**: 4,734 ms
- **p90 latency**: 5,595 ms
- **Avg memory**: 442 MiB

## Solution

Change the sort key to `ORDER BY (project_id, <sort_column>)` — removing `name`. ClickHouse can now read directly in sort order within each project, applying `name` as a lightweight filter, and stop as soon as LIMIT is satisfied.

`command_events_by_hit_rate` is intentionally **not** changed. `EXPLAIN PLAN` confirmed that ClickHouse does not use `ReadType: InReverseOrder` for Float32 sort keys (it falls back to `ReadType: Default` — full scan + sort). This is likely due to IEEE 754 NaN/Inf comparison edge cases. Since removing `name` can't enable the optimization, keeping it narrows the scan range (180K vs 500K rows).

## Local Benchmarks

500K synthetic rows, single project, 3 name values evenly distributed.

### `command_events_by_ran_at` — ORDER BY ran_at DESC LIMIT 20

| Query | Before (rows read) | After (rows read) | Improvement |
|---|---:|---:|---|
| `name IN ('cache')` | 180,224 | 8,480 | **~21x** |
| `name IN ('cache', 'generate')` | 344,064 | 8,480 | **~41x** |
| No name filter | 508,067 | 8,480 | **~60x** |

### `command_events_by_duration` — ORDER BY duration DESC LIMIT 20

| Query | Before (rows read) | After (rows read) | Improvement |
|---|---:|---:|---|
| `name IN ('cache')` | 180,224 | 8,480 | **~21x** |
| `name IN ('cache', 'generate')` | 344,064 | 8,480 | **~41x** |

### `command_events_by_hit_rate` — NOT changed (Float32 prevents InReverseOrder)

Verified via `EXPLAIN PLAN`: Float32 sort key → `ReadType: Default` (full scan), Int32 sort key → `ReadType: InReverseOrder` (early stop). Removing `name` without the optimization just widens the scan:

| Query | With name (current) | Without name | 
|---|---:|---:|
| `name IN ('cache')` | 180,224 | 500,001 (**worse**) |

## Test plan

- [x] Migration runs successfully locally (rollback + re-apply verified)
- [x] Row counts match between MV and source table after migration
- [x] All 58 `command_events_test.exs` tests pass
- [x] Benchmarked all three MVs with EXPLAIN PLAN verification
- [ ] Monitor ClickHouse query stats after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)