### PR TITLE
chore(ci): move release macOS jobs to Namespace runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,7 +415,7 @@ jobs:
     name: Release CLI
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: macos-26
+    runs-on: namespace-profile-default-macos
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -561,7 +561,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: macos-26
+    runs-on: namespace-profile-default-macos
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_GITHUB_TOKEN }}
@@ -655,7 +655,7 @@ jobs:
     name: Release iOS App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: macos-26
+    runs-on: namespace-profile-default-macos
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Switch `release-cli`, `release-app`, and `release-ios` jobs from `macos-26` GitHub runners to `namespace-profile-default-macos`

## Test plan
- [ ] Verify next release workflow run picks up the Namespace runners successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)