### PR TITLE
fix(cli): include transitive search paths through dynamic framework dependencies

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -463,6 +463,7 @@ public class GraphTraverser: GraphTraversing {
     > {
         try linkableDependencies(path: path, name: name, shouldExcludeHostAppDependencies: false)
             .union(staticPrecompiledFrameworksDependencies(path: path, name: name))
+            .union(transitiveStaticDependenciesOfDynamicFrameworkDependencies(path: path, name: name))
     }
 
     public func linkableDependencies(path: Path.AbsolutePath, name: String) throws -> Set<
@@ -1694,6 +1695,24 @@ public class GraphTraverser: GraphTraversing {
 
         return Set(precompiledStatic + precompiledDependencies)
             .compactMap { dependencyReference(to: $0, from: .target(name: name, path: path)) }
+    }
+
+    private func transitiveStaticDependenciesOfDynamicFrameworkDependencies(
+        path: Path.AbsolutePath,
+        name: String
+    ) -> Set<GraphDependencyReference> {
+        let targetGraphDependency = GraphDependency.target(name: name, path: path)
+
+        let directDynamicDeps = graph.dependencies[targetGraphDependency, default: []]
+            .filter(or(isDependencyDynamicLibrary, isDependencyFramework))
+
+        let transitiveStaticDeps = directDynamicDeps.flatMap { dynamicDep in
+            transitiveStaticDependencies(from: dynamicDep)
+        }
+
+        return Set(transitiveStaticDeps.compactMap {
+            dependencyReference(to: $0, from: targetGraphDependency)
+        })
     }
 
     private func staticPrecompiledXCFrameworksDependencies(

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3803,6 +3803,45 @@ final class GraphTraverserTests: TuistUnitTestCase {
         ])
     }
 
+    func test_searchablePathDependencies_when_transitiveStaticDependenciesThroughDynamicFramework() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let dynamicFramework = Target.test(name: "MyDynamicFramework", product: .framework)
+        let staticFramework = Target.test(name: "StaticLib", product: .staticFramework)
+        let project = Project.test(targets: [app, dynamicFramework, staticFramework])
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: project.path): [
+                .target(name: dynamicFramework.name, path: project.path),
+            ],
+            .target(name: dynamicFramework.name, path: project.path): [
+                .target(name: staticFramework.name, path: project.path),
+            ],
+            .target(name: staticFramework.name, path: project.path): [],
+        ]
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let searchablePaths = try subject.searchablePathDependencies(path: project.path, name: app.name)
+        let linkableDeps = try subject.linkableDependencies(path: project.path, name: app.name)
+
+        // Then: searchablePathDependencies includes the transitive static dep
+        XCTAssertTrue(
+            searchablePaths.contains(
+                .product(target: staticFramework.name, productName: staticFramework.productNameWithExtension)
+            )
+        )
+        // And: linkableDependencies does NOT include the transitive static dep (it's inside the dynamic framework)
+        XCTAssertFalse(
+            linkableDeps.contains(
+                .product(target: staticFramework.name, productName: staticFramework.productNameWithExtension)
+            )
+        )
+    }
+
     func test_librariesSwiftIncludePaths() throws {
         // Given
         let target = Target.test(name: "Main")


### PR DESCRIPTION
## Summary

Resolves #9676.

When you have a setup like `App -> DynamicFramework -> StaticSPMPackage`, the app fails to compile with "Unable to find module dependency" errors. This happens because the Swift compiler needs `FRAMEWORK_SEARCH_PATHS` pointing to the `.swiftmodule` files of those SPM packages, but Tuist wasn't generating them.

Here's why: `searchablePathDependencies()` (which produces `FRAMEWORK_SEARCH_PATHS`) delegates to `linkableDependencies()`. That method is responsible for figuring out what a target needs to *link* against. For linking, it correctly stops traversing at dynamic framework boundaries because the static libraries are already linked *inside* the dynamic framework. The app shouldn't link them again. But search paths are different from linker inputs. The Swift compiler still needs to find the `.swiftmodule` files for those transitive packages so it can resolve the types referenced in the dynamic framework's module interface. `searchablePathDependencies` was missing that second pass.

This PR adds a small helper that looks at a target's direct dynamic framework dependencies, collects their transitive static deps, and includes those in the search paths. It does not change `linkableDependencies` at all, so linking behavior stays the same.

## Test plan

- Added a unit test that creates an `App -> DynamicFramework -> StaticFramework` graph and verifies:
  - `searchablePathDependencies` for the app **includes** the static framework
  - `linkableDependencies` for the app **does not** include the static framework (no double-linking)