### PR TITLE
fix(server): add IF NOT EXISTS to ClickHouse MV migration for concurrent safety

### DIFF
--- a/server/priv/ingest_repo/migrations/20260302220000_optimize_command_events_by_ran_at_sort_key.exs
+++ b/server/priv/ingest_repo/migrations/20260302220000_optimize_command_events_by_ran_at_sort_key.exs
@@ -31,7 +31,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW command_events_by_ran_at
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
     ENGINE = MergeTree
     ORDER BY (project_id, ran_at)
     POPULATE
@@ -43,7 +43,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW command_events_by_duration
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_duration
     ENGINE = MergeTree
     ORDER BY (project_id, duration)
     POPULATE
@@ -57,7 +57,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW command_events_by_ran_at
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
     ENGINE = MergeTree
     ORDER BY (project_id, name, ran_at)
     POPULATE
@@ -69,7 +69,7 @@ defmodule Tuist.IngestRepo.Migrations.OptimizeCommandEventsMvSortKeys do
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
-    CREATE MATERIALIZED VIEW command_events_by_duration
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_duration
     ENGINE = MergeTree
     ORDER BY (project_id, name, duration)
     POPULATE


### PR DESCRIPTION
## Summary

- Adds `IF NOT EXISTS` to all 4 `CREATE MATERIALIZED VIEW` statements in the `20260302220000` migration

## Problem

The migration from #9675 failed in production with `TABLE_ALREADY_EXISTS` because multiple Elixir instances ran it concurrently. ClickHouse doesn't support Ecto's advisory lock mechanism, so `@disable_migration_lock true` is required for all ClickHouse migrations. This means the `DROP VIEW ... SYNC` + `CREATE MATERIALIZED VIEW` sequence races: if instance A completes the CREATE before instance B reaches it, instance B fails.

## Fix

Adding `IF NOT EXISTS` makes the CREATE idempotent. When two instances race:
1. Both execute `DROP VIEW IF EXISTS ... SYNC` (idempotent — second is a no-op)
2. Both execute `CREATE MATERIALIZED VIEW IF NOT EXISTS ...` (idempotent — second is a no-op)

The first instance to reach CREATE wins and populates the view; the second gracefully skips it.

## Test plan

- [x] Verified the diff only adds `IF NOT EXISTS` to the 4 CREATE statements (both `up` and `down`)
- [ ] Deploy to staging and verify migration completes successfully
- [ ] Verify `command_events_by_ran_at` and `command_events_by_duration` MVs exist with correct sort keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)