### PR TITLE
fix(cli): treat opaque directories as files in buildable folder resolution

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -44,6 +44,13 @@ extension XcodeGraph.BuildableFolder {
             .glob(directory: path, include: ["**/*"]).collect()
             .filter { !exclusions.contains($0) }
         let resolvedFiles = try await allPaths.concurrentCompactMap(maxConcurrentTasks: 100) { filePath -> BuildableFolderFile? in
+            if filePath.isInOpaqueDirectory { return nil }
+            if filePath.isOpaqueDirectory {
+                return BuildableFolderFile(
+                    path: filePath,
+                    compilerFlags: compilerFlagsByPath[filePath]
+                )
+            }
             if try await fileSystem.exists(filePath, isDirectory: true) { return nil }
             return BuildableFolderFile(
                 path: filePath,

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperTests.swift
@@ -170,6 +170,40 @@ struct BuildableFolderManifestMapperTests {
         #expect(fileWithFlags?.compilerFlags == "-O0")
     }
 
+    @Test(.inTemporaryDirectory) func from_treatsOpaqueDirectoriesAsFiles() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+        let sourcesPath = temporaryDirectory.appending(component: "Sources")
+        let xcassetsPath = sourcesPath.appending(component: "Assets.xcassets")
+        try await fileSystem.makeDirectory(at: xcassetsPath.appending(component: "AccentColor.colorset"))
+        try await fileSystem.touch(xcassetsPath.appending(components: "AccentColor.colorset", "Contents.json"))
+        try await fileSystem.touch(xcassetsPath.appending(component: "Contents.json"))
+        try await fileSystem.touch(sourcesPath.appending(component: "File.swift"))
+
+        let manifest = ProjectDescription.BuildableFolder.folder(
+            .path(temporaryDirectory.pathString),
+            exceptions: .exceptions([])
+        )
+
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryDirectory,
+            rootDirectory: temporaryDirectory
+        )
+
+        let got = try await XcodeGraph.BuildableFolder.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            targetName: "Target"
+        )
+
+        let resolvedPaths = Set(got.resolvedFiles.map(\.path))
+
+        #expect(resolvedPaths.contains(xcassetsPath))
+        #expect(resolvedPaths.contains(sourcesPath.appending(component: "File.swift")))
+        #expect(!resolvedPaths.contains(xcassetsPath.appending(component: "Contents.json")))
+        #expect(!resolvedPaths.contains(xcassetsPath.appending(components: "AccentColor.colorset", "Contents.json")))
+    }
+
     @Test(.inTemporaryDirectory) func from_withNestedGlobPattern_excludesNestedFiles() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 


### PR DESCRIPTION
## Summary

Buildable folder resolution was not properly handling opaque directories (`.xcassets`, `.scnassets`, `.xcdatamodeld`, etc.). These are directories that Xcode treats as file-like entries and should appear as single items in `resolvedFiles` rather than being traversed into individual files.

Before #9678, the glob included everything (directories and files), so `.xcassets` happened to be in `resolvedFiles` alongside its inner files. After #9678 excluded all directories, `.xcassets` was removed entirely, breaking `TuistAssets` accessor generation for targets using `buildableFolders`.

This fix properly handles opaque directories: they are kept in `resolvedFiles` as file-like entries, while their inner contents are excluded (matching how standard source globbing handles them via `isInOpaqueDirectory`).

## Test plan

- Tested e2e with the reproducer project -- both `TuistAssets+FrameworkDynamic.swift` and `TuistAssets+FrameworkStatic.swift` are now generated
- Added `from_treatsOpaqueDirectoriesAsFiles` test verifying `.xcassets` directories appear in `resolvedFiles` while their inner files do not
- All existing `BuildableFolderManifestMapperTests` and `SynthesizedResourceInterfaceProjectMapperTests` pass