### PR TITLE
fix(android): send git ref and remote URL origin in Gradle build reports

### DIFF
--- a/android/app/src/main/java/dev/tuist/app/TuistApplication.kt
+++ b/android/app/src/main/java/dev/tuist/app/TuistApplication.kt
@@ -4,8 +4,4 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class TuistApplication : Application() {
-    companion object {
-        const val APP_TAG = "TuistApp"
-    }
-}
+class TuistApplication : Application()

--- a/gradle/src/main/kotlin/dev/tuist/gradle/GitInfoProvider.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/GitInfoProvider.kt
@@ -4,6 +4,7 @@ interface GitInfoProvider {
     fun branch(): String?
     fun commitSha(): String?
     fun ref(): String?
+    fun remoteUrlOrigin(): String?
 }
 
 class ProcessGitInfoProvider(
@@ -20,7 +21,20 @@ class ProcessGitInfoProvider(
     }
 
     override fun commitSha(): String? = runCatching { gitCommandRunner(listOf("rev-parse", "HEAD")) }.getOrNull()
-    override fun ref(): String? = runCatching { gitCommandRunner(listOf("describe", "--tags", "--always")) }.getOrNull()
+
+    override fun ref(): String? {
+        val ciRef = ciRef()
+        if (ciRef != null) return ciRef
+        return runCatching { gitCommandRunner(listOf("describe", "--tags", "--always")) }.getOrNull()
+    }
+
+    override fun remoteUrlOrigin(): String? =
+        runCatching { gitCommandRunner(listOf("config", "--get", "remote.origin.url")) }.getOrNull()
+
+    private fun ciRef(): String? =
+        refEnvironmentVariables
+            .mapNotNull { environmentProvider(it) }
+            .firstOrNull { it.isNotEmpty() }
 
     private fun ciBranch(): String? =
         branchEnvironmentVariables
@@ -28,6 +42,13 @@ class ProcessGitInfoProvider(
             .firstOrNull { it.isNotEmpty() }
 
     companion object {
+        private val refEnvironmentVariables = listOf(
+            // GitHub Actions
+            "GITHUB_REF",
+            // GitLab CI
+            "CI_MERGE_REQUEST_REF_PATH",
+        )
+
         private val branchEnvironmentVariables = listOf(
             // GitHub Actions
             "GITHUB_HEAD_REF",

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
@@ -91,6 +91,7 @@ data class BuildReportRequest(
     @SerializedName("git_branch") val gitBranch: String?,
     @SerializedName("git_commit_sha") val gitCommitSha: String?,
     @SerializedName("git_ref") val gitRef: String?,
+    @SerializedName("git_remote_url_origin") val gitRemoteUrlOrigin: String?,
     @SerializedName("root_project_name") val rootProjectName: String?,
     val tasks: List<TaskReportEntry>
 )
@@ -397,6 +398,7 @@ internal fun buildReport(
         gitBranch = gitInfoProvider.branch(),
         gitCommitSha = gitInfoProvider.commitSha(),
         gitRef = gitInfoProvider.ref(),
+        gitRemoteUrlOrigin = gitInfoProvider.remoteUrlOrigin(),
         rootProjectName = rootProjectName,
         tasks = taskOutcomes.map { task ->
             TaskReportEntry(

--- a/gradle/src/test/kotlin/dev/tuist/gradle/GitInfoProviderTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/GitInfoProviderTest.kt
@@ -135,4 +135,67 @@ class GitInfoProviderTest {
 
         assertEquals("azure-branch", provider.branch())
     }
+
+    @Test
+    fun `ref prefers GITHUB_REF over git describe`() {
+        val provider = ProcessGitInfoProvider(
+            environmentProvider = { key ->
+                when (key) {
+                    "GITHUB_REF" -> "refs/pull/123/merge"
+                    else -> null
+                }
+            },
+            gitCommandRunner = { "v1.0.0" }
+        )
+
+        assertEquals("refs/pull/123/merge", provider.ref())
+    }
+
+    @Test
+    fun `ref falls back to git describe when no CI env vars`() {
+        val provider = ProcessGitInfoProvider(
+            environmentProvider = { null },
+            gitCommandRunner = { args ->
+                when (args.first()) {
+                    "describe" -> "v1.0.0"
+                    else -> "fallback"
+                }
+            }
+        )
+
+        assertEquals("v1.0.0", provider.ref())
+    }
+
+    @Test
+    fun `ref returns null when git fails and no CI env vars`() {
+        val provider = ProcessGitInfoProvider(
+            environmentProvider = { null },
+            gitCommandRunner = { throw RuntimeException("git not found") }
+        )
+
+        assertEquals(null, provider.ref())
+    }
+
+    @Test
+    fun `remoteUrlOrigin returns git remote origin URL`() {
+        val provider = ProcessGitInfoProvider(
+            environmentProvider = { null },
+            gitCommandRunner = { args ->
+                if (args.contains("remote.origin.url")) "https://github.com/tuist/tuist.git"
+                else "fallback"
+            }
+        )
+
+        assertEquals("https://github.com/tuist/tuist.git", provider.remoteUrlOrigin())
+    }
+
+    @Test
+    fun `remoteUrlOrigin returns null when git fails`() {
+        val provider = ProcessGitInfoProvider(
+            environmentProvider = { null },
+            gitCommandRunner = { throw RuntimeException("git not found") }
+        )
+
+        assertEquals(null, provider.remoteUrlOrigin())
+    }
 }

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildInsightsTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildInsightsTest.kt
@@ -11,11 +11,13 @@ import kotlin.test.assertTrue
 private class TestGitInfoProvider(
     private val branch: String? = null,
     private val commitSha: String? = null,
-    private val ref: String? = null
+    private val ref: String? = null,
+    private val remoteUrlOrigin: String? = null
 ) : GitInfoProvider {
     override fun branch(): String? = branch
     override fun commitSha(): String? = commitSha
     override fun ref(): String? = ref
+    override fun remoteUrlOrigin(): String? = remoteUrlOrigin
 }
 
 private class TestCIDetector(private val isCi: Boolean = false) : CIDetector {
@@ -107,6 +109,7 @@ class TuistBuildInsightsTest {
             gitBranch = "main",
             gitCommitSha = "abc",
             gitRef = "v1",
+            gitRemoteUrlOrigin = "https://github.com/tuist/tuist.git",
             rootProjectName = null,
             tasks = emptyList()
         )
@@ -119,6 +122,7 @@ class TuistBuildInsightsTest {
         assertTrue(json.contains("\"git_branch\""))
         assertTrue(json.contains("\"git_commit_sha\""))
         assertTrue(json.contains("\"git_ref\""))
+        assertTrue(json.contains("\"git_remote_url_origin\""))
     }
 
     @Test
@@ -241,6 +245,24 @@ class TuistBuildInsightsTest {
         assertEquals("feature/test", report.gitBranch)
         assertEquals("abc123def456", report.gitCommitSha)
         assertEquals("v1.0.0", report.gitRef)
+        assertNull(report.gitRemoteUrlOrigin)
+    }
+
+    @Test
+    fun `buildReport includes git remote URL origin from provider`() {
+        val report = buildReport(
+            id = "test-id",
+            taskOutcomes = emptyList(),
+            buildFailed = false,
+            totalDurationMs = 100,
+            ciDetector = TestCIDetector(false),
+            gitInfoProvider = TestGitInfoProvider(
+                branch = "main",
+                remoteUrlOrigin = "https://github.com/tuist/tuist.git"
+            )
+        )
+
+        assertEquals("https://github.com/tuist/tuist.git", report.gitRemoteUrlOrigin)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The Gradle build insights plugin was sending `git_ref` from `git describe --tags --always`, which returns tags or short commit SHAs — but the server requires `refs/pull/NNN/merge` format to post PR comments
- Now checks CI environment variables (`GITHUB_REF`, `CI_MERGE_REQUEST_REF_PATH`) first before falling back to `git describe`
- Adds `git_remote_url_origin` (from `git config --get remote.origin.url`) to build reports — this field was missing entirely, preventing the server from identifying the repository for PR comments

## Test plan
- [x] All Gradle plugin tests pass locally
- [ ] CI passes
- [ ] Verify Tuist report comment appears on the PR after CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)