### PR TITLE
perf(cache): write upload temp files to storage filesystem for atomic renames

### DIFF
--- a/cache/lib/cache/gradle/disk.ex
+++ b/cache/lib/cache/gradle/disk.ex
@@ -79,6 +79,20 @@ defmodule Cache.Gradle.Disk do
   end
 
   @doc """
+  Ensures the parent directory for a Gradle artifact exists and returns its path.
+
+  Returns `{:ok, dir_path}` on success, or `{:error, reason}` if directory creation fails.
+  """
+  def ensure_artifact_directory(account_handle, project_handle, cache_key) do
+    path = account_handle |> key(project_handle, cache_key) |> Disk.artifact_path()
+    dir = Path.dirname(path)
+
+    with :ok <- Disk.ensure_directory(path) do
+      {:ok, dir}
+    end
+  end
+
+  @doc """
   Returns file stat information for a Gradle build cache artifact.
 
   ## Examples

--- a/cache/lib/cache_web/controllers/gradle_controller.ex
+++ b/cache/lib/cache_web/controllers/gradle_controller.ex
@@ -169,12 +169,12 @@ defmodule CacheWeb.GradleController do
   end
 
   defp save_new_artifact(conn, account_handle, project_handle, cache_key) do
-    case BodyReader.read(conn, max_bytes: @max_upload_bytes) do
-      {:ok, data, conn_after} ->
-        size = data_size(data)
-        :telemetry.execute([:cache, :gradle, :upload, :attempt], %{size: size}, %{})
-        persist_artifact(conn_after, account_handle, project_handle, cache_key, data, size)
-
+    with {:ok, target_dir} <- Gradle.Disk.ensure_artifact_directory(account_handle, project_handle, cache_key),
+         {:ok, data, conn_after} <- BodyReader.read(conn, max_bytes: @max_upload_bytes, tmp_dir: target_dir) do
+      size = data_size(data)
+      :telemetry.execute([:cache, :gradle, :upload, :attempt], %{size: size}, %{})
+      persist_artifact(conn_after, account_handle, project_handle, cache_key, data, size)
+    else
       {:error, :too_large, conn_after} ->
         :telemetry.execute([:cache, :gradle, :upload, :error], %{count: 1}, %{reason: :too_large})
         send_error(conn_after, :request_entity_too_large, "Request body exceeded allowed size")
@@ -190,6 +190,11 @@ defmodule CacheWeb.GradleController do
       {:error, _reason, conn_after} ->
         :telemetry.execute([:cache, :gradle, :upload, :error], %{count: 1}, %{reason: :read_error})
         send_error(conn_after, :internal_server_error, "Failed to persist artifact")
+
+      {:error, reason} ->
+        Logger.error("Failed to ensure Gradle artifact directory: #{inspect(reason)}")
+        :telemetry.execute([:cache, :gradle, :upload, :error], %{count: 1}, %{reason: :persist_error})
+        send_error(conn, :internal_server_error, "Failed to persist artifact")
     end
   end
 

--- a/cache/lib/cache_web/controllers/module_cache_controller.ex
+++ b/cache/lib/cache_web/controllers/module_cache_controller.ex
@@ -482,7 +482,9 @@ defmodule CacheWeb.ModuleCacheController do
   defp translate_add_part_error(reason), do: {:error, reason}
 
   defp read_part_body(conn) do
-    opts = [max_bytes: @max_part_size, read_length: 262_144, read_timeout: 60_000]
+    tmp_dir = buffered_part_tmp_dir()
+    File.mkdir_p(tmp_dir)
+    opts = [max_bytes: @max_part_size, read_length: 262_144, read_timeout: 60_000, tmp_dir: tmp_dir]
 
     case BodyReader.read(conn, opts) do
       {:ok, {:file, tmp_path}, conn_after} ->
@@ -513,10 +515,11 @@ defmodule CacheWeb.ModuleCacheController do
   end
 
   defp tmp_path do
-    base = System.tmp_dir!()
     unique = :erlang.unique_integer([:positive, :monotonic])
-    Path.join(base, "cache-part-#{unique}")
+    Path.join(buffered_part_tmp_dir(), "cache-part-#{unique}")
   end
+
+  defp buffered_part_tmp_dir, do: Path.join(Cache.Disk.storage_dir(), "tmp")
 
   defp validate_part_numbers(:invalid), do: {:error, :parts_mismatch}
 

--- a/cache/test/cache/gradle/disk_test.exs
+++ b/cache/test/cache/gradle/disk_test.exs
@@ -131,6 +131,26 @@ defmodule Cache.Gradle.DiskTest do
     end
   end
 
+  describe "ensure_artifact_directory/3" do
+    test "creates parent directory and returns its path", %{test_storage_dir: test_storage_dir} do
+      assert {:ok, dir} = GradleDisk.ensure_artifact_directory(@test_account, @test_project, @test_cache_key)
+      assert File.dir?(dir)
+      assert String.starts_with?(dir, test_storage_dir)
+    end
+
+    test "returns directory containing the artifact path" do
+      assert {:ok, dir} = GradleDisk.ensure_artifact_directory(@test_account, @test_project, @test_cache_key)
+      expected_artifact_path = Disk.artifact_path(@test_key)
+      assert dir == Path.dirname(expected_artifact_path)
+    end
+
+    test "is idempotent" do
+      assert {:ok, dir1} = GradleDisk.ensure_artifact_directory(@test_account, @test_project, @test_cache_key)
+      assert {:ok, dir2} = GradleDisk.ensure_artifact_directory(@test_account, @test_project, @test_cache_key)
+      assert dir1 == dir2
+    end
+  end
+
   describe "integration test" do
     test "put and exists? roundtrip" do
       original_data = "This is test artifact content for roundtrip testing"

--- a/cache/test/cache_web/controllers/gradle_controller_test.exs
+++ b/cache/test/cache_web/controllers/gradle_controller_test.exs
@@ -1,0 +1,274 @@
+defmodule CacheWeb.GradleControllerTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  import ExUnit.CaptureLog
+  import Phoenix.ConnTest
+  import Plug.Conn
+
+  alias Cache.Authentication
+  alias Cache.Gradle
+  alias Cache.S3Transfers
+  alias Ecto.Adapters.SQL.Sandbox
+
+  @endpoint CacheWeb.Endpoint
+
+  setup :set_mimic_from_context
+
+  setup context do
+    :ok = Sandbox.checkout(Cache.Repo)
+
+    context = Cache.BufferTestHelpers.setup_s3_transfers_buffer(context)
+
+    {:ok, test_storage_dir} = Briefly.create(directory: true)
+
+    Cache.Disk
+    |> stub(:storage_dir, fn -> test_storage_dir end)
+    |> stub(:artifact_path, fn key -> Path.join(test_storage_dir, key) end)
+
+    stub(Authentication, :server_url, fn -> "http://localhost:4000" end)
+
+    {:ok, Map.merge(context, %{conn: build_conn(), test_storage_dir: test_storage_dir})}
+  end
+
+  describe "PUT /api/cache/gradle/:cache_key" do
+    test "saves artifact successfully when authenticated", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      body = "test artifact content"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      Gradle.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^cache_key, ^body ->
+        :ok
+      end)
+
+      capture_log(fn ->
+        conn =
+          conn
+          |> put_req_header("authorization", "Bearer valid-token")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> put(
+            "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+            body
+          )
+
+        assert conn.status == 201
+        assert conn.resp_body == ""
+      end)
+
+      :ok = Cache.S3TransfersBuffer.flush()
+
+      uploads = S3Transfers.pending(:upload, 10)
+      assert length(uploads) == 1
+      upload = hd(uploads)
+      assert upload.type == :upload
+      assert upload.account_handle == account_handle
+      assert upload.project_handle == project_handle
+      assert upload.artifact_type == :gradle
+      assert upload.key == "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+    end
+
+    test "streams large artifact to temp file on same filesystem as storage", %{
+      conn: conn,
+      test_storage_dir: test_storage_dir
+    } do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      large_body = :binary.copy("0123456789abcdef", 150_000)
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      Gradle.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^cache_key, {:file, tmp_path} ->
+        assert File.exists?(tmp_path)
+        assert File.stat!(tmp_path).size == byte_size(large_body)
+
+        assert String.starts_with?(tmp_path, test_storage_dir),
+               "Expected temp file #{tmp_path} to be under storage dir #{test_storage_dir}"
+
+        File.rm(tmp_path)
+        :ok
+      end)
+
+      capture_log(fn ->
+        conn =
+          conn
+          |> put_req_header("authorization", "Bearer valid-token")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> Plug.Conn.put_private(:body_read_opts, length: 128_000, read_length: 128_000, read_timeout: 60_000)
+          |> put(
+            "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+            large_body
+          )
+
+        assert conn.status == 201
+        assert conn.resp_body == ""
+      end)
+
+      :ok = Cache.S3TransfersBuffer.flush()
+
+      uploads = S3Transfers.pending(:upload, 10)
+      assert length(uploads) == 1
+      upload = hd(uploads)
+      assert upload.type == :upload
+      assert upload.account_handle == account_handle
+      assert upload.project_handle == project_handle
+      assert upload.artifact_type == :gradle
+      assert upload.key == "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+    end
+
+    test "skips save when artifact already exists", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      body = "test artifact content"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(Gradle.Disk, :exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        true
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          body
+        )
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "returns 500 when disk write fails", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      body = "test artifact content"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      Gradle.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^cache_key, ^body ->
+        {:error, :enospc}
+      end)
+
+      capture_log(fn ->
+        conn =
+          conn
+          |> put_req_header("authorization", "Bearer valid-token")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> put(
+            "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+            body
+          )
+
+        assert conn.status == 500
+        response = json_response(conn, 500)
+        assert response["message"] == "Failed to persist artifact"
+      end)
+    end
+
+    test "treats put_file exists error as success", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      large_body = :binary.copy("0123456789abcdef", 150_000)
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      Gradle.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^cache_key, {:file, tmp_path} ->
+        assert File.exists?(tmp_path)
+        File.rm(tmp_path)
+        {:error, :exists}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> Plug.Conn.put_private(:body_read_opts, length: 128_000, read_length: 128_000, read_timeout: 60_000)
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          large_body
+        )
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "returns 401 when authorization header is missing", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:error, 401, "Missing Authorization header"}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          "body"
+        )
+
+      assert conn.status == 401
+      response = json_response(conn, 401)
+      assert response["message"] == "Missing Authorization header"
+    end
+
+    test "returns 404 when project is not accessible", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:error, 404, "Unauthorized or not found"}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer invalid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          "body"
+        )
+
+      assert conn.status == 404
+      response = json_response(conn, 404)
+      assert response["message"] == "Unauthorized or not found"
+    end
+  end
+end

--- a/cache/test/cache_web/controllers/module_cache_controller_test.exs
+++ b/cache/test/cache_web/controllers/module_cache_controller_test.exs
@@ -343,6 +343,35 @@ defmodule CacheWeb.ModuleCacheControllerTest do
       assert upload.parts[1].size == 1000
     end
 
+    test "stores buffered part temp file under storage dir", %{conn: conn, test_storage_dir: test_storage_dir} do
+      {:ok, upload_id} =
+        MultipartUploads.start_upload("test-account", "test-project", "builds", "abc123", "test.zip")
+
+      body = String.duplicate("x", 1000)
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post(
+          "/api/cache/module/part?account_handle=test-account&project_handle=test-project&upload_id=#{upload_id}&part_number=2",
+          body
+        )
+
+      assert conn.status == 204
+
+      {:ok, upload} = MultipartUploads.get_upload(upload_id)
+      assert Map.has_key?(upload.parts, 2)
+      part_path = upload.parts[2].path
+
+      assert String.starts_with?(part_path, test_storage_dir),
+             "Expected part temp file #{part_path} to be under storage dir #{test_storage_dir}"
+    end
+
     test "returns 404 for unknown upload_id", %{conn: conn} do
       body = String.duplicate("x", 1000)
 


### PR DESCRIPTION
## Summary

- Ensures temp files created during Gradle and module cache uploads are written to the same filesystem as final artifact storage, enabling atomic `File.rename/2` instead of cross-device copy failures
- Adds `Gradle.Disk.ensure_artifact_directory/3` to pre-create the artifact's parent directory and pass it as `tmp_dir` to `BodyReader.read/2`
- Updates `ModuleCacheController.read_part_body/1` to use `storage_dir()/tmp` instead of `System.tmp_dir!()` for buffered part temp files
- Adds comprehensive controller tests for the Gradle upload flow and a buffered-part temp file location test for the module cache controller