### PR TITLE
fix(cache): zero-downtime deploys via unique socket paths

### DIFF
--- a/cache/config/runtime.exs
+++ b/cache/config/runtime.exs
@@ -26,7 +26,7 @@ if config_env() == :prod do
       path ->
         File.mkdir_p!(Path.dirname(path))
         suffix = 4 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
-        unique_path = String.replace_trailing(path, ".sock", "-#{suffix}.sock")
+        unique_path = Path.rootname(path) <> "-#{suffix}" <> Path.extname(path)
         Application.put_env(:cache, :socket_path, unique_path)
 
         [

--- a/cache/lib/cache/socket_linker.ex
+++ b/cache/lib/cache/socket_linker.ex
@@ -60,8 +60,8 @@ defmodule Cache.SocketLinker do
 
     case File.ln_s(target, tmp_link) do
       :ok ->
+        :ok = File.chmod(target, 0o777)
         :ok = File.rename(tmp_link, link)
-        :ok = File.chmod(link, 0o777)
         Logger.info("Socket link promoted: #{link} -> #{target}")
         cleanup_stale_sockets(target)
 


### PR DESCRIPTION
During deploys, the old and new cache containers both bind to the same Unix socket path. The new container removes the socket before binding, which kills in-flight requests from nginx and can cause 502 errors.

This branch fixes it by giving each container a unique socket path (`cache-<random>.sock`) and having `SocketLinker` atomically swap a stable symlink once the new socket is ready. Old sockets are cleaned up after promotion.

Also fixes a permission race where the socket was exposed to nginx via the symlink before `chmod 0o777` ran — now permissions are set before the symlink swap.