### PR TITLE
fix(gradle): use Action<T> for Groovy DSL compatibility

### DIFF
--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
@@ -1,5 +1,6 @@
 package dev.tuist.gradle
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.Logger
@@ -164,8 +165,8 @@ open class TuistExtension {
     /**
      * Configure build cache settings.
      */
-    fun buildCache(configure: BuildCacheExtension.() -> Unit) {
-        buildCache.configure()
+    fun buildCache(action: Action<BuildCacheExtension>) {
+        action.execute(buildCache)
     }
 
     /**
@@ -176,8 +177,8 @@ open class TuistExtension {
     /**
      * Configure test quarantine settings.
      */
-    fun testQuarantine(configure: TestQuarantineExtension.() -> Unit) {
-        testQuarantine.configure()
+    fun testQuarantine(action: Action<TestQuarantineExtension>) {
+        action.execute(testQuarantine)
     }
 }
 


### PR DESCRIPTION
## Summary
- The `buildCache` and `testQuarantine` configuration functions in `TuistExtension` used Kotlin lambda receivers (`T.() -> Unit`), which don't properly delegate closure scope in Groovy
- This caused "unknown property" errors when Groovy users configured these blocks with the standard closure syntax in `settings.gradle`
- Switching to Gradle's `Action<T>` interface ensures closures are correctly delegated

**Before (Groovy — broken):**
```groovy
tuist {
    buildCache {
        push = System.getenv('CI') != null  // ❌ "Could not set unknown property 'push'"
    }
}
```

**After (Groovy — works):**
```groovy
tuist {
    buildCache {
        push = System.getenv('CI') != null  // ✅
    }
}
```

Kotlin DSL usage is unaffected — `Action<T>` accepts Kotlin lambdas transparently.

## Test plan
- [ ] Verify Kotlin DSL `settings.gradle.kts` still works with block syntax
- [ ] Verify Groovy `settings.gradle` works with block syntax (`buildCache { push = ... }`)
- [ ] Verify direct property assignment still works (`buildCache.push = ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)