### PR TITLE
fix(cli): bump Rosalind to 0.7.22 and swift-protobuf to 1.35.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2403c9b34815e85e224f77dd26edaeb8b9e42b0875aab3780bc9df94276f6743",
+  "originHash" : "5d75c916805f1901624d929c035fcf87235194ee02d6bb47987d1f6cf41644ce",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -166,7 +166,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.32.0"
+        "version" : "1.35.1"
       }
     },
     {
@@ -591,7 +591,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.15.0"
+        "version" : "0.15.3"
       }
     },
     {
@@ -623,7 +623,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.7.0"
+        "version" : "0.7.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1645,7 +1645,7 @@ let package = Package(
             id: "frazer-rbsn.OrderedSet", .upToNextMajor(from: "2.0.0")
         ),
         .package(id: "grpc.grpc-swift-2", from: "2.0.0"),
-        .package(id: "apple.swift-protobuf", exact: "1.32.0"),
+        .package(id: "apple.swift-protobuf", exact: "1.35.1"),
         .package(id: "grpc.grpc-swift-protobuf", from: "2.0.0"),
         .package(id: "grpc.grpc-swift-nio-transport", from: "2.0.0"),
         .package(id: "facebook.zstd", from: "1.5.0"),


### PR DESCRIPTION
## Summary
- Bump Rosalind from 0.7.0 to 0.7.22 — resolves `aapt2` from `ANDROID_HOME`/`ANDROID_SDK_ROOT` and provides a clear error when it's not found (tuist/Rosalind#425)
- Bump `swift-protobuf` from 1.32.0 to 1.35.1 (required by the new Rosalind version)

## Test plan
- [ ] CI passes (SwiftPM resolution, build, tests)
- [ ] `tuist inspect bundle` works on CI with `ANDROID_HOME` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)