### PR TITLE
fix(cli): prevent phantom targets from inflating clean build count

### DIFF
--- a/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
+++ b/cli/Sources/TuistXCActivityLog/XCActivityLogController.swift
@@ -441,8 +441,10 @@ public struct XCActivityLogController: XCActivityLogControlling {
 
         for step in buildSteps {
             if !step.fetchedFromCache {
-                guard let targetIdentifier = targetIdentifiers[step.identifier] else { continue }
-                targetsCompiledCount[targetIdentifier, default: 0] += 1
+                guard let targetIdentifier = targetIdentifiers[step.identifier],
+                    targetsCompiledCount[targetIdentifier] != nil
+                else { continue }
+                targetsCompiledCount[targetIdentifier]! += 1
             }
         }
 
@@ -479,7 +481,6 @@ public struct XCActivityLogController: XCActivityLogControlling {
             totalTargets = targets.count
         }
 
-        // If at least 50% of the targets are clean, we categorise the build as clean.
         if targetsCategory.values.filter({ $0 == .clean }).count > totalTargets / 2 {
             return .clean
         } else {


### PR DESCRIPTION
## Summary
- In `buildCategory()`, `targetsCompiledCount[targetIdentifier, default: 0] += 1` could create new entries for identifiers that don't correspond to actual build targets (e.g. device-specific or machine-name identifiers from the xcactivitylog). These phantom entries would always be classified as `.clean` (since `filesCompiledCount == targetFilesCount` for a single phantom step), inflating the clean count and biasing the overall build classification toward "clean" even for incremental builds.
- Guards the increment so only entries for known targets (those already seeded from the `targets` array) are updated.

## Context
This was discovered while investigating https://community.tuist.dev/t/tuist-inspect-build-misclassifies-incremental-builds-as-clean-xcode-26-cache/920 — the phantom target bug may not be the full root cause of the reported issue but it is a correctness fix to the classification algorithm.

## Test plan
- [x] All 17 existing `TuistXCActivityLogTests` pass (clean build, incremental build, Xcode 26.2, Xcode 26.4 with compilation cache clean/incremental, failed build, warning build, cache hits/misses/uploads, log file discovery tests)
- [x] Verified E2E by adding debug logging to `buildCategory()` and running the test suite against both the PR #9689 fixture xcactivitylogs (`xcode_26_4_clean_build_with_cache.xcactivitylog` → `.clean`, `xcode_26_4_incremental_build_with_cache.xcactivitylog` → `.incremental`) and locally-generated xcactivitylogs from the [sample reproduction project](https://community.tuist.dev/t/tuist-inspect-build-misclassifies-incremental-builds-as-clean-xcode-26-cache/920). The debug output showed phantom device-specific identifiers (e.g. `Marek's MacBook_...`) appearing as extra entries in `targetsCompiledCount` and being classified as `.clean`, inflating the clean count. After the fix, only actual target identifiers are counted.


🤖 Generated with [Claude Code](https://claude.com/claude-code)