### PR TITLE
fix(cache): resolve symlinks in two passes to handle broken symlinks in target dirs

### DIFF
--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -239,49 +239,68 @@ defmodule Cache.Registry.ReleaseWorker do
   defp resolve_symlinks(directory) do
     case System.cmd("find", [directory, "-type", "l"], stderr_to_stdout: true) do
       {output, 0} ->
-        output
-        |> String.split("\n", trim: true)
-        |> resolve_symlink_entries()
+        symlink_paths = String.split(output, "\n", trim: true)
+        {directory_symlinks, non_directory_symlinks} = classify_symlinks(symlink_paths)
+
+        with :ok <- resolve_non_directory_symlinks(non_directory_symlinks) do
+          resolve_directory_symlinks(directory_symlinks)
+        end
 
       {output, status} ->
         {:error, {:find_symlinks_failed, status, output}}
     end
   end
 
-  defp resolve_symlink_entries([]), do: :ok
+  defp classify_symlinks(symlink_paths) do
+    Enum.split_with(symlink_paths, fn path ->
+      match?({:ok, %File.Stat{type: :directory}}, File.stat(path))
+    end)
+  end
 
-  defp resolve_symlink_entries([symlink_path | rest]) do
+  defp resolve_non_directory_symlinks([]), do: :ok
+
+  defp resolve_non_directory_symlinks([symlink_path | rest]) do
     case File.stat(symlink_path) do
       {:ok, %File.Stat{type: :regular}} ->
         content = File.read!(symlink_path)
         File.rm!(symlink_path)
         File.write!(symlink_path, content)
-        resolve_symlink_entries(rest)
-
-      {:ok, %File.Stat{type: :directory}} ->
-        resolve_directory_symlink(symlink_path)
-        resolve_symlink_entries(rest)
 
       _ ->
         File.rm(symlink_path)
-        resolve_symlink_entries(rest)
     end
+
+    resolve_non_directory_symlinks(rest)
   end
 
-  defp resolve_directory_symlink(symlink_path) do
+  defp resolve_directory_symlinks(directory_symlinks) do
+    {cyclic, non_cyclic} =
+      Enum.split_with(directory_symlinks, fn path ->
+        case File.read_link(path) do
+          {:ok, target} ->
+            resolved = resolve_symlink_target(path, target)
+            symlink_creates_cycle?(Path.expand(path), resolved)
+
+          _ ->
+            false
+        end
+      end)
+
+    Enum.each(cyclic, &remove_cyclic_directory_symlink/1)
+    Enum.each(non_cyclic, &resolve_non_cyclic_directory_symlink/1)
+  end
+
+  defp remove_cyclic_directory_symlink(symlink_path) do
+    {:ok, target} = File.read_link(symlink_path)
+    File.rm!(symlink_path)
+    Logger.info("Removed recursive directory symlink #{symlink_path} -> #{target}")
+  end
+
+  defp resolve_non_cyclic_directory_symlink(symlink_path) do
     {:ok, target} = File.read_link(symlink_path)
     resolved_target = resolve_symlink_target(symlink_path, target)
-    expanded_symlink = Path.expand(symlink_path)
-
     File.rm!(symlink_path)
-
-    if symlink_creates_cycle?(expanded_symlink, resolved_target) do
-      Logger.info("Removed recursive directory symlink #{symlink_path} -> #{target}")
-    else
-      File.cp_r!(resolved_target, symlink_path, dereference_symlinks: true)
-    end
-
-    :ok
+    File.cp_r!(resolved_target, symlink_path)
   end
 
   defp symlink_creates_cycle?(symlink_path, resolved_target) do

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -286,20 +286,21 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       refute Enum.any?(String.split(output, "\n"), &String.starts_with?(&1, "l"))
     end
 
-    test "zip_directory resolves directory symlinks and removes recursive ones" do
+    test "zip_directory resolves directory symlinks whose target contains broken symlinks" do
       root = Briefly.create!(directory: true)
       source_dir = Path.join(root, "repo")
       archive_path = Path.join(root, "source_archive.zip")
 
-      File.mkdir_p!(Path.join(source_dir, "Sources/LocalReceiptParsing"))
-      File.write!(Path.join(source_dir, "Sources/main.swift"), "print(\"hello\")")
-      File.write!(Path.join(source_dir, "Sources/LocalReceiptParsing/LocalReceiptParsing.swift"), "")
-      File.write!(Path.join(source_dir, "target.md"), "content")
-      File.ln_s!("target.md", Path.join(source_dir, "link.md"))
-      File.ln_s!("Sources", Path.join(source_dir, "CustomEntitlementComputation"))
-      File.ln_s!("Sources/LocalReceiptParsing", Path.join(source_dir, "LocalReceiptParsing"))
-      File.mkdir_p!(Path.join(source_dir, "Tests/InstallationTests/CarthageInstallation"))
-      File.ln_s!("../../../", Path.join(source_dir, "Tests/InstallationTests/CarthageInstallation/purchases-root"))
+      # On ext4 with htree, "BuildScripts" hashes before "Tests" in readdir order,
+      # so `find -type l` discovers the BuildScripts directory symlink BEFORE the
+      # broken symlink inside Tests/. This reproduces the production crash where
+      # single-pass resolution called File.cp_r! with dereference_symlinks: true
+      # on a directory containing a broken symlink (target doesn't exist), causing
+      # a File.CopyError with :enoent.
+      File.mkdir_p!(Path.join(source_dir, "Tests/nested"))
+      File.write!(Path.join(source_dir, "Tests/nested/real_file.swift"), "")
+      File.ln_s!("nonexistent_submodule_path", Path.join(source_dir, "Tests/nested/broken"))
+      File.ln_s!("Tests", Path.join(source_dir, "BuildScripts"))
 
       assert :ok = ReleaseWorker.zip_directory(source_dir, archive_path)
 
@@ -309,14 +310,10 @@ defmodule Cache.Registry.ReleaseWorkerTest do
 
       assert symlink_lines == []
 
-      file_lines = Enum.filter(lines, &String.starts_with?(&1, "-"))
-      assert Enum.any?(file_lines, &String.contains?(&1, "link.md"))
-
       dir_lines = Enum.filter(lines, &String.starts_with?(&1, "d"))
-      assert Enum.any?(dir_lines, &String.contains?(&1, "CustomEntitlementComputation"))
-      assert Enum.any?(dir_lines, &String.contains?(&1, "LocalReceiptParsing"))
+      assert Enum.any?(dir_lines, &String.contains?(&1, "BuildScripts"))
 
-      refute Enum.any?(lines, &String.contains?(&1, "purchases-root"))
+      refute Enum.any?(lines, &String.contains?(&1, "broken"))
     end
 
     test "zip_directory rejects symlinks that point outside root" do


### PR DESCRIPTION
## Summary

Fixes the production crash in `resolve_directory_symlink/1` where `File.cp_r!(..., dereference_symlinks: true)` fails when a directory symlink's target contains broken symlinks (e.g. dangling submodule references in `purchases-ios-spm`).

**Root cause**: The previous single-pass symlink resolution processed symlinks in `find -type l` order, which is filesystem-dependent (ext4 uses hash-based readdir). On production, `BuildScripts`-style directory symlinks were resolved *before* broken symlinks inside their target directories were cleaned up. `File.cp_r!` with `dereference_symlinks: true` crashes with `:enoent` when it encounters a broken symlink.

**Fix** (two changes):
- **Two-pass resolution**: Classify symlinks upfront, resolve non-directory symlinks first (files dereferenced, broken ones deleted), then resolve directory symlinks. This ensures broken symlinks inside target dirs are cleaned before `File.cp_r!` copies them.
- **Remove `dereference_symlinks: true`**: This was the direct crash trigger. Without it, any remaining broken symlinks in copied dirs are preserved as-is rather than crashing.

## Test Plan

The new test deterministically reproduces the production crash by using directory names (`BuildScripts`, `Tests`) that force ext4's htree to return the directory symlink *before* the broken symlink in `find` output. Verified red→green:

- **RED**: Old code crashes with `File.CopyError: .../Tests/nested/nonexistent_submodule_path: no such file or directory`
- **GREEN**: Fixed code resolves cleanly, 14/14 tests pass