### PR TITLE
fix(cli): bump Rosalind to 0.7.22 and restore dependency versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d256e61eef0e6610a95ec08ab5c957d73f3564ae3ac441e494b61bf40045d0aa",
+  "originHash" : "f513ebb5daa61b63bbd487b878ad68f09f0e8ea16d91bd5f3873f63064d1266d",
   "pins" : [
     {
       "identity" : "1024jp.GzipSwift",
@@ -166,7 +166,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.32.0"
+        "version" : "1.35.1"
       }
     },
     {
@@ -415,7 +415,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.2.45"
+        "version" : "0.2.46"
       }
     },
     {
@@ -607,7 +607,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.15.2"
+        "version" : "0.15.3"
       }
     },
     {
@@ -639,7 +639,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.7.0"
+        "version" : "0.7.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1653,7 +1653,7 @@ let package = Package(
         .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.46")),
         .package(id: "modelcontextprotocol.swift-sdk", .upToNextMajor(from: "0.9.0")),
         .package(id: "swiftyJSON.SwiftyJSON", .upToNextMajor(from: "5.0.2")),
-        .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.0")),
+        .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.22")),
         .package(id: "swiftGen.StencilSwiftKit", exact: "2.10.1"),
         .package(id: "swiftGen.SwiftGen", exact: "6.6.2"),
         .package(id: "sparkle-project.Sparkle", from: "2.6.4"),


### PR DESCRIPTION
## Summary
- Bumps Rosalind minimum from `0.7.0` to `0.7.22` in Package.swift to prevent accidental downgrades
- Restores `Package.resolved` pins that were accidentally downgraded by the Gradle plugin release PR (#9705):
  - `tuist.Rosalind`: 0.7.0 → 0.7.22
  - `apple.swift-protobuf`: 1.32.0 → 1.35.1
  - `MobileNativeFoundation.XCLogParser`: 0.2.45 → 0.2.46
  - `tuist.FileSystem`: 0.15.2 → 0.15.3

## Context
The Gradle plugin release PR merged with an older `Package.resolved` that reverted dependency bumps from #9701. This caused `tuist inspect bundle` to fail on Android CI because the older Rosalind version couldn't locate `aapt2`.

## Test plan
- [ ] CI passes (SwiftPM build, tests)
- [ ] `tuist inspect bundle` works again on Android CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)