### PR TITLE
fix(cli):  archive builds for static targets with xcassets

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -103,6 +103,15 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 status: .required,
                 condition: .when(target.dependencyPlatformFilters)
             ))
+            // Setting PACKAGE_RESOURCE_BUNDLE_NAME tells Xcode that a companion bundle target
+            // owns the compiled asset catalogs, which suppresses LinkAssetCatalog on this target
+            // while preserving GenerateAssetSymbols for typed resource accessors. Without this,
+            // xcodebuild archive fails for static targets because LinkAssetCatalog references
+            // an UninstalledProducts path that doesn't exist during archiving.
+            var base = modifiedTarget.settings?.base ?? SettingsDictionary()
+            base["PACKAGE_RESOURCE_BUNDLE_NAME"] = .string(bundleName)
+            modifiedTarget.settings = modifiedTarget.settings?.with(base: base)
+                ?? Settings(base: base, configurations: [:])
             additionalTargets.append(resourcesTarget)
         }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1005,6 +1005,27 @@ struct ResourcesProjectMapperTests {
         #expect(xcstringsSources.first?.path == expectedXcstringsPath)
     }
 
+    @Test
+    func mapWhenStaticTargetHasResourcesSetsPackageResourceBundleName() async throws {
+        // Given
+        let resources: [ResourceFileElement] = [
+            .file(path: "/Resources/Assets.xcassets"),
+        ]
+        let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: .init(resources))
+        let project = Project.test(targets: [target])
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
+
+        // When
+        let (gotProject, _) = try await subject.map(project: project)
+
+        // Then
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        let expectedBundleName = "\(project.name)_\(target.name)"
+        let bundleNameSetting = gotTarget.settings?.base["PACKAGE_RESOURCE_BUNDLE_NAME"]
+        #expect(bundleNameSetting == .string(expectedBundleName))
+    }
+
     // MARK: - Helpers
 
     private func verifySideEffects(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/9742

## Summary

- Fixes `xcodebuild archive` failing for static targets that have `.xcassets` resources, a regression introduced in #9666
- Sets `PACKAGE_RESOURCE_BUNDLE_NAME` on static targets that have a companion resource bundle, which tells Xcode to suppress `LinkAssetCatalog` while preserving `GenerateAssetSymbols` for typed resource accessors
- Handles the case where `target.settings` is `nil` by constructing a new `Settings` instance instead of silently dropping the build setting

## Context

PR #9666 added xcassets/xcstrings to the Sources build phase of static targets to enable Xcode's typed asset symbol generation (`ImageResource`, `ColorResource`). This works for regular builds but breaks archive because `LinkAssetCatalog` outputs to `UninstalledProducts/iphoneos`: a path that doesn't exist during archiving of static libraries.

The fix mirrors SwiftPM's PIF builder approach: when a companion bundle target owns the compiled asset catalogs, SwiftPM sets `PACKAGE_RESOURCE_BUNDLE_NAME` on the main target. This causes Xcode's `isMainPackageWithResourceBundle` check to be true, suppressing `LinkAssetCatalog` while still allowing `GenerateAssetSymbols` to produce typed Swift accessors.

## Test plan

- [x] All 27 `ResourcesProjectMapperTests` pass including new test for `PACKAGE_RESOURCE_BUNDLE_NAME`
- [x] Verified with the [minimal reproduction project](https://github.com/user-attachments/files/25752617/xcassets-archive-bug-repro.zip) from the issue: both `xcodebuild build` and `xcodebuild archive` succeed

Closes #9721