### PR TITLE
fix(server): include org projects for OAuth-authenticated users

### DIFF
--- a/server/lib/tuist/projects.ex
+++ b/server/lib/tuist/projects.ex
@@ -218,6 +218,14 @@ defmodule Tuist.Projects do
     |> maybe_filter_recent(opts)
   end
 
+  def list_accessible_projects(%AuthenticatedAccount{account: %{user_id: user_id} = account, all_projects: true}, opts)
+      when not is_nil(user_id) do
+    case Accounts.get_user_by_id(user_id) do
+      nil -> list_accessible_projects(account, opts)
+      user -> list_accessible_projects(user, opts)
+    end
+  end
+
   def list_accessible_projects(%AuthenticatedAccount{account: account}, opts) do
     list_accessible_projects(account, opts)
   end

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -238,6 +238,36 @@ defmodule Tuist.ProjectsTest do
                )
     end
 
+    test "get all project accounts for an authenticated account with all_projects includes org projects" do
+      user = AccountsFixtures.user_fixture()
+      user_account = Accounts.get_account_from_user(user)
+
+      organization = AccountsFixtures.organization_fixture()
+      org_account = Accounts.get_account_from_organization(organization)
+      Accounts.add_user_to_organization(user, organization, role: :user)
+
+      personal_project =
+        ProjectsFixtures.project_fixture(account_id: user_account.id, preload: [:account])
+
+      org_project =
+        ProjectsFixtures.project_fixture(account_id: org_account.id, preload: [:account])
+
+      got =
+        Projects.get_all_project_accounts(%AuthenticatedAccount{
+          account: user_account,
+          scopes: [],
+          all_projects: true
+        })
+
+      got_handles = got |> Enum.map(& &1.handle) |> Enum.sort()
+
+      assert got_handles ==
+               Enum.sort([
+                 "#{user_account.name}/#{personal_project.name}",
+                 "#{org_account.name}/#{org_project.name}"
+               ])
+    end
+
     test "get all project accounts for a project subject" do
       project = ProjectsFixtures.project_fixture()
 


### PR DESCRIPTION
## Summary

- iOS app users were seeing "No projects found" when all their projects belonged to organizations
- Root cause: OAuth tokens (used by the iOS app) are encoded as `AuthenticatedAccount` with `all_projects: true` against the user's personal `Account`. The `list_accessible_projects(%AuthenticatedAccount{})` clause delegated to the `%Account{}` clause, which only queries projects for that single account — missing all organization projects
- Fix: when `all_projects` is `true` and the account belongs to a user (personal account), look up the `User` and delegate to the `%User{}` clause, which includes organization memberships

## Test plan

- [x] Added test: `AuthenticatedAccount` with `all_projects: true` returns projects from both personal account and organizations
- [x] All existing `projects_test.exs` tests pass (75 tests)
- [x] All `projects_controller_test.exs` tests pass (29 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)