### PR TITLE
fix(server): fix flaky overview live empty states test

### DIFF
--- a/server/test/tuist_web/live/overview_live_test.exs
+++ b/server/test/tuist_web/live/overview_live_test.exs
@@ -89,6 +89,7 @@ defmodule TuistWeb.OverviewLiveTest do
   } do
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
+    render_async(lv)
 
     assert has_element?(
              lv,


### PR DESCRIPTION
## Summary
- Add `render_async(lv)` call in the "shows empty states" test to wait for async assigns to resolve before asserting
- The empty state element only renders when `@binary_cache_hit_rate_analytics.ok?` is true, which requires the `assign_async` to complete — without `render_async`, the test races against the async task

## Test plan
- [ ] Verify the "shows empty states" test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)