### PR TITLE
feat(cli): log test targets that will be tested

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -636,6 +636,14 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
         }
 
+        let testedTargetNames = testActionTargets.map(\.name).sorted()
+        if !testedTargetNames.isEmpty {
+            Logger.current
+                .notice(
+                    "Testing the following targets: \(testedTargetNames.joined(separator: ", "))"
+                )
+        }
+
         return true
     }
 


### PR DESCRIPTION
When running `tuist test`, the CLI now logs which targets will be tested. This complements the existing log that shows which targets are skipped by selective testing, giving users visibility into what's actually going to run.