### PR TITLE
fix(server): use correct query param key for test cases environment selector

### DIFF
--- a/server/lib/tuist_web/live/test_cases_live.html.heex
+++ b/server/lib/tuist_web/live/test_cases_live.html.heex
@@ -8,24 +8,24 @@
       >
         <.dropdown_item
           value="any"
-          label="Any"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "any")}"}
+          label={dgettext("dashboard_tests", "Any")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "any")}"}
           data-selected={@analytics_environment == "any"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
           value="local"
-          label="Local"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "local")}"}
+          label={dgettext("dashboard_tests", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
           data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
           value="ci"
-          label="CI"
-          patch={"?#{Query.put(@uri.query, "analytics_environment", "ci")}"}
+          label={dgettext("dashboard_tests", "CI")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
         >
           <:right_icon><.check /></:right_icon>

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -44,6 +44,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.ex:234
 #: lib/tuist_web/live/flaky_tests_live.html.heex:11
 #: lib/tuist_web/live/test_cases_live.ex:364
+#: lib/tuist_web/live/test_cases_live.html.heex:11
 #: lib/tuist_web/live/test_runs_live.ex:371
 #: lib/tuist_web/live/tests_live.ex:395
 #: lib/tuist_web/live/tests_live.ex:402
@@ -159,6 +160,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:27
 #: lib/tuist_web/live/test_case_live.ex:107
 #: lib/tuist_web/live/test_cases_live.ex:366
+#: lib/tuist_web/live/test_cases_live.html.heex:27
 #: lib/tuist_web/live/test_runs_live.ex:373
 #: lib/tuist_web/live/tests_live.ex:397
 #: lib/tuist_web/live/tests_live.html.heex:50
@@ -605,6 +607,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.ex:235
 #: lib/tuist_web/live/flaky_tests_live.html.heex:19
 #: lib/tuist_web/live/test_cases_live.ex:365
+#: lib/tuist_web/live/test_cases_live.html.heex:19
 #: lib/tuist_web/live/test_run_live.html.heex:1435
 #: lib/tuist_web/live/test_runs_live.ex:372
 #: lib/tuist_web/live/tests_live.ex:396


### PR DESCRIPTION
## Summary
- Fixes the environment selector on the test cases page (`/tests/test-cases`) doing nothing when changed
- The dropdown was using `analytics_environment` (underscore) as the query param key, while the handler reads `analytics-environment` (hyphen), causing the selection to always default to "any"
- Also wraps dropdown labels in `dgettext` to match other pages