### PR TITLE
fix(server): prevent LiveView path params from leaking into query strings

### DIFF
--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -103,7 +103,9 @@ defmodule TuistWeb.BuildRunLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: project}} = socket) do
+    params = Query.query_params(uri)
+
     if Project.gradle_project?(project) do
       {:noreply, TuistWeb.GradleBuildLive.assign_handle_params(socket, params)}
     else

--- a/server/lib/tuist_web/live/build_runs_live.ex
+++ b/server/lib/tuist_web/live/build_runs_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.BuildRunsLive do
   alias Tuist.Projects
   alias Tuist.Projects.Project
   alias TuistWeb.Helpers.OpenGraph
+  alias TuistWeb.Utilities.Query
 
   def mount(_params, _session, %{assigns: %{selected_project: project, selected_account: account}} = socket) do
     slug = Projects.get_project_slug_from_id(project.id)
@@ -29,7 +30,9 @@ defmodule TuistWeb.BuildRunsLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: project}} = socket) do
+    params = Query.query_params(uri)
+
     if Project.gradle_project?(project) do
       {:noreply, TuistWeb.GradleBuildRunsLive.assign_handle_params(socket, params)}
     else

--- a/server/lib/tuist_web/live/builds_live.ex
+++ b/server/lib/tuist_web/live/builds_live.ex
@@ -32,7 +32,9 @@ defmodule TuistWeb.BuildsLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: project}} = socket) do
+    params = Query.query_params(uri)
+
     if Project.gradle_project?(project) do
       {:noreply,
        socket

--- a/server/lib/tuist_web/live/bundles_live.ex
+++ b/server/lib/tuist_web/live/bundles_live.ex
@@ -40,7 +40,8 @@ defmodule TuistWeb.BundlesLive do
   end
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  def handle_params(params, _uri, %{assigns: %{selected_project: project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: project}} = socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
 
     bundles_sort_order = params["bundles-sort-order"] || "desc"

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -109,7 +109,8 @@ defmodule TuistWeb.CacheRunsLive do
     base ++ organization
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: _project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: _project}} = socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
 
     cache_runs_sort_by = params["cache_runs_sort_by"] || "ran_at"

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -52,7 +52,8 @@ defmodule TuistWeb.FlakyTestsLive do
     ]
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
 
     {

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -29,7 +29,8 @@ defmodule TuistWeb.GenerateRunsLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: _project}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: _project}} = socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
 
     generate_runs_sort_by = params["generate_runs_sort_by"] || "ran_at"

--- a/server/lib/tuist_web/live/gradle_cache_live.ex
+++ b/server/lib/tuist_web/live/gradle_cache_live.ex
@@ -34,7 +34,9 @@ defmodule TuistWeb.GradleCacheLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     {
       :noreply,
       socket

--- a/server/lib/tuist_web/live/module_cache_live.ex
+++ b/server/lib/tuist_web/live/module_cache_live.ex
@@ -31,7 +31,9 @@ defmodule TuistWeb.ModuleCacheLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     uri =
       URI.new!(
         "?" <>

--- a/server/lib/tuist_web/live/overview_live.ex
+++ b/server/lib/tuist_web/live/overview_live.ex
@@ -80,7 +80,8 @@ defmodule TuistWeb.OverviewLive do
     {:noreply, push_patch(socket, to: "#{socket.assigns.uri_path}?#{query_params}")}
   end
 
-  def handle_params(params, request_uri, %{assigns: %{selected_project: project}} = socket) do
+  def handle_params(_params, request_uri, %{assigns: %{selected_project: project}} = socket) do
+    params = Query.query_params(request_uri)
     full_uri = URI.parse(request_uri)
 
     socket =

--- a/server/lib/tuist_web/live/previews_live.ex
+++ b/server/lib/tuist_web/live/previews_live.ex
@@ -36,7 +36,8 @@ defmodule TuistWeb.PreviewsLive do
      |> assign(:available_filters, define_filters())}
   end
 
-  def handle_params(params, _uri, %{assigns: %{selected_project: project, available_filters: available_filters}} = socket) do
+  def handle_params(_params, uri, %{assigns: %{selected_project: project, available_filters: available_filters}} = socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
     filters = Filter.Operations.decode_filters_from_query(params, available_filters)
     filter_name = params["name"] || ""

--- a/server/lib/tuist_web/live/qa_live.ex
+++ b/server/lib/tuist_web/live/qa_live.ex
@@ -30,7 +30,9 @@ defmodule TuistWeb.QALive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     {
       :noreply,
       socket

--- a/server/lib/tuist_web/live/quarantined_tests_live.ex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.ex
@@ -74,7 +74,8 @@ defmodule TuistWeb.QuarantinedTestsLive do
     base_filters ++ [quarantined_by_filter]
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
 
     {

--- a/server/lib/tuist_web/live/run_detail_live.ex
+++ b/server/lib/tuist_web/live/run_detail_live.ex
@@ -42,7 +42,8 @@ defmodule TuistWeb.RunDetailLive do
      end)}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = build_uri(params)
     selected_tab = selected_tab(params)
 

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -116,7 +116,8 @@ defmodule TuistWeb.TestCaseLive do
     end
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
     selected_tab = params["tab"] || "overview"
 

--- a/server/lib/tuist_web/live/test_case_run_live.ex
+++ b/server/lib/tuist_web/live/test_case_run_live.ex
@@ -70,7 +70,8 @@ defmodule TuistWeb.TestCaseRunLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = URI.new!("?" <> URI.encode_query(params))
     selected_tab = params["tab"] || "overview"
 

--- a/server/lib/tuist_web/live/test_cases_live.ex
+++ b/server/lib/tuist_web/live/test_cases_live.ex
@@ -80,7 +80,9 @@ defmodule TuistWeb.TestCasesLive do
     ]
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     {
       :noreply,
       socket

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -75,7 +75,8 @@ defmodule TuistWeb.TestRunLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
     uri = build_uri(params)
     selected_tab = selected_tab(params)
     selected_test_tab = params["test-tab"] || "test-cases"

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -88,7 +88,9 @@ defmodule TuistWeb.TestRunsLive do
     base ++ organization
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     params =
       if not Map.has_key?(socket.assigns, :current_params) and Query.has_cursor?(params) do
         Query.clear_cursors(params)

--- a/server/lib/tuist_web/live/tests_live.ex
+++ b/server/lib/tuist_web/live/tests_live.ex
@@ -35,7 +35,9 @@ defmodule TuistWeb.TestsLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     uri =
       URI.new!(
         "?" <>

--- a/server/lib/tuist_web/live/xcode_cache_live.ex
+++ b/server/lib/tuist_web/live/xcode_cache_live.ex
@@ -32,7 +32,9 @@ defmodule TuistWeb.XcodeCacheLive do
     {:ok, socket}
   end
 
-  def handle_params(params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
+    params = Query.query_params(uri)
+
     {
       :noreply,
       socket

--- a/server/lib/tuist_web/utilities/query.ex
+++ b/server/lib/tuist_web/utilities/query.ex
@@ -158,4 +158,31 @@ defmodule TuistWeb.Utilities.Query do
   def has_cursor?(params) when is_map(params) do
     Map.has_key?(params, "after") or Map.has_key?(params, "before")
   end
+
+  @doc """
+  Extracts query parameters from a URI.
+
+  ## Parameters
+
+    * `uri` - A URI string (typically from `handle_params`)
+
+  ## Examples
+
+      iex> TuistWeb.Utilities.Query.query_params("https://tuist.dev/tuist/project/tests?analytics_environment=local")
+      %{"analytics_environment" => "local"}
+
+      iex> TuistWeb.Utilities.Query.query_params("https://tuist.dev/tuist/project/tests")
+      %{}
+
+      iex> TuistWeb.Utilities.Query.query_params(nil)
+      %{}
+  """
+  def query_params(uri) when is_binary(uri) do
+    case URI.parse(uri).query do
+      nil -> %{}
+      query -> URI.decode_query(query)
+    end
+  end
+
+  def query_params(nil), do: %{}
 end


### PR DESCRIPTION
On `main`, when changing some widgets/environments, path parameters leak into the URL
<img width="2318" height="256" alt="CleanShot 2026-03-05 at 17 50 27@2x" src="https://github.com/user-attachments/assets/e7bae164-33a7-414a-87f1-21dfea959114" />


Adds a quick utility to... not do that.