### PR TITLE
perf(server): pre-aggregate cas_events with daily stats MV

### DIFF
--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -898,15 +898,15 @@ defmodule Tuist.Builds.Analytics do
       ClickHouseRepo.query!(
         """
         SELECT
-          toStartOfInterval(inserted_at, INTERVAL #{interval_str}) as date,
-          SUM(size) as total_size
-        FROM cas_events
+          toStartOfInterval(date, INTERVAL #{interval_str}) as period,
+          SUM(total_size) as total_size
+        FROM cas_events_daily_stats
         WHERE project_id = {project_id:Int64}
           AND action = {action:String}
-          AND inserted_at >= {start_dt:DateTime}
-          AND inserted_at <= {end_dt:DateTime}
-        GROUP BY date
-        ORDER BY date
+          AND date >= toDate({start_dt:DateTime})
+          AND date <= toDate({end_dt:DateTime})
+        GROUP BY period
+        ORDER BY period
         """,
         %{
           project_id: project_id,
@@ -938,12 +938,12 @@ defmodule Tuist.Builds.Analytics do
     result =
       ClickHouseRepo.query!(
         """
-        SELECT SUM(size) as total_size
-        FROM cas_events
+        SELECT SUM(total_size) as total_size
+        FROM cas_events_daily_stats
         WHERE project_id = {project_id:Int64}
           AND action = {action:String}
-          AND inserted_at >= {start_dt:DateTime}
-          AND inserted_at <= {end_dt:DateTime}
+          AND date >= toDate({start_dt:DateTime})
+          AND date <= toDate({end_dt:DateTime})
         """,
         %{
           project_id: project_id,

--- a/server/priv/ingest_repo/migrations/20260305100000_create_cas_events_daily_stats_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260305100000_create_cas_events_daily_stats_mv.exs
@@ -1,0 +1,69 @@
+defmodule Tuist.IngestRepo.Migrations.CreateCasEventsDailyStatsMv do
+  @moduledoc """
+  Creates a materialized view that pre-aggregates CAS events into daily stats.
+
+  The `cas_events` table stores individual upload/download events and is queried
+  with `SUM(size)` grouped by date intervals. With ~12M rows read on average,
+  the p90 latency reaches ~1.9s and p99 ~4.4s.
+
+  This materialized view pre-computes daily `SUM(size)` and `count()` per
+  (project_id, action, date), reducing row reads from millions to at most
+  hundreds (one row per day per action). The analytics queries can then
+  re-aggregate these daily totals into coarser intervals (week, month) cheaply.
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE TABLE IF NOT EXISTS cas_events_daily_stats (
+      project_id Int64,
+      action Enum8('upload' = 0, 'download' = 1),
+      date Date,
+      total_size SimpleAggregateFunction(sum, Int64),
+      event_count SimpleAggregateFunction(sum, UInt64)
+    )
+    ENGINE = AggregatingMergeTree
+    ORDER BY (project_id, action, date)
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS cas_events_daily_stats_mv
+    TO cas_events_daily_stats
+    AS SELECT
+      project_id,
+      action,
+      toDate(inserted_at) AS date,
+      sum(size) AS total_size,
+      count() AS event_count
+    FROM cas_events
+    GROUP BY project_id, action, date
+    """
+
+    # Backfill from existing data
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    INSERT INTO cas_events_daily_stats
+    SELECT
+      project_id,
+      action,
+      toDate(inserted_at) AS date,
+      sum(size) AS total_size,
+      count() AS event_count
+    FROM cas_events
+    GROUP BY project_id, action, date
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS cas_events_daily_stats_mv"
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP TABLE IF EXISTS cas_events_daily_stats"
+  end
+end


### PR DESCRIPTION
## Summary

- Creates a materialized view (`cas_events_daily_stats_mv`) backed by an `AggregatingMergeTree` table that pre-aggregates `SUM(size)` and `count()` per `(project_id, action, date)` from the `cas_events` table
- Updates `cas_action_analytics/3` and `total_cas_size/4` in `Builds.Analytics` to query the pre-aggregated table instead of scanning raw events
- Backfills existing data in the migration

## Problem

Two slow queries on `cas_events` are optimized by this PR:

### Query 1: Time-series aggregation (`cas_action_analytics/3`)
```sql
SELECT toStartOfInterval(inserted_at, INTERVAL ...) AS date, SUM(size) AS total_size
FROM cas_events
WHERE project_id = ? AND action = ? AND inserted_at >= ? AND inserted_at <= ?
GROUP BY date ORDER BY date
```
- **Successful runs:** 272
- **Avg read rows:** 12,109,263
- **p90 latency:** 1,892 ms
- **p99 latency:** 4,379 ms

### Query 2: Total size (`total_cas_size/4`)
```sql
SELECT SUM(size) AS total_size
FROM cas_events
WHERE project_id = ? AND action = ? AND inserted_at >= ? AND inserted_at <= ?
```
- **Successful runs:** 488 (called 2x per analytics request — current + previous period for trend)
- **Avg read rows:** 6,063,642
- **p90 latency:** 651 ms
- **p99 latency:** 3,331 ms

Even though the table's ORDER BY `(project_id, action, inserted_at)` allows efficient filtering, every individual event row must still be read and aggregated.

## Solution

This follows the same pattern we've used successfully for other ClickHouse analytics optimizations:

| Optimization | PR | Approach | Impact |
|---|---|---|---|
| `test_case_runs` analytics | #9710, #9713 | MV with `AggregatingMergeTree` for daily stats | ~28M → hundreds of rows |
| `branch_ci` projection | #9684 | Added `project_id` to projection | Faster DISTINCT queries |
| **`cas_events` (this PR)** | — | MV with `AggregatingMergeTree` for daily stats | **~12M / ~6M → hundreds of rows** |

The materialized view pre-computes daily totals, so both queries re-aggregate at most ~365 rows (one per day) instead of millions of individual events.

### Validated locally

Correctness (all 14 monthly buckets match exactly):
```
old: [[~D[2025-01-01], 12813414586], [~D[2025-02-01], 38361602094], ...]
new: [[~D[2025-01-01], 12813414586], [~D[2025-02-01], 38361602094], ...]
```

Total size (identical):
```
old: [[550293825388]]  (9.7ms)
new: [[550293825388]]  (2.6ms)
```

Row reduction on local dataset: 43,992 raw rows → 802 daily stat rows (55x).

## Test plan

- [x] Verified query correctness against local ClickHouse (old vs new results match exactly)
- [x] Verified migration runs cleanly (create table, create MV, backfill)
- [x] Verified rollback path (DROP VIEW, DROP TABLE)
- [ ] Monitor query performance in staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)