### PR TITLE
perf(server): add secondary indexes to command_events_by_ran_at MV

### DIFF
--- a/server/lib/tuist_web/live/module_cache_live.ex
+++ b/server/lib/tuist_web/live/module_cache_live.ex
@@ -189,7 +189,7 @@ defmodule TuistWeb.ModuleCacheLive do
       fourteen_days_ago = DateTime.add(DateTime.utc_now(), -14, :day)
 
       events =
-        from(e in Event,
+        from(e in {"command_events_by_ran_at", Event},
           where:
             e.project_id == ^project.id and
               e.cacheable_targets_count > 0 and

--- a/server/priv/ingest_repo/migrations/20260306100000_add_indexes_to_command_events_by_ran_at.exs
+++ b/server/priv/ingest_repo/migrations/20260306100000_add_indexes_to_command_events_by_ran_at.exs
@@ -1,0 +1,95 @@
+defmodule Tuist.IngestRepo.Migrations.AddIndexesToCommandEventsByRanAt do
+  @moduledoc """
+  Recreates `command_events_by_ran_at` with secondary indexes.
+
+  ClickHouse does not support ALTER INDEX on implicit-storage materialized
+  views, so we must drop and recreate with explicit column + INDEX definitions.
+
+  Indexes added:
+
+  - `idx_user_id` (minmax): user_id filtering currently scans 844K avg rows
+  - `idx_is_ci` (minmax): is_ci filtering currently scans 319K avg rows
+  - `idx_name` (bloom_filter): name IN (...) filtering
+  - `idx_cacheable_targets_count` (minmax): cacheable_targets_count > 0
+    filtering for ModuleCacheLive queries routed to this MV
+  """
+
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS command_events_by_ran_at SYNC"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at (
+      `id` UUID,
+      `legacy_id` UInt64,
+      `name` String,
+      `subcommand` Nullable(String),
+      `command_arguments` Nullable(String),
+      `duration` Int32,
+      `client_id` String,
+      `tuist_version` String,
+      `swift_version` String,
+      `macos_version` String,
+      `project_id` Int64,
+      `created_at` DateTime64(6),
+      `updated_at` DateTime64(6),
+      `cacheable_targets` Array(String),
+      `local_cache_target_hits` Array(String),
+      `remote_cache_target_hits` Array(String),
+      `is_ci` Bool,
+      `test_targets` Array(String),
+      `local_test_target_hits` Array(String),
+      `remote_test_target_hits` Array(String),
+      `status` Nullable(Int32),
+      `error_message` Nullable(String),
+      `user_id` Nullable(Int32),
+      `remote_cache_target_hits_count` Nullable(Int32),
+      `remote_test_target_hits_count` Nullable(Int32),
+      `git_commit_sha` Nullable(String),
+      `git_ref` Nullable(String),
+      `preview_id` Nullable(UUID),
+      `git_branch` Nullable(String),
+      `ran_at` DateTime64(6),
+      `build_run_id` Nullable(UUID),
+      `cacheable_targets_count` UInt32,
+      `local_cache_hits_count` UInt32,
+      `remote_cache_hits_count` UInt32,
+      `test_targets_count` UInt32,
+      `local_test_hits_count` UInt32,
+      `remote_test_hits_count` UInt32,
+      `hit_rate` Nullable(Float32),
+      `test_run_id` Nullable(UUID),
+      `cache_endpoint` String,
+      INDEX idx_name name TYPE bloom_filter GRANULARITY 4,
+      INDEX idx_is_ci is_ci TYPE minmax GRANULARITY 128,
+      INDEX idx_user_id user_id TYPE minmax GRANULARITY 32,
+      INDEX idx_cacheable_targets_count cacheable_targets_count TYPE minmax GRANULARITY 16
+    )
+    ENGINE = MergeTree
+    ORDER BY (project_id, ran_at)
+    SETTINGS index_granularity = 8192
+    POPULATE
+    AS SELECT * FROM command_events
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "DROP VIEW IF EXISTS command_events_by_ran_at SYNC"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS command_events_by_ran_at
+    ENGINE = MergeTree
+    ORDER BY (project_id, ran_at)
+    POPULATE
+    AS SELECT * FROM command_events
+    """
+  end
+end


### PR DESCRIPTION
## Summary

The `command_events_by_ran_at` materialized view was created without any secondary indexes, so queries that filter by `user_id`, `is_ci`, `name`, or `cacheable_targets_count` must scan every granule within the project's data range.

### Optimization 1: Add secondary indexes to the MV

Adds 4 secondary indexes to the MV's inner storage table (matching what the base `command_events` table already has):

| Index | Type | Target Query | Current Performance |
|---|---|---|---|
| `idx_user_id` | minmax GRANULARITY 32 | `user_id = ?` filter | **844K avg read rows**, p50=756ms, p90=2.1s |
| `idx_is_ci` | minmax GRANULARITY 128 | `is_ci != ?` filter | **319K avg read rows**, p50=715ms, p90=1.7s |
| `idx_name` | bloom_filter GRANULARITY 4 | `name IN (...)` filter | Reduces granule scans |
| `idx_cacheable_targets_count` | minmax GRANULARITY 16 | `cacheable_targets_count > 0` | Supports ModuleCacheLive routing |

These indexes let ClickHouse skip granules that cannot contain matching rows, significantly reducing read rows for filtered queries.

### Optimization 2: Route ModuleCacheLive through `command_events_by_ran_at`

The `ModuleCacheLive.assign_recent_runs/2` query was hitting the base `command_events` table (sorted by `project_id, name, ran_at`). Since it doesn't filter by `name`, the MV sorted by `(project_id, ran_at)` is better aligned, enabling ClickHouse's read-in-order optimization for `ORDER BY ran_at DESC`.

- Current: **48K avg read rows**, p50=122ms, p90=383ms (against base table)
- Expected: Fewer reads via read-in-order + `idx_cacheable_targets_count` index

## Test plan

- [x] Migration runs successfully locally (dev + test)
- [x] Migration rollback works
- [x] `ModuleCacheLive` tests pass
- [x] `command_events` tests pass (58 tests, 0 failures)
- [ ] Monitor ClickHouse query performance after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)