### PR TITLE
feat(cli): registry migration skill

### DIFF
--- a/skills/skills/migrate-registry/SKILL.md
+++ b/skills/skills/migrate-registry/SKILL.md
@@ -205,6 +205,26 @@ xcodebuild -resolvePackageDependencies
 - **Resolver not found**: activate `mise` or use the project's existing toolchain setup first.
 - **Mixed dependency styles**: keep package declarations in the single location used by that project type.
 
+### Step 5 - Check build scripts that assume `SourcePackages/checkouts`
+
+Registry migration can break post-build scripts that hardcode package checkout paths.
+
+- **Check all build phases**: search for any script that references `SourcePackages/checkouts/...`
+- **Why it breaks**: registry-backed packages are stored under `SourcePackages/registry/downloads/.../{version}/`, and the version directory changes on updates
+- **Fix**: replace hardcoded checkout paths with dynamic lookup logic or Xcode-provided variables
+- **Common example**: Firebase Crashlytics archive or dSYM upload scripts often hardcode `SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
+
+Example:
+
+```bash
+PACKAGE_SCRIPT=$(find "${BUILD_DIR%/Build/*}/SourcePackages" -path "*/Crashlytics/run" | head -n 1)
+if [ -z "$PACKAGE_SCRIPT" ]; then
+  echo "error: Could not find package build script"
+  exit 1
+fi
+"$PACKAGE_SCRIPT"
+```
+
 ## Authentication
 
 Authentication is optional.
@@ -222,6 +242,7 @@ tuist registry login
 - Registry setup matches the project type
 - All eligible package references were migrated before validation
 - Unsupported packages were recorded and left URL-based
+- Build scripts no longer assume `SourcePackages/checkouts/...` for any migrated package
 - The resolver command for the project type succeeds
 - Packages missing from the registry remain URL-based
 - Dotted repository names use `_` in the registry identifier


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

> Skill helping migrate SPM to registry
### How to test locally
/migrate-registry

## Summary

- broadens the `migrate-registry` skill to cover generated Tuist projects, Swift packages, and Xcode projects
- switches the workflow to migrate all package references first, then validate with the resolver that matches the project type
- limits `.xcworkspace` cleanup to generated Tuist projects that actually commit generated workspaces
- aligns registry setup guidance with Tuist docs by using `registryEnabled` for generated projects and `tuist registry setup` elsewhere

## Test plan

- [ ] Generated Tuist projects use the correct declaration location and resolver for their integration style
- [ ] Swift packages use `swift package resolve` after migrating `Package.swift`
- [ ] Xcode projects use `xcodebuild -resolvePackageDependencies` after replacing package references
- [ ] Generated `.xcworkspace` cleanup only appears for generated Tuist projects that commit workspaces
- [ ] Missing registry packages are reverted to their original URL-based declarations
- [ ] Dotted repository names still use `_` in registry identifiers