### PR TITLE
fix(cli): expose ProjectDescription product on Linux for DocC generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1042,6 +1042,17 @@ var targets: [Target] = [
     ),
 ]
 
+// MARK: - Cross-platform targets (outside macOS gate)
+
+targets.append(contentsOf: [
+    .target(
+        name: "ProjectDescription",
+        dependencies: [],
+        path: "cli/Sources/ProjectDescription",
+        exclude: ["AGENTS.md"]
+    ),
+])
+
 // MARK: - macOS-only targets
 
 #if os(macOS)
@@ -1164,12 +1175,6 @@ targets.append(contentsOf: [
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),
         ]
-    ),
-    .target(
-        name: "ProjectDescription",
-        dependencies: [],
-        path: "cli/Sources/ProjectDescription",
-        exclude: ["AGENTS.md"]
     ),
     .target(
         name: "ProjectAutomation",


### PR DESCRIPTION
The `ProjectDescription` library product was only declared inside an `#if os(macOS)` block in `Package.swift`. The DocC documentation CI job runs on Linux (`swift:6.2` container), so `swift package generate-documentation --product ProjectDescription` was failing with "no product named ProjectDescription".

This moves the `ProjectDescription` product declaration outside the macOS-only gate, keeping it as a dynamic library on macOS (needed for manifest runtime loading) and a regular library on Linux (sufficient for DocC generation).