### PR TITLE
fix(server): delegate select_widget event to child live view modules

### DIFF
--- a/server/lib/tuist_web/live/builds_live.ex
+++ b/server/lib/tuist_web/live/builds_live.ex
@@ -77,15 +77,12 @@ defmodule TuistWeb.BuildsLive do
      |> push_event("replace-url", %{url: "?" <> query})}
   end
 
-  def handle_event("select_widget", %{"widget" => widget}, socket) do
-    query = Query.put(socket.assigns.uri.query, "analytics-selected-widget", widget)
-    uri = URI.new!("?" <> query)
-
-    {:noreply,
-     socket
-     |> assign(:analytics_selected_widget, widget)
-     |> assign(:uri, uri)
-     |> push_event("replace-url", %{url: "?" <> query})}
+  def handle_event("select_widget", %{"widget" => _widget} = params, %{assigns: %{selected_project: project}} = socket) do
+    if Project.gradle_project?(project) do
+      TuistWeb.GradleBuildsLive.handle_event("select_widget", params, socket)
+    else
+      TuistWeb.XcodeBuildsLive.handle_event("select_widget", params, socket)
+    end
   end
 
   def handle_event(


### PR DESCRIPTION
## Summary
- `BuildsLive.handle_event("select_widget")` was handling the event with a simplified implementation that only updated the selected widget assign and URL, but never recomputed `analytics_chart_data`
- This caused the chart to show stale data when switching widgets (e.g. "Build success rate" tooltip when "Failed builds" was selected)
- Fixed by delegating to `XcodeBuildsLive.handle_event` / `GradleBuildsLive.handle_event` which already contain the correct chart-updating logic

## Test plan
- [ ] Open the builds dashboard page
- [ ] Click between "Total builds", "Build success rate", "Failed builds" widgets
- [ ] Verify the chart updates correctly: series name, tooltip format, y-axis labels, and line color all change to match the selected widget
- [ ] Verify "Avg. build duration" widget still shows its own separate chart with percentile lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)