### PR TITLE
feat(docs): add OpenCode MCP setup instructions

### DIFF
--- a/docs/docs/en/guides/features/agentic-coding/mcp.md
+++ b/docs/docs/en/guides/features/agentic-coding/mcp.md
@@ -37,6 +37,28 @@ Open **Settings → Connectors → Add custom connector**, then set:
 Complete OAuth in the browser when prompted.
 :::
 
+::: details OpenCode
+Add the Tuist MCP server to `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "tuist": {
+      "type": "remote",
+      "url": "https://tuist.dev/mcp"
+    }
+  }
+}
+```
+
+Then authenticate the server:
+
+```bash
+opencode mcp auth tuist
+```
+:::
+
 ::: details Cursor
 Open **Cursor Settings → Tools & Integrations → MCP Tools** and add:
 


### PR DESCRIPTION
## Summary
- add an OpenCode section to the MCP guide with the `opencode.json` remote server configuration
- document the hosted Tuist MCP URL at `https://tuist.dev/mcp`
- include the `opencode mcp auth tuist` authentication step after configuration