### PR TITLE
fix(cli): use relative paths for cached xcframework references in generated projects

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -707,7 +707,7 @@ class ProjectFileElements {
 
     @discardableResult
     func addFileElementWithAbsolutePath(
-        from _: AbsolutePath,
+        from sourceRootPath: AbsolutePath,
         fileAbsolutePath: AbsolutePath,
         name: String?,
         expectedSignature: String?,
@@ -715,11 +715,12 @@ class ProjectFileElements {
         pbxproj: PBXProj
     ) -> PBXFileReference {
         let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
+        let relativePath = fileAbsolutePath.relative(to: sourceRootPath)
         let file = PBXFileReference(
-            sourceTree: .absolute,
+            sourceTree: .sourceRoot,
             name: name,
             lastKnownFileType: lastKnownFileType,
-            path: fileAbsolutePath.pathString,
+            path: relativePath.pathString,
             expectedSignature: expectedSignature,
             xcLanguageSpecificationIdentifier:
             xcLanguageSpecificationIdentifierFromLastKnownFileType(lastKnownFileType)

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -620,7 +620,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let frameworksGroup = groups.frameworks
         let fileReference = frameworksGroup.children.first as? PBXFileReference
         XCTAssertEqual(fileReference?.name, "StytchCore.xcframework")
-        XCTAssertEqual(fileReference?.sourceTree, .absolute)
+        XCTAssertEqual(fileReference?.sourceTree, .sourceRoot)
 
         let projectGroupChildren = groups.sortedMain.group(named: projectGroupName)?.children ?? []
         let projectGroupHasXCFramework = projectGroupChildren.contains { element in
@@ -896,8 +896,8 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         let frameworkElement = subject.compiled[frameworkPath]
         XCTAssertNotNil(frameworkElement)
-        XCTAssertEqual(frameworkElement?.sourceTree, .absolute)
-        XCTAssertEqual(frameworkElement?.path, frameworkPath.pathString)
+        XCTAssertEqual(frameworkElement?.sourceTree, .sourceRoot)
+        XCTAssertEqual(frameworkElement?.path, frameworkPath.relative(to: sourceRootPath).pathString)
         XCTAssertEqual(frameworkElement?.name, frameworkPath.basename)
     }
 
@@ -951,8 +951,8 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         let frameworkElement = subject.compiled[frameworkPath]
         XCTAssertNotNil(frameworkElement)
-        XCTAssertEqual(frameworkElement?.sourceTree, .absolute)
-        XCTAssertEqual(frameworkElement?.path, frameworkPath.pathString)
+        XCTAssertEqual(frameworkElement?.sourceTree, .sourceRoot)
+        XCTAssertEqual(frameworkElement?.path, frameworkPath.relative(to: sourceRootPath).pathString)
         XCTAssertEqual(frameworkElement?.name, frameworkPath.basename)
 
         // Then


### PR DESCRIPTION
## Summary

When `keepSourceTargets: true` is set in `cacheOptions`, Tuist generates xcframework references in the pbxproj with hardcoded absolute paths to the local binary cache (e.g., `/Users/.../.cache/tuist/Binaries/.../Sovran.xcframework` with `sourceTree = "<absolute>"`). These paths are machine-specific and cause build failures on CI or other developers' machines.

This is a long-standing bug -- both 4.149.1 and 4.154.5 produce identical absolute paths. The issue manifests whenever the generated project is used on a different machine where the cache paths don't match.

The fix changes `addFileElementWithAbsolutePath` in `ProjectFileElements` to compute a relative path from the project's source root and use `sourceTree = SOURCE_ROOT` instead of `sourceTree = absolute`. This produces portable paths like `../../../.cache/tuist/Binaries/.../Sovran.xcframework` that resolve correctly across machines.

## Test plan

- Updated existing unit tests for `ProjectFileElements` to verify the new source tree and relative path behavior
- Verified with the reporter's reproduction project (Segment + Sovran + JSONSafeEncoding dependencies with `keepSourceTargets: true`) that generated pbxproj files no longer contain absolute paths
- Confirmed that both 4.149.1 and 4.154.5 produce the same absolute paths, confirming this is not a regression but a pre-existing bug