### PR TITLE
feat(skills): add comparison skills for builds, tests, bundles, generations, and cache runs

### DIFF
--- a/skills/skills/compare-builds/SKILL.md
+++ b/skills/skills/compare-builds/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: compare-builds
+description: Compares two Xcode build runs to identify duration regressions, cache changes, and new issues. Can be invoked with build IDs, dashboard URLs, or branch names (e.g. `tuist compare-builds --base main --head feature-branch`).
+---
+
+# Compare Builds
+
+## Quick Start
+
+You'll typically receive two build identifiers (IDs, dashboard URLs, or branch names). Follow these steps:
+
+1. Run `tuist build list --json` to find builds on each branch.
+2. Run `tuist build show <build-id> --json` for both base and head builds.
+3. Compare duration, status, cache hit rates, and other metrics.
+4. Summarize regressions, improvements, and recommendations.
+
+If only one identifier is provided, use the project's default branch as the baseline.
+
+## Step 1: Resolve Builds
+
+### If base/head are build IDs or dashboard URLs
+
+Fetch each directly:
+
+```bash
+tuist build show <base-id> --json
+tuist build show <head-id> --json
+```
+
+### If base/head are branch names
+
+List recent builds on each branch and pick the latest:
+
+```bash
+tuist build list --git-branch <base-branch> --json --page-size 1
+tuist build list --git-branch <head-branch> --json --page-size 1
+```
+
+Then fetch full details with `tuist build show <id> --json`.
+
+### Defaults
+
+- If no base is provided, use the project's default branch (usually `main`).
+- If no head is provided, detect the current git branch with `git rev-parse --abbrev-ref HEAD`.
+
+## Step 2: Compare Top-Level Metrics
+
+After fetching both builds, compare:
+
+| Metric | What to check |
+|---|---|
+| `duration` | Flag if head is >10% slower than base |
+| `status` | Flag if base succeeded but head failed |
+| `cacheable_tasks_count` | Note if task count changed |
+| `cacheable_task_local_hits_count` | Compare local hit counts |
+| `cacheable_task_remote_hits_count` | Compare remote hit counts |
+| Cache hit rate | `(local_hits + remote_hits) / cacheable_tasks_count * 100` |
+| `category` | Note if one is `clean` and the other `incremental` (makes duration comparison less meaningful) |
+| `scheme` / `configuration` | Ensure both builds used the same scheme and configuration for a fair comparison |
+
+Compute the cache miss delta: `base_misses - head_misses`. Positive means head has fewer misses (improvement). Negative means regression.
+
+## Step 3: Investigate Duration Regressions
+
+If the head build is significantly slower:
+
+1. Check if the `category` differs (clean vs incremental builds are not directly comparable).
+2. Check if cache hit rate dropped, which would explain longer builds.
+3. If both are incremental with similar cache rates, the regression is likely in compilation time.
+
+## Step 4: Investigate Cache Changes
+
+Compare cache statistics:
+
+- **Hit rate dropped**: Possible causes include dependency changes, build setting changes, or Xcode version updates.
+- **Hit rate improved**: Likely due to better cache warming or fewer source changes.
+- **Task count changed**: New targets added or removed.
+
+## Step 5: Check Build Context
+
+Compare environment details:
+
+- `xcode_version` and `macos_version`: Different versions can affect build times and cache validity.
+- `is_ci`: CI vs local builds may have different performance characteristics.
+- `git_branch` and `git_commit_sha`: Verify the builds are from the expected commits.
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Overall verdict**: Better, worse, or neutral compared to base.
+2. **Duration**: Absolute and percentage change.
+3. **Cache hit rate**: Change in hit rate with explanation.
+4. **Status**: Any status changes (pass to fail or vice versa).
+5. **Environment**: Note any environment differences that affect comparability.
+6. **Recommendations**: Actionable next steps based on findings.
+
+Example:
+
+```
+Build Comparison: base (abc123 on main) vs head (def456 on feature-x)
+
+Duration: 45.2s -> 62.8s (+39%) -- REGRESSION
+Cache hit rate: 85% -> 72% (-13%) -- 8 new cache misses
+Status: success -> success
+
+Root cause: Cache hit rate dropped due to 8 targets with invalidated caches.
+The dependency hash changed for FeatureModule, cascading to 7 downstream targets.
+
+Recommendations:
+- Investigate why FeatureModule's cache was invalidated
+- Consider splitting large targets to reduce cascade impact
+```
+
+## Done Checklist
+
+- Resolved both base and head builds
+- Compared duration, cache, and status metrics
+- Identified root causes for any regressions
+- Provided actionable recommendations

--- a/skills/skills/compare-bundles/SKILL.md
+++ b/skills/skills/compare-bundles/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: compare-bundles
+description: Compares two app bundles to identify size changes, new or removed artifacts, and platform differences. Can be invoked with bundle IDs, dashboard URLs, or branch names.
+---
+
+# Compare Bundles
+
+## Quick Start
+
+You'll typically receive two bundle identifiers. Follow these steps:
+
+1. Run `tuist bundle list --json` to find bundles on each branch.
+2. Run `tuist bundle show <bundle-id> --json` for both base and head bundles.
+3. Compare install size, download size, and other metadata.
+4. Summarize size changes with actionable recommendations.
+
+## Step 1: Resolve Bundles
+
+### If base/head are bundle IDs or dashboard URLs
+
+Fetch each directly:
+
+```bash
+tuist bundle show <base-id> --json
+tuist bundle show <head-id> --json
+```
+
+### If base/head are branch names
+
+List recent bundles on each branch and pick the latest:
+
+```bash
+tuist bundle list --git-branch <base-branch> --json
+tuist bundle list --git-branch <head-branch> --json
+```
+
+Then fetch full details with `tuist bundle show <id> --json`.
+
+### Defaults
+
+- If no base is provided, use the project's default branch (usually `main`).
+- If no head is provided, detect the current git branch.
+
+## Step 2: Compare Top-Level Metrics
+
+After fetching both bundles, compare:
+
+| Metric | What to check |
+|---|---|
+| `install_size` | Flag if head is >5% larger |
+| `download_size` | Flag if head is >5% larger |
+| `version` | Note version changes |
+| `supported_platforms` | Note platform changes |
+| `app_bundle_id` | Should match between base and head |
+
+Compute deltas:
+- Install size delta: `head_install_size - base_install_size`
+- Download size delta: `head_download_size - base_download_size`
+- Percentage change: `delta / base_size * 100`
+
+## Step 3: Analyze Size Changes
+
+If size increased significantly (>5%):
+
+1. Check if `version` changed, which might explain expected size growth.
+2. Check if `supported_platforms` changed (adding a platform increases size).
+3. Look at the `artifacts` field in the bundle details for individual artifact sizes.
+
+Common causes of size increases:
+- New frameworks or libraries added
+- Asset catalogs grew (new images, videos)
+- Unoptimized resources (large PNGs instead of compressed formats)
+- Debug symbols included in release builds
+- New localizations added
+
+Common causes of size decreases:
+- Removed unused frameworks
+- Optimized assets
+- Tree shaking or dead code elimination improvements
+- Moved functionality to on-demand resources
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Overall verdict**: Size increased, decreased, or stable.
+2. **Install size**: Absolute and percentage change.
+3. **Download size**: Absolute and percentage change.
+4. **Version**: Note if version changed.
+5. **Platforms**: Note any platform changes.
+6. **Recommendations**: Actionable next steps for size regressions.
+
+Example:
+
+```
+Bundle Comparison: base (v2.1.0 on main) vs head (v2.2.0 on feature-x)
+
+Install Size: 45.2 MB -> 52.8 MB (+16.8%) -- REGRESSION
+Download Size: 28.1 MB -> 32.4 MB (+15.3%) -- REGRESSION
+Version: 2.1.0 -> 2.2.0
+Platforms: iOS, macOS (unchanged)
+
+The install size increased by 7.6 MB. This is a significant increase
+that may affect user download and storage experience.
+
+Recommendations:
+- Review new frameworks or assets added in this version
+- Check for uncompressed resources or oversized image assets
+- Consider using asset compression or on-demand resources
+- Run `xcrun bitcode_strip` analysis to check for unnecessary bitcode
+```
+
+## Done Checklist
+
+- Resolved both base and head bundles
+- Compared install and download sizes
+- Analyzed root causes of size changes
+- Provided actionable recommendations

--- a/skills/skills/compare-cache-runs/SKILL.md
+++ b/skills/skills/compare-cache-runs/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: compare-cache-runs
+description: Compares two `tuist cache` runs to identify cache hit rate changes and root-cause analysis of cache invalidation. Can be invoked with cache run IDs, dashboard URLs, or branch names.
+---
+
+# Compare Cache Runs
+
+## Quick Start
+
+You'll typically receive two cache run identifiers. Follow these steps:
+
+1. Run `tuist cache-run list --json` to find cache runs on each branch.
+2. Run `tuist cache-run show <id> --json` for both base and head cache runs.
+3. Compare duration, status, and cache hit rates.
+4. Summarize cache changes with root cause analysis.
+
+## Step 1: Resolve Cache Runs
+
+### If base/head are cache run IDs or dashboard URLs
+
+Fetch each directly:
+
+```bash
+tuist cache-run show <base-id> --json
+tuist cache-run show <head-id> --json
+```
+
+### If base/head are branch names
+
+List recent cache runs on each branch:
+
+```bash
+tuist cache-run list --git-branch <base-branch> --json --page-size 1
+tuist cache-run list --git-branch <head-branch> --json --page-size 1
+```
+
+Then fetch full details with `tuist cache-run show <id> --json`.
+
+### Defaults
+
+- If no base is provided, use the project's default branch (usually `main`).
+- If no head is provided, detect the current git branch.
+
+## Step 2: Compare Top-Level Metrics
+
+After fetching both cache runs, compare:
+
+| Metric | What to check |
+|---|---|
+| `duration` | Flag if head is >10% slower |
+| `status` | Flag if base succeeded but head failed |
+| `cacheable_targets` | Note if target count changed |
+| `local_cache_target_hits` | Compare local hit counts |
+| `remote_cache_target_hits` | Compare remote hit counts |
+| `is_ci` | Note if one is CI and the other local |
+
+Compute cache hit rates:
+- Base: `(local_hits + remote_hits) / cacheable_targets * 100`
+- Head: same formula
+- Delta: `head_rate - base_rate`
+
+## Step 3: Analyze Cache Invalidation
+
+If cache hit rate dropped, the key question is: **which target(s) caused the invalidation cascade?**
+
+Cache invalidation in `tuist cache` works the same way as in `tuist generate`:
+1. A "root cause" target has a direct change (source file modified, build setting changed, etc.)
+2. All targets that depend on the root cause target also get invalidated because their `dependencies` hash changes.
+3. This cascade can invalidate many targets from a single root change.
+
+### Identifying root cause targets
+
+Without the module cache target detail endpoint (available via MCP), use these heuristics:
+
+1. Check `git diff` between the base and head commits to see which files changed.
+2. Map changed files to their Tuist targets/modules.
+3. Targets with direct source changes are likely root causes.
+4. Targets that only changed due to dependency hash cascading are secondary invalidations.
+
+### Common root causes of cache invalidation
+
+| Cause | Description |
+|---|---|
+| Source changes | Files in the target's source directory were modified |
+| Resource changes | Assets, XIBs, storyboards, or other resources changed |
+| Build settings | Target or project build settings were modified |
+| Dependency changes | An external dependency version changed |
+| Info.plist changes | The target's Info.plist was modified |
+| Entitlements changes | The entitlements file was modified |
+| Deployment target | The minimum deployment target changed |
+| Headers | Public or project headers changed |
+| Project settings | Shared project-level settings changed |
+
+## Step 4: Assess Impact
+
+Categorize the cache invalidation:
+
+- **Expected**: Source files were intentionally changed, causing expected cache misses.
+- **Unexpected**: No source changes but cache was invalidated (build settings, Xcode version, etc.).
+- **Cascade**: A small change invalidated many downstream targets.
+
+For `tuist cache` specifically, also consider:
+- Cache warming strategy: Was the cache run warming from scratch or incrementally?
+- The `command_arguments` field can reveal if different flags were used.
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Overall verdict**: Cache hit rate improved, regressed, or stable.
+2. **Cache hit rate**: Base rate vs head rate with delta.
+3. **Duration**: Absolute and percentage change.
+4. **Root cause targets**: Which targets had direct changes.
+5. **Cascade impact**: How many targets were invalidated due to dependency cascading.
+6. **Recommendations**: How to minimize cache invalidation.
+
+Example:
+
+```
+Cache Run Comparison: base (run-123 on main) vs head (run-456 on feature-x)
+
+Duration: 95.2s -> 142.8s (+50%) -- REGRESSION
+Cache hit rate: 88% (44/50) -> 60% (30/50) (-28%) -- REGRESSION
+Status: success -> success
+
+Root cause: CoreModule had source changes (5 files modified).
+This cascaded to 14 downstream targets that depend on CoreModule.
+
+Cache invalidation breakdown:
+- Direct changes: CoreModule (sources changed)
+- Cascade: UIKit, Networking, Analytics, + 11 others (dependency hash changed)
+
+Recommendations:
+- Consider splitting CoreModule into smaller, more focused modules
+- Use interface/implementation module pattern for frequently-changed modules
+- Run `tuist cache` on the feature branch after rebasing to warm caches
+```
+
+## Done Checklist
+
+- Resolved both base and head cache runs
+- Compared duration and cache hit rates
+- Identified root cause targets for cache invalidation
+- Analyzed cascade impact
+- Provided actionable recommendations for reducing cache misses

--- a/skills/skills/compare-generations/SKILL.md
+++ b/skills/skills/compare-generations/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: compare-generations
+description: Compares two `tuist generate` runs to identify cache hit rate changes and root-cause analysis of cache invalidation. Can be invoked with generation IDs, dashboard URLs, or branch names.
+---
+
+# Compare Generations
+
+## Quick Start
+
+You'll typically receive two generation identifiers. Follow these steps:
+
+1. Run `tuist generate list --json` to find generations on each branch.
+2. Run `tuist generate show <id> --json` for both base and head generations.
+3. Compare duration, status, and cache hit rates.
+4. Summarize cache changes with root cause analysis.
+
+## Step 1: Resolve Generations
+
+### If base/head are generation IDs or dashboard URLs
+
+Fetch each directly:
+
+```bash
+tuist generate show <base-id> --json
+tuist generate show <head-id> --json
+```
+
+### If base/head are branch names
+
+List recent generations on each branch:
+
+```bash
+tuist generate list --git-branch <base-branch> --json --page-size 1
+tuist generate list --git-branch <head-branch> --json --page-size 1
+```
+
+Then fetch full details with `tuist generate show <id> --json`.
+
+### Defaults
+
+- If no base is provided, use the project's default branch (usually `main`).
+- If no head is provided, detect the current git branch.
+
+## Step 2: Compare Top-Level Metrics
+
+After fetching both generations, compare:
+
+| Metric | What to check |
+|---|---|
+| `duration` | Flag if head is >10% slower |
+| `status` | Flag if base succeeded but head failed |
+| `cacheable_targets` | Note if target count changed |
+| `local_cache_target_hits` | Compare local hit counts |
+| `remote_cache_target_hits` | Compare remote hit counts |
+| `is_ci` | Note if one is CI and the other local |
+
+Compute cache hit rates:
+- Base: `(local_hits + remote_hits) / cacheable_targets * 100`
+- Head: same formula
+- Delta: `head_rate - base_rate`
+
+## Step 3: Analyze Cache Invalidation
+
+If cache hit rate dropped, the key question is: **which target(s) caused the invalidation cascade?**
+
+Cache invalidation typically works like this:
+1. A "root cause" target has a direct change (source file modified, build setting changed, etc.)
+2. All targets that depend on the root cause target also get invalidated because their `dependencies` hash changes.
+3. This cascade can invalidate many targets from a single root change.
+
+### Identifying root cause targets
+
+Without the module cache target detail endpoint (available via MCP), use these heuristics:
+
+1. Check `git diff` between the base and head commits to see which files changed.
+2. Map changed files to their Tuist targets/modules.
+3. Targets with direct source changes are likely root causes.
+4. Targets that only changed due to dependency hash cascading are secondary invalidations.
+
+### Common root causes of cache invalidation
+
+| Cause | Description |
+|---|---|
+| Source changes | Files in the target's source directory were modified |
+| Resource changes | Assets, XIBs, storyboards, or other resources changed |
+| Build settings | Target or project build settings were modified |
+| Dependency changes | An external dependency version changed |
+| Info.plist changes | The target's Info.plist was modified |
+| Entitlements changes | The entitlements file was modified |
+| Deployment target | The minimum deployment target changed |
+| Headers | Public or project headers changed |
+| Project settings | Shared project-level settings changed |
+
+## Step 4: Assess Impact
+
+Categorize the cache invalidation:
+
+- **Expected**: Source files were intentionally changed, causing expected cache misses.
+- **Unexpected**: No source changes but cache was invalidated (build settings, Xcode version, etc.).
+- **Cascade**: A small change invalidated many downstream targets.
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Overall verdict**: Cache hit rate improved, regressed, or stable.
+2. **Cache hit rate**: Base rate vs head rate with delta.
+3. **Duration**: Absolute and percentage change.
+4. **Root cause targets**: Which targets had direct changes.
+5. **Cascade impact**: How many targets were invalidated due to dependency cascading.
+6. **Recommendations**: How to minimize cache invalidation.
+
+Example:
+
+```
+Generation Comparison: base (gen-123 on main) vs head (gen-456 on feature-x)
+
+Duration: 12.5s -> 28.3s (+126%) -- REGRESSION
+Cache hit rate: 92% (46/50) -> 64% (32/50) (-28%) -- REGRESSION
+Status: success -> success
+
+Root cause: FoundationModule had source changes (3 files modified).
+This cascaded to 14 downstream targets that depend on FoundationModule.
+
+Cache invalidation breakdown:
+- Direct changes: FoundationModule (sources changed)
+- Cascade: NetworkModule, AuthModule, UIModule, + 11 others (dependency hash changed)
+
+Recommendations:
+- Consider splitting FoundationModule into smaller modules to reduce cascade impact
+- The 14 cascaded targets could benefit from more granular dependency declarations
+- If FoundationModule changes frequently, consider interface/implementation module splitting
+```
+
+## Done Checklist
+
+- Resolved both base and head generations
+- Compared duration and cache hit rates
+- Identified root cause targets for cache invalidation
+- Analyzed cascade impact
+- Provided actionable recommendations for reducing cache misses

--- a/skills/skills/compare-test-case/SKILL.md
+++ b/skills/skills/compare-test-case/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: compare-test-case
+description: Compares a single test case's behavior across two branches, analyzing pass/fail status, duration, flakiness, and failure details. Useful for investigating test regressions introduced by a feature branch.
+---
+
+# Compare Test Case
+
+## Quick Start
+
+You'll typically receive a test case identifier and two branches. Follow these steps:
+
+1. Run `tuist test case show <id-or-identifier> --json` to get the test case metrics.
+2. Run `tuist test case run list <identifier> --json` to see runs across branches.
+3. Compare behavior between base and head branches.
+4. Inspect failures with `tuist test case run show <run-id> --json`.
+5. Summarize findings with root cause analysis.
+
+## Step 1: Resolve the Test Case
+
+### By ID or dashboard URL
+
+```bash
+tuist test case show <test-case-id> --json
+```
+
+### By identifier (Module/Suite/TestCase)
+
+```bash
+tuist test case show Module/Suite/TestCase --json
+```
+
+### If no test case is provided
+
+Discover flaky or failing tests to investigate:
+
+```bash
+tuist test case list --flaky --json --page-size 10
+```
+
+Key fields from the response:
+- `id` -- unique identifier for subsequent commands
+- `name`, `module_name`, `suite_name` -- the test identity
+- `reliability_rate` -- percentage of successful runs
+- `flakiness_rate` -- percentage of flaky runs in the last 30 days
+- `total_runs` / `failed_runs` -- volume context
+- `is_flaky` / `is_quarantined` -- current flags
+
+## Step 2: Get Runs on Each Branch
+
+List test case runs filtered by the test case, and look at the `git_branch` field:
+
+```bash
+tuist test case run list <identifier> --json --page-size 20
+```
+
+Separate runs by branch. For each branch, compute:
+- Pass rate: `passed_runs / total_runs * 100`
+- Average duration
+- Flaky run count
+- Most recent status
+
+### Defaults
+
+- If no base branch is provided, use the project's default branch (usually `main`).
+- If no head branch is provided, detect the current git branch.
+
+## Step 3: Compare Branch Behavior
+
+| Metric | Base branch | Head branch | Verdict |
+|---|---|---|---|
+| Pass rate | e.g. 100% | e.g. 60% | REGRESSION |
+| Avg duration | e.g. 0.5s | e.g. 2.1s | REGRESSION |
+| Flaky runs | 0 | 3 | NEW FLAKINESS |
+| Last status | success | failure | REGRESSION |
+
+Classify the change:
+- **Newly failing**: 100% pass rate on base, <100% on head
+- **Newly flaky**: No flaky runs on base, flaky runs on head
+- **Duration regression**: >50% increase in average duration
+- **Fixed**: Failing on base, passing on head
+- **Stable**: Same behavior on both branches
+
+## Step 4: Inspect Failures
+
+For each failing run on the head branch:
+
+```bash
+tuist test case run show <test-case-run-id> --json
+```
+
+Examine:
+- `failures[].message` -- the assertion or error message
+- `failures[].path` -- source file path
+- `failures[].line_number` -- exact line of failure
+- `failures[].issue_type` -- type of issue
+- `repetitions` -- shows retry behavior (e.g., pass-fail-pass means flaky)
+- `crash_report` -- crash data if the test runner crashed
+
+## Step 5: Identify Root Cause
+
+Based on the comparison:
+
+### Newly failing
+- Check commits between base and head branches for changes to the test file or the code under test.
+- Look at the failure message for clues about what changed.
+
+### Newly flaky
+- Common patterns: timing/async issues, shared state, environment dependencies.
+- Check if `repetitions` show intermittent pass/fail patterns.
+- See the fix-flaky-tests skill for detailed flaky test analysis patterns.
+
+### Duration regression
+- Check if setup/teardown time increased.
+- Check if the test is doing more work (new assertions, larger data sets).
+- Check if a dependency became slower.
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Test case info**: Name, module, suite, overall reliability.
+2. **Base branch behavior**: Pass rate, avg duration, flaky count.
+3. **Head branch behavior**: Pass rate, avg duration, flaky count.
+4. **Verdict**: What changed and classification.
+5. **Root cause**: Hypothesis based on failure analysis.
+6. **Recommendations**: Specific file paths, line numbers, and fix suggestions.
+
+Example:
+
+```
+Test Case Comparison: AuthModuleTests/LoginTests/test_login_with_expired_token
+
+Overall reliability: 85% (was 100% before head branch)
+
+Base (main):
+  Pass rate: 100% (15/15 runs)
+  Avg duration: 0.3s
+  Flaky: No
+
+Head (feature/auth-refactor):
+  Pass rate: 60% (3/5 runs)
+  Avg duration: 0.5s
+  Flaky: Yes (2 flaky runs)
+
+Verdict: NEWLY FLAKY -- test was stable on main but intermittently fails on feature branch
+
+Root cause: The auth refactor introduced an async token refresh that races with the
+test's synchronous assertion. Failures show "Expected status 401, got nil" at
+Tests/AuthModuleTests/LoginTests.swift:42, suggesting the response arrives before
+the token refresh completes.
+
+Recommendations:
+- Add an await/expectation before the assertion at LoginTests.swift:42
+- Consider mocking the token refresh to make the test deterministic
+```
+
+## Done Checklist
+
+- Resolved the test case identity
+- Gathered runs on both branches
+- Compared pass rates, durations, and flakiness
+- Inspected failure details for failing runs
+- Identified root cause with file paths and line numbers
+- Provided actionable fix recommendations

--- a/skills/skills/compare-test-runs/SKILL.md
+++ b/skills/skills/compare-test-runs/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: compare-test-runs
+description: Compares two test runs to identify new failures, newly flaky tests, fixed tests, and duration regressions. Can be invoked with test run IDs, dashboard URLs, or branch names.
+---
+
+# Compare Test Runs
+
+## Quick Start
+
+You'll typically receive two test run identifiers. Follow these steps:
+
+1. Run `tuist test show <id> --json` for both base and head test runs.
+2. Run `tuist test case run list --test-run-id <id> --json` to get individual test case results.
+3. Compare failures, flaky tests, durations, and overall status.
+4. Inspect failing test cases with `tuist test case run show <id> --json`.
+5. Summarize findings with actionable recommendations.
+
+## Step 1: Resolve Test Runs
+
+### If base/head are test run IDs or dashboard URLs
+
+Fetch each directly:
+
+```bash
+tuist test show <base-id> --json
+tuist test show <head-id> --json
+```
+
+### If base/head are branch names
+
+List recent test case runs on each branch to identify test run IDs:
+
+```bash
+tuist test case run list --json --page-size 5
+```
+
+Look at `test_run_id` fields to find recent test runs per branch.
+
+### Defaults
+
+- If no base is provided, use the project's default branch (usually `main`).
+- If no head is provided, detect the current git branch.
+
+## Step 2: Compare Top-Level Metrics
+
+After fetching both test runs, compare:
+
+| Metric | What to check |
+|---|---|
+| `status` | Flag if base passed but head failed |
+| `duration` | Flag if head is >10% slower |
+| `total_test_count` | Note if test count changed (new or removed tests) |
+| `failed_test_count` | Compare failure counts |
+| `flaky_test_count` | Compare flaky counts |
+| `avg_test_duration` | Flag significant changes |
+
+## Step 3: Get Test Case Results
+
+Fetch test case runs for both test runs:
+
+```bash
+tuist test case run list --test-run-id <base-test-run-id> --json --page-size 100
+tuist test case run list --test-run-id <head-test-run-id> --json --page-size 100
+```
+
+Match test cases by their `name` + `module_name` + `suite_name` across both runs.
+
+## Step 4: Classify Changes
+
+Group test cases into categories:
+
+1. **New failures**: Tests that passed in base but failed in head.
+2. **Fixed tests**: Tests that failed in base but passed in head.
+3. **Newly flaky**: Tests not flaky in base but flaky in head.
+4. **No longer flaky**: Tests that were flaky in base but stable in head.
+5. **New tests**: Tests present in head but not in base.
+6. **Removed tests**: Tests present in base but not in head.
+7. **Duration regressions**: Tests with >50% duration increase.
+
+## Step 5: Inspect Failures
+
+For each new failure, get detailed information:
+
+```bash
+tuist test case run show <test-case-run-id> --json
+```
+
+Key fields to examine:
+- `failures[].message` -- the assertion or error message
+- `failures[].path` -- source file path
+- `failures[].line_number` -- exact line of failure
+- `failures[].issue_type` -- type of issue
+- `repetitions` -- if present, shows retry behavior (flaky detection)
+- `crash_report` -- crash data if test runner crashed
+
+## Step 6: Inspect Attachments
+
+The `tuist test case run show` output includes attachment and crash report information. Review:
+- Screenshots or UI test artifacts
+- Log files or crash reports
+- Any diagnostic data attached to failing runs
+
+## Summary Format
+
+Produce a summary with:
+
+1. **Overall verdict**: Better, worse, or neutral compared to base.
+2. **New failures**: List each with failure message, file path, and line number.
+3. **New flaky tests**: List with flakiness context.
+4. **Fixed tests**: List tests that are now passing.
+5. **Duration**: Overall and notable per-test regressions.
+6. **Recommendations**: Actionable next steps for each issue.
+
+Example:
+
+```
+Test Run Comparison: base (run-123 on main) vs head (run-456 on feature-x)
+
+Status: success -> failure -- REGRESSION
+Duration: 120.5s -> 145.2s (+21%)
+Tests: 342 -> 345 (3 new tests)
+Failures: 0 -> 2 (2 new failures)
+Flaky: 1 -> 3 (2 newly flaky)
+
+New Failures:
+1. AuthModuleTests/LoginTests/test_login_with_expired_token
+   Message: "Expected status 401, got 500"
+   File: Tests/AuthModuleTests/LoginTests.swift:42
+   Likely cause: Server error handling changed for expired tokens
+
+2. NetworkTests/RetryTests/test_retry_on_timeout
+   Message: "Timed out waiting for retry"
+   File: Tests/NetworkTests/RetryTests.swift:87
+   Likely cause: Timeout threshold too low after network layer refactor
+
+Newly Flaky:
+1. CacheTests/WriteCacheTests/test_concurrent_writes (flaky in 3/5 runs)
+
+Recommendations:
+- Fix expired token handling in AuthModule
+- Increase timeout in RetryTests or mock the network layer
+- Investigate concurrent write synchronization in CacheTests
+```
+
+## Done Checklist
+
+- Resolved both base and head test runs
+- Compared top-level metrics
+- Identified new failures, fixed tests, and flaky changes
+- Inspected failure details for new failures
+- Provided actionable recommendations with file paths


### PR DESCRIPTION
## Summary

This complements #9732 by adding six agent skills that mirror the MCP comparison prompts on the CLI side. Each skill provides a structured workflow that guides AI agents through fetching data with existing CLI commands (`tuist build list/show`, `tuist test case run list/show`, `tuist bundle list/show`, `tuist generate list/show`, `tuist cache-run list/show`), comparing base vs head, and producing actionable summaries.

The new skills are:
- **compare-builds** -- compare two Xcode build runs (duration, cache hits, status)
- **compare-test-runs** -- compare two test runs (new failures, flaky tests, duration)
- **compare-bundles** -- compare two app bundles (install/download size, artifacts)
- **compare-test-case** -- compare a single test case across branches (pass rate, flakiness)
- **compare-generations** -- compare two `tuist generate` runs (cache hit rates, invalidation root cause)
- **compare-cache-runs** -- compare two `tuist cache` runs (cache hit rates, invalidation root cause)

## Test plan

- [ ] Verify each skill file has valid YAML frontmatter and renders correctly
- [ ] Test skills with an AI agent against a real Tuist project