### PR TITLE
fix(server): truncate requested tasks column to first two entries

### DIFF
--- a/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
@@ -97,10 +97,17 @@
           </:col>
           <:col :let={build} label={dgettext("dashboard_gradle", "Requested tasks")}>
             <.text_cell label={
-              if(build.requested_tasks == [],
-                do: dgettext("dashboard_gradle", "Unknown"),
-                else: Enum.join(build.requested_tasks, " ")
-              )
+              case build.requested_tasks do
+                [] ->
+                  dgettext("dashboard_gradle", "Unknown")
+
+                tasks ->
+                  truncated = Enum.take(tasks, 2)
+
+                  if length(tasks) > 2,
+                    do: Enum.join(truncated, " ") <> " +#{length(tasks) - 2}",
+                    else: Enum.join(truncated, " ")
+              end
             } />
           </:col>
           <:col :let={build} label={dgettext("dashboard_gradle", "Built by")}>


### PR DESCRIPTION
## Summary
- Truncates the "Requested tasks" column in the Gradle build runs table to show only the first two tasks
- When there are more than two tasks, displays a `+N` suffix (e.g., `assembleDebug test +3`)

## Test plan
- [ ] Verify builds with 0 tasks still show "Unknown"
- [ ] Verify builds with 1-2 tasks display normally
- [ ] Verify builds with 3+ tasks show first two plus "+N" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)