### PR TITLE
fix(server): attribute Gradle builds to authenticated user

### DIFF
--- a/server/lib/tuist_web/controllers/api/gradle_controller.ex
+++ b/server/lib/tuist_web/controllers/api/gradle_controller.ex
@@ -111,7 +111,7 @@ defmodule TuistWeb.API.GradleController do
     }
   )
 
-  def create_build(%{assigns: %{selected_project: project, selected_account: account}, body_params: body} = conn, _params) do
+  def create_build(%{assigns: %{selected_project: project}, body_params: body} = conn, _params) do
     tasks =
       Enum.map(body.tasks, fn task ->
         %{
@@ -129,7 +129,7 @@ defmodule TuistWeb.API.GradleController do
     attrs = %{
       id: body[:id] || UUIDv7.generate(),
       project_id: project.id,
-      account_id: account.id,
+      account_id: TuistWeb.Authentication.authenticated_subject_account(conn).id,
       duration_ms: body.duration_ms,
       status: body.status,
       gradle_version: body[:gradle_version],

--- a/server/test/tuist_web/controllers/api/gradle_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/gradle_controller_test.exs
@@ -67,9 +67,39 @@ defmodule TuistWeb.API.GradleControllerTest do
       assert build.gradle_version == "8.5"
       assert build.is_ci == true
       assert build.requested_tasks == ["assembleDebug", "test"]
+      assert build.account_id == user.account.id
       assert build.tasks_executed_count == 1
       assert build.tasks_local_hit_count == 1
       assert build.cacheable_tasks_count == 2
+    end
+
+    test "attributes the build to the authenticated user, not the organization", %{conn: conn} do
+      stub(Tuist.VCS, :enqueue_vcs_pull_request_comment, fn _ -> :ok end)
+
+      member = AccountsFixtures.user_fixture(preload: [:account])
+      organization = AccountsFixtures.organization_fixture(creator: member, preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: organization.account.id)
+
+      conn = Authentication.put_current_user(conn, member)
+
+      body = %{
+        duration_ms: 5000,
+        status: "success",
+        tasks: []
+      }
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/projects/#{organization.account.name}/#{project.name}/gradle/builds", body)
+
+      response = json_response(conn, 201)
+
+      Buffer.flush()
+
+      {:ok, build} = Gradle.get_build(response["id"])
+      assert build.account_id == member.account.id
+      refute build.account_id == organization.account.id
     end
 
     test "creates a build with no tasks", %{conn: conn, user: user, project: project} do


### PR DESCRIPTION
## Summary
- Gradle builds were attributed to the organization account (`selected_account`) instead of the authenticated user's account
- Changed `gradle_controller.ex` to use `Authentication.authenticated_subject_account(conn)`, matching how `builds_controller`, `runs_controller`, and `tests_controller` already work
- Added a test that creates a build on an org project and verifies it's attributed to the member, not the org

## Test plan
- [x] Existing tests pass (`mix test test/tuist_web/controllers/api/gradle_controller_test.exs`)
- [x] New test verifies org vs user attribution
- [x] Verified e2e: new builds on localhost show `account_id=1` (tuistrocks) instead of `account_id=2` (tuist org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)