### PR TITLE
fix(noora): update storybook domain to noora.storybook.dev

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -156,11 +156,11 @@ services:
       - key: SECRET_KEY_BASE
         generateValue: true
       - key: PHX_HOST
-        value: storybook.noora.tuist.dev
+        value: noora.storybook.dev
       - key: PORT
         value: "8080"
     domains:
-      - storybook.noora.tuist.dev
+      - noora.storybook.dev
 
   # ── Preview environment ─────────────────────────────────────────────
   # Each PR touching server/** gets an isolated preview with its own


### PR DESCRIPTION
## Summary
- Updates the Noora storybook Render service domain from `storybook.noora.tuist.dev` to `noora.storybook.dev`
- Updates `PHX_HOST` env var to match the new domain

## Test plan
- [ ] Verify Render picks up the domain change after merge
- [ ] Confirm `noora.storybook.dev` resolves correctly (DNS CNAME must point to `noora-storybook.onrender.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)