### PR TITLE
chore(cli): replace `tuist setup cache` with `tuist setup`

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -102,9 +102,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -156,9 +156,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -201,9 +201,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install

--- a/.github/workflows/cli-cache-ee.yml
+++ b/.github/workflows/cli-cache-ee.yml
@@ -128,8 +128,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install
@@ -174,8 +174,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install
@@ -223,8 +223,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install
@@ -105,9 +105,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install
@@ -135,9 +135,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -174,9 +174,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache.outputs.cache-matched-key == ''
         run: tuist install
@@ -204,9 +204,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -246,9 +246,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -295,9 +295,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -337,9 +337,9 @@ jobs:
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
         run: tuist auth login
-      - name: Setup Tuist cache
+      - name: Setup Tuist
         if: github.event.pull_request.head.repo.fork != true
-        run: tuist setup cache
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,8 +82,8 @@ jobs:
           working_directory: docs
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: tuist install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,8 +503,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install
@@ -650,8 +650,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install dependencies
         run: tuist install
 
@@ -740,8 +740,8 @@ jobs:
           cache: "false"
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Restore cache
         id: cache-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -87,8 +87,8 @@ jobs:
       - uses: jdx/mise-action@v2
       - name: Authenticate with Tuist
         run: tuist auth login
-      - name: Setup Tuist cache
-        run: tuist setup cache
+      - name: Setup Tuist
+        run: tuist setup
       - name: Install Tuist dependencies
         if: steps.cache-restore.outputs.cache-matched-key == ''
         run: tuist install

--- a/mise/tasks/install.sh
+++ b/mise/tasks/install.sh
@@ -6,6 +6,6 @@ set -eo pipefail
 if [[ "$OSTYPE" == "darwin"* ]]; then
   if [[ -z "$CI" ]]; then
     tuist install
-    tuist setup cache
+    tuist setup
   fi
 fi


### PR DESCRIPTION
## Summary
- Replaces `tuist setup cache` with `tuist setup` across all CI workflows and the local mise install script
- `tuist setup` sets up both cache and insights in a single command
- Also renames the CI step from "Setup Tuist cache" to "Setup Tuist"

## Test plan
- [ ] CI workflows run successfully with `tuist setup`
- [ ] Local `mise run install` works with `tuist setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)