### PR TITLE
fix(server): add render_async to flaky overview live tests

### DIFF
--- a/server/test/tuist_web/live/overview_live_test.exs
+++ b/server/test/tuist_web/live/overview_live_test.exs
@@ -58,6 +58,7 @@ defmodule TuistWeb.OverviewLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
+    render_async(lv)
 
     assert has_element?(lv, ".tuist-widget span", "50.0%")
   end
@@ -78,6 +79,7 @@ defmodule TuistWeb.OverviewLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
+    render_async(lv)
 
     assert has_element?(lv, "div[data-part=average-build-time-chart] span", "1.0s")
   end


### PR DESCRIPTION
The binary cache hit rate and average build time tests in `OverviewLiveTest` were not calling `render_async(lv)` before asserting on content loaded via `assign_async`, causing intermittent failures. This is the same fix applied in #9727 for the empty states test.