### PR TITLE
fix(server): allow MCP session recreation for missing sessions

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -318,7 +318,7 @@ defmodule TuistWeb.Router do
   scope "/" do
     pipe_through [:mcp]
 
-    forward "/mcp", EMCP.Transport.StreamableHTTP, server: Tuist.MCP.Server, recreate_missing_session: false
+    forward "/mcp", EMCP.Transport.StreamableHTTP, server: Tuist.MCP.Server
   end
 
   scope path: "/api",


### PR DESCRIPTION
## Summary

When using the MCP endpoint in production, clients would get repeated `Session not found` errors before eventually succeeding. This happened because `recreate_missing_session: false` was set, which makes EMCP return a 404 when it receives a session ID it doesn't recognize (e.g., after a deploy, process restart, or when a load balancer routes to a different instance).

Since MCP requests are essentially stateless, removing this option lets EMCP use its default behavior of silently recreating unknown sessions, which provides a much better experience without any real downside.

## Test plan

- Deploy to staging and verify MCP tools work without "Session not found" errors
- Confirm session recreation works transparently after server restarts