### PR TITLE
fix(cli): restore generate run analytics on dashboard

### DIFF
--- a/cli/Sources/TuistGenerateCommand/GenerateRunCommand.swift
+++ b/cli/Sources/TuistGenerateCommand/GenerateRunCommand.swift
@@ -17,6 +17,7 @@
         public static var configuration: CommandConfiguration {
             CommandConfiguration(
                 commandName: "run",
+                _superCommandName: "generate",
                 abstract: "Generates an Xcode workspace to start working on the project.",
                 discussion:
                 "Use 'tuist generate list' and 'tuist generate show' to inspect generation runs."


### PR DESCRIPTION
## Summary
- Adds `_superCommandName: "generate"` to `GenerateRunCommand` so analytics events report the command name as "generate" instead of "run"
- Without this, generate runs don't appear on the dashboard because the server filters by `name == "generate"`
- Same fix as #9451 which resolved the identical issue for cache runs

## Test plan
- [ ] Run `tuist generate` and verify the analytics event name is "generate"
- [ ] Check the dashboard shows new generate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)