### PR TITLE
fix(ci): download trivy directly from GitHub CDN

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -390,8 +390,10 @@ jobs:
           cache: "false"
           working_directory: server
       - name: Install Trivy
+        env:
+          TRIVY_VERSION: "0.69.3"
         run: |
-          sudo curl -sfL https://github.com/aquasecurity/trivy/releases/download/v0.63.0/trivy_0.63.0_Linux-64bit.tar.gz -o /tmp/trivy.tar.gz
+          curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o /tmp/trivy.tar.gz
           sudo tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
           rm /tmp/trivy.tar.gz
       - name: Restore Mix Cache


### PR DESCRIPTION
## Summary
- Replace `ubi:aquasecurity/trivy` in the server Security job's mise install_args with a direct `curl` download from the GitHub releases CDN
- The `ubi:` backend hits `api.github.com` to resolve releases, consuming rate-limited API calls and failing when the 5000 req/hour budget is exhausted
- GitHub releases CDN (`github.com/.../releases/download/...`) doesn't require API auth

## Test plan
- [ ] Server Security check passes (trivy is available and `mise run security` works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)