### PR TITLE
fix(cli): add audio and video file extensions to validResourceExtensions

### DIFF
--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
@@ -16,7 +16,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public static let validResourceExtensions: [String] = [
         // Resource
         "md", "xcstrings", "plist", "rtf", "tutorial", "sks", "xcprivacy", "gpx", "strings", "stringsdict",
-        "geojson", "txt", "json", "js", "mp3", "wav",
+        "geojson", "txt", "json", "js", "mp4", "mov", "avi", "mp3", "wav", "aac",
 
         // User interface
         "storyboard", "xib",


### PR DESCRIPTION
While working on a project that had mp3 files as resources, I noticed that the bundle accessor file wasn't present in the Derived folder. This PR adds common audio and video file extensions as valid resources.