### PR TITLE
fix(cli): override SYMROOT in cache warm builds to prevent custom build location mismatch

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -355,6 +355,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
                 .xcarg("CODE_SIGNING_ALLOWED", "NO"),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
+                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
             ]
             try await xcodeBuildController.build(
                 xcodebuildTarget,
@@ -416,6 +417,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_ALLOWED", "NO"),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .configuration(configuration),
+                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
             ]
             // We currently skip building for maccatalyst as we prefer to generate a bundle for iOS instead.
             // iOS bundles should be compatible with maccatalyst ones
@@ -591,6 +593,7 @@ import XcodeGraph
                         .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                         .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                         .configuration(configuration),
+                        .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
                         // To prevent the rejection when publishing on the App Store
                         // https://developer.apple.com/library/archive/qa/qa1964/_index.html
                     ] + (isReleaseConfiguration ? [
@@ -636,6 +639,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                 .configuration(configuration),
+                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
                 // To prevent the rejection when publishing on the App Store
                 // https://developer.apple.com/library/archive/qa/qa1964/_index.html
             ] + (isReleaseConfiguration ? [
@@ -717,6 +721,7 @@ import XcodeGraph
                     .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                     .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                     .configuration(configuration),
+                    .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
                 ] + (isReleaseConfiguration ? [
                     .xcarg("GCC_INSTRUMENT_PROGRAM_FLOW_ARCS", "NO"),
                     .xcarg("CLANG_ENABLE_CODE_COVERAGE", "NO"),


### PR DESCRIPTION
## Summary

When a workspace has custom build location settings (e.g., `BuildLocationStyle = CustomLocation` with a relative `CustomBuildProductsPath`), `tuist cache` warm builds succeed but the subsequent XCFramework packaging step fails with:

```
xcodebuild -create-xcframework ... error: at least one framework or library must be specified
```

### Root Cause

The `-derivedDataPath` flag passed to xcodebuild only controls where derived data (indexes, logs, module caches) goes. It does **not** override `SYMROOT` / `BUILD_DIR` when those are explicitly set via workspace-level build location settings (`WorkspaceSettings.xcsettings`).

During cache warm:
1. Tuist creates a temporary `derivedDataPath` and passes it to xcodebuild
2. xcodebuild builds successfully, but writes `.framework` files to the custom build location (e.g., `.build/xcode/Products/`) instead of `derivedDataPath/Build/Products/`
3. Tuist then looks for artifacts at `derivedDataPath/Build/Products/<Configuration-SDK>/`
4. That directory is empty, so `create-xcframework` is called with zero `-framework` arguments

### Fix

Explicitly set `SYMROOT` as a command-line build setting override in all five cache warm xcodebuild invocations (`buildMacros`, `buildBundles`, `buildBinarySchemes` simulator/device, `buildCatalystScheme`). Command-line build settings take precedence over project/workspace settings, ensuring build products always land where Tuist expects them.

```swift
.xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString)
```

### Reproduction

1. Set workspace custom build location in `WorkspaceSettings.xcsettings`:
   ```xml
   <key>BuildLocationStyle</key>
   <string>CustomLocation</string>
   <key>CustomBuildLocationType</key>
   <string>RelativeToWorkspace</string>
   <key>CustomBuildProductsPath</key>
   <string>.build/xcode/Products</string>
   ```
2. Run `tuist cache --external-only`
3. Build succeeds but XCFramework creation fails with "at least one framework or library must be specified"

### Test plan

- [ ] Verify `tuist cache` succeeds with custom workspace build location settings
- [ ] Verify `tuist cache` still works correctly with default build location settings
- [ ] Verify `create-xcframework` receives proper `-framework` arguments in verbose log