### PR TITLE
fix(android): exclude JNA from Shadow JAR relocation

### DIFF
--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -42,8 +42,9 @@ tasks.shadowJar {
     relocate("com.google.gson", "dev.tuist.shadow.gson")
     relocate("org.tomlj", "dev.tuist.shadow.tomlj")
     relocate("org.antlr", "dev.tuist.shadow.antlr")
-    relocate("com.sun.jna", "dev.tuist.shadow.jna")
-    minimize()
+    minimize {
+        exclude(dependency("net.java.dev.jna:.*"))
+    }
 }
 
 tasks.jar {

--- a/gradle/src/main/kotlin/dev/tuist/gradle/MacOSSystemMetrics.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/MacOSSystemMetrics.kt
@@ -121,15 +121,15 @@ private const val kIOMainPortDefault = 0
 object MacOSSystemMetrics {
     private val systemLib: SystemLib? = try {
         Native.load("System", SystemLib::class.java)
-    } catch (e: Exception) { null }
+    } catch (e: Throwable) { null }
 
     private val ioKit: IOKitLib? = try {
         Native.load("IOKit", IOKitLib::class.java)
-    } catch (e: Exception) { null }
+    } catch (e: Throwable) { null }
 
     private val cf: CoreFoundationLib? = try {
         Native.load("CoreFoundation", CoreFoundationLib::class.java)
-    } catch (e: Exception) { null }
+    } catch (e: Throwable) { null }
 
     val isAvailable: Boolean get() = systemLib != null && ioKit != null && cf != null
 


### PR DESCRIPTION
## Summary
- Removed `relocate("com.sun.jna", ...)` from Shadow JAR config — JNA uses JNI native methods with hardcoded C symbol names, so relocation breaks the linkage causing `UnsatisfiedLinkError`
- Excluded JNA from `minimize()` — JNA loads classes reflectively via `Native.load()`, so the minimizer can't trace the dependency and strips it
- Changed `catch (e: Exception)` to `catch (e: Throwable)` in `MacOSSystemMetrics` — `UnsatisfiedLinkError` is an `Error`, not `Exception`, so the original catch wouldn't handle it gracefully

## Test plan
- [x] `./gradlew shadowJar` builds successfully
- [x] Shadow JAR contains `com/sun/jna/` classes (not relocated)
- [x] `./gradlew test` passes
- [ ] Verify on macOS arm64 with JDK 21 that machine metrics are collected without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)