### PR TITLE
chore(processor): add processor staging deploy workflow

### DIFF
--- a/.github/workflows/processor-staging-deploy.yml
+++ b/.github/workflows/processor-staging-deploy.yml
@@ -1,0 +1,39 @@
+name: Processor Staging Deploy
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Sha of the commit to be deployed
+        required: true
+
+defaults:
+  run:
+    working-directory: processor
+
+jobs:
+  deploy:
+    runs-on: namespace-profile-default
+    timeout-minutes: 45
+    environment: processor-staging
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
+      - uses: 1password/install-cli-action@v2
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+          working_directory: processor
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.CACHE_SSH_PRIVATE_KEY }}
+      - name: Deploy with Kamal
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mise run deploy "staging"


### PR DESCRIPTION
## Summary
- Adds `processor-staging-deploy.yml` workflow (mirrors `cache-staging-deploy.yml` pattern)
- Enables `workflow_dispatch` with `commit_sha` input for deploying processor to staging
- Needed to test the server-side xcactivitylog processing PR (#9752) end-to-end

## Test plan
- [ ] Merge and trigger via `gh workflow run "Processor Staging Deploy" -f commit_sha=<sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)