### PR TITLE
fix(docs): install curl in swift container for mise-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -211,6 +211,8 @@ jobs:
         with:
           path: .build
           key: ${{ steps.spm-cache.outputs.cache-primary-key }}
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y curl
       - uses: jdx/mise-action@v2
       - name: Deploy to Cloudflare Pages
         env:


### PR DESCRIPTION
## Summary
- The `build-deploy-project-description` CI job runs in a `swift:6.2` Docker container that doesn't include `curl`
- The `jdx/mise-action@v2` step requires `curl` to download and install mise
- Adds `apt-get update && apt-get install -y curl` before the mise-action step

Fixes https://github.com/tuist/tuist/actions/runs/23013247396/job/66829452749

## Test plan
- [ ] Verify the `Build and deploy ProjectDescription docs` job passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)