### PR TITLE
fix(docs): scope mise to docs/ and add 1password-cli for deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Install system dependencies
         run: apt-get update && apt-get install -y curl
       - uses: jdx/mise-action@v2
+        with:
+          working_directory: docs
+      - uses: 1password/install-cli-action@v2
       - name: Deploy to Cloudflare Pages
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
## Summary
- Follows up on #9817 which added `curl` to the `swift:6.2` container
- Adds `working_directory: docs` to mise-action so it only installs node, pnpm, and wrangler from `docs/mise.toml` (with CDN URLs via `docs/mise.lock`) instead of the full root toolset which hits GitHub API rate limits
- Adds `1password/install-cli-action@v2` for the `op run` command in the deploy step

## Test plan
- [ ] Verify the `Build and deploy ProjectDescription docs` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)