### PR TITLE
fix(docs): run deploy step from docs/ so mise resolves npx

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -218,9 +218,10 @@ jobs:
           working_directory: docs
       - uses: 1password/install-cli-action@v2
       - name: Deploy to Cloudflare Pages
+        working-directory: docs
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           CLOUDFLARE_API_TOKEN: op://tuist/Cloudflare/CLOUDFLARE_API_TOKEN
           CLOUDFLARE_ACCOUNT_ID: op://tuist/Cloudflare/CLOUDFLARE_ACCOUNT_ID
         run: |
-          op run -- npx wrangler pages deploy --commit-hash ${{ github.sha }} --branch main --project-name tuist-projectdescription .build/documentation
+          op run -- npx wrangler pages deploy --commit-hash ${{ github.sha }} --branch main --project-name tuist-projectdescription ../.build/documentation


### PR DESCRIPTION
## Summary
- Follows up on #9820 — mise-action installs node via `docs/mise.toml`, but the deploy step ran from the repo root where mise can't resolve the `npx` shim
- Adds `working-directory: docs` to the deploy step and adjusts the path to `../.build/documentation`

## Test plan
- [ ] Verify the `Build and deploy ProjectDescription docs` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)