### PR TITLE
fix(server): exclude up_to_date tasks from Gradle Cache tab

### DIFF
--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -204,7 +204,11 @@ defmodule TuistWeb.GradleBuildLive do
     sort_order = params["cacheable-tasks-sort-order"] || "desc"
 
     flop_params = %{
-      filters: [%{field: :cacheable, op: :==, value: true}] ++ text_filters ++ dropdown_filters,
+      filters:
+        [
+          %{field: :cacheable, op: :==, value: true},
+          %{field: :outcome, op: :!=, value: "up_to_date"}
+        ] ++ text_filters ++ dropdown_filters,
       page: String.to_integer(params["cacheable-tasks-page"] || "1"),
       page_size: @table_page_size,
       order_by: [sort_by],

--- a/server/test/tuist_web/live/gradle_build_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_live_test.exs
@@ -165,6 +165,33 @@ defmodule TuistWeb.GradleBuildLiveTest do
     refute html =~ ":lib:test"
   end
 
+  test "gradle cache tab excludes up_to_date tasks", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    build_id =
+      GradleFixtures.build_fixture(
+        project_id: project.id,
+        inserted_at: @now,
+        tasks: [
+          %{task_path: ":app:compileKotlin", outcome: "executed", cacheable: true, duration_ms: 1000},
+          %{task_path: ":app:compileJava", outcome: "up_to_date", cacheable: true, duration_ms: 500},
+          %{task_path: ":app:assembleDebug", outcome: "local_hit", cacheable: true, duration_ms: 200}
+        ]
+      )
+
+    {:ok, _lv, html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs/#{build_id}?tab=gradle-cache"
+      )
+
+    assert html =~ ":app:compileKotlin"
+    assert html =~ ":app:assembleDebug"
+    refute html =~ ":app:compileJava"
+  end
+
   test "search event triggers filtering via form change", %{
     conn: conn,
     organization: organization,


### PR DESCRIPTION
## Summary
- The cacheable tasks table in the Gradle Cache tab was incorrectly showing tasks with `up_to_date` outcome
- Added a `outcome != "up_to_date"` filter to the cacheable tasks query, consistent with how `compute_task_counts/1` already excludes these tasks from `cacheable_tasks_count`
- Added a test verifying `up_to_date` tasks are excluded from the Gradle Cache tab

## Test plan
- [x] Existing tests pass (`mix test test/tuist_web/live/gradle_build_live_test.exs`)
- [x] New test verifies `up_to_date` cacheable tasks are excluded from the Gradle Cache tab table

🤖 Generated with [Claude Code](https://claude.com/claude-code)