### PR TITLE
feat(server): pre-built base image for faster Render preview builds

### DIFF
--- a/.github/workflows/server-preview-base-image.yml
+++ b/.github/workflows/server-preview-base-image.yml
@@ -1,0 +1,40 @@
+name: Server — Preview Base Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - server/Dockerfile.preview-base
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: Build preview base image
+    runs-on: namespace-profile-default-with-volume
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile.preview-base
+          push: true
+          tags: |
+            ghcr.io/tuist/tuist-preview-base:latest
+            ghcr.io/tuist/tuist-preview-base:${{ github.sha }}

--- a/render.yaml
+++ b/render.yaml
@@ -183,6 +183,10 @@ services:
         - server/**
         - tuist_common/**
     envVars:
+      - key: RUNNER_IMAGE
+        value: ghcr.io/tuist/tuist-preview-base:latest
+      - key: PREBUILT_RUNNER
+        value: true
       - key: MIX_ENV
         value: stag
       - key: TUIST_HOSTED

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,8 @@ ARG ELIXIR_VERSION=1.19.1
 ARG OTP_VERSION=28.1
 ARG DEBIAN_VERSION=bookworm-20251020-slim
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+# For preview environments, override with ghcr.io/tuist/tuist-preview-base:latest
+# to skip system package and ClickHouse installation (~7 min savings).
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 # ========================================
@@ -81,14 +83,21 @@ RUN mix release
 # ========================================
 # Stage 4: Final runtime image
 # ========================================
+# When RUNNER_IMAGE is the preview base (ghcr.io/tuist/tuist-preview-base:latest),
+# system packages, locale, and ClickHouse are already installed — the conditional
+# RUN steps below become no-ops, saving ~7 minutes on preview builds.
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && \
+ARG PREBUILT_RUNNER=false
+ARG EMBED_CLICKHOUSE=false
+
+RUN if [ "$PREBUILT_RUNNER" = "false" ]; then \
+  apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y curl build-essential gcc wget libvips libstdc++6 openssl libncurses5 locales ca-certificates postgresql-client zip unzip git \
-  && apt-get clean && rm -f /var/lib/apt/lists/*_*
-
-RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+  && apt-get clean && rm -f /var/lib/apt/lists/*_* && \
+  sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen; \
+  fi
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
@@ -99,7 +108,6 @@ RUN chown nobody /app
 
 ARG MIX_ENV=prod
 ARG TUIST_HOSTED=1
-ARG EMBED_CLICKHOUSE=false
 ENV MIX_ENV=$MIX_ENV
 ENV TUIST_HOSTED=$TUIST_HOSTED
 
@@ -116,9 +124,8 @@ RUN if [ "$TUIST_HOSTED" = "0" ]; then \
   rm -rf /app/priv/secrets/prod.yml.enc; \
   fi
 
-# Optionally embed ClickHouse for environments without a separate ClickHouse service
-# (e.g. preview environments). Set EMBED_CLICKHOUSE=true to enable.
-RUN if [ "$EMBED_CLICKHOUSE" = "true" ]; then \
+# Install ClickHouse only when not using the prebuilt runner (which has it already).
+RUN if [ "$PREBUILT_RUNNER" = "false" ] && [ "$EMBED_CLICKHOUSE" = "true" ]; then \
   echo "Installing embedded ClickHouse..."; \
   curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
   echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" > /etc/apt/sources.list.d/clickhouse.list && \
@@ -130,7 +137,7 @@ RUN if [ "$EMBED_CLICKHOUSE" = "true" ]; then \
   fi
 
 COPY server/clickhouse-preview-config.xml /tmp/clickhouse-preview-config.xml
-RUN if [ "$EMBED_CLICKHOUSE" = "true" ]; then \
+RUN if [ "$EMBED_CLICKHOUSE" = "true" ] || [ "$PREBUILT_RUNNER" = "true" ]; then \
   cp /tmp/clickhouse-preview-config.xml /etc/clickhouse-server/config.d/preview.xml; \
   fi && rm -f /tmp/clickhouse-preview-config.xml
 

--- a/server/Dockerfile.preview-base
+++ b/server/Dockerfile.preview-base
@@ -1,0 +1,22 @@
+ARG DEBIAN_VERSION=bookworm-20251020-slim
+FROM debian:${DEBIAN_VERSION}
+
+RUN apt-get update -y && \
+  apt-get upgrade -y && \
+  apt-get install -y curl build-essential gcc wget libvips libstdc++6 openssl libncurses5 locales ca-certificates postgresql-client zip unzip git \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+RUN echo "Installing embedded ClickHouse..." && \
+  curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" > /etc/apt/sources.list.d/clickhouse.list && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server clickhouse-client && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* && \
+  mkdir -p /var/lib/clickhouse/coordination/log /var/lib/clickhouse/coordination/snapshots && \
+  chown -R nobody:nogroup /var/lib/clickhouse /var/log/clickhouse-server /etc/clickhouse-server


### PR DESCRIPTION
## Summary
- Render doesn't share Docker layer cache across preview instances, so each PR preview rebuilds everything from scratch (~15 min)
- Adds a pre-built runner base image (`ghcr.io/tuist/tuist-preview-base`) containing system packages and ClickHouse
- Preview builds use this base image via `RUNNER_IMAGE` + `PREBUILT_RUNNER` build args, skipping ~7 min of apt-get and ClickHouse installation
- A GitHub Actions workflow rebuilds the base image on changes to `server/Dockerfile.preview-base`
- Non-preview builds (prod, staging, canary, self-hosted) are unaffected — they still use the default `debian:bookworm` base

## How it works
1. `server/Dockerfile.preview-base` → pushed to `ghcr.io/tuist/tuist-preview-base:latest` via CI
2. `render.yaml` preview section passes `RUNNER_IMAGE=ghcr.io/tuist/tuist-preview-base:latest` and `PREBUILT_RUNNER=true`
3. `server/Dockerfile` Stage 4 skips system package and ClickHouse install when `PREBUILT_RUNNER=true`

## Bootstrap
The base image needs to be built once before previews can use it. After merging, manually trigger the `Server — Preview Base Image` workflow via `workflow_dispatch`.

## Test plan
- [ ] Manually trigger `Server — Preview Base Image` workflow to build and push the base image
- [ ] Create a test PR touching `server/` and verify preview builds faster
- [ ] Verify non-preview deployments (staging, canary, prod) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)