### PR TITLE
fix(cli): correct SYMROOT path in cache warm builds

### DIFF
--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -355,7 +355,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
                 .xcarg("CODE_SIGNING_ALLOWED", "NO"),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
-                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
+                .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
             ]
             try await xcodeBuildController.build(
                 xcodebuildTarget,
@@ -417,7 +417,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_ALLOWED", "NO"),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .configuration(configuration),
-                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
+                .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
             ]
             // We currently skip building for maccatalyst as we prefer to generate a bundle for iOS instead.
             // iOS bundles should be compatible with maccatalyst ones
@@ -593,7 +593,7 @@ import XcodeGraph
                         .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                         .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                         .configuration(configuration),
-                        .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
+                        .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
                         // To prevent the rejection when publishing on the App Store
                         // https://developer.apple.com/library/archive/qa/qa1964/_index.html
                     ] + (isReleaseConfiguration ? [
@@ -639,7 +639,7 @@ import XcodeGraph
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                 .configuration(configuration),
-                .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
+                .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
                 // To prevent the rejection when publishing on the App Store
                 // https://developer.apple.com/library/archive/qa/qa1964/_index.html
             ] + (isReleaseConfiguration ? [
@@ -721,7 +721,7 @@ import XcodeGraph
                     .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                     .xcarg("COMPILER_INDEX_STORE_ENABLE", "NO"),
                     .configuration(configuration),
-                    .xcarg("SYMROOT", derivedDataPath.appending(component: "Build").pathString),
+                    .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
                 ] + (isReleaseConfiguration ? [
                     .xcarg("GCC_INSTRUMENT_PROGRAM_FLOW_ARCS", "NO"),
                     .xcarg("CLANG_ENABLE_CODE_COVERAGE", "NO"),


### PR DESCRIPTION
## Summary

Fixes the `tuist cache` CI job that has been failing since PR #9803 (`cc35dbc`) with:

```
xcodebuild -create-xcframework ... error: at least one framework or library must be specified
```

### Root Cause

PR #9803 added explicit `SYMROOT` overrides to prevent custom build location mismatches. However, it set SYMROOT to `derivedDataPath/Build` instead of `derivedDataPath/Build/Products`.

When `-derivedDataPath <path>` is used, xcodebuild internally sets SYMROOT to `<path>/Build/Products` so that `CONFIGURATION_BUILD_DIR` (`$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)`) resolves to `<path>/Build/Products/<config>/`.

By overriding SYMROOT to `<path>/Build` (missing `/Products`), build products landed at `<path>/Build/<config>/` while the artifact collection code looked in `<path>/Build/Products/<config>/` — finding nothing — so `xcodebuild -create-xcframework` was invoked with zero `-framework` arguments.

### Fix

Changed all 5 SYMROOT overrides from `derivedDataPath/Build` to `derivedDataPath/Build/Products`.

## Test plan

Built the `tuist` executable locally with the fix and ran `tuist cache` e2e. All 41 cacheable targets (including TuistCASAnalytics, which was failing in CI) were cached successfully as XCFrameworks:

```
Creating XCFramework for TuistCASAnalytics
...
41 targets stored: AEXML, CYaml, Colorizer, CryptoSwift, Gzip, Kanna, ...
All cacheable targets have been cached successfully as xcframeworks
```

- [x] `tuist cache` succeeds locally with the fix applied
- [ ] CI "Cache" job passes on `main` after merge (the Cache job only runs on the `main` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)