### PR TITLE
chore(server): drop build_runs_old and build_runs_new tables

### DIFF
--- a/server/priv/ingest_repo/migrations/20260314120000_drop_build_runs_old.exs
+++ b/server/priv/ingest_repo/migrations/20260314120000_drop_build_runs_old.exs
@@ -1,0 +1,16 @@
+defmodule Tuist.IngestRepo.Migrations.DropBuildRunsOld do
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    IngestRepo.query!("DROP TABLE IF EXISTS build_runs_old")
+    IngestRepo.query!("DROP TABLE IF EXISTS build_runs_new")
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- Drops leftover `build_runs_old` and `build_runs_new` tables from the ReplacingMergeTree conversion

## Test plan
- [ ] Verify no queries reference these tables
- [ ] Deploy after confirming build_runs is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)