### PR TITLE
fix(server): stabilize marketing counters

### DIFF
--- a/server/assets/marketing/css/shared/pages.css
+++ b/server/assets/marketing/css/shared/pages.css
@@ -3,6 +3,17 @@
   flex-direction: column;
   align-items: center;
 
+  & > [data-part="stats"] {
+    & [data-part="stat"] {
+      & > [data-part="value"] {
+        display: inline-block;
+        font-variant-numeric: tabular-nums;
+        font-feature-settings: "tnum";
+        white-space: nowrap;
+      }
+    }
+  }
+
   & > section,
   & > header:not(#marketing-navbar),
   & > figure {


### PR DESCRIPTION
## Summary
- apply tabular numerals to marketing counters animated with `CounterAnimation`
- keep the fix shared so it covers cache, build insights, test insights, flaky tests, and selective testing pages
- prevent digit width changes from making the animated values feel jittery

## Testing
- not run (CSS-only change)