### PR TITLE
feat(cli): publish CLI spec JSON as release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -562,7 +562,7 @@ jobs:
             mise.lock
             build/ProjectDescription.xcframework.zip
             build/tuist.zip
-            build/tuist.usage.json
+            build/tuist.spec.json
             build/SHASUMS256.txt
             build/SHASUMS512.txt
           retention-days: 1
@@ -1406,7 +1406,7 @@ jobs:
             build/SHASUMS256.txt
             build/SHASUMS512.txt
             build/ProjectDescription.xcframework.zip
-            build/tuist.usage.json
+            build/tuist.spec.json
 
       - name: Create App GitHub Release
         if: needs.check-releases.outputs.app-should-release == 'true' && needs.release-app.result == 'success'

--- a/docs/docs/en/contributors/releases.md
+++ b/docs/docs/en/contributors/releases.md
@@ -66,7 +66,7 @@ When releasable changes are detected:
 1. **Version calculation**: The pipeline determines the next version number
 2. **Changelog generation**: git cliff creates a changelog from commit messages
 3. **Build process**: The component is built and tested
-4. **Artifact generation**: Release-specific assets are produced, such as the CLI bundles, checksums, and the `tuist.usage.json` usage artifact generated from `tuist --experimental-dump-help`
+4. **Artifact generation**: Release-specific assets are produced, such as the CLI bundles, checksums, and the `tuist.spec.json` CLI specification generated from `tuist --experimental-dump-help`
 5. **Release creation**: A GitHub release is created with artifacts
 6. **Distribution**: Updates are pushed to package managers (e.g., Homebrew for CLI)
 
@@ -108,7 +108,7 @@ Users need to clear their cache after updating.
 
 The release workflow is defined in `.github/workflows/release.yml`.
 
-It coordinates the component-specific jobs for the CLI, app, server, cache, Gradle plugin, skills, and Noora releases. For the CLI, it also generates and publishes a `tuist.usage.json` artifact so downstream tooling can consume the command interface.
+It coordinates the component-specific jobs for the CLI, app, server, cache, Gradle plugin, skills, and Noora releases. For the CLI, it also generates and publishes a `tuist.spec.json` artifact so downstream tooling can consume the command interface.
 
 The workflow:
 - Runs on pushes to main

--- a/mise/tasks/cli/bundle.sh
+++ b/mise/tasks/cli/bundle.sh
@@ -153,10 +153,10 @@ echo "$(format_section "Bundling")"
     xcodebuild -create-xcframework -framework ProjectDescription.framework -output ProjectDescription.xcframework
     zip -q -r --symlinks ProjectDescription.xcframework.zip ProjectDescription.xcframework
 
-    echo "$(format_subsection "Generating tuist.usage.json")"
-    USAGE_TMP_DIR=$(mktemp -d)
-    ./tuist --experimental-dump-help --path "$USAGE_TMP_DIR" > tuist.usage.json
-    rm -rf "$USAGE_TMP_DIR"
+    echo "$(format_subsection "Generating tuist.spec.json")"
+    SPEC_TMP_DIR=$(mktemp -d)
+    ./tuist --experimental-dump-help --path "$SPEC_TMP_DIR" > tuist.spec.json
+    rm -rf "$SPEC_TMP_DIR"
 
     rm -rf tuist ProjectDescription.framework ProjectDescription.xcframework ProjectDescription.framework.dSYM Templates vendor
 


### PR DESCRIPTION
## Summary

Publishes a `tuist.spec.json` artifact as part of CLI releases. The file is the raw JSON output from `tuist --experimental-dump-help`, giving downstream tooling access to the full command interface without needing to run the binary.

## Validation

- Ran `tuist --experimental-dump-help` locally and confirmed valid JSON output
- `bash -n mise/tasks/cli/bundle.sh`