### PR TITLE
fix(server): coerce cpu_usage_percent to float for ClickHouse

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -224,7 +224,7 @@ defmodule Tuist.Builds do
         %{
           build_run_id: build.id,
           timestamp: metric.timestamp,
-          cpu_usage_percent: metric.cpu_usage_percent,
+          cpu_usage_percent: metric.cpu_usage_percent / 1,
           memory_used_bytes: metric.memory_used_bytes,
           memory_total_bytes: metric.memory_total_bytes,
           network_bytes_in: metric.network_bytes_in,

--- a/server/lib/tuist/gradle.ex
+++ b/server/lib/tuist/gradle.ex
@@ -106,7 +106,7 @@ defmodule Tuist.Gradle do
         %{
           gradle_build_id: build_id,
           timestamp: metric.timestamp,
-          cpu_usage_percent: metric.cpu_usage_percent,
+          cpu_usage_percent: metric.cpu_usage_percent / 1,
           memory_used_bytes: metric.memory_used_bytes,
           memory_total_bytes: metric.memory_total_bytes,
           network_bytes_in: metric.network_bytes_in,


### PR DESCRIPTION
## Summary
- ClickHouse `Float32` columns reject integer values (e.g. `100`), causing `Ecto.ChangeError` during `insert_all` for machine metrics
- Uses Elixir's `/` operator which always returns a float (`100 / 1` → `100.0`)
- Fixes both Xcode builds (`builds.ex`) and Gradle builds (`gradle.ex`)

## Test plan
- [ ] Deploy to production and verify builds with `cpu_usage_percent: 100` no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)