### PR TITLE
fix(server): preserve flaky flag for quarantined test cases

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1722,6 +1722,7 @@ defmodule Tuist.Tests do
       from(test_case in TestCase,
         hints: ["FINAL"],
         where: test_case.is_flaky == true,
+        where: test_case.is_quarantined == false,
         where: test_case.id not in subquery(recent_flaky_subquery)
       )
 

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -4647,6 +4647,27 @@ defmodule Tuist.TestsTest do
       {:ok, fetched_test_case} = Tests.get_test_case_by_id(non_flaky_test_case_id)
       assert fetched_test_case.is_flaky == false
     end
+
+    test "does not clear flaky flag for quarantined test cases" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = Ecto.UUID.generate()
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          id: test_case_id,
+          project_id: project.id,
+          is_flaky: true,
+          is_quarantined: true
+        )
+
+      IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+
+      {:ok, _count} = Tests.clear_stale_flaky_flags()
+
+      {:ok, fetched_test_case} = Tests.get_test_case_by_id(test_case_id)
+      assert fetched_test_case.is_flaky == true
+      assert fetched_test_case.is_quarantined == true
+    end
   end
 
   describe "is_new detection for test case runs" do


### PR DESCRIPTION
## Summary
- Quarantined tests aren't being run, so they never have recent flaky occurrences
- The `clear_stale_flaky_flags` worker was incorrectly unmarking them after 14 days of no flaky runs
- Added `where: test_case.is_quarantined == false` to exclude quarantined tests from the cleanup query

## Test plan
- [x] Added test: "does not clear flaky flag for quarantined test cases"
- [ ] Verify existing `clear_stale_flaky_flags` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)