### PR TITLE
fix(server): dispatch PubSub build events by project type

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -92,7 +92,7 @@ defmodule Tuist.Builds do
         Tuist.PubSub.broadcast(
           build,
           "#{project.account.name}/#{project.name}",
-          :build_created
+          :xcode_build_created
         )
       end
 

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -123,7 +123,7 @@ defmodule TuistWeb.BuildRunLive do
   end
 
   @impl true
-  def handle_info({:build_created, build}, socket) do
+  def handle_info({:xcode_build_created, build}, socket) do
     if build.id == socket.assigns.run.id do
       run =
         build.id

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -92,7 +92,9 @@
           <:icon_left><.download /></:icon_left>
         </.button>
         <.button
-          :if={@run.status != "processing" && @has_build_download.ok? && @has_build_download.result}
+          :if={
+            @run.status != "processing" && @has_build_download.ok? && @has_build_download.result
+          }
           href={
             ~p"/#{@selected_project.account.name}/#{@selected_project.name}/builds/build-runs/#{@run.id}/download"
           }

--- a/server/lib/tuist_web/live/build_runs_live.ex
+++ b/server/lib/tuist_web/live/build_runs_live.ex
@@ -40,7 +40,7 @@ defmodule TuistWeb.BuildRunsLive do
     end
   end
 
-  def handle_info({:build_created, _build}, socket) do
+  def handle_info({:xcode_build_created, _build}, socket) do
     {:noreply, TuistWeb.XcodeBuildRunsLive.handle_info_build_created(socket)}
   end
 

--- a/server/lib/tuist_web/live/builds_live.ex
+++ b/server/lib/tuist_web/live/builds_live.ex
@@ -46,20 +46,12 @@ defmodule TuistWeb.BuildsLive do
     end
   end
 
-  def handle_info({:build_created, _build}, socket) do
-    {:noreply, TuistWeb.XcodeBuildsLive.handle_info_build_created(socket)}
+  def handle_info({:xcode_build_created, _build}, socket) do
+    TuistWeb.XcodeBuildsLive.handle_info({:xcode_build_created, nil}, socket)
   end
 
   def handle_info({:gradle_build_created, _build}, socket) do
-    if Query.has_pagination_params?(socket.assigns.uri.query) do
-      {:noreply, socket}
-    else
-      {:noreply,
-       socket
-       |> TuistWeb.GradleBuildsLive.assign_handle_params(socket.assigns.current_params)
-       |> TuistWeb.GradleBuildsLive.assign_configuration_insights_options(socket.assigns.current_params)
-       |> TuistWeb.GradleBuildsLive.assign_initial_configuration_insights()}
-    end
+    TuistWeb.GradleBuildsLive.handle_info({:gradle_build_created, nil}, socket)
   end
 
   def handle_info(_event, socket) do

--- a/server/lib/tuist_web/live/gradle_builds_live.ex
+++ b/server/lib/tuist_web/live/gradle_builds_live.ex
@@ -23,6 +23,20 @@ defmodule TuistWeb.GradleBuildsLive do
     |> assign_recent_builds()
   end
 
+  def handle_info({:gradle_build_created, _build}, socket) do
+    if Query.has_pagination_params?(socket.assigns.uri.query) do
+      {:noreply, socket}
+    else
+      {:noreply,
+       socket
+       |> assign_handle_params(socket.assigns.current_params)
+       |> assign_configuration_insights_options(socket.assigns.current_params)
+       |> assign_initial_configuration_insights()}
+    end
+  end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
+
   def handle_event("select_widget", %{"widget" => widget}, socket) do
     query = Query.put(socket.assigns.uri.query, "analytics-selected-widget", widget)
     uri = URI.new!("?" <> query)

--- a/server/lib/tuist_web/live/xcode_builds_live.ex
+++ b/server/lib/tuist_web/live/xcode_builds_live.ex
@@ -44,13 +44,15 @@ defmodule TuistWeb.XcodeBuildsLive do
     |> assign_recent_builds()
   end
 
-  def handle_info_build_created(socket) do
+  def handle_info({:xcode_build_created, _build}, socket) do
     if Query.has_pagination_params?(socket.assigns.uri.query) do
-      socket
+      {:noreply, socket}
     else
-      socket |> assign_analytics(socket.assigns.current_params) |> assign_recent_builds()
+      {:noreply, socket |> assign_analytics(socket.assigns.current_params) |> assign_recent_builds()}
     end
   end
+
+  def handle_info(_event, socket), do: {:noreply, socket}
 
   def handle_event("select_widget", %{"widget" => widget}, socket) do
     query = Query.put(socket.assigns.uri.query, "analytics-selected-widget", widget)

--- a/server/lib/tuist_web/live/xcode_cache_live.ex
+++ b/server/lib/tuist_web/live/xcode_cache_live.ex
@@ -103,7 +103,7 @@ defmodule TuistWeb.XcodeCacheLive do
     {:noreply, push_patch(socket, to: "/#{selected_account.name}/#{selected_project.name}/xcode-cache?#{query_params}")}
   end
 
-  def handle_info({:build_created, _build}, socket) do
+  def handle_info({:xcode_build_created, _build}, socket) do
     # Only update when pagination is inactive
     if Query.has_pagination_params?(socket.assigns.uri.query) do
       {:noreply, socket}


### PR DESCRIPTION
## Summary

Fixes TUIST-8C

- Guard `handle_info` PubSub handlers in `BuildsLive` by project type so `:build_created` events are ignored for Gradle projects and `:gradle_build_created` events are ignored for Xcode projects
- Move PubSub handling logic from `BuildsLive` into `XcodeBuildsLive.handle_info_build_created/1` and `GradleBuildsLive.handle_info_build_created/1` so each module owns its own refresh behavior
- Both handlers now return `{:noreply, socket}` tuples directly, making the delegation from `BuildsLive` a clean pass-through

## Root Cause

When a `:build_created` PubSub event arrived for a Gradle project, `BuildsLive` unconditionally delegated to `XcodeBuildsLive.handle_info_build_created/1`, which calls `assign_async` with keys `[:recent_builds, :recent_builds_chart_data, :successful_builds_count, :failed_builds_count]`. This overwrote the Gradle template's plain assigns with `AsyncResult` structs, causing `Protocol.UndefinedError: protocol Enumerable not implemented for Phoenix.LiveView.AsyncResult` when the Gradle template tried to enumerate `@recent_builds_chart_data`.