### PR TITLE
fix(server): add alter_sync = 2 to flaky projection migration

### DIFF
--- a/server/priv/ingest_repo/migrations/20260316120000_add_ran_at_to_flaky_projection.exs
+++ b/server/priv/ingest_repo/migrations/20260316120000_add_ran_at_to_flaky_projection.exs
@@ -13,29 +13,31 @@ defmodule Tuist.IngestRepo.Migrations.AddRanAtToFlakyProjection do
 
   def up do
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky"
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky SETTINGS alter_sync = 2"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE test_case_runs
-    ADD PROJECTION proj_by_project_flaky (
+    ADD PROJECTION IF NOT EXISTS proj_by_project_flaky (
       SELECT id, project_id, is_flaky, is_ci, test_case_id, test_run_id, ran_at, inserted_at
       ORDER BY project_id, is_flaky, test_case_id, inserted_at
     )
+    SETTINGS alter_sync = 2
     """
   end
 
   def down do
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
-    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky"
+    execute "ALTER TABLE test_case_runs DROP PROJECTION IF EXISTS proj_by_project_flaky SETTINGS alter_sync = 2"
 
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE test_case_runs
-    ADD PROJECTION proj_by_project_flaky (
+    ADD PROJECTION IF NOT EXISTS proj_by_project_flaky (
       SELECT id, project_id, is_flaky, test_case_id, test_run_id, inserted_at
       ORDER BY project_id, is_flaky, test_case_id, inserted_at
     )
+    SETTINGS alter_sync = 2
     """
   end
 end


### PR DESCRIPTION
## Summary
- Adds `SETTINGS alter_sync = 2` to the DROP and ADD projection statements in the flaky projection migration
- Adds `IF NOT EXISTS` to the ADD PROJECTION statement
- Fixes canary deploy failure: `NO_SUCH_PROJECTION_IN_TABLE` caused by the ADD not fully propagating before MATERIALIZE runs

## Test plan
- [x] Follows the same pattern as recent projection migrations (e.g., `20260303100000`, `20260310120001`)
- [ ] Deploy to canary and verify migration succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)