### PR TITLE
docs(cli): suggest using `tuist xcodebuild` when building for previews

### DIFF
--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -30,25 +30,25 @@ When building for device, it is currently your responsibility to ensure the app 
 ::: code-group
 ```bash [Tuist Project (Debug)]
 tuist generate App
-xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -sdk iphonesimulator # Build the app for the simulator
-xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -sdk iphonesimulator # Build the app for the simulator
+tuist xcodebuild build -scheme App -workspace App.xcworkspace -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App
 ```
 ```bash [Tuist Project (Release)]
 tuist generate App
-xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -sdk iphonesimulator # Build the app for the simulator
-xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -sdk iphonesimulator # Build the app for the simulator
+tuist xcodebuild build -scheme App -workspace App.xcworkspace -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Release
 ```
 ```bash [Xcode Project (Debug)]
-xcodebuild -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
-xcodebuild -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
+tuist xcodebuild -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Debug --platforms iOS
 tuist share App.ipa # Share an existing .ipa file
 ```
 ```bash [Xcode Project (Release)]
-xcodebuild -scheme App -project App.xcodeproj -configuration Release # Build the app for the simulator
-xcodebuild -scheme App -project App.xcodeproj -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild -scheme App -project App.xcodeproj -configuration Release # Build the app for the simulator
+tuist xcodebuild -scheme App -project App.xcodeproj -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Release --platforms iOS
 tuist share App.ipa # Share an existing .ipa file
 ```


### PR DESCRIPTION
Resolves <https://tuist-community.slack.com/archives/C018QG7U7SN/p1773414223346729>

I noticed that the deprecation notice of the `tuist build` suggests using `tuist xcodebuild build ...` and saw that the docs for the Previews feature only suggests using `xcodebuild build ...`. It's better to use the `tuist xcodebuild build ...` to get the analytics automatically.

### How to test locally

`mise run dev` and navigate to the previews page.
