### PR TITLE
docs(cli): add missing `build` after the `tuist xcodebuild`

### DIFF
--- a/docs/docs/en/guides/features/previews.md
+++ b/docs/docs/en/guides/features/previews.md
@@ -41,14 +41,14 @@ tuist xcodebuild build -scheme App -workspace App.xcworkspace -configuration Rel
 tuist share App --configuration Release
 ```
 ```bash [Xcode Project (Debug)]
-tuist xcodebuild -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
-tuist xcodebuild -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild build -scheme App -project App.xcodeproj -configuration Debug # Build the app for the simulator
+tuist xcodebuild build -scheme App -project App.xcodeproj -configuration Debug -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Debug --platforms iOS
 tuist share App.ipa # Share an existing .ipa file
 ```
 ```bash [Xcode Project (Release)]
-tuist xcodebuild -scheme App -project App.xcodeproj -configuration Release # Build the app for the simulator
-tuist xcodebuild -scheme App -project App.xcodeproj -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
+tuist xcodebuild build -scheme App -project App.xcodeproj -configuration Release # Build the app for the simulator
+tuist xcodebuild build -scheme App -project App.xcodeproj -configuration Release -destination 'generic/platform=iOS' # Build the app for the device
 tuist share App --configuration Release --platforms iOS
 tuist share App.ipa # Share an existing .ipa file
 ```


### PR DESCRIPTION
Fixing the [comments from copilot](https://github.com/tuist/tuist/pull/9860#discussion_r2940760868) in [this PR](https://github.com/tuist/tuist/pull/9860).

When using `tuist xcodebuild`, we have to provide an explicit xcodebuild action (in this case `build`).

### How to test locally

`mise run dev` and navigate to the previews page.
