### PR TITLE
fix(cli): warm up mock invocation tracking before concurrent access in test

### DIFF
--- a/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
@@ -611,6 +611,29 @@ struct InspectResultBundleServiceTests {
             )
             .willReturn()
 
+        // Warm up mock invocation tracking to avoid lazy var race conditions
+        // when the mock is first accessed from concurrent tasks.
+        verify(createTestCaseRunAttachmentService)
+            .createAttachment(
+                fullHandle: .any,
+                serverURL: .any,
+                testCaseRunId: .any,
+                fileName: .any,
+                filePath: .any,
+                repetitionNumber: .any
+            )
+            .called(0)
+
+        verify(createCrashReportService)
+            .createCrashReport(
+                fullHandle: .any,
+                serverURL: .any,
+                crashReport: .any,
+                testCaseRunId: .any,
+                testCaseRunAttachmentId: .any
+            )
+            .called(0)
+
         // When
         _ = try await subject.inspectResultBundle(
             resultBundlePath: resultBundlePath,


### PR DESCRIPTION
Automated flaky test fix generated by Flaky Fix Runner.\n\nThis PR addresses flaky test case f22b1775-30c5-431e-8e13-2bae243e331f.