### PR TITLE
fix(server): avoid GitHub API rate limits when installing Render CLI

### DIFF
--- a/.github/workflows/server-canary-deployment.yml
+++ b/.github/workflows/server-canary-deployment.yml
@@ -55,7 +55,5 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
       - name: Trigger canary deploy with Render CLI
-        env:
-          MISE_GITHUB_ATTESTATIONS: 0
         run: |
-          mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"
+          mise exec -- cli_v2.6.1 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -61,10 +61,8 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
       - name: Trigger canary deploy with Render CLI
-        env:
-          MISE_GITHUB_ATTESTATIONS: 0
         run: |
-          mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"
+          mise exec -- cli_v2.6.1 deploys create srv-d35uiopr0fns73bfve00 --output json --confirm --wait --commit "$GITHUB_SHA"
   acceptance-tests:
     name: Acceptance Tests
     runs-on: namespace-profile-default-macos
@@ -132,10 +130,8 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
       - name: Trigger production deploy with Render CLI
-        env:
-          MISE_GITHUB_ATTESTATIONS: 0
         run: |
-          mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
+          mise exec -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
   production-hotfix:
     environment: server-production
     name: Hotfix Production Deployment
@@ -167,7 +163,5 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
       - name: Trigger production deploy with Render CLI
-        env:
-          MISE_GITHUB_ATTESTATIONS: 0
         run: |
-          mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"
+          mise exec -- cli_v2.6.1 deploys create srv-d35an4ggjchc73evd8m0 --output json --confirm --wait --commit "$GITHUB_SHA"

--- a/.github/workflows/server-staging-deployment.yml
+++ b/.github/workflows/server-staging-deployment.yml
@@ -46,8 +46,6 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           sed -i 's/version: "[^"]*"/version: "'$VERSION'"/' mix.exs
-      - name: Trigger canary deploy with Render CLI
-        env:
-          MISE_GITHUB_ATTESTATIONS: 0
+      - name: Trigger staging deploy with Render CLI
         run: |
-          mise exec "github:render-oss/cli@2.6.1" -- cli_v2.6.1 deploys create srv-d35uk7pr0fns73bg0gq0 --output json --confirm --wait --commit "$GITHUB_SHA"
+          mise exec -- cli_v2.6.1 deploys create srv-d35uk7pr0fns73bg0gq0 --output json --confirm --wait --commit "$GITHUB_SHA"

--- a/mise.lock
+++ b/mise.lock
@@ -51,6 +51,13 @@ backend = "aqua:orhun/git-cliff"
 "platforms.macos-x64" = { checksum = "sha512:0b6e4f4683f372bfb484d81e2e6ae4a305f571bfc9ddb63a618dae92346d3f91102a2e8eb7becca8937ed6d72b1df3f795e1f9e5b871704fa28f580e2ac6976c", url = "https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-apple-darwin.tar.gz"}
 "platforms.windows-x64" = { url = "https://github.com/orhun/git-cliff/releases/download/v2.6.0/git-cliff-2.6.0-x86_64-pc-windows-msvc.zip"}
 
+[[tools."github:render-oss/cli"]]
+version = "2.6.1"
+backend = "github:render-oss/cli"
+"platforms.linux-x64" = { checksum = "sha256:84a0085a9408f35daa23aed9aadcf9a01b2e39d0d0250ca4dc564283d1f8f6c2", url = "https://github.com/render-oss/cli/releases/download/v2.6.1/cli_2.6.1_linux_amd64.zip", url_api = "https://api.github.com/repos/render-oss/cli/releases/assets/326532423"}
+"platforms.linux-x64-musl" = { checksum = "sha256:84a0085a9408f35daa23aed9aadcf9a01b2e39d0d0250ca4dc564283d1f8f6c2", url = "https://github.com/render-oss/cli/releases/download/v2.6.1/cli_2.6.1_linux_amd64.zip", url_api = "https://api.github.com/repos/render-oss/cli/releases/assets/326532423"}
+"platforms.macos-arm64" = { checksum = "sha256:3766bf821cbff2509bc671a9e1dc37bccd92440eb74775fe0ad9dfe47c39a84b", url = "https://github.com/render-oss/cli/releases/download/v2.6.1/cli_2.6.1_darwin_arm64.zip", url_api = "https://api.github.com/repos/render-oss/cli/releases/assets/326532431"}
+
 [[tools.gradle]]
 version = "8.12.1"
 backend = "aqua:gradle/gradle"

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@
     age = "1.2.1"
     protoc = "32.1"
     "1password-cli" = "2.32.0"
+    "github:render-oss/cli" = "2.6.1"
     bats = "1.11.1"
     java = "21"
     gradle = "8.12"


### PR DESCRIPTION
## Summary
- Adds `render-oss/cli` to `mise.toml` so it's managed as a locked tool with pinned CDN URLs and checksums in `mise.lock`
- Replaces ad-hoc `mise exec "github:render-oss/cli@2.6.1"` calls in deployment workflows with `mise exec -- cli_v2.6.1`, which uses the locked URLs
- Removes `MISE_GITHUB_ATTESTATIONS: 0` env vars that were workarounds for the same issue

This fixes the 403 rate limit errors during deployment ([failed run](https://github.com/tuist/tuist/actions/runs/23150572534/job/67250925182#step:8:20)) caused by mise hitting the GitHub API to resolve release assets.

## Test plan
- [ ] Trigger a canary deployment and verify the Render CLI installs without API rate limit errors
- [ ] Verify deployment completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)