### PR TITLE
fix(ci): remove New Contributors from git-cliff to avoid GitHub API rate limits

### DIFF
--- a/app/cliff.toml
+++ b/app/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/cache/cliff.toml
+++ b/cache/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/cli/cliff.toml
+++ b/cli/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/gradle/cliff.toml
+++ b/gradle/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/noora/cliff.toml
+++ b/noora/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/server/cliff.toml
+++ b/server/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}

--- a/skills/cliff.toml
+++ b/skills/cliff.toml
@@ -38,19 +38,6 @@ body = """
 {%- endfor -%}
 {% endfor %}
 
-{%- if github -%}
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-  {% raw %}\n{% endraw -%}
-  ## New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-  * [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution
-    {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-    {%- endif %}
-{%- endfor -%}
-{%- endif -%}
-
 {% if version %}
     {% if previous.version %}
       **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}


### PR DESCRIPTION
## Summary
- Remove the "New Contributors" section from all 7 `cliff.toml` files (cli, server, cache, app, gradle, skills, noora)
- GitHub Support confirmed that git-cliff's `is_first_time` contributor calculation fetches **all commits** from the repository, which exhausts our GitHub API rate limits
- Per-commit metadata (PR title, author, PR number) is preserved — only the expensive all-history contributor lookup is removed

## Context
GitHub Support response:
> Reviewing the API usage for tuist/tuist, we notice a lot of requests are generated by git-cliff. We're aware that this tool has a longstanding issue with the "new contributors" calculation which requires fetching all commits from the repository.

## Test plan
- [ ] Verify release workflow still generates changelogs correctly (just without the "New Contributors" section)
- [ ] Monitor GitHub API rate limit usage after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)