### PR TITLE
fix(server): handle unmatched events in SSOSettingsLive

### DIFF
--- a/server/lib/tuist_web/live/sso_settings_live.ex
+++ b/server/lib/tuist_web/live/sso_settings_live.ex
@@ -68,12 +68,20 @@ defmodule TuistWeb.SSOSettingsLive do
     |> then(&{:noreply, &1})
   end
 
+  def handle_event("select_provider", _params, socket) do
+    {:noreply, socket}
+  end
+
   def handle_event("validate_sso", %{"sso" => form_params}, socket) do
     socket
     |> assign(current_form_params: form_params)
     |> compute_form_valid()
     |> compute_has_changes()
     |> then(&{:noreply, &1})
+  end
+
+  def handle_event("validate_sso", _params, socket) do
+    {:noreply, socket}
   end
 
   def handle_event("save_sso", _params, %{assigns: %{sso_enabled: false}} = socket) do

--- a/server/test/tuist_web/live/sso_settings_live_test.exs
+++ b/server/test/tuist_web/live/sso_settings_live_test.exs
@@ -287,6 +287,23 @@ defmodule TuistWeb.SSOSettingsLiveTest do
     end
   end
 
+  test "handles validate_sso event without sso params", %{conn: conn, account: account} do
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/sso")
+
+    html = render_hook(lv, "validate_sso", %{})
+
+    assert html =~ "Single Sign-On"
+  end
+
+  test "handles select_provider event with empty value", %{conn: conn, account: account} do
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/sso")
+
+    render_hook(lv, "toggle_sso")
+    html = render_hook(lv, "select_provider", %{"value" => []})
+
+    assert html =~ "Single Sign-On"
+  end
+
   describe "disable SSO" do
     test "disables Google SSO", %{conn: conn, user: user} do
       %{account: google_account} =


### PR DESCRIPTION
## Summary
- Fixes `FunctionClauseError` in `TuistWeb.SSOSettingsLive.handle_event/3` (TUIST-67, 64 occurrences since March 2)
- Adds catch-all clauses for `validate_sso` (params missing `"sso"` key when SSO inputs are hidden) and `select_provider` (empty value array from Zag.js select)

## Test plan
- [x] Added test for `validate_sso` event without `"sso"` params
- [x] Added test for `select_provider` event with empty value
- [x] All 22 existing SSO settings tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)