### PR TITLE
fix(processor): limit concurrent file reads to prevent emfile errors

### DIFF
--- a/processor/config/deploy.yml
+++ b/processor/config/deploy.yml
@@ -8,6 +8,7 @@ servers:
       publish: 4002:4002
       health-cmd: "curl -f http://localhost:4002/health || exit 1"
       health-interval: 10s
+      ulimit: "nofile=65536:65536"
 
 ssh:
   user: github-actions

--- a/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/Array+ConcurrentMap.swift
+++ b/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/Array+ConcurrentMap.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+extension Array where Element: Sendable {
+    func concurrentMap<B: Sendable>(
+        maxConcurrentTasks: Int,
+        _ transform: @Sendable @escaping (Element) async throws -> B
+    ) async throws -> [B] {
+        try await withThrowingTaskGroup(
+            of: B.self,
+            returning: [B].self
+        ) { group in
+            var results: [B] = []
+            for (index, element) in enumerated() {
+                if index >= maxConcurrentTasks {
+                    if let result = try await group.next() {
+                        results.append(result)
+                    }
+                }
+                group.addTask {
+                    try await transform(element)
+                }
+            }
+
+            for try await result in group {
+                results.append(result)
+            }
+
+            return results
+        }
+    }
+
+    func concurrentCompactMap<B: Sendable>(
+        maxConcurrentTasks: Int,
+        _ transform: @Sendable @escaping (Element) async throws -> B?
+    ) async throws -> [B] {
+        try await withThrowingTaskGroup(
+            of: B?.self,
+            returning: [B].self
+        ) { group in
+            var results: [B] = []
+            for (index, element) in enumerated() {
+                if index >= maxConcurrentTasks {
+                    if let result = try await group.next() {
+                        if let value = result {
+                            results.append(value)
+                        }
+                    }
+                }
+                group.addTask {
+                    try await transform(element)
+                }
+            }
+
+            for try await result in group {
+                if let value = result {
+                    results.append(value)
+                }
+            }
+
+            return results
+        }
+    }
+}

--- a/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -48,11 +48,11 @@ public struct XCActivityLogParser: Sendable {
 
         let casReader = CASMetadataReader(casMetadataPath: casMetadataPath)
 
-        let cacheableTasks = await analyzeCacheableTasks(
+        let cacheableTasks = try await analyzeCacheableTasks(
             buildSteps: steps,
             casReader: casReader
         )
-        let casOutputs = await analyzeCASOutputs(
+        let casOutputs = try await analyzeCASOutputs(
             from: steps,
             casReader: casReader
         )
@@ -241,7 +241,7 @@ public struct XCActivityLogParser: Sendable {
     private func analyzeCacheableTasks(
         buildSteps: [BuildStep],
         casReader: CASMetadataReader
-    ) async -> [CacheableTask] {
+    ) async throws -> [CacheableTask] {
         var keyStatuses = [String: (taskType: String, hasQuery: Bool, hasMaterialize: Bool, hasUpload: Bool, isMiss: Bool)]()
         var keyDescriptions = [String: String]()
         var keyNodeIDs = [String: Set<String>]()
@@ -290,47 +290,35 @@ public struct XCActivityLogParser: Sendable {
         let descriptions = keyDescriptions
         let nodeIDs = keyNodeIDs
 
-        return await withTaskGroup(of: CacheableTask.self, returning: [CacheableTask].self) { group in
-            for (key, status) in keyStatuses {
-                let description = descriptions[key]
-                let casOutputNodeIDs = Array(nodeIDs[key] ?? [])
-                group.addTask {
-                    let cacheStatus: String
-                    if status.isMiss { cacheStatus = "miss" }
-                    else if status.hasQuery { cacheStatus = "hit_remote" }
-                    else { cacheStatus = "hit_local" }
+        return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 50) { (key, status) in
+            let cacheStatus: String
+            if status.isMiss { cacheStatus = "miss" }
+            else if status.hasQuery { cacheStatus = "hit_remote" }
+            else { cacheStatus = "hit_local" }
 
-                    let readDuration: Double?
-                    if cacheStatus == "hit_remote" || cacheStatus == "miss" {
-                        readDuration = await casReader.readKeyValueMetadata(key: key, operationType: "read")?.duration
-                    } else {
-                        readDuration = nil
-                    }
-
-                    let writeDuration: Double?
-                    if status.hasUpload {
-                        writeDuration = await casReader.readKeyValueMetadata(key: key, operationType: "write")?.duration
-                    } else {
-                        writeDuration = nil
-                    }
-
-                    return CacheableTask(
-                        type: status.taskType,
-                        status: cacheStatus,
-                        key: key,
-                        read_duration: readDuration,
-                        write_duration: writeDuration,
-                        description: description,
-                        cas_output_node_ids: casOutputNodeIDs
-                    )
-                }
+            let readDuration: Double?
+            if cacheStatus == "hit_remote" || cacheStatus == "miss" {
+                readDuration = await casReader.readKeyValueMetadata(key: key, operationType: "read")?.duration
+            } else {
+                readDuration = nil
             }
 
-            var results = [CacheableTask]()
-            for await task in group {
-                results.append(task)
+            let writeDuration: Double?
+            if status.hasUpload {
+                writeDuration = await casReader.readKeyValueMetadata(key: key, operationType: "write")?.duration
+            } else {
+                writeDuration = nil
             }
-            return results
+
+            return CacheableTask(
+                type: status.taskType,
+                status: cacheStatus,
+                key: key,
+                read_duration: readDuration,
+                write_duration: writeDuration,
+                description: descriptions[key],
+                cas_output_node_ids: Array(nodeIDs[key] ?? [])
+            )
         }
     }
 
@@ -339,7 +327,7 @@ public struct XCActivityLogParser: Sendable {
     private func analyzeCASOutputs(
         from buildSteps: [BuildStep],
         casReader: CASMetadataReader
-    ) async -> [CASOutput] {
+    ) async throws -> [CASOutput] {
         var downloads = [(nodeID: String, type: String)]()
         var uploads = [(nodeID: String, type: String)]()
 
@@ -377,23 +365,12 @@ public struct XCActivityLogParser: Sendable {
             uniqueUploads.append(meta)
         }
 
-        return await withTaskGroup(of: CASOutput?.self, returning: [CASOutput].self) { group in
-            for meta in uniqueDownloads {
-                group.addTask {
-                    await createCASOutput(nodeID: meta.nodeID, type: meta.type, operation: "download", casReader: casReader)
-                }
-            }
-            for meta in uniqueUploads {
-                group.addTask {
-                    await createCASOutput(nodeID: meta.nodeID, type: meta.type, operation: "upload", casReader: casReader)
-                }
-            }
+        let allItems: [(nodeID: String, type: String, operation: String)] =
+            uniqueDownloads.map { ($0.nodeID, $0.type, "download") } +
+            uniqueUploads.map { ($0.nodeID, $0.type, "upload") }
 
-            var results = [CASOutput]()
-            for await output in group {
-                if let output { results.append(output) }
-            }
-            return results
+        return try await allItems.concurrentCompactMap(maxConcurrentTasks: 50) { item in
+            await createCASOutput(nodeID: item.nodeID, type: item.type, operation: item.operation, casReader: casReader)
         }
     }
 


### PR DESCRIPTION
## Summary
- Cap CAS metadata task group concurrency to 50 in `analyzeCacheableTasks` and `analyzeCASOutputs` using a `concurrentMap`/`concurrentCompactMap` helper (same pattern as the CLI's `Array+ExecutionContext`)
- Bump container `nofile` ulimit from default (~1024) to 65536

## Context
Sentry issue [PROCESSOR-1](https://tuist.sentry.io/issues/PROCESSOR-1): `MatchError` on `{:error, :emfile}` from `:zip.unzip`. The root cause is unbounded `withTaskGroup` concurrency in the NIF's CAS metadata analysis — for large builds with hundreds of cache keys/CAS outputs, every key spawned a concurrent task reading files from disk, exhausting file descriptors.

## Test plan
- [x] All 12 Swift NIF tests pass
- [x] All 7 Elixir processor tests pass
- [ ] Deploy to staging and process a large build to verify no `:emfile` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)