### PR TITLE
chore(server): reduce Render preview environment cost

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -180,10 +180,11 @@ services:
     repo: https://github.com/tuist/tuist
     dockerfilePath: server/Dockerfile
     dockerCommand: /app/bin/start-preview
-    plan: standard
+    plan: starter
     numInstances: 1
     previews:
       generation: manual
+      expireAfterDays: 1
     buildFilter:
       paths:
         - server/**


### PR DESCRIPTION
## Summary
- Downgrade preview instances from `standard` to `starter` plan
- Add `expireAfterDays: 1` so previews are automatically deleted 1 day after last deploy, preventing them from running for weeks (~$158/PR)

## Test plan
- [ ] Verify next preview environment spins up on starter plan
- [ ] Verify preview is auto-deleted ~1 day after last deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)