### PR TITLE
chore(server): add top-level expireAfterDays for Render previews

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,8 @@
 version: "1"
 
+previews:
+  expireAfterDays: 1
+
 services:
   - &server-base
     type: web
@@ -184,7 +187,6 @@ services:
     numInstances: 1
     previews:
       generation: manual
-      expireAfterDays: 1
     buildFilter:
       paths:
         - server/**


### PR DESCRIPTION
## Summary
- Move `expireAfterDays: 1` to the top-level `previews` key where Render expects it (was incorrectly placed under the service-level `previews` block)
- This auto-deletes preview environments after 1 day of inactivity, preventing cost accumulation

## Test plan
- [ ] Verify render.yaml is valid in the Render dashboard
- [ ] Confirm preview environments are cleaned up after 1 day of inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)