### PR TITLE
fix(noora): fix Toggle reset in Chrome when inside LiveView forms

### DIFF
--- a/noora/js/Toggle.js
+++ b/noora/js/Toggle.js
@@ -22,16 +22,38 @@ export default {
   mounted() {
     this.toggle = new Toggle(this.el, this.context());
     this.toggle.init();
+
+    // Stop change/input events from the hidden input from bubbling to parent
+    // forms. Without this, the hidden input triggers phx-change on the parent
+    // form, causing the server to re-render with stale toggle state.
+    this._stopFormEvent = (e) => {
+      if (e.target.matches("[data-part='hidden-input']")) {
+        e.stopPropagation();
+      }
+    };
+    this.el.addEventListener("change", this._stopFormEvent);
+    this.el.addEventListener("input", this._stopFormEvent);
+  },
+
+  updated() {
+    const serverChecked = getBooleanOption(this.el, "checked");
+    if (this.toggle.api.checked !== serverChecked) {
+      this.toggle.api.setChecked(serverChecked);
+    } else {
+      this.toggle.render();
+    }
   },
 
   beforeDestroy() {
+    this.el.removeEventListener("change", this._stopFormEvent);
+    this.el.removeEventListener("input", this._stopFormEvent);
     this.toggle.destroy();
   },
 
   context() {
     return {
       id: this.el.id,
-      checked: getBooleanOption(this.el, "checked"),
+      defaultChecked: getBooleanOption(this.el, "checked"),
       disabled: getBooleanOption(this.el, "disabled"),
       onCheckedChange: (details) => {
         if (this.el.dataset.onCheckedChange) {

--- a/server/lib/tuist_web/live/sso_settings_live.ex
+++ b/server/lib/tuist_web/live/sso_settings_live.ex
@@ -39,9 +39,7 @@ defmodule TuistWeb.SSOSettingsLive do
   end
 
   @impl true
-  def handle_event("toggle_sso", _params, socket) do
-    sso_enabled = not socket.assigns.sso_enabled
-
+  def handle_event("toggle_sso", %{"checked" => sso_enabled}, socket) do
     socket
     |> assign(sso_enabled: sso_enabled, sso_enforced: sso_enabled and socket.assigns.sso_enforced, flash_message: nil)
     |> compute_form_valid()
@@ -49,9 +47,9 @@ defmodule TuistWeb.SSOSettingsLive do
     |> then(&{:noreply, &1})
   end
 
-  def handle_event("toggle_sso_enforced", _params, socket) do
+  def handle_event("toggle_sso_enforced", %{"checked" => sso_enforced}, socket) do
     socket
-    |> assign(sso_enforced: not socket.assigns.sso_enforced, flash_message: nil)
+    |> assign(sso_enforced: sso_enforced, flash_message: nil)
     |> compute_has_changes()
     |> then(&{:noreply, &1})
   end

--- a/server/lib/tuist_web/live/sso_settings_live.html.heex
+++ b/server/lib/tuist_web/live/sso_settings_live.html.heex
@@ -18,7 +18,7 @@
           <.toggle
             id="sso-enabled-toggle"
             checked={@sso_enabled}
-            phx-click="toggle_sso"
+            data-on-checked-change="toggle_sso"
           />
           <div data-part="label-text">
             <span data-part="title">
@@ -211,7 +211,7 @@
           <.toggle
             id="sso-enforced-toggle"
             checked={@sso_enforced}
-            phx-click="toggle_sso_enforced"
+            data-on-checked-change="toggle_sso_enforced"
           />
           <div data-part="label-text">
             <span data-part="title">


### PR DESCRIPTION
## Summary
- Fix Toggle component immediately resetting to initial value when clicked inside a LiveView form in Chrome
- Root cause: Zag's `checked` (controlled mode) never changes internal state — combined with the hidden input triggering `phx-change`, the server re-rendered with stale state
- Use `defaultChecked` (uncontrolled mode), stop hidden input event propagation, and use `data-on-checked-change` for direct event delivery

## Test plan
- [ ] Toggle SSO on/off on the SSO settings page in Chrome — should toggle immediately without resetting
- [ ] Toggle SSO enforced — same behavior
- [ ] Save SSO settings — ensure the form still submits correctly
- [ ] Verify in Firefox as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)