### PR TITLE
fix(noora): remove setChecked race condition from Toggle updated hook

### DIFF
--- a/noora/js/Toggle.js
+++ b/noora/js/Toggle.js
@@ -36,12 +36,7 @@ export default {
   },
 
   updated() {
-    const serverChecked = getBooleanOption(this.el, "checked");
-    if (this.toggle.api.checked !== serverChecked) {
-      this.toggle.api.setChecked(serverChecked);
-    } else {
-      this.toggle.render();
-    }
+    this.toggle.render();
   },
 
   beforeDestroy() {


### PR DESCRIPTION
## Summary
- Follow-up to #9875 — fixes a race condition where `setChecked()` in the Toggle's `updated()` hook would undo user clicks when LiveView re-renders with stale state before the toggle event is processed
- Now `updated()` just calls `render()` (matching the Checkbox component pattern), letting Zag's internal state be the visual authority

## Test plan
- [ ] Toggle SSO on/off on the SSO settings page in Chrome — should toggle instantly without resetting
- [ ] Toggle SSO on/off in Firefox — should work with smooth animation
- [ ] Toggle SSO enforced on/off — same behavior in both browsers
- [ ] Save SSO settings — form still submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)