### PR TITLE
fix(server): skip Marketing.Stats polling in dev

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -172,10 +172,10 @@ defmodule Tuist.Application do
         ],
         else: []
     )
-    # Marketing.Stats polls ClickHouse on init. Skip it in test where
-    # ClickHouse tables may not exist when the app boots for migrations.
+    # Marketing.Stats polls ClickHouse on init. Skip it in test (tables
+    # may not exist) and dev (noisy debug logs every 5 s).
     |> Kernel.++(
-      if Environment.test?(),
+      if Environment.test?() or Environment.dev?(),
         do: [],
         else: [Tuist.Marketing.Stats]
     )


### PR DESCRIPTION
## Summary
- Skip starting the `Marketing.Stats` GenServer in dev environments
- It polls ClickHouse every 5s for marketing page counters, flooding the console with debug query logs during local development

## Test plan
- [ ] Run `mise run dev` and verify no more periodic ClickHouse query logs in the console
- [ ] Verify marketing stats still work in production/staging (GenServer only skipped in test and dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)