### PR TITLE
fix(cli): sort BuildableFolder resolvedFiles for deterministic ordering

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -57,6 +57,7 @@ extension XcodeGraph.BuildableFolder {
                 compilerFlags: compilerFlagsByPath[filePath]
             )
         }
+        .sorted { $0.path < $1.path }
 
         return XcodeGraph.BuildableFolder(
             path: path,

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Target+ManifestMapperTests.swift
@@ -118,8 +118,8 @@ final class TargetManifestMapperTests: TuistUnitTestCase {
                         ]),
                     ],
                     resolvedFiles: [
-                        BuildableFolderFile(path: buildableFlagsFile, compilerFlags: "-print-stats"),
                         BuildableFolderFile(path: buildableSourceFile, compilerFlags: nil),
+                        BuildableFolderFile(path: buildableFlagsFile, compilerFlags: "-print-stats"),
                     ]
                 ),
             ]


### PR DESCRIPTION
## Summary
## Summary

### Root Cause

The `resolvedFiles` array in `BuildableFolder.from()` (`cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift:46`) was produced using `concurrentCompactMap`, which returns results in non-deterministic order depending on which concurrent tasks complete first. The test `TargetManifestMapperTests.test_from()` at line 104 asserted exact equality against a specific ordering of `resolvedFiles`, so it would intermittently fail when file system glob + concurrent mapping returned files in a different order (e.g., `[buildable.swift, flags.swift]` vs `[flags.swift, buildable.swift]`).

### Fix

1. **Production code** (`BuildableFolder+ManifestMapper.swift:60`): Added `.sorted { $0.path < $1.path }` after the `concurrentCompactMap` to guarantee deterministic ordering of `resolvedFiles` by path.

2. **Test expectation** (`Target+ManifestMapperTests.swift:120-123`): Updated the expected `resolvedFiles` order to match the now-sorted output (`buildable.swift` before `flags.swift`).

### Verification

- Ran the specific test 50 times with `xcodebuild test -test-iterations 50 -run-tests-until-failure` — all 50 iterations passed consistently.
- Ran the related `BuildableFolderManifestMapperTests` and `BuildableFolderManifestMapperFolderExistsTests` suites 10 times each — all passed.
- Linting passed with no issues.

## Context
- Test case: https://tuist.dev/tuist/tuist/tests/test-cases/686b2202-aa57-49ee-8788-c92801e0d51a
- OpenCode session: https://opncd.ai/share/hnnPJ6vN