### PR TITLE
fix(cli): allow iOS bundle targets to have dependencies

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -585,6 +585,12 @@ public struct GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .extensionKitExtension),
             LintableTarget(platform: .macOS, product: .bundle),
         ],
+        LintableTarget(platform: .iOS, product: .bundle): [
+            LintableTarget(platform: .iOS, product: .staticLibrary),
+            LintableTarget(platform: .iOS, product: .dynamicLibrary),
+            LintableTarget(platform: .iOS, product: .framework),
+            LintableTarget(platform: .iOS, product: .staticFramework),
+        ],
         LintableTarget(platform: .macOS, product: .bundle): [
             LintableTarget(platform: .iOS, product: .app),
             LintableTarget(platform: .iOS, product: .staticLibrary),

--- a/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1775,6 +1775,36 @@ struct GraphLinterTests {
         #expect(got.isEmpty == true)
     }
 
+    @Test(.inTemporaryDirectory, .withMockedXcodeController) func lint_ios_bundle_allows_ios_dependencies() async throws {
+        let path: AbsolutePath = "/project"
+
+        let bundle = Target.test(name: "Bundle", platform: .iOS, product: .bundle)
+        let framework = Target.test(name: "Framework", platform: .iOS, product: .framework)
+        let staticLibrary = Target.test(name: "StaticLibrary", platform: .iOS, product: .staticLibrary)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: bundle.name, path: path): Set([
+                .target(name: framework.name, path: path),
+                .target(name: staticLibrary.name, path: path),
+            ]),
+        ]
+
+        let project = Project.test(path: path, targets: [bundle, framework, staticLibrary])
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            dependencies: dependencies
+        )
+
+        // When
+        let got = try await subject.lint(graphTraverser: GraphTraverser(graph: graph), configGeneratedProjectOptions: .test())
+
+        // Then
+        #expect(got.isEmpty == true)
+    }
+
     @Test(.inTemporaryDirectory, .withMockedXcodeController) func lintDifferentBundleIdentifiers() async throws {
         // Given
         let path: AbsolutePath = "/project"


### PR DESCRIPTION
## Summary
- iOS bundle targets with dependencies (e.g. frameworks, static libraries) were incorrectly rejected by the graph linter as an "invalid or not yet supported combination"
- Adds `LintableTarget(platform: .iOS, product: .bundle)` to the `validLinks` table, allowing iOS bundles to depend on static libraries, dynamic libraries, frameworks, and static frameworks
- This unblocks use cases like EarlGrey's bundle target that compiles code and links against frameworks

## Test plan
- [x] Added `lint_ios_bundle_allows_ios_dependencies` test verifying iOS bundles can have iOS dependencies without linting errors
- [x] All 67 existing `GraphLinterTests` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)