### PR TITLE
fix(server): keep legacy /builds routes for backwards compatibility

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -442,6 +442,9 @@ defmodule TuistWeb.Router do
         end
 
         scope "/builds" do
+          get "/", BuildsController, :index
+          get "/:build_id", BuildsController, :show
+          post "/", BuildsController, :create
           post "/upload/start", BuildsController, :multipart_start
           post "/upload/generate-url", BuildsController, :multipart_generate_url
           post "/upload/complete", BuildsController, :multipart_complete


### PR DESCRIPTION
## Summary
- Restores the `GET /`, `GET /:build_id`, and `POST /` routes under `/api/projects/:account_handle/:project_handle/builds` that were removed in #9773
- These routes are needed for backwards compatibility with older CLI versions (e.g. 4.157.2) that call `POST /builds` directly instead of `POST /xcode/builds`
- The new `/xcode/builds` routes remain unchanged

## Test plan
- [x] All 19 existing `builds_controller_test.exs` tests pass
- Verified the 404 was caused by the missing route (generic Phoenix 404, not a LoaderPlug "project not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)