### PR TITLE
fix(server): normalize build storage key to lowercase

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -21,7 +21,7 @@ defmodule Tuist.Builds do
   def valid_ci_providers, do: ["github", "gitlab", "bitrise", "circleci", "buildkite", "codemagic"]
 
   def build_storage_key(account_handle, project_handle, build_id) do
-    "#{account_handle}/#{project_handle}/builds/#{build_id}/build.zip"
+    "#{account_handle}/#{project_handle}/builds/#{String.downcase(build_id)}/build.zip"
   end
 
   def total_count do


### PR DESCRIPTION
## Summary
- Downcases the `build_id` in `build_storage_key/3` to ensure consistent S3 key casing
- The CLI sends UUIDs in uppercase (e.g. `EB92C48A-...`), but Ecto stores them lowercase (`eb92c48a-...`), causing `object_exists?` to return false and hiding the "Download build" button on the build run detail page

## Test plan
- [ ] Verify the "Download build" button appears on build run pages for new builds
- [ ] Note: existing builds with uppercase keys in S3 will not be affected (they were already broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)