### PR TITLE
fix(server): drop temporary build_runs_new table

### DIFF
--- a/server/priv/ingest_repo/migrations/20260318120000_drop_build_runs_new.exs
+++ b/server/priv/ingest_repo/migrations/20260318120000_drop_build_runs_new.exs
@@ -1,0 +1,15 @@
+defmodule Tuist.IngestRepo.Migrations.DropBuildRunsNew do
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    IngestRepo.query!("DROP TABLE IF EXISTS build_runs_new")
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- Follow-up to #9854 — the `EXCHANGE TABLES` operation leaves the old `build_runs` table behind as `build_runs_new`
- Adds a ClickHouse migration to `DROP TABLE IF EXISTS build_runs_new` to clean it up

## Test plan
- [ ] Verify migration runs cleanly on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)