### PR TITLE
Update homepage hero copy

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -40,7 +40,7 @@ defmodule TuistWeb.Marketing.MarketingController do
       :head_description,
       dgettext(
         "marketing",
-        "We focus on optimizing your setup, so your team can focus on shipping"
+        "We virtually join your team to optimize your setup, so you can focus on shipping"
       )
     )
     |> assign(

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
@@ -22,7 +22,7 @@
         <p>
           {dgettext(
             "marketing",
-            "We focus on optimizing your setup, so your team can focus on shipping"
+            "We virtually join your team to optimize your setup, so you can focus on shipping"
           )}
         </p>
       </div>

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -2363,5 +2363,5 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:41
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:23
 #, elixir-autogen, elixir-format
-msgid "We focus on optimizing your setup, so your team can focus on shipping"
+msgid "We virtually join your team to optimize your setup, so you can focus on shipping"
 msgstr ""


### PR DESCRIPTION
Updates the homepage hero section to better reflect Tuist's positioning as a platform team service. The headline now reads "Your mobile platform team, as a service" and the subtitle mentions both Xcode and Gradle support instead of just iOS.