### PR TITLE
fix(noora): prevent table column headers from wrapping to two rows

### DIFF
--- a/noora/css/table.css
+++ b/noora/css/table.css
@@ -153,6 +153,7 @@
     color: var(--noora-surface-label-primary);
     font: var(--noora-font-weight-medium) var(--noora-font-body-medium);
     text-align: left;
+    white-space: nowrap;
 
     & > [data-part="sort-link"] {
       color: unset;


### PR DESCRIPTION
Before:
<img width="1231" height="605" alt="image" src="https://github.com/user-attachments/assets/2d35dff9-5da7-4924-b295-aa74bea4db03" />

After:
<img width="1231" height="605" alt="image" src="https://github.com/user-attachments/assets/0a159c73-b0b2-4244-9eb9-2072b1df7904" />


## Summary

- Adds `white-space: nowrap` to `th` in `noora/css/table.css`
- The table already has `overflow-x: auto` and `min-width: max-content`, so it will scroll horizontally instead of wrapping header text (e.g. "Hit rate" → two lines)

## Test plan

- [ ] Open a page with a table (e.g. Cache Runs) and verify column headers remain on a single line
- [ ] Narrow the viewport and verify the table scrolls horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)