### PR TITLE
fix(server): make /cache/ac endpoint fire-and-forget to eliminate DB reads

### DIFF
--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -354,58 +354,20 @@ defmodule TuistWeb.API.CacheController do
         %{assigns: %{selected_project: selected_project}, body_params: %{hash: hash}} = conn,
         _params
       ) do
-    cache_action_item =
-      Tuist.KeyValueStore.get_or_update(
-        [
-          Atom.to_string(__MODULE__),
-          "upload_cache_action_item",
-          selected_project.id,
-          hash
-        ],
-        [
-          ttl: Map.get(conn.assigns, :cache_ttl, to_timeout(minute: 1)),
-          cache: Map.get(conn.assigns, :cache, :tuist),
-          locking: true
-        ],
-        fn ->
-          CacheActionItems.get_cache_action_item(%{
-            project: selected_project,
-            hash: hash
-          })
-        end
+    :ok =
+      Pipeline.async_push(
+        {:create_cache_action_item,
+         %{
+           project_id: selected_project.id,
+           hash: hash,
+           inserted_at: DateTime.utc_now(:second),
+           updated_at: DateTime.utc_now(:second)
+         }}
       )
 
-    cond do
-      is_nil(cache_action_item) ->
-        :ok =
-          Pipeline.async_push(
-            {:create_cache_action_item,
-             %{
-               project_id: selected_project.id,
-               hash: hash,
-               inserted_at: DateTime.utc_now(:second),
-               updated_at: DateTime.utc_now(:second)
-             }}
-          )
-
-        conn
-        |> put_status(:created)
-        |> json(%{
-          hash: hash
-        })
-
-      conn |> get_req_header("x-tuist-cli-version") |> List.first() == "4.28.0" ->
-        conn
-        |> put_status(:created)
-        |> json(%{
-          hash: hash
-        })
-
-      true ->
-        conn
-        |> put_status(:ok)
-        |> json(%{hash: cache_action_item.hash})
-    end
+    conn
+    |> put_status(:created)
+    |> json(%{hash: hash})
   end
 
   operation(:multipart_start,

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -5,7 +5,6 @@ defmodule TuistWeb.API.CacheControllerTest do
   alias Tuist.Accounts
   alias Tuist.API.Pipeline
   alias Tuist.CacheActionItems
-  alias Tuist.CacheActionItems.CacheActionItem
   alias Tuist.Projects.Workers.CleanProjectWorker
   alias Tuist.Repo
   alias Tuist.Storage
@@ -414,7 +413,7 @@ defmodule TuistWeb.API.CacheControllerTest do
              }
     end
 
-    test "returns created with the cache action item when the CLI version is 4.28.0", %{
+    test "returns created even if the cache action item already exists", %{
       conn: conn,
       cache: cache
     } do
@@ -422,55 +421,27 @@ defmodule TuistWeb.API.CacheControllerTest do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
       project = ProjectsFixtures.project_fixture(account_id: account.id)
-
-      conn =
-        conn
-        |> Authentication.put_current_user(user)
-        |> put_req_header("x-tuist-cli-version", "4.28.0")
-
-      CacheActionItems.create_cache_action_item(%{
-        hash: "hash",
-        project: project
-      })
-
-      # When
-      conn =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> assign(:cache, cache)
-        |> post(
-          ~p"/api/projects/#{account.name}/#{project.name}/cache/ac",
-          %{
-            hash: "hash"
-          }
-        )
-
-      # Then
-      cache_action_item = Repo.one(CacheActionItem)
-      response = json_response(conn, :created)
-
-      assert response == %{
-               "hash" => "hash"
-             }
-
-      assert cache_action_item.hash == response["hash"]
-    end
-
-    test "returns ok if the cache action item already exists", %{conn: conn, cache: cache} do
-      # Given
-      user = AccountsFixtures.user_fixture()
-      account = Accounts.get_account_from_user(user)
-      project = ProjectsFixtures.project_fixture(account_id: account.id)
+      project_id = project.id
+      date = DateTime.utc_now(:second)
+      stub(DateTime, :utc_now, fn :second -> date end)
+      hash = "hash"
 
       conn = Authentication.put_current_user(conn, user)
 
-      hash = "hash"
+      CacheActionItems.create_cache_action_item(%{
+        hash: hash,
+        project: project
+      })
 
-      cache_action_item =
-        CacheActionItems.create_cache_action_item(%{
-          hash: hash,
-          project: project
-        })
+      expect(Pipeline, :async_push, 1, fn {:create_cache_action_item,
+                                           %{
+                                             project_id: ^project_id,
+                                             hash: ^hash,
+                                             inserted_at: ^date,
+                                             updated_at: ^date
+                                           }} ->
+        :ok
+      end)
 
       # When
       conn =
@@ -480,18 +451,14 @@ defmodule TuistWeb.API.CacheControllerTest do
         |> post(
           ~p"/api/projects/#{account.name}/#{project.name}/cache/ac",
           %{
-            hash: "hash"
+            hash: hash
           }
         )
 
       # Then
-      response = json_response(conn, :ok)
+      response = json_response(conn, :created)
 
-      assert response == %{
-               "hash" => "hash"
-             }
-
-      assert cache_action_item.hash == response["hash"]
+      assert response == %{"hash" => hash}
     end
 
     test "returns a payment_required method if the account doesn't have a subscription and has gone above the threshold",


### PR DESCRIPTION
## Summary

- The `/cache/ac` endpoint was doing a synchronous DB SELECT (`get_cache_action_item`) inside a Cachex transaction lock on every request, just to distinguish `201` vs `200` responses
- In CI bursts with 100+ unique artifact hashes, this caused 100+ concurrent DB reads, exhausting the connection pool — observed as 60s Cloudflare 502s in production
- The inserts were already batched through the Broadway pipeline (`insert_all` in batches of 20); the SELECT was entirely redundant since the CLI doesn't act differently on 201 vs 200
- Now the endpoint is truly fire-and-forget: push to pipeline, return 201, done — `ON CONFLICT DO NOTHING` handles duplicate hashes safely

## Test plan

- [ ] Existing cache controller tests pass (26 tests, 0 failures)
- [ ] Removed the now-irrelevant "returns ok if already exists" and "returns 201 for CLI 4.28.0" tests; added "returns created even if already exists" covering the new unified behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)