### PR TITLE
feat(server): make POST /tests mostly asynchronous

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -24,6 +24,7 @@ defmodule Tuist.Tests do
   alias Tuist.Accounts.Account
   alias Tuist.Alerts.Workers.FlakyThresholdCheckWorker
   alias Tuist.ClickHouseRepo
+  alias Tuist.Tests.Workers.ProcessTestRunWorker
   alias Tuist.IngestRepo
   alias Tuist.Projects.Project
   alias Tuist.Repo
@@ -178,6 +179,7 @@ defmodule Tuist.Tests do
   def get_test_run_failures_count(test_run_id) do
     query =
       from tcr in TestCaseRun,
+        hints: ["FINAL"],
         where: tcr.test_run_id == ^test_run_id and tcr.status == "failure",
         select: count(tcr.id)
 
@@ -232,26 +234,361 @@ defmodule Tuist.Tests do
          |> Test.create_changeset(attrs)
          |> IngestRepo.insert() do
       {:ok, test} ->
-        {test_case_ids_with_flaky_run, test_case_runs} = create_test_modules(test, test_modules)
+        {minimal_test_case_runs, module_ids, suite_ids_by_module, test_case_run_ids_by_module} =
+          build_minimal_test_case_runs(test, test_modules)
 
-        test = mark_test_run_as_flaky(test, test_case_ids_with_flaky_run)
+        IngestRepo.insert_all(TestCaseRun, minimal_test_case_runs)
 
-        schedule_flaky_threshold_check(test.project_id, test_case_ids_with_flaky_run)
+        schedule_process_test_run(test, test_modules, module_ids, suite_ids_by_module, test_case_run_ids_by_module)
 
-        project = Tuist.Projects.get_project_by_id(test.project_id)
-
-        Tuist.PubSub.broadcast(
-          test,
-          "#{project.account.name}/#{project.name}",
-          :test_created
-        )
-
-        {:ok, %{test | test_case_runs: test_case_runs}}
+        {:ok, %{test | test_case_runs: minimal_test_case_runs}}
 
       {:error, changeset} ->
         {:error, changeset}
     end
   end
+
+  @doc """
+  Processes the deferred parts of a test run asynchronously (called by ProcessTestRunWorker).
+
+  Inserts module/suite aggregates, runs flaky and new-test-case detection, creates full
+  TestCase records, re-inserts TestCaseRun rows with correct is_flaky/is_new flags, inserts
+  failures and repetitions, fires PubSub, and schedules FlakyThresholdCheckWorker.
+  """
+  def process_test_run_deferred(%{
+        "test_id" => test_id,
+        "test_modules" => serialized_modules,
+        "module_ids" => module_ids,
+        "suite_ids_by_module" => suite_ids_by_module,
+        "test_case_run_ids_by_module" => test_case_run_ids_by_module
+      }) do
+    {:ok, test} = get_test(test_id)
+    test_modules = atomize_test_module_keys(serialized_modules)
+
+    test_case_run_data = get_test_case_run_data(test, test_modules)
+
+    {test_case_ids_with_flaky_run, _test_case_runs} =
+      [test_modules, module_ids, suite_ids_by_module, test_case_run_ids_by_module]
+      |> Enum.zip()
+      |> Enum.flat_map_reduce([], fn {module_attrs, module_id, suite_name_to_id, case_run_ids}, acc_test_case_runs ->
+        module_name = Map.get(module_attrs, :name)
+        test_suites = Map.get(module_attrs, :test_suites, [])
+        test_cases = Map.get(module_attrs, :test_cases, [])
+
+        module_test_case_run_data =
+          test_case_run_data
+          |> Enum.filter(fn {{_name, mod_name, _suite}, _data} -> mod_name == module_name end)
+          |> Map.new()
+
+        module_is_flaky = any_test_case_run_flaky?(Map.values(module_test_case_run_data))
+
+        {:ok, _} =
+          %TestModuleRun{}
+          |> TestModuleRun.create_changeset(%{
+            id: module_id,
+            name: module_name,
+            test_run_id: test.id,
+            status: Map.get(module_attrs, :status),
+            is_flaky: module_is_flaky,
+            duration: Map.get(module_attrs, :duration, 0),
+            test_suite_count: length(test_suites),
+            test_case_count: length(test_cases),
+            avg_test_case_duration: calculate_avg_test_case_duration(test_cases),
+            inserted_at: NaiveDateTime.utc_now()
+          })
+          |> IngestRepo.insert()
+
+        test_cases_by_suite =
+          Enum.group_by(test_cases, &(Map.get(&1, :test_suite_name, "") || ""))
+
+        suite_runs =
+          Enum.map(test_suites, fn suite_attrs ->
+            suite_name = Map.get(suite_attrs, :name)
+            suite_id = Map.get(suite_name_to_id, suite_name)
+            suite_test_cases = Map.get(test_cases_by_suite, suite_name, [])
+
+            suite_data =
+              module_test_case_run_data
+              |> Enum.filter(fn {{_name, _module, suite}, _data} -> suite == suite_name end)
+              |> Enum.map(fn {_key, data} -> data end)
+
+            %{
+              id: suite_id,
+              name: suite_name,
+              test_run_id: test.id,
+              test_module_run_id: module_id,
+              status: Map.get(suite_attrs, :status),
+              is_flaky: any_test_case_run_flaky?(suite_data),
+              duration: Map.get(suite_attrs, :duration, 0),
+              test_case_count: length(suite_test_cases),
+              avg_test_case_duration: calculate_avg_test_case_duration(suite_test_cases),
+              inserted_at: NaiveDateTime.utc_now()
+            }
+          end)
+
+        IngestRepo.insert_all(TestSuiteRun, suite_runs)
+
+        {flaky_ids, test_case_runs} =
+          create_deferred_test_cases_for_module(
+            test,
+            module_id,
+            test_cases,
+            suite_name_to_id,
+            module_name,
+            module_test_case_run_data,
+            case_run_ids
+          )
+
+        {flaky_ids, acc_test_case_runs ++ test_case_runs}
+      end)
+
+    test = mark_test_run_as_flaky(test, test_case_ids_with_flaky_run)
+
+    schedule_flaky_threshold_check(test.project_id, test_case_ids_with_flaky_run)
+
+    project = Tuist.Projects.get_project_by_id(test.project_id)
+
+    Tuist.PubSub.broadcast(
+      test,
+      "#{project.account.name}/#{project.name}",
+      :test_created
+    )
+
+    :ok
+  end
+
+  defp build_minimal_test_case_runs(test, test_modules) do
+    now = NaiveDateTime.utc_now()
+
+    Enum.reduce(test_modules, {[], [], [], []}, fn module_attrs, {runs_acc, mod_ids_acc, suite_ids_acc, case_run_ids_acc} ->
+      module_id = UUIDv7.generate()
+      module_name = Map.get(module_attrs, :name)
+      test_suites = Map.get(module_attrs, :test_suites, [])
+      test_cases = Map.get(module_attrs, :test_cases, [])
+
+      suite_name_to_id =
+        Map.new(test_suites, fn suite_attrs ->
+          {Map.get(suite_attrs, :name), UUIDv7.generate()}
+        end)
+
+      {module_test_case_runs, case_run_ids} =
+        Enum.map_reduce(test_cases, [], fn case_attrs, ids_acc ->
+          test_case_run_id = UUIDv7.generate()
+          case_name = Map.get(case_attrs, :name)
+          suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
+          test_suite_run_id = Map.get(suite_name_to_id, suite_name)
+          test_case_id = generate_test_case_id(test.project_id, case_name, module_name, suite_name)
+
+          test_case_run = %{
+            id: test_case_run_id,
+            name: case_name,
+            test_run_id: test.id,
+            test_module_run_id: module_id,
+            test_suite_run_id: test_suite_run_id,
+            test_case_id: test_case_id,
+            project_id: test.project_id,
+            is_ci: test.is_ci,
+            scheme: test.scheme,
+            account_id: test.account_id,
+            ran_at: test.ran_at,
+            git_branch: test.git_branch,
+            git_commit_sha: test.git_commit_sha || "",
+            status: Map.get(case_attrs, :status),
+            is_flaky: test_case_is_flaky?(case_attrs),
+            is_new: false,
+            duration: Map.get(case_attrs, :duration, 0),
+            inserted_at: now,
+            module_name: module_name,
+            suite_name: suite_name
+          }
+
+          {test_case_run, ids_acc ++ [test_case_run_id]}
+        end)
+
+      {
+        runs_acc ++ module_test_case_runs,
+        mod_ids_acc ++ [module_id],
+        suite_ids_acc ++ [suite_name_to_id],
+        case_run_ids_acc ++ [case_run_ids]
+      }
+    end)
+  end
+
+  defp schedule_process_test_run(test, test_modules, module_ids, suite_ids_by_module, test_case_run_ids_by_module) do
+    %{
+      test_id: test.id,
+      test_modules: test_modules,
+      module_ids: module_ids,
+      suite_ids_by_module: suite_ids_by_module,
+      test_case_run_ids_by_module: test_case_run_ids_by_module
+    }
+    |> ProcessTestRunWorker.new()
+    |> Oban.insert!()
+
+    :ok
+  end
+
+  defp create_deferred_test_cases_for_module(test, module_id, test_cases, suite_name_to_id, module_name, test_case_run_data, case_run_ids) do
+    test_case_data_list =
+      test_cases
+      |> Enum.map(fn case_attrs ->
+        case_name = Map.get(case_attrs, :name)
+        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
+        identity_key = {case_name, module_name, suite_name}
+        %{status: status, is_flaky: is_flaky} = Map.get(test_case_run_data, identity_key)
+
+        %{
+          name: case_name,
+          module_name: module_name,
+          suite_name: suite_name,
+          status: status,
+          is_flaky: is_flaky and test.is_ci,
+          duration: Map.get(case_attrs, :duration, 0),
+          ran_at: test.ran_at
+        }
+      end)
+      |> Enum.uniq_by(fn data -> {data.name, data.module_name, data.suite_name} end)
+
+    {test_case_id_map, test_case_ids_with_flaky_run, new_test_case_ids} =
+      create_test_cases(test.project_id, test_case_data_list)
+
+    {updated_tcrs, all_failures, all_repetitions} =
+      Enum.zip(test_cases, case_run_ids)
+      |> Enum.reduce({[], [], []}, fn {case_attrs, test_case_run_id}, {tcrs_acc, failures_acc, reps_acc} ->
+        case_name = Map.get(case_attrs, :name)
+        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
+        identity_key = {case_name, module_name, suite_name}
+        %{status: status, is_flaky: is_flaky, is_new: is_new} = Map.get(test_case_run_data, identity_key)
+
+        initial_is_flaky = test_case_is_flaky?(case_attrs)
+
+        tcrs_acc =
+          if is_flaky != initial_is_flaky or is_new do
+            test_suite_run_id = Map.get(suite_name_to_id, suite_name)
+            test_case_id = Map.get(test_case_id_map, identity_key)
+
+            updated_tcr = %{
+              id: test_case_run_id,
+              name: case_name,
+              test_run_id: test.id,
+              test_module_run_id: module_id,
+              test_suite_run_id: test_suite_run_id,
+              test_case_id: test_case_id,
+              project_id: test.project_id,
+              is_ci: test.is_ci,
+              scheme: test.scheme,
+              account_id: test.account_id,
+              ran_at: test.ran_at,
+              git_branch: test.git_branch,
+              git_commit_sha: test.git_commit_sha || "",
+              status: status,
+              is_flaky: is_flaky,
+              is_new: is_new,
+              duration: Map.get(case_attrs, :duration, 0),
+              inserted_at: NaiveDateTime.utc_now(),
+              module_name: module_name,
+              suite_name: suite_name
+            }
+
+            [updated_tcr | tcrs_acc]
+          else
+            tcrs_acc
+          end
+
+        failures = Map.get(case_attrs, :failures, [])
+
+        test_case_failures =
+          Enum.map(failures, fn failure_attrs ->
+            %{
+              id: UUIDv7.generate(),
+              test_case_run_id: test_case_run_id,
+              message: Map.get(failure_attrs, :message),
+              path: Map.get(failure_attrs, :path),
+              line_number: Map.get(failure_attrs, :line_number),
+              issue_type: Map.get(failure_attrs, :issue_type) || "unknown",
+              inserted_at: NaiveDateTime.utc_now()
+            }
+          end)
+
+        repetitions = Map.get(case_attrs, :repetitions, [])
+
+        test_case_repetitions =
+          Enum.map(repetitions, fn rep_attrs ->
+            %{
+              id: UUIDv7.generate(),
+              test_case_run_id: test_case_run_id,
+              repetition_number: Map.get(rep_attrs, :repetition_number),
+              name: Map.get(rep_attrs, :name),
+              status: Map.get(rep_attrs, :status),
+              duration: Map.get(rep_attrs, :duration, 0),
+              inserted_at: NaiveDateTime.utc_now()
+            }
+          end)
+
+        {tcrs_acc, test_case_failures ++ failures_acc, test_case_repetitions ++ reps_acc}
+      end)
+
+    IngestRepo.insert_all(TestCaseRun, updated_tcrs)
+    IngestRepo.insert_all(TestCaseFailure, all_failures)
+
+    if Enum.any?(all_repetitions) do
+      IngestRepo.insert_all(TestCaseRunRepetition, all_repetitions)
+    end
+
+    create_first_run_events_for_new_cases(test_case_id_map, test_case_run_data, test_cases, module_name, new_test_case_ids)
+
+    {test_case_ids_with_flaky_run, updated_tcrs}
+  end
+
+  defp create_first_run_events_for_new_cases(test_case_id_map, test_case_run_data, test_cases, module_name, new_test_case_ids) do
+    events =
+      test_cases
+      |> Enum.uniq_by(fn case_attrs ->
+        case_name = Map.get(case_attrs, :name)
+        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
+        {case_name, module_name, suite_name}
+      end)
+      |> Enum.flat_map(fn case_attrs ->
+        case_name = Map.get(case_attrs, :name)
+        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
+        identity_key = {case_name, module_name, suite_name}
+        %{is_new: is_new} = Map.get(test_case_run_data, identity_key)
+        test_case_id = Map.get(test_case_id_map, identity_key)
+
+        if is_new and test_case_id in new_test_case_ids do
+          [
+            %{
+              id: TestCaseEvent.first_run_id(test_case_id),
+              test_case_id: test_case_id,
+              event_type: "first_run",
+              actor_id: nil,
+              inserted_at: NaiveDateTime.utc_now()
+            }
+          ]
+        else
+          []
+        end
+      end)
+
+    if Enum.any?(events) do
+      IngestRepo.insert_all(TestCaseEvent, events)
+    end
+  end
+
+  defp atomize_test_module_keys(test_modules) when is_list(test_modules) do
+    Enum.map(test_modules, &deep_atomize_keys/1)
+  end
+
+  defp deep_atomize_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} ->
+      key = if is_binary(k), do: String.to_existing_atom(k), else: k
+      {key, deep_atomize_value(v)}
+    end)
+  end
+
+  defp deep_atomize_value(list) when is_list(list), do: Enum.map(list, &deep_atomize_keys/1)
+  defp deep_atomize_value(map) when is_map(map), do: deep_atomize_keys(map)
+  defp deep_atomize_value(value), do: value
 
   defp schedule_flaky_threshold_check(_project_id, []), do: :ok
 
@@ -509,7 +846,7 @@ defmodule Tuist.Tests do
   Returns a tuple of {test_case_runs, meta} with pagination info.
   """
   def list_test_case_runs(attrs, opts \\ []) do
-    base_query = from(tcr in TestCaseRun)
+    base_query = from(tcr in TestCaseRun, hints: ["FINAL"])
     preloads = Keyword.get(opts, :preload, [])
 
     {results, meta} = Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRun)
@@ -569,62 +906,6 @@ defmodule Tuist.Tests do
     end
   rescue
     _ -> :error
-  end
-
-  defp create_test_modules(test, test_modules) do
-    test_case_run_data = get_test_case_run_data(test, test_modules)
-
-    Enum.flat_map_reduce(test_modules, [], fn module_attrs, acc_test_case_runs ->
-      module_id = UUIDv7.generate()
-      module_name = Map.get(module_attrs, :name)
-
-      test_suites = Map.get(module_attrs, :test_suites, [])
-      test_cases = Map.get(module_attrs, :test_cases, [])
-
-      test_suite_count = length(test_suites)
-      test_case_count = length(test_cases)
-
-      avg_test_case_duration = calculate_avg_test_case_duration(test_cases)
-
-      module_test_case_run_data =
-        test_case_run_data
-        |> Enum.filter(fn {{_name, mod_name, _suite}, _data} -> mod_name == module_name end)
-        |> Map.new()
-
-      module_is_flaky = any_test_case_run_flaky?(Map.values(module_test_case_run_data))
-
-      module_run_attrs = %{
-        id: module_id,
-        name: module_name,
-        test_run_id: test.id,
-        status: Map.get(module_attrs, :status),
-        is_flaky: module_is_flaky,
-        duration: Map.get(module_attrs, :duration, 0),
-        test_suite_count: test_suite_count,
-        test_case_count: test_case_count,
-        avg_test_case_duration: avg_test_case_duration,
-        inserted_at: NaiveDateTime.utc_now()
-      }
-
-      {:ok, _module_run} =
-        %TestModuleRun{}
-        |> TestModuleRun.create_changeset(module_run_attrs)
-        |> IngestRepo.insert()
-
-      suite_name_to_id = create_test_suites(test, module_id, test_suites, test_cases, module_test_case_run_data)
-
-      {flaky_ids, test_case_runs} =
-        create_test_cases_for_module(
-          test,
-          module_id,
-          test_cases,
-          suite_name_to_id,
-          module_name,
-          module_test_case_run_data
-        )
-
-      {flaky_ids, acc_test_case_runs ++ test_case_runs}
-    end)
   end
 
   defp get_test_case_run_data(test, test_modules) do
@@ -741,180 +1022,6 @@ defmodule Tuist.Tests do
     )
     |> ClickHouseRepo.all()
     |> MapSet.new()
-  end
-
-  defp create_test_suites(test, module_id, test_suites, test_cases, test_case_run_data) do
-    test_cases_by_suite =
-      Enum.group_by(test_cases, fn case_attrs ->
-        Map.get(case_attrs, :test_suite_name, "")
-      end)
-
-    {test_suite_runs, suite_name_to_id} =
-      Enum.map_reduce(test_suites, %{}, fn suite_attrs, acc ->
-        suite_id = UUIDv7.generate()
-        suite_name = Map.get(suite_attrs, :name)
-
-        suite_test_cases = Map.get(test_cases_by_suite, suite_name, [])
-        test_case_count = length(suite_test_cases)
-
-        avg_test_case_duration = calculate_avg_test_case_duration(suite_test_cases)
-
-        suite_data =
-          test_case_run_data
-          |> Enum.filter(fn {{_name, _module, suite}, _data} -> suite == suite_name end)
-          |> Enum.map(fn {_key, data} -> data end)
-
-        suite_is_flaky = any_test_case_run_flaky?(suite_data)
-
-        suite_run = %{
-          id: suite_id,
-          name: suite_name,
-          test_run_id: test.id,
-          test_module_run_id: module_id,
-          status: Map.get(suite_attrs, :status),
-          is_flaky: suite_is_flaky,
-          duration: Map.get(suite_attrs, :duration, 0),
-          test_case_count: test_case_count,
-          avg_test_case_duration: avg_test_case_duration,
-          inserted_at: NaiveDateTime.utc_now()
-        }
-
-        updated_mapping = Map.put(acc, suite_name, suite_id)
-        {suite_run, updated_mapping}
-      end)
-
-    IngestRepo.insert_all(TestSuiteRun, test_suite_runs)
-    suite_name_to_id
-  end
-
-  defp create_test_cases_for_module(test, module_id, test_cases, suite_name_to_id, module_name, test_case_run_data) do
-    test_case_data_list =
-      test_cases
-      |> Enum.map(fn case_attrs ->
-        case_name = Map.get(case_attrs, :name)
-        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
-        identity_key = {case_name, module_name, suite_name}
-        %{status: status, is_flaky: is_flaky} = Map.get(test_case_run_data, identity_key)
-
-        %{
-          name: case_name,
-          module_name: module_name,
-          suite_name: suite_name,
-          status: status,
-          is_flaky: is_flaky and test.is_ci,
-          duration: Map.get(case_attrs, :duration, 0),
-          ran_at: test.ran_at
-        }
-      end)
-      |> Enum.uniq_by(fn data -> {data.name, data.module_name, data.suite_name} end)
-
-    {test_case_id_map, test_case_ids_with_flaky_run, new_test_case_ids} =
-      create_test_cases(test.project_id, test_case_data_list)
-
-    {test_case_runs, all_failures, all_repetitions} =
-      Enum.reduce(test_cases, {[], [], []}, fn case_attrs, {runs_acc, failures_acc, reps_acc} ->
-        suite_name = Map.get(case_attrs, :test_suite_name, "") || ""
-
-        test_suite_run_id = Map.get(suite_name_to_id, suite_name)
-
-        test_case_run_id = UUIDv7.generate()
-
-        case_name = Map.get(case_attrs, :name)
-        identity_key = {case_name, module_name, suite_name}
-        test_case_id = Map.get(test_case_id_map, identity_key)
-
-        repetitions = Map.get(case_attrs, :repetitions, [])
-
-        %{status: status, is_flaky: is_flaky, is_new: is_new} = Map.get(test_case_run_data, identity_key)
-
-        test_case_run = %{
-          id: test_case_run_id,
-          name: case_name,
-          test_run_id: test.id,
-          test_module_run_id: module_id,
-          test_suite_run_id: test_suite_run_id,
-          test_case_id: test_case_id,
-          project_id: test.project_id,
-          is_ci: test.is_ci,
-          scheme: test.scheme,
-          account_id: test.account_id,
-          ran_at: test.ran_at,
-          git_branch: test.git_branch,
-          git_commit_sha: test.git_commit_sha || "",
-          status: status,
-          is_flaky: is_flaky,
-          is_new: is_new,
-          duration: Map.get(case_attrs, :duration, 0),
-          inserted_at: NaiveDateTime.utc_now(),
-          module_name: module_name,
-          suite_name: suite_name || ""
-        }
-
-        failures = Map.get(case_attrs, :failures, [])
-
-        test_case_failures =
-          Enum.map(failures, fn failure_attrs ->
-            %{
-              id: UUIDv7.generate(),
-              test_case_run_id: test_case_run_id,
-              message: Map.get(failure_attrs, :message),
-              path: Map.get(failure_attrs, :path),
-              line_number: Map.get(failure_attrs, :line_number),
-              issue_type: Map.get(failure_attrs, :issue_type) || "unknown",
-              inserted_at: NaiveDateTime.utc_now()
-            }
-          end)
-
-        test_case_repetitions =
-          Enum.map(repetitions, fn rep_attrs ->
-            %{
-              id: UUIDv7.generate(),
-              test_case_run_id: test_case_run_id,
-              repetition_number: Map.get(rep_attrs, :repetition_number),
-              name: Map.get(rep_attrs, :name),
-              status: Map.get(rep_attrs, :status),
-              duration: Map.get(rep_attrs, :duration, 0),
-              inserted_at: NaiveDateTime.utc_now()
-            }
-          end)
-
-        {[test_case_run | runs_acc], test_case_failures ++ failures_acc, test_case_repetitions ++ reps_acc}
-      end)
-
-    IngestRepo.insert_all(TestCaseRun, test_case_runs)
-    IngestRepo.insert_all(TestCaseFailure, all_failures)
-
-    if Enum.any?(all_repetitions) do
-      IngestRepo.insert_all(TestCaseRunRepetition, all_repetitions)
-    end
-
-    create_first_run_events(test_case_runs, new_test_case_ids)
-
-    {test_case_ids_with_flaky_run, test_case_runs}
-  end
-
-  defp create_first_run_events(test_case_runs, new_test_case_ids) do
-    new_test_case_runs =
-      Enum.filter(test_case_runs, fn run ->
-        run.is_new and run.test_case_id in new_test_case_ids
-      end)
-
-    if Enum.any?(new_test_case_runs) do
-      now = NaiveDateTime.utc_now()
-
-      events =
-        Enum.map(new_test_case_runs, fn run ->
-          %{
-            id: TestCaseEvent.first_run_id(run.test_case_id),
-            test_case_id: run.test_case_id,
-            event_type: "first_run",
-            actor_id: nil,
-            inserted_at: now
-          }
-        end)
-
-      IngestRepo.insert_all(TestCaseEvent, events)
-    end
   end
 
   defp calculate_avg_test_case_duration(test_cases) do

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -454,6 +454,7 @@ defmodule Tuist.Tests.Analytics do
     test_case_counts =
       ClickHouseRepo.all(
         from(t in TestCaseRun,
+          hints: ["FINAL"],
           where: t.test_run_id in ^test_run_ids,
           group_by: t.test_run_id,
           select: %{

--- a/server/lib/tuist/tests/workers/process_test_run_worker.ex
+++ b/server/lib/tuist/tests/workers/process_test_run_worker.ex
@@ -1,0 +1,27 @@
+defmodule Tuist.Tests.Workers.ProcessTestRunWorker do
+  @moduledoc """
+  Oban worker that processes the deferred parts of a test run.
+
+  After `Tests.create_test/1` inserts the test run and minimal test case runs
+  synchronously (so the CLI can immediately upload attachments using the returned
+  test_case_run IDs), this worker handles the remaining heavy work:
+
+  - Test module and suite run aggregates
+  - Cross-run flaky detection (ClickHouse reads against commit SHA)
+  - New test case detection (ClickHouse reads against default branch)
+  - Full TestCase records with duration averages
+  - Updated TestCaseRun rows with correct is_flaky / is_new flags
+  - TestCaseFailure and TestCaseRunRepetition records
+  - First-run events for new test cases
+  - PubSub broadcast and FlakyThresholdCheckWorker scheduling
+  """
+
+  use Oban.Worker, max_attempts: 3
+
+  alias Tuist.Tests
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    Tests.process_test_run_deferred(args)
+  end
+end

--- a/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
@@ -17,10 +17,12 @@ defmodule TuistTestSupport.Fixtures.RunsFixtures do
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   def optimize_test_case_runs do
+    Oban.drain_queue(queue: :default)
     SQL.query!(IngestRepo, "OPTIMIZE TABLE test_case_runs FINAL", [])
   end
 
   def optimize_test_runs do
+    Oban.drain_queue(queue: :default)
     SQL.query!(IngestRepo, "OPTIMIZE TABLE test_runs FINAL", [])
   end
 
@@ -105,33 +107,37 @@ defmodule TuistTestSupport.Fixtures.RunsFixtures do
         }
       ])
 
-    case Tests.create_test(%{
-           id: Keyword.get(attrs, :id, UUIDv7.generate()),
-           project_id: project_id,
-           account_id: account_id,
-           duration: Keyword.get(attrs, :duration, 2000),
-           status: Keyword.get(attrs, :status, "success"),
-           scheme: Keyword.get(attrs, :scheme),
-           model_identifier: Keyword.get(attrs, :model_identifier, "Mac15,6"),
-           macos_version: Keyword.get(attrs, :macos_version, "11.2.3"),
-           xcode_version: Keyword.get(attrs, :xcode_version, "12.4"),
-           git_branch: Keyword.get(attrs, :git_branch, "main"),
-           git_ref: Keyword.get(attrs, :git_ref),
-           git_commit_sha: Keyword.get(attrs, :git_commit_sha, "abc123"),
-           ran_at: Keyword.get(attrs, :ran_at, NaiveDateTime.utc_now()),
-           is_ci: Keyword.get(attrs, :is_ci, false),
-           build_run_id: Keyword.get(attrs, :build_run_id),
-           gradle_build_id: Keyword.get(attrs, :gradle_build_id),
-           build_system: Keyword.get(attrs, :build_system, "xcode"),
-           ci_run_id: Keyword.get(attrs, :ci_run_id),
-           ci_project_handle: Keyword.get(attrs, :ci_project_handle),
-           ci_host: Keyword.get(attrs, :ci_host),
-           ci_provider: Keyword.get(attrs, :ci_provider),
-           test_modules: test_modules
-         }) do
-      {:ok, test} -> {:ok, test}
-      {:error, changeset} -> {:error, changeset}
-    end
+    result =
+      case Tests.create_test(%{
+             id: Keyword.get(attrs, :id, UUIDv7.generate()),
+             project_id: project_id,
+             account_id: account_id,
+             duration: Keyword.get(attrs, :duration, 2000),
+             status: Keyword.get(attrs, :status, "success"),
+             scheme: Keyword.get(attrs, :scheme),
+             model_identifier: Keyword.get(attrs, :model_identifier, "Mac15,6"),
+             macos_version: Keyword.get(attrs, :macos_version, "11.2.3"),
+             xcode_version: Keyword.get(attrs, :xcode_version, "12.4"),
+             git_branch: Keyword.get(attrs, :git_branch, "main"),
+             git_ref: Keyword.get(attrs, :git_ref),
+             git_commit_sha: Keyword.get(attrs, :git_commit_sha, "abc123"),
+             ran_at: Keyword.get(attrs, :ran_at, NaiveDateTime.utc_now()),
+             is_ci: Keyword.get(attrs, :is_ci, false),
+             build_run_id: Keyword.get(attrs, :build_run_id),
+             gradle_build_id: Keyword.get(attrs, :gradle_build_id),
+             build_system: Keyword.get(attrs, :build_system, "xcode"),
+             ci_run_id: Keyword.get(attrs, :ci_run_id),
+             ci_project_handle: Keyword.get(attrs, :ci_project_handle),
+             ci_host: Keyword.get(attrs, :ci_host),
+             ci_provider: Keyword.get(attrs, :ci_provider),
+             test_modules: test_modules
+           }) do
+        {:ok, test} -> {:ok, test}
+        {:error, changeset} -> {:error, changeset}
+      end
+
+    Oban.drain_queue(queue: :default)
+    result
   end
 
   def cas_output_fixture(attrs \\ []) do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -931,6 +931,7 @@ defmodule Tuist.TestsTest do
 
       # When
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then
       assert test.id == test_attrs.id
@@ -1005,6 +1006,7 @@ defmodule Tuist.TestsTest do
 
       # When
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then
       # Verify test suites were created
@@ -1154,6 +1156,7 @@ defmodule Tuist.TestsTest do
 
       # When
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then
       # Verify test was created with failure status
@@ -1662,6 +1665,7 @@ defmodule Tuist.TestsTest do
 
       # When
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then - test run should be marked as flaky with original status preserved
       assert test.status == "success"
@@ -1735,6 +1739,7 @@ defmodule Tuist.TestsTest do
 
       # When
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then - test run should NOT be marked as flaky for non-CI
       assert test.status == "success"
@@ -1796,6 +1801,7 @@ defmodule Tuist.TestsTest do
       }
 
       {:ok, ci_test} = Tests.create_test(ci_test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Get the test case ID from the CI run
       {ci_test_case_runs, _meta} =
@@ -1844,6 +1850,7 @@ defmodule Tuist.TestsTest do
       }
 
       {:ok, _non_ci_test} = Tests.create_test(non_ci_test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # TestCase should STILL be marked as flaky (non-CI run should not clear it)
       {:ok, test_case_after_non_ci} = Tests.get_test_case_by_id(test_case_id)
@@ -2490,10 +2497,9 @@ defmodule Tuist.TestsTest do
           ]
         })
 
-      # Second test run should be marked as flaky (cross-run detection)
-      assert second_test.is_flaky == true
+      Oban.drain_queue(queue: :default)
 
-      # Verify the ClickHouse record is also updated
+      # Second test run should be marked as flaky (cross-run detection)
       RunsFixtures.optimize_test_runs()
       {:ok, refetched_second_test} = Tests.get_test(second_test.id)
       assert refetched_second_test.is_flaky == true
@@ -4926,6 +4932,7 @@ defmodule Tuist.TestsTest do
       }
 
       {:ok, test} = Tests.create_test(test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then - the test case run should be marked as new
       {test_case_runs, _meta} =
@@ -5086,6 +5093,7 @@ defmodule Tuist.TestsTest do
       }
 
       {:ok, ci_test} = Tests.create_test(ci_feature_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then - the test case run should still be marked as new (non-CI runs don't count)
       {test_case_runs, _meta} =
@@ -5171,6 +5179,7 @@ defmodule Tuist.TestsTest do
       }
 
       {:ok, feature_test} = Tests.create_test(feature_test_attrs)
+      Oban.drain_queue(queue: :default)
 
       # Then - one should be new, one should not
       {test_case_runs, _meta} =
@@ -5239,6 +5248,8 @@ defmodule Tuist.TestsTest do
           is_ci: true,
           test_modules: [test_module]
         })
+
+      Oban.drain_queue(queue: :default)
 
       # Then - there should be exactly one first_run event
       {test_case_runs, _meta} =

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -1216,6 +1216,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
       # Then
       response = json_response(conn, :ok)
+      Oban.drain_queue(queue: :default)
       {:ok, test_run} = Tests.get_test(response["id"])
 
       assert test_run.duration == 10_000

--- a/server/test/tuist_web/live/test_cases_live_test.exs
+++ b/server/test/tuist_web/live/test_cases_live_test.exs
@@ -127,7 +127,7 @@ defmodule TuistWeb.TestCasesLiveTest do
   end
 
   defp create_test_run_with_cases(project, account) do
-    Tuist.Tests.create_test(%{
+    result = Tuist.Tests.create_test(%{
       id: UUIDv7.generate(),
       project_id: project.id,
       account_id: account.id,
@@ -154,5 +154,8 @@ defmodule TuistWeb.TestCasesLiveTest do
         }
       ]
     })
+
+    Oban.drain_queue(queue: :default)
+    result
   end
 end


### PR DESCRIPTION
## Summary

- The sync path now inserts only the `Test` row and minimal `TestCaseRun` rows so the CLI can immediately upload attachments using the returned `test_case_run_id`s
- A new `ProcessTestRunWorker` Oban job handles the deferred work: module/suite run aggregates, test case upserts, cross-run flaky detection, `is_new` detection, failure/repetition records, first-run events, PubSub broadcast, and `FlakyThresholdCheckWorker` scheduling
- Module/suite/TCR IDs are pre-generated in the sync path so the worker can insert aggregate rows that reference already-committed TCR rows
- Added `hints: ["FINAL"]` to `list_test_case_runs`, `get_test_run_failures_count`, and `test_runs_metrics` to deduplicate ClickHouse rows when TCRs are re-inserted with updated `is_flaky`/`is_new` flags

## Test plan

- [ ] All 3247 existing tests pass (`mix test`)
- [ ] Verify CLI can upload attachments immediately after `POST /tests` returns (test_case_run_id is available synchronously)
- [ ] Verify test modules, suites, test cases, failures, and repetitions appear in the UI after the Oban job processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)