### PR TITLE
feat(cli): process builds remotely

### DIFF
--- a/cli/Sources/TuistInspectCommand/Services/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectBuildCommandService.swift
@@ -51,7 +51,6 @@
         private let gitController: GitControlling
         private let ciController: CIControlling
         private let xcodeProjectOrWorkspacePathLocator: XcodeProjectOrWorkspacePathLocating
-        private let machineMetricsReader: MachineMetricsReader
 
         init(
             derivedDataLocator: DerivedDataLocating = DerivedDataLocator(),
@@ -67,8 +66,7 @@
             serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
             gitController: GitControlling = GitController(),
             ciController: CIControlling = CIController(),
-            xcodeProjectOrWorkspacePathLocator: XcodeProjectOrWorkspacePathLocating = XcodeProjectOrWorkspacePathLocator(),
-            machineMetricsReader: MachineMetricsReader = MachineMetricsReader()
+            xcodeProjectOrWorkspacePathLocator: XcodeProjectOrWorkspacePathLocating = XcodeProjectOrWorkspacePathLocator()
         ) {
             self.derivedDataLocator = derivedDataLocator
             self.fileSystem = fileSystem
@@ -84,7 +82,6 @@
             self.gitController = gitController
             self.ciController = ciController
             self.xcodeProjectOrWorkspacePathLocator = xcodeProjectOrWorkspacePathLocator
-            self.machineMetricsReader = machineMetricsReader
         }
 
         func run(
@@ -137,30 +134,10 @@
                 referenceDate: referenceDate
             )
 
-            let useRemoteProcessing = Environment.current.variables["TUIST_INSPECT_BUILD_MODE"] == "remote"
-            if useRemoteProcessing {
-                do {
-                    try await createRemoteBuild(
-                        mostRecentActivityLogPath: mostRecentActivityLogPath,
-                        projectPath: projectPath
-                    )
-                } catch {
-                    AlertController.current.warning(
-                        .alert(
-                            "Remote build upload failed: \(error.localizedDescription). Falling back to local mode."
-                        )
-                    )
-                    try await createLocalBuild(
-                        mostRecentActivityLogPath: mostRecentActivityLogPath,
-                        projectPath: projectPath
-                    )
-                }
-            } else {
-                try await createLocalBuild(
-                    mostRecentActivityLogPath: mostRecentActivityLogPath,
-                    projectPath: projectPath
-                )
-            }
+            try await createRemoteBuild(
+                mostRecentActivityLogPath: mostRecentActivityLogPath,
+                projectPath: projectPath
+            )
         }
 
         private func mostRecentActivityLogPath(
@@ -199,68 +176,6 @@
             return mostRecentActivityLogPath
         }
 
-        private func createLocalBuild(
-            mostRecentActivityLogPath: AbsolutePath,
-            projectPath: AbsolutePath
-        ) async throws {
-            let xcactivityLog = try await xcActivityLogController.parse(mostRecentActivityLogPath)
-            let config =
-                try await configLoader
-                    .loadConfig(path: projectPath)
-            let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-            guard let fullHandle = config.fullHandle else {
-                throw InspectBuildCommandServiceError.missingFullHandle
-            }
-
-            let gitInfo = try gitController.gitInfo(workingDirectory: projectPath)
-            let ciInfo = ciController.ciInfo()
-            let customMetadata = readCustomMetadata()
-
-            let buildStartDate = Date(timeIntervalSinceReferenceDate: xcactivityLog.mainSection.timeStartedRecording)
-            let buildEndDate = Date(timeIntervalSinceReferenceDate: xcactivityLog.mainSection.timeStoppedRecording)
-            let machineMetrics = try await machineMetricsReader.readSamples(
-                startDate: buildStartDate,
-                endDate: buildEndDate
-            )
-
-            let build = try await createBuildService.createBuild(
-                fullHandle: fullHandle,
-                serverURL: serverURL,
-                id: xcactivityLog.mainSection.uniqueIdentifier,
-                category: xcactivityLog.category,
-                configuration: Environment.current.variables["CONFIGURATION"],
-                customMetadata: customMetadata,
-                duration: Int(xcactivityLog.mainSection.timeStoppedRecording * 1000)
-                    - Int(xcactivityLog.mainSection.timeStartedRecording * 1000),
-                files: xcactivityLog.files,
-                gitBranch: gitInfo.branch,
-                gitCommitSHA: gitInfo.sha,
-                gitRef: gitInfo.ref,
-                gitRemoteURLOrigin: gitInfo.remoteURLOrigin,
-                isCI: Environment.current.isCI,
-                issues: truncateIssuesIfNeeded(xcactivityLog.issues),
-                modelIdentifier: machineEnvironment.modelIdentifier(),
-                macOSVersion: machineEnvironment.macOSVersion,
-                scheme: Environment.current.schemeName,
-                targets: xcactivityLog.targets,
-                xcodeCacheUploadEnabled: config.cache.upload,
-                xcodeVersion: try await xcodeBuildController.version()?.description,
-                status: xcactivityLog.buildStep.errorCount == 0 ? .success : .failure,
-                ciRunId: ciInfo?.runId,
-                ciProjectHandle: ciInfo?.projectHandle,
-                ciHost: ciInfo?.host,
-                ciProvider: ciInfo?.provider,
-                cacheableTasks: xcactivityLog.cacheableTasks,
-                casOutputs: config.cache.upload ? xcactivityLog.casOutputs :
-                    xcactivityLog.casOutputs.filter { $0.operation != .upload },
-                machineMetrics: machineMetrics
-            )
-            AlertController.current.success(
-                .alert("View the analyzed build at \(build.url.absoluteString)")
-            )
-        }
-
-        // swiftlint:disable:next function_body_length
         private func createRemoteBuild(
             mostRecentActivityLogPath: AbsolutePath,
             projectPath: AbsolutePath
@@ -365,18 +280,6 @@
             let zipPath = tempDirectory.appending(component: "build.zip")
             try await fileSystem.zipFileOrDirectoryContent(at: buildDirectory, to: zipPath)
             return zipPath
-        }
-
-        private func truncateIssuesIfNeeded(_ issues: [XCActivityIssue]) -> [XCActivityIssue] {
-            issues
-                .prefix(1000)
-                .map {
-                    var issue = $0
-                    if let message = issue.message, message.count > 1000 {
-                        issue.message = message.prefix(1000) + "..."
-                    }
-                    return issue
-                }
         }
 
         private func path(_ path: String?) async throws -> AbsolutePath {

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
@@ -29,6 +29,7 @@ struct InspectBuildCommandServiceTests {
     private let derivedDataLocator = MockDerivedDataLocating()
     private let fileSystem = FileSystem()
     private let createBuildService = MockCreateBuildServicing()
+    private let uploadBuildService = MockUploadBuildServicing()
     private let machineEnvironment = MockMachineEnvironmentRetrieving()
     private let xcodeBuildController = MockXcodeBuildControlling()
     private let backgroundProcessRunner = MockBackgroundProcessRunning()
@@ -47,6 +48,7 @@ struct InspectBuildCommandServiceTests {
             machineEnvironment: machineEnvironment,
             xcodeBuildController: xcodeBuildController,
             createBuildService: createBuildService,
+            uploadBuildService: uploadBuildService,
             configLoader: configLoader,
             xcActivityLogController: xcActivityLogController,
             backgroundProcessRunner: backgroundProcessRunner,
@@ -96,6 +98,10 @@ struct InspectBuildCommandServiceTests {
                 machineMetrics: .any
             )
             .willReturn(.test())
+
+        given(uploadBuildService)
+            .uploadBuild(buildId: .any, fullHandle: .any, serverURL: .any, filePath: .any)
+            .willReturn(())
 
         given(machineEnvironment)
             .modelIdentifier()
@@ -150,30 +156,14 @@ struct InspectBuildCommandServiceTests {
         given(derivedDataLocator)
             .locate(for: .any)
             .willReturn(derivedDataPath)
+        let activityLogUUID = UUID().uuidString
         let buildLogsPath = derivedDataPath.appending(components: "Logs", "Build")
         let activityLogPath = buildLogsPath.appending(
-            components: "\(UUID().uuidString).xcactivitylog"
+            component: "\(activityLogUUID).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(
-                .test(
-                    buildStep: .test(
-                        errorCount: 1
-                    ),
-                    category: .incremental,
-                    issues: [
-                        .test(),
-                    ],
-                    files: [
-                        .test(),
-                    ],
-                    targets: [
-                        .test(),
-                    ]
-                )
-            )
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -212,36 +202,45 @@ struct InspectBuildCommandServiceTests {
         try await subject.run(path: nil)
 
         // Then
+        verify(uploadBuildService)
+            .uploadBuild(
+                buildId: .value(activityLogUUID),
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                filePath: .any
+            )
+            .called(1)
+
         verify(createBuildService)
             .createBuild(
                 fullHandle: .value("tuist/tuist"),
                 serverURL: .any,
-                id: .any,
+                id: .value(activityLogUUID),
                 category: .value(.incremental),
                 configuration: .value("Debug"),
                 customMetadata: .any,
-                duration: .value(10000),
-                files: .value([.test()]),
+                duration: .value(0),
+                files: .value([]),
                 gitBranch: .value("branch"),
                 gitCommitSHA: .value("sha"),
                 gitRef: .value("git-ref"),
                 gitRemoteURLOrigin: .value("https://github.com/tuist/tuist"),
                 isCI: .value(false),
-                issues: .value([.test()]),
+                issues: .value([]),
                 modelIdentifier: .value("Mac15,3"),
                 macOSVersion: .value("13.2.0"),
                 scheme: .value("App"),
-                targets: .value([.test()]),
+                targets: .value([]),
                 xcodeCacheUploadEnabled: .any,
                 xcodeVersion: .value("16.0.0"),
-                status: .value(.failure),
+                status: .value(.processing),
                 ciRunId: .value("123"),
                 ciProjectHandle: .value("test-project"),
                 ciHost: .value("github.com"),
                 ciProvider: .value(.github),
                 cacheableTasks: .value([]),
                 casOutputs: .value([]),
-                machineMetrics: .any
+                machineMetrics: .value([])
             )
             .called(1)
     }
@@ -266,12 +265,9 @@ struct InspectBuildCommandServiceTests {
         let activityLogPath = buildLogsPath.appending(
             components: "\(UUID().uuidString).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(
-                .test()
-            )
         var numberOfAttempts = 0
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
@@ -380,6 +376,7 @@ struct InspectBuildCommandServiceTests {
         )
 
         try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
         try await fileSystem.writeAsPlist(
             XCLogStoreManifestPlist(
                 logs: [
@@ -397,9 +394,6 @@ struct InspectBuildCommandServiceTests {
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
         ).willReturn(.test(path: activityLogPath))
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
 
         given(gitController)
             .gitInfo(workingDirectory: .any)
@@ -431,10 +425,11 @@ struct InspectBuildCommandServiceTests {
                 .willReturn(derivedDataPath)
             let buildLogsPath = derivedDataPath.appending(components: "Logs", "Build")
             let activityLogPath = buildLogsPath.appending(
-                components: "\(UUID().uuidString).xcacvitiylog"
+                components: "\(UUID().uuidString).xcactivitylog"
             )
 
             try await fileSystem.makeDirectory(at: buildLogsPath)
+            try await fileSystem.writeText("fake", at: activityLogPath)
             try await fileSystem.writeAsPlist(
                 XCLogStoreManifestPlist(
                     logs: [
@@ -448,9 +443,6 @@ struct InspectBuildCommandServiceTests {
                 ),
                 at: buildLogsPath.appending(component: "LogStoreManifest.plist")
             )
-            given(xcActivityLogController)
-                .parse(.value(activityLogPath))
-                .willReturn(.test())
             given(xcActivityLogController).mostRecentActivityLogFile(
                 projectDerivedDataDirectory: .value(derivedDataPath),
                 filter: .any
@@ -525,6 +517,7 @@ struct InspectBuildCommandServiceTests {
             components: "\(UUID().uuidString).xcactivitylog"
         )
         try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
         try await fileSystem.writeAsPlist(
             XCLogStoreManifestPlist(
                 logs: [
@@ -538,9 +531,6 @@ struct InspectBuildCommandServiceTests {
             ),
             at: buildLogsPath.appending(component: "LogStoreManifest.plist")
         )
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -583,10 +573,9 @@ struct InspectBuildCommandServiceTests {
         let activityLogPath = buildLogsPath.appending(
             components: "\(UUID().uuidString).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -661,10 +650,9 @@ struct InspectBuildCommandServiceTests {
         let activityLogPath = buildLogsPath.appending(
             components: "\(UUID().uuidString).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -742,10 +730,9 @@ struct InspectBuildCommandServiceTests {
         let activityLogPath = buildLogsPath.appending(
             components: "\(UUID().uuidString).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -820,10 +807,9 @@ struct InspectBuildCommandServiceTests {
         let activityLogPath = buildLogsPath.appending(
             components: "\(UUID().uuidString).xcactivitylog"
         )
+        try await fileSystem.makeDirectory(at: buildLogsPath)
+        try await fileSystem.writeText("fake", at: activityLogPath)
 
-        given(xcActivityLogController)
-            .parse(.value(activityLogPath))
-            .willReturn(.test())
         given(xcActivityLogController).mostRecentActivityLogFile(
             projectDerivedDataDirectory: .value(derivedDataPath),
             filter: .any
@@ -878,31 +864,12 @@ struct InspectBuildCommandServiceTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func remoteBuild_uses_activityLog_uuid_as_buildId() async throws {
+    func uses_activityLog_uuid_as_buildId() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let projectPath = temporaryDirectory.appending(component: "App.xcodeproj")
         let mockedEnvironment = try #require(Environment.mocked)
         mockedEnvironment.workspacePath = projectPath
         mockedEnvironment.variables["TUIST_INSPECT_BUILD_WAIT"] = "YES"
-        mockedEnvironment.variables["TUIST_INSPECT_BUILD_MODE"] = "remote"
-
-        let localUploadBuildService = MockUploadBuildServicing()
-        let localSubject = InspectBuildCommandService(
-            derivedDataLocator: derivedDataLocator,
-            fileSystem: fileSystem,
-            machineEnvironment: machineEnvironment,
-            xcodeBuildController: xcodeBuildController,
-            createBuildService: createBuildService,
-            uploadBuildService: localUploadBuildService,
-            configLoader: configLoader,
-            xcActivityLogController: xcActivityLogController,
-            backgroundProcessRunner: backgroundProcessRunner,
-            dateService: dateService,
-            serverEnvironmentService: serverEnvironmentService,
-            gitController: gitController,
-            ciController: ciController,
-            xcodeProjectOrWorkspacePathLocator: xcodeProjectOrWorkspacePathLocator
-        )
 
         given(xcodeProjectOrWorkspacePathLocator)
             .locate(from: .any)
@@ -930,11 +897,7 @@ struct InspectBuildCommandServiceTests {
             )
         )
 
-        given(localUploadBuildService)
-            .uploadBuild(buildId: .any, fullHandle: .any, serverURL: .any, filePath: .any)
-            .willReturn(())
-
-        try await localSubject.run(path: nil)
+        try await subject.run(path: nil)
 
         verify(createBuildService)
             .createBuild(
@@ -950,7 +913,7 @@ struct InspectBuildCommandServiceTests {
             )
             .called(1)
 
-        verify(localUploadBuildService)
+        verify(uploadBuildService)
             .uploadBuild(
                 buildId: .value(activityLogUUID),
                 fullHandle: .any,

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,6 @@
     ERL_AFLAGS = "-kernel shell_history enabled -kernel shell_history_file_bytes 1024000"
     # Only used in a local, development environment
     TUIST_CACHE_API_KEY = "7a3de63bb6136d94539e9976b1c54bfd553467c2c4775f84b7b2baf27f8b38c6"
-    TUIST_INSPECT_BUILD_MODE = "remote"
 
 [tasks.cla-sign]
     description = "Sign the CLA by adding current user to signatures.json"


### PR DESCRIPTION
## Summary
- Removes the `TUIST_INSPECT_BUILD_MODE` environment variable and the local/remote mode toggle from `InspectBuildCommandService`
- The CLI now always uploads xcactivitylog files to the server for remote processing (previously gated behind `TUIST_INSPECT_BUILD_MODE=remote`)
- Removes the `createLocalBuild` method, `truncateIssuesIfNeeded` helper, and `machineMetricsReader` dependency from the service
- Updates all tests to exercise the remote processing path, ensuring activity log files exist on disk for bundling

Continues the work started in #9752.

## Test plan
- [ ] Verify `tuist inspect build` uploads the build for remote processing
- [ ] Verify build metadata (git info, CI info, custom metadata) is correctly passed through
- [ ] Verify error handling for missing full handle and missing activity logs still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)