### PR TITLE
feat(server): add OpenTelemetry tracing to POST /tests endpoint

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -64,6 +64,9 @@ defmodule Tuist.Application do
       OpentelemetryLoggerMetadata.setup()
       OpentelemetryBandit.setup()
       OpentelemetryPhoenix.setup(adapter: :bandit)
+      OpentelemetryEcto.setup([:tuist, :repo])
+      OpentelemetryEcto.setup([:tuist, :ingest_repo])
+      OpentelemetryEcto.setup([:tuist, :click_house_repo])
       OpentelemetryFinch.setup()
       OpentelemetryBroadway.setup()
     end

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -21,6 +21,8 @@ defmodule Tuist.Tests do
 
   import Ecto.Query
 
+  require OpenTelemetry.Tracer
+
   alias Tuist.Accounts.Account
   alias Tuist.Alerts.Workers.FlakyThresholdCheckWorker
   alias Tuist.ClickHouseRepo
@@ -220,6 +222,10 @@ defmodule Tuist.Tests do
     test_modules = Map.get(attrs, :test_modules, [])
     is_ci = Map.get(attrs, :is_ci, false)
     has_flaky_tests = has_any_flaky_test_case?(test_modules)
+    test_case_count = Enum.sum(Enum.map(test_modules, fn m -> length(Map.get(m, :test_cases, [])) end))
+
+    OpenTelemetry.Tracer.set_attribute("test.module_count", length(test_modules))
+    OpenTelemetry.Tracer.set_attribute("test.case_count", test_case_count)
 
     attrs =
       if has_flaky_tests and is_ci do
@@ -232,7 +238,10 @@ defmodule Tuist.Tests do
          |> Test.create_changeset(attrs)
          |> IngestRepo.insert() do
       {:ok, test} ->
-        {test_case_ids_with_flaky_run, test_case_runs} = create_test_modules(test, test_modules)
+        {test_case_ids_with_flaky_run, test_case_runs} =
+          OpenTelemetry.Tracer.with_span "tests.create_test_modules" do
+            create_test_modules(test, test_modules)
+          end
 
         test = mark_test_run_as_flaky(test, test_case_ids_with_flaky_run)
 


### PR DESCRIPTION
## Summary

- Set up `OpentelemetryEcto` for all three repos (`Tuist.Repo`, `Tuist.IngestRepo`, `Tuist.ClickHouseRepo`) so every Ecto/DB query automatically appears as a child span under the Phoenix request span
- Add `test.module_count` and `test.case_count` attributes on the current span to correlate test suite size with latency
- Wrap `create_test_modules` in a `tests.create_test_modules` child span to separate DB insert time from other work

Previously the `POST /tests` endpoint had no child spans, making the internal bottleneck (bulk DB inserts for test cases, modules, suites) invisible in traces. This is the instrumentation needed to diagnose the 9–126s latency observed for large test suites.

## Test plan

- [ ] Deploy to staging and submit a large test run via the CLI
- [ ] Verify `tests.create_test_modules` span appears in Grafana/traces
- [ ] Verify Ecto query child spans appear under the Phoenix request span for `ingest_repo` and `repo`
- [ ] Confirm `test.case_count` attribute is visible on the span

🤖 Generated with [Claude Code](https://claude.com/claude-code)