### PR TITLE
fix(server): convert ClickHouse env vars from string to integer and bump pool to 80

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,8 +30,6 @@ services:
         value: 1
       - key: TUIST_DATABASE_POOL_SIZE
         value: 40
-      - key: TUIST_CLICKHOUSE_POOL_SIZE
-        value: 40
       - key: TUIST_S3_POOL_COUNT
         value: 1
       - key: TUIST_S3_POOL_SIZE


### PR DESCRIPTION
## Summary

- Fixes `clickhouse_pool_size`, `clickhouse_queue_interval`, and `clickhouse_queue_target` to convert string env vars to integers (matching the `database_*` equivalents)
- Sets `TUIST_CLICKHOUSE_POOL_SIZE=80` for production

## Root cause

Setting `TUIST_CLICKHOUSE_POOL_SIZE` via render.yaml passed a string `"40"` to DBConnection, which expects an integer. This caused `ArgumentError: ranges (first..last) expect both sides to be integers, got: 1.."40"`. The previous implicit fallback to `database_pool_size` worked because that function already does `String.to_integer`.

## Test plan
- [ ] Deploy and confirm no more `ArgumentError` errors
- [ ] Monitor Sentry for pool exhaustion errors with the new pool size of 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)