### PR TITLE
fix(server): convert ClickHouse env vars from string to integer and bump pool to 80

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,8 @@ services:
         value: 1
       - key: TUIST_DATABASE_POOL_SIZE
         value: 40
+      - key: TUIST_CLICKHOUSE_POOL_SIZE
+        value: 80
       - key: TUIST_S3_POOL_COUNT
         value: 1
       - key: TUIST_S3_POOL_SIZE

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -505,15 +505,24 @@ defmodule Tuist.Environment do
   end
 
   def clickhouse_pool_size(secrets \\ secrets()) do
-    get([:clickhouse, :pool_size], secrets) || database_pool_size(secrets)
+    case get([:clickhouse, :pool_size], secrets) do
+      pool_size when is_binary(pool_size) -> String.to_integer(pool_size)
+      _ -> database_pool_size(secrets)
+    end
   end
 
   def clickhouse_queue_interval(secrets \\ secrets()) do
-    get([:clickhouse, :queue_interval], secrets) || database_queue_interval(secrets)
+    case get([:clickhouse, :queue_interval], secrets) do
+      queue_interval when is_binary(queue_interval) -> String.to_integer(queue_interval)
+      _ -> database_queue_interval(secrets)
+    end
   end
 
   def clickhouse_queue_target(secrets \\ secrets()) do
-    get([:clickhouse, :queue_target], secrets) || database_queue_target(secrets)
+    case get([:clickhouse, :queue_target], secrets) do
+      queue_target when is_binary(queue_target) -> String.to_integer(queue_target)
+      _ -> database_queue_target(secrets)
+    end
   end
 
   def anthropic_api_key(secrets \\ secrets()) do


### PR DESCRIPTION
## Summary

- Fixes `clickhouse_pool_size`, `clickhouse_queue_interval`, and `clickhouse_queue_target` to convert string env vars to integers
- Sets `TUIST_CLICKHOUSE_POOL_SIZE=80` for production

## Root cause

Setting `TUIST_CLICKHOUSE_POOL_SIZE` via render.yaml passed a string `"40"` to DBConnection, which expects an integer. This caused `ArgumentError: ranges (first..last) expect both sides to be integers, got: 1.."40"` ([Sentry issue](https://tuist.sentry.io/issues/103829577/)). The previous implicit fallback to `database_pool_size` worked because that function already does `String.to_integer`.

The same bug existed in `clickhouse_queue_interval` and `clickhouse_queue_target` — fixed all three to match the pattern used by their `database_*` equivalents.

## Why 80

- Topology: 2 Phoenix replicas → 2 ClickHouse replicas (`max_concurrent_queries=100` each)
- 2 × 80 = 160 total connections, spread across 2 ClickHouse nodes ≈ 80 per node (within the 100 limit)
- Addresses pool exhaustion ("connection not available, request dropped from queue") during peak traffic

## Test plan
- [ ] Deploy and confirm no more `ArgumentError` errors
- [ ] Monitor Sentry for pool exhaustion errors with the new pool size

🤖 Generated with [Claude Code](https://claude.com/claude-code)