### PR TITLE
fix(server): reduce Bandit socket idle timeout from 60s to 15s

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -193,7 +193,10 @@ if Enum.member?([:prod, :stag, :can, :dev], env) do
     check_origin: check_origin,
     http: [
       ip: http_ip,
-      port: port
+      port: port,
+      thousand_island_options: [
+        read_timeout: to_timeout(second: 15)
+      ]
     ]
 
   # ## Configuring the mailer


### PR DESCRIPTION
## Summary

- Reduces Bandit's `thousand_island_options.read_timeout` from 60s (default) to 15s

## Context

When the CLI fires ~130 parallel `POST /cache/ac` requests in a 250ms burst, 129 complete in 100-520ms but one straggler connection can sit idle at the TCP level for up to 60s before Bandit's `read_timeout` fires. The request never reaches Phoenix (no `x-request-id` in the 502 response), blocking the CLI for a full minute.

The socket-level `read_timeout` is an idle timer — it only fires when zero bytes are flowing on the connection. Active transfers (large uploads, streaming) keep resetting the timer, so they are unaffected. 15s is still 30x longer than the slowest normal request.

## References

- **Thousand Island `read_timeout` docs** ([`thousand_island` v1.4.2](https://hexdocs.pm/thousand_island/ThousandIsland.html#start_link/1)):
  > `read_timeout`: How long to wait for client data before closing the connection, in milliseconds. Defaults to 60_000

- **Default defined in** [`ThousandIsland.ServerConfig`](https://github.com/mtrudel/thousand_island/blob/main/lib/thousand_island/server_config.ex#L39): `read_timeout: 60_000`

- **Bandit passes this through** via the `thousand_island_options` key in its configuration ([Bandit docs](https://hexdocs.pm/bandit/Bandit.html#t:options/0))

## Test plan

- [ ] Deploy to staging and verify normal API requests work
- [ ] Verify large payload endpoints (`/api/runs` with 50MB body) still work — the timer resets on every received byte
- [ ] Verify WebSocket/LiveView connections are unaffected (they have their own keepalive)
- [ ] Monitor for `Bandit.HTTPError` body read timeout errors — they should now fire at 15s instead of 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)