### PR TITLE
fix(cli): resolve swift package graph namespaces

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -102,6 +102,8 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             (
                 id: String,
                 name: String,
+                identityName: String,
+                manifestName: String,
                 folder: AbsolutePath,
                 targetToArtifactPaths: [String: AbsolutePath],
                 info: PackageInfo,
@@ -112,10 +114,12 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             let name = dependency.packageRef.name
             let packageFolder: AbsolutePath
             let hash: String?
+            let identityName: String
             switch dependency.packageRef.kind {
             case "remote", "remoteSourceControl":
                 packageFolder = checkoutsFolder.appending(component: dependency.subpath)
                 hash = dependency.state?.checkoutState?.revision
+                identityName = packageFolder.basename
             case "local", "fileSystem", "localSourceControl":
                 // Depending on the swift version, the information is available either in `path` or in `location`
                 guard let path = dependency.packageRef.path ?? dependency.packageRef.location else {
@@ -128,15 +132,29 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
                     validating: path.replacingOccurrences(of: "/private/var", with: "/var")
                 )
                 hash = nil
+                identityName = packageFolder.basename
             case "registry":
                 let registryFolder = path.appending(try RelativePath(validating: "registry/downloads"))
                 packageFolder = registryFolder.appending(try RelativePath(validating: dependency.subpath))
                 hash = try dependency.state?.version.map { try contentHasher.hash([dependency.packageRef.identity, $0]) }
+                identityName = packageFolder.parentDirectory.basename
             default:
                 throw SwiftPackageManagerGraphGeneratorError.unsupportedDependencyKind(dependency.packageRef.kind)
             }
 
-            let packageInfo = try await manifestLoader.loadPackage(at: packageFolder, disableSandbox: disableSandbox)
+            let loadedPackageInfo = try await manifestLoader.loadPackage(at: packageFolder, disableSandbox: disableSandbox)
+            let packageInfo = PackageInfo(
+                name: dependency.packageRef.name,
+                products: loadedPackageInfo.products,
+                targets: loadedPackageInfo.targets,
+                traits: loadedPackageInfo.traits,
+                dependencies: loadedPackageInfo.dependencies,
+                platforms: loadedPackageInfo.platforms,
+                cLanguageStandard: loadedPackageInfo.cLanguageStandard,
+                cxxLanguageStandard: loadedPackageInfo.cxxLanguageStandard,
+                swiftLanguageVersions: loadedPackageInfo.swiftLanguageVersions,
+                toolsVersion: loadedPackageInfo.toolsVersion
+            )
             let targetToArtifactPaths = try workspaceState.object.artifacts
                 .filter { $0.packageRef.identity == dependency.packageRef.identity }
                 .reduce(into: [:]) { result, artifact in
@@ -146,6 +164,8 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             return (
                 id: dependency.packageRef.identity.lowercased(),
                 name: name,
+                identityName: identityName,
+                manifestName: loadedPackageInfo.name,
                 folder: packageFolder,
                 targetToArtifactPaths: targetToArtifactPaths,
                 info: packageInfo,
@@ -166,14 +186,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         // References:
         // - https://github.com/tuist/tuist/pull/7518
         // - https://community.tuist.dev/t/swift-package-registry-overriding-local-dependency-in-tuist-generated-project/902
-        packageInfos = Dictionary(grouping: packageInfos, by: {
-            if $0.kind == "registry" {
-                // A package is uniquely identified by a scoped identifier in the form scope.package-name.
-                return String($0.name.split(separator: ".").last ?? "").lowercased()
-            } else {
-                return $0.name.lowercased()
-            }
-        })
+        packageInfos = Dictionary(grouping: packageInfos, by: \.id)
         .compactMap { _, groupedPackageInfos in
             if let localPackage = groupedPackageInfos.first(where: {
                 ["local", "fileSystem", "localSourceControl"].contains($0.kind)
@@ -186,7 +199,101 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             }
         }
 
+        var packageReferenceNameByAlias: [String: String] = [:]
+        for packageInfo in packageInfos {
+            for alias in [
+                packageInfo.id,
+                packageInfo.name.lowercased(),
+                packageInfo.identityName.lowercased(),
+                packageInfo.manifestName.lowercased(),
+            ] {
+                packageReferenceNameByAlias[alias] = packageInfo.name
+            }
+        }
+
+        packageInfos = packageInfos.map { packageInfo in
+            let directDependencyReferenceNameByIdentity = Dictionary<String, String>(
+                uniqueKeysWithValues: packageInfo.info.dependencies.compactMap { dependency in
+                    guard let referenceName = packageReferenceNameByAlias[dependency.identity.lowercased()] else { return nil }
+                    return (dependency.identity.lowercased(), referenceName)
+                }
+            )
+
+            let normalizedTargets = packageInfo.info.targets.map { target in
+                let normalizedDependencies = target.dependencies.map { dependency in
+                    switch dependency {
+                    case let .product(name, package, moduleAliases, condition):
+                        return PackageInfo.Target.Dependency.product(
+                            name: name,
+                            package: directDependencyReferenceNameByIdentity[package.lowercased()] ?? package,
+                            moduleAliases: moduleAliases,
+                            condition: condition
+                        )
+                    case .byName, .target:
+                        return dependency
+                    }
+                }
+
+                return PackageInfo.Target(
+                    name: target.name,
+                    path: target.path,
+                    url: target.url,
+                    sources: target.sources,
+                    resources: target.resources,
+                    exclude: target.exclude,
+                    dependencies: normalizedDependencies,
+                    publicHeadersPath: target.publicHeadersPath,
+                    type: target.type,
+                    settings: target.settings,
+                    checksum: target.checksum,
+                    packageAccess: target.packageAccess
+                )
+            }
+
+            let normalizedPackageInfo = PackageInfo(
+                name: packageInfo.info.name,
+                products: packageInfo.info.products,
+                targets: normalizedTargets,
+                traits: packageInfo.info.traits,
+                dependencies: packageInfo.info.dependencies,
+                platforms: packageInfo.info.platforms,
+                cLanguageStandard: packageInfo.info.cLanguageStandard,
+                cxxLanguageStandard: packageInfo.info.cxxLanguageStandard,
+                swiftLanguageVersions: packageInfo.info.swiftLanguageVersions,
+                toolsVersion: packageInfo.info.toolsVersion
+            )
+
+            return (
+                id: packageInfo.id,
+                name: packageInfo.name,
+                identityName: packageInfo.identityName,
+                manifestName: packageInfo.manifestName,
+                folder: packageInfo.folder,
+                targetToArtifactPaths: packageInfo.targetToArtifactPaths,
+                info: normalizedPackageInfo,
+                hash: packageInfo.hash,
+                kind: packageInfo.kind
+            )
+        }
+
         let packageInfoDictionary = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, $0.info) })
+        let packageInfoDictionaryForExternalDependencies = Dictionary(uniqueKeysWithValues: packageInfos.map {
+            (
+                $0.name,
+                PackageInfo(
+                    name: $0.identityName,
+                    products: $0.info.products,
+                    targets: $0.info.targets,
+                    traits: $0.info.traits,
+                    dependencies: $0.info.dependencies,
+                    platforms: $0.info.platforms,
+                    cLanguageStandard: $0.info.cLanguageStandard,
+                    cxxLanguageStandard: $0.info.cxxLanguageStandard,
+                    swiftLanguageVersions: $0.info.swiftLanguageVersions,
+                    toolsVersion: $0.info.toolsVersion
+                )
+            )
+        })
         let packageToFolder = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, $0.folder) })
         let packageToTargetsToArtifactPaths = Dictionary(uniqueKeysWithValues: packageInfos.map {
             ($0.name, $0.targetToArtifactPaths)
@@ -218,7 +325,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
 
         let externalDependencies = try await packageInfoMapper.resolveExternalDependencies(
             path: path,
-            packageInfos: packageInfoDictionary,
+            packageInfos: packageInfoDictionaryForExternalDependencies,
             packageToFolder: packageToFolder,
             packageToTargetsToArtifactPaths: packageToTargetsToArtifactPaths,
             packageModuleAliases: mutablePackageModuleAliases

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -119,6 +119,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
     private let fileSystem: FileSysteming
     private let rootDirectoryLocator: RootDirectoryLocating
 
+    fileprivate static func externalDependencyKey(packageName: String, productName: String) -> String {
+        "\(packageName)::\(productName)"
+    }
+
     public init(
         moduleMapGenerator: SwiftPackageManagerModuleMapGenerating = SwiftPackageManagerModuleMapGenerator(),
         fileSystem: FileSysteming = FileSystem(),
@@ -142,6 +146,15 @@ public struct PackageInfoMapper: PackageInfoMapping {
         packageToTargetsToArtifactPaths: [String: [String: AbsolutePath]],
         packageModuleAliases: [String: [String: String]]
     ) async throws -> [String: [ProjectDescription.TargetDependency]] {
+        let manifestNameOccurrences = packageInfos.values.reduce(into: [String: Int]()) { result, packageInfo in
+            result[packageInfo.name, default: 0] += 1
+        }
+        let productNameOccurrences = packageInfos.values.reduce(into: [String: Int]()) { result, packageInfo in
+            for product in packageInfo.products {
+                result[product.name, default: 0] += 1
+            }
+        }
+
         let targetDependencyToFramework: [String: Path] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             try packageInfo.value.targets.forEach { target in
                 guard target.type == .binary else { return }
@@ -176,7 +189,8 @@ public struct PackageInfoMapper: PackageInfoMapping {
             .reduce(into: [:]) { result, packageInfo in
                 let moduleAliases = packageModuleAliases[packageInfo.value.name]
                 for product in packageInfo.value.products {
-                    result[moduleAliases?[product.name] ?? product.name] = try product.targets.flatMap { target in
+                    let productName = moduleAliases?[product.name] ?? product.name
+                    let dependencies: [ProjectDescription.TargetDependency] = try product.targets.flatMap { target in
                         try ResolvedDependency.fromTarget(
                             name: moduleAliases?[target] ?? target,
                             targetDependencyToFramework: targetDependencyToFramework,
@@ -201,6 +215,19 @@ public struct PackageInfoMapper: PackageInfoMapping {
                                 )
                             }
                         }
+                    }
+                    result[PackageInfoMapper.externalDependencyKey(packageName: packageInfo.key, productName: productName)] =
+                        dependencies
+
+                    if manifestNameOccurrences[packageInfo.value.name] == 1 {
+                        result[PackageInfoMapper.externalDependencyKey(
+                            packageName: packageInfo.value.name,
+                            productName: productName
+                        )] = dependencies
+                    }
+
+                    if productNameOccurrences[product.name] == 1 {
+                        result[productName] = dependencies
                     }
                 }
             }
@@ -617,9 +644,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
             dependencies = try linkerDependencies + target.dependencies.compactMap {
                 switch $0 {
-                case let .product(name: name, package: _, moduleAliases: moduleAliases, condition: condition):
+                case let .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition):
                     try mapDependency(
                         name: name,
+                        packageName: package,
                         packageInfo: packageInfo,
                         packageType: packageType,
                         condition: condition,
@@ -686,6 +714,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
     private func mapDependency(
         name: String,
+        packageName: String? = nil,
         packageInfo: PackageInfo,
         packageType: PackageType,
         condition: PackageInfo.PackageConditionDescription?,
@@ -727,9 +756,23 @@ public struct PackageInfoMapper: PackageInfoMapping {
         } else {
             if let aliasedName = moduleAliases?[name] {
                 dependencyModuleAliases[name] = aliasedName
-                return .external(name: aliasedName, condition: platformCondition)
+                if let packageName {
+                    return .external(
+                        name: PackageInfoMapper.externalDependencyKey(packageName: packageName, productName: aliasedName),
+                        condition: platformCondition
+                    )
+                } else {
+                    return .external(name: aliasedName, condition: platformCondition)
+                }
             } else {
-                return .external(name: name, condition: platformCondition)
+                if let packageName {
+                    return .external(
+                        name: PackageInfoMapper.externalDependencyKey(packageName: packageName, productName: name),
+                        condition: platformCondition
+                    )
+                } else {
+                    return .external(name: name, condition: platformCondition)
+                }
             }
         }
     }

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -219,6 +219,108 @@ struct SwiftPackageManagerGraphLoaderTests {
         }
     }
 
+    @Test
+    func load_when_packagesShareManifestName_preservesDistinctPackageReferenceNames() async throws {
+        try await withMockedDependencies {
+            try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryDirectory in
+                let packageSettings = PackageSettings.test()
+
+                let workspacePath = temporaryDirectory.appending(components: [
+                    ".build", "workspace-state.json",
+                ])
+                try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+                try await fileSystem.writeText(
+                    """
+                    {
+                      "object" : {
+                        "artifacts" : [],
+                        "dependencies" : [
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "apple.swift-async-algorithms",
+                              "kind" : "registry",
+                              "location" : "apple.swift-async-algorithms",
+                              "name" : "apple.swift-async-algorithms"
+                            },
+                            "state" : {
+                              "name" : "registryDownload",
+                              "version" : "1.1.3"
+                            },
+                            "subpath" : "apple/swift-async-algorithms/1.1.3"
+                          },
+                          {
+                            "basedOn" : null,
+                            "packageRef" : {
+                              "identity" : "coenttb.swift-async-algorithms-fork",
+                              "kind" : "registry",
+                              "location" : "coenttb.swift-async-algorithms-fork",
+                              "name" : "coenttb.swift-async-algorithms-fork"
+                            },
+                            "state" : {
+                              "name" : "registryDownload",
+                              "version" : "1.2.0"
+                            },
+                            "subpath" : "coenttb/swift-async-algorithms-fork/1.2.0"
+                          }
+                        ]
+                      }
+                    }
+                    """,
+                    at: workspacePath
+                )
+
+                try await fileSystem.makeDirectory(
+                    at: temporaryDirectory.appending(components: [".build", "Derived"])
+                )
+                try await fileSystem.touch(
+                    temporaryDirectory.appending(components: [
+                        ".build", "Derived", "Package.resolved",
+                    ])
+                )
+                try await fileSystem.touch(
+                    temporaryDirectory.appending(component: "Package.resolved")
+                )
+
+                given(manifestLoader)
+                    .loadPackage(at: .any, disableSandbox: .value(true))
+                    .willProduce { path, _ in
+                        if path == temporaryDirectory {
+                            return .test(name: "Root")
+                        } else {
+                            return .test(name: "swift-async-algorithms")
+                        }
+                    }
+
+                given(packageInfoMapper)
+                    .resolveExternalDependencies(
+                        path: .any,
+                        packageInfos: .any,
+                        packageToFolder: .any,
+                        packageToTargetsToArtifactPaths: .any,
+                        packageModuleAliases: .any
+                    )
+                    .willProduce { _, packageInfos, _, _, _ in
+                        #expect(Set(packageInfos.keys) == [
+                            "apple.swift-async-algorithms",
+                            "coenttb.swift-async-algorithms-fork",
+                        ])
+                        #expect(Set(packageInfos.values.map(\.name)) == [
+                            "apple.swift-async-algorithms",
+                            "coenttb.swift-async-algorithms-fork",
+                        ])
+                        return [:]
+                    }
+
+                _ = try await subject.load(
+                    packagePath: temporaryDirectory.appending(component: "Package.swift"),
+                    packageSettings: packageSettings,
+                    disableSandbox: true
+                )
+            }
+        }
+    }
+
     @Test(.inTemporaryDirectory, .withMockedDependencies())
     func load_when_dependency_via_local_registry_and_scm() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -321,6 +321,60 @@ struct PackageInfoMapperTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedSwiftVersionProvider
+    ) func resolveDependencies_whenProductsShareNameAcrossPackages_qualifiesByPackageName() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let applePath = basePath.appending(component: "apple.swift-async-algorithms")
+        let forkPath = basePath.appending(component: "coenttb.swift-async-algorithms-fork")
+
+        try await fileSystem.makeDirectory(at: applePath.appending(try RelativePath(validating: "Sources/AsyncAlgorithms")))
+        try await fileSystem.makeDirectory(at: forkPath.appending(try RelativePath(validating: "Sources/AsyncAlgorithms")))
+
+        let resolvedDependencies = try await subject.resolveExternalDependencies(
+            path: basePath,
+            packageInfos: [
+                "apple.swift-async-algorithms": .test(
+                    name: "apple.swift-async-algorithms",
+                    products: [
+                        .init(name: "AsyncAlgorithms", type: .library(.automatic), targets: ["AsyncAlgorithms"]),
+                    ],
+                    targets: [
+                        .test(name: "AsyncAlgorithms"),
+                    ]
+                ),
+                "coenttb.swift-async-algorithms-fork": .test(
+                    name: "coenttb.swift-async-algorithms-fork",
+                    products: [
+                        .init(name: "AsyncAlgorithms", type: .library(.automatic), targets: ["AsyncAlgorithms"]),
+                    ],
+                    targets: [
+                        .test(name: "AsyncAlgorithms"),
+                    ]
+                ),
+            ],
+            packageToFolder: [
+                "apple.swift-async-algorithms": applePath,
+                "coenttb.swift-async-algorithms-fork": forkPath,
+            ],
+            packageToTargetsToArtifactPaths: [:],
+            packageModuleAliases: [:]
+        )
+
+        #expect(
+            resolvedDependencies ==
+                [
+                    "apple.swift-async-algorithms::AsyncAlgorithms": [
+                        .project(target: "AsyncAlgorithms", path: .relativeToManifest(applePath.pathString)),
+                    ],
+                    "coenttb.swift-async-algorithms-fork::AsyncAlgorithms": [
+                        .project(target: "AsyncAlgorithms", path: .relativeToManifest(forkPath.pathString)),
+                    ],
+                ]
+        )
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
     ) func resolveDependencies_whenHasModuleAliases() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "Package/Sources/Target_1")))


### PR DESCRIPTION
## Summary

Fix Swift package graph resolution in Tuist for packages whose dependency/product references use different names across:
- workspace package refs
- SwiftPM dependency identities
- manifest package names

This is scoped to package graph resolution only.
It does not include FileSystem API changes or unrelated filesystem cleanups.

## Problem

The `FileSystem` branch that depends on `swift-file-system` compiles in its own SwiftPM context, but Tuist failed while generating or resolving the generated Xcode workspace graph.

The root issue was that Tuist resolved external package products with inconsistent package namespaces, which broke cases like:
- duplicate product names across different packages
- package dependency identities that differ from workspace package ref names
- unqualified external product lookups when the product name is unique

## Changes

- normalize target product dependency package names in `SwiftPackageManagerGraphLoader`
- resolve external products by package-qualified key when needed in `PackageInfoMapper`
- preserve unqualified lookup for unique external product names
- add regressions covering duplicate package/product namespaces and mixed naming schemes

## Validation

- `../FileSystem` builds directly with `swift build --replace-scm-with-registry`
- with this Tuist fix applied, `tuist generate --no-open` succeeds while pointing Tuist at the `FileSystem` branch that depends on `swift-file-system`
- generated graph includes the expected distinct package projects, including `swift-file-system` and `coenttb.swift-async-algorithms-fork`
