### PR TITLE
fix(cli): remove unsupported DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER build setting

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -354,7 +354,6 @@ struct ConfigGenerator: ConfigGenerating {
 
             if target.destinations.contains(.macCatalyst) {
                 settings["SUPPORTS_MACCATALYST"] = "YES"
-                settings["DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER"] = "YES"
             } else {
                 settings["SUPPORTS_MACCATALYST"] = "NO"
             }

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -582,7 +582,6 @@ struct ConfigGeneratorTests {
             "TARGETED_DEVICE_FAMILY": "1,2,6",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.1",
             "SUPPORTS_MACCATALYST": "YES",
-            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "YES",
             "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "NO",
             "SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD": "NO",
         ]


### PR DESCRIPTION
## Summary
- Removes the `DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES` build setting that Tuist was adding to all targets (including SPM dependencies) when Mac Catalyst was in the destinations
- Xcode no longer supports this setting and emits a warning: *"DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER is not supported. Remove the build setting and conditionalize PRODUCT_BUNDLE_IDENTIFIER instead."*

Closes #9475

## Test plan
- [x] Reproduced the issue with a test project (macCatalyst app + Alamofire SPM dependency) — confirmed the warning appears before the fix and is gone after
- [x] Verified the setting no longer appears in generated `.pbxproj` files
- [x] All 311 TuistGeneratorTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)