### PR TITLE
feat(cli): add --cache-profile option to cache warm with profile-driven exclusions

### DIFF
--- a/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
+++ b/cli/Sources/TuistCacheCommand/CacheWarmCommand.swift
@@ -44,6 +44,12 @@
         var targets: [String] = []
 
         @Flag(
+            help: "If passed, the command doesn't cache the targets passed in the `--targets` argument, but only their dependencies. Deprecated: use `--cache-profile only-external` instead.",
+            envKey: .cacheExternalOnly
+        )
+        var externalOnly: Bool = false
+
+        @Flag(
             name: .long,
             help: "When passed, it generates the project and skips warming the cache. This is useful for debugging purposes.",
             envKey: .cacheGenerateOnly
@@ -74,10 +80,18 @@
                 return
             }
 
+            if externalOnly {
+                AlertController.current.warning(.alert(
+                    "The \(.command("--external-only")) flag is deprecated.",
+                    takeaway: "Use \(.command("--cache-profile only-external")) instead."
+                ))
+            }
+
             try await Extension.cacheService.run(
                 path: path,
                 configuration: configuration,
                 targetsToBinaryCache: Set(targets),
+                externalOnly: externalOnly,
                 generateOnly: generateOnly,
                 cacheProfile: cacheProfile
             )

--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -439,6 +439,7 @@ public enum EnvKey: String, CaseIterable {
 
     // CACHE
 
+    case cacheExternalOnly = "TUIST_CACHE_EXTERNAL_ONLY"
     case cacheProfile = "TUIST_CACHE_PROFILE"
     case cacheGenerateOnly = "TUIST_CACHE_GENERATE_ONLY"
     case cachePrintHashes = "TUIST_CACHE_PRINT_HASHES"

--- a/cli/Sources/TuistExtension/Extension.swift
+++ b/cli/Sources/TuistExtension/Extension.swift
@@ -12,6 +12,7 @@ public protocol CacheServicing {
         path: String?,
         configuration: String?,
         targetsToBinaryCache: Set<String>,
+        externalOnly: Bool,
         generateOnly: Bool,
         cacheProfile: String?
     ) async throws
@@ -31,6 +32,7 @@ public struct EmptyCacheService: CacheServicing {
         path _: String?,
         configuration _: String?,
         targetsToBinaryCache _: Set<String>,
+        externalOnly _: Bool,
         generateOnly _: Bool,
         cacheProfile _: String?
     ) async throws {

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -90,6 +90,7 @@ import XcodeGraph
             path directory: String?,
             configuration: String?,
             targetsToBinaryCache: Set<String>,
+            externalOnly: Bool,
             generateOnly: Bool,
             cacheProfile: String?
         ) async throws {
@@ -116,14 +117,26 @@ import XcodeGraph
             // Lint
             try cacheWarmGraphLinter.lint(graph: graph)
 
-            // Resolve the cache profile using the same logic as `tuist generate`.
-            // When --cache-profile is omitted the config default (or onlyExternal fallback) applies.
-            let resolvedCacheProfileType = cacheProfile.map { CacheProfileType(stringLiteral: $0) }
-            let profile = try config.resolveCacheProfile(
-                ignoreBinaryCache: false,
-                includedTargets: [],
-                cacheProfile: resolvedCacheProfileType
-            )
+            // Resolve the effective cache profile.
+            // - When --cache-profile is specified, resolve it via the same logic as `tuist generate`.
+            // - When --external-only is used (deprecated), map to the .onlyExternal profile.
+            // - When neither is specified, default to .allPossible (cache everything) to preserve
+            //   the original behavior of `tuist cache` without flags.
+            // Note: includedTargets is [] because --targets filtering is applied separately below
+            // in cacheableTargets(), not through the profile resolver.
+            let profile: CacheProfile
+            if let cacheProfile {
+                let resolvedCacheProfileType = CacheProfileType(stringLiteral: cacheProfile)
+                profile = try config.resolveCacheProfile(
+                    ignoreBinaryCache: false,
+                    includedTargets: [],
+                    cacheProfile: resolvedCacheProfileType
+                )
+            } else if externalOnly {
+                profile = .onlyExternal
+            } else {
+                profile = .allPossible
+            }
 
             // Hash
             Logger.current.info("Hashing cacheable targets")

--- a/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
+++ b/cli/Tests/TuistKitTests/CommandEnvironmentVariables/CommandEnvironmentVariableTests.swift
@@ -857,6 +857,7 @@ struct CommandEnvironmentVariableTests {
     }
 
     @Test(.withMockedEnvironment()) func cacheWarmCommandUsesEnvVars() throws {
+        setVariable(.cacheExternalOnly, value: "true")
         setVariable(.cacheProfile, value: "development")
         setVariable(.cacheGenerateOnly, value: "true")
         setVariable(.cachePrintHashes, value: "true")
@@ -865,6 +866,7 @@ struct CommandEnvironmentVariableTests {
         setVariable(.cacheTargets, value: "Fmk1,Fmk2")
 
         let commandWithEnvVars = try CacheWarmCommand.parse([])
+        #expect(commandWithEnvVars.externalOnly == true)
         #expect(commandWithEnvVars.cacheProfile == "development")
         #expect(commandWithEnvVars.generateOnly == true)
         #expect(commandWithEnvVars.printHashes == true)
@@ -873,6 +875,7 @@ struct CommandEnvironmentVariableTests {
         #expect(commandWithEnvVars.targets == ["Fmk1", "Fmk2"])
 
         let commandWithArgs = try CacheWarmCommand.parse([
+            "--external-only",
             "--cache-profile", "development",
             "--generate-only",
             "--print-hashes",
@@ -881,6 +884,7 @@ struct CommandEnvironmentVariableTests {
             "--",
             "Fmk1", "Fmk2",
         ])
+        #expect(commandWithArgs.externalOnly == true)
         #expect(commandWithArgs.cacheProfile == "development")
         #expect(commandWithArgs.generateOnly == true)
         #expect(commandWithArgs.printHashes == true)


### PR DESCRIPTION
## Summary

Adds a `--cache-profile` option to `tuist cache` that allows users to specify which cache profile to use during cache warming. When specified, the profile's configuration takes priority:

- **Profile's `base`** determines external-only behavior (overrides `--external-only` flag)
- **Profile's `exceptTargetQueries`** excludes specified targets from caching
- Both `.named()` and `.tagged()` queries are supported

When `--cache-profile` is not specified, existing behavior is preserved.

### Problem

When using local Swift packages via `Tuist/Package.swift` (`.package(path:)`), Tuist treats them as external dependencies. Running `tuist cache --external-only` caches these local packages as XCFrameworks unnecessarily.

`CacheProfile` supports `exceptTargetQueries` for excluding targets during **generation** (via `TargetReplacementDecider`), but cache **warm** has no way to leverage profile configuration.

Reproducible sample project: https://github.com/gnejfejf2/tuist-cache-profile-sample

```
$ tuist cache --external-only
Targets to be cached: Alamofire, Alamofire_Alamofire, CommonKit
                                                      ^^^^^^^^^ should be excluded
```

### Changes

- `CacheWarmCommand.swift`: Added `--cache-profile` CLI option
- `CacheServicing` protocol: Added `cacheProfile: String?` parameter
- `CacheWarmCommandService.swift`:
  - Added `ProfileResolution` struct and `resolveProfile()` method
  - When `--cache-profile` is specified, profile's `base` overrides `--external-only`:
    - `.onlyExternal` → external-only mode
    - `.allPossible` → cache all targets
    - `.none` → no caching
  - Profile's `exceptTargetQueries` are resolved against the graph and excluded from caching

### Usage

```bash
# Profile takes priority -- profile's base determines behavior,
# exceptTargetQueries excludes specified targets
tuist cache --cache-profile development

# Can combine with --external-only, but profile overrides it when specified
tuist cache --external-only --cache-profile development

# Without --cache-profile, existing behavior is preserved
tuist cache --external-only
```

### Design decisions

- **Explicit opt-in via CLI flag** rather than automatic profile resolution, respecting that cache profiles were originally a consumer-side control
- **Profile base overrides --external-only** because the profile already encodes this information, avoiding conflicting signals
- **No breaking changes to default behavior** -- existing `tuist cache` commands work exactly as before

## Test plan

- [x] Verified with [sample project](https://github.com/gnejfejf2/tuist-cache-profile-sample) that CommonKit appears in cache targets without profile (the bug)
- [x] Verify with EE build that `--cache-profile development` excludes CommonKit

Resolves #9945