### PR TITLE
Link homepage features to marketing pages instead of docs

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/home.html.heex
@@ -369,7 +369,7 @@
         <p data-part="description">
           {dgettext(
             "marketing",
-            "From code to feedback in minutes. Instant previews and AI-powered testing close the loop between building and validating."
+            "From code to feedback in minutes. Instant previews close the loop between building and validating."
           )}
         </p>
       </header>

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -2298,11 +2298,6 @@ msgstr ""
 msgid "Flaky tests dashboard showing test history and automation creation modal"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:370
-#, elixir-autogen, elixir-format
-msgid "From code to feedback in minutes. Instant previews and AI-powered testing close the loop between building and validating."
-msgstr ""
-
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:280
 #: lib/tuist_web/marketing/live/marketing_selective_testing_live.ex:36
 #: lib/tuist_web/marketing/live/marketing_selective_testing_live.html.heex:14
@@ -2370,4 +2365,9 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Open the %{feature} feature page"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:370
+#, elixir-autogen, elixir-format
+msgid "From code to feedback in minutes. Instant previews close the loop between building and validating."
 msgstr ""


### PR DESCRIPTION
## Summary
- Updated 6 feature links on the marketing homepage to point to their dedicated marketing pages (`/cache`, `/build-insights`, `/selective-testing`, `/flaky-tests`, `/test-insights`, `/previews`) instead of external documentation URLs
- Removed `target="_blank"` and `rel="noopener noreferrer"` from these links since they are now internal navigation
- Generated Projects and Registry links remain pointing to docs (no marketing pages exist for them)

## Test plan
- [ ] Verify each feature link on the homepage navigates to the correct marketing page
- [ ] Verify Generated Projects and Registry links still open docs in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)