### PR TITLE
perf(server): use test_case_branch_presence MV for branch/CI queries

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -32,10 +32,10 @@ defmodule Tuist.Tests do
   alias Tuist.Tests.QuarantinedTestCase
   alias Tuist.Tests.Test
   alias Tuist.Tests.TestCase
+  alias Tuist.Tests.TestCaseBranchPresence
   alias Tuist.Tests.TestCaseEvent
   alias Tuist.Tests.TestCaseFailure
   alias Tuist.Tests.TestCaseRun
-  alias Tuist.Tests.TestCaseBranchPresence
   alias Tuist.Tests.TestCaseRunAttachment
   alias Tuist.Tests.TestCaseRunDashboardCount
   alias Tuist.Tests.TestCaseRunRepetition

--- a/server/lib/tuist/tests/test_case_branch_presence.ex
+++ b/server/lib/tuist/tests/test_case_branch_presence.ex
@@ -1,4 +1,5 @@
 defmodule Tuist.Tests.TestCaseBranchPresence do
+  @moduledoc false
   use Ecto.Schema
 
   @primary_key false


### PR DESCRIPTION
## Summary

Switches `get_test_case_ids_with_ci_runs_on_branch` to query the `test_case_branch_presence` MV instead of the full `test_case_runs` table.

**Depends on:** #9943 (creates the MV)

## Context

The query scans ~14.5M rows from `test_case_runs` (p50=331ms, p90=2.8s, p99=6s). The MV has ORDER BY `(project_id, git_branch, is_ci, ran_at, test_case_id)` — a full prefix match on the WHERE clause — and is much smaller (one row per unique project+branch+test_case combo instead of one row per run).

## Changes

- New `TestCaseBranchPresence` Ecto schema for the MV
- `get_test_case_ids_with_ci_runs_on_branch` queries `TestCaseBranchPresence` instead of `TestCaseRun`

## Test plan

- [ ] Verify MV exists and has data (after #9943 is deployed)
- [ ] Deploy and monitor p50/p90 latency for this query
- [ ] Verify `is_new` detection still works correctly on test submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)