### PR TITLE
fix(server): add allow_nullable_key to branch presence MV

### DIFF
--- a/server/priv/ingest_repo/migrations/20260320120000_create_test_case_branch_presence_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260320120000_create_test_case_branch_presence_mv.exs
@@ -25,6 +25,7 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseBranchPresenceMv do
     CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_branch_presence
     ENGINE = MergeTree
     ORDER BY (project_id, git_branch, is_ci, ran_at, test_case_id)
+    SETTINGS allow_nullable_key = 1
     POPULATE
     AS SELECT
       project_id,


### PR DESCRIPTION
## Summary

Adds `SETTINGS allow_nullable_key = 1` to the `test_case_branch_presence` MV.

## Context

`test_case_id` is `Nullable(UUID)` and is part of the ORDER BY key. ClickHouse requires `allow_nullable_key = 1` for this, otherwise the migration fails with:

```
Code: 44. DB::Exception: Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled.
```

This is blocking the canary deploy.

## Test plan

- [x] Migration runs successfully locally
- [ ] CI Test and Seed jobs pass
- [ ] Canary deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)