### PR TITLE
perf(server): recreate branch presence MV with ReplacingMergeTree dedup

### DIFF
--- a/server/priv/ingest_repo/migrations/20260320140000_recreate_branch_presence_mv_with_dedup.exs
+++ b/server/priv/ingest_repo/migrations/20260320140000_recreate_branch_presence_mv_with_dedup.exs
@@ -40,7 +40,9 @@ defmodule Tuist.IngestRepo.Migrations.RecreateBranchPresenceMvWithDedup do
 
     backfill("test_case_runs", "test_case_branch_presence_new")
 
-    IngestRepo.query!("EXCHANGE TABLES test_case_branch_presence AND test_case_branch_presence_new")
+    IngestRepo.query!(
+      "EXCHANGE TABLES test_case_branch_presence AND test_case_branch_presence_new"
+    )
   end
 
   def down do


### PR DESCRIPTION
## Summary

Recreates `test_case_branch_presence` as `ReplacingMergeTree(ran_at)` with ORDER BY `(project_id, git_branch, is_ci, test_case_id)`.

## Context

The current `MergeTree` MV stores every row from `test_case_runs` — same size as the source table. A single query for project 1078 reads **50M rows** (p99=2.9s), defeating the purpose of the MV.

`ReplacingMergeTree(ran_at)` deduplicates to one row per unique `(project_id, git_branch, is_ci, test_case_id)`, keeping the latest `ran_at`. This dramatically reduces the table size.

`ran_at` moves out of the ORDER BY into the version column — the query filters on `ran_at >= ?` after the PrimaryKey binary search on `(project_id, git_branch, is_ci)`.

## After deploy

Backfill partition by partition:

```sql
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202511;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202512;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202601;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202602;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202603;
```

Then optimize to force deduplication:

```sql
OPTIMIZE TABLE `.inner_id.<uuid>` FINAL
```

(Get the inner table UUID from `SELECT uuid FROM system.tables WHERE name = 'test_case_branch_presence'`)

## Test plan

- [x] Migration runs locally
- [ ] Deploy and backfill
- [ ] Verify row count is much smaller than source table
- [ ] Monitor p50/p99 latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)