### PR TITLE
fix(server): simplify branch presence MV migration

### DIFF
--- a/server/priv/ingest_repo/migrations/20260320140000_recreate_branch_presence_mv_with_dedup.exs
+++ b/server/priv/ingest_repo/migrations/20260320140000_recreate_branch_presence_mv_with_dedup.exs
@@ -11,21 +11,19 @@ defmodule Tuist.IngestRepo.Migrations.RecreateBranchPresenceMvWithDedup do
   The query uses ran_at >= ? as a filter (not in ORDER BY), so it's applied
   after the PrimaryKey binary search on (project_id, git_branch, is_ci).
 
-  To avoid downtime, the new MV is created under a temporary name, backfilled,
-  then atomically swapped with the old one via EXCHANGE TABLES.
+  Backfill manually after deploy, partition by partition.
   """
   use Ecto.Migration
   alias Tuist.IngestRepo
-  require Logger
 
   @disable_ddl_transaction true
   @disable_migration_lock true
 
   def up do
-    IngestRepo.query!("DROP VIEW IF EXISTS test_case_branch_presence_new")
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_branch_presence")
 
     IngestRepo.query!("""
-    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_branch_presence_new
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_branch_presence
     ENGINE = ReplacingMergeTree(ran_at)
     ORDER BY (project_id, git_branch, is_ci, test_case_id)
     SETTINGS allow_nullable_key = 1
@@ -37,43 +35,9 @@ defmodule Tuist.IngestRepo.Migrations.RecreateBranchPresenceMvWithDedup do
       ran_at
     FROM test_case_runs
     """)
-
-    backfill("test_case_runs", "test_case_branch_presence_new")
-
-    IngestRepo.query!(
-      "EXCHANGE TABLES test_case_branch_presence AND test_case_branch_presence_new"
-    )
   end
 
   def down do
     :ok
-  end
-
-  defp backfill(source, destination) do
-    {:ok, %{rows: partitions}} =
-      IngestRepo.query(
-        """
-        SELECT DISTINCT partition
-        FROM system.parts
-        WHERE database = currentDatabase() AND table = {table:String} AND active
-        ORDER BY partition
-        """,
-        %{table: source}
-      )
-
-    for [partition] <- partitions do
-      Logger.info("Backfilling partition #{partition} from #{source} into #{destination}")
-
-      IngestRepo.query!(
-        """
-        INSERT INTO #{destination}
-        SELECT project_id, git_branch, is_ci, test_case_id, ran_at
-        FROM #{source}
-        WHERE toYYYYMM(inserted_at) = {partition:UInt32}
-        """,
-        %{partition: String.to_integer(partition)},
-        timeout: 600_000
-      )
-    end
   end
 end


### PR DESCRIPTION
## Summary

Removes the backfill and EXCHANGE TABLES from the branch presence MV migration. The MV is recreated empty — backfill manually after deploy.

## Context

`EXCHANGE TABLES` causes "Table is shutting down" errors on ClickHouse Cloud (ZooKeeper path conflict during inner table swap). Simplifying to drop + recreate avoids this.

## After deploy

Backfill partition by partition:

```sql
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202511;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202512;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202601;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202602;
INSERT INTO test_case_branch_presence SELECT project_id, git_branch, is_ci, test_case_id, ran_at FROM test_case_runs WHERE toYYYYMM(inserted_at) = 202603;
```

## Test plan

- [ ] CI passes
- [ ] Deploy succeeds
- [ ] Backfill and verify row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)