### PR TITLE
feat(server): add OpenTelemetry Ecto tracing for all database repos

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -76,10 +76,10 @@ defmodule Tuist.Application do
       OpentelemetryPhoenix.setup(adapter: :bandit)
       OpentelemetryFinch.setup()
       OpentelemetryBroadway.setup()
-      ecto_opts = [additional_span_attributes: %{"metrics.skip" => true}]
-      OpentelemetryEcto.setup([:tuist, :repo], ecto_opts)
-      OpentelemetryEcto.setup([:tuist, :ingest_repo], ecto_opts)
-      OpentelemetryEcto.setup([:tuist, :click_house_repo], ecto_opts)
+      ecto_skip_metrics = [additional_span_attributes: %{"metrics.skip" => true}]
+      OpentelemetryEcto.setup([event_prefix: [:tuist, :repo]] ++ ecto_skip_metrics)
+      OpentelemetryEcto.setup([event_prefix: [:tuist, :ingest_repo]] ++ ecto_skip_metrics)
+      OpentelemetryEcto.setup([event_prefix: [:tuist, :click_house_repo]] ++ ecto_skip_metrics)
     end
   end
 


### PR DESCRIPTION
## Summary

- Sets up `OpentelemetryEcto` for all three database repos (`Tuist.Repo`, `Tuist.IngestRepo`, `Tuist.ClickHouseRepo`) so every DB query automatically appears as a child span under the Phoenix request span
- This is a prerequisite for diagnosing slow endpoints — once deployed, traces will show individual query durations without requiring per-endpoint instrumentation

## Test plan

- [ ] Deploy to staging and trigger requests that hit Postgres and ClickHouse
- [ ] Verify Ecto query child spans appear in Grafana under the Phoenix request span
- [ ] Confirm spans include repo name, query source, and duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)