### PR TITLE
fix(cli): fix static framework core data bundle crash

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -272,7 +272,9 @@ public class GraphTraverser: GraphTraversing {
         guard let target = graph.projects[path]?.targets[name] else { return [] }
 
         func canHostResources(target: Target) -> Bool {
-            target.supportsResources && (target.product != .staticFramework || target.containsResources)
+            let isStatic = target.product == .staticFramework
+            let isDelegatedToBundle = target.metadata.tags.contains("tuist:resourcesDelegatedToBundle")
+            return target.supportsResources && (!isStatic || (target.containsResources && !isDelegatedToBundle))
         }
 
         guard canHostResources(target: target) else { return [] }
@@ -1501,7 +1503,9 @@ public class GraphTraverser: GraphTraversing {
 
     private func isEmbeddableDependencyTarget(dependency: GraphDependency) -> Bool {
         testTarget(dependency: dependency) {
-            $0.product.isDynamic || $0.product == .staticFramework && $0.containsResources
+            let isStatic = $0.product == .staticFramework
+            let isDelegatedToBundle = $0.metadata.tags.contains("tuist:resourcesDelegatedToBundle")
+            return $0.product.isDynamic || isStatic && $0.containsResources && !isDelegatedToBundle
         }
     }
 

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -100,6 +100,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 }
             }
             modifiedTarget.resources.resources = []
+            modifiedTarget.metadata.tags.insert("tuist:resourcesDelegatedToBundle")
             modifiedTarget.copyFiles = []
             modifiedTarget.buildableFolders = remainingBuildableFolders
             modifiedTarget.dependencies.append(.target(

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -777,6 +777,31 @@ struct GenerateAcceptanceTestiOSAppWithCoreData {
     }
 }
 
+struct GenerateAcceptanceTestiOSAppWithCoreDataInStaticFramework {
+    @Test(.withFixture("generated_ios_app_with_coredata_in_static_framework"), .inTemporaryDirectory)
+    func ios_app_with_coredata_in_static_framework() async throws {
+        // Given
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(components: "App", "App.xcodeproj")
+
+        // When
+        try await run(GenerateCommand.self)
+
+        // Then: Framework is linked as static — must NOT be embedded in App
+        try TuistTest.expectFrameworkNotEmbedded("Framework", by: "App", inXcodeProj: xcodeprojPath)
+
+        // Then: build succeeds (CoreData model compiles and NSManagedObject subclass is generated)
+        try await run(BuildCommand.self, "App")
+
+        // Then: compiled CoreData model is inside the companion bundle, not the framework itself
+        try await XCTAssertProductWithDestinationContainsResource(
+            "Framework_Framework.bundle",
+            destination: "Debug-iphonesimulator",
+            resource: "Users.momd"
+        )
+    }
+}
+
 struct GenerateAcceptanceTestiOSAppWithAppClip {
     @Test(.withFixture("generated_ios_app_with_appclip"), .inTemporaryDirectory)
     func ios_app_with_appclip() async throws {

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -563,6 +563,8 @@ struct ResourcesProjectMapperTests {
         #expect(gotTarget.name == target.name)
         #expect(gotTarget.product == target.product)
         #expect(gotTarget.resources.resources.count == 0)
+        #expect(gotTarget.coreDataModels == coreDataModels)
+        #expect(gotTarget.metadata.tags.contains("tuist:resourcesDelegatedToBundle"))
         #expect(gotTarget.sources.count == 2)
         #expect(gotTarget.sources.last?.path == expectedPath)
         #expect(gotTarget.sources.last?.contentHash != nil)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/9597

When a static framework target contains CoreData models, Tuist incorrectly embeds the framework as a dynamic one and misplaces the resource bundle. This causes a crash at runtime:
`Fatal error: unable to find bundle named Framework_Framework`.

### Root cause

`ResourcesProjectMapper` delegates resources (including `.xcdatamodeld`) to a companion bundle target, but didn't mark the original target as having done so. As a result, `GraphTraverser` still treated the static framework as if it contained resources and added it to the `Embedded Frameworks` build phase. This turns the static framework effectively dynamic — evidenced by the binary inspection on device:
```
$ file App.app/Frameworks/Framework.framework/Framework
Mach-O universal binary with 1 architecture: [arm64:Mach-O 64-bit dynamically linked shared library arm64]
```
And an empty `__TEXT` segment in the linked binary:
```
Section
  sectname __text
   segname __TEXT
      addr 0x00000000000002e8
      size 0x0000000000000000
    offset 744
     align 2^0 (1)
    reloff 0
    nreloc 0
     flags 0x80000400
```

The bundle ends up inside `Frameworks/Framework.framework` rather than next to the app binary, so `TuistBundle+Framework.swift` cannot locate it at runtime, causing a crash: `Fatal error: unable to find bundle named Framework_Framework`.

### Fix

- Tag the source target with `tuist:resourcesDelegatedToBundle` in `ResourcesProjectMapper` once its resources are moved to the companion bundle.
- In `GraphTraverser.canHostResources` and `isEmbeddableDependencyTarget`, skip static frameworks that carry this tag so they are no longer embedded and the bundle is placed correctly.

### How to test locally

1. Open the example project:
```
cd examples/xcode/generated_ios_app_with_coredata_in_static_framework
tuist generate
```
2. Verify in `App → Build Phases`:
   - `Embedded Frameworks` is **empty**
   - `Dependencies` phase is present and contains `Framework_Framework.bundle`
3. Run the app on a simulator — no crash should occur.
4. Run `ResourcesProjectMapperTests` in `TuistGeneratorTests`.
5. Run `ios_app_with_coredata_in_static_framework` in `TuistGeneratorAcceptanceTests`.
