### PR TITLE
fix(cli): Support  optional Buildable Folders

### DIFF
--- a/cli/Sources/ProjectDescription/BuildableFolder.swift
+++ b/cli/Sources/ProjectDescription/BuildableFolder.swift
@@ -5,21 +5,31 @@
 public struct BuildableFolder: Sendable, Codable, Equatable, ExpressibleByStringLiteral {
     public var path: Path
     public var exceptions: BuildableFolderExceptions
+    public var optional: Bool
 
     /// Creates an instance of a buildable folder.
-    /// - Parameter path: Path to the buildable folder.
+    /// - Parameters:
+    ///   - path: Path to the buildable folder.
+    ///   - exceptions: Files or directories to exclude, or per-file build settings overrides.
+    ///   - optional: When `true`, the folder generation skipped with a warning if it does not exist. Defaults to `false`.
     /// - Returns: An instance of buildable folder.
-    public static func folder(_ path: Path, exceptions: BuildableFolderExceptions = .exceptions([])) -> Self {
-        Self(path: path, exceptions: exceptions)
+    public static func folder(
+        _ path: Path,
+        exceptions: BuildableFolderExceptions = .exceptions([]),
+        optional: Bool = false
+    ) -> Self {
+        Self(path: path, exceptions: exceptions, optional: optional)
     }
 
-    init(path: Path, exceptions: BuildableFolderExceptions) {
+    init(path: Path, exceptions: BuildableFolderExceptions, optional: Bool = false) {
         self.path = path
         self.exceptions = exceptions
+        self.optional = optional
     }
 
     public init(stringLiteral value: String) {
         path = .init(stringLiteral: value)
         exceptions = .exceptions([])
+        optional = false
     }
 }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -3,6 +3,7 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistEnvironment
+import TuistAlert
 import TuistLogging
 import TuistSupport
 import XcodeGraph
@@ -25,11 +26,19 @@ extension XcodeGraph.BuildableFolder {
         manifest: ProjectDescription.BuildableFolder,
         generatorPaths: GeneratorPaths,
         targetName: String
-    ) async throws -> XcodeGraph.BuildableFolder {
+    ) async throws -> XcodeGraph.BuildableFolder? {
         let path = try generatorPaths.resolve(path: manifest.path)
         let fileSystem = FileSystem()
 
         if try await !fileSystem.exists(path) {
+            if manifest.optional {
+                AlertController.current.warning(
+                    .alert(
+                        "The target \(targetName) has an optional buildableFolder at \(path.pathString) that does not exist. It will be skipped."
+                    )
+                )
+                return nil
+            }
             throw BuildableFolderManifestMapperError.folderNotFound(targetName: targetName, path: path)
         }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -2,8 +2,8 @@ import FileSystem
 import Foundation
 import Path
 import ProjectDescription
-import TuistEnvironment
 import TuistAlert
+import TuistEnvironment
 import TuistLogging
 import TuistSupport
 import XcodeGraph

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -140,7 +140,7 @@ extension XcodeGraph.Target {
         }
 
         let metadata = XcodeGraph.TargetMetadata(tags: Set(manifest.metadata.tags))
-        let buildableFolders = try await manifest.buildableFolders.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let buildableFolders = try await manifest.buildableFolders.concurrentCompactMap(maxConcurrentTasks: maxConcurrentTasks) {
             try await XcodeGraph.BuildableFolder.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperFolderExistsTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperFolderExistsTests.swift
@@ -28,6 +28,42 @@ struct BuildableFolderManifestMapperFolderExistsTests {
         }
     }
 
+    @Test(.inTemporaryDirectory) func from_whenFolderDoesNotExistAndIsOptional_returnsNil() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let folderPath = temporaryDirectory.appending(component: "NonExistingFolder")
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryDirectory,
+            rootDirectory: temporaryDirectory
+        )
+        let manifest = ProjectDescription.BuildableFolder.folder(.path(folderPath.pathString), optional: true)
+
+        let got = try await XcodeGraph.BuildableFolder.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            targetName: "Target"
+        )
+
+        #expect(got == nil)
+    }
+
+    @Test(.inTemporaryDirectory) func from_whenFolderDoesNotExistAndIsNotOptional_throwsBuildableFolderNotFound() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let folderPath = temporaryDirectory.appending(component: "NonExistingFolder")
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryDirectory,
+            rootDirectory: temporaryDirectory
+        )
+        let manifest = ProjectDescription.BuildableFolder.folder(.path(folderPath.pathString), optional: false)
+
+        await #expect(throws: BuildableFolderManifestMapperError.folderNotFound(targetName: "Target", path: folderPath)) {
+            try await XcodeGraph.BuildableFolder.from(
+                manifest: manifest,
+                generatorPaths: generatorPaths,
+                targetName: "Target"
+            )
+        }
+    }
+
     @Test(.inTemporaryDirectory) func from_whenFolderExists_mapsCorrectly() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let folderPath = temporaryDirectory.appending(component: "ExistingFolder")
@@ -41,11 +77,11 @@ struct BuildableFolderManifestMapperFolderExistsTests {
         )
         let manifest = ProjectDescription.BuildableFolder.folder(.path(folderPath.pathString))
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         #expect(got.path == folderPath)
         #expect(got.resolvedFiles.count == 1)

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildableFolder+ManifestMapperTests.swift
@@ -32,11 +32,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 
@@ -64,11 +64,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 
@@ -94,11 +94,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 
@@ -125,11 +125,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 
@@ -157,11 +157,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let fileWithFlags = got.resolvedFiles.first {
             $0.path == temporaryDirectory.appending(components: "Sources", "File.swift")
@@ -190,11 +190,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 
@@ -225,11 +225,11 @@ struct BuildableFolderManifestMapperTests {
             rootDirectory: temporaryDirectory
         )
 
-        let got = try await XcodeGraph.BuildableFolder.from(
+        let got = try #require(try await XcodeGraph.BuildableFolder.from(
             manifest: manifest,
             generatorPaths: generatorPaths,
             targetName: "Target"
-        )
+        ))
 
         let resolvedPaths = Set(got.resolvedFiles.map(\.path))
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/9971>
Related to <https://github.com/tuist/tuist/issues/9609>

Before https://github.com/tuist/tuist/pull/9609, non-existent buildable folder paths were silently ignored during generation. That PR introduced the "required" behaviour for buildable folders.

So, basically, this allows setting up behaviour on the buildable folders.
(Warnings instead of the errors) 

### How to test locally
Run tests, or create Tuist definition that marks buildable folder as optional/non-optional(default)


> Document how to test your changes locally
running tests should be enough
