### PR TITLE
fix(server): use atom key for OpentelemetryEcto span attributes

### DIFF
--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -76,7 +76,7 @@ defmodule Tuist.Application do
       OpentelemetryPhoenix.setup(adapter: :bandit)
       OpentelemetryFinch.setup()
       OpentelemetryBroadway.setup()
-      ecto_skip_metrics = [additional_span_attributes: %{"metrics.skip" => true}]
+      ecto_skip_metrics = [additional_span_attributes: %{:"metrics.skip" => true}]
       OpentelemetryEcto.setup([event_prefix: [:tuist, :repo]] ++ ecto_skip_metrics)
       OpentelemetryEcto.setup([event_prefix: [:tuist, :ingest_repo]] ++ ecto_skip_metrics)
       OpentelemetryEcto.setup([event_prefix: [:tuist, :click_house_repo]] ++ ecto_skip_metrics)


### PR DESCRIPTION
## Summary

- Fixes canary deploy crash caused by `NimbleOptions.ValidationError: invalid value for map key: expected atom, got: "metrics.skip"`
- Uses `:"metrics.skip"` (atom) instead of `"metrics.skip"` (string) in the `additional_span_attributes` map

## Test plan

- [ ] Deploy to canary and verify the app starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)