### PR TITLE
fix(cli): support .tbd stub files in xcframeworks

### DIFF
--- a/cli/Sources/XcodeGraph/Sources/XcodeMetadata/Providers/XCFrameworkMetadataProvider.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeMetadata/Providers/XCFrameworkMetadataProvider.swift
@@ -157,12 +157,24 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider,
 
         switch library.path.extension {
         case "framework":
-            binaryPath = try AbsolutePath(
+            let frameworkPath = try AbsolutePath(
                 validating: library.identifier, relativeTo: xcframeworkPath
             )
             .appending(try RelativePath(validating: library.path.pathString))
-            .appending(component: library.path.basenameWithoutExt)
-            linking = try? self.linking(binaryPath: binaryPath)
+            let expectedBinaryPath = frameworkPath
+                .appending(component: library.path.basenameWithoutExt)
+            let tbdPath = frameworkPath
+                .appending(component: "\(library.path.basenameWithoutExt).tbd")
+            if try await fileSystem.exists(expectedBinaryPath) {
+                binaryPath = expectedBinaryPath
+                linking = try? self.linking(binaryPath: binaryPath)
+            } else if try await fileSystem.exists(tbdPath) {
+                binaryPath = tbdPath
+                linking = .dynamic
+            } else {
+                binaryPath = expectedBinaryPath
+                linking = nil
+            }
         case "a":
             binaryPath = try AbsolutePath(
                 validating: library.identifier, relativeTo: xcframeworkPath

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/Info.plist
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-x86_64-simulator</string>
+			<key>LibraryPath</key>
+			<string>MyTBDFramework.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>MyTBDFramework.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-arm64/MyTBDFramework.framework/Modules/module.modulemap
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-arm64/MyTBDFramework.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module MyTBDFramework {
+  header "MyTBDFramework.h"
+  export *
+}

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-arm64/MyTBDFramework.framework/MyTBDFramework.tbd
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-arm64/MyTBDFramework.framework/MyTBDFramework.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ arm64-ios ]
+install-name:    '/System/Library/PrivateFrameworks/MyTBDFramework.framework/MyTBDFramework'
+current-version: 1
+exports:
+  - targets:         [ arm64-ios ]
+    symbols:         [ _MyTBDFrameworkVersionNumber, _MyTBDFrameworkVersionString ]
+...

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-x86_64-simulator/MyTBDFramework.framework/Modules/module.modulemap
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-x86_64-simulator/MyTBDFramework.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module MyTBDFramework {
+  header "MyTBDFramework.h"
+  export *
+}

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-x86_64-simulator/MyTBDFramework.framework/MyTBDFramework.tbd
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/MyTBDFramework.xcframework/ios-x86_64-simulator/MyTBDFramework.framework/MyTBDFramework.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-ios-simulator ]
+install-name:    '/System/Library/PrivateFrameworks/MyTBDFramework.framework/MyTBDFramework'
+current-version: 1
+exports:
+  - targets:         [ x86_64-ios-simulator ]
+    symbols:         [ _MyTBDFrameworkVersionNumber, _MyTBDFrameworkVersionString ]
+...

--- a/cli/Sources/XcodeGraph/Tests/XcodeMetadataTests/XCFrameworkMetadataProviderTests.swift
+++ b/cli/Sources/XcodeGraph/Tests/XcodeMetadataTests/XCFrameworkMetadataProviderTests.swift
@@ -235,6 +235,40 @@ struct XCFrameworkMetadataProviderTests {
     }
 
     @Test
+    func loadMetadataTBDFramework() async throws {
+        // Given
+        let frameworkPath = AssertionsTesting.fixturePath(
+            path: try RelativePath(validating: "MyTBDFramework.xcframework")
+        )
+
+        // When
+        let metadata = try await subject.loadMetadata(at: frameworkPath, expectedSignature: nil, status: .required)
+
+        // Then
+        let expectedInfoPlist = XCFrameworkInfoPlist(libraries: [
+            XCFrameworkInfoPlist.Library(
+                identifier: "ios-x86_64-simulator",
+                path: try RelativePath(validating: "MyTBDFramework.framework"),
+                mergeable: false,
+                platform: .iOS,
+                architectures: [.x8664]
+            ),
+            XCFrameworkInfoPlist.Library(
+                identifier: "ios-arm64",
+                path: try RelativePath(validating: "MyTBDFramework.framework"),
+                mergeable: false,
+                platform: .iOS,
+                architectures: [.arm64]
+            ),
+        ])
+
+        #expect(metadata.path == frameworkPath)
+        #expect(metadata.infoPlist == expectedInfoPlist)
+        #expect(metadata.linking == .dynamic)
+        #expect(metadata.mergeable == false)
+    }
+
+    @Test
     func loadMetadataFrameworkMissingArchitecture() async throws {
         // Given
         let frameworkPath = AssertionsTesting.fixturePath(


### PR DESCRIPTION
> [!NOTE]
> @Kyle-Ye reached out seeking help with using Tuist to generate the Xcode project for his amazing `OpenSwiftUIProject` project, and we came across a limitation of Tuist, which I'm addressing in this PR.

## Summary

- XCFrameworks containing text-based stub (`.tbd`) files instead of Mach-O binaries are now recognized by `XCFrameworkMetadataProvider`
- When a `.framework` slice doesn't contain the expected binary but has a `.tbd` file, it's treated as a dynamic library stub
- Added test fixture and test for `.tbd`-based xcframeworks

This fixes `tuist generate` failing on packages like [DarwinPrivateFrameworks](https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks) that ship xcframeworks with only `.tbd` stubs for Apple private frameworks. The error was:

```
Couldn't find any supported architecture references at .../CoreUI.xcframework.
It's possible that the .xcframework was not generated properly or that it got corrupted.
```

Context: https://github.com/OpenSwiftUIProject/OpenSwiftUI/pull/807#issuecomment-4103849936

🤖 Generated with [Claude Code](https://claude.com/claude-code)