### PR TITLE
perf(server): pass project_id to test_runs_metrics for ClickHouse primary key match

### DIFF
--- a/server/lib/tuist/mcp/components/tools/list_test_runs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_test_runs.ex
@@ -65,8 +65,8 @@ defmodule Tuist.MCP.Components.Tools.ListTestRuns do
       })
 
     metrics_map =
-      runs
-      |> Tests.Analytics.test_runs_metrics()
+      project.id
+      |> Tests.Analytics.test_runs_metrics(runs)
       |> Map.new(&{&1.test_run_id, &1})
 
     {:ok,

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -448,13 +448,13 @@ defmodule Tuist.Tests.Analytics do
   - skipped_tests: Number of skipped test targets
   - ran_tests: Number of test cases that actually ran
   """
-  def test_runs_metrics(test_runs) when is_list(test_runs) do
+  def test_runs_metrics(project_id, test_runs) when is_list(test_runs) do
     test_run_ids = Enum.map(test_runs, & &1.id)
 
     test_case_counts =
       ClickHouseRepo.all(
         from(t in TestCaseRun,
-          where: t.test_run_id in ^test_run_ids,
+          where: t.project_id == ^project_id and t.test_run_id in ^test_run_ids,
           group_by: t.test_run_id,
           select: %{
             test_run_id: t.test_run_id,

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -626,7 +626,7 @@ defmodule Tuist.VCS do
          test_run_url: test_run_url,
          project: project
        }) do
-    metrics_data = TestsAnalytics.test_runs_metrics(test_runs)
+    metrics_data = TestsAnalytics.test_runs_metrics(project.id, test_runs)
     metrics_map = Map.new(metrics_data, &{&1.test_run_id, &1})
 
     rows =
@@ -658,7 +658,7 @@ defmodule Tuist.VCS do
          test_run_url: test_run_url,
          project: project
        }) do
-    metrics_data = TestsAnalytics.test_runs_metrics(test_runs)
+    metrics_data = TestsAnalytics.test_runs_metrics(project.id, test_runs)
     metrics_map = Map.new(metrics_data, &{&1.test_run_id, &1})
 
     rows =

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -153,7 +153,7 @@ defmodule TuistWeb.API.TestsController do
     }
 
     {test_runs, meta} = Tests.list_test_runs(attrs)
-    metrics_list = Tests.Analytics.test_runs_metrics(test_runs)
+    metrics_list = Tests.Analytics.test_runs_metrics(selected_project.id, test_runs)
     metrics_map = Map.new(metrics_list, &{&1.test_run_id, &1})
 
     json(conn, %{

--- a/server/test/tuist/mcp/components/tools/test_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/test_tools_test.exs
@@ -45,7 +45,7 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
          }}
       end)
 
-      stub(Analytics, :test_runs_metrics, fn _runs ->
+      stub(Analytics, :test_runs_metrics, fn _project_id, _runs ->
         [%{test_run_id: "run-1", total_tests: 50, ran_tests: 45, skipped_tests: 5}]
       end)
 

--- a/server/test/tuist/tests/analytics_test.exs
+++ b/server/test/tuist/tests/analytics_test.exs
@@ -203,7 +203,7 @@ defmodule Tuist.Tests.AnalyticsTest do
     end
   end
 
-  describe "test_runs_metrics/1" do
+  describe "test_runs_metrics/2" do
     test "returns metrics and command event data for test runs" do
       # Given
       project = ProjectsFixtures.project_fixture()
@@ -254,6 +254,7 @@ defmodule Tuist.Tests.AnalyticsTest do
           id: UUIDv7.generate(),
           test_run_id: test_run_one.id,
           test_module_run_id: module_run_id_one,
+          project_id: project.id,
           module_name: "MyTests",
           suite_name: "TestSuite",
           name: "testOne",
@@ -266,6 +267,7 @@ defmodule Tuist.Tests.AnalyticsTest do
           id: UUIDv7.generate(),
           test_run_id: test_run_two.id,
           test_module_run_id: module_run_id_two,
+          project_id: project.id,
           module_name: "MyTests",
           suite_name: "TestSuite",
           name: "testSuccess",
@@ -278,6 +280,7 @@ defmodule Tuist.Tests.AnalyticsTest do
           id: UUIDv7.generate(),
           test_run_id: test_run_two.id,
           test_module_run_id: module_run_id_two,
+          project_id: project.id,
           module_name: "MyTests",
           suite_name: "TestSuite",
           name: "testFailure",
@@ -290,6 +293,7 @@ defmodule Tuist.Tests.AnalyticsTest do
           id: UUIDv7.generate(),
           test_run_id: test_run_two.id,
           test_module_run_id: module_run_id_two,
+          project_id: project.id,
           module_name: "MyTests",
           suite_name: "TestSuite",
           name: "testAnother",
@@ -333,7 +337,7 @@ defmodule Tuist.Tests.AnalyticsTest do
         )
 
       # When
-      got = Analytics.test_runs_metrics([test_run_one, test_run_two])
+      got = Analytics.test_runs_metrics(project.id, [test_run_one, test_run_two])
 
       # Then
       assert length(got) == 2
@@ -391,6 +395,7 @@ defmodule Tuist.Tests.AnalyticsTest do
           id: UUIDv7.generate(),
           test_run_id: test_run.id,
           test_module_run_id: UUIDv7.generate(),
+          project_id: project.id,
           module_name: "MyTests",
           suite_name: "TestSuite",
           name: "testOne",
@@ -402,7 +407,7 @@ defmodule Tuist.Tests.AnalyticsTest do
       ])
 
       # When
-      got = Analytics.test_runs_metrics([test_run])
+      got = Analytics.test_runs_metrics(project.id, [test_run])
 
       # Then
       assert length(got) == 1

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -47,7 +47,7 @@ defmodule TuistWeb.API.TestsControllerTest do
          }}
       end)
 
-      stub(Analytics, :test_runs_metrics, fn _test_runs ->
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs ->
         [%{test_run_id: test_run_id, total_tests: 42, ran_tests: 40, skipped_tests: 2}]
       end)
 
@@ -90,7 +90,7 @@ defmodule TuistWeb.API.TestsControllerTest do
          }}
       end)
 
-      stub(Analytics, :test_runs_metrics, fn _test_runs -> [] end)
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs -> [] end)
 
       # When
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/tests")
@@ -103,7 +103,7 @@ defmodule TuistWeb.API.TestsControllerTest do
 
     test "filters test runs by git_branch", %{conn: conn, user: user, project: project} do
       # Given
-      stub(Analytics, :test_runs_metrics, fn _test_runs -> [] end)
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs -> [] end)
 
       expect(Tests, :list_test_runs, fn attrs ->
         assert %{field: :git_branch, op: :==, value: "main"} in attrs.filters
@@ -128,7 +128,7 @@ defmodule TuistWeb.API.TestsControllerTest do
 
     test "filters test runs by status", %{conn: conn, user: user, project: project} do
       # Given
-      stub(Analytics, :test_runs_metrics, fn _test_runs -> [] end)
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs -> [] end)
 
       expect(Tests, :list_test_runs, fn attrs ->
         assert %{field: :status, op: :==, value: "failure"} in attrs.filters
@@ -153,7 +153,7 @@ defmodule TuistWeb.API.TestsControllerTest do
 
     test "filters test runs by scheme", %{conn: conn, user: user, project: project} do
       # Given
-      stub(Analytics, :test_runs_metrics, fn _test_runs -> [] end)
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs -> [] end)
 
       expect(Tests, :list_test_runs, fn attrs ->
         assert %{field: :scheme, op: :==, value: "MyApp"} in attrs.filters
@@ -204,7 +204,7 @@ defmodule TuistWeb.API.TestsControllerTest do
          }}
       end)
 
-      stub(Analytics, :test_runs_metrics, fn _test_runs -> [] end)
+      stub(Analytics, :test_runs_metrics, fn _project_id, _test_runs -> [] end)
 
       # When
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/tests")


### PR DESCRIPTION
## Summary
- Changed `test_runs_metrics/1` to `test_runs_metrics/2`, accepting an explicit `project_id` parameter
- Adds `project_id` to the WHERE clause so ClickHouse can binary-search on the primary key prefix before falling back to the bloom filter on `test_run_id`
- Updated all 4 callers (vcs.ex ×2, tests_controller.ex, MCP list_test_runs.ex) — all already had project context available

## Performance analysis

**Current production stats** (from ClickHouse query log):
- Avg read rows: **94,337,790** (~94M rows per call)
- p50 latency: **341 ms**
- p90 latency: **1,355 ms**

**Why it's slow:** The `test_case_runs` table ORDER BY is `(project_id, test_case_id, ran_at, id)`. Without `project_id` in the WHERE clause, ClickHouse can't use the primary key at all — it falls through to the `idx_test_run_id` bloom filter which must scan every granule across all projects and partitions.

**EXPLAIN indexes=1** confirms the difference (local dev DB):

```
--- WITHOUT project_id ---
PrimaryKey
  Condition: true          ← no key used, scans all granules
  Parts: 12/12
  Granules: 12/12

--- WITH project_id ---
PrimaryKey
  Keys: project_id
  Condition: (project_id in [3, 3])
  Search Algorithm: binary search   ← narrows to one project first
  Parts: 12/12
  Granules: 12/12
```

With `project_id` in the WHERE, ClickHouse binary-searches the primary key to the target project's data, then applies the bloom filter on `test_run_id` within that subset only. For a typical production deployment with hundreds of projects, this should reduce read rows from ~94M to the single project's data (~100K-1M rows depending on project size).

## Test plan
- [x] `mix test test/tuist/tests/analytics_test.exs` — 35 tests pass
- [x] `mix test test/tuist_web/controllers/api/tests_controller_test.exs` — tests pass
- [x] `mix test test/tuist/mcp/components/tools/test_tools_test.exs` — tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)