### PR TITLE
fix(cli): fix macro copy script failing on clean builds

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -494,7 +494,9 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             """
             if [[ -f "$BUILD_DIR/$CONFIGURATION/\($0)" ]]; then
                 mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
-                cp -f "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
+                if [[ "$BUILD_DIR/$CONFIGURATION/\($0)" != "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)" ]]; then
+                    cp -f "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
+                fi
             fi
             """
         }

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2021,7 +2021,7 @@ struct BuildPhaseGeneratorTests {
         #expect(buildPhase != nil)
 
         let expectedScript =
-            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    cp -f \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\nfi"
+            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    if [[ \"$BUILD_DIR/$CONFIGURATION/macro\" != \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n        cp -f \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\n    fi\nfi"
         #expect(buildPhase?.shellScript?.contains(expectedScript) == true)
         #expect(buildPhase?.inputPaths.contains("$BUILD_DIR/$CONFIGURATION/\(macroExecutable.productName)") == true)
         #expect(


### PR DESCRIPTION
## Summary

When building for macOS, `$BUILD_DIR/$CONFIGURATION` and `$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME` resolve to the same path (e.g. `.../Build/Products/Debug/MockableMacro`). PR #9962 removed the `! -f` destination guard and switched to `cp -f`, but `cp -f` fails with exit code 1 when source and destination are identical:

```
cp: .../Debug/MockableMacro and .../Debug/MockableMacro are identical (not copied).
```

This causes the "Copy Swift Macro executable" script phase to fail on every macOS build.

**Fix:** Add a guard to skip the copy when source and destination paths are the same.

Regression from https://github.com/tuist/tuist/pull/9962

## Test plan

- [x] Verify `BuildPhaseGeneratorTests` pass
- [ ] Clean build (`rm -rf DerivedData`) with `xcodebuild build-for-testing` no longer fails on the Mockable script phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)