### PR TITLE
fix(server): enrich transport logs with request context and reduce noise

### DIFF
--- a/cache/lib/cache/application.ex
+++ b/cache/lib/cache/application.ex
@@ -97,6 +97,7 @@ defmodule Cache.Application do
           :selected_project_handle,
           :method,
           :route,
+          :request_path,
           :reason,
           :error,
           :kind,

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -114,6 +114,7 @@ defmodule Tuist.Application do
           :selected_project_handle,
           :method,
           :route,
+          :request_path,
           :reason,
           :error,
           :kind,

--- a/tuist_common/lib/tuist_common/http/transport.ex
+++ b/tuist_common/lib/tuist_common/http/transport.ex
@@ -52,7 +52,8 @@ defmodule TuistCommon.HTTP.Transport do
 
     %{
       method: (conn && conn.method) || "unknown",
-      route: (conn && conn.private[:phoenix_route]) || "unknown"
+      route: (conn && conn.private[:phoenix_route]) || "unknown",
+      request_path: conn && conn.request_path
     }
   end
 

--- a/tuist_common/lib/tuist_common/http/transport_logger.ex
+++ b/tuist_common/lib/tuist_common/http/transport_logger.ex
@@ -32,6 +32,9 @@ defmodule TuistCommon.HTTP.TransportLogger do
   end
 
   def handle_event([:bandit, :request, :stop], measurements, metadata, _config) do
+    request_meta = Transport.bandit_request_metadata(metadata)
+    Logger.metadata(Map.to_list(request_meta))
+
     if Transport.bandit_request_timeout?(metadata) do
       Logger.warning(
         "Bandit request body read timed out",
@@ -53,10 +56,16 @@ defmodule TuistCommon.HTTP.TransportLogger do
         :ok
 
       reason ->
-        Logger.warning(
-          "Thousand Island connection dropped",
+        log_metadata =
           Map.to_list(Transport.thousand_island_drop_log_metadata(measurements, metadata, reason))
-        )
+
+        case reason do
+          r when r in ["timeout", "closed"] ->
+            Logger.debug("Thousand Island connection dropped", log_metadata)
+
+          _ ->
+            Logger.warning("Thousand Island connection dropped", log_metadata)
+        end
     end
   end
 

--- a/tuist_common/test/tuist_common/http/transport_logger_test.exs
+++ b/tuist_common/test/tuist_common/http/transport_logger_test.exs
@@ -23,7 +23,7 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
       capture_log(
         [
           format: "$metadata$message",
-          metadata: [:request_id, :method, :route, :connection_span_context]
+          metadata: [:request_id, :method, :route, :request_path, :connection_span_context]
         ],
         fn ->
           :telemetry.execute(
@@ -35,6 +35,7 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
               connection_telemetry_span_context: make_ref(),
               conn: %{
                 method: "POST",
+                request_path: "/upload/abc123",
                 private: %{phoenix_route: "/upload"},
                 resp_headers: [{"x-request-id", "req_123"}]
               }
@@ -47,15 +48,20 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
     assert log =~ "request_id=req_123"
     assert log =~ "method=POST"
     assert log =~ "route=/upload"
+    assert log =~ "request_path=/upload/abc123"
     assert log =~ "connection_span_context="
   end
 
-  test "logs Thousand Island drops with normalized reason and remote address", %{
+  test "logs Thousand Island timeout/closed drops at debug level", %{
     handler_suffix: _handler_suffix
   } do
     log =
       capture_log(
-        [format: "$metadata$message", metadata: [:reason, :remote_address, :recv_oct]],
+        [
+          level: :debug,
+          format: "$metadata[$level] $message",
+          metadata: [:reason, :remote_address, :recv_oct]
+        ],
         fn ->
           :telemetry.execute(
             [:thousand_island, :connection, :stop],
@@ -74,9 +80,81 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
         end
       )
 
-    assert log =~ "Thousand Island connection dropped"
+    assert log =~ "[debug] Thousand Island connection dropped"
     assert log =~ "reason=closed"
     assert log =~ "remote_address=127.0.0.1"
     assert log =~ "recv_oct=64"
+  end
+
+  test "logs Thousand Island shutdown drops at warning level", %{
+    handler_suffix: _handler_suffix
+  } do
+    log =
+      capture_log(
+        [format: "$metadata[$level] $message", metadata: [:reason]],
+        fn ->
+          :telemetry.execute(
+            [:thousand_island, :connection, :stop],
+            %{
+              duration: System.convert_time_unit(3, :millisecond, :native),
+              recv_oct: 64,
+              send_oct: 32
+            },
+            %{
+              telemetry_span_context: make_ref(),
+              remote_address: {127, 0, 0, 1},
+              remote_port: 4000,
+              error: {:shutdown, :something}
+            }
+          )
+        end
+      )
+
+    assert log =~ "[warning] Thousand Island connection dropped"
+    assert log =~ "reason=shutdown"
+  end
+
+  test "propagates route and method from Bandit request to Thousand Island connection drop", %{
+    handler_suffix: _handler_suffix
+  } do
+    log =
+      capture_log(
+        [level: :debug, format: "$metadata$message", metadata: [:method, :route, :request_path, :reason]],
+        fn ->
+          :telemetry.execute(
+            [:bandit, :request, :stop],
+            %{duration: System.convert_time_unit(1, :millisecond, :native)},
+            %{
+              conn: %{
+                method: "GET",
+                request_path: "/api/projects/my-project",
+                private: %{phoenix_route: "/api/projects"},
+                resp_headers: []
+              }
+            }
+          )
+
+          :telemetry.execute(
+            [:thousand_island, :connection, :stop],
+            %{
+              duration: System.convert_time_unit(5, :millisecond, :native),
+              recv_oct: 100,
+              send_oct: 50
+            },
+            %{
+              telemetry_span_context: make_ref(),
+              remote_address: {127, 0, 0, 1},
+              remote_port: 4000,
+              error: :timeout
+            }
+          )
+        end
+      )
+
+    assert log =~ "Thousand Island connection dropped"
+    assert log =~ "method=GET"
+    assert log =~ "route=/api/projects"
+    assert log =~ "request_path=/api/projects/my-project"
+    assert log =~ "reason=timeout"
   end
 end


### PR DESCRIPTION
> [!NOTE]
> Bandit exceptions happen in production with this error `invalid UTF-8 on urlencoded params, got byte 173` so I'm adding additional logs to better understand the format of those params.

## Summary
- Propagate `method`, `route`, and `request_path` from Bandit request events into Logger process metadata, so they appear on Thousand Island connection drop logs
- Add `:request_path` to Loki structured metadata allowlist in both server and cache
- Downgrade timeout/closed connection drops from `warning` to `debug` since they are normal TCP lifecycle events (client disconnected, idle timeout)

## Test plan
- [x] Existing transport logger tests updated and passing
- [x] New test verifying metadata propagation from Bandit request to Thousand Island connection drop
- [x] New test verifying log level differentiation (debug for timeout/closed, warning for shutdown/other)

🤖 Generated with [Claude Code](https://claude.com/claude-code)