### PR TITLE
fix(server): use script-relative path for .tuist-dev-instance file

### DIFF
--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -7,7 +7,7 @@ else
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
-PROJECT_ROOT="${MISE_PROJECT_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 INSTANCE_FILE="${PROJECT_ROOT}/.tuist-dev-instance"
 
 validate_suffix() {


### PR DESCRIPTION
## Summary
- Fix `dev_instance_env.sh` to always resolve the repo root relative to the script's own location instead of using `MISE_PROJECT_ROOT`
- `MISE_PROJECT_ROOT` differs depending on which `mise.toml` sources the script — when sourced from `server/mise.toml`, it pointed to `server/`, creating `server/.tuist-dev-instance` instead of the repo root
- This caused suffix mismatches between configs, leading to database connection failures (e.g. databases created with one suffix but the server expecting another)
-
🤖 Generated with [Claude Code](https://claude.com/claude-code)