### PR TITLE
fix(server): use TUIST_SERVER_URL for endpoint URL in dev mode

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -676,11 +676,11 @@ defmodule Tuist.Environment do
   end
 
   defp app_base_url(secrets) do
-    get([:app, :url], secrets) || default_app_url()
-  end
-
-  defp default_app_url do
-    if dev?(), do: System.get_env("TUIST_SERVER_URL") || "http://localhost:8080", else: "http://localhost:8080"
+    if dev?() do
+      System.get_env("TUIST_SERVER_URL") || get([:app, :url], secrets) || "http://localhost:8080"
+    else
+      get([:app, :url], secrets) || "http://localhost:8080"
+    end
   end
 
   defp get_route_info(path) do


### PR DESCRIPTION
## Summary
- In dev mode, `app_base_url` was reading the URL from secrets first (e.g. `http://tahani:8080`), ignoring the `TUIST_SERVER_URL` env var set by `dev_instance_env.sh`
- This caused the endpoint's `url` config to show port 8080 instead of the scoped port (e.g. 8712)
- Now `TUIST_SERVER_URL` takes precedence over secrets in dev mode, so the endpoint URL reflects the correct scoped port

🤖 Generated with [Claude Code](https://claude.com/claude-code)