### PR TITLE
fix(server): use sum instead of counter for pool busy/starved metrics

### DIFF
--- a/docs/docs/en/guides/server/self-host/telemetry.md
+++ b/docs/docs/en/guides/server/self-host/telemetry.md
@@ -462,7 +462,7 @@ The total number of users.
 
 A set of metrics related to the database connection.
 
-The repo pool metrics are sampled internally every 100ms and then exposed to Prometheus on `/metrics`. The `last_value` metrics below show the most recent pool state at scrape time. The pressure metrics further down are counters and sums derived from those 100ms samples, which makes short saturation windows easier to spot even when they recover before the next scrape.
+The repo pool metrics are sampled internally every 100ms and then exposed to Prometheus on `/metrics`. The `last_value` metrics below show the most recent pool state at scrape time. The pressure metrics further down are sums derived from those 100ms samples, which makes short saturation windows easier to spot even when they recover before the next scrape.
 
 ### `tuist_repo_pool_checkout_queue_length` (last_value) {#tuist_repo_pool_checkout_queue_length-last_value}
 
@@ -508,7 +508,7 @@ The sum of queued checkout requests observed across repo pool polls. This is use
 | `repo` | The repository that emitted the metric, such as `postgres`, `clickhouse_read`, or `clickhouse_write`. |
 | `database` | The backing database type, such as `postgres` or `clickhouse`. |
 
-### `tuist_repo_pool_checkout_queue_busy_samples_total` (counter) {#tuist_repo_pool_checkout_queue_busy_samples_total-counter}
+### `tuist_repo_pool_checkout_queue_busy_samples_sum` (sum) {#tuist_repo_pool_checkout_queue_busy_samples_sum-sum}
 
 The number of repo pool polls where at least one database checkout request was waiting in the queue.
 
@@ -519,7 +519,7 @@ The number of repo pool polls where at least one database checkout request was w
 | `repo` | The repository that emitted the metric, such as `postgres`, `clickhouse_read`, or `clickhouse_write`. |
 | `database` | The backing database type, such as `postgres` or `clickhouse`. |
 
-### `tuist_repo_pool_checkout_queue_starved_samples_total` (counter) {#tuist_repo_pool_checkout_queue_starved_samples_total-counter}
+### `tuist_repo_pool_checkout_queue_starved_samples_sum` (sum) {#tuist_repo_pool_checkout_queue_starved_samples_sum-sum}
 
 The number of repo pool polls where checkout requests were queued and no ready connections were available. A sustained increase here usually means the pool is saturated.
 

--- a/tuist_common/lib/tuist_common/repo/prom_ex_plugin.ex
+++ b/tuist_common/lib/tuist_common/repo/prom_ex_plugin.ex
@@ -56,7 +56,7 @@ defmodule TuistCommon.Repo.PromExPlugin do
                   "The sum of queued DB checkout requests observed across repo pool polls.",
                 measurement: :checkout_queue_observed
               ),
-              counter(
+              sum(
                 @metrics_prefix ++ [:checkout_queue, :busy_samples],
                 event_name: @pool_metrics_event_name,
                 tags: [:repo, :database],
@@ -64,7 +64,7 @@ defmodule TuistCommon.Repo.PromExPlugin do
                   "The number of repo pool polls where at least one DB checkout was queued.",
                 measurement: :checkout_queue_busy_count
               ),
-              counter(
+              sum(
                 @metrics_prefix ++ [:checkout_queue, :starved_samples],
                 event_name: @pool_metrics_event_name,
                 tags: [:repo, :database],


### PR DESCRIPTION
## Summary
- **Fix**: `busy_samples` and `starved_samples` pool metrics used `counter()` which counts telemetry events regardless of measurement value — all three repos (postgres, clickhouse_read, clickhouse_write) always showed identical values
- **Change**: Switch to `sum()` so the actual measurement (0 or 1) is accumulated, making each repo reflect its own pool pressure independently
- **Docs**: Update telemetry docs to reflect the metric type change from counter to sum

🤖 Generated with [Claude Code](https://claude.com/claude-code)