### PR TITLE
fix(server): add total_samples metric for correct pool starvation %

### DIFF
--- a/docs/docs/en/guides/server/self-host/telemetry.md
+++ b/docs/docs/en/guides/server/self-host/telemetry.md
@@ -497,6 +497,17 @@ The configured number of connections in the pool.
 | `repo` | The repository that emitted the metric, such as `postgres`, `clickhouse_read`, or `clickhouse_write`. |
 | `database` | The backing database type, such as `postgres` or `clickhouse`. |
 
+### `tuist_repo_pool_checkout_queue_total_samples_sum` (sum) {#tuist_repo_pool_checkout_queue_total_samples_sum-sum}
+
+The total number of repo pool polls taken (increments by 1 on every poll). Use this as the denominator when computing busyness or starvation percentages: `rate(busy_samples) / rate(total_samples)` or `rate(starved_samples) / rate(total_samples)`.
+
+#### Tags {#tuist_repo_pool_checkout_queue_total_samples_sum-tags}
+
+| Tag | Description |
+|--- | ---- |
+| `repo` | The repository that emitted the metric, such as `postgres`, `clickhouse_read`, or `clickhouse_write`. |
+| `database` | The backing database type, such as `postgres` or `clickhouse`. |
+
 ### `tuist_repo_pool_checkout_queue_observed_sum` (sum) {#tuist_repo_pool_checkout_queue_observed_sum-sum}
 
 The sum of queued checkout requests observed across repo pool polls. This is useful for detecting short bursts of pool contention that may not be visible in the latest queue-length sample alone.

--- a/tuist_common/lib/tuist_common/repo/prom_ex_plugin.ex
+++ b/tuist_common/lib/tuist_common/repo/prom_ex_plugin.ex
@@ -49,6 +49,14 @@ defmodule TuistCommon.Repo.PromExPlugin do
             :"#{@plugin_name}_repo_pool_pressure_metrics",
             [
               sum(
+                @metrics_prefix ++ [:checkout_queue, :total_samples],
+                event_name: @pool_metrics_event_name,
+                tags: [:repo, :database],
+                description:
+                  "The total number of repo pool polls taken (increments by 1 on every poll).",
+                measurement: :checkout_queue_total_count
+              ),
+              sum(
                 @metrics_prefix ++ [:checkout_queue, :observed],
                 event_name: @pool_metrics_event_name,
                 tags: [:repo, :database],
@@ -141,6 +149,7 @@ defmodule TuistCommon.Repo.PromExPlugin do
         ready_conn_count = Map.get(measurements, :ready_conn_count, 0)
 
         measurements
+        |> Map.put(:checkout_queue_total_count, 1)
         |> Map.put(:checkout_queue_observed, checkout_queue_length)
         |> Map.put(:checkout_queue_busy_count, if(checkout_queue_length > 0, do: 1, else: 0))
         |> Map.put(


### PR DESCRIPTION
## Summary
- Adds a `total_samples` counter that increments on every pool poll (every 100ms), providing the correct denominator for pool busyness/starvation percentages
- After deploying, update the Grafana "Checkout Queue Starvation %" panel to divide by `total_samples` instead of `busy_samples`

### What was wrong

> [!NOTE]
> **How the metrics work:** Every 100ms we poll each DB connection pool and check its checkout queue (requests waiting for a connection). We record three counters:
> - **`busy_samples`** — ticks when the queue has at least one waiting request
> - **`starved_samples`** — ticks when the queue has waiting requests AND there are zero idle connections
> - **`total_samples`** *(new)* — ticks on every poll, regardless of queue state
>
> **The bug:** The Grafana starvation gauge divided `starved_samples` by `busy_samples`. Both counters only increment during polls that have queue pressure — idle polls contribute to neither. So the question being answered was "of the moments the pool was busy, how often was it also starved?" and the answer is almost always ~100%, because brief bursts of queue pressure naturally coincide with all connections being in use.
>
> **The fix:** The question we actually want to answer is "what fraction of *all* time is the pool starved?". That requires dividing by the total number of polls, not just the busy ones. The new `total_samples` counter provides that denominator, so idle periods correctly bring the percentage down.


🤖 Generated with [Claude Code](https://claude.com/claude-code)