### PR TITLE
perf(cli): use dictionary lookup for target resolution in PackageInfoMapper

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -302,6 +302,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
             uniquingKeysWith: { userDefined, _ in userDefined }
         )
 
+        let targetsByName = Dictionary(uniqueKeysWithValues: packageInfo.targets.map { ($0.name, $0) })
         var mutableTargetToProducts: [String: Set<PackageInfo.Product>] = [:]
         for product in packageInfo.products {
             var targetsToProcess = Set(product.targets)
@@ -312,12 +313,12 @@ public struct PackageInfoMapper: PackageInfoMapping {
                     continue
                 }
                 mutableTargetToProducts[target, default: []].insert(product)
-                let dependencies = packageInfo.targets.first(where: { $0.name == target })!.dependencies
-                for dependency in dependencies {
+                guard let targetInfo = targetsByName[target] else { continue }
+                for dependency in targetInfo.dependencies {
                     switch dependency {
                     case let .target(name, _):
                         targetsToProcess.insert(name)
-                    case let .byName(name, _) where packageInfo.targets.contains(where: { $0.name == name }):
+                    case let .byName(name, _) where targetsByName[name] != nil:
                         targetsToProcess.insert(name)
                     case .byName, .product:
                         continue


### PR DESCRIPTION
In `PackageInfoMapper.map(packageInfo:...)`, target lookups within the `while` loop used `Array.first(where:)` and `Array.contains(where:)`, both O(n) per call. For packages with many targets (e.g., Firebase with ~100
  targets), this results in O(n*m) complexity.
  >
  > This PR pre-builds a `[String: PackageInfo.Target]` dictionary before the loop, replacing:
  > - `packageInfo.targets.first(where: { $0.name == target })!` → `targetsByName[target]` (O(1), force unwrap removed)
  > - `packageInfo.targets.contains(where: { $0.name == name })` → `targetsByName[name] != nil` (O(1))
  >
  > This is safe because SPM guarantees unique target names within a package, so `Dictionary(uniqueKeysWithValues:)` will not crash.
  >
  > Overall complexity improves from O(n*m) to O(n+m). No behavioral changes — the resulting `targetToProducts` mapping is identical.

  ### How to test locally

  1. Run existing `PackageInfoMapper` tests to verify no regressions
  2. Add a large SPM dependency with many targets (e.g., `firebase-ios-sdk`) to a Tuist project
  3. Run `tuist generate` and verify the generated project is identical to before this change