### PR TITLE
perf(server): optimize slow ClickHouse queries on test tables

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -40,6 +40,7 @@ defmodule Tuist.Tests do
   alias Tuist.Tests.TestCaseFailure
   alias Tuist.Tests.TestCaseRun
   alias Tuist.Tests.TestCaseRunAttachment
+  alias Tuist.Tests.TestCaseRunByShardId
   alias Tuist.Tests.TestCaseRunByTestRun
   alias Tuist.Tests.TestCaseRunDashboardCount
   alias Tuist.Tests.TestCaseRunRepetition
@@ -666,7 +667,7 @@ defmodule Tuist.Tests do
 
         {:shard_id, shard_id} ->
           mv_ids =
-            from(mv in TestCaseRunByTestRun,
+            from(mv in TestCaseRunByShardId,
               where: mv.shard_id == ^shard_id,
               select: mv.id
             )

--- a/server/lib/tuist/tests/test_case_run_by_shard_id.ex
+++ b/server/lib/tuist/tests/test_case_run_by_shard_id.ex
@@ -1,0 +1,13 @@
+defmodule Tuist.Tests.TestCaseRunByShardId do
+  @moduledoc """
+  Minimal read-only schema backed by the `test_case_runs_by_shard_id`
+  materialized view. Ordered by `(shard_id, id)` for efficient lookups
+  when filtering sharded test runs.
+  """
+  use Ecto.Schema
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false}
+  schema "test_case_runs_by_shard_id" do
+    field :shard_id, Ecto.UUID
+  end
+end

--- a/server/lib/tuist/tests/test_case_run_by_test_run.ex
+++ b/server/lib/tuist/tests/test_case_run_by_test_run.ex
@@ -2,7 +2,7 @@ defmodule Tuist.Tests.TestCaseRunByTestRun do
   @moduledoc """
   Slim read-only schema backed by the `test_case_runs_by_test_run` materialized
   view. Ordered by `(test_run_id, id)`, making queries that filter by
-  `test_run_id` or `shard_id` efficient.
+  `test_run_id` efficient.
 
   Used for:
   - Aggregation queries (`get_test_run_metrics`, `get_test_run_failures_count`)
@@ -17,6 +17,5 @@ defmodule Tuist.Tests.TestCaseRunByTestRun do
     field :is_flaky, :boolean, default: false
     field :duration, Ch, type: "Int32"
     field :inserted_at, Ch, type: "DateTime64(6)"
-    field :shard_id, Ch, type: "Nullable(UUID)"
   end
 end

--- a/server/priv/ingest_repo/migrations/20260325120001_add_shard_id_to_test_case_runs_by_test_run_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260325120001_add_shard_id_to_test_case_runs_by_test_run_mv.exs
@@ -1,9 +1,10 @@
 defmodule Tuist.IngestRepo.Migrations.AddShardIdToTestCaseRunsByTestRunMv do
   @moduledoc """
-  Recreates the `test_case_runs_by_test_run` materialized view to include
-  `shard_id`. Sharded test runs filter by `shard_id` instead of `test_run_id`,
-  and without this column the MV cannot serve those queries — causing 607 M+
-  row full scans on the main table.
+  Creates a dedicated `test_case_runs_by_shard_id` MV ordered by
+  `(shard_id, id)` for efficient shard_id lookups.
+
+  Sharded test runs filter by `shard_id` instead of `test_run_id`, and without
+  a dedicated MV those queries cause 607 M+ row full scans on the main table.
   """
   use Ecto.Migration
   alias Tuist.IngestRepo
@@ -13,29 +14,20 @@ defmodule Tuist.IngestRepo.Migrations.AddShardIdToTestCaseRunsByTestRunMv do
   @disable_migration_lock true
 
   def up do
-    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_test_run")
-
     IngestRepo.query!("""
-    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_test_run
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_shard_id
     ENGINE = MergeTree
-    ORDER BY (test_run_id, id)
-    AS SELECT id, test_run_id, status, is_flaky, duration, inserted_at, shard_id
+    ORDER BY (shard_id, id)
+    AS SELECT id, assumeNotNull(shard_id) AS shard_id
     FROM test_case_runs
+    WHERE shard_id IS NOT NULL
     """)
 
     backfill_by_partition()
   end
 
   def down do
-    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_test_run")
-
-    IngestRepo.query!("""
-    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_test_run
-    ENGINE = MergeTree
-    ORDER BY (test_run_id, id)
-    AS SELECT id, test_run_id, status, is_flaky, duration, inserted_at
-    FROM test_case_runs
-    """)
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_shard_id")
   end
 
   defp backfill_by_partition do
@@ -51,14 +43,14 @@ defmodule Tuist.IngestRepo.Migrations.AddShardIdToTestCaseRunsByTestRunMv do
       )
 
     for [partition] <- partitions do
-      Logger.info("Backfilling partition #{partition} into test_case_runs_by_test_run")
+      Logger.info("Backfilling partition #{partition} into test_case_runs_by_shard_id")
 
       IngestRepo.query!(
         """
-        INSERT INTO test_case_runs_by_test_run (id, test_run_id, status, is_flaky, duration, inserted_at, shard_id)
-        SELECT id, test_run_id, status, is_flaky, duration, inserted_at, shard_id
+        INSERT INTO test_case_runs_by_shard_id (id, shard_id)
+        SELECT id, assumeNotNull(shard_id)
         FROM test_case_runs
-        WHERE toYYYYMM(inserted_at) = {partition:UInt32}
+        WHERE toYYYYMM(inserted_at) = {partition:UInt32} AND shard_id IS NOT NULL
         """,
         %{partition: String.to_integer(partition)},
         timeout: 1_200_000


### PR DESCRIPTION
## Summary

- **Slim MV `test_case_runs_by_test_run`** (6 columns: `id`, `test_run_id`, `status`, `is_flaky`, `duration`, `inserted_at`): After the main `test_case_runs` table was reordered to `(project_id, test_case_id, ran_at, id)`, queries filtering by `test_run_id` regressed to full scans (24-30M rows). The MV ordered by `(test_run_id, id)` restores PK binary search for `get_test_run_metrics`, `get_test_run_failures_count`, and as an ID subquery for paginated `list_test_case_runs`.
- **Dedicated MV `test_case_runs_by_shard_id`** (2 columns: `id`, `shard_id`): Sharded test runs filter by `shard_id` instead of `test_run_id`, causing 607M+ row full scans. This MV ordered by `(shard_id, id)` gives PK binary search for those queries. Only rows with non-null `shard_id` are stored, keeping it minimal. Uses `assumeNotNull()` to avoid nullable key issues.
- **Shards timing queries rewritten from JOIN to IN-subquery**: The `fetch_timing_data` queries on `test_suite_runs`/`test_module_runs` used a JOIN to `test_runs` which forced full scans (~67M rows). Rewriting to `WHERE test_run_id IN (SELECT id FROM test_runs WHERE ...)` lets ClickHouse use primary keys on both tables.
- **Backfills are partition-by-partition** to avoid memory pressure on the 300M+ row table.

### Query improvements

| Query | Before | After |
|-------|--------|-------|
| `COUNT(*) WHERE test_run_id = ?` | 24M rows scanned | MV PrimaryKey lookup |
| `SELECT * WHERE test_run_id = ? ORDER BY name LIMIT 20` | 30M rows scanned | MV subquery → idx_id bloom |
| `COUNT(*) WHERE shard_id = ?` | 607M rows scanned | MV PrimaryKey lookup |
| `SELECT * WHERE shard_id = ? ORDER BY name LIMIT 20` | 607M rows scanned | MV subquery → idx_id bloom |
| `test_suite_runs JOIN test_runs` (shards) | 67M rows full scan | IN-subquery, both PKs used |

## Test plan

- [x] `mix test test/tuist/tests_test.exs` — 175 tests pass
- [x] `mix test test/tuist/tests/analytics_test.exs` — all pass
- [x] `mix test test/tuist/shards_test.exs` — 16 tests pass
- [x] Verified EXPLAIN plans on local ClickHouse
- [x] Verified backfill runs partition-by-partition
- [x] Verified MV only stores rows with non-null shard_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)