### PR TITLE
perf(server): paginate shard_id queries on MV instead of main table

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -654,36 +654,53 @@ defmodule Tuist.Tests do
   Returns a tuple of {test_case_runs, meta} with pagination info.
   """
   def list_test_case_runs(attrs, opts \\ []) do
-    base_query =
-      case extract_mv_scope_filter(attrs) do
-        {:test_run_id, test_run_id} ->
-          mv_ids =
-            from(mv in TestCaseRunByTestRun,
-              where: mv.test_run_id == ^test_run_id,
-              select: mv.id
-            )
-
-          from(tcr in TestCaseRun, where: tcr.id in subquery(mv_ids))
-
-        {:shard_id, shard_id} ->
-          mv_ids =
-            from(mv in TestCaseRunByShardId,
-              where: mv.shard_id == ^shard_id,
-              select: mv.id
-            )
-
-          from(tcr in TestCaseRun, where: tcr.id in subquery(mv_ids))
-
-        nil ->
-          from(tcr in TestCaseRun)
-      end
-
     preloads = Keyword.get(opts, :preload, [])
 
+    case extract_mv_scope_filter(attrs) do
+      {:shard_id, _shard_id} ->
+        list_test_case_runs_via_shard_mv(attrs, preloads)
+
+      {:test_run_id, test_run_id} ->
+        mv_ids =
+          from(mv in TestCaseRunByTestRun,
+            where: mv.test_run_id == ^test_run_id,
+            select: mv.id
+          )
+
+        base_query = from(tcr in TestCaseRun, where: tcr.id in subquery(mv_ids))
+        list_test_case_runs_from(base_query, attrs, preloads)
+
+      nil ->
+        list_test_case_runs_from(from(tcr in TestCaseRun), attrs, preloads)
+    end
+  end
+
+  defp list_test_case_runs_from(base_query, attrs, preloads) do
     {results, meta} = Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRun)
 
     results =
       results
+      |> ClickHouseRepo.preload(preloads)
+      |> Repo.preload(:ran_by_account)
+
+    {results, meta}
+  end
+
+  defp list_test_case_runs_via_shard_mv(attrs, preloads) do
+    base_query = from(mv in TestCaseRunByShardId)
+
+    {slim_results, meta} =
+      Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRunByShardId)
+
+    ids = Enum.map(slim_results, & &1.id)
+
+    full_results = ClickHouseRepo.all(from(tcr in TestCaseRun, hints: ["FINAL"], where: tcr.id in ^ids))
+
+    ordered_by_id = Map.new(full_results, &{&1.id, &1})
+    ordered = ids |> Enum.map(&Map.get(ordered_by_id, &1)) |> Enum.reject(&is_nil/1)
+
+    results =
+      ordered
       |> ClickHouseRepo.preload(preloads)
       |> Repo.preload(:ran_by_account)
 

--- a/server/lib/tuist/tests/test_case_run_by_shard_id.ex
+++ b/server/lib/tuist/tests/test_case_run_by_shard_id.ex
@@ -1,13 +1,27 @@
 defmodule Tuist.Tests.TestCaseRunByShardId do
   @moduledoc """
-  Minimal read-only schema backed by the `test_case_runs_by_shard_id`
-  materialized view. Ordered by `(shard_id, id)` for efficient lookups
-  when filtering sharded test runs.
+  Read-only schema backed by the `test_case_runs_by_shard_id` materialized
+  view. Ordered by `(shard_id, name, id)` for efficient filtering, sorting,
+  and pagination of sharded test runs.
+
+  Only rows with non-null shard_id are stored.
+  For full row data, look up the returned IDs in the main `test_case_runs` table.
   """
   use Ecto.Schema
+
+  @derive {
+    Flop.Schema,
+    filterable: [:shard_id, :name, :status, :is_flaky, :is_new, :duration, :shard_index], sortable: [:name, :duration]
+  }
 
   @primary_key {:id, Ecto.UUID, autogenerate: false}
   schema "test_case_runs_by_shard_id" do
     field :shard_id, Ecto.UUID
+    field :name, Ch, type: "String"
+    field :status, Ch, type: "Enum8('success' = 0, 'failure' = 1, 'skipped' = 2)"
+    field :is_flaky, :boolean, default: false
+    field :is_new, :boolean, default: false
+    field :duration, Ch, type: "Int32"
+    field :shard_index, Ch, type: "Nullable(Int32)"
   end
 end

--- a/server/priv/ingest_repo/migrations/20260325120002_recreate_test_case_runs_by_shard_id_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260325120002_recreate_test_case_runs_by_shard_id_mv.exs
@@ -1,0 +1,81 @@
+defmodule Tuist.IngestRepo.Migrations.RecreateTestCaseRunsByShardIdMv do
+  @moduledoc """
+  Recreates the `test_case_runs_by_shard_id` MV with additional columns needed
+  for filtering and sorting. The previous version only stored `(id, shard_id)`,
+  which forced the main table lookup via `id IN (huge set)` — too slow because
+  a single shard can match tens of thousands of rows and the bloom filter on
+  `id` degenerates to a full scan.
+
+  With the extra columns, we can paginate and count directly on the MV, then
+  fetch only the 20 displayed rows from the main table by ID.
+
+  Only rows with non-null shard_id are stored.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_shard_id")
+
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_shard_id
+    ENGINE = MergeTree
+    ORDER BY (shard_id, name, id)
+    AS SELECT
+      id, assumeNotNull(shard_id) AS shard_id, name,
+      status, is_flaky, is_new, duration, shard_index
+    FROM test_case_runs
+    WHERE shard_id IS NOT NULL
+    """)
+
+    backfill_by_partition()
+  end
+
+  def down do
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_shard_id")
+
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_shard_id
+    ENGINE = MergeTree
+    ORDER BY (shard_id, id)
+    AS SELECT id, assumeNotNull(shard_id) AS shard_id
+    FROM test_case_runs
+    WHERE shard_id IS NOT NULL
+    """)
+  end
+
+  defp backfill_by_partition do
+    {:ok, %{rows: partitions}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT partition
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = {table:String} AND active
+        ORDER BY partition
+        """,
+        %{table: "test_case_runs"}
+      )
+
+    for [partition] <- partitions do
+      Logger.info("Backfilling partition #{partition} into test_case_runs_by_shard_id")
+
+      IngestRepo.query!(
+        """
+        INSERT INTO test_case_runs_by_shard_id
+          (id, shard_id, name, status, is_flaky, is_new, duration, shard_index)
+        SELECT
+          id, assumeNotNull(shard_id), name,
+          status, is_flaky, is_new, duration, shard_index
+        FROM test_case_runs
+        WHERE toYYYYMM(inserted_at) = {partition:UInt32} AND shard_id IS NOT NULL
+        """,
+        %{partition: String.to_integer(partition)},
+        timeout: 1_200_000
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The `id IN (subquery)` pattern for `shard_id` doesn't scale — a single shard can match tens of thousands of test_case_runs, and the bloom filter on `id` degenerates to a full scan (512M+ rows, p50 ~4.6s).

**Fix:** Fatten the `test_case_runs_by_shard_id` MV with columns needed for filtering and sorting (`name`, `status`, `is_flaky`, `is_new`, `duration`, `shard_index`), then:
- **Count:** Flop counts directly on the MV — instant PK binary search
- **Data:** Flop paginates on the MV (gets 20 IDs), then fetches those 20 full rows from the main table (trivially fast)

The MV only contains rows where `shard_id IS NOT NULL`, keeping it small. ORDER BY is `(shard_id, name, id)` to match the default sort.

### EXPLAIN comparison (local ClickHouse)

**Count query:**
| | Approach | Parts scanned |
|-|----------|--------------|
| Before | `SELECT count(*) FROM test_case_runs WHERE id IN (SELECT id FROM mv ...) AND shard_id = ?` | 12/12 parts → bloom filter narrows to 2/12 (in prod: most of 300M+ rows) |
| After | `SELECT count(*) FROM test_case_runs_by_shard_id WHERE shard_id = ?` | `ReadFromPreparedSource (_exact_count_projection)` — **zero scan** |

**Data query:**
| | Approach | Parts scanned |
|-|----------|--------------|
| Before | `SELECT * FROM test_case_runs WHERE id IN (SELECT id FROM mv ...) ORDER BY name LIMIT 20` | 12/12 parts → bloom filter narrows to 2/12 (in prod: 512M rows) |
| After step 1 | `SELECT id FROM test_case_runs_by_shard_id WHERE shard_id = ? ORDER BY name LIMIT 20` | **1/1 parts, 1/1 granules** (PK binary search) |
| After step 2 | `SELECT * FROM test_case_runs FINAL WHERE id IN (20 IDs)` | **0/12 parts** via idx_id bloom (only 20 IDs) |

### Timing (local, 1816 rows — improvements are proportionally much larger at production scale)

| Query | Before (10 runs) | After (10 runs) |
|-------|-----------------|-----------------|
| Count | 68ms | 16ms (4.3x) |
| Data | 84ms | 55ms (1.5x) |

At production scale (300M+ rows), the "before" pattern scans ~512M rows (p50 3.5-4.6s) while the "after" pattern does a PK lookup on the MV + fetches 20 rows.

## Test plan

- [x] 227 tests pass (`tests_test.exs`, `analytics_test.exs`, `shards_test.exs`)
- [x] Migration runs partition-by-partition, only backfills rows with non-null shard_id
- [x] EXPLAIN verified: count uses `_exact_count_projection`, data uses PK binary search
- [x] Timing verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)