### PR TITLE
perf(server): drop FINAL from shard_id 20-row ID lookup

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -694,7 +694,7 @@ defmodule Tuist.Tests do
 
     ids = Enum.map(slim_results, & &1.id)
 
-    full_results = ClickHouseRepo.all(from(tcr in TestCaseRun, hints: ["FINAL"], where: tcr.id in ^ids))
+    full_results = ClickHouseRepo.all(from(tcr in TestCaseRun, where: tcr.id in ^ids))
 
     ordered_by_id = Map.new(full_results, &{&1.id, &1})
     ordered = ids |> Enum.map(&Map.get(ordered_by_id, &1)) |> Enum.reject(&is_nil/1)


### PR DESCRIPTION
## Summary

One-line fix: remove `FINAL` from the 20-row ID lookup in `list_test_case_runs_via_shard_mv`.

`FINAL` on a 300M+ row `ReplacingMergeTree` forces ClickHouse to deduplicate the entire table at query time before filtering by ID — causing 66M rows read, 1.1 GiB memory usage, and 15s timeouts.

For a 20-row ID lookup after MV pagination, `FINAL` is unnecessary:
- The MV already gave us the correct page of IDs
- Any rare pre-merge duplicates are harmless for display
- `Map.new` already deduplicates by ID (keeps last row)

## Test plan

- [x] Tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)