### PR TITLE
perf(server): add project_id to shard MV for efficient main table lookup

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -693,8 +693,10 @@ defmodule Tuist.Tests do
       Tuist.ClickHouseFlop.validate_and_run!(base_query, attrs, for: TestCaseRunByShardId)
 
     ids = Enum.map(slim_results, & &1.id)
+    project_ids = slim_results |> Enum.map(& &1.project_id) |> Enum.uniq()
 
-    full_results = ClickHouseRepo.all(from(tcr in TestCaseRun, where: tcr.id in ^ids))
+    full_results =
+      ClickHouseRepo.all(from(tcr in TestCaseRun, where: tcr.project_id in ^project_ids and tcr.id in ^ids))
 
     ordered_by_id = Map.new(full_results, &{&1.id, &1})
     ordered = ids |> Enum.map(&Map.get(ordered_by_id, &1)) |> Enum.reject(&is_nil/1)

--- a/server/lib/tuist/tests/test_case_run_by_shard_id.ex
+++ b/server/lib/tuist/tests/test_case_run_by_shard_id.ex
@@ -23,5 +23,6 @@ defmodule Tuist.Tests.TestCaseRunByShardId do
     field :is_new, :boolean, default: false
     field :duration, Ch, type: "Int32"
     field :shard_index, Ch, type: "Nullable(Int32)"
+    field :project_id, Ch, type: "Int64"
   end
 end

--- a/server/priv/ingest_repo/migrations/20260325120003_add_project_id_to_shard_id_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260325120003_add_project_id_to_shard_id_mv.exs
@@ -1,0 +1,79 @@
+defmodule Tuist.IngestRepo.Migrations.AddProjectIdToShardIdMv do
+  @moduledoc """
+  Recreates `test_case_runs_by_shard_id` to include `project_id`.
+
+  The 20-row ID lookup on the main table (`WHERE id IN (20 IDs)`) reads
+  231M+ rows because the bloom filter on `id` isn't selective across many
+  partitions. Adding `project_id` lets the lookup use the main table's PK
+  prefix: `WHERE project_id = ? AND id IN (20 IDs)`.
+  """
+  use Ecto.Migration
+  alias Tuist.IngestRepo
+  require Logger
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_shard_id")
+
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_shard_id
+    ENGINE = MergeTree
+    ORDER BY (shard_id, name, id)
+    AS SELECT
+      id, assumeNotNull(shard_id) AS shard_id, name,
+      status, is_flaky, is_new, duration, shard_index, project_id
+    FROM test_case_runs
+    WHERE shard_id IS NOT NULL
+    """)
+
+    backfill_by_partition()
+  end
+
+  def down do
+    IngestRepo.query!("DROP VIEW IF EXISTS test_case_runs_by_shard_id")
+
+    IngestRepo.query!("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS test_case_runs_by_shard_id
+    ENGINE = MergeTree
+    ORDER BY (shard_id, name, id)
+    AS SELECT
+      id, assumeNotNull(shard_id) AS shard_id, name,
+      status, is_flaky, is_new, duration, shard_index
+    FROM test_case_runs
+    WHERE shard_id IS NOT NULL
+    """)
+  end
+
+  defp backfill_by_partition do
+    {:ok, %{rows: partitions}} =
+      IngestRepo.query(
+        """
+        SELECT DISTINCT partition
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = {table:String} AND active
+        ORDER BY partition
+        """,
+        %{table: "test_case_runs"}
+      )
+
+    for [partition] <- partitions do
+      Logger.info("Backfilling partition #{partition} into test_case_runs_by_shard_id")
+
+      IngestRepo.query!(
+        """
+        INSERT INTO test_case_runs_by_shard_id
+          (id, shard_id, name, status, is_flaky, is_new, duration, shard_index, project_id)
+        SELECT
+          id, assumeNotNull(shard_id), name,
+          status, is_flaky, is_new, duration, shard_index, project_id
+        FROM test_case_runs
+        WHERE toYYYYMM(inserted_at) = {partition:UInt32} AND shard_id IS NOT NULL
+        """,
+        %{partition: String.to_integer(partition)},
+        timeout: 1_200_000
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The 20-row ID lookup on the main table after shard MV pagination (`WHERE id IN (20 IDs)`) reads 231M+ rows (p50 3.9s) because the bloom filter on `id` isn't selective across many partitions.

**Fix:** Add `project_id` to the shard MV. The lookup becomes `WHERE project_id IN (?) AND id IN (20 IDs)` — ClickHouse uses the main table's PK prefix (`project_id`) for binary search, then the bloom filter on `id` confirms within the narrow range.

### EXPLAIN (local)

| Query | PK match | Parts | Granules |
|-------|----------|-------|----------|
| `WHERE id IN (1 ID)` | id only (last in PK) | 12/12 → bloom 0/12 | 0/12 |
| `WHERE project_id IN (1) AND id IN (1 ID)` | project_id (PK prefix) | **0/12** | **0/0** |

## Test plan

- [x] Tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)