### PR TITLE
chore(cli): resolve SwiftFormat lint errors in test files

### DIFF
--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardMatrixOutputServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardMatrixOutputServiceTests.swift
@@ -44,18 +44,18 @@ struct ShardMatrixOutputServiceTests {
 
         let content = try await fileSystem.readTextFile(at: cwd.appending(component: ".tuist-shard-child-pipeline.yml"))
         #expect(content == """
-            shard-0:
-              extends: .tuist-shard
-              variables:
-                TUIST_SHARD_INDEX: "0"
+        shard-0:
+          extends: .tuist-shard
+          variables:
+            TUIST_SHARD_INDEX: "0"
 
-            shard-1:
-              extends: .tuist-shard
-              variables:
-                TUIST_SHARD_INDEX: "1"
+        shard-1:
+          extends: .tuist-shard
+          variables:
+            TUIST_SHARD_INDEX: "1"
 
 
-            """)
+        """)
     }
 
     @Test(.withMockedEnvironment())
@@ -68,11 +68,11 @@ struct ShardMatrixOutputServiceTests {
 
         let content = try await fileSystem.readTextFile(at: cwd.appending(component: ".tuist-shard-continuation.json"))
         #expect(content == """
-            {
-              "shard-count" : 2,
-              "shard-indices" : "0,1"
-            }
-            """)
+        {
+          "shard-count" : 2,
+          "shard-indices" : "0,1"
+        }
+        """)
     }
 
     @Test(.withMockedEnvironment())
@@ -85,17 +85,17 @@ struct ShardMatrixOutputServiceTests {
 
         let content = try await fileSystem.readTextFile(at: cwd.appending(component: ".tuist-shard-pipeline.yml"))
         #expect(content == """
-            steps:
-              - label: "Shard #0"
-                env:
-                  TUIST_SHARD_INDEX: "0"
+        steps:
+          - label: "Shard #0"
+            env:
+              TUIST_SHARD_INDEX: "0"
 
-              - label: "Shard #1"
-                env:
-                  TUIST_SHARD_INDEX: "1"
+          - label: "Shard #1"
+            env:
+              TUIST_SHARD_INDEX: "1"
 
 
-            """)
+        """)
     }
 
     @Test(.withMockedEnvironment())
@@ -138,33 +138,33 @@ struct ShardMatrixOutputServiceTests {
 
         let content = try await fileSystem.readTextFile(at: cwd.appending(component: ".tuist-shard-matrix.json"))
         #expect(content == """
+        {
+          "id" : "test-id",
+          "reference" : "test-ref",
+          "shard_count" : 2,
+          "shards" : [
             {
-              "id" : "test-id",
-              "reference" : "test-ref",
-              "shard_count" : 2,
-              "shards" : [
-                {
-                  "estimated_duration_ms" : 1000,
-                  "index" : 0,
-                  "test_targets" : [
-                    "Target0"
-                  ]
-                },
-                {
-                  "estimated_duration_ms" : 1000,
-                  "index" : 1,
-                  "test_targets" : [
-                    "Target1"
-                  ]
-                }
+              "estimated_duration_ms" : 1000,
+              "index" : 0,
+              "test_targets" : [
+                "Target0"
+              ]
+            },
+            {
+              "estimated_duration_ms" : 1000,
+              "index" : 1,
+              "test_targets" : [
+                "Target1"
               ]
             }
-            """)
+          ]
+        }
+        """)
     }
 }
 
-fileprivate extension Components.Schemas.ShardPlan {
-    static func test(shardCount: Int = 3) -> Self {
+extension Components.Schemas.ShardPlan {
+    fileprivate static func test(shardCount: Int = 3) -> Self {
         Components.Schemas.ShardPlan(
             id: "test-id",
             reference: "test-ref",

--- a/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Sharding/ShardServiceTests.swift
@@ -257,7 +257,10 @@ struct ShardServiceTests {
         let filtered = try subject.filterXCTestRun(
             plistData: plistData,
             modules: ["TuistGeneratorAcceptanceTests"],
-            suites: ["TuistGeneratorAcceptanceTests": ["GenerateAcceptanceTestAppWithMacBundle", "GenerateAcceptanceTestSPMPackage"]]
+            suites: ["TuistGeneratorAcceptanceTests": [
+                "GenerateAcceptanceTestAppWithMacBundle",
+                "GenerateAcceptanceTestSPMPackage",
+            ]]
         )
 
         // Then: module kept, OnlyTestIdentifiers set to assigned suites
@@ -266,7 +269,10 @@ struct ShardServiceTests {
         let targets = configurations[0]["TestTargets"] as! [[String: Any]]
         #expect(targets.count == 1)
         #expect(targets[0]["BlueprintName"] as? String == "TuistGeneratorAcceptanceTests")
-        #expect(targets[0]["OnlyTestIdentifiers"] as? [String] == ["GenerateAcceptanceTestAppWithMacBundle", "GenerateAcceptanceTestSPMPackage"])
+        #expect(targets[0]["OnlyTestIdentifiers"] as? [String] == [
+            "GenerateAcceptanceTestAppWithMacBundle",
+            "GenerateAcceptanceTestSPMPackage",
+        ])
     }
 
     @Test

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -9,10 +9,10 @@ import TuistAutomation
 import TuistConfigLoader
 import TuistCore
 import TuistLoader
+import TuistRootDirectoryLocator
 import TuistSupport
 import TuistTesting
 import TuistUniqueIDGenerator
-import TuistRootDirectoryLocator
 import TuistXCActivityLog
 import TuistXCResultService
 import XcodeGraph


### PR DESCRIPTION
## Summary
- Fix SwiftFormat lint errors in 3 test files that are failing CI on main
- Issues: unsorted imports, incorrect indentation, trailing whitespace, extension access control, line wrapping, trailing commas

## Test plan
- [x] `swiftformat --lint` passes on all 3 files
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)