### PR TITLE
fix(server): query ShardRun table for shard balance analytics

### DIFF
--- a/server/lib/tuist/shards/analytics.ex
+++ b/server/lib/tuist/shards/analytics.ex
@@ -174,23 +174,22 @@ defmodule Tuist.Shards.Analytics do
 
   defp shard_balance_sessions(project_id, start_datetime, end_datetime) do
     ClickHouseRepo.all(
-      from(t in Test,
-        where: t.project_id == ^project_id,
-        where: not is_nil(t.shard_plan_id),
-        where: t.ran_at >= ^start_datetime,
-        where: t.ran_at <= ^end_datetime,
-        group_by: t.shard_plan_id,
+      from(sr in ShardRun,
+        where: sr.project_id == ^project_id,
+        where: sr.ran_at >= ^start_datetime,
+        where: sr.ran_at <= ^end_datetime,
+        group_by: sr.shard_plan_id,
         having: count() > 1,
         select: %{
-          plan_id: t.shard_plan_id,
+          plan_id: sr.shard_plan_id,
           balance:
             fragment(
               "if(avg(?) > 0, greatest(0, 1 - (stddevPop(?) / avg(?))), 1)",
-              t.duration,
-              t.duration,
-              t.duration
+              sr.duration,
+              sr.duration,
+              sr.duration
             ),
-          ran_at: max(t.ran_at)
+          ran_at: max(sr.ran_at)
         }
       )
     )

--- a/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/runs_fixtures.ex
@@ -24,6 +24,10 @@ defmodule TuistTestSupport.Fixtures.RunsFixtures do
     SQL.query!(IngestRepo, "OPTIMIZE TABLE test_runs FINAL", [])
   end
 
+  def optimize_shard_runs do
+    SQL.query!(IngestRepo, "OPTIMIZE TABLE shard_runs FINAL", [])
+  end
+
   def build_fixture(attrs \\ []) do
     project_id =
       Keyword.get_lazy(attrs, :project_id, fn ->

--- a/server/test/tuist/shards/analytics_test.exs
+++ b/server/test/tuist/shards/analytics_test.exs
@@ -191,7 +191,7 @@ defmodule Tuist.Shards.AnalyticsTest do
   end
 
   describe "shard_balance_analytics/2" do
-    test "returns balance analytics with test runs linked to shard plans" do
+    test "returns balance analytics from shard runs linked to shard plans" do
       stub(DateTime, :utc_now, fn -> ~U[2024-06-15 12:00:00Z] end)
       project = ProjectsFixtures.project_fixture()
 
@@ -226,7 +226,7 @@ defmodule Tuist.Shards.AnalyticsTest do
           ]
         )
 
-      RunsFixtures.optimize_test_runs()
+      RunsFixtures.optimize_shard_runs()
 
       result =
         Analytics.shard_balance_analytics(project.id,
@@ -244,6 +244,7 @@ defmodule Tuist.Shards.AnalyticsTest do
       assert is_number(result.p99)
       assert is_number(result.trend)
       assert is_number(result.total_average)
+      assert result.total_average > 0
     end
 
     test "returns zeros when no data exists" do


### PR DESCRIPTION
## Summary
- The shard balance analytics query was reading from the `Test` table grouped by `shard_plan_id`, but all shards for a plan are merged into a single `Test` row by `create_or_update_sharded_test`. This meant `having: count() > 1` always filtered out every plan, resulting in "No data".
- Changed the query to use the `ShardRun` table instead, which has one row per shard with individual durations — exactly what's needed to compute the balance (coefficient of variation).
- Updated tests to optimize the `shard_runs` table and assert `total_average > 0`.

## Test plan
- [x] Existing `shard_balance_analytics` tests updated and passing
- [ ] Verify on staging that "Avg. shard balance" shows data for projects with sharded runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)