### PR TITLE
perf(cli): use Set for target name lookups in SchemeLinter

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -92,7 +92,7 @@ struct SchemeLinter: SchemeLinting {
     }
 
     private func lintExpandVariableTarget(schemes: [Scheme], targets: [Target]) -> [LintingIssue] {
-        let targetNames = targets.map(\.name)
+        let targetNames = Set(targets.map(\.name))
         var issues: [LintingIssue] = []
 
         for scheme in schemes {
@@ -123,7 +123,7 @@ struct SchemeLinter: SchemeLinting {
     }
 
     private func lintCodeCoverageTargets(schemes: [Scheme], targets: [Target]) -> [LintingIssue] {
-        let targetNames = targets.map(\.name)
+        let targetNames = Set(targets.map(\.name))
         var issues: [LintingIssue] = []
 
         for scheme in schemes {


### PR DESCRIPTION
### Description

  Optimize target name lookups in `SchemeLinter` by using `Set` instead of `Array` for `contains()` checks.

  **Before:**
  ```swift
  let targetNames = targets.map(\.name) // Array
  !targetNames.contains(target.name)    // O(n) per call

  After:
  let targetNames = Set(targets.map(\.name)) // Set
  !targetNames.contains(target.name)          // O(1) per call

  Both lintExpandVariableTarget and lintCodeCoverageTargets iterate over schemes and check target name membership inside loops. Using a Set reduces each contains() call from O(n) to O(1).

  How to test locally

  This is a pure refactor with no behavioral change — Set.contains() returns the same result as Array.contains(). The change only affects lookup performance, not logic.
  ```