### PR TITLE
perf(cli): precompute Xcode version key set in DefaultSettingsProvider

### DIFF
--- a/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -237,11 +237,9 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
             return { key, _ in essentialKeys.contains(key) && !excludedKeys.contains(key) }
         case let .recommended(excludedKeys):
             let xcodeVersion = try await XcodeController.current.selectedVersion()
+            let higherVersionKeys = Set(newXcodeKeys.filter { $0.key > xcodeVersion }.values.flatMap { $0 })
             return { key, _ in
-                // Filter keys that are from higher Xcode version than current (otherwise return true)
-                !newXcodeKeys
-                    .filter { $0.key > xcodeVersion }
-                    .values.flatMap { $0 }.contains(key) &&
+                !higherVersionKeys.contains(key) &&
                     !excludedKeys.contains(key)
             }
         case .none:


### PR DESCRIPTION
### Description

  Optimize `createFilter` in `DefaultSettingsProvider` by precomputing the set of higher Xcode version keys once, instead of recomputing it on every closure invocation.

  **Before:**
  ```swift
  return { key, _ in
      !newXcodeKeys
          .filter { $0.key > xcodeVersion }
          .values.flatMap { $0 }.contains(key) &&
          !excludedKeys.contains(key)
  }

  Every time the returned closure is called, it filters the dictionary, flattens the values, and performs a linear search — all O(n) per call.

  After:
  let higherVersionKeys = Set(newXcodeKeys.filter { $0.key > xcodeVersion }.values.flatMap { $0 })
  return { key, _ in
      !higherVersionKeys.contains(key) &&
          !excludedKeys.contains(key)
  }

  The Set is built once before the closure is returned. Each subsequent contains() call is O(1).

  How to test locally

  This is a pure refactor with no behavioral change — Set.contains() returns the same result as Array.contains(). The change only affects lookup performance, not logic.
  ```