### PR TITLE
perf(cli): use Set for header path lookups in TargetContentHasher

### DIFF
--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -223,8 +223,8 @@ public struct TargetContentHasher: TargetContentHashing {
             .map { ($0, $0.resolvedFiles.sorted(by: { $0.path < $1.path })) }
             .concurrentFlatMap {
                 (buildableFolder: BuildableFolder, buildableFiles: [BuildableFolderFile]) in
-                let publicHeaders = buildableFolder.exceptions.flatMap(\.publicHeaders)
-                let privateHeaders = buildableFolder.exceptions.flatMap(\.privateHeaders)
+                let publicHeaders = Set(buildableFolder.exceptions.flatMap(\.publicHeaders))
+                let privateHeaders = Set(buildableFolder.exceptions.flatMap(\.privateHeaders))
 
                 return try await buildableFiles.concurrentMap { buildableFile in
                     let fileHash = try await contentHasher.hash(path: buildableFile.path)


### PR DESCRIPTION
### Description

  Optimize header path lookups in `TargetContentHasher` by using `Set` instead of `Array` for `publicHeaders` and `privateHeaders`.

  **Before:**
  ```swift
  let publicHeaders = buildableFolder.exceptions.flatMap(\.publicHeaders)   // Array
  let privateHeaders = buildableFolder.exceptions.flatMap(\.privateHeaders) // Array

  return try await buildableFiles.concurrentMap { buildableFile in
      if publicHeaders.contains(buildableFile.path) { ... }  // O(n) per file
      if privateHeaders.contains(buildableFile.path) { ... }  // O(n) per file
  }

  After:
  let publicHeaders = Set(buildableFolder.exceptions.flatMap(\.publicHeaders))   // Set
  let privateHeaders = Set(buildableFolder.exceptions.flatMap(\.privateHeaders)) // Set

  return try await buildableFiles.concurrentMap { buildableFile in
      if publicHeaders.contains(buildableFile.path) { ... }  // O(1) per file
      if privateHeaders.contains(buildableFile.path) { ... }  // O(1) per file
  }

  The contains() calls run inside concurrentMap over every buildable file, making this a hot path during cache hashing. Converting to Set reduces each lookup from O(n) to O(1).

  How to test locally

  This is a pure refactor with no behavioral change — Set.contains() returns the same result as Array.contains(). The change only affects lookup performance, not logic.
  ```