### PR TITLE
perf(cli): use min() instead of sorted().first in GraphLoader

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/cli/Sources/TuistCore/Graph/GraphLoader.swift
@@ -175,7 +175,7 @@ public struct GraphLoader: GraphLoading {
             )
 
         case let .sdk(name, status, _):
-            return try platforms.sorted().first.map { platform in
+            return try platforms.min().map { platform in
                 try loadSDK(
                     name: name,
                     platform: platform,
@@ -197,7 +197,7 @@ public struct GraphLoader: GraphLoading {
             }
 
         case .xctest:
-            return try platforms.sorted().first.map { platform in
+            return try platforms.min().map { platform in
                 try loadXCTestSDK(platform: platform)
             }
         }


### PR DESCRIPTION
### Description

  Replace `.sorted().first` with `.min()` in `GraphLoader` for finding the minimum platform.

  **Before:**
  ```swift
  platforms.sorted().first  // O(n log n) — sorts entire array, then takes first element

  After:
  platforms.min()  // O(n) — single pass to find minimum

  Both .sdk and .xctest cases only need the smallest platform value, not a fully sorted array. .min() achieves the same result in a single linear pass.

  How to test locally

  This is a pure refactor with no behavioral change — .sorted().first and .min() return the same value. The change only affects algorithmic complexity, not logic.
  ```