### PR TITLE
perf(cli): replace string concatenation loop with joined(separator:) …

### DIFF
--- a/cli/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/cli/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -41,16 +41,9 @@ public struct ContentHasher: ContentHashing {
     }
 
     public func hash(_ dictionary: [String: String]) throws -> String {
-        let sortedKeys = dictionary.keys.sorted { $0 < $1 }
-        var dictString = ""
-        for (counter, key) in sortedKeys.enumerated() {
-            let value: String = dictionary[key]!
-            dictString += "\(key):\(value)"
-            let isLastKey = counter == (sortedKeys.count - 1)
-            if !isLastKey {
-                dictString += "-"
-            }
-        }
+        let dictString = dictionary.keys.sorted()
+            .map { "\($0):\(dictionary[$0]!)" }
+            .joined(separator: "-")
         return try hash(dictString)
     }
 


### PR DESCRIPTION
### Description

  Replace string concatenation in a loop with `map().joined(separator:)` in `ContentHasher.hash(_:)`.

  **Before:**
  ```swift
  let sortedKeys = dictionary.keys.sorted { $0 < $1 }
  var dictString = ""
  for (counter, key) in sortedKeys.enumerated() {
      let value: String = dictionary[key]!
      dictString += "\(key):\(value)"
      let isLastKey = counter == (sortedKeys.count - 1)
      if !isLastKey {
          dictString += "-"
      }
  }
  return try hash(dictString)

  Each += allocates a new String, copying all previous characters. With N keys this results in O(n²) total character copies.

  After:
  let dictString = dictionary.keys.sorted()
      .map { "\($0):\(dictionary[$0]!)" }
      .joined(separator: "-")
  return try hash(dictString)

  joined(separator:) pre-calculates the total length and allocates once, reducing the complexity to O(n). This method is in ContentHasher, a hot path called for every target and file during cache hashing.

  How to test locally

  This is a pure refactor with no behavioral change — the output string format (key1:value1-key2:value2-...) is identical. The change only affects allocation performance, not logic.
  ```