### PR TITLE
fix(server): fix BadMapError crash when requesting non-existent project

### DIFF
--- a/server/lib/tuist_web/controllers/api/projects_controller.ex
+++ b/server/lib/tuist_web/controllers/api/projects_controller.ex
@@ -245,17 +245,17 @@ defmodule TuistWeb.API.ProjectsController do
         |> put_status(:not_found)
         |> json(%Error{message: "Account #{account_handle} not found."})
 
+      is_nil(project) ->
+        conn
+        |> put_status(:not_found)
+        |> json(%Error{message: "Project #{account_handle}/#{project_handle} not found."})
+
       Authorization.authorize(:project_read, user, account) != :ok ->
         conn
         |> put_status(:forbidden)
         |> json(%Error{
           message: "You don't have permission to read the #{project.name} project."
         })
-
-      is_nil(project) ->
-        conn
-        |> put_status(:not_found)
-        |> json(%Error{message: "Project #{account_handle}/#{project_handle} not found."})
 
       !is_nil(project) ->
         Tuist.PubSub.broadcast(%{user: user}, "projects.#{project.id}", :show)

--- a/server/test/tuist_web/controllers/api/projects_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/projects_controller_test.exs
@@ -537,6 +537,27 @@ defmodule TuistWeb.API.ProjectsControllerTest do
              }
     end
 
+    test "Returns a not found error if a project does not exist under another user's account", %{
+      conn: conn,
+      user: user
+    } do
+      # Given
+      conn = Authentication.put_current_user(conn, user)
+
+      organization = AccountsFixtures.organization_fixture()
+      account = Accounts.get_account_from_organization(organization)
+
+      # When
+      conn = get(conn, "/api/projects/#{account.name}/non-existing-project")
+
+      # Then
+      response = json_response(conn, :not_found)
+
+      assert response == %{
+               "message" => "Project #{account.name}/non-existing-project not found."
+             }
+    end
+
     test "Returns an unauthenticated error if a user doesn't have a permission to read the project",
          %{
            conn: conn,


### PR DESCRIPTION
## Summary
- Fixes a `BadMapError` crash in `ProjectsController.show/2` when requesting a non-existent project under another user's account (Sentry TUIST-A0)
- The `cond` block checked authorization (which accessed `project.name`) before checking if `project` was nil — reordered so the nil check comes first
- Added a test reproducing the exact scenario

## Test plan
- [x] Added test: "Returns a not found error if a project does not exist under another user's account"
- [x] All 30 existing projects controller tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)