### PR TITLE
fix(server): fix broken sharding docs link in dashboard

### DIFF
--- a/server/lib/tuist_web/live/shards_live.html.heex
+++ b/server/lib/tuist_web/live/shards_live.html.heex
@@ -623,7 +623,7 @@
       <div :if={Enum.empty?(@sharded_runs)} data-part="empty-sharded-runs">
         <.empty_card_section
           title={dgettext("dashboard_tests", "No sharded runs")}
-          get_started_href="https://docs.tuist.dev/en/guides/features/sharding"
+          get_started_href="https://docs.tuist.dev/en/guides/features/test-sharding"
           data-part="empty-sharded-runs-table-card-section"
         >
           <:image>


### PR DESCRIPTION
## Summary
- Fix broken docs link on the shards dashboard page (`/tests/shards`)
- The link pointed to `/en/guides/features/sharding` which doesn't exist; updated to `/en/guides/features/test-sharding`

## Test plan
- [ ] Visit a project's shards page with no sharded runs and verify the "Get started" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)