### PR TITLE
fix(cache): ignore unexpected SQLiteBuffer messages

### DIFF
--- a/cache/lib/cache/sqlite_buffer.ex
+++ b/cache/lib/cache/sqlite_buffer.ex
@@ -94,6 +94,13 @@ defmodule Cache.SQLiteBuffer do
   end
 
   @impl true
+  def handle_info(message, state) do
+    buffer_name = state.buffer_module.buffer_name()
+    Logger.warning("#{buffer_name} buffer received unexpected message: #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  @impl true
   def terminate(_reason, state) do
     buffer_name = state.buffer_module.buffer_name()
     Logger.notice("Flushing #{buffer_name} buffer before shutdown...")

--- a/cache/test/cache/sqlite_buffer_test.exs
+++ b/cache/test/cache/sqlite_buffer_test.exs
@@ -3,6 +3,7 @@ defmodule Cache.SQLiteBufferTest do
   use Mimic
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Cache.CacheArtifact
   alias Cache.CacheArtifactsBuffer
@@ -225,6 +226,31 @@ defmodule Cache.SQLiteBufferTest do
 
     record = KeyValueRepo.get_by!(KeyValueEntry, key: key)
     assert record.json_payload == payload
+  end
+
+  test "unexpected info messages are logged and ignored" do
+    key = "keyvalue:unexpected-message:account:project"
+    payload = Jason.encode!(%{entries: [%{"value" => "unexpected"}]})
+
+    suffix = :erlang.unique_integer([:positive])
+    buffer = :"sqlite_buffer_unexpected_message_test_#{suffix}"
+    {:ok, pid} = SQLiteBuffer.start_link(name: buffer, buffer_module: KeyValueBuffer)
+
+    Sandbox.allow(KeyValueRepo, self(), pid)
+
+    log =
+      capture_log(fn ->
+        send(pid, {[:alias | make_ref()], :dropped})
+        true = :ets.insert(buffer, {key, {:write, %{key: key, json_payload: payload}}})
+        :ok = SQLiteBuffer.flush(buffer)
+      end)
+
+    assert log =~ "key_values buffer received unexpected message"
+
+    record = KeyValueRepo.get_by!(KeyValueEntry, key: key)
+    assert record.json_payload == payload
+
+    :ok = GenServer.stop(pid)
   end
 
   test "concurrent writes to the same key preserve last value" do


### PR DESCRIPTION
## Summary
- ignore unexpected `handle_info/2` messages in `Cache.SQLiteBuffer` instead of crashing
- log the unexpected message so we can still investigate its source later
- add a regression test for the `{[:alias | ref], :dropped}` message shape seen in production

Fixes CACHE-2T, CACHE-2S, and some random 502s that popped up.

## Testing
- mise run format --check
- mise run credo
- mise run test