### PR TITLE
fix(cache): reduce upload memory pressure

### DIFF
--- a/cache/lib/cache/body_reader.ex
+++ b/cache/lib/cache/body_reader.ex
@@ -2,8 +2,8 @@ defmodule Cache.BodyReader do
   @moduledoc """
   Handles reading request bodies from Plug connections.
 
-  Small bodies are read into memory, large bodies are streamed to temporary files
-  to avoid memory pressure.
+  Bodies that fit within the configured read chunk stay in memory, while larger
+  bodies are streamed to temporary files or devices to avoid memory pressure.
 
   ## Timeout Strategy
 
@@ -16,7 +16,8 @@ defmodule Cache.BodyReader do
   """
 
   @max_upload_bytes 25 * 1024 * 1024
-  @default_opts [length: @max_upload_bytes, read_length: 262_144]
+  @default_read_length 262_144
+  @default_opts [length: @default_read_length, read_length: @default_read_length]
 
   @doc """
   Reads the request body from the connection.
@@ -28,18 +29,18 @@ defmodule Cache.BodyReader do
   """
 
   def read(conn, opts \\ []) do
-    merged_opts = Keyword.merge(read_opts(conn), opts)
     max_bytes = Keyword.get(opts, :max_bytes, @max_upload_bytes)
+    merged_opts = merged_opts(conn, opts, max_bytes)
 
     conn
-    |> Plug.Conn.read_body(merged_opts)
+    |> Plug.Conn.read_body(plug_read_opts(merged_opts))
     |> handle_read_result(conn, merged_opts, :store, max_bytes)
   rescue
     Bandit.HTTPError ->
       {:error, :cancelled, conn}
 
-    Bandit.TransportError ->
-      {:error, :cancelled, conn}
+    e in [Bandit.TransportError] ->
+      normalize_transport_error(e, conn)
   end
 
   @doc """
@@ -49,19 +50,19 @@ defmodule Cache.BodyReader do
   or `{:error, reason, conn}` on failure.
   """
   def read_to_device(conn, device, opts \\ []) do
-    merged_opts = Keyword.merge(read_opts(conn), opts)
     max_bytes = Keyword.get(opts, :max_bytes, @max_upload_bytes)
+    merged_opts = merged_opts(conn, opts, max_bytes)
     writer = fn chunk -> :file.write(device, chunk) end
 
     conn
-    |> Plug.Conn.read_body(merged_opts)
+    |> Plug.Conn.read_body(plug_read_opts(merged_opts))
     |> handle_device_result(conn, merged_opts, writer, max_bytes)
   rescue
     Bandit.HTTPError ->
       {:error, :cancelled, conn}
 
-    Bandit.TransportError ->
-      {:error, :cancelled, conn}
+    e in [Bandit.TransportError] ->
+      normalize_transport_error(e, conn)
   end
 
   defp handle_device_result({:ok, body, conn_after}, _conn, _opts, writer, max_bytes) do
@@ -106,11 +107,15 @@ defmodule Cache.BodyReader do
   Useful when the upload already exists and we need to consume the body.
   """
 
-  def drain(conn) do
-    opts = read_opts(conn)
+  def drain(conn, opts \\ []) do
+    max_bytes = Keyword.get(opts, :max_bytes, @max_upload_bytes)
+    merged_opts = merged_opts(conn, opts, max_bytes)
 
-    case conn |> Plug.Conn.read_body(opts) |> handle_read_result(conn, opts, :discard, @max_upload_bytes) do
-      {:ok, _, conn_after} -> {:ok, conn_after}
+    case conn
+         |> Plug.Conn.read_body(plug_read_opts(merged_opts))
+         |> handle_read_result(conn, merged_opts, :discard, max_bytes) do
+      {:ok, :discarded, conn_after} -> {:ok, conn_after}
+      {:ok, conn_after, _bytes_read} -> {:ok, conn_after}
       {:error, _reason, conn_after} -> {:error, conn_after}
     end
   rescue
@@ -121,7 +126,14 @@ defmodule Cache.BodyReader do
   defp handle_read_result(result, conn, opts, mode, max_bytes) do
     case result do
       {:ok, body, conn_after} ->
-        {:ok, body, conn_after}
+        if byte_size(body) > max_bytes do
+          {:error, :too_large, conn_after}
+        else
+          case mode do
+            :store -> {:ok, body, conn_after}
+            :discard -> {:ok, :discarded, conn_after}
+          end
+        end
 
       {:more, chunk, conn_after} ->
         read_chunks(conn_after, opts, chunk, byte_size(chunk), mode, max_bytes)
@@ -140,6 +152,9 @@ defmodule Cache.BodyReader do
   defp normalize_error(:too_large, conn), do: {:error, :too_large, conn}
   defp normalize_error(reason, conn) when reason in [:timeout, :econnaborted], do: {:error, :timeout, conn}
   defp normalize_error(reason, conn), do: {:error, reason, conn}
+
+  defp normalize_transport_error(%{error: :timeout}, conn), do: {:error, :timeout, conn}
+  defp normalize_transport_error(_error, conn), do: {:error, :cancelled, conn}
 
   defp read_chunks(conn, opts, _first_chunk, bytes_read, :discard, max_bytes) do
     read_loop(conn, opts, bytes_read, fn _chunk -> :ok end, max_bytes)
@@ -180,14 +195,14 @@ defmodule Cache.BodyReader do
     chunk_opts = Keyword.put(opts, :read_timeout, chunk_timeout(opts))
 
     conn
-    |> Plug.Conn.read_body(chunk_opts)
+    |> Plug.Conn.read_body(plug_read_opts(chunk_opts))
     |> handle_loop_result(conn, opts, bytes_read, writer, max_bytes)
   rescue
     Bandit.HTTPError ->
       {:error, :cancelled, conn}
 
-    Bandit.TransportError ->
-      {:error, :cancelled, conn}
+    e in [Bandit.TransportError] ->
+      normalize_transport_error(e, conn)
   end
 
   defp handle_loop_result(result, conn, opts, bytes_read, writer, max_bytes) do
@@ -202,7 +217,7 @@ defmodule Cache.BodyReader do
         write_chunk(conn_after, opts, bytes_read, chunk, writer, max_bytes, true)
 
       {:error, reason} ->
-        {:error, reason, conn}
+        normalize_error(reason, conn)
     end
   end
 
@@ -232,9 +247,25 @@ defmodule Cache.BodyReader do
     Path.join(base, ".cache-upload-#{unique}")
   end
 
-  defp read_opts(conn) do
-    base_opts = Map.get(conn.private, :body_read_opts, @default_opts)
-    TuistCommon.BodyReader.read_opts(conn, base_opts)
+  defp merged_opts(conn, opts, max_bytes) do
+    conn.private
+    |> Map.get(:body_read_opts, @default_opts)
+    |> Keyword.merge(opts)
+    |> normalize_length(max_bytes)
+    |> then(&TuistCommon.BodyReader.read_opts(conn, &1))
+  end
+
+  defp normalize_length(opts, max_bytes) do
+    length =
+      opts
+      |> Keyword.get(:length, Keyword.get(opts, :read_length, @default_read_length))
+      |> min(max_bytes)
+
+    Keyword.put(opts, :length, length)
+  end
+
+  defp plug_read_opts(opts) do
+    Keyword.drop(opts, [:max_bytes, :tmp_dir])
   end
 
   defp chunk_timeout(opts) do

--- a/cache/lib/cache_web/controllers/gradle_controller.ex
+++ b/cache/lib/cache_web/controllers/gradle_controller.ex
@@ -162,7 +162,7 @@ defmodule CacheWeb.GradleController do
   defp handle_existing_artifact(conn) do
     :telemetry.execute([:cache, :gradle, :upload, :exists], %{count: 1}, %{})
 
-    case BodyReader.drain(conn) do
+    case BodyReader.drain(conn, max_bytes: @max_upload_bytes) do
       {:ok, conn_after} -> send_resp(conn_after, :ok, "")
       {:error, conn_after} -> send_resp(conn_after, :ok, "")
     end

--- a/cache/lib/cache_web/controllers/xcode_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_controller.ex
@@ -11,6 +11,8 @@ defmodule CacheWeb.XcodeController do
 
   require Logger
 
+  @max_upload_bytes 25 * 1024 * 1024
+
   plug OpenApiSpex.Plug.CastAndValidate,
     json_render_error_v2: true
 
@@ -139,14 +141,14 @@ defmodule CacheWeb.XcodeController do
   defp handle_existing_artifact(conn) do
     :telemetry.execute([:cache, :xcode, :upload, :exists], %{count: 1}, %{})
 
-    {_, conn_after} = BodyReader.drain(conn)
+    {_, conn_after} = BodyReader.drain(conn, max_bytes: @max_upload_bytes)
     send_resp(conn_after, :no_content, "")
   end
 
   defp save_new_artifact(conn, account_handle, project_handle, id) do
     case Xcode.Disk.ensure_artifact_directory(account_handle, project_handle, id) do
       {:ok, target_dir} ->
-        case BodyReader.read(conn, tmp_dir: target_dir) do
+        case BodyReader.read(conn, max_bytes: @max_upload_bytes, tmp_dir: target_dir) do
           {:ok, data, conn_after} ->
             size = get_data_size(data)
             :telemetry.execute([:cache, :xcode, :upload, :attempt], %{size: size}, %{})

--- a/cache/test/cache/body_reader_test.exs
+++ b/cache/test/cache/body_reader_test.exs
@@ -2,10 +2,33 @@ defmodule Cache.BodyReaderTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  import Plug.Conn
+
   alias Cache.BodyReader
   alias Plug.Adapters.Test.Conn
 
   describe "read/1" do
+    test "enforces max_bytes for single-chunk bodies" do
+      conn = Plug.Test.conn(:post, "/", "123456")
+
+      assert {:error, :too_large, _conn_after} = BodyReader.read(conn, max_bytes: 5)
+    end
+
+    test "streams bodies larger than the initial read chunk to a temp file" do
+      {:ok, tmp_dir} = Briefly.create(directory: true)
+      body = :binary.copy("0123456789abcdef", 10_000)
+
+      conn =
+        :post
+        |> Plug.Test.conn("/", body)
+        |> put_private(:body_read_opts, length: 128_000, read_length: 128_000, read_timeout: 60_000)
+
+      assert {:ok, {:file, tmp_path}, _conn_after} = BodyReader.read(conn, tmp_dir: tmp_dir)
+      assert File.read!(tmp_path) == body
+
+      File.rm(tmp_path)
+    end
+
     test "handles Bandit.TransportError during initial read" do
       conn = %Plug.Conn{adapter: {Conn, nil}}
 
@@ -14,6 +37,16 @@ defmodule Cache.BodyReaderTest do
       end)
 
       assert {:error, :cancelled, ^conn} = BodyReader.read(conn)
+    end
+
+    test "maps Bandit.TransportError timeout during initial read to timeout" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+
+      expect(Plug.Conn, :read_body, fn _conn, _opts ->
+        raise Bandit.TransportError, message: "Request body read timed out", error: :timeout
+      end)
+
+      assert {:error, :timeout, ^conn} = BodyReader.read(conn)
     end
 
     test "handles Bandit.TransportError during chunked read" do
@@ -35,6 +68,190 @@ defmodule Cache.BodyReaderTest do
       end)
 
       assert {:error, :cancelled, ^conn} = BodyReader.read(conn)
+    end
+
+    test "maps Bandit.TransportError timeout during chunked read to timeout" do
+      {:ok, tmp_dir} = Briefly.create(directory: true)
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Request body read timed out", error: :timeout
+        end
+      end)
+
+      assert {:error, :timeout, ^conn} = BodyReader.read(conn, tmp_dir: tmp_dir)
+      assert File.ls!(tmp_dir) == []
+    end
+
+    test "normalizes timeout during chunked read" do
+      {:ok, tmp_dir} = Briefly.create(directory: true)
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          {:error, :timeout}
+        end
+      end)
+
+      assert {:error, :timeout, ^conn} = BodyReader.read(conn, tmp_dir: tmp_dir)
+      assert File.ls!(tmp_dir) == []
+    end
+
+    test "normalizes econnaborted during chunked read" do
+      {:ok, tmp_dir} = Briefly.create(directory: true)
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          {:error, :econnaborted}
+        end
+      end)
+
+      assert {:error, :timeout, ^conn} = BodyReader.read(conn, tmp_dir: tmp_dir)
+      assert File.ls!(tmp_dir) == []
+    end
+  end
+
+  describe "read_to_device/3" do
+    test "maps Bandit.TransportError timeout during chunked device writes to timeout" do
+      {:ok, path} = Briefly.create()
+      {:ok, device} = :file.open(path, [:write, :binary])
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Request body read timed out", error: :timeout
+        end
+      end)
+
+      try do
+        assert {:error, :timeout, ^conn} = BodyReader.read_to_device(conn, device)
+      after
+        :file.close(device)
+      end
+    end
+
+    test "normalizes timeout during chunked device writes" do
+      {:ok, path} = Briefly.create()
+      {:ok, device} = :file.open(path, [:write, :binary])
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          {:error, :timeout}
+        end
+      end)
+
+      try do
+        assert {:error, :timeout, ^conn} = BodyReader.read_to_device(conn, device)
+      after
+        :file.close(device)
+      end
+    end
+
+    test "normalizes econnaborted during chunked device writes" do
+      {:ok, path} = Briefly.create()
+      {:ok, device} = :file.open(path, [:write, :binary])
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      chunk = String.duplicate("x", 200_000)
+
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          {:error, :econnaborted}
+        end
+      end)
+
+      try do
+        assert {:error, :timeout, ^conn} = BodyReader.read_to_device(conn, device)
+      after
+        :file.close(device)
+      end
+    end
+  end
+
+  describe "drain/2" do
+    test "honors a custom max_bytes limit" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, String.duplicate("a", 20), conn}
+        else
+          {:ok, String.duplicate("b", 10), conn}
+        end
+      end)
+
+      assert {:ok, _conn_after} = BodyReader.drain(conn, max_bytes: 30)
+    end
+
+    test "returns the connection for multi-chunk drains" do
+      conn = %Plug.Conn{adapter: {Conn, nil}}
+      call_count = :counters.new(1, [])
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, String.duplicate("a", 20), conn}
+        else
+          {:ok, String.duplicate("b", 10), conn}
+        end
+      end)
+
+      assert {:ok, ^conn} = BodyReader.drain(conn, max_bytes: 30)
     end
   end
 end

--- a/cache/test/cache_web/controllers/gradle_controller_test.exs
+++ b/cache/test/cache_web/controllers/gradle_controller_test.exs
@@ -131,6 +131,53 @@ defmodule CacheWeb.GradleControllerTest do
       assert upload.key == "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
     end
 
+    test "returns timeout instead of acknowledging a chunked upload timeout as success", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      chunk = String.duplicate("x", 200_000)
+      call_count = :counters.new(1, [])
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(Gradle.Disk, :exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+
+      reject(Gradle.Disk, :put, 4)
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Request body read timed out", error: :timeout
+        end
+      end)
+
+      capture_log(fn ->
+        conn =
+          conn
+          |> put_req_header("authorization", "Bearer valid-token")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> put(
+            "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+            chunk
+          )
+
+        assert conn.status == 408
+        response = json_response(conn, 408)
+        assert response["message"] == "Request body read timed out"
+      end)
+
+      :ok = Cache.S3TransfersBuffer.flush()
+      assert S3Transfers.pending(:upload, 10) == []
+    end
+
     test "skips save when artifact already exists", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"
@@ -149,6 +196,36 @@ defmodule CacheWeb.GradleControllerTest do
         conn
         |> put_req_header("authorization", "Bearer valid-token")
         |> put_req_header("content-type", "application/octet-stream")
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          body
+        )
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "skips save for large duplicate uploads without returning 500", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      body = :binary.copy("0123456789abcdef", 20_000)
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(Gradle.Disk, :exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        true
+      end)
+
+      reject(Gradle.Disk, :put, 4)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> Plug.Conn.put_private(:body_read_opts, length: 128_000, read_length: 128_000, read_timeout: 60_000)
         |> put(
           "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
           body

--- a/cache/test/cache_web/controllers/xcode_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_controller_test.exs
@@ -110,6 +110,50 @@ defmodule CacheWeb.XcodeControllerTest do
       assert upload.key == "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
     end
 
+    test "returns timeout instead of acknowledging a chunked upload timeout as success", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      id = "abc123"
+      chunk = String.duplicate("x", 200_000)
+      call_count = :counters.new(1, [])
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(Xcode.Disk, :exists?, fn ^account_handle, ^project_handle, ^id ->
+        false
+      end)
+
+      reject(Xcode.Disk, :put, 4)
+
+      expect(Plug.Conn, :read_body, 2, fn conn, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        if count == 0 do
+          {:more, chunk, conn}
+        else
+          raise Bandit.TransportError, message: "Request body read timed out", error: :timeout
+        end
+      end)
+
+      capture_log(fn ->
+        conn =
+          conn
+          |> put_req_header("authorization", "Bearer valid-token")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> post("/api/cache/cas/#{id}?account_handle=#{account_handle}&project_handle=#{project_handle}", chunk)
+
+        assert conn.status == 408
+        response = json_response(conn, 408)
+        assert response["message"] == "Request body read timed out"
+      end)
+
+      :ok = S3TransfersBuffer.flush()
+      assert S3Transfers.pending(:upload, 10) == []
+    end
+
     test "skips save when artifact already exists", %{conn: conn} do
       account_handle = "test-account"
       project_handle = "test-project"
@@ -128,6 +172,33 @@ defmodule CacheWeb.XcodeControllerTest do
         conn
         |> put_req_header("authorization", "Bearer valid-token")
         |> put_req_header("content-type", "application/octet-stream")
+        |> post("/api/cache/cas/#{id}?account_handle=#{account_handle}&project_handle=#{project_handle}", body)
+
+      assert conn.status == 204
+      assert conn.resp_body == ""
+    end
+
+    test "skips save for large duplicate uploads without returning 500", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      id = "abc123"
+      body = :binary.copy("0123456789abcdef", 20_000)
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(Xcode.Disk, :exists?, fn ^account_handle, ^project_handle, ^id ->
+        true
+      end)
+
+      reject(Xcode.Disk, :put, 4)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> Plug.Conn.put_private(:body_read_opts, length: 128_000, read_length: 128_000, read_timeout: 60_000)
         |> post("/api/cache/cas/#{id}?account_handle=#{account_handle}&project_handle=#{project_handle}", body)
 
       assert conn.status == 204

--- a/tuist_common/lib/tuist_common/body_reader.ex
+++ b/tuist_common/lib/tuist_common/body_reader.ex
@@ -182,8 +182,11 @@ defmodule TuistCommon.BodyReader do
         cleanup_internal_opts(base_opts)
 
       content_length ->
+        bytes_for_initial_read =
+          min(content_length, Keyword.get(base_opts, :length, content_length))
+
         timeout_opts = Keyword.take(base_opts, [:min_timeout, :max_timeout, :min_throughput])
-        dynamic_timeout = calculate_timeout(content_length, timeout_opts)
+        dynamic_timeout = calculate_timeout(bytes_for_initial_read, timeout_opts)
 
         base_opts
         |> cleanup_internal_opts()

--- a/tuist_common/test/tuist_common/body_reader_test.exs
+++ b/tuist_common/test/tuist_common/body_reader_test.exs
@@ -45,6 +45,14 @@ defmodule TuistCommon.BodyReaderTest do
       assert Keyword.get(opts, :read_timeout) <= 600_000
     end
 
+    test "bases the initial timeout on the configured first read length" do
+      conn = %Plug.Conn{req_headers: [{"content-length", "25000000"}]}
+      opts = BodyReader.read_opts(conn, length: 262_144)
+
+      assert Keyword.get(opts, :length) == 262_144
+      assert Keyword.get(opts, :read_timeout) == 60_000
+    end
+
     test "returns base opts with default timeout when content-length is missing" do
       conn = %Plug.Conn{req_headers: []}
       opts = BodyReader.read_opts(conn, length: 50_000_000)
@@ -131,7 +139,7 @@ defmodule TuistCommon.BodyReaderTest do
   describe "get_content_length/1" do
     test "returns content length as integer" do
       conn = %Plug.Conn{req_headers: [{"content-length", "12345"}]}
-      assert BodyReader.get_content_length(conn) == 12345
+      assert BodyReader.get_content_length(conn) == 12_345
     end
 
     test "returns nil when header is missing" do

--- a/tuist_common/test/tuist_common/http/transport_logger_test.exs
+++ b/tuist_common/test/tuist_common/http/transport_logger_test.exs
@@ -119,7 +119,11 @@ defmodule TuistCommon.HTTP.TransportLoggerTest do
   } do
     log =
       capture_log(
-        [level: :debug, format: "$metadata$message", metadata: [:method, :route, :request_path, :reason]],
+        [
+          level: :debug,
+          format: "$metadata$message",
+          metadata: [:method, :route, :request_path, :reason]
+        ],
         fn ->
           :telemetry.execute(
             [:bandit, :request, :stop],

--- a/tuist_common/test/tuist_common/http/transport_prom_ex_plugin_test.exs
+++ b/tuist_common/test/tuist_common/http/transport_prom_ex_plugin_test.exs
@@ -15,7 +15,7 @@ defmodule TuistCommon.HTTP.TransportPromExPluginTest do
 
       assert timeout_metric.tag_values.(%{
                conn: %{method: "POST", private: %{phoenix_route: "/foo"}, request_path: "/foo"}
-             }) == %{method: "POST", route: "/foo"}
+             }) == %{method: "POST", route: "/foo", request_path: "/foo"}
     end
 
     test "tracks Bandit failures from native stop and exception events" do
@@ -28,13 +28,18 @@ defmodule TuistCommon.HTTP.TransportPromExPluginTest do
       assert stop_metric.tag_values.(%{
                conn: %{method: "GET", private: %{}, request_path: "/bar", status: 500},
                error: nil
-             }) == %{method: "GET", route: "unknown", reason: "server_error"}
+             }) == %{
+               method: "GET",
+               route: "unknown",
+               reason: "server_error",
+               request_path: "/bar"
+             }
 
       assert exception_metric.event_name == [:bandit, :request, :exception]
 
       assert exception_metric.tag_values.(%{
                conn: %{method: "GET", private: %{}, request_path: "/bar"}
-             }) == %{method: "GET", route: "unknown", reason: "exception"}
+             }) == %{method: "GET", route: "unknown", reason: "exception", request_path: "/bar"}
     end
 
     test "tracks Thousand Island drop and error counters from native events" do


### PR DESCRIPTION
Reduces upload memory pressure in the cache service by changing request body handling to keep only the initial read chunk in memory, then stream larger uploads to temporary files or devices. It also preserves the existing upload size limits and improves timeout handling so interrupted chunked uploads no longer get acknowledged as successful.

Fixes a rare OOM condition.

<details>
<summary>RCA</summary>

## Executive summary

`cache-us-east.tuist.dev` returned a large burst of `502`s because the cache app process (`beam.smp`) was **killed by the kernel OOM killer**.

The app container then restarted, and nginx temporarily failed to connect to `unix:/run/cache/current.sock`, producing the observed `502`s.

The evidence does **not** currently look like a classic monotonic memory leak. It looks more like **load-triggered transient memory blow-up** during a sharp upload-heavy burst, especially on request paths where uploads are read by Phoenix directly.

The most suspicious application behavior is:

- nginx has `proxy_request_buffering off`, so upload pressure goes straight to the app
- `Cache.BodyReader.read/2` only switches to temp-file streaming after the first `Plug.Conn.read_body/2` returns `:more`
- `CacheWeb.XcodeController.handle_existing_artifact/1` uses `BodyReader.drain/1`, which still reads request bodies through the same path, meaning duplicate uploads can still be materialized in memory before being discarded

## High-confidence conclusions

1. The immediate cause of the outage was **OOM kill of `beam.smp`**.
2. nginx `502`s were a **symptom after the crash**, not the primary cause.
3. The crash happened during a **sharp request burst** dominated by `[customer-a]`, especially `PUT /api/cache/keyvalue` and `POST /api/cache/cas/...`.
4. Current post-restart memory is **stable**, which argues **against** a simple continuously-growing leak.
5. The upload handling path is a credible explanation for **burst memory pressure**.

---

## Timeline

### 10:45:18 UTC — kernel kills BEAM

Kernel log excerpt:

```text
Mar 26 10:45:18 cache-us-east kernel: sshd-auth invoked oom-killer: gfp_mask=0x140cca(GFP_HIGHUSER_MOVABLE|__GFP_COMP), order=0, oom_score_adj=0
Mar 26 10:45:18 cache-us-east kernel: oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=sshd.service,mems_allowed=0,global_oom,task_memcg=/system.slice/docker-1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a.scope,task=beam.smp,pid=49296,uid=990
Mar 26 10:45:18 cache-us-east kernel: Out of memory: Killed process 49296 (beam.smp) total-vm:33870360kB, anon-rss:14344164kB, file-rss:448kB, shmem-rss:15188kB, UID:990 pgtables:53124kB oom_score_adj:0
```

Relevant memory state from the same kernel OOM dump:

```text
Mar 26 10:45:18 cache-us-east kernel: free:20948 free_pcp:345 free_cma:0
Mar 26 10:45:18 cache-us-east kernel: 5140 pages in swap cache
Mar 26 10:45:18 cache-us-east kernel: Free swap  = 112kB
Mar 26 10:45:18 cache-us-east kernel: Total swap = 8388604kB
```

Relevant process table line from the OOM dump:

```text
Mar 26 10:45:18 cache-us-east kernel: [  49296]   990 49296  8467590  3589950  3586041      112      3797 54398976  2047190             0 beam.smp
```

Interpretation:

- the host was out of memory
- swap was effectively exhausted
- the victim was the BEAM inside the cache container
- `anon-rss` was roughly **14.3 GiB** on a **15 GiB** host

### 10:45:20 UTC — nginx sees upstream resets

nginx log excerpt immediately after the crash:

```text
Mar 26 10:45:20 cache-us-east nginx[39748]: 2026/03/26 10:45:20 [error] 39748#39748: *3122576 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 64.6.38.249, server: cache-us-east.tuist.dev, request: "PUT /api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0", upstream: "http://unix:/run/cache/current.sock:/api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a]", host: "cache-us-east.tuist.dev"
Mar 26 10:45:20 cache-us-east nginx[39748]: 2026/03/26 10:45:20 [error] 39748#39748: *3124397 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 64.6.38.249, server: cache-us-east.tuist.dev, request: "POST /api/cache/cas/651F40AE3B009B4A2C9B6A5E9E8133B5F0ACA060081919E50C619DA2A7FF701B?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0", upstream: "http://unix:/run/cache/current.sock:/api/cache/cas/651F40AE3B009B4A2C9B6A5E9E8133B5F0ACA060081919E50C619DA2A7FF701B?account_handle=[customer-a]&project_handle=[customer-a]", host: "cache-us-east.tuist.dev"
```

Interpretation:

- nginx still had in-flight upstream requests to the unix socket
- the app process died underneath them
- nginx therefore saw `connection reset by peer`

### 10:45:20–10:45:21 UTC — container exits and is restarted

System / container runtime excerpt:

```text
Mar 26 10:45:18 cache-us-east systemd[1]: docker-1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a.scope: A process of this unit has been killed by the OOM killer.
Mar 26 10:45:20 cache-us-east dockerd[1406]: time="2026-03-26T10:45:20.417564016Z" level=info msg="ignoring event" container=1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Mar 26 10:45:20 cache-us-east dockerd[1437]: time="2026-03-26T10:45:20.421256485Z" level=info msg="shim disconnected" id=1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a namespace=moby
Mar 26 10:45:20 cache-us-east dockerd[1437]: time="2026-03-26T10:45:20.422474728Z" level=info msg="cleaning up after shim disconnected" id=1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a namespace=moby
Mar 26 10:45:20 cache-us-east dockerd[1437]: time="2026-03-26T10:45:20.422489306Z" level=info msg="cleaning up dead shim" id=1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a namespace=moby
Mar 26 10:45:20 cache-us-east dockerd[1437]: time="2026-03-26T10:45:20.847241184Z" level=info msg="connecting to shim 1b433bace101093417d426843b886c906129cf96de19fa08e5b70439edaa545a" address="unix:///run/containerd/s/1f7671422bf58289a2f3c557f87924d2f8f3ee2f45d8e0d2f6d7699309e94a56" namespace=moby protocol=ttrpc version=3
Mar 26 10:45:21 cache-us-east dockerd[1406]: time="2026-03-26T10:45:21.064864654Z" level=info msg="sbJoin: gwep4 ''->'96adb8fb5b67', gwep6 ''->''" eid=96adb8fb5b67 ep=cache-web-production-1f25ea43c16d85f4e711c3f65da5d0597354ba69_uncommitted_85251ccbfa239b8a net=kamal nid=465e5e6aac3c
```

Container state after the incident:

```text
$ docker inspect ... --format "{{.RestartCount}} {{.State.StartedAt}}"
1 2026-03-26T10:45:20.808132038Z
```

Interpretation:

- the cache container was restarted once
- the new container came up immediately after the OOM kill

### 10:45:21 UTC onward — nginx sees connection refused during restart gap

nginx log excerpt:

```text
Mar 26 10:45:21 cache-us-east nginx[39748]: 2026/03/26 10:45:21 [error] 39748#39748: *3124397 connect() to unix:/run/cache/current.sock failed (111: Connection refused) while connecting to upstream, client: 64.6.38.249, server: cache-us-east.tuist.dev, request: "PUT /api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0", upstream: "http://unix:/run/cache/current.sock:/api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a]", host: "cache-us-east.tuist.dev"
```

Interpretation:

- BEAM had died and the replacement instance was not yet serving on `current.sock`
- nginx was healthy, but the upstream app socket was unavailable

---

## Access-log evidence

### Total 502s in the incident minute

```text
$ grep "[26/Mar/2026:10:45:" /var/log/nginx/access.log | grep " 502 " | wc -l
8001
```

### First and last sampled `502` access-log lines from the incident minute

Early in the failure window:

```text
74.122.201.246 - - [26/Mar/2026:10:45:20 +0000] "POST /api/cache/cas/DF9201D72C595D24A9F240A9DC4997B7737D24DD10DCCA3AED7749180E29AEEB?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0" 502 150 "-" "tuist (unknown version) CFNetwork/3826.600.41 Darwin/24.6.0" rt=3.027 uct=0.000 uht=- urt=3.027 upstream_addr=unix:/run/cache/current.sock status=502 request_length=8630 method=POST
```

Later in the restart gap:

```text
64.6.38.249 - - [26/Mar/2026:10:45:23 +0000] "POST /api/cache/cas/99283C9B3B6ADB4F9518564062D58CC532C0308C50CD4A59CE2C920A49C19AAC?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0" 502 150 "-" "tuist (unknown version) CFNetwork/3860.400.51 Darwin/25.3.0" rt=0.000 uct=- uht=- urt=0.000 upstream_addr=unix:/run/cache/current.sock status=502 request_length=217 method=POST
```

Interpretation:

- the earlier `502`s with `rt=3.027` were likely in-flight requests that were reset when BEAM died
- the later `502`s with `rt=0.000` line up with immediate `connect() ... failed (111: Connection refused)` after the restart gap began

### Top clients during the `10:45` incident minute

```text
5903 64.6.38.249
1470 74.122.201.246
543 74.122.202.246
72 74.122.202.248
12 74.122.202.247
1 62.96.154.15
```

### Top accounts during the `10:45` incident minute

```text
7916 account_handle=[customer-a]
72 account_handle=[customer-b]
12 account_handle=[customer-c]
```

`[customer-a]` dominated the error burst.

### Requests by second immediately before the crash

Counts from the sharp burst just before the OOM:

```text
204  second=10
455  second=11
1067 second=12
1523 second=13
2158 second=14
1821 second=15
2394 second=16
426  second=17
21   second=18
```

The biggest spike in the sampled pre-crash window was **2394 requests at `10:45:16`**.

### Top request shapes in the `10:45:16`–`10:45:18` slice

```text
664 PUT /api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a]
151 POST /api/cache/cas/BC3E95086325501035D74A7630D082DD065BDB5719011200494A9B0BB032B120?account_handle=[customer-a]&project_handle=[customer-a]
106 POST /api/cache/cas/DF9201D72C595D24A9F240A9DC4997B7737D24DD10DCCA3AED7749180E29AEEB?account_handle=[customer-a]&project_handle=[customer-a]
96 POST /api/cache/cas/DE600208FE11DD55292E55CA2F93F6E677D3B09A0B35FE727358919C3F0238FE?account_handle=[customer-a]&project_handle=[customer-a]
72 POST /api/cache/cas/34514485C1630171AB7D8481360DAF5D947DB157A24C13CB7868C1E5A66562FD?account_handle=[customer-a]&project_handle=[customer-a]
```

This slice shows:

- a heavy concentration of `PUT /api/cache/keyvalue`
- repeated uploads for the same CAS IDs
- traffic concentrated on `[customer-a]`

### Sample successful requests just before the kill

```text
64.6.38.249 - - [26/Mar/2026:10:45:16 +0000] "POST /api/cache/cas/626514F15D3B0F4B35311177E1284FD61F53C5CE64FE082F2FA9A7AA8B0A4A72?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0" 204 0 "-" "tuist (unknown version) CFNetwork/3860.400.51 Darwin/25.3.0" rt=0.223 uct=0.000 uht=0.223 urt=0.223 upstream_addr=unix:/run/cache/current.sock status=204 request_length=9122 method=POST
64.6.38.249 - - [26/Mar/2026:10:45:16 +0000] "PUT /api/cache/keyvalue?account_handle=[customer-a]&project_handle=[customer-a] HTTP/2.0" 204 0 "-" "tuist (unknown version) CFNetwork/3860.400.51 Darwin/25.3.0" rt=0.224 uct=0.000 uht=0.224 urt=0.224 upstream_addr=unix:/run/cache/current.sock status=204 request_length=1151 method=PUT
```

This confirms the service was still successfully serving the same traffic pattern immediately before the OOM.

---

## Current post-restart state

### Container state

```text
cache-web-production-1f25ea43c16d85f4e711c3f65da5d0597354ba69_uncommitted_85251ccbfa239b8a   Up 30 minutes
```

### Host memory now

```text
               total        used        free      shared  buff/cache   available
Mem:            15Gi       3.4Gi       3.2Gi        51Mi       9.0Gi        11Gi
Swap:          8.0Gi       140Mi       7.9Gi

NAME              TYPE SIZE   USED PRIO
/var/lib/swapfile file   8G 140.4M   -2
```

### Container memory now

Sampled over ~30 seconds:

```text
11:01:18  3.302GiB / 15.25GiB  149.12%
11:01:24  3.31GiB  / 15.25GiB   96.40%
11:01:30  3.31GiB  / 15.25GiB   72.36%
11:01:36  3.307GiB / 15.25GiB   12.65%
11:01:42  3.3GiB   / 15.25GiB  119.15%
11:01:48  3.319GiB / 15.25GiB  103.82%
```

### BEAM RSS now

Sampled from `/proc/$pid/status` over ~30 seconds:

```text
VmRSS:   2951636 kB
RssAnon: 2806892 kB
RssFile:   49916 kB
VmSwap:        0 kB
---
VmRSS:   2953572 kB
RssAnon: 2808516 kB
RssFile:   50228 kB
VmSwap:        0 kB
---
VmRSS:   2952644 kB
RssAnon: 2807480 kB
RssFile:   50336 kB
VmSwap:        0 kB
---
VmRSS:   2959092 kB
RssAnon: 2814228 kB
RssFile:   50036 kB
VmSwap:        0 kB
---
VmRSS:   2940700 kB
RssAnon: 2795080 kB
RssFile:   50792 kB
VmSwap:        0 kB
---
VmRSS:   2940480 kB
RssAnon: 2793896 kB
RssFile:   51756 kB
VmSwap:        0 kB
```

### Live BEAM memory metrics now

```text
cache_prom_ex_beam_memory_allocated_bytes 822808496
cache_prom_ex_beam_memory_binary_total_bytes 456939472
cache_prom_ex_beam_memory_processes_total_bytes 127603672
cache_prom_ex_beam_memory_ets_total_bytes 45089312
cache_prom_ex_beam_memory_code_total_bytes 62484487
cache_prom_ex_beam_memory_atom_total_bytes 2189816
cache_prom_ex_beam_memory_persistent_term_total_bytes 1968536
```

### SQLite buffer state now

```text
tuist_cache_sqlite_buffer_pending_s3_transfers 0
tuist_cache_sqlite_buffer_pending_cache_artifacts 0
tuist_cache_sqlite_buffer_pending_key_values 4
tuist_cache_sqlite_buffer_pending_total 4
```

Interpretation:

- post-restart memory is currently **stable**, not continuously rising
- queues are effectively empty
- that does **not** prove there is no leak, but it argues against a simple always-growing one

---

## Relevant code paths inspected

### nginx sends upload pressure directly to Phoenix

`cache/platform/nginx.nix`

- line `181`: `proxy_buffering off`
- line `182`: `proxy_request_buffering off`

Relevant excerpt:

```nix
proxy_buffering off;
proxy_request_buffering off;
```

Interpretation:

- nginx is not first buffering request bodies to disk before handing them to the app
- upload pressure lands directly on the Phoenix/Bandit process tree

### `Cache.BodyReader` default upload settings

`cache/lib/cache/body_reader.ex`

- line `19`: `@default_opts [length: @max_upload_bytes, read_length: 262_144]`
- line `30`: `def read(conn, opts \\ []) do`
- line `109`: `def drain(conn) do`

Relevant excerpt:

```elixir
@max_upload_bytes 25 * 1024 * 1024
@default_opts [length: @max_upload_bytes, read_length: 262_144]
```

And the initial read path:

```elixir
def read(conn, opts \\ []) do
  merged_opts = Keyword.merge(read_opts(conn), opts)
  max_bytes = Keyword.get(opts, :max_bytes, @max_upload_bytes)

  conn
  |> Plug.Conn.read_body(merged_opts)
  |> handle_read_result(conn, merged_opts, :store, max_bytes)
end
```

Important behavior:

- `BodyReader.read/2` only switches to temp-file storage after `Plug.Conn.read_body/2` returns `{:more, chunk, conn}`
- for bodies that fit in the first call, the body is returned as a binary and can be kept in memory

Also note a correctness issue in this implementation:

- on the initial `{:ok, body, conn_after}` path in `handle_read_result/5`, there is no `max_bytes` check before returning the body

### Existing-artifact Xcode uploads are drained through the same request-body path

`cache/lib/cache_web/controllers/xcode_controller.ex`

- line `139`: `defp handle_existing_artifact(conn) do`
- line `146`: `defp save_new_artifact(conn, account_handle, project_handle, id) do`

Relevant excerpt:

```elixir
defp handle_existing_artifact(conn) do
  :telemetry.execute([:cache, :xcode, :upload, :exists], %{count: 1}, %{})

  {_, conn_after} = BodyReader.drain(conn)
  send_resp(conn_after, :no_content, "")
end
```

Interpretation:

- if the artifact already exists, the server still reads the body to drain the request
- because `BodyReader.drain/1` still uses `Plug.Conn.read_body/2`, duplicate uploads can still be materialized in memory before being discarded

### Why this is suspicious for this incident

The request logs around the incident show:

- many `POST /api/cache/cas/...`
- many repeated uploads for identical CAS IDs
- heavy concurrent `PUT /api/cache/keyvalue`
- no nginx request buffering in front of the app

Taken together, this makes the upload path a credible explanation for **transient memory blow-up under bursty duplicate upload traffic**.

---

## Negative evidence / things checked

### No app logs around the crash window

I checked container logs around the incident window:

- `docker logs --since "2026-03-26T10:44:30" --until "2026-03-26T10:45:19" ...`
- `docker logs --since "2026-03-26T10:45:21" --until "2026-03-26T10:45:40" ...`

Both returned no useful output for the crash window.

That means the strongest evidence came from:

- kernel OOM logs
- nginx logs
- access logs
- current post-restart memory metrics

---

## Assessment: leak vs burst

### What is proven

- BEAM was OOM-killed.
- The host was effectively out of RAM and swap.
- The outage coincided with a sharp burst of upload-heavy traffic.
- The current service is stable at ~3.3 GiB container memory / ~2.95 GiB BEAM RSS.

### What is not proven

- I do **not** have a per-process BEAM heap snapshot from the moment of failure.
- I do **not** have production RPC data for allocator state or process memory at incident time.
- I therefore cannot prove a leak in a specific process.

### Best current interpretation

This does **not** look like a simple monotonic memory leak.

It looks more like:

1. very sharp burst of traffic
2. upload-heavy request mix
3. duplicate CAS uploads
4. direct request-body handling in Phoenix/Bandit
5. transient binary / allocator pressure
6. host OOM kill of `beam.smp`

---

## Most likely remediation direction

The most likely fix direction is to reduce app-side memory pressure for uploads:

1. **Stream to file/device earlier**
   - make the upload path spill to file from the first chunk instead of waiting for `{:more, ...}`

2. **Make `drain/1` truly low-memory**
   - avoid materializing large duplicate upload bodies in memory just to discard them

3. **Enforce `max_bytes` consistently**
   - including the initial `{:ok, body, conn_after}` path in `Cache.BodyReader`

4. **Consider whether nginx should buffer request bodies for these endpoints**
   - current config sends upload pressure directly to the app

---

## Appendix: additional current metrics

These are relevant but should not be confused with live RAM usage.

KeyValue SQLite metrics:

```text
cache_kv_db_file_size_bytes 30826020864
cache_kv_wal_file_size_bytes 27443352
cache_kv_sqlite_in_use_bytes 18921070592
cache_kv_sqlite_reclaimable_bytes 11904950272
cache_kv_sqlite_page_count 7525884
cache_kv_sqlite_freelist_pages 2906482
cache_kv_sqlite_page_size_bytes 4096
```

Notes:

- the key-value SQLite DB is large on disk (~30.8 GiB)
- the DB size is **not** itself proof of RAM pressure
- current BEAM ETS and process memory are much smaller than the OOM-time RSS from kernel logs


</details>