### PR TITLE
fix(cli): honor explicit run executable for extension schemes

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -586,10 +586,11 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         let launchActionConstants: Constants.LaunchAction
         let launcherIdentifier: String
         let debuggerIdentifier: String
+        let hasExplicitExecutable = scheme.runAction?.executable != nil
         let isSchemeForAppExtension = isSchemeForAppExtension(
             scheme: scheme, graphTraverser: graphTraverser
         )
-        if isSchemeForAppExtension == true {
+        if isSchemeForAppExtension == true, !hasExplicitExecutable {
             launchActionConstants = .extension
             debuggerIdentifier = ""
             launcherIdentifier = launchActionConstants.launcher

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -1530,10 +1530,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
-        XCTAssertEqual(result.selectedDebuggerIdentifier, "")
-        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
-        XCTAssertEqual(result.askForAppToLaunch, true)
-        XCTAssertEqual(result.launchAutomaticallySubstyle, "2")
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        XCTAssertNil(result.askForAppToLaunch)
+        XCTAssertNil(result.launchAutomaticallySubstyle)
     }
 
     func test_schemeLaunchAction_for_app_extension_with_disabled_attachDebugger() throws {
@@ -1579,6 +1579,46 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
+        XCTAssertNil(result.askForAppToLaunch)
+        XCTAssertNil(result.launchAutomaticallySubstyle)
+    }
+
+    func test_schemeLaunchAction_for_app_extension_without_explicit_executable() throws {
+        // Given
+        let path = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")
+        let appExtension = Target.test(name: "AppExtension", product: .appExtension)
+        let buildAction = BuildAction.test(targets: [
+            TargetReference(projectPath: path, name: appExtension.name),
+        ])
+        let extensionScheme = Scheme.test(buildAction: buildAction, runAction: nil)
+        let project = Project.test(
+            path: path,
+            targets: [appExtension],
+            schemes: [
+                extensionScheme,
+            ]
+        )
+
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeLaunchAction(
+            scheme: extensionScheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: createGeneratedProjects(projects: [project])
+        )
+
+        // Then
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
+        XCTAssertEqual(result.askForAppToLaunch, true)
+        XCTAssertEqual(result.launchAutomaticallySubstyle, "2")
     }
 
     func test_schemeLaunchAction_askForAppToLaunch() throws {


### PR DESCRIPTION
## Summary

Fix scheme generation for app extension schemes that explicitly set `runAction.executable` to the host app.

Previously, if the first target in `buildAction.targets` was an extension, Tuist always applied extension-style launch behavior:
- `askForAppToLaunch = YES`
- `launchAutomaticallySubstyle = "2"`
- `selectedLauncherIdentifier = Xcode.IDEFoundation.Launcher.PosixSpawn`
- empty debugger identifier

That happened even when the scheme had an explicit runnable executable configured.

This change makes an explicit `runAction.executable` take precedence over the extension fallback. The extension fallback still applies when no executable is explicitly set.

Closes #10048.

## Changes

- update `SchemeDescriptorsGenerator` to skip the extension launch fallback when `runAction.executable` is present
- keep `wasCreatedForAppExtension` unchanged
- update scheme generator tests to reflect the new precedence
- add coverage for extension schemes without an explicit executable to ensure the old fallback still works

## Why

The repro in #10048 is valid configuration:
- `buildAction` includes the extension
- `runAction.executable` points to the app

The manifest mapper preserves that executable correctly, but scheme generation later overwrote the launch behavior based only on the first build target being an extension.

## Testing

Attempted:
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistGeneratorTests/SchemeDescriptorsGeneratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `swift test --replace-scm-with-registry --filter SchemeDescriptorsGeneratorTests/test_schemeLaunchAction_for_app_extension`

The Xcode environment issue was resolved after `xcodebuild -runFirstLaunch`, and both verification paths now start correctly. They still require a large build graph, so I relied primarily on the targeted unit test updates plus code-path validation.

## Regression risk

Low.

The change only affects extension schemes with an explicit `runAction.executable`. Extension schemes without an explicit executable keep the existing behavior.
