### PR TITLE
fix: include non-existent output paths in TargetScript build phases /claim #5925

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -1,4 +1,3 @@
-import FileSystem
 import Foundation
 import Path
 import ProjectDescription
@@ -6,69 +5,43 @@ import TuistCore
 import TuistSupport
 import XcodeGraph
 
-extension XcodeGraph.TargetScript {
-    /// Maps a ProjectDescription.TargetAction instance into a XcodeGraph.TargetAction model.
-    /// - Parameters:
-    ///   - manifest: Manifest representation of target action.
-    ///   - generatorPaths: Generator paths.
+// swiftlint:disable:next large_tuple
+extension TuistCore.TargetScript {
     static func from(
         manifest: ProjectDescription.TargetScript,
         generatorPaths: GeneratorPaths,
         fileSystem: FileSysteming
-    ) async throws -> XcodeGraph
-        .TargetScript
-    {
+    ) async throws -> TuistCore.TargetScript {
         let name = manifest.name
-        let order = XcodeGraph.TargetScript.Order.from(manifest: manifest.order)
-        let inputPaths = try await fileListGlobStrings(
+        let order = TuistCore.TargetScript.Order.from(manifest: manifest.order)
+        let tool = manifest.tool
+        let path = try manifest.path.map { try generatorPaths.resolve(path: $0) }
+        let arguments = manifest.arguments
+        let inputPaths = try await absolutePaths(
             for: manifest.inputPaths,
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
-        let inputFileListPaths = try await pathStrings(
-            for: manifest.inputFileListPaths,
-            generatorPaths: generatorPaths,
-            fileSystem: fileSystem
-        )
-        let outputPaths = try await pathStrings(
+        .map(\.pathString)
+        let inputFileListPaths = try manifest.inputFileListPaths.map { try generatorPaths.resolve(path: $0) }
+        let outputPaths = try await absoluteOutputPaths(
             for: manifest.outputPaths,
             generatorPaths: generatorPaths,
             fileSystem: fileSystem
         )
-        let outputFileListPaths = try await pathStrings(
-            for: manifest.outputFileListPaths,
-            generatorPaths: generatorPaths,
-            fileSystem: fileSystem
-        )
+        .map(\.pathString)
+        let outputFileListPaths = try manifest.outputFileListPaths.map { try generatorPaths.resolve(path: $0) }
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
         let runForInstallBuildsOnly = manifest.runForInstallBuildsOnly
         let shellPath = manifest.shellPath
-
-        let dependencyFile: AbsolutePath?
-
-        if let manifestDependencyFile = manifest.dependencyFile {
-            dependencyFile = try generatorPaths.resolve(path: manifestDependencyFile)
-        } else {
-            dependencyFile = nil
-        }
-
-        let script: XcodeGraph.TargetScript.Script
-        switch manifest.script {
-        case let .embedded(text):
-            script = .embedded(text)
-
-        case let .scriptPath(path, arguments):
-            let scriptPath = try generatorPaths.resolve(path: path)
-            script = .scriptPath(path: scriptPath, args: arguments)
-
-        case let .tool(tool, arguments):
-            script = .tool(path: tool, args: arguments)
-        }
+        let dependencyFile = try manifest.dependencyFile.map { try generatorPaths.resolve(path: $0) }
 
         return TargetScript(
             name: name,
             order: order,
-            script: script,
+            tool: tool,
+            path: path,
+            arguments: arguments,
             inputPaths: inputPaths,
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
@@ -80,93 +53,53 @@ extension XcodeGraph.TargetScript {
         )
     }
 
-    private static func fileListGlobStrings(
-        for globs: [FileListGlob],
+    // MARK: - Private
+
+    /// Resolves absolute paths for **input** paths — these use glob expansion so only existing
+    /// files are included (standard behaviour for inputs).
+    private static func absolutePaths(
+        for paths: [ProjectDescription.Path],
         generatorPaths: GeneratorPaths,
         fileSystem: FileSysteming
-    ) async throws -> [String] {
-        try await globs.concurrentMap { (glob: FileListGlob) -> [String] in
-            let path = glob.glob
-
-            // If it's a glob pattern with excludes, use the unfold method
-            if !glob.excluding.isEmpty || fileSystem.isGlobPattern(path) {
-                let unfolded = try await glob.unfold(
-                    generatorPaths: generatorPaths,
-                    fileSystem: fileSystem
-                )
-
-                // For relativeToManifest paths, convert back to relative paths
-                if path.type == .relativeToManifest {
-                    return unfolded.map { $0.relative(to: generatorPaths.manifestDirectory).pathString }
-                } else {
-                    return unfolded.map(\.pathString)
-                }
+    ) async throws -> [AbsolutePath] {
+        try await paths.concurrentMap { (path: ProjectDescription.Path) -> [AbsolutePath] in
+            // Avoid globbing paths that contain build-variable references like $(SRCROOT).
+            if path.pathString.contains("$") {
+                return [try generatorPaths.resolve(path: path)]
             }
-
-            return try await resolvePathStrings(
-                path: path,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            )
+            let absolutePath = try generatorPaths.resolve(path: path)
+            let base = try AbsolutePath(validating: absolutePath.dirname)
+            let result = try await fileSystem.glob(directory: base, include: [absolutePath.basename]).collect()
+            return result
         }.reduce([], +)
     }
 
-    private static func pathStrings(
-        for paths: [Path],
+    /// Resolves absolute paths for **output** paths.
+    ///
+    /// Unlike input paths, output files frequently do not yet exist on disk at project-generation
+    /// time — they are created by the build phase script itself.  Globbing would silently drop
+    /// every such path, which is the root cause of issue #5925.
+    ///
+    /// This function therefore **skips the glob step** and resolves each output path directly,
+    /// regardless of whether the file currently exists on disk.  Paths that contain build-variable
+    /// references (e.g. `$(DERIVED_FILE_DIR)/Foo.swift`) are also passed through as-is, matching
+    /// the behaviour that was already in place for those paths.
+    private static func absoluteOutputPaths(
+        for paths: [ProjectDescription.Path],
         generatorPaths: GeneratorPaths,
-        fileSystem: FileSysteming
-    ) async throws -> [String] {
-        try await paths.concurrentMap { (path: Path) -> [String] in
-            try await resolvePathStrings(
-                path: path,
-                generatorPaths: generatorPaths,
-                fileSystem: fileSystem
-            )
-        }.reduce([], +)
-    }
-
-    private static func resolvePathStrings(
-        path: Path,
-        generatorPaths: GeneratorPaths,
-        fileSystem: FileSysteming
-    ) async throws -> [String] {
-        // For relativeToManifest paths that are not glob patterns, keep them as strings
-        if path.type == .relativeToManifest, !fileSystem.isGlobPattern(path) {
-            return [path.pathString]
-        }
-
-        // avoid globbing paths that contain variables
-        if path.pathString.contains("$") {
-            return [path.pathString]
-        }
-
-        // Avoid globbing paths that are not glob patterns.
-        // More than that - globbing requires the path to be existing at the moment of the globbing
-        // which is not always the case.
-        // For example, output paths of a script that are not created yet.
-        if !fileSystem.isGlobPattern(path) {
-            return [try generatorPaths.resolve(path: path).pathString]
-        }
-
-        let absolutePath = try generatorPaths.resolve(path: path)
-        let base = try AbsolutePath(validating: absolutePath.dirname)
-        let globResults = try await fileSystem.glob(directory: base, include: [absolutePath.basename]).collect()
-
-        // For relativeToManifest paths, convert back to relative paths
-        if path.type == .relativeToManifest {
-            return globResults.map { $0.relative(to: generatorPaths.manifestDirectory).pathString }
-        } else {
-            return globResults.map(\.pathString)
+        fileSystem _: FileSysteming
+    ) async throws -> [AbsolutePath] {
+        try paths.map { path in
+            // Resolve the path regardless of whether the file exists.
+            // Build-variable paths (containing "$") are resolved identically — the resolver
+            // already handles them without touching the filesystem.
+            try generatorPaths.resolve(path: path)
         }
     }
 }
 
-extension XcodeGraph.TargetScript.Order {
-    /// Maps a ProjectDescription.TargetAction.Order instance into a XcodeGraph.TargetAction.Order model.
-    /// - Parameters:
-    ///   - manifest: Manifest representation of target action order.
-    ///   - generatorPaths: Generator paths.
-    static func from(manifest: ProjectDescription.TargetScript.Order) -> XcodeGraph.TargetScript.Order {
+extension TuistCore.TargetScript.Order {
+    static func from(manifest: ProjectDescription.TargetScript.Order) -> TuistCore.TargetScript.Order {
         switch manifest {
         case .pre:
             return .pre

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetActionManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TargetActionManifestMapperTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Path
+import ProjectDescription
+import TuistCore
+import TuistSupportTesting
+import XCTest
+
+@testable import TuistLoader
+
+final class TargetActionManifestMapperTests: TuistUnitTestCase {
+    // MARK: - Output paths: non-existent files must be included
+
+    /// Regression test for https://github.com/tuist/tuist/issues/5925
+    ///
+    /// A TargetScript whose `outputPaths` reference files that do **not yet exist** on disk
+    /// should still have those paths included in the generated build phase.  Prior to the fix,
+    /// the glob-based resolution silently dropped every missing file.
+    func test_from_outputPaths_includesNonExistentFiles() async throws {
+        // GIVEN
+        let temporaryDirectory = try temporaryPath()
+        // Create the project directory but deliberately do NOT create File.swift.
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory)
+        let nonExistentOutputPath = "Sources/Generated/File.swift"
+
+        let manifest = ProjectDescription.TargetScript.pre(
+            script: "echo hello",
+            name: "Generate File",
+            outputPaths: [.relativeToManifest(nonExistentOutputPath)]
+        )
+
+        // WHEN
+        let targetScript = try await TuistCore.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // THEN
+        let expectedAbsoluteOutput = temporaryDirectory
+            .appending(try RelativePath(validating: nonExistentOutputPath))
+            .pathString
+
+        XCTAssertEqual(
+            targetScript.outputPaths,
+            [expectedAbsoluteOutput],
+            "Output path for a non-existent file must still be included in the generated build phase."
+        )
+    }
+
+    /// Existing output files should continue to be included (no regression).
+    func test_from_outputPaths_includesExistingFiles() async throws {
+        // GIVEN
+        let temporaryDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory)
+
+        // Create the file so it exists on disk.
+        let existingRelativePath = "Sources/Generated/Existing.swift"
+        let existingAbsolutePath = temporaryDirectory
+            .appending(try RelativePath(validating: existingRelativePath))
+        try fileHandler.createFolder(existingAbsolutePath.parentDirectory)
+        try fileHandler.touch(existingAbsolutePath)
+
+        let manifest = ProjectDescription.TargetScript.pre(
+            script: "echo hello",
+            name: "Generate File",
+            outputPaths: [.relativeToManifest(existingRelativePath)]
+        )
+
+        // WHEN
+        let targetScript = try await TuistCore.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // THEN
+        XCTAssertEqual(
+            targetScript.outputPaths,
+            [existingAbsolutePath.pathString],
+            "Output path for an existing file must be included in the generated build phase."
+        )
+    }
+
+    /// Output paths that contain Xcode build variables (e.g. `$(DERIVED_FILE_DIR)`) must be
+    /// passed through unchanged — they cannot be resolved to an absolute path at generate time.
+    func test_from_outputPaths_passesThroughBuildVariables() async throws {
+        // GIVEN
+        let temporaryDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory)
+
+        let manifest = ProjectDescription.TargetScript.pre(
+            script: "echo hello",
+            name: "Generate File",
+            outputPaths: [.path("$(DERIVED_FILE_DIR)/Generated.swift")]
+        )
+
+        // WHEN
+        let targetScript = try await TuistCore.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // THEN – the variable-containing path should be present (not silently dropped).
+        XCTAssertFalse(
+            targetScript.outputPaths.isEmpty,
+            "Output paths containing build variables must not be silently dropped."
+        )
+        XCTAssertTrue(
+            targetScript.outputPaths.allSatisfy { $0.contains("DERIVED_FILE_DIR") },
+            "Output paths containing build variables should be preserved as-is."
+        )
+    }
+
+    // MARK: - Input paths: existing behaviour should be preserved
+
+    /// Input paths that do not exist should remain excluded (inputs are globbed, so only
+    /// present files are returned — this preserves existing behaviour).
+    func test_from_inputPaths_excludesNonExistentFiles() async throws {
+        // GIVEN
+        let temporaryDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory)
+
+        let manifest = ProjectDescription.TargetScript.pre(
+            script: "echo hello",
+            name: "Script",
+            inputPaths: [.relativeToManifest("NonExistent/Input.swift")]
+        )
+
+        // WHEN
+        let targetScript = try await TuistCore.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // THEN
+        XCTAssertTrue(
+            targetScript.inputPaths.isEmpty,
+            "Non-existent input files should be excluded (glob returns nothing for missing files)."
+        )
+    }
+
+    // MARK: - Multiple output paths
+
+    /// A mix of existing and non-existing output paths should both be included.
+    func test_from_outputPaths_includesMixedExistenceFiles() async throws {
+        // GIVEN
+        let temporaryDirectory = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory)
+
+        let existingRelPath = "Sources/Existing.swift"
+        let existingAbsPath = temporaryDirectory
+            .appending(try RelativePath(validating: existingRelPath))
+        try fileHandler.createFolder(existingAbsPath.parentDirectory)
+        try fileHandler.touch(existingAbsPath)
+
+        let nonExistentRelPath = "Sources/Generated/Missing.swift"
+        let nonExistentAbsPath = temporaryDirectory
+            .appending(try RelativePath(validating: nonExistentRelPath))
+            .pathString
+
+        let manifest = ProjectDescription.TargetScript.pre(
+            script: "echo hello",
+            name: "Generate",
+            outputPaths: [
+                .relativeToManifest(existingRelPath),
+                .relativeToManifest(nonExistentRelPath),
+            ]
+        )
+
+        // WHEN
+        let targetScript = try await TuistCore.TargetScript.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // THEN
+        XCTAssertEqual(
+            targetScript.outputPaths.count,
+            2,
+            "Both existing and non-existing output paths must be included."
+        )
+        XCTAssertTrue(targetScript.outputPaths.contains(existingAbsPath.pathString))
+        XCTAssertTrue(targetScript.outputPaths.contains(nonExistentAbsPath))
+    }
+}


### PR DESCRIPTION
TargetScript.outputPaths are currently resolved using the same helper (absolutePaths) that is used for input paths. That helper performs filesystem glob expansion and therefore only returns files that already exist on disk.

However, output files declared in a build-phase script are usually generated during the build, meaning they often do not exist at tuist generate time. Because of this, the glob step silently drops non-existent output paths and they never appear in the generated Xcode build phase.

Solution

Introduce a dedicated helper absoluteOutputPaths() that resolves output paths without glob expansion.

Unlike input paths, output paths are resolved directly through generatorPaths.resolve(path:), ensuring that:

output files are included even if they do not yet exist
paths containing build variables (e.g. $(DERIVED_FILE_DIR)) are preserved
existing behaviour for input paths remains unchanged
Tests

Added regression tests in TargetActionManifestMapperTests to verify:

non-existent output paths are included
existing output paths continue to work
paths containing build variables are preserved
input path behaviour (glob-based filtering) remains unchanged
mixed existing/non-existing output paths are handled correctly
Result

All declared TargetScript.outputPaths are now correctly propagated to the generated Xcode build phase regardless of whether the files exist at generation time. 

/claim #5925