### PR TITLE
refactor(server): add new cache endpoints as disabled

### DIFF
--- a/server/lib/tuist_web/live/ops_cache_live.ex
+++ b/server/lib/tuist_web/live/ops_cache_live.ex
@@ -45,7 +45,8 @@ defmodule TuistWeb.OpsCacheLive do
   def handle_event("add", %{"url" => url, "display_name" => display_name}, socket) do
     case CacheEndpoints.create_cache_endpoint(%{
            url: url,
-           display_name: display_name
+           display_name: display_name,
+           enabled: false
          }) do
       {:ok, _endpoint} ->
         endpoints = CacheEndpoints.list_cache_endpoints()

--- a/server/test/tuist_web/live/ops_cache_live_test.exs
+++ b/server/test/tuist_web/live/ops_cache_live_test.exs
@@ -74,7 +74,7 @@ defmodule TuistWeb.OpsCacheLiveTest do
     assert {:error, :not_found} = CacheEndpoints.get_cache_endpoint(endpoint.id)
   end
 
-  test "adds a new endpoint", %{conn: conn} do
+  test "adds a new endpoint in disabled state", %{conn: conn} do
     # Given
     {:ok, lv, _html} = live(conn, ~p"/ops/cache")
 
@@ -87,8 +87,9 @@ defmodule TuistWeb.OpsCacheLiveTest do
     |> render_submit()
 
     # Then
-    endpoints = CacheEndpoints.list_cache_endpoints()
-    assert Enum.any?(endpoints, fn e -> e.display_name == "New Node" end)
+    assert {:ok, endpoint} = CacheEndpoints.get_cache_endpoint_by_url("https://cache-new.tuist.dev")
+    assert endpoint.display_name == "New Node"
+    assert endpoint.enabled == false
   end
 
   test "shows empty state when no endpoints exist", %{conn: conn} do


### PR DESCRIPTION
When I add a new endpoint, I want to be able to add it, _then_ verify it works correctly and explicitly enable it. PR switches the default to disabled so things don't immediately get thrown to the wolves.