### PR TITLE
fix(cli): mark generated bundle accessors as nonisolated

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -299,7 +299,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         extern "C" {
         #endif
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void);
+        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
 
         #define SWIFTPM_MODULE_BUNDLE \(targetName)_SWIFTPM_MODULE_BUNDLE()
 
@@ -370,7 +370,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         // MARK: - Objective-C Bundle Accessor
         @objc
         public final class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
-        @objc public class var bundle: Bundle {
+        @objc public nonisolated class var bundle: Bundle {
             return .module
         }
         }
@@ -386,7 +386,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
             target
                 .product
         ), the bundle containing the resources is copied into the final product.
-            static let module: Bundle = {
+            nonisolated static let module: Bundle = {
                 let bundleName = "\(bundleName)"
                 let bundleFinderResourceURL = Bundle(for: BundleFinder.self).resourceURL
                 var candidates = [
@@ -439,7 +439,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
             target
                 .product
         ), the bundle for classes within this module can be used directly.
-            static let module = Bundle(for: BundleFinder.self)
+            nonisolated static let module = Bundle(for: BundleFinder.self)
         }
         """
     }


### PR DESCRIPTION
Resolves #9759

Generated bundle accessors should remain callable from nonisolated code even when a module opts into Swift 6 default `MainActor` isolation.
Updated the generated accessors to emit `nonisolated`.

### How to test locally
* with local `tuist` version run `tuist generate` and inspect generated `TuistBundle+*.swift` files
    * good examples inside repo are `examples/xcode/generated_ios_app_with_framework_and_resources` and `examples/xcode/generated_ios_static_library_with_string_resources`  
    * #9759 also provides a nice reproducible example for testing 