### PR TITLE
fix(server): strip port 80/443 from MCP OAuth resource URL

### DIFF
--- a/server/lib/tuist_web/request_origin.ex
+++ b/server/lib/tuist_web/request_origin.ex
@@ -6,9 +6,7 @@ defmodule TuistWeb.RequestOrigin do
     host = forwarded_value(conn, "x-forwarded-host") || conn.host
     port = forwarded_value(conn, "x-forwarded-port") || Integer.to_string(conn.port)
 
-    default_port = if scheme == "https", do: "443", else: "80"
-
-    if String.contains?(host, ":") or port == default_port do
+    if String.contains?(host, ":") or port in ["80", "443"] do
       "#{scheme}://#{host}"
     else
       "#{scheme}://#{host}:#{port}"

--- a/server/test/tuist_web/request_origin_test.exs
+++ b/server/test/tuist_web/request_origin_test.exs
@@ -45,6 +45,20 @@ defmodule TuistWeb.RequestOriginTest do
     assert RequestOrigin.from_conn(conn) == "https://mcp.tuist.dev:9443"
   end
 
+  test "strips port 80 even when scheme is https" do
+    conn =
+      :get
+      |> conn("/")
+      |> Map.put(:scheme, :http)
+      |> Map.put(:host, "internal")
+      |> Map.put(:port, 4000)
+      |> put_req_header("x-forwarded-proto", "https")
+      |> put_req_header("x-forwarded-host", "tuist.dev")
+      |> put_req_header("x-forwarded-port", "80")
+
+    assert RequestOrigin.from_conn(conn) == "https://tuist.dev"
+  end
+
   test "uses first value when forwarded headers contain a list" do
     conn =
       :get


### PR DESCRIPTION
## Summary
- Fixes MCP OAuth failing with `Protected resource https://tuist.dev:80/mcp does not match expected https://tuist.dev/mcp`
- The reverse proxy forwards `x-forwarded-port: 80` with `x-forwarded-proto: https`, causing `RequestOrigin` to produce `https://tuist.dev:80` instead of `https://tuist.dev`
- Strips both port 80 and 443 unconditionally since neither should appear explicitly in URLs

## Test plan
- [x] Added test for the exact failing scenario (HTTPS scheme with forwarded port 80)
- [ ] Verify MCP OAuth flow works after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)