### PR TITLE
fix(server): pass database name to SYSTEM SYNC DATABASE REPLICA

### DIFF
--- a/server/priv/ingest_repo/migrations/20260326120000_recreate_test_case_runs_by_test_run_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260326120000_recreate_test_case_runs_by_test_run_mv.exs
@@ -32,7 +32,8 @@ defmodule Tuist.IngestRepo.Migrations.RecreateTestCaseRunsByTestRunMv do
     FROM test_case_runs
     """)
 
-    IngestRepo.query!("SYSTEM SYNC DATABASE REPLICA")
+    {:ok, %{rows: [[db]]}} = IngestRepo.query("SELECT currentDatabase()")
+    IngestRepo.query!("SYSTEM SYNC DATABASE REPLICA #{db}")
 
     backfill_by_partition()
   end


### PR DESCRIPTION
## Summary

- `SYSTEM SYNC DATABASE REPLICA` requires an explicit database name — resolve it at runtime via `SELECT currentDatabase()`
- Fixes deploy failure: `Syntax error: failed at position 29 (end of query). Expected one of: ON, identifier.`

## Test plan

- [ ] Deploy succeeds on staging/canary


🤖 Generated with [Claude Code](https://claude.com/claude-code)