### PR TITLE
fix(cache): avoid queueing uploads that already exist in S3

### DIFF
--- a/cache/lib/cache/s3_transfers.ex
+++ b/cache/lib/cache/s3_transfers.ex
@@ -9,6 +9,7 @@ defmodule Cache.S3Transfers do
   import Ecto.Query
 
   alias Cache.Repo
+  alias Cache.S3
   alias Cache.S3Transfer
   alias Cache.S3TransfersBuffer
 
@@ -115,7 +116,24 @@ defmodule Cache.S3Transfers do
     Enum.each(ids, &S3TransfersBuffer.enqueue_delete/1)
   end
 
+  @doc """
+  Asynchronously checks S3 and enqueues an artifact upload only when missing.
+  """
+  def enqueue_upload_if_missing(account_handle, project_handle, artifact_type, key) do
+    Task.start(fn ->
+      if !S3.exists?(key, type: storage_type(artifact_type)) do
+        enqueue(:upload, account_handle, project_handle, artifact_type, key)
+      end
+    end)
+
+    :ok
+  end
+
   defp enqueue(type, account_handle, project_handle, artifact_type, key) do
     S3TransfersBuffer.enqueue(type, account_handle, project_handle, artifact_type, key)
   end
+
+  defp storage_type(:xcode_cache), do: :xcode_cache
+  defp storage_type(:registry), do: :registry
+  defp storage_type(_artifact_type), do: :cache
 end

--- a/cache/lib/cache_web/controllers/gradle_controller.ex
+++ b/cache/lib/cache_web/controllers/gradle_controller.ex
@@ -209,7 +209,7 @@ defmodule CacheWeb.GradleController do
 
         key = Gradle.Disk.key(account_handle, project_handle, cache_key)
         :ok = CacheArtifacts.track_artifact_access(key)
-        S3Transfers.enqueue_gradle_upload(account_handle, project_handle, key)
+        S3Transfers.enqueue_upload_if_missing(account_handle, project_handle, :gradle, key)
         send_resp(conn, :created, "")
 
       {:error, :exists} ->

--- a/cache/lib/cache_web/controllers/xcode_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_controller.ex
@@ -189,7 +189,7 @@ defmodule CacheWeb.XcodeController do
 
         key = Xcode.Disk.key(account_handle, project_handle, id)
         :ok = CacheArtifacts.track_artifact_access(key)
-        S3Transfers.enqueue_xcode_upload(account_handle, project_handle, key)
+        S3Transfers.enqueue_upload_if_missing(account_handle, project_handle, :xcode_cache, key)
         send_resp(conn, :no_content, "")
 
       {:error, :exists} ->

--- a/cache/lib/cache_web/controllers/xcode_module_controller.ex
+++ b/cache/lib/cache_web/controllers/xcode_module_controller.ex
@@ -415,7 +415,7 @@ defmodule CacheWeb.XcodeModuleController do
               Disk.key(upload.account_handle, upload.project_handle, upload.category, upload.hash, upload.name)
 
             :ok = CacheArtifacts.track_artifact_access(key)
-            S3Transfers.enqueue_module_upload(upload.account_handle, upload.project_handle, key)
+            S3Transfers.enqueue_upload_if_missing(upload.account_handle, upload.project_handle, :xcode_module, key)
 
             :telemetry.execute(
               [:cache, :xcode_module, :multipart, :complete],

--- a/cache/test/cache_web/controllers/gradle_controller_test.exs
+++ b/cache/test/cache_web/controllers/gradle_controller_test.exs
@@ -8,6 +8,7 @@ defmodule CacheWeb.GradleControllerTest do
 
   alias Cache.Authentication
   alias Cache.Gradle
+  alias Cache.S3
   alias Cache.S3Transfers
   alias Ecto.Adapters.SQL.Sandbox
 
@@ -37,9 +38,17 @@ defmodule CacheWeb.GradleControllerTest do
       project_handle = "test-project"
       cache_key = "abc123"
       body = "test artifact content"
+      key = "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+      test_pid = self()
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        false
       end)
 
       Gradle.Disk
@@ -64,6 +73,11 @@ defmodule CacheWeb.GradleControllerTest do
         assert conn.resp_body == ""
       end)
 
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
       :ok = Cache.S3TransfersBuffer.flush()
 
       uploads = S3Transfers.pending(:upload, 10)
@@ -73,7 +87,7 @@ defmodule CacheWeb.GradleControllerTest do
       assert upload.account_handle == account_handle
       assert upload.project_handle == project_handle
       assert upload.artifact_type == :gradle
-      assert upload.key == "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+      assert upload.key == key
     end
 
     test "streams large artifact to temp file on same filesystem as storage", %{
@@ -84,9 +98,17 @@ defmodule CacheWeb.GradleControllerTest do
       project_handle = "test-project"
       cache_key = "abc123"
       large_body = :binary.copy("0123456789abcdef", 150_000)
+      key = "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+      test_pid = self()
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        false
       end)
 
       Gradle.Disk
@@ -119,6 +141,11 @@ defmodule CacheWeb.GradleControllerTest do
         assert conn.resp_body == ""
       end)
 
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
       :ok = Cache.S3TransfersBuffer.flush()
 
       uploads = S3Transfers.pending(:upload, 10)
@@ -128,7 +155,54 @@ defmodule CacheWeb.GradleControllerTest do
       assert upload.account_handle == account_handle
       assert upload.project_handle == project_handle
       assert upload.artifact_type == :gradle
-      assert upload.key == "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+      assert upload.key == key
+    end
+
+    test "does not enqueue upload when Gradle artifact already exists in S3", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      cache_key = "abc123"
+      body = "test artifact content"
+      key = "#{account_handle}/#{project_handle}/gradle/ab/c1/#{cache_key}"
+      test_pid = self()
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        true
+      end)
+
+      Gradle.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^cache_key ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^cache_key, ^body ->
+        :ok
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put(
+          "/api/cache/gradle/#{cache_key}?account_handle=#{account_handle}&project_handle=#{project_handle}",
+          body
+        )
+
+      assert conn.status == 201
+      assert conn.resp_body == ""
+
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
+      :ok = Cache.S3TransfersBuffer.flush()
+      assert S3Transfers.pending(:upload, 10) == []
     end
 
     test "returns timeout instead of acknowledging a chunked upload timeout as success", %{conn: conn} do

--- a/cache/test/cache_web/controllers/xcode_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_controller_test.exs
@@ -29,9 +29,17 @@ defmodule CacheWeb.XcodeControllerTest do
       project_handle = "test-project"
       id = "abc123"
       body = "test artifact content"
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
+      test_pid = self()
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :xcode_cache
+        send(test_pid, {:s3_exists_checked, self()})
+        false
       end)
 
       Xcode.Disk
@@ -53,6 +61,11 @@ defmodule CacheWeb.XcodeControllerTest do
         assert conn.resp_body == ""
       end)
 
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
       :ok = S3TransfersBuffer.flush()
 
       uploads = S3Transfers.pending(:upload, 10)
@@ -62,7 +75,7 @@ defmodule CacheWeb.XcodeControllerTest do
       assert upload.account_handle == account_handle
       assert upload.project_handle == project_handle
       assert upload.artifact_type == :xcode_cache
-      assert upload.key == "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
+      assert upload.key == key
     end
 
     test "streams large artifact to temporary file", %{conn: conn} do
@@ -70,9 +83,17 @@ defmodule CacheWeb.XcodeControllerTest do
       project_handle = "test-project"
       id = "abc123"
       large_body = :binary.copy("0123456789abcdef", 150_000)
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
+      test_pid = self()
 
       expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :xcode_cache
+        send(test_pid, {:s3_exists_checked, self()})
+        false
       end)
 
       Xcode.Disk
@@ -98,6 +119,11 @@ defmodule CacheWeb.XcodeControllerTest do
         assert conn.resp_body == ""
       end)
 
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
       :ok = S3TransfersBuffer.flush()
 
       uploads = S3Transfers.pending(:upload, 10)
@@ -107,7 +133,51 @@ defmodule CacheWeb.XcodeControllerTest do
       assert upload.account_handle == account_handle
       assert upload.project_handle == project_handle
       assert upload.artifact_type == :xcode_cache
-      assert upload.key == "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
+      assert upload.key == key
+    end
+
+    test "does not enqueue upload when artifact already exists in S3", %{conn: conn} do
+      account_handle = "test-account"
+      project_handle = "test-project"
+      id = "abc123"
+      body = "test artifact content"
+      key = "#{account_handle}/#{project_handle}/xcode/ab/c1/#{id}"
+      test_pid = self()
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, ^account_handle, ^project_handle ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :xcode_cache
+        send(test_pid, {:s3_exists_checked, self()})
+        true
+      end)
+
+      Xcode.Disk
+      |> expect(:exists?, fn ^account_handle, ^project_handle, ^id ->
+        false
+      end)
+      |> expect(:put, fn ^account_handle, ^project_handle, ^id, ^body ->
+        :ok
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post("/api/cache/cas/#{id}?account_handle=#{account_handle}&project_handle=#{project_handle}", body)
+
+      assert conn.status == 204
+      assert conn.resp_body == ""
+
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
+      :ok = S3TransfersBuffer.flush()
+      assert S3Transfers.pending(:upload, 10) == []
     end
 
     test "returns timeout instead of acknowledging a chunked upload timeout as success", %{conn: conn} do

--- a/cache/test/cache_web/controllers/xcode_module_controller_test.exs
+++ b/cache/test/cache_web/controllers/xcode_module_controller_test.exs
@@ -398,6 +398,8 @@ defmodule CacheWeb.XcodeModuleControllerTest do
     test "completes upload successfully", %{conn: conn} do
       hash = "abc123"
       name = "test.zip"
+      key = "test-account/test-project/module/builds/ab/c1/#{hash}/#{name}"
+      test_pid = self()
       {:ok, upload_id} = MultipartUploads.start_upload("test-account", "test-project", "builds", hash, name)
 
       tmp_path = Path.join(System.tmp_dir!(), "test-part-#{:erlang.unique_integer([:positive])}")
@@ -408,6 +410,12 @@ defmodule CacheWeb.XcodeModuleControllerTest do
 
       expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        false
       end)
 
       expect(XcodeModule.Disk, :complete_assembly, fn ^assembly_path, completed_upload, [^tmp_path] ->
@@ -433,6 +441,11 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       # Upload should be removed from state after completion
       assert {:error, :not_found} = MultipartUploads.get_upload(upload_id)
 
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
       # Verify S3 upload was enqueued via S3Transfers table
       :ok = Cache.S3TransfersBuffer.flush()
       transfer = :upload |> S3Transfers.pending(10) |> List.first()
@@ -440,7 +453,55 @@ defmodule CacheWeb.XcodeModuleControllerTest do
       assert transfer.account_handle == "test-account"
       assert transfer.project_handle == "test-project"
       assert transfer.artifact_type == :xcode_module
-      assert transfer.key == "test-account/test-project/module/builds/ab/c1/abc123/test.zip"
+      assert transfer.key == key
+    end
+
+    test "does not enqueue multipart upload when artifact already exists in S3", %{conn: conn} do
+      hash = "abc123"
+      name = "test.zip"
+      key = "test-account/test-project/module/builds/ab/c1/#{hash}/#{name}"
+      test_pid = self()
+      {:ok, upload_id} = MultipartUploads.start_upload("test-account", "test-project", "builds", hash, name)
+
+      tmp_path = Path.join(System.tmp_dir!(), "test-part-#{:erlang.unique_integer([:positive])}")
+      File.write!(tmp_path, "test content")
+      MultipartUploads.add_part(upload_id, 1, tmp_path, 12)
+      {:ok, upload} = MultipartUploads.get_upload(upload_id)
+      assembly_path = upload.assembly_path
+
+      expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
+        {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        true
+      end)
+
+      expect(XcodeModule.Disk, :complete_assembly, fn ^assembly_path, _completed_upload, [^tmp_path] ->
+        :ok
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/api/cache/module/complete?account_handle=test-account&project_handle=test-project&upload_id=#{upload_id}",
+          JSON.encode!(%{parts: [1]})
+        )
+
+      assert conn.status == 204
+      assert {:error, :not_found} = MultipartUploads.get_upload(upload_id)
+
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+
+      :ok = Cache.S3TransfersBuffer.flush()
+      assert S3Transfers.pending(:upload, 10) == []
     end
 
     test "returns 404 for unknown upload_id", %{conn: conn} do
@@ -492,6 +553,8 @@ defmodule CacheWeb.XcodeModuleControllerTest do
     test "assembles multiple parts in order", %{conn: conn} do
       hash = "xyz789"
       name = "multi.zip"
+      key = "test-account/test-project/module/builds/xy/z7/#{hash}/#{name}"
+      test_pid = self()
       {:ok, upload_id} = MultipartUploads.start_upload("test-account", "test-project", "builds", hash, name)
 
       tmp_path1 = Path.join(System.tmp_dir!(), "test-part-#{:erlang.unique_integer([:positive])}")
@@ -510,6 +573,12 @@ defmodule CacheWeb.XcodeModuleControllerTest do
 
       expect(Authentication, :ensure_project_accessible, fn _conn, "test-account", "test-project" ->
         {:ok, "Bearer valid-token"}
+      end)
+
+      expect(S3, :exists?, fn ^key, opts ->
+        assert Keyword.get(opts, :type) == :cache
+        send(test_pid, {:s3_exists_checked, self()})
+        true
       end)
 
       expect(XcodeModule.Disk, :complete_assembly, fn ^assembly_path, completed_upload, part_paths ->
@@ -532,6 +601,11 @@ defmodule CacheWeb.XcodeModuleControllerTest do
         )
 
       assert conn.status == 204
+
+      assert_receive {:s3_exists_checked, task_pid}, 1_000
+      ref = Process.monitor(task_pid)
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
     end
   end
 end


### PR DESCRIPTION
Okay, so the `S3TransferWorker` worked like this:
1. thing gets uploaded
2. s3 transfer gets queued
3. worker checks whether item already exists in s3 -> upload if no, skip if yes

this meant that _every upload_ got an `s3_transfers` row, and was touched by the Oban worker, regardless of upstream state.
that meant three things:
1. _lots of rows_
2. database write contention
3. items that actually _needed_ to be uploaded because they were missing from S3 were stuck behind 20000 other items that were no-ops and skips

so... this now checks S3 existence in a small background task (still not affecting hot path) and only enqueues an S3 transfer if upstream is missing the artifact