### PR TITLE
fix(cli): skip static products linting when warning targets is .none

### DIFF
--- a/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -13,7 +13,10 @@ protocol StaticProductsGraphLinting {
 
 struct StaticProductsGraphLinter: StaticProductsGraphLinting {
     func lint(graphTraverser: GraphTraversing, configGeneratedProjectOptions: TuistGeneratedProjectOptions) -> [LintingIssue] {
-        warnings(
+        if case .none = configGeneratedProjectOptions.generationOptions.staticSideEffectsWarningTargets {
+            return []
+        }
+        return warnings(
             in: Array(graphTraverser.dependencies.keys),
             graphTraverser: graphTraverser,
             configGeneratedProjectOptions: configGeneratedProjectOptions

--- a/cli/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1286,6 +1286,41 @@ class StaticProductsGraphLinterTests: XCTestCase {
 
     // MARK: - Helpers
 
+    func test_lint_whenStaticSideEffectsWarningTargetsIsNone_returnsNoIssues() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.test(name: "App")
+        let framework = Target.test(name: "Framework", product: .framework)
+        let project = Project.test(path: "/tmp/app", name: "AppProject", targets: [app, framework])
+        let package = Package.remote(url: "https://test.tuist.io", requirement: .branch("main"))
+        let appDependency = GraphDependency.target(name: app.name, path: path)
+        let frameworkDependency = GraphDependency.target(name: framework.name, path: path)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            appDependency: Set([frameworkDependency, .packageProduct(path: path, product: "Package", type: .runtime)]),
+            frameworkDependency: Set([.packageProduct(path: path, product: "Package", type: .runtime)]),
+            .packageProduct(path: path, product: "Package", type: .runtime): Set(),
+        ]
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            packages: [path: ["Package": package]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let results = subject.lint(
+            graphTraverser: graphTraverser,
+            configGeneratedProjectOptions: .test(
+                generationOptions: .test(staticSideEffectsWarningTargets: .none)
+            )
+        )
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
     private func warning(product node: String, type: String = "Target", linkedBy: [GraphDependency]) -> LintingIssue {
         let reason =
             "\(type) \'\(node)\' has been linked from \(linkedBy.map(\.description).listed()), it is a static product so may introduce unwanted side effects."


### PR DESCRIPTION
When `staticSideEffectsWarningTargets` is set to `.none`, the `StaticProductsGraphLinter` still performs the full DFS traversal of the dependency graph before discarding all results. This adds an early return to skip the traversal entirely, matching the user's intent of "no warnings."

On a large project (~6,700 targets), this reduces lint time from ~36s to ~10s.

### How to test locally

1. Set `staticSideEffectsWarningTargets: .none` in `Tuist.swift`
2. Run `tuist generate` and observe that no static side-effect warnings are emitted
3. Run the test:
```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistGeneratorTests/StaticProductsGraphLinterTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```