### PR TITLE
fix(server): prevent stale CSS by fixing cache headers

### DIFF
--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -44,7 +44,7 @@ defmodule TuistWeb.Endpoint do
     at: "/",
     from: :tuist,
     gzip: true,
-    cache_control_for_etags: "public, max-age=31536000, immutable",
+    cache_control_for_etags: "public, max-age=0, must-revalidate",
     only: TuistWeb.static_paths()
 
   # Code reloading can be explicitly enabled under the

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -691,7 +691,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   end
 
   defp put_resp_header_cache_control(conn, _opts) do
-    put_resp_header(conn, "cache-control", "public, max-age=86400, immutable")
+    put_resp_header(conn, "cache-control", "public, max-age=60, stale-while-revalidate=86400")
   end
 
   defp put_resp_header_server(conn, _opts) do


### PR DESCRIPTION
## Summary
- Changed `Plug.Static` ETag cache from `max-age=31536000, immutable` (1 year, never revalidate) to `max-age=0, must-revalidate` so non-digested static assets always revalidate via ETags
- Changed marketing HTML cache from `max-age=86400, immutable` to `max-age=60, stale-while-revalidate=86400` so browsers pick up new asset URLs within a minute of deploys

## Context
Browsers (especially on iPhone) were showing outdated CSS because:
1. Non-digested static files (e.g. `/app/assets/bundle.css`) were served with a 1-year immutable cache — once cached, the browser would never check for updates
2. Marketing HTML pages used `immutable`, preventing browsers from fetching the updated HTML that references new digested asset URLs after deploys

Digested/versioned assets (with `?vsn=` query strings) already default to 1-year cache via `cache_control_for_vsn_requests`, so those remain optimally cached.

## Test plan
- [ ] Deploy to staging and verify `cache-control` headers on static assets and marketing pages
- [ ] Confirm digested assets still get long-lived cache headers
- [ ] Test on iPhone Safari after a CSS change to verify fresh styles load

🤖 Generated with [Claude Code](https://claude.com/claude-code)