### PR TITLE
Fix docs redirect deployment

### DIFF
--- a/docs/docs/en/guides/features/test-sharding/generated-projects.md
+++ b/docs/docs/en/guides/features/test-sharding/generated-projects.md
@@ -386,5 +386,7 @@ workflows:
 ```
 
 ::: tip
+<!-- -->
 Bitrise does not support dynamic parallel job creation at runtime. Define a fixed number of shard workflows in your pipeline stages — workflows within a stage run in parallel automatically.
+<!-- -->
 :::

--- a/docs/docs/en/guides/features/test-sharding/gradle.md
+++ b/docs/docs/en/guides/features/test-sharding/gradle.md
@@ -375,5 +375,7 @@ workflows:
 ```
 
 ::: tip
+<!-- -->
 Bitrise does not support dynamic parallel job creation at runtime. Define a fixed number of shard workflows in your pipeline stages — workflows within a stage run in parallel automatically.
+<!-- -->
 :::

--- a/docs/docs/en/guides/features/test-sharding/xcode.md
+++ b/docs/docs/en/guides/features/test-sharding/xcode.md
@@ -416,5 +416,7 @@ workflows:
 ```
 
 ::: tip
+<!-- -->
 Bitrise does not support dynamic parallel job creation at runtime. Define a fixed number of shard workflows in your pipeline stages — workflows within a stage run in parallel automatically.
+<!-- -->
 :::


### PR DESCRIPTION
## Summary
- add the required HTML comment delimiters around three `::: tip` blocks in the test sharding docs
- unblock the `Documentation` workflow so Cloudflare Pages can deploy the existing `docs.tuist.dev -> tuist.dev/{locale}/docs/...` redirects

## Root cause
The redirect rules were added, but the docs site was never redeployed because the main-branch docs workflow failed during `lint-localization`. Three VitePress admonitions in the English test sharding docs were missing the HTML comments required for translation segmentation.

## Impact
- a follow-up merge should allow the docs deploy job to run through and publish the redirect rules already present in `docs/.vitepress/config.mjs`
- no content changes beyond the required localization markers

## Validation
- `mise run lint-localization`
- `DOCS_LOCALES=en mise run build`
