### PR TITLE
fix(server): update gettext source reference

### DIFF
--- a/server/priv/gettext/errors.pot
+++ b/server/priv/gettext/errors.pot
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 
-#: lib/tuist_web/live/docs_live.ex:59
+#: lib/tuist_web/live/docs_live.ex:60
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:656
 #, elixir-autogen, elixir-format
 msgid "Page not found"


### PR DESCRIPTION
## Summary
- Run `mix gettext.extract` to update stale source line reference in `errors.pot` (`docs_live.ex:59` → `docs_live.ex:60`)

## Test plan
- No functional change — only a `.pot` file source location update

🤖 Generated with [Claude Code](https://claude.com/claude-code)