### PR TITLE
fix(server): reverse recent builds chart data for chronological order

### DIFF
--- a/server/lib/tuist_web/live/xcode_builds_live.ex
+++ b/server/lib/tuist_web/live/xcode_builds_live.ex
@@ -294,7 +294,9 @@ defmodule TuistWeb.XcodeBuildsLive do
           )
 
         recent_builds_chart_data =
-          Enum.map(recent_builds, fn run ->
+          recent_builds
+          |> Enum.reverse()
+          |> Enum.map(fn run ->
             color =
               case run.status do
                 "success" -> "var:noora-chart-primary"


### PR DESCRIPTION
## Summary
- The bar chart on the Xcode builds page showed the most recent builds on the left, unlike all other dashboard charts
- Reverse the chart data so time flows left-to-right (oldest → newest), matching the convention used everywhere else

🤖 Generated with [Claude Code](https://claude.com/claude-code)