### PR TITLE
fix(server): prevent open redirect via protocol-relative return_to paths

### DIFF
--- a/server/lib/tuist_web/controllers/user_session_controller.ex
+++ b/server/lib/tuist_web/controllers/user_session_controller.ex
@@ -68,6 +68,10 @@ defmodule TuistWeb.UserSessionController do
     end
   end
 
+  def new(conn, %{"return_to" => "//" <> _}) do
+    redirect(conn, to: ~p"/users/log_in")
+  end
+
   def new(conn, %{"return_to" => "/" <> _ = return_to}) do
     conn
     |> put_session(:user_return_to, return_to)

--- a/server/test/tuist_web/controllers/user_session_controller_test.exs
+++ b/server/test/tuist_web/controllers/user_session_controller_test.exs
@@ -151,6 +151,12 @@ defmodule TuistWeb.UserSessionControllerTest do
       assert redirected_to(conn) == ~p"/users/log_in"
       refute get_session(conn, :user_return_to)
     end
+
+    test "ignores protocol-relative return_to paths", %{conn: conn} do
+      conn = get(conn, ~p"/docs/login?#{%{return_to: "//evil.example"}}")
+      assert redirected_to(conn) == ~p"/users/log_in"
+      refute get_session(conn, :user_return_to)
+    end
   end
 
   describe "DELETE /users/log_out" do


### PR DESCRIPTION
## Summary
- Adds a guard clause to reject `return_to` values starting with `//` (protocol-relative URLs) to prevent open redirect attacks (e.g. `//evil.example`)
- Adds a test to verify the behavior

## Test plan
- [ ] `mix test test/tuist_web/controllers/user_session_controller_test.exs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)