### PR TITLE
feat(noora): support multiple filters of the same type

### DIFF
--- a/noora/lib/noora/filter.ex
+++ b/noora/lib/noora/filter.ex
@@ -154,6 +154,7 @@ defmodule Noora.Filter do
     """
     defstruct [
       :id,
+      :instance_id,
       :field,
       :display_name,
       :type,
@@ -162,6 +163,9 @@ defmodule Noora.Filter do
       :operator,
       :value
     ]
+
+    def effective_instance_id(%__MODULE__{instance_id: nil, id: id}), do: id
+    def effective_instance_id(%__MODULE__{instance_id: iid}), do: iid
   end
 
   defmodule Operations do
@@ -172,11 +176,11 @@ defmodule Noora.Filter do
     @valid_actions [:change_value, :change_operator, :delete]
 
     def update_filters(current_filters, :change_value, params) do
-      filter_id = params["payload_filter_id"]
+      instance_id = params["payload_filter_id"]
       new_value = params["value"]
 
       Enum.map(current_filters, fn filter ->
-        if filter.id == filter_id do
+        if Filter.effective_instance_id(filter) == instance_id do
           %{filter | value: new_value}
         else
           filter
@@ -185,7 +189,7 @@ defmodule Noora.Filter do
     end
 
     def update_filters(current_filters, :change_operator, params) do
-      filter_id = params["payload_filter_id"]
+      instance_id = params["payload_filter_id"]
 
       case coerce_operator(params["value"]) do
         nil ->
@@ -193,7 +197,7 @@ defmodule Noora.Filter do
 
         new_operator ->
           Enum.map(current_filters, fn filter ->
-            if filter.id == filter_id,
+            if Filter.effective_instance_id(filter) == instance_id,
               do: %{filter | operator: new_operator},
               else: filter
           end)
@@ -201,16 +205,40 @@ defmodule Noora.Filter do
     end
 
     def update_filters(current_filters, :delete, params) do
-      filter_id = params["payload_filter_id"]
-      Enum.reject(current_filters, &(&1.id == filter_id))
+      instance_id = params["payload_filter_id"]
+      Enum.reject(current_filters, &(Filter.effective_instance_id(&1) == instance_id))
     end
 
     def add_filter_to_query(filter_id, socket, params \\ nil) do
       params = params || URI.decode_query(socket.assigns.uri.query)
       filter = Enum.find(socket.assigns.available_filters, &(&1.id == filter_id))
-      filter_params = encode_filters_to_query([filter])
 
-      params |> Map.merge(filter_params) |> Map.drop(["before", "after"])
+      instance_id = next_instance_id(filter_id, params)
+      filter_with_instance = %{filter | instance_id: instance_id}
+      filter_params = encode_filters_to_query([filter_with_instance])
+
+      updated_params = params |> Map.merge(filter_params) |> Map.drop(["before", "after"])
+      {updated_params, instance_id}
+    end
+
+    def next_instance_id(filter_id, params) do
+      existing_keys = Map.keys(params)
+
+      if Enum.any?(existing_keys, &(&1 == "filter_#{filter_id}_op")) do
+        existing_numbers =
+          existing_keys
+          |> Enum.flat_map(fn key ->
+            case Regex.run(~r/^filter_#{Regex.escape(filter_id)}__(\d+)_(?:op|val)$/, key, capture: :all_but_first) do
+              [n] -> [String.to_integer(n)]
+              _ -> []
+            end
+          end)
+
+        next = if Enum.empty?(existing_numbers), do: 1, else: Enum.max(existing_numbers) + 1
+        "#{filter_id}__#{next}"
+      else
+        filter_id
+      end
     end
 
     def update_filters_in_query(params, socket, query_params \\ nil) do
@@ -271,10 +299,12 @@ defmodule Noora.Filter do
 
     def encode_filters_to_query(filters) when is_list(filters) do
       Enum.reduce(filters, %{}, fn filter, acc ->
+        iid = Filter.effective_instance_id(filter)
+
         acc
-        |> Map.put("filter_#{filter.id}_op", to_string(filter.operator))
+        |> Map.put("filter_#{iid}_op", to_string(filter.operator))
         |> Map.put(
-          "filter_#{filter.id}_val",
+          "filter_#{iid}_val",
           if(is_nil(filter.value), do: "", else: to_string(filter.value))
         )
       end)
@@ -286,29 +316,32 @@ defmodule Noora.Filter do
       |> Enum.flat_map(&build_filter(&1, params, available_filters))
     end
 
-    # Extract filter IDs from query parameters
+    # Extract instance IDs from query parameters
     defp extract_filter_ids(params) do
       params
       |> Map.keys()
       |> Enum.filter(&String.starts_with?(&1, "filter_"))
       |> Enum.map(fn key ->
-        Regex.run(~r/^filter_([^_]+(?:_[^_]+)*)_(?:op|val)$/, key, capture: :all_but_first)
+        Regex.run(~r/^filter_(.+)_(?:op|val)$/, key, capture: :all_but_first)
       end)
       |> Enum.reject(&is_nil/1)
       |> Enum.map(&List.first/1)
       |> Enum.uniq()
     end
 
-    # Build a filter from ID, params, and available filters
-    defp build_filter(id, params, available_filters) do
+    # Build a filter from instance ID, params, and available filters
+    defp build_filter(instance_id, params, available_filters) do
+      base_id = Regex.replace(~r/__\d+$/, instance_id, "")
+
       with base_filter when not is_nil(base_filter) <-
-             Enum.find(available_filters, &(&1.id == id)),
-           op_str when not is_nil(op_str) <- params["filter_#{id}_op"],
+             Enum.find(available_filters, &(&1.id == instance_id)) ||
+               Enum.find(available_filters, &(&1.id == base_id)),
+           op_str when not is_nil(op_str) <- params["filter_#{instance_id}_op"],
            operator when not is_nil(operator) <- coerce_operator(op_str) do
-        val = normalize_value(params["filter_#{id}_val"])
+        val = normalize_value(params["filter_#{instance_id}_val"])
         processed_val = coerce_option_value(val, base_filter)
 
-        create_filter(base_filter, operator, processed_val)
+        create_filter(base_filter, operator, processed_val, instance_id)
       else
         _ -> []
       end
@@ -348,11 +381,11 @@ defmodule Noora.Filter do
 
     defp coerce_option_value(val, _), do: val
 
-    defp create_filter(base_filter, operator, val) do
+    defp create_filter(base_filter, operator, val, instance_id) do
       if base_filter.type == :option && !is_nil(val) && !Enum.member?(base_filter.options, val) do
         []
       else
-        [%{base_filter | operator: operator, value: val}]
+        [%{base_filter | operator: operator, value: val, instance_id: instance_id}]
       end
     end
   end
@@ -390,25 +423,26 @@ defmodule Noora.Filter do
     end
   end
 
-  defp filter_available_filters(available_filters, active_filters) do
-    active_filter_ids = Enum.map(active_filters, & &1.id)
-    Enum.reject(available_filters, fn filter -> filter.id in active_filter_ids end)
+  defp filter_available_filters(available_filters, _active_filters) do
+    available_filters
   end
 
   attr(:filter, Filter, required: true)
 
   def active_filter(assigns) do
+    assigns = assign(assigns, :iid, Filter.effective_instance_id(assigns.filter))
+
     ~H"""
-    <div id={@filter.id} class="noora-filter">
+    <div id={@iid} class="noora-filter">
       <span data-part="label">{@filter.display_name}</span>
       <div
         :if={length(operators(@filter.type)) > 1}
-        id={"filter-#{@filter.id}-operator-dropdown"}
+        id={"filter-#{@iid}-operator-dropdown"}
         phx-hook="NooraDropdown"
         data-part="dropdown"
         data-on-select="update_filter"
         data-meta-type="change_operator"
-        data-meta-payload_filter_id={@filter.id}
+        data-meta-payload_filter_id={@iid}
       >
         <div data-part="trigger">
           <span data-part="label">
@@ -438,12 +472,12 @@ defmodule Noora.Filter do
       </span>
       <div
         :if={@filter.type === :option}
-        id={"filter-#{@filter.id}-value-dropdown"}
+        id={"filter-#{@iid}-value-dropdown"}
         phx-hook="NooraDropdown"
         data-part="dropdown"
         data-on-select="update_filter"
         data-meta-type="change_value"
-        data-meta-payload_filter_id={@filter.id}
+        data-meta-payload_filter_id={@iid}
       >
         <div data-part="trigger">
           <span :if={!is_nil(@filter.value)} data-part="badge">
@@ -473,7 +507,7 @@ defmodule Noora.Filter do
       </div>
       <div
         :if={@filter.type !== :option}
-        id={"filter-#{@filter.id}-value-popover"}
+        id={"filter-#{@iid}-value-popover"}
         phx-hook="NooraPopover"
         data-part="popover"
       >
@@ -493,7 +527,7 @@ defmodule Noora.Filter do
             <span>Filter by {@filter.display_name}</span>
             <form phx-submit="update_filter">
               <input type="hidden" name="type" value="change_value" />
-              <input type="hidden" name="payload_filter_id" value={@filter.id} />
+              <input type="hidden" name="payload_filter_id" value={@iid} />
               <.text_input
                 name="value"
                 type="basic"
@@ -534,7 +568,7 @@ defmodule Noora.Filter do
                   label="Cancel"
                   phx-click={
                     JS.dispatch("phx:close-popover",
-                      detail: %{id: "filter-#{@filter.id}-value-popover"}
+                      detail: %{id: "filter-#{@iid}-value-popover"}
                     )
                   }
                 />
@@ -548,7 +582,7 @@ defmodule Noora.Filter do
         data-part="delete-icon"
         phx-click="update_filter"
         phx-value-type="delete"
-        phx-value-payload_filter_id={@filter.id}
+        phx-value-payload_filter_id={@iid}
       >
         <.trash_x />
       </button>

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -349,7 +349,7 @@ defmodule TuistWeb.BuildRunLive do
   end
 
   defp handle_event_xcode("add_filter", %{"value" => filter_id}, socket) do
-    updated_params = Filter.Operations.add_filter_to_query(filter_id, socket)
+    {updated_params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
 
     {:noreply,
      socket
@@ -357,8 +357,8 @@ defmodule TuistWeb.BuildRunLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/builds/build-runs/#{socket.assigns.run.id}?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   defp handle_event_xcode("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -292,7 +292,10 @@ defmodule TuistWeb.BundleLive do
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
     query_params = URI.decode_query(socket.assigns.uri.query)
     filter = Enum.find(socket.assigns.file_breakdown_available_filters, &(&1.id == filter_id))
-    filter_params = Filter.Operations.encode_filters_to_query([filter])
+
+    instance_id = Noora.Filter.Operations.next_instance_id(filter_id, query_params)
+    filter_with_instance = %{filter | instance_id: instance_id}
+    filter_params = Filter.Operations.encode_filters_to_query([filter_with_instance])
 
     updated_params =
       query_params
@@ -305,8 +308,8 @@ defmodule TuistWeb.BundleLive do
        to:
          "/#{socket.assigns.selected_account.name}/#{socket.assigns.selected_project.name}/bundles/#{socket.assigns.bundle.id}?#{URI.encode_query(updated_params)}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/bundles_live.ex
+++ b/server/lib/tuist_web/live/bundles_live.ex
@@ -310,10 +310,8 @@ defmodule TuistWeb.BundlesLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     {:noreply,
      socket
@@ -321,8 +319,8 @@ defmodule TuistWeb.BundlesLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/bundles?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/cache_runs_live.ex
+++ b/server/lib/tuist_web/live/cache_runs_live.ex
@@ -137,7 +137,7 @@ defmodule TuistWeb.CacheRunsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params = Filter.Operations.add_filter_to_query(filter_id, socket)
+    {updated_params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
 
     {:noreply,
      socket
@@ -145,8 +145,8 @@ defmodule TuistWeb.CacheRunsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/module-cache/cache-runs?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -67,10 +67,8 @@ defmodule TuistWeb.FlakyTestsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("page", "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, "page", "1")
 
     {:noreply,
      socket
@@ -78,8 +76,8 @@ defmodule TuistWeb.FlakyTestsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/flaky-tests?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/generate_runs_live.ex
+++ b/server/lib/tuist_web/live/generate_runs_live.ex
@@ -64,10 +64,8 @@ defmodule TuistWeb.GenerateRunsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     {:noreply,
      socket
@@ -75,8 +73,8 @@ defmodule TuistWeb.GenerateRunsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/module-cache/generate-runs?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -132,16 +132,14 @@ defmodule TuistWeb.GradleBuildLive do
         do: "cacheable-tasks-page",
         else: "tasks-page"
 
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put(page_param, "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, page_param, "1")
 
     {:noreply,
      socket
      |> push_patch(to: "#{build_run_path(socket)}?#{URI.encode_query(updated_params)}")
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -36,18 +36,16 @@ defmodule TuistWeb.GradleBuildRunsLive do
   end
 
   def handle_event_add_filter(filter_id, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("page", "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, "page", "1")
 
     account_name = socket.assigns.selected_project.account.name
     project_name = socket.assigns.selected_project.name
 
     socket
     |> push_patch(to: ~p"/#{account_name}/#{project_name}/builds/build-runs?#{updated_params}")
-    |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-    |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})
+    |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+    |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})
   end
 
   def handle_event_search(search, socket) do

--- a/server/lib/tuist_web/live/previews_live.ex
+++ b/server/lib/tuist_web/live/previews_live.ex
@@ -60,10 +60,8 @@ defmodule TuistWeb.PreviewsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     {:noreply,
      socket
@@ -71,8 +69,8 @@ defmodule TuistWeb.PreviewsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/previews?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/quarantined_tests_live.ex
+++ b/server/lib/tuist_web/live/quarantined_tests_live.ex
@@ -89,10 +89,8 @@ defmodule TuistWeb.QuarantinedTestsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("page", "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, "page", "1")
 
     {:noreply,
      socket
@@ -100,8 +98,8 @@ defmodule TuistWeb.QuarantinedTestsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/quarantined-tests?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/run_detail_live.ex
+++ b/server/lib/tuist_web/live/run_detail_live.ex
@@ -82,10 +82,8 @@ defmodule TuistWeb.RunDetailLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("binary-cache-page", "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, "binary-cache-page", "1")
 
     {:noreply,
      socket
@@ -93,8 +91,8 @@ defmodule TuistWeb.RunDetailLive do
        to:
          ~p"/#{socket.assigns.selected_account.name}/#{socket.assigns.selected_project.name}/runs/#{socket.assigns.run.id}?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/shards_live.ex
+++ b/server/lib/tuist_web/live/shards_live.ex
@@ -55,10 +55,8 @@ defmodule TuistWeb.ShardsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     {:noreply,
      socket
@@ -66,8 +64,8 @@ defmodule TuistWeb.ShardsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/shards?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -204,13 +204,13 @@ defmodule TuistWeb.TestCaseLive do
         %{"value" => filter_id},
         %{assigns: %{selected_account: account, selected_project: project, test_case_id: test_case_id}} = socket
       ) do
-    updated_params = Filter.Operations.add_filter_to_query(filter_id, socket)
+    {updated_params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
 
     {:noreply,
      socket
      |> push_patch(to: ~p"/#{account.name}/#{project.name}/tests/test-cases/#{test_case_id}?#{updated_params}")
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event(

--- a/server/lib/tuist_web/live/test_cases_live.ex
+++ b/server/lib/tuist_web/live/test_cases_live.ex
@@ -93,10 +93,8 @@ defmodule TuistWeb.TestCasesLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Map.put("page", "1")
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Map.put(params, "page", "1")
 
     {:noreply,
      socket
@@ -104,8 +102,8 @@ defmodule TuistWeb.TestCasesLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/test-cases?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -192,10 +192,8 @@ defmodule TuistWeb.TestRunLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> reset_test_tab_page(socket)
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = reset_test_tab_page(params, socket)
 
     {:noreply,
      socket
@@ -203,8 +201,8 @@ defmodule TuistWeb.TestRunLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/test-runs/#{socket.assigns.run.id}?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -108,10 +108,8 @@ defmodule TuistWeb.TestRunsLive do
   end
 
   def handle_event("add_filter", %{"value" => filter_id}, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     {:noreply,
      socket
@@ -119,8 +117,8 @@ defmodule TuistWeb.TestRunsLive do
        to:
          ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/tests/test-runs?#{updated_params}"
      )
-     |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-     |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})}
+     |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+     |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})}
   end
 
   def handle_event("update_filter", params, socket) do

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -42,18 +42,16 @@ defmodule TuistWeb.XcodeBuildRunsLive do
   end
 
   def handle_event_add_filter(filter_id, socket) do
-    updated_params =
-      filter_id
-      |> Filter.Operations.add_filter_to_query(socket)
-      |> Query.clear_cursors()
+    {params, instance_id} = Filter.Operations.add_filter_to_query(filter_id, socket)
+    updated_params = Query.clear_cursors(params)
 
     socket
     |> push_patch(
       to:
         ~p"/#{socket.assigns.selected_project.account.name}/#{socket.assigns.selected_project.name}/builds/build-runs?#{updated_params}"
     )
-    |> push_event("open-dropdown", %{id: "filter-#{filter_id}-value-dropdown"})
-    |> push_event("open-popover", %{id: "filter-#{filter_id}-value-popover"})
+    |> push_event("open-dropdown", %{id: "filter-#{instance_id}-value-dropdown"})
+    |> push_event("open-popover", %{id: "filter-#{instance_id}-value-popover"})
   end
 
   def handle_event_update_filter(params, socket) do

--- a/server/test/support/tuist_test_support/cases/conn_case.ex
+++ b/server/test/support/tuist_test_support/cases/conn_case.ex
@@ -34,6 +34,7 @@ defmodule TuistTestSupport.Cases.ConnCase do
 
   setup tags do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
+    Mimic.stub(Tuist.Tasks, :run_async, fn fun -> fun.() end)
 
     on_exit(fn ->
       TuistTestSupport.Utilities.truncate_clickhouse_tables()


### PR DESCRIPTION
## Summary
- Allow users to add multiple instances of the same filter type (e.g., "Ran by is not CI" AND "Ran by is not john")
- Adds `instance_id` field to `Noora.Filter.Filter` struct to separate type identity (`id`) from instance identity (`instance_id`)
- First instance keeps backward-compatible URLs (`filter_ran_by_op`), subsequent instances use `__N` suffix (`filter_ran_by__1_op`)
- Filter dropdown no longer hides filter types that already have active instances
- Also fixes flaky `RunsControllerTest` tests by stubbing `Tuist.Tasks.run_async` in `ConnCase` to run synchronously

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` passes (3382 tests, 0 failures)
- [ ] Manual: add two "Ran by" filters with different values, verify both appear and URL encodes correctly
- [ ] Manual: reload page with multi-filter URL, verify filters restore correctly
- [ ] Manual: delete one filter instance, verify the other remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)