### PR TITLE
fix(server): update OG image title font size to 128px

### DIFF
--- a/server/lib/tuist/marketing/open_graph.ex
+++ b/server/lib/tuist/marketing/open_graph.ex
@@ -33,7 +33,7 @@ defmodule Tuist.Marketing.OpenGraph do
     text_options = [
       font: "Inter Variable",
       font_weight: 500,
-      font_size: 100,
+      font_size: 128,
       text_fill_color: [46, 48, 57]
     ]
 


### PR DESCRIPTION
## Summary
- Updates the marketing OG image title font size from 100px to 128px to match the design spec

## Test plan
- [ ] Regenerate marketing OG images and verify the title font size is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)