### PR TITLE
fix(server): add og:image dimensions for better LinkedIn rendering

### DIFF
--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -76,6 +76,8 @@ defmodule TuistWeb.LayoutComponents do
     <% else %>
       <meta property="og:image" content={assigns[:head_image]} />
     <% end %>
+    <meta property="og:image:width" content="1920" />
+    <meta property="og:image:height" content="1080" />
     """
   end
 

--- a/server/lib/tuist_web/controllers/api_html/docs.html.heex
+++ b/server/lib/tuist_web/controllers/api_html/docs.html.heex
@@ -12,6 +12,8 @@
       property="og:image"
       content={Tuist.Environment.app_url(path: "/images/open-graph/api-docs-card.jpeg")}
     />
+    <meta property="og:image:width" content="1920" />
+    <meta property="og:image:height" content="1080" />
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@tuistdev" />

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
@@ -27,6 +27,8 @@
           )
         }
       />
+      <meta property="og:image:width" content="1920" />
+      <meta property="og:image:height" content="1080" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@tuistdev" />
       <meta

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:73
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "View in web browser"
 msgstr ""


### PR DESCRIPTION
## Summary
- Add `og:image:width` (1920) and `og:image:height` (1080) meta tags to all pages that set OG image tags
- LinkedIn (and other social platforms) render OG images at a small size when these dimension meta tags are missing
- Updated the shared layout component, newsletter issue template, and API docs template

## Test plan
- [ ] Share a page URL on LinkedIn and verify the OG image renders at full size
- [ ] Check OG tags with a validator like [opengraph.xyz](https://www.opengraph.xyz/) or Facebook's sharing debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)