### PR TITLE
feat(cli): add --no-lint flag to tuist generate

### DIFF
--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -112,6 +112,7 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
         public let defaultSwiftVersion: String
         public let manifestEnvironment: [String]
         public let onOutdatedDependencies: OutdatedDependenciesAction
+        public var skipLint: Bool
 
         public init(
             resolveDependenciesWithSystemScm: Bool,
@@ -131,7 +132,8 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
             warningsAsErrors: WarningsAsErrors = .none,
             defaultSwiftVersion: String = GenerationOptions.defaultSwiftVersionValue,
             manifestEnvironment: [String] = [],
-            onOutdatedDependencies: OutdatedDependenciesAction = .warn
+            onOutdatedDependencies: OutdatedDependenciesAction = .warn,
+            skipLint: Bool = false
         ) {
             self.resolveDependenciesWithSystemScm = resolveDependenciesWithSystemScm
             self.disablePackageVersionLocking = disablePackageVersionLocking
@@ -151,6 +153,7 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
             self.defaultSwiftVersion = defaultSwiftVersion
             self.manifestEnvironment = manifestEnvironment
             self.onOutdatedDependencies = onOutdatedDependencies
+            self.skipLint = skipLint
         }
 
         #if DEBUG

--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -52,6 +52,7 @@ public enum EnvKey: String, CaseIterable {
     case generateOpen = "TUIST_GENERATE_OPEN"
     case generateBinaryCache = "TUIST_GENERATE_BINARY_CACHE"
     case generateCacheProfile = "TUIST_GENERATE_CACHE_PROFILE"
+    case generateLint = "TUIST_GENERATE_LINT"
 
     // GRAPH
 

--- a/cli/Sources/TuistGenerateCommand/GenerateRunCommand.swift
+++ b/cli/Sources/TuistGenerateCommand/GenerateRunCommand.swift
@@ -65,6 +65,12 @@
         )
         var cacheProfile: CacheProfileType?
 
+        @Flag(
+            help: "Run graph linting during generation.",
+            envKey: .generateLint
+        )
+        var lint: Bool = true
+
         @Option(
             name: .shortAndLong,
             help: "Configuration to generate for."
@@ -86,6 +92,7 @@
                 path: path,
                 includedTargets: Set(includedTargets),
                 noOpen: !open,
+                skipLint: !lint,
                 configuration: configuration,
                 ignoreBinaryCache: !binaryCache,
                 cacheProfile: cacheProfile

--- a/cli/Sources/TuistKit/Generator/Generator.swift
+++ b/cli/Sources/TuistKit/Generator/Generator.swift
@@ -68,7 +68,9 @@ public class Generator: Generating {
         // When mutating the graph to use cache, we currently end up double linking some frameworks.
         // To workaround those false positive warnings, we lint the graph before we replace source modules with xcframeworks
         // And assume the changes in the mapper are correct.
-        try await lint(graphTraverser: GraphTraverser(graph: environment.initialGraphWithSources ?? graph))
+        if options?.skipLint != true {
+            try await lint(graphTraverser: GraphTraverser(graph: environment.initialGraphWithSources ?? graph))
+        }
 
         // Generate
         let defaultSwiftVersion = options?.defaultSwiftVersion

--- a/cli/Sources/TuistKit/Services/GenerateService.swift
+++ b/cli/Sources/TuistKit/Services/GenerateService.swift
@@ -82,6 +82,7 @@ public struct GenerateService {
         path: String?,
         includedTargets: Set<TargetQuery>,
         noOpen: Bool,
+        skipLint: Bool = false,
         configuration: String?,
         ignoreBinaryCache: Bool,
         cacheProfile: CacheProfileType?
@@ -138,9 +139,13 @@ public struct GenerateService {
             cacheProfile: resolvedCacheProfile,
             cacheStorage: cacheStorage
         )
+        var options = config.project.generatedProject?.generationOptions
+        if skipLint {
+            options?.skipLint = true
+        }
         let (workspacePath, _, _) = try await generator.generateWithGraph(
             path: path,
-            options: config.project.generatedProject?.generationOptions
+            options: options
         )
         await persistGenerationMetadata(workspacePath: workspacePath)
         if !noOpen {


### PR DESCRIPTION
Adds a `--no-lint` flag to `tuist generate` that skips graph linting entirely.

Graph linting is a validation-only step that does not affect the generated project. On large projects (~6,700 targets), linting can take ~36s. This flag allows developers to skip it during local development while keeping it enabled in CI.

Follows the existing `--no-open` and `--no-binary-cache` flag patterns.

Also available via environment variable: `TUIST_GENERATE_LINT=false`.

### How to test locally

1. Run `tuist generate --no-lint` and verify no lint warnings are emitted
2. Run `tuist generate` (without flag) and verify lint warnings still appear
3. Run tests:
```
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing TuistKitTests/GenerateServiceTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```