### PR TITLE
fix(server): remove broadcast listeners from analytics dashboard pages

### DIFF
--- a/server/lib/tuist_web/live/builds_live.ex
+++ b/server/lib/tuist_web/live/builds_live.ex
@@ -25,10 +25,6 @@ defmodule TuistWeb.BuildsLive do
         TuistWeb.XcodeBuildsLive.assign_mount(socket, params)
       end
 
-    if connected?(socket) do
-      Tuist.PubSub.subscribe("#{account.name}/#{project.name}")
-    end
-
     {:ok, socket}
   end
 
@@ -44,14 +40,6 @@ defmodule TuistWeb.BuildsLive do
     else
       {:noreply, TuistWeb.XcodeBuildsLive.assign_handle_params(socket, params)}
     end
-  end
-
-  def handle_info({:xcode_build_created, _build}, socket) do
-    TuistWeb.XcodeBuildsLive.handle_info({:xcode_build_created, nil}, socket)
-  end
-
-  def handle_info({:gradle_build_created, _build}, socket) do
-    TuistWeb.GradleBuildsLive.handle_info({:gradle_build_created, nil}, socket)
   end
 
   def handle_info(_event, socket) do

--- a/server/lib/tuist_web/live/gradle_cache_live.ex
+++ b/server/lib/tuist_web/live/gradle_cache_live.ex
@@ -27,10 +27,6 @@ defmodule TuistWeb.GradleCacheLive do
       |> assign(:head_title, "#{dgettext("dashboard_gradle", "Gradle Cache")} · #{slug} · Tuist")
       |> assign(OpenGraph.og_image_assigns("gradle-cache"))
 
-    if connected?(socket) do
-      Tuist.PubSub.subscribe("#{account.name}/#{project.name}")
-    end
-
     {:ok, socket}
   end
 
@@ -102,17 +98,6 @@ defmodule TuistWeb.GradleCacheLive do
       end
 
     {:noreply, push_patch(socket, to: "/#{selected_account.name}/#{selected_project.name}/gradle-cache?#{query_params}")}
-  end
-
-  def handle_info({:gradle_build_created, _build}, socket) do
-    if Query.has_pagination_params?(socket.assigns.uri.query) do
-      {:noreply, socket}
-    else
-      {:noreply,
-       socket
-       |> assign_analytics(socket.assigns.current_params)
-       |> assign_recent_builds(socket.assigns.current_params)}
-    end
   end
 
   def handle_info(_event, socket) do

--- a/server/lib/tuist_web/live/module_cache_live.ex
+++ b/server/lib/tuist_web/live/module_cache_live.ex
@@ -24,10 +24,6 @@ defmodule TuistWeb.ModuleCacheLive do
       |> assign(:head_title, "#{dgettext("dashboard_cache", "Module Cache")} · #{slug} · Tuist")
       |> assign(OpenGraph.og_image_assigns("module-cache"))
 
-    if connected?(socket) do
-      Tuist.PubSub.subscribe("#{account.name}/#{project.name}")
-    end
-
     {:ok, socket}
   end
 
@@ -114,13 +110,6 @@ defmodule TuistWeb.ModuleCacheLive do
       end
 
     {:noreply, push_patch(socket, to: "/#{selected_account.name}/#{selected_project.name}/module-cache?#{query_params}")}
-  end
-
-  def handle_info({:command_event_created, _event}, socket) do
-    {:noreply,
-     socket
-     |> assign_analytics(socket.assigns.current_params)
-     |> assign_recent_runs(socket.assigns.current_params)}
   end
 
   def handle_info(_event, socket) do

--- a/server/lib/tuist_web/live/test_runs_live.ex
+++ b/server/lib/tuist_web/live/test_runs_live.ex
@@ -27,10 +27,6 @@ defmodule TuistWeb.TestRunsLive do
       |> assign(OpenGraph.og_image_assigns("test-runs"))
       |> assign(:available_filters, define_filters(project))
 
-    if connected?(socket) do
-      Tuist.PubSub.subscribe("#{account.name}/#{project.name}")
-    end
-
     {:ok, socket}
   end
 
@@ -237,18 +233,6 @@ defmodule TuistWeb.TestRunsLive do
       )
 
     {:noreply, socket}
-  end
-
-  def handle_info({:test_created, %{name: "test"}}, socket) do
-    # Only update when pagination is inactive
-    if Query.has_pagination_params?(socket.assigns.uri.query) do
-      {:noreply, socket}
-    else
-      {:noreply,
-       socket
-       |> assign_analytics(socket.assigns.current_params)
-       |> assign_test_runs(socket.assigns.current_params)}
-    end
   end
 
   def handle_info(_event, socket) do

--- a/server/lib/tuist_web/live/xcode_cache_live.ex
+++ b/server/lib/tuist_web/live/xcode_cache_live.ex
@@ -25,10 +25,6 @@ defmodule TuistWeb.XcodeCacheLive do
       |> assign(:head_title, "#{dgettext("dashboard_cache", "Xcode Cache")} · #{slug} · Tuist")
       |> assign(OpenGraph.og_image_assigns("xcode-cache"))
 
-    if connected?(socket) do
-      Tuist.PubSub.subscribe("#{account.name}/#{project.name}")
-    end
-
     {:ok, socket}
   end
 
@@ -101,18 +97,6 @@ defmodule TuistWeb.XcodeCacheLive do
       end
 
     {:noreply, push_patch(socket, to: "/#{selected_account.name}/#{selected_project.name}/xcode-cache?#{query_params}")}
-  end
-
-  def handle_info({:xcode_build_created, _build}, socket) do
-    # Only update when pagination is inactive
-    if Query.has_pagination_params?(socket.assigns.uri.query) do
-      {:noreply, socket}
-    else
-      {:noreply,
-       socket
-       |> assign_analytics(socket.assigns.current_params)
-       |> assign_recent_builds(socket.assigns.current_params)}
-    end
   end
 
   def handle_info(_event, socket) do


### PR DESCRIPTION
## Summary
- Remove PubSub broadcast subscriptions and handlers from analytics-heavy dashboard pages (module cache, xcode cache, gradle cache, builds, test runs)
- These pages were refreshing on every broadcast message, which could fire every second during active CI, causing unnecessary load
- Table-only pages (e.g. cache runs) keep their broadcast listeners since they benefit from instant updates

## Test plan
- [ ] Verify analytics pages (module cache, xcode cache, gradle cache, builds, test runs) load correctly without live updates
- [ ] Verify table-only pages (cache runs) still receive live updates on new events
- [ ] Confirm no compile warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)