### PR TITLE
fix(cli): use unconditional public import Foundation in generated bundle accessor

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -265,11 +265,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         case .local:
             (
                 """
-                #if hasFeature(InternalImportsByDefault)
                 public import Foundation
-                #else
-                import Foundation
-                #endif
                 """,
                 publicBundleAccessorString(for: target)
             )


### PR DESCRIPTION
## Summary
- Removes the `#if hasFeature(InternalImportsByDefault)` guard from the generated `TuistBundle+*.swift` files for local projects
- Always uses `public import Foundation` since the generated file declares `@objc public final class ...Resources: NSObject`, which requires Foundation types to be publicly visible
- Fixes "ambiguous implicit access level for import of 'Foundation'" error when `InternalImportsByDefault` is not active and another file (e.g. `Dump.swift`) uses `internal import Foundation`

## Test plan
- [ ] Generate a project with resources using `tuist generate` and verify `Derived/Sources/TuistBundle+*.swift` uses `public import Foundation` without the `#if hasFeature` guard
- [ ] Build the project and confirm no "ambiguous implicit access level" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)