### PR TITLE
fix(cli): resource/file glob excluding with ** pattern incorrectly excludes all sibling files

### DIFF
--- a/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -25,7 +25,10 @@ extension XcodeGraph.FileElement {
             var excluded: Set<AbsolutePath> = []
             for path in excluding {
                 let absolute = try AbsolutePath(validating: path)
-                excluded.insert(absolute.upToLastNonGlob)
+                let globComponents = absolute.components.drop(while: { !$0.isGlobComponent })
+                if globComponents.allSatisfy({ $0 == "**" }) {
+                    excluded.insert(absolute.upToLastNonGlob)
+                }
                 let globs = try await fileSystem.glob(
                     directory: .root,
                     include: [String(absolute.pathString.dropFirst())]

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -23,7 +23,10 @@ extension XcodeGraph.ResourceFileElement {
             var excluded: Set<AbsolutePath> = []
             for path in excluding {
                 let absolute = try AbsolutePath(validating: path)
-                excluded.insert(absolute.upToLastNonGlob)
+                let globComponents = absolute.components.drop(while: { !$0.isGlobComponent })
+                if globComponents.allSatisfy({ $0 == "**" }) {
+                    excluded.insert(absolute.upToLastNonGlob)
+                }
                 let globs = try await fileSystem.glob(
                     directory: .root,
                     include: [String(absolute.pathString.dropFirst())]

--- a/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/cli/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -145,7 +145,7 @@ extension AbsolutePath: Swift.ExpressibleByStringLiteral {
 }
 
 extension String {
-    var isGlobComponent: Bool {
+    public var isGlobComponent: Bool {
         let globCharacters = CharacterSet(charactersIn: "*{}")
         return rangeOfCharacter(from: globCharacters) != nil
     }

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/FileElement+ManifestMapperTests.swift
@@ -144,6 +144,38 @@ final class FileElementManifestMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(got)
     }
 
+    func test_excluding_glob_by_extension_does_not_exclude_siblings() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let sourcesFolder = temporaryPath.appending(component: "Sources")
+        let jsonFile = sourcesFolder.appending(component: "config.json")
+        let txtFile = sourcesFolder.appending(component: "readme.txt")
+        try await fileSystem.makeDirectory(at: sourcesFolder)
+        try await fileSystem.writeText("{}", at: jsonFile)
+        try await fileSystem.writeText("", at: txtFile)
+        try await fileSystem.writeText("", at: sourcesFolder.appending(component: "MyApp.swift"))
+        let manifest = ProjectDescription.FileElement.glob(
+            pattern: "Sources/**",
+            excluding: ["Sources/**/*.swift"]
+        )
+
+        // When
+        let got = try await XcodeGraph.FileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem,
+            includeFiles: { try await !self.fileSystem.exists($0, isDirectory: true) }
+        )
+
+        // Then
+        XCTAssertEqual(got.map(\.path).sorted(), [jsonFile, txtFile].sorted())
+    }
+
     func test_from_excludes_files_matching_excluding_pattern() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -367,6 +367,43 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_excluding_glob_by_extension_does_not_exclude_siblings() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let sourcesFolder = temporaryPath.appending(component: "Sources")
+        let jsonFile = sourcesFolder.appending(component: "config.json")
+        let txtFile = sourcesFolder.appending(component: "readme.txt")
+        try await fileSystem.makeDirectory(at: sourcesFolder)
+        try await fileSystem.writeText("{}", at: jsonFile)
+        try await fileSystem.writeText("", at: txtFile)
+        try await fileSystem.writeText("", at: sourcesFolder.appending(component: "MyApp.swift"))
+        let manifest = ProjectDescription.ResourceFileElement.glob(
+            pattern: "Sources/**",
+            excluding: ["Sources/**/*.swift"]
+        )
+
+        // When
+        let got = try await XcodeGraph.ResourceFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertBetterEqual(
+            got,
+            [
+                .file(path: jsonFile, tags: []),
+                .file(path: txtFile, tags: []),
+            ]
+        )
+    }
+
     func test_excluding_when_pattern_is_file() async throws {
         // Given
         let temporaryPath = try temporaryPath()


### PR DESCRIPTION
## Summary

- Fixes a bug where using `excluding` with a glob pattern containing `**` (e.g. `Sources/**/*.swift`) would silently drop **all** files matched by the outer glob, not just those matching the excluding pattern
- Root cause: `upToLastNonGlob` for a pattern like `Sources/**/*.swift` returns `Sources/`, which was inserted into the excluded set and caused the `isDescendantOfOrEqual` filter to reject every file in that directory
- Fix applied to both `ResourceFileElement+ManifestMapper.swift` and `FileElement+ManifestMapper.swift`: only insert the path directly when the excluding pattern has no glob components; for glob patterns, rely solely on the expanded file list
- Adds a regression test `test_excluding_glob_by_extension_does_not_exclude_siblings`

Closes #10113

## Test Plan

- [ ] `TuistLoaderTests/ResourceFileElementManifestMapperTests/test_excluding_glob_by_extension_does_not_exclude_siblings` passes
- [ ] All existing `test_excluding_*` tests continue to pass
- [ ] `tuist generate` on a project with `resources: [.glob(pattern: "Sources/**", excluding: ["Sources/**/*.swift"])]` correctly includes non-Swift resource files