### PR TITLE
fix(server): fix Project description link in docs references sidebar

### DIFF
--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -440,6 +440,10 @@ defmodule Tuist.Docs.Sidebar do
           %Item{label: "tuist.toml", slug: "/en/references/tuist-toml"},
           %Item{
             label: "Project description",
+            url: "https://projectdescription.tuist.dev/documentation/projectdescription"
+          },
+          %Item{
+            label: "Server API",
             url: "https://tuist.dev/api/docs"
           },
           %Item{


### PR DESCRIPTION
## Summary
- The "Project description" reference in the docs sidebar was incorrectly pointing to `https://tuist.dev/api/docs` (the Server API) instead of `https://projectdescription.tuist.dev/documentation/projectdescription`
- Added a separate "Server API" reference entry so both are accessible

## Test plan
- [ ] Verify the "Project description" link in the references sidebar navigates to `projectdescription.tuist.dev`
- [ ] Verify the new "Server API" link navigates to `tuist.dev/api/docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)