### PR TITLE
fix(cli): archive shard bundle directly from source with exclude patterns

### DIFF
--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -20,14 +20,22 @@ public enum AppleArchiverError: LocalizedError, Equatable {
 
 @Mockable
 public protocol AppleArchiving {
-    func compress(directory: AbsolutePath, to archivePath: AbsolutePath) async throws
+    func compress(
+        directory: AbsolutePath,
+        to archivePath: AbsolutePath,
+        excludePatterns: [String]
+    ) async throws
     func decompress(archive: AbsolutePath, to directory: AbsolutePath) async throws
 }
 
 public struct AppleArchiver: AppleArchiving {
     public init() {}
 
-    public func compress(directory: AbsolutePath, to archivePath: AbsolutePath) async throws {
+    public func compress(
+        directory: AbsolutePath,
+        to archivePath: AbsolutePath,
+        excludePatterns: [String] = []
+    ) async throws {
         let source = FilePath(directory.pathString)
         let destination = FilePath(archivePath.pathString)
 
@@ -55,7 +63,19 @@ public struct AppleArchiver: AppleArchiving {
         defer { try? encodeStream.close() }
 
         let keySet = ArchiveHeader.FieldKeySet("TYP,PAT,DAT,UID,GID,MOD,FLG,MTM,CTM,SLC,LNK")!
-        try encodeStream.writeDirectoryContents(archiveFrom: source, keySet: keySet)
+
+        let filter: ArchiveHeader.EntryFilter = { _, path, _ in
+            let pathString = path.string
+            if excludePatterns.contains(where: { pathString.contains($0) }) {
+                return .skip
+            }
+            return .ok
+        }
+        try encodeStream.writeDirectoryContents(
+            archiveFrom: source,
+            keySet: keySet,
+            selectUsing: filter
+        )
 
         try encodeStream.close()
         try compressStream.close()

--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -188,24 +188,14 @@
             return shardPlan
         }
 
-        /// Creates a compressed archive of the test products bundle, stripping files not needed for test execution
+        /// Creates a compressed archive of the test products bundle, excluding files not needed for test execution
         /// (dSYMs, .swiftmodule directories) to significantly reduce upload size.
         private func archiveXCTestProducts(_ xctestproductsPath: AbsolutePath, to archivePath: AbsolutePath) async throws {
-            try await fileSystem.runInTemporaryDirectory(prefix: "tuist-shard-stripped") { strippedPath in
-                let strippedProductsPath = strippedPath.appending(component: xctestproductsPath.basename)
-                try await fileSystem.copy(xctestproductsPath, to: strippedProductsPath)
-
-                // Remove .dSYM and .swiftmodule directories which are only needed for
-                // symbolication/compilation, not for running tests.
-                let stripPatterns = ["**/*.dSYM", "**/*.swiftmodule"]
-                for pattern in stripPatterns {
-                    for try await path in try fileSystem.glob(directory: strippedProductsPath, include: [pattern]) {
-                        try await fileSystem.remove(path)
-                    }
-                }
-
-                try await appleArchiver.compress(directory: strippedProductsPath, to: archivePath)
-            }
+            try await appleArchiver.compress(
+                directory: xctestproductsPath,
+                to: archivePath,
+                excludePatterns: [".dSYM", ".swiftmodule"]
+            )
         }
     }
 #endif

--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import FileSystemTesting
+import Foundation
 import Path
 import Testing
 import TuistAppleArchiver
@@ -16,7 +17,7 @@ struct AppleArchiverTests {
         try await fileSystem.writeText("hello world", at: sourceDir.appending(component: "file.txt"))
 
         let archivePath = temporaryDirectory.appending(component: "archive.aar")
-        try await subject.compress(directory: sourceDir, to: archivePath)
+        try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
 
         let exists = try await fileSystem.exists(archivePath)
         #expect(exists)
@@ -42,7 +43,7 @@ struct AppleArchiverTests {
         )
 
         let archivePath = temporaryDirectory.appending(component: "archive.aar")
-        try await subject.compress(directory: sourceDir, to: archivePath)
+        try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -66,7 +67,7 @@ struct AppleArchiverTests {
         try await fileSystem.writeText("root", at: sourceDir.appending(component: "root.txt"))
 
         let archivePath = temporaryDirectory.appending(component: "archive.aar")
-        try await subject.compress(directory: sourceDir, to: archivePath)
+        try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -79,5 +80,65 @@ struct AppleArchiverTests {
             at: extractDir.appending(components: ["a", "b", "c", "deep.txt"])
         )
         #expect(deepContent == "deep")
+    }
+
+    @Test(.inTemporaryDirectory) func compress_excludes_matching_patterns() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let sourceDir = temporaryDirectory.appending(component: "source")
+        try await fileSystem.makeDirectory(at: sourceDir)
+        try await fileSystem.writeText("keep", at: sourceDir.appending(component: "file.txt"))
+        let dsymDir = sourceDir.appending(components: ["Module.framework.dSYM", "Contents", "Resources"])
+        try await fileSystem.makeDirectory(at: dsymDir)
+        try await fileSystem.writeText("debug", at: dsymDir.appending(component: "DWARF"))
+        let swiftmoduleDir = sourceDir.appending(component: "Module.swiftmodule")
+        try await fileSystem.makeDirectory(at: swiftmoduleDir)
+        try await fileSystem.writeText("module", at: swiftmoduleDir.appending(component: "arm64.swiftmodule"))
+
+        let archivePath = temporaryDirectory.appending(component: "archive.aar")
+        try await subject.compress(
+            directory: sourceDir,
+            to: archivePath,
+            excludePatterns: [".dSYM", ".swiftmodule"]
+        )
+
+        let extractDir = temporaryDirectory.appending(component: "extracted")
+        try await fileSystem.makeDirectory(at: extractDir)
+        try await subject.decompress(archive: archivePath, to: extractDir)
+
+        let fileExists = try await fileSystem.exists(extractDir.appending(component: "file.txt"))
+        #expect(fileExists)
+        let dsymExists = try await fileSystem.exists(extractDir.appending(component: "Module.framework.dSYM"))
+        #expect(!dsymExists)
+        let swiftmoduleExists = try await fileSystem.exists(extractDir.appending(component: "Module.swiftmodule"))
+        #expect(!swiftmoduleExists)
+    }
+
+    @Test(.inTemporaryDirectory) func compress_handles_broken_symlinks() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let sourceDir = temporaryDirectory.appending(component: "source")
+        try await fileSystem.makeDirectory(at: sourceDir)
+        try await fileSystem.writeText("keep", at: sourceDir.appending(component: "file.txt"))
+        try await fileSystem.createSymbolicLink(
+            from: sourceDir.appending(component: "broken_link"),
+            to: try AbsolutePath(validating: "/nonexistent/target")
+        )
+
+        let archivePath = temporaryDirectory.appending(component: "archive.aar")
+        try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
+
+        let extractDir = temporaryDirectory.appending(component: "extracted")
+        try await fileSystem.makeDirectory(at: extractDir)
+        try await subject.decompress(archive: archivePath, to: extractDir)
+
+        let fileContent = try await fileSystem.readTextFile(at: extractDir.appending(component: "file.txt"))
+        #expect(fileContent == "keep")
+        let linkDest = try FileManager.default.destinationOfSymbolicLink(
+            atPath: extractDir.appending(component: "broken_link").pathString
+        )
+        #expect(linkDest == "/nonexistent/target")
     }
 }


### PR DESCRIPTION
## Summary

- Fix `fileSystem.copy()` crash on `.xctestproducts` bundles that contain dSYMs with broken `Relocations` symlinks
- Add `excludePatterns` parameter to `AppleArchiver.compress` using AppleArchive's `EntryFilter` callback to skip `.dSYM` and `.swiftmodule` entries during archival
- Remove the copy-then-delete approach entirely -- archive directly from the source directory

### Root cause

The `.xctestproducts` bundle contains a symlink `Tests/0/Debug-iphonesimulator -> ../../Binaries/0/Debug-iphonesimulator`. Inside the resolved directory, some dSYMs have broken `Relocations` symlinks (pointing to non-existent paths). `fileSystem.copy()` fails when it encounters these broken symlinks:

```
Error Domain=NSCocoaErrorDomain Code=260 "The file "Relocations" couldn't be opened because there is no such file."
```

### Fix

Instead of copy -> strip dSYMs -> compress, we now compress directly from the source using AppleArchive's `EntryFilter` to skip entries matching exclude patterns. AppleArchive handles broken symlinks gracefully (preserves them as-is), so no copy is needed.

This is also faster since it avoids copying 7+ GB of data to a temporary directory.

### E2E validation

Compiled and linked against the actual `TuistAppleArchiver` framework, tested on a real 28 GB `.xctestproducts` bundle:

```
Compressing (excluding .dSYM and .swiftmodule)...
Compressed in 21.7s (1.99 GB)
Decompressing...
Decompressed in 11.2s
Symlink preserved: true
Remaining dSYMs: NONE ✓
```

After extraction, validated with `xcodebuild test-without-building -testProductsPath <extracted> -enumerate-tests` -- xcodebuild successfully found the scheme and parsed all test targets from the xctestrun file.

## Test plan

- [x] `compress_excludes_matching_patterns` -- verifies .dSYM and .swiftmodule are excluded from archive
- [x] `compress_handles_broken_symlinks` -- verifies broken symlinks don't crash and are preserved through round-trip
- [x] All existing tests pass (round-trip, symlinks, directory structure)
- [x] E2E: compress real 28 GB bundle with `TuistAppleArchiver` -> decompress -> xcodebuild validates xctestrun

🤖 Generated with [Claude Code](https://claude.com/claude-code)