### PR TITLE
fix(server): allow long test case names to wrap in header

### DIFF
--- a/server/assets/app/css/pages/test_case.css
+++ b/server/assets/app/css/pages/test_case.css
@@ -19,11 +19,12 @@
       display: flex;
       flex-direction: column;
       gap: var(--noora-spacing-4);
+      min-width: 0;
 
       & > [data-part="title"] {
         display: flex;
         flex-direction: row;
-        align-items: center;
+        align-items: flex-start;
         gap: var(--noora-spacing-4);
 
         & > [data-part="badge-success"] {
@@ -73,6 +74,7 @@
           margin: var(--noora-spacing-0);
           color: var(--noora-surface-label-primary);
           font: var(--noora-font-weight-medium) var(--noora-font-heading-large);
+          word-break: break-word;
         }
       }
 
@@ -85,6 +87,7 @@
 
     & > [data-part="actions"] {
       display: flex;
+      flex-shrink: 0;
       flex-direction: row;
       gap: var(--noora-spacing-4);
     }


### PR DESCRIPTION
## Summary
- Long test case names on the test case detail page no longer compress the Quarantine/Mark as flaky buttons
- The title text wraps to multiple lines instead, with the status icon staying aligned to the top

## Test plan
- [ ] Open a test case with a long name and verify the title wraps while buttons remain full-sized
- [ ] Verify short test case names still display correctly on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)