### PR TITLE
fix(cli): fix xctestproducts lookup after AppleArchive extraction

### DIFF
--- a/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardService.swift
@@ -30,7 +30,6 @@ public protocol ShardServicing {
 public enum ShardServiceError: LocalizedError, Equatable {
     case cannotDeriveReference
     case invalidDownloadURL(String)
-    case testProductsNotFound
     case invalidXCTestRun
 
     public var errorDescription: String? {
@@ -40,8 +39,6 @@ public enum ShardServiceError: LocalizedError, Equatable {
                 "Cannot derive a shard plan reference. Pass --shard-reference explicitly or run in a supported CI environment (GitHub Actions, GitLab CI, CircleCI, Buildkite, Codemagic)."
         case let .invalidDownloadURL(url):
             return "Invalid shard download URL: \(url)"
-        case .testProductsNotFound:
-            return "No .xctestproducts bundle found in the downloaded shard archive."
         case .invalidXCTestRun:
             return "The .xctestrun file has an invalid format."
         }
@@ -101,16 +98,9 @@ public struct ShardService: ShardServicing {
         let shardArchivePath = try await fileClient.download(url: downloadURL)
         Logger.current.debug("Downloaded test products bundle.")
 
-        let unzippedPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-unzip")
-        try await appleArchiver.decompress(archive: shardArchivePath, to: unzippedPath)
+        let testProductsPath = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-shard-unzip")
+        try await appleArchiver.decompress(archive: shardArchivePath, to: testProductsPath)
         try? await fileSystem.remove(shardArchivePath)
-
-        guard let testProductsPath = try await fileSystem
-            .glob(directory: unzippedPath, include: ["*.xctestproducts"])
-            .first(where: { _ in true })
-        else {
-            throw ShardServiceError.testProductsNotFound
-        }
         Logger.current.debug("Extracted test products to \(testProductsPath.pathString)")
 
         let xcTestRunPaths = try await fileSystem


### PR DESCRIPTION
## Summary

AppleArchive extracts directory contents directly into the target path (no wrapper directory), so after decompression the `Binaries/`, `Tests/`, etc. are at the root of the extraction directory. The glob for `*.xctestproducts` found nothing, causing "No .xctestproducts bundle found in the downloaded shard archive."

Fix: use the extraction directory directly as the test products path instead of searching for a `.xctestproducts` wrapper.

## Test plan

- [x] Builds successfully
- [ ] Shard download/extract works end-to-end on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)