### PR TITLE
test(server): stabilize flaky overview and runs tests

### DIFF
--- a/server/test/support/tuist_test_support/utilities.ex
+++ b/server/test/support/tuist_test_support/utilities.ex
@@ -11,6 +11,11 @@ defmodule TuistTestSupport.Utilities do
   """
   def with_flushed_ingestion_buffers(fun) when is_function(fun, 0) do
     result = fun.()
+    flush_ingestion_buffers()
+    result
+  end
+
+  def flush_ingestion_buffers do
     Tuist.CommandEvents.Event.Buffer.flush()
     Tuist.Gradle.Build.Buffer.flush()
     Tuist.Gradle.Task.Buffer.flush()
@@ -18,7 +23,17 @@ defmodule TuistTestSupport.Utilities do
     Tuist.Xcode.XcodeProject.Buffer.flush()
     Tuist.Xcode.XcodeTarget.Buffer.flush()
     Tuist.Builds.Build.Buffer.flush()
-    result
+    flush_test_buffers()
+  end
+
+  def flush_test_buffers do
+    Tuist.Tests.TestCase.Buffer.flush()
+    Tuist.Tests.TestCaseRun.Buffer.flush()
+    Tuist.Tests.TestModuleRun.Buffer.flush()
+    Tuist.Tests.TestSuiteRun.Buffer.flush()
+    Tuist.Tests.TestCaseFailure.Buffer.flush()
+    Tuist.Tests.TestCaseRunRepetition.Buffer.flush()
+    Tuist.Tests.TestCaseEvent.Buffer.flush()
   end
 
   def truncate_clickhouse_tables do

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -13,6 +13,7 @@ defmodule TuistWeb.API.RunsControllerTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Utilities
   alias TuistWeb.Authentication
 
   defp get_builds_for_project(project_id, opts \\ []) do
@@ -26,7 +27,7 @@ defmodule TuistWeb.API.RunsControllerTest do
 
   setup do
     stub(VCS, :enqueue_vcs_pull_request_comment, fn _args -> {:ok, %{}} end)
-    TuistTestSupport.Utilities.truncate_clickhouse_tables()
+    Utilities.truncate_clickhouse_tables()
     :ok
   end
 
@@ -1348,6 +1349,8 @@ defmodule TuistWeb.API.RunsControllerTest do
       assert test_run.status == "success"
 
       # Verify test cases were stored with correct statuses
+      Utilities.flush_test_buffers()
+
       {test_cases, _meta} =
         Tests.list_test_case_runs(%{
           filters: [%{field: :test_run_id, op: :==, value: test_run.id}],
@@ -1455,6 +1458,8 @@ defmodule TuistWeb.API.RunsControllerTest do
       {:ok, test_run} = Tests.get_test(response["id"])
 
       assert test_run.status == "success"
+
+      Utilities.flush_test_buffers()
 
       {test_cases, _meta} =
         Tests.list_test_case_runs(%{

--- a/server/test/tuist_web/live/overview_live_test.exs
+++ b/server/test/tuist_web/live/overview_live_test.exs
@@ -10,6 +10,8 @@ defmodule TuistWeb.OverviewLiveTest do
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
 
+  @render_async_timeout 1_000
+
   setup %{conn: conn} do
     user = AccountsFixtures.user_fixture(handle: "user123#{System.unique_integer([:positive])}")
 
@@ -58,7 +60,7 @@ defmodule TuistWeb.OverviewLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     assert has_element?(lv, ".tuist-widget span", "50.0%")
   end
@@ -79,7 +81,7 @@ defmodule TuistWeb.OverviewLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     assert has_element?(lv, "div[data-part=average-build-time-chart] span", "1.0s")
   end
@@ -91,7 +93,7 @@ defmodule TuistWeb.OverviewLiveTest do
   } do
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     assert has_element?(
              lv,


### PR DESCRIPTION
## Summary
- increase the async wait used by `OverviewLiveTest` so it stops failing on the default 100ms LiveView timeout
- add reusable test-buffer flushing in `TuistTestSupport.Utilities`
- flush test ingestion buffers before asserting freshly created test case runs in `RunsControllerTest`

## Root Cause
- `OverviewLiveTest` was relying on `render_async/1`, which defaults to ExUnit's 100ms receive timeout while the page kicks off several `assign_async` tasks
- the `RunsController` tests queried ClickHouse-backed test case runs immediately after the request, racing the async ingestion buffers

## Validation
- `cd server && mix format --check-formatted test/support/tuist_test_support/utilities.ex test/tuist_web/live/overview_live_test.exs test/tuist_web/controllers/api/runs_controller_test.exs`
- `cd server && mix credo --strict test/support/tuist_test_support/utilities.ex test/tuist_web/live/overview_live_test.exs test/tuist_web/controllers/api/runs_controller_test.exs`
- `cd server && MIX_ENV=test TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_159 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_159 mix test test/tuist_web/live/overview_live_test.exs`
- `cd server && MIX_ENV=test TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_159 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_159 mix test test/tuist_web/controllers/api/runs_controller_test.exs`
- `cd server && MIX_ENV=test TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_159 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_159 mix test`
