### PR TITLE
fix(xcode_processor): fix NIF build dependency and launchctl bootstrap

### DIFF
--- a/xcode_processor/mise/tasks/build-release.sh
+++ b/xcode_processor/mise/tasks/build-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description "Build a production release (NIF + Elixir)"
-#MISE depends ["build-nif"]
+#MISE depends=["build-nif"]
 #MISE raw=true
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Fix mise `depends` syntax: `depends=["build-nif"]` not `depends ["build-nif"]` (missing `=`). This was the root cause of the NIF not being built -- mise silently ignored the malformed directive.
- Retry `launchctl bootstrap` after `bootout` to handle the race condition that causes "Input/output error"

## Test plan
- [ ] Merge and verify deploy workflow builds the NIF and deploys successfully
- [ ] Health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)