### PR TITLE
fix(cli): preserve .swiftmodule directories in shard archives

### DIFF
--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -188,13 +188,13 @@
             return shardPlan
         }
 
-        /// Creates a compressed archive of the test products bundle, excluding files not needed for test execution
-        /// (dSYMs, .swiftmodule directories) to significantly reduce upload size.
+        /// Creates a compressed archive of the test products bundle, excluding dSYMs
+        /// to reduce upload size.
         private func archiveXCTestProducts(_ xctestproductsPath: AbsolutePath, to archivePath: AbsolutePath) async throws {
             try await appleArchiver.compress(
                 directory: xctestproductsPath,
                 to: archivePath,
-                excludePatterns: [".dSYM", ".swiftmodule"]
+                excludePatterns: [".dSYM"]
             )
         }
     }


### PR DESCRIPTION
## Summary
- Stop stripping `.swiftmodule` directories from `.xctestproducts` shard archives
- Previously excluded to reduce upload size, but this breaks tests that compile Swift at runtime (e.g. acceptance tests invoking manifest compilation via `GenerateCommand`)
- Size impact: ~3% increase in archive size (~240MB compressed for a 28GB `.xctestproducts`, ~65MB for Tuist's own project)

## Context
Discovered while consolidating acceptance tests into a sharded workflow (tuist/tuist#10128). The shard runner couldn't compile manifests because `ProjectDescription.framework`'s `.swiftmodule` was stripped from the archive, leaving only runtime linking info.

## Test plan
- [ ] Verify sharded acceptance tests can compile manifests on the shard runner
- [ ] Verify shard upload/download still works with the larger archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)