### PR TITLE
fix(cli): fix cross-project test host embed and TEST_HOST settings

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -456,15 +456,10 @@ public class GraphTraverser: GraphTraversing {
             }
         )
 
-        // Exclude any products embed in unit test host apps
+        // Unit tests never embed frameworks — they either run inside a host app
+        // (which embeds the frameworks) or standalone (where DYLD paths are used instead).
         if target.target.product == .unitTests {
-            if let hostApp = unitTestHost(path: path, name: name) {
-                references.subtract(
-                    embeddableFrameworks(path: hostApp.path, name: hostApp.target.name)
-                )
-            } else {
-                references = Set()
-            }
+            references = Set()
         }
 
         return references

--- a/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/cli/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -303,7 +303,7 @@ public struct DefaultSettingsProvider: DefaultSettingsProviding {
             return [:]
         }
 
-        let targetDependencies = graphTraverser.directLocalTargetDependencies(path: projectPath, name: target.name).sorted()
+        let targetDependencies = graphTraverser.directTargetDependencies(path: projectPath, name: target.name).sorted()
         let appDependency = targetDependencies.first { $0.target.product.canHostTests() }
 
         guard let app = appDependency else {

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1722,6 +1722,36 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
+    func test_embeddableFrameworks_whenHostedTestTarget_withDirectFrameworkNotInHost() throws {
+        // Given: Unit test depends on a host app AND a framework that the host does NOT depend on.
+        // The framework should NOT be embedded in the .xctest bundle.
+        let featureFramework = Target.test(name: "FeatureA", product: .framework)
+        let app = Target.test(name: "SharedTestHost", product: .app)
+        let tests = Target.test(name: "FeatureATests", product: .unitTests)
+        let hostProject = Project.test(path: "/path/host", targets: [app])
+        let featureProject = Project.test(path: "/path/feature", targets: [featureFramework, tests])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: hostProject.path): Set(),
+            .target(name: featureFramework.name, path: featureProject.path): Set(),
+            .target(name: tests.name, path: featureProject.path): Set([
+                .target(name: app.name, path: hostProject.path),
+                .target(name: featureFramework.name, path: featureProject.path),
+            ]),
+        ]
+        let graph = Graph.test(
+            projects: [hostProject.path: hostProject, featureProject.path: featureProject],
+            dependencies: dependencies
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.embeddableFrameworks(path: featureProject.path, name: tests.name).sorted()
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+
     func test_embeddableFrameworks_whenUITest_andAppPrecompiledDependencies() throws {
         // Given
         let app = Target.test(name: "App", product: .app)

--- a/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -307,6 +307,66 @@ struct ConfigGeneratorTests {
         assert(config: releaseConfig, contains: testHostSettings)
     }
 
+    @Test(
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateTestTargetConfiguration_crossProjectHost() async throws {
+        // Given: Unit test in one project depends on a host app in another project
+        let dir = try #require(FileSystem.temporaryTestDirectory)
+
+        let hostAppTarget = Target.test(
+            name: "SharedTestHost",
+            destinations: .iOS,
+            product: .app
+        )
+        let testTarget = Target.test(name: "Test", destinations: .iOS, product: .unitTests)
+
+        let hostProjectPath = dir.appending(component: "SharedTestHost")
+        let featureProjectPath = dir.appending(component: "FeatureA")
+
+        let hostProject = Project.test(path: hostProjectPath, name: "SharedTestHost", targets: [hostAppTarget])
+        let featureProject = Project.test(path: featureProjectPath, name: "FeatureA", targets: [testTarget])
+
+        let graph = Graph.test(
+            name: featureProject.name,
+            path: featureProject.path,
+            projects: [hostProjectPath: hostProject, featureProjectPath: featureProject],
+            dependencies: [
+                GraphDependency.target(
+                    name: testTarget.name,
+                    path: featureProjectPath
+                ): Set([.target(name: hostAppTarget.name, path: hostProjectPath)]),
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        _ = try await subject.generateTargetConfig(
+            testTarget,
+            project: featureProject,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: featureProject.settings,
+            fileElements: .init(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: featureProjectPath
+        )
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let testHostSettings: SettingsDictionary = [
+            "TEST_HOST":
+                "$(BUILT_PRODUCTS_DIR)/SharedTestHost.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SharedTestHost",
+            "BUNDLE_LOADER": "$(TEST_HOST)",
+        ]
+
+        assert(config: debugConfig, contains: testHostSettings)
+        assert(config: releaseConfig, contains: testHostSettings)
+    }
+
     @Test(.withMockedXcodeController, .inTemporaryDirectory) func generateUITestTargetConfiguration() async throws {
         // Given / When
         try await generateTestTargetConfig(appName: "App", uiTest: true)


### PR DESCRIPTION
## Summary

Fixes two issues when a unit test target depends on a host app in another project via `.project(target:path:)`:

- **TEST_HOST not set**: `DefaultSettingsProvider.testBundleTargetDerivedSettings()` used `directLocalTargetDependencies` which only finds same-project deps. Changed to `directTargetDependencies` so cross-project host apps are found and `TEST_HOST`/`BUNDLE_LOADER` are set correctly.
- **Unnecessary framework embedding**: `embeddableFrameworks()` was subtracting host app frameworks from the test's embed set, but the test's own direct framework deps (not in the host) remained embedded. Unit tests should never embed frameworks — they run inside the host app process or use DYLD paths. Simplified to unconditionally clear embeddable frameworks for unit tests.

> [!NOTE]
> **History of the embed logic change:**
>
> The subtract approach in `embeddableFrameworks()` was introduced in [#664](https://github.com/tuist/tuist/pull/664) (Nov 2019) by @kwridan to fix duplicate symbol errors when hosted unit tests redundantly embedded their host app's transitive dependencies. The fix subtracted the host's embeddable frameworks from the test's set.
>
> Later, [#1812](https://github.com/tuist/tuist/pull/1812) (Sep 2020) by @davidaharris added the `else { references = Set() }` branch for non-hosted unit tests, recognizing they should embed nothing either (they use DYLD search paths via `runPathSearchPaths` instead).
>
> However, nobody circled back to simplify the hosted branch — the subtract worked when the test's frameworks were a subset of the host's, but broke for cross-project test hosts where the test has its own direct framework dependencies not present in the host.
>
> This PR unifies both branches to `references = Set()`. The behavioral change is: if a hosted unit test depends on a dynamic framework that the host app does NOT depend on, it will no longer be embedded in the `.xctest` bundle. This matches Xcode's native behavior — hosted tests run inside the host app process and should not embed frameworks. If a test needs a framework, it should be added to the host app's dependencies instead.

## Test plan

- [x] Added `test_embeddableFrameworks_whenHostedTestTarget_withDirectFrameworkNotInHost` — verifies hosted unit test with a direct framework dep not in the host returns empty embeddable frameworks
- [x] Added `generateTestTargetConfiguration_crossProjectHost` — verifies `TEST_HOST` and `BUNDLE_LOADER` are set correctly when the host app is in a different project
- [x] All existing `GraphTraverserTests` embed tests pass (4/4)
- [x] All existing `ConfigGeneratorTests` pass (40/40)
- [x] Verified with a reproduction project (`Workspace` with `SharedTestHost` app in one project, `FeatureA` framework + tests in another) — the generated `.xctest` no longer embeds `FeatureA.framework` and `TEST_HOST` is correctly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)