### PR TITLE
fix(xcode_processor): align webhook secret with server production config

### DIFF
--- a/xcode_processor/platform/secrets.yaml
+++ b/xcode_processor/platform/secrets.yaml
@@ -1,5 +1,5 @@
 secret_key_base: ENC[AES256_GCM,data:+uaSp2RrJedbYquitmSmWD+r8+fSRmaB9F8a5XFOhCv45aaMMX3t7mbvZZmOUCl+jEueAVicJ1qDy4NU4M24sQ==,iv:AizUFDm27SkPz+2W/JHgAk1LfTvr+5irMHilkKQ5BXo=,tag:Zixk0MsU9BjvjmGxXQU2lQ==,type:str]
-webhook_secret: ENC[AES256_GCM,data:8GLUrsV6ZeB4n3fHZNejxxtSc0/GMHHZksxThJE+NPkHhGHqIoFCiuvuc1eW6k9Q+E5fIMgfKVwrI2vN6jeiDw==,iv:FfkSzZV6DZm+TC+kTh481YQE3DRn2WPUmk4xVW8qsAw=,tag:/TEHns0T3ElWB1P4yHB0Tg==,type:str]
+webhook_secret: ENC[AES256_GCM,data:l4cc7aYiuwnwmOzlFwti7yVJFos+USVy88/F+tUfJPk7tuZmYr7WxfEoVip4pa8nnuP4St1V3LawEtAF3EtbVw==,iv:TP5//HGM4C+U0XBC+qiEr5ji5W1/EvQtitRnp3fHbk8=,tag:e9upixGSuymXaJFBI/Ajaw==,type:str]
 s3_endpoint: ENC[AES256_GCM,data:M47l1T5HyPaVJGgRA7pbTC5C/3Pw1Q==,iv:rhqYjSYcemBw82Id1ZER5TLPmEZq3zTtKV4voVNDO9I=,tag:rCjMHAad5v2Xevd5Pibyxg==,type:str]
 s3_bucket: ENC[AES256_GCM,data:ih6SywUO/fqSe4X+IMCiQVnH5VJR8fm5WQ==,iv:Y5CZ0qBAAEAWv90jSVDVpH6TwyWdkVTzu7LCDoHv79s=,tag:hBaftmIJoV0X24f71UdDMg==,type:str]
 s3_access_key_id: ENC[AES256_GCM,data:O8p1jurHjM921p0LJ8gAaKzpsj59yi5qAuM3sfzuepbQSjUnEZQeTFsBW/RGpPu3WRuOzLAI,iv:BfhVnr7CYAObRD0+So/oMldUdwXyRl215ZWB3rKdxc8=,tag:R/LjOZgdOtAZvl9gUFPCWw==,type:str]
@@ -48,8 +48,8 @@ sops:
             UVpaWlpNUkI5KzJES2FKa0hqNGFZQ0UKaeCe3iK3F0apR6T0beSerDinXoyKecR3
             QJ5ORAyrtoMUfDoUfOJ5WOGibSfPxnguRDubzL8go5Yu+kvBMwg+QA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-30T18:15:00Z"
-    mac: ENC[AES256_GCM,data:J4xXkXz+2XuVRRW2DnC0OFDs6fXhiT8o1ua/8JDgLnmdwUUKKnNi7Gp9WcjbeLBqSm7uOGsr7/JCBPODPSfBoFTCZNbJdFcgpgsEVI/JghFbWn8hfdPg/Mp02VgXCv5zZI4VS/xpulcPk9USkcY2lIxw5ZHljaGr9eZqRDfXvP4=,iv:Ky2E/G3xGBR5pVWzDx5Kmcm1IrybjKtGTvIN/WzVn7c=,tag:bRh53DgzXPb/P8o5oMR6SA==,type:str]
+    lastmodified: "2026-04-01T07:58:23Z"
+    mac: ENC[AES256_GCM,data:0w5Thx6RsTz0uD7QsGNoSk5TEb3LsiG0TT9JoWjV3junIz+Xv9jPP8jLHpjzQRTHw9dVBaXnA1kHtZUk/5s+xdTzNm9luwAM22SLvtwByoII33BxldifcEMJhX/1DM3NITn1x2D7gSqEKOzPmIM/LTxh3XZx7FrCwcMSScpadBc=,iv:KI+K6Iwwdw3JWhnHFOuWpzx1TvL0FzE+Q2f5cfKFdGE=,tag:u1dB0sjF2aOWjHpKkB8u1w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.3


### PR DESCRIPTION
## Summary
- The xcode_processor's sops-encrypted `webhook_secret` did not match the server's production secret, causing all webhook requests to fail with 403 "Invalid signature"
- Updated the sops-encrypted value to match the server's production config

## Test plan
- [ ] Deploy xcode_processor to staging/production
- [ ] Re-run `tuist inspect test` and verify the xcresult processing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)