### PR TITLE
fix(xcode_processor): add delay between launchctl bootout and bootstrap

### DIFF
--- a/xcode_processor/mise/tasks/deploy.sh
+++ b/xcode_processor/mise/tasks/deploy.sh
@@ -55,6 +55,7 @@ rm release.tar.gz
 
 sudo launchctl bootout system/org.nixos.dev.tuist.xcode-processor 2>/dev/null || true
 echo "==> Stopped"
+sleep 3
 
 # Swap the symlink atomically
 ln -sfn "\${RELEASE_PATH}" "\${CURRENT_LINK}"
@@ -86,6 +87,7 @@ echo "ERROR: Health check failed after 60s"
 if [ -n "\${PREVIOUS_RELEASE}" ] && [ -d "\${PREVIOUS_RELEASE}" ]; then
     echo "==> Rolling back to \${PREVIOUS_RELEASE}..."
     sudo launchctl bootout system/org.nixos.dev.tuist.xcode-processor 2>/dev/null || true
+    sleep 3
     ln -sfn "\${PREVIOUS_RELEASE}" "\${CURRENT_LINK}"
     sudo launchctl bootstrap system /Library/LaunchDaemons/org.nixos.dev.tuist.xcode-processor.plist
 


### PR DESCRIPTION
## Summary
- macOS launchctl needs a brief delay after `bootout` before `bootstrap` can succeed
- Without it, bootstrap fails with "Input/output error" (exit code 5), causing every CI deploy to fail
- Adds `sleep 3` after bootout in both the deploy and rollback paths

## Test plan
- [ ] Re-run the xcode-processor deploy workflow and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)