### PR TITLE
fix(cli): resolve result bundle symlink before remote upload

### DIFF
--- a/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
+++ b/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
@@ -171,8 +171,12 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
             throw UploadResultBundleServiceError.missingFullHandle
         }
 
+        // xcodebuild creates result-bundle as a symlink to result-bundle.xcresult,
+        // so we resolve it to ensure the archiver zips the actual directory.
+        let resolvedResultBundlePath = try await fileSystem.resolveSymbolicLink(resultBundlePath)
+
         if !quarantinedTests.isEmpty {
-            try await writeQuarantinedTests(quarantinedTests, to: resultBundlePath)
+            try await writeQuarantinedTests(quarantinedTests, to: resolvedResultBundlePath)
         }
 
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
@@ -186,7 +190,7 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
         let testRunId = UUID().uuidString.lowercased()
 
         try await analyticsArtifactUploadService.uploadResultBundle(
-            resultBundlePath,
+            resolvedResultBundlePath,
             fullHandle: fullHandle,
             commandEventId: testRunId,
             serverURL: serverURL

--- a/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
@@ -830,6 +830,44 @@ struct UploadResultBundleServiceTests {
         #expect(entries[1]["target"] == "CoreTests")
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func uploadResultBundle_resolvesSymlinkBeforeUpload() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcresultPath = temporaryDirectory.appending(component: "result-bundle.xcresult")
+        try await fileSystem.makeDirectory(at: xcresultPath)
+        let symlinkPath = temporaryDirectory.appending(component: "result-bundle")
+        try FileManager.default.createSymbolicLink(
+            atPath: symlinkPath.pathString,
+            withDestinationPath: xcresultPath.pathString
+        )
+
+        given(analyticsArtifactUploadService)
+            .uploadResultBundle(
+                .any,
+                fullHandle: .any,
+                commandEventId: .any,
+                serverURL: .any
+            )
+            .willReturn()
+
+        _ = try await subject.uploadResultBundle(
+            resultBundlePath: symlinkPath,
+            config: .test(fullHandle: "tuist/tuist"),
+            quarantinedTests: [],
+            shardPlanId: nil,
+            shardIndex: nil
+        )
+
+        verify(analyticsArtifactUploadService)
+            .uploadResultBundle(
+                .value(xcresultPath),
+                fullHandle: .any,
+                commandEventId: .any,
+                serverURL: .any
+            )
+            .called(1)
+    }
+
     @Test(.withMockedEnvironment())
     func uploadResultBundle_throwsWhenFullHandleMissing() async throws {
         await #expect(

--- a/xcode_processor/lib/xcode_processor/xcresult_processor.ex
+++ b/xcode_processor/lib/xcode_processor/xcresult_processor.ex
@@ -215,21 +215,10 @@ defmodule XcodeProcessor.XCResultProcessor do
   end
 
   defp find_xcresult(temp_dir) do
-    by_extension =
-      temp_dir
-      |> Path.join("**/*.xcresult")
-      |> Path.wildcard()
-      |> List.first()
-
-    # When uploaded via `tuist test --inspect-mode remote`, the result bundle
-    # directory may not have the .xcresult extension (e.g. named "result-bundle").
-    # All xcresult bundles contain a database.sqlite3, so we use it as a fallback marker.
-    by_extension ||
-      temp_dir
-      |> Path.join("**/database.sqlite3")
-      |> Path.wildcard()
-      |> Enum.map(&Path.dirname/1)
-      |> Enum.find(&File.dir?/1)
+    temp_dir
+    |> Path.join("**/*.xcresult")
+    |> Path.wildcard()
+    |> List.first()
   end
 
   defp cleanup_temp(temp_dir) do

--- a/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
+++ b/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
@@ -48,42 +48,6 @@ defmodule XcodeProcessor.XCResultProcessorTest do
       assert {:ok, ^parsed_data} = XCResultProcessor.process("some/key.zip")
     end
 
-    test "finds xcresult bundle without .xcresult extension" do
-      temp_dir =
-        Path.join(
-          System.tmp_dir!(),
-          "xcresult_no_ext_test_#{:erlang.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(temp_dir)
-      on_exit(fn -> File.rm_rf(temp_dir) end)
-
-      {:ok, fixture_zip} =
-        :zip.create(
-          ~c"#{Path.join(temp_dir, "fixture.zip")}",
-          [
-            {~c"result-bundle/Info.plist", "fake-plist-content"},
-            {~c"result-bundle/database.sqlite3", "fake-db"}
-          ]
-        )
-
-      parsed_data = %{"tests" => [%{"name" => "testExample", "status" => "passed"}]}
-
-      stub(ExAws.S3, :download_file, fn _bucket, _key, dest_path ->
-        File.cp!(to_string(fixture_zip), dest_path)
-        %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}
-      end)
-
-      expect(ExAws, :request, fn _ -> {:ok, :done} end)
-
-      expect(XcodeProcessor.XCResultNIF, :parse, fn xcresult_path, _root_dir ->
-        assert String.ends_with?(xcresult_path, "result-bundle")
-        {:ok, parsed_data}
-      end)
-
-      assert {:ok, ^parsed_data} = XCResultProcessor.process("some/key.zip")
-    end
-
     test "raises when S3 download fails" do
       stub(ExAws.S3, :download_file, fn _bucket, _key, _dest_path ->
         %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}


### PR DESCRIPTION
## Summary
- xcodebuild creates `result-bundle` as a symlink to `result-bundle.xcresult`
- The archiver was zipping the symlink itself, resulting in a broken symlink on the server
- Now resolves the symlink before uploading so the actual `.xcresult` directory is zipped
- Reverts the `database.sqlite3` fallback in xcode_processor since symlink resolution ensures the `.xcresult` extension is always present

## Test plan
- [ ] `tuist test --inspect-mode remote` successfully uploads and processes the result bundle
- [ ] xcode_processor finds the `.xcresult` directory in the uploaded zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)