### PR TITLE
fix(cli): deduplicate entries during Apple Archive compression

### DIFF
--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -2,6 +2,7 @@ import AppleArchive
 import Foundation
 import Mockable
 import Path
+import Synchronization
 import System
 
 public enum AppleArchiverError: LocalizedError, Equatable {
@@ -62,16 +63,19 @@ public struct AppleArchiver: AppleArchiving {
         }
         defer { try? encodeStream.close() }
 
-        // Exclude SLC (symlink content) and LNK (link) so symlinks are
-        // dereferenced during compression. Otherwise, both the symlink and its
-        // target end up in the archive, causing EEXIST errors during extraction.
-        let keySet = ArchiveHeader.FieldKeySet("TYP,PAT,DAT,UID,GID,MOD,FLG,MTM,CTM")!
+        let keySet = ArchiveHeader.FieldKeySet("TYP,PAT,DAT,UID,GID,MOD,FLG,MTM,CTM,SLC,LNK")!
 
+        // writeDirectoryContents may visit the same file twice when the source
+        // directory contains symlinks to sibling directories. Track seen paths
+        // and skip duplicates to prevent EEXIST errors during extraction.
+        let seenPaths = Mutex(Set<String>())
         let filter: ArchiveHeader.EntryFilter = { _, path, _ in
             let pathString = path.string
             if excludePatterns.contains(where: { pathString.contains($0) }) {
                 return .skip
             }
+            let inserted = seenPaths.withLock { $0.insert(pathString).inserted }
+            guard inserted else { return .skip }
             return .ok
         }
         try encodeStream.writeDirectoryContents(
@@ -86,26 +90,6 @@ public struct AppleArchiver: AppleArchiving {
     }
 
     public func decompress(archive: AbsolutePath, to directory: AbsolutePath) async throws {
-        do {
-            try extract(from: archive, to: directory)
-        } catch {
-            // Apple Archive's writeDirectoryContents may produce duplicate entries
-            // when the source directory contains symlinks to sibling directories.
-            // The extractor fails with EEXIST (renamex_np) on the second entry.
-            // Clear the partially-extracted contents and retry; the duplicate
-            // entries are identical so last-write-wins is safe.
-            guard error.localizedDescription.contains("File exists") else { throw error }
-            let fm = FileManager.default
-            if let contents = try? fm.contentsOfDirectory(atPath: directory.pathString) {
-                for item in contents {
-                    try? fm.removeItem(atPath: "\(directory.pathString)/\(item)")
-                }
-            }
-            try extract(from: archive, to: directory)
-        }
-    }
-
-    private func extract(from archive: AbsolutePath, to directory: AbsolutePath) throws {
         let source = FilePath(archive.pathString)
         let destination = FilePath(directory.pathString)
 

--- a/cli/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -301,6 +301,52 @@ struct TestAcceptanceTestMultiplatformApp {
     }
 }
 
+struct TestAcceptanceTestShardWithRemoteTestProducts {
+    @Test(
+        .withFixtureConnectedToCanary("generated_ios_app_with_tests"),
+        .inTemporaryDirectory
+    ) func shard_with_remote_test_products() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let testProductsPath = temporaryDirectory.appending(component: "MacFrameworkTests.xctestproducts")
+        let shardReference = "acceptance-test-\(Int.random(in: 100_000 ... 999_999))"
+
+        Environment.mocked?.variables["GITHUB_ACTIONS"] = "true"
+        Environment.mocked?.variables["GITHUB_RUN_ID"] = shardReference
+        Environment.mocked?.variables["GITHUB_RUN_ATTEMPT"] = "1"
+        let githubOutputPath = temporaryDirectory.appending(component: "github_output")
+        try await FileSystem().writeText("", at: githubOutputPath)
+        Environment.mocked?.variables["GITHUB_OUTPUT"] = githubOutputPath.pathString
+
+        // Build phase: build tests and upload shard archive to server
+        try await TuistTest.run(
+            TestCommand.self,
+            [
+                "MacFrameworkTests",
+                "--build-only",
+                "--shard-total", "1",
+                "--path", fixtureDirectory.pathString,
+                "--",
+                "-testProductsPath", testProductsPath.pathString,
+                "-destination", "platform=macOS",
+            ]
+        )
+
+        // Test phase: download shard archive and run tests
+        try await TuistTest.run(
+            TestCommand.self,
+            [
+                "MacFrameworkTests",
+                "--without-building",
+                "--shard-index", "0",
+                "--path", fixtureDirectory.pathString,
+                "--",
+                "-destination", "platform=macOS",
+            ]
+        )
+    }
+}
+
 struct TestAcceptanceTestShardWithLocalTestProducts {
     @Test(
         .withFixtureConnectedToCanary("generated_ios_app_with_tests"),


### PR DESCRIPTION
## Summary

Apple Archive's `writeDirectoryContents` visits the same file twice when the source directory contains symlinks to sibling directories (e.g. `Tests/0/Debug -> ../../Binaries/0/Debug` in xctestproducts). This produces duplicate archive entries that cause `renamex_np` EEXIST errors during extraction.

**Root cause**: `writeDirectoryContents` follows symlinks during directory traversal and re-visits adjacent files, producing two entries for the same path. Confirmed locally: the archive contains `Tests/0/TuistAcceptanceTests.xctestrun` twice.

**Fix**: Track seen paths in the entry filter using a `Mutex<Set<String>>` and skip duplicates during compression. This prevents duplicate entries from being written to the archive.

**Regression**: The issue manifests when `.swiftmodule` directories are included in shard archives (since #10137 / 4.172.0), as these contain symlinks.

Also adds an acceptance test (`TestAcceptanceTestShardWithRemoteTestProducts`) that exercises the full shard upload+download+decompress flow against canary.

## Test plan
- [ ] Shard archive no longer contains duplicate entries
- [ ] Shard decompression no longer fails with "File already exists" errors  
- [ ] New acceptance test passes: shard build+upload, then download+decompress+test
- [ ] Existing `TestAcceptanceTestShardWithLocalTestProducts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)