### PR TITLE
fix(cli): add AppleArchiver symlink regression test

### DIFF
--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -56,6 +56,39 @@ struct AppleArchiverTests {
         #expect(content == "target content")
     }
 
+    @Test(.inTemporaryDirectory) func compress_and_decompress_handles_symlinked_sibling_directories() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fileSystem = FileSystem()
+
+        let sourceDir = temporaryDirectory.appending(component: "source")
+        let supportDir = sourceDir.appending(component: "Support")
+        let testsDir = sourceDir.appending(component: "Tests")
+        try await fileSystem.makeDirectory(at: supportDir)
+        try await fileSystem.makeDirectory(at: testsDir)
+        try await fileSystem.writeText("xctestrun", at: supportDir.appending(component: "QontoCI.xctestrun"))
+        try await fileSystem.createSymbolicLink(
+            from: testsDir.appending(component: "SupportLink"),
+            to: try RelativePath(validating: "../Support")
+        )
+
+        let archivePath = temporaryDirectory.appending(component: "archive.aar")
+        try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
+
+        let extractDir = temporaryDirectory.appending(component: "extracted")
+        try await fileSystem.makeDirectory(at: extractDir)
+        try await subject.decompress(archive: archivePath, to: extractDir)
+
+        let content = try await fileSystem.readTextFile(
+            at: extractDir.appending(components: ["Support", "QontoCI.xctestrun"])
+        )
+        #expect(content == "xctestrun")
+
+        let resolvedLink = try await fileSystem.resolveSymbolicLink(
+            extractDir.appending(components: ["Tests", "SupportLink"])
+        )
+        #expect(resolvedLink == extractDir.appending(component: "Support"))
+    }
+
     @Test(.inTemporaryDirectory) func compress_and_decompress_preserves_directory_structure() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()


### PR DESCRIPTION
## What changed
Adds a focused `AppleArchiver` regression test for `.xctestproducts`-style layouts that include symlinked sibling directories.

## Why it changed
Qonto hit shard download/extraction failures on `4.173.0+` with errors like `QontoCI.xctestrun already exists` during archive extraction.

## Root cause
When the source tree contains symlinked sibling directories, Apple Archive can revisit the same logical path more than once during compression. That produces duplicate archive entries, and extraction later fails when the second entry tries to materialize an existing file.

## Impact
This keeps the existing `AppleArchiver` deduplication behavior covered so the shard archive regression does not come back.

## Validation
- `xcodebuild build-for-testing -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination 'platform=macOS,arch=arm64' -only-testing:TuistAppleArchiverTests/AppleArchiverTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild test-without-building -workspace Tuist.xcworkspace -scheme TuistUnitTests -destination 'platform=macOS,arch=arm64' -only-testing:TuistAppleArchiverTests/AppleArchiverTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

Both commands passed locally.