### PR TITLE
fix(docs): Clarify account token account handle in auth docs

### DIFF
--- a/server/priv/docs/en/guides/server/authentication.md
+++ b/server/priv/docs/en/guides/server/authentication.md
@@ -80,14 +80,14 @@ For CI environments that don't support OIDC, or when you need fine-grained contr
 ### Creating an account token {#creating-an-account-token}
 
 ```bash
-tuist account tokens create account \
+tuist account tokens create account-handle \
   --scopes project:cache:read project:cache:write \
   --name ci-cache-token \
   --expires 1y
 ```
 
 > [!IMPORTANT]
-> Replace `account` with the handle of the account that owns the projects you want the token to access. This can be an organization account, not necessarily your personal account.
+> Replace `account-handle` with the handle of the account that owns the projects you want the token to access. This can be an organization account, not necessarily your personal account.
 
 The command accepts the following options:
 
@@ -135,7 +135,7 @@ Scope groups provide a convenient way to grant multiple related scopes with a si
 For CI environments that don't support OIDC, you can create an account token with the `ci` scope group to authenticate your CI workflows:
 
 ```bash
-tuist account tokens create account --scopes ci --name ci
+tuist account tokens create account-handle --scopes ci --name ci
 ```
 
 This creates a token with all the scopes needed for typical CI operations (cache, previews, bundles, tests, builds, and runs). Store the generated token as a secret in your CI environment and set it as the `TUIST_TOKEN` environment variable.
@@ -145,13 +145,13 @@ This creates a token with all the scopes needed for typical CI operations (cache
 To list all tokens for an account:
 
 ```bash
-tuist account tokens list account
+tuist account tokens list account-handle
 ```
 
 To revoke a token by name:
 
 ```bash
-tuist account tokens revoke account ci-cache-token
+tuist account tokens revoke account-handle ci-cache-token
 ```
 
 ### Using account tokens {#using-account-tokens}


### PR DESCRIPTION
## Summary
Clarify that the `account` argument in account token commands must be the handle of the account that owns the target projects.

## What Changed
- Replaced `my-account` with the more neutral placeholder `account`
- Added an admonition under the first example explaining that the account can be an organization account, not necessarily the user's personal account
- Updated the related `create`, `list`, and `revoke` examples to use the same placeholder consistently

## Why
The previous example could be read as "use your own account" rather than "use the account that owns the projects you need to access," which is the important distinction for shared organization setups.

## Validation
- Reviewed the rendered markdown structure locally via diff
- No build or test run; documentation-only change