### PR TITLE
fix(docs): preserve anchor scrolling in docs

### DIFF
--- a/server/assets/docs/docs.js
+++ b/server/assets/docs/docs.js
@@ -31,10 +31,21 @@ function closeMobileSidebar() {
   document.getElementById("docs-sidebar")?.removeAttribute("data-mobile-open");
 }
 
+function maybeScrollToTopForNavigation({ kind, to } = {}) {
+  if (!to || kind === "initial") return;
+
+  const destination = new URL(to, window.location.origin);
+  if (destination.hash) return;
+
+  requestAnimationFrame(() => {
+    window.scrollTo(0, 0);
+  });
+}
+
 window.addEventListener("phx:page-loading-start", (_info) => topbar.show(300));
-window.addEventListener("phx:page-loading-stop", (_info) => {
+window.addEventListener("phx:page-loading-stop", (info) => {
   topbar.hide();
-  window.scrollTo(0, 0);
+  maybeScrollToTopForNavigation(info.detail);
   closeMobileSidebar();
   initDocsSearch();
 });


### PR DESCRIPTION
## Summary
- preserve native browser anchor scrolling for docs URLs that include a hash
- keep the existing LiveView scroll-to-top behavior for docs page navigations without a hash
- use LiveView's `phx:page-loading-stop` metadata instead of unconditional global scroll resets

## Root cause
The docs bundle always called `window.scrollTo(0, 0)` after every LiveView page load. That overrode the browser's normal anchor handling for shared links like `/docs/...#section` and jumped users back to the top of the page.

## Validation
- `mix esbuild docs`
