### PR TITLE
fix(cli): use combined module map to avoid argument list too long errors

### DIFF
--- a/cli/Sources/TuistConstants/Constants.swift
+++ b/cli/Sources/TuistConstants/Constants.swift
@@ -47,6 +47,7 @@ public enum Constants {
         public static let entitlements = "Entitlements"
         public static let privacyManifest = "PrivacyManifests"
         public static let moduleMaps = "ModuleMaps"
+        public static let frameworkSearchPaths = "FrameworkSearchPaths"
         public static let sources = "Sources"
         public static let testPlans = "TestPlans"
         public static let signingKeychain = "signing.keychain"

--- a/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Path
 import PathKit
+import TuistConstants
 import TuistCore
 import TuistLogging
 import TuistSupport
@@ -40,7 +41,7 @@ protocol LinkGenerating {
         path: AbsolutePath,
         sourceRootPath: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) throws
+    ) throws -> [SideEffectDescriptor]
 }
 
 /// When generating build settings like "framework search path", some of the path might be relative to paths
@@ -80,8 +81,8 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
         path: AbsolutePath,
         sourceRootPath: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) throws {
-        try setupSearchAndIncludePaths(
+    ) throws -> [SideEffectDescriptor] {
+        let sideEffects = try setupSearchAndIncludePaths(
             target: target,
             pbxTarget: pbxTarget,
             sourceRootPath: sourceRootPath,
@@ -122,6 +123,8 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
             pbxproj: pbxproj,
             fileElements: fileElements
         )
+
+        return sideEffects
     }
 
     private func setupSearchAndIncludePaths(
@@ -130,8 +133,8 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
         sourceRootPath: AbsolutePath,
         path: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) throws {
-        try setupFrameworkSearchPath(
+    ) throws -> [SideEffectDescriptor] {
+        let sideEffects = try setupFrameworkSearchPath(
             target: target,
             pbxTarget: pbxTarget,
             sourceRootPath: sourceRootPath,
@@ -170,6 +173,8 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
             path: path,
             graphTraverser: graphTraverser
         )
+
+        return sideEffects
     }
 
     func generatePackages(
@@ -293,13 +298,15 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
         pbxTarget.buildPhases.append(embedPhase)
     }
 
+    private static let frameworkSearchPathConsolidationThreshold = 20
+
     func setupFrameworkSearchPath(
         target: Target,
         pbxTarget: PBXTarget,
         sourceRootPath: AbsolutePath,
         path: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) throws {
+    ) throws -> [SideEffectDescriptor] {
         let linkableModules = try graphTraverser.searchablePathDependencies(path: path, name: target.name).sorted()
 
         let precompiledPaths = linkableModules.compactMap(\.precompiledPath)
@@ -312,13 +319,80 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
             }
         }
 
-        let uniquePaths = Array(Set(precompiledPaths + sdkPaths))
+        let uniquePrecompiledPaths = Array(Set(precompiledPaths))
+        let uniqueSdkPaths = Array(Set(sdkPaths))
+
+        guard uniquePrecompiledPaths.count >= Self.frameworkSearchPathConsolidationThreshold else {
+            let uniquePaths = Array(Set(precompiledPaths + sdkPaths))
+            try setup(
+                setting: "FRAMEWORK_SEARCH_PATHS",
+                paths: uniquePaths,
+                pbxTarget: pbxTarget,
+                sourceRootPath: sourceRootPath
+            )
+            return []
+        }
+
+        // Write precompiled framework search paths to a response file.
+        // Clang and ld support @file syntax to read flags from a file,
+        // bypassing the ARG_MAX command-line limit that C/ObjC compilation hits.
+        let responseFilePath = sourceRootPath
+            .appending(
+                components: Constants.DerivedDirectory.name,
+                Constants.DerivedDirectory.frameworkSearchPaths,
+                "\(target.name).resp"
+            )
+
+        let precompiledXcodeValues = uniquePrecompiledPaths
+            .map { $0.xcodeValue(sourceRootPath: sourceRootPath) }
+            .uniqued()
+            .sorted()
+
+        // Response file must contain absolute paths since clang doesn't expand
+        // build setting variables. Convert $(SRCROOT)/... to absolute paths.
+        let responseFileContent = precompiledXcodeValues
+            .map { "-F" + $0.replacingOccurrences(of: "$(SRCROOT)", with: sourceRootPath.pathString) }
+            .joined(separator: "\n")
+            + "\n"
+
+        let sideEffect = SideEffectDescriptor.file(FileDescriptor(
+            path: responseFilePath,
+            contents: Data(responseFileContent.utf8)
+        ))
+
+        // FRAMEWORK_SEARCH_PATHS: only SDK paths (short, no ARG_MAX risk)
         try setup(
             setting: "FRAMEWORK_SEARCH_PATHS",
-            paths: uniquePaths,
+            paths: uniqueSdkPaths,
             pbxTarget: pbxTarget,
             sourceRootPath: sourceRootPath
         )
+
+        let responseFileRef = "@$(SRCROOT)/\(responseFilePath.relative(to: sourceRootPath))"
+
+        // OTHER_CFLAGS: add @response_file so clang reads -F flags from file
+        try setup(
+            setting: "OTHER_CFLAGS",
+            values: [responseFileRef],
+            pbxTarget: pbxTarget
+        )
+
+        // OTHER_SWIFT_FLAGS: add -Xcc @response_file so Swift's clang invocations
+        // also pick up the framework search paths
+        try setup(
+            setting: "OTHER_SWIFT_FLAGS",
+            values: ["-Xcc", responseFileRef],
+            pbxTarget: pbxTarget
+        )
+
+        // OTHER_LDFLAGS: add @response_file so the linker finds the frameworks
+        try setup(
+            setting: "OTHER_LDFLAGS",
+            values: [responseFileRef],
+            pbxTarget: pbxTarget
+        )
+
+        return [sideEffect]
     }
 
     func setupHeadersSearchPath(
@@ -427,6 +501,22 @@ struct LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_lengt
         }
         let value = SettingValue
             .array(["$(inherited)"] + paths.map { $0.xcodeValue(sourceRootPath: sourceRootPath) }.uniqued().sorted())
+        let newSetting = [name: value]
+        let helper = SettingsHelper()
+        for configuration in configurationList.buildConfigurations {
+            try helper.extend(buildSettings: &configuration.buildSettings, with: newSetting)
+        }
+    }
+
+    private func setup(
+        setting name: String,
+        values: [String],
+        pbxTarget: PBXTarget
+    ) throws {
+        guard let configurationList = pbxTarget.buildConfigurationList else {
+            throw LinkGeneratorError.missingConfigurationList(targetName: pbxTarget.name)
+        }
+        let value = SettingValue.array(["$(inherited)"] + values)
         let newSetting = [name: value]
         let helper = SettingsHelper()
         for configuration in configurationList.buildConfigurations {

--- a/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -139,7 +139,7 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         )
 
         Logger.current.debug("Generating targets for project \(project.name)")
-        let nativeTargets = try await generateTargets(
+        let (nativeTargets, targetSideEffects) = try await generateTargets(
             project: project,
             pbxproj: pbxproj,
             pbxProject: pbxProject,
@@ -170,7 +170,7 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         )
 
         Logger.current.debug("Generating project schemes for project \(project.name)")
-        let (schemes, sideEffects) = try schemeDescriptorsGenerator.generateProjectSchemes(
+        let (schemes, schemeSideEffects) = try schemeDescriptorsGenerator.generateProjectSchemes(
             project: project,
             generatedProject: generatedProject,
             graphTraverser: graphTraverser
@@ -186,7 +186,7 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             xcodeprojPath: project.xcodeProjPath,
             xcodeProj: xcodeProj,
             schemeDescriptors: schemes,
-            sideEffectDescriptors: sideEffects
+            sideEffectDescriptors: targetSideEffects + schemeSideEffects
         )
     }
 
@@ -231,13 +231,14 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         pbxProject: PBXProject,
         fileElements: ProjectFileElements,
         graphTraverser: GraphTraversing
-    ) async throws -> [String: PBXTarget] {
+    ) async throws -> (nativeTargets: [String: PBXTarget], sideEffects: [SideEffectDescriptor]) {
         var nativeTargets: [String: PBXTarget] = [:]
+        var sideEffects: [SideEffectDescriptor] = []
         let sortedTargets = project.targets.values.sorted()
         Logger.current.debug("Generating \(sortedTargets.count) targets for project \(project.name)")
         for target in sortedTargets {
             Logger.current.debug("Generating target \(target.name) in project \(project.name)")
-            let nativeTarget = try await targetGenerator.generateTarget(
+            let (nativeTarget, targetSideEffects) = try await targetGenerator.generateTarget(
                 target: target,
                 project: project,
                 pbxproj: pbxproj,
@@ -248,6 +249,7 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
                 graphTraverser: graphTraverser
             )
             nativeTargets[target.name] = nativeTarget
+            sideEffects.append(contentsOf: targetSideEffects)
             Logger.current.debug("Finished generating target \(target.name) in project \(project.name)")
         }
 
@@ -260,7 +262,7 @@ struct ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             graphTraverser: graphTraverser
         )
         Logger.current.debug("Finished generating target dependencies for project \(project.name)")
-        return nativeTargets
+        return (nativeTargets, sideEffects)
     }
 
     private func generateTestTargetIdentity(

--- a/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -17,7 +17,7 @@ protocol TargetGenerating {
         fileElements: ProjectFileElements,
         path: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) async throws -> PBXTarget
+    ) async throws -> (PBXTarget, [SideEffectDescriptor])
 
     func generateTargetDependencies(
         path: AbsolutePath,
@@ -64,7 +64,7 @@ struct TargetGenerator: TargetGenerating {
         fileElements: ProjectFileElements,
         path: AbsolutePath,
         graphTraverser: GraphTraversing
-    ) async throws -> PBXTarget {
+    ) async throws -> (PBXTarget, [SideEffectDescriptor]) {
         Logger.current.debug("TargetGenerator: Starting generation for target \(target.name)")
 
         let pbxTarget: PBXTarget
@@ -135,7 +135,7 @@ struct TargetGenerator: TargetGenerating {
 
         // Links
         Logger.current.debug("TargetGenerator: Generating links for \(target.name)")
-        try linkGenerator.generateLinks(
+        let linkSideEffects = try linkGenerator.generateLinks(
             target: target,
             pbxTarget: pbxTarget,
             pbxproj: pbxproj,
@@ -162,7 +162,7 @@ struct TargetGenerator: TargetGenerating {
         )
 
         Logger.current.debug("TargetGenerator: Finished generation for target \(target.name)")
-        return pbxTarget
+        return (pbxTarget, linkSideEffects)
     }
 
     private func generateSynchronizedGroups(

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -9,6 +9,10 @@ import XcodeGraph
 /// Mapper that maps the `MODULE_MAP` build setting to the `-fmodule-map-file` compiler flags.
 /// It is required to avoid embedding the module map into the frameworks during cache operations, which would make the framework
 /// not portable, as the modulemap could contain absolute paths.
+///
+/// To avoid "Argument list too long" errors for targets with many transitive dependencies, this mapper generates a single
+/// combined module map file per target using `extern module` declarations, rather than adding individual
+/// `-fmodule-map-file` flags for each dependency.
 public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_body_length
     private static let modulemapFileSetting = "MODULEMAP_FILE"
     private static let otherCFlagsSetting = "OTHER_CFLAGS"
@@ -21,6 +25,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     }
 
     private struct DependencyMetadata: Hashable {
+        let moduleName: String
         let moduleMapPath: AbsolutePath?
         let headerSearchPaths: [String]
     }
@@ -45,6 +50,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         }
 
         var graph = graph
+        var sideEffects: [SideEffectDescriptor] = []
 
         graph.projects = Dictionary(uniqueKeysWithValues: graph.projects.map { projectPath, project in
             var project = project
@@ -61,12 +67,28 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                     mappedSettingsDictionary[Self.modulemapFileSetting] = nil
                 }
 
+                let combinedModuleMap = Self.combinedModuleMapContent(
+                    targetID: targetID,
+                    project: project,
+                    targetToDependenciesMetadata: targetToDependenciesMetadata
+                )
+
+                if let combinedModuleMap {
+                    sideEffects.append(
+                        .file(FileDescriptor(
+                            path: combinedModuleMap.path,
+                            contents: combinedModuleMap.content
+                        ))
+                    )
+                }
+
                 mappedSettingsDictionary = applyModuleMapFlags(
                     to: mappedSettingsDictionary,
                     targetID: targetID,
                     targetToDependenciesMetadata: targetToDependenciesMetadata,
                     dependenciesDerivedDirectory: derivedDirectory,
-                    xcodeProjParent: project.xcodeProjPath.parentDirectory
+                    xcodeProjParent: project.xcodeProjPath.parentDirectory,
+                    combinedModuleMapPath: combinedModuleMap?.path
                 )
 
                 let targetSettings = target.settings ?? Settings(
@@ -83,6 +105,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
                             targetToDependenciesMetadata: targetToDependenciesMetadata,
                             dependenciesDerivedDirectory: derivedDirectory,
                             xcodeProjParent: project.xcodeProjPath.parentDirectory,
+                            combinedModuleMapPath: combinedModuleMap?.path,
                             onlyExistingKeys: true
                         )
                         return (
@@ -106,7 +129,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
             return (projectPath, project)
         })
-        return (graph, [], environment)
+        return (graph, sideEffects, environment)
     } // swiftlint:enable function_body_length
 
     /// The `tuist-derived/` directory for an external SPM-generated project, or `nil` for local projects.
@@ -217,6 +240,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
 
             dependenciesMetadata.insert(
                 DependencyMetadata(
+                    moduleName: dependency.target.productName,
                     moduleMapPath: dependencyModuleMapPath,
                     headerSearchPaths: headerSearchPaths
                 )
@@ -238,6 +262,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         targetToDependenciesMetadata: [TargetID: Set<DependencyMetadata>],
         dependenciesDerivedDirectory: AbsolutePath?,
         xcodeProjParent: AbsolutePath,
+        combinedModuleMapPath: AbsolutePath?,
         onlyExistingKeys: Bool = false
     ) -> SettingsDictionary {
         var settings = settings
@@ -246,9 +271,9 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
            let updated = Self.updatedOtherSwiftFlags(
                targetID: targetID,
                oldOtherSwiftFlags: settings[Self.otherSwiftFlagsSetting],
-               targetToDependenciesMetadata: targetToDependenciesMetadata,
                dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-               xcodeProjParent: xcodeProjParent
+               xcodeProjParent: xcodeProjParent,
+               combinedModuleMapPath: combinedModuleMapPath
            )
         {
             settings[Self.otherSwiftFlagsSetting] = updated
@@ -258,9 +283,9 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
            let updated = Self.updatedOtherCFlags(
                targetID: targetID,
                oldOtherCFlags: settings[Self.otherCFlagsSetting],
-               targetToDependenciesMetadata: targetToDependenciesMetadata,
                dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-               xcodeProjParent: xcodeProjParent
+               xcodeProjParent: xcodeProjParent,
+               combinedModuleMapPath: combinedModuleMapPath
            )
         {
             settings[Self.otherCFlagsSetting] = updated
@@ -318,16 +343,52 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
         return .array(mappedHeaderSearchPaths)
     }
 
+    private static func combinedModuleMapContent(
+        targetID: TargetID,
+        project: Project,
+        targetToDependenciesMetadata: [TargetID: Set<DependencyMetadata>]
+    ) -> (path: AbsolutePath, content: Data)? {
+        guard let dependenciesMetadata = targetToDependenciesMetadata[targetID] else { return nil }
+
+        let moduleMapsMetadata = dependenciesMetadata
+            .filter { $0.moduleMapPath != nil }
+            .sorted { $0.moduleName < $1.moduleName }
+
+        guard !moduleMapsMetadata.isEmpty else { return nil }
+
+        let content = moduleMapsMetadata
+            .map { "extern module \($0.moduleName) \"\($0.moduleMapPath!.pathString)\"" }
+            .joined(separator: "\n")
+            + "\n"
+
+        let combinedPath: AbsolutePath
+        if case .external = project.type,
+           let scratch = project.swiftPackageManagerScratchDirectory
+        {
+            combinedPath = scratch.appending(
+                components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                Constants.DerivedDirectory.dependenciesModuleMapsDirectory,
+                "\(targetID.targetName)-deps.modulemap"
+            )
+        } else {
+            combinedPath = targetID.projectPath.appending(
+                components: Constants.DerivedDirectory.name,
+                Constants.DerivedDirectory.moduleMaps,
+                "\(targetID.targetName)-deps.modulemap"
+            )
+        }
+
+        return (path: combinedPath, content: Data(content.utf8))
+    }
+
     private static func updatedOtherSwiftFlags(
         targetID: TargetID,
         oldOtherSwiftFlags: SettingsDictionary.Value?,
-        targetToDependenciesMetadata: [TargetID: Set<DependencyMetadata>],
         dependenciesDerivedDirectory: AbsolutePath?,
-        xcodeProjParent: AbsolutePath
+        xcodeProjParent: AbsolutePath,
+        combinedModuleMapPath: AbsolutePath?
     ) -> SettingsDictionary.Value? {
-        guard let dependenciesModuleMaps = targetToDependenciesMetadata[targetID]?.compactMap(\.moduleMapPath),
-              !dependenciesModuleMaps.isEmpty
-        else { return nil }
+        guard let combinedModuleMapPath else { return nil }
 
         var mappedOtherSwiftFlags: [String]
         switch oldOtherSwiftFlags ?? .array(["$(inherited)"]) {
@@ -337,18 +398,16 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             mappedOtherSwiftFlags = value.split(separator: " ").map(String.init)
         }
 
-        for moduleMap in dependenciesModuleMaps.sorted() {
-            let reference = referenceString(
-                for: moduleMap,
-                relativeTo: targetID.projectPath,
-                dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-                xcodeProjParent: xcodeProjParent
-            )
-            mappedOtherSwiftFlags.append(contentsOf: [
-                "-Xcc",
-                "-fmodule-map-file=\(reference)",
-            ])
-        }
+        let reference = referenceString(
+            for: combinedModuleMapPath,
+            relativeTo: targetID.projectPath,
+            dependenciesDerivedDirectory: dependenciesDerivedDirectory,
+            xcodeProjParent: xcodeProjParent
+        )
+        mappedOtherSwiftFlags.append(contentsOf: [
+            "-Xcc",
+            "-fmodule-map-file=\(reference)",
+        ])
 
         return .array(mappedOtherSwiftFlags)
     }
@@ -356,13 +415,11 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
     private static func updatedOtherCFlags(
         targetID: TargetID,
         oldOtherCFlags: SettingsDictionary.Value?,
-        targetToDependenciesMetadata: [TargetID: Set<DependencyMetadata>],
         dependenciesDerivedDirectory: AbsolutePath?,
-        xcodeProjParent: AbsolutePath
+        xcodeProjParent: AbsolutePath,
+        combinedModuleMapPath: AbsolutePath?
     ) -> SettingsDictionary.Value? {
-        guard let dependenciesModuleMaps = targetToDependenciesMetadata[targetID]?.compactMap(\.moduleMapPath),
-              !dependenciesModuleMaps.isEmpty
-        else { return nil }
+        guard let combinedModuleMapPath else { return nil }
 
         var mappedOtherCFlags: [String]
         switch oldOtherCFlags ?? .array(["$(inherited)"]) {
@@ -372,15 +429,15 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             mappedOtherCFlags = value.split(separator: " ").map(String.init)
         }
 
-        for moduleMap in dependenciesModuleMaps.sorted() {
-            let reference = referenceString(
-                for: moduleMap,
-                relativeTo: targetID.projectPath,
-                dependenciesDerivedDirectory: dependenciesDerivedDirectory,
-                xcodeProjParent: xcodeProjParent
-            )
-            mappedOtherCFlags.append("-fmodule-map-file=\(reference)")
-        }
+        let reference = referenceString(
+            for: combinedModuleMapPath,
+            relativeTo: targetID.projectPath,
+            dependenciesDerivedDirectory: dependenciesDerivedDirectory,
+            xcodeProjParent: xcodeProjParent
+        )
+        mappedOtherCFlags.append(
+            "-fmodule-map-file=\(reference)"
+        )
 
         return .array(mappedOtherCFlags)
     }

--- a/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -368,6 +368,7 @@ public struct ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_bod
             combinedPath = scratch.appending(
                 components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
                 Constants.DerivedDirectory.dependenciesModuleMapsDirectory,
+                project.name.sanitizedModuleName,
                 "\(targetID.targetName)-deps.modulemap"
             )
         } else {

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1832,7 +1832,7 @@ struct BuildPhaseGeneratorTests {
         )
 
         // When
-        let pbxTarget = try await TargetGenerator().generateTarget(
+        let (pbxTarget, _) = try await TargetGenerator().generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -1916,7 +1916,7 @@ struct BuildPhaseGeneratorTests {
         )
 
         // When
-        let pbxTarget = try await TargetGenerator().generateTarget(
+        let (pbxTarget, _) = try await TargetGenerator().generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -1989,7 +1989,7 @@ struct BuildPhaseGeneratorTests {
         )
 
         // When
-        let pbxTarget = try await TargetGenerator().generateTarget(
+        let (pbxTarget, _) = try await TargetGenerator().generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,

--- a/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -396,7 +396,7 @@ final class LinkGeneratorTests: XCTestCase {
             .willReturn(dependencies)
 
         // When
-        try subject.generateLinks(
+        _ = try subject.generateLinks(
             target: target,
             pbxTarget: pbxTarget,
             pbxproj: pbxproj,
@@ -560,7 +560,7 @@ final class LinkGeneratorTests: XCTestCase {
             .searchablePathDependencies(path: .any, name: .any)
             .willReturn(Set(dependencies))
         // When
-        try subject.setupFrameworkSearchPath(
+        let sideEffects = try subject.setupFrameworkSearchPath(
             target: target,
             pbxTarget: xcodeprojElements.pbxTarget,
             sourceRootPath: sourceRootPath,
@@ -569,6 +569,7 @@ final class LinkGeneratorTests: XCTestCase {
         )
 
         // Then
+        XCTAssertTrue(sideEffects.isEmpty)
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["FRAMEWORK_SEARCH_PATHS"]?.arrayValue, [
             "$(inherited)",
@@ -578,6 +579,82 @@ final class LinkGeneratorTests: XCTestCase {
             "$(SRCROOT)/Dependencies/Libraries",
             "$(SRCROOT)/Dependencies/XCFrameworks",
         ])
+    }
+
+    func test_setupFrameworkSearchPath_consolidatesIntoResponseFile_whenManyPrecompiledPaths() throws {
+        // Given
+        var dependencies: [GraphDependencyReference] = []
+        for i in 0 ..< 25 {
+            dependencies.append(
+                GraphDependencyReference.testXCFramework(
+                    path: try AbsolutePath(validating: "/path/cache/hash\(i)/Module\(i).xcframework")
+                )
+            )
+        }
+        dependencies.append(
+            GraphDependencyReference.testSDK(path: "/XCTest.framework", source: .developer)
+        )
+
+        let sourceRootPath = try AbsolutePath(validating: "/path")
+        let xcodeprojElements = createXcodeprojElements()
+        let target = Target.test(name: "MyTarget")
+        let path = try AbsolutePath(validating: "/path/")
+        let graphTraverser = MockGraphTraversing()
+        given(graphTraverser)
+            .searchablePathDependencies(path: .any, name: .any)
+            .willReturn(Set(dependencies))
+
+        // When
+        let sideEffects = try subject.setupFrameworkSearchPath(
+            target: target,
+            pbxTarget: xcodeprojElements.pbxTarget,
+            sourceRootPath: sourceRootPath,
+            path: path,
+            graphTraverser: graphTraverser
+        )
+
+        // Then
+
+        // Should produce a response file side effect
+        XCTAssertEqual(sideEffects.count, 1)
+        guard case let .file(fileDescriptor) = sideEffects.first else {
+            XCTFail("Expected file side effect")
+            return
+        }
+        XCTAssertTrue(fileDescriptor.path.pathString.hasSuffix("Derived/FrameworkSearchPaths/MyTarget.resp"))
+
+        // Response file should contain -F flags with absolute paths
+        let responseContent = String(data: fileDescriptor.contents!, encoding: .utf8)!
+        for i in 0 ..< 25 {
+            XCTAssertTrue(
+                responseContent.contains("-F/path/cache/hash\(i)"),
+                "Response file should contain -F flag for hash\(i)"
+            )
+        }
+
+        // FRAMEWORK_SEARCH_PATHS should only contain SDK paths (no precompiled)
+        let config = xcodeprojElements.config
+        let frameworkSearchPaths = config.buildSettings["FRAMEWORK_SEARCH_PATHS"]?.arrayValue ?? []
+        XCTAssertTrue(frameworkSearchPaths.contains("$(inherited)"))
+        XCTAssertTrue(frameworkSearchPaths.contains("$(PLATFORM_DIR)/Developer/Library/Frameworks"))
+        for i in 0 ..< 25 {
+            XCTAssertFalse(
+                frameworkSearchPaths.contains { $0.contains("hash\(i)") },
+                "FRAMEWORK_SEARCH_PATHS should not contain precompiled path hash\(i)"
+            )
+        }
+
+        // OTHER_CFLAGS should reference the response file
+        let otherCFlags = config.buildSettings["OTHER_CFLAGS"]?.arrayValue ?? []
+        XCTAssertTrue(otherCFlags.contains { $0.contains("@$(SRCROOT)/Derived/FrameworkSearchPaths/MyTarget.resp") })
+
+        // OTHER_SWIFT_FLAGS should reference the response file
+        let otherSwiftFlags = config.buildSettings["OTHER_SWIFT_FLAGS"]?.arrayValue ?? []
+        XCTAssertTrue(otherSwiftFlags.contains { $0.contains("@$(SRCROOT)/Derived/FrameworkSearchPaths/MyTarget.resp") })
+
+        // OTHER_LDFLAGS should reference the response file
+        let otherLDFlags = config.buildSettings["OTHER_LDFLAGS"]?.arrayValue ?? []
+        XCTAssertTrue(otherLDFlags.contains { $0.contains("@$(SRCROOT)/Derived/FrameworkSearchPaths/MyTarget.resp") })
     }
 
     func test_setupHeadersSearchPath() throws {

--- a/cli/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -18,8 +18,8 @@ class MockTargetGenerator: TargetGenerating {
         fileElements _: ProjectFileElements,
         path _: AbsolutePath,
         graphTraverser _: GraphTraversing
-    ) async throws -> PBXTarget {
-        generateTargetStub?() ?? PBXNativeTarget(name: target.name)
+    ) async throws -> (PBXTarget, [SideEffectDescriptor]) {
+        (generateTargetStub?() ?? PBXNativeTarget(name: target.name), [])
     }
 
     func generateTargetDependencies(

--- a/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -77,7 +77,7 @@ struct TargetGeneratorTests {
         )
 
         // When
-        let generatedTarget = try await subject.generateTarget(
+        let (generatedTarget, _) = try await subject.generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -145,7 +145,7 @@ struct TargetGeneratorTests {
         )
 
         // When
-        let generatedTarget = try await subject.generateTarget(
+        let (generatedTarget, _) = try await subject.generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -216,7 +216,7 @@ struct TargetGeneratorTests {
         )
 
         // When
-        let generatedTarget = try await subject.generateTarget(
+        let (generatedTarget, _) = try await subject.generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -274,7 +274,7 @@ struct TargetGeneratorTests {
         )
 
         // When
-        let generatedTarget = try await subject.generateTarget(
+        let (generatedTarget, _) = try await subject.generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,
@@ -395,7 +395,7 @@ struct TargetGeneratorTests {
         )
 
         // When
-        let pbxTarget = try await subject.generateTarget(
+        let (pbxTarget, _) = try await subject.generateTarget(
             target: target,
             project: project,
             pbxproj: pbxproj,

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -1,3 +1,4 @@
+import Path
 import TuistCore
 import TuistGenerator
 import XcodeGraph
@@ -90,20 +91,20 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Then
+        let combinedModuleMapPathA = projectAPath.appending(components: "Derived", "ModuleMaps", "A-deps.modulemap")
+        let combinedModuleMapPathB1 = projectBPath.appending(components: "Derived", "ModuleMaps", "B1-deps.modulemap")
+
         let mappedTargetA = Target.test(
             name: "A",
             settings: .test(base: [
                 "OTHER_CFLAGS": .array([
                     "Other",
-                    "-fmodule-map-file=$(SRCROOT)/../B/B1/B1.module",
-                    "-fmodule-map-file=$(SRCROOT)/../B/B2/B2.module",
+                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
                 ]),
                 "OTHER_SWIFT_FLAGS": .array([
                     "Other",
                     "-Xcc",
-                    "-fmodule-map-file=$(SRCROOT)/../B/B1/B1.module",
-                    "-Xcc",
-                    "-fmodule-map-file=$(SRCROOT)/../B/B2/B2.module",
+                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
                 ]),
                 "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B1/include", "$(SRCROOT)/../B/B2/include"]),
             ]),
@@ -122,8 +123,15 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         let mappedTargetB1 = Target.test(
             name: "B1",
             settings: .test(base: [
-                "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
-                "OTHER_SWIFT_FLAGS": .array(["$(inherited)", "-Xcc", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
+                "OTHER_CFLAGS": .array([
+                    "$(inherited)",
+                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap",
+                ]),
+                "OTHER_SWIFT_FLAGS": .array([
+                    "$(inherited)",
+                    "-Xcc",
+                    "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/B1-deps.modulemap",
+                ]),
                 "HEADER_SEARCH_PATHS": .array(["$(SRCROOT)/B1/include", "$(SRCROOT)/B2/include"]),
             ]),
             dependencies: [
@@ -165,7 +173,41 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             ),
             gotGraph
         )
-        XCTAssertEqual(gotSideEffects, [])
+
+        // Verify side effects: combined module map files for A and B1
+        let sideEffectPaths = gotSideEffects.compactMap { sideEffect -> AbsolutePath? in
+            if case let .file(descriptor) = sideEffect { return descriptor.path }
+            return nil
+        }.sorted()
+        XCTAssertEqual(sideEffectPaths, [combinedModuleMapPathA, combinedModuleMapPathB1].sorted())
+
+        // Verify combined module map content for target A (has B1 and B2 module maps)
+        let sideEffectA = gotSideEffects.first { sideEffect in
+            if case let .file(descriptor) = sideEffect { return descriptor.path == combinedModuleMapPathA }
+            return false
+        }
+        if case let .file(descriptorA) = sideEffectA {
+            let contentA = String(data: descriptorA.contents!, encoding: .utf8)!
+            let b1ModuleMapPath = projectBPath.appending(components: "B1", "B1.module").pathString
+            let b2ModuleMapPath = projectBPath.appending(components: "B2", "B2.module").pathString
+            XCTAssertTrue(contentA.contains("extern module B1 \"\(b1ModuleMapPath)\""))
+            XCTAssertTrue(contentA.contains("extern module B2 \"\(b2ModuleMapPath)\""))
+        } else {
+            XCTFail("Expected file side effect for target A combined module map")
+        }
+
+        // Verify combined module map content for target B1 (has only B2 module map)
+        let sideEffectB1 = gotSideEffects.first { sideEffect in
+            if case let .file(descriptor) = sideEffect { return descriptor.path == combinedModuleMapPathB1 }
+            return false
+        }
+        if case let .file(descriptorB1) = sideEffectB1 {
+            let contentB1 = String(data: descriptorB1.contents!, encoding: .utf8)!
+            let b2ModuleMapPath = projectBPath.appending(components: "B2", "B2.module").pathString
+            XCTAssertEqual(contentB1, "extern module B2 \"\(b2ModuleMapPath)\"\n")
+        } else {
+            XCTFail("Expected file side effect for target B1 combined module map")
+        }
     }
 
     func test_maps_modulemap_build_flag_to_target_with_empty_settings() throws {
@@ -222,18 +264,20 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Then
+        let combinedModuleMapPath = projectAPath.appending(components: "Derived", "ModuleMaps", "A-deps.modulemap")
+
         let mappedTargetA = Target.test(
             name: "A",
             settings: Settings(
                 base: [
                     "OTHER_CFLAGS": .array([
                         "$(inherited)",
-                        "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                        "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
                     ]),
                     "OTHER_SWIFT_FLAGS": .array([
                         "$(inherited)",
                         "-Xcc",
-                        "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                        "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
                     ]),
                     "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B/include"]),
                 ],
@@ -283,7 +327,17 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             ),
             gotGraph
         )
-        XCTAssertEqual(gotSideEffects, [])
+
+        // Verify side effect: combined module map for A
+        XCTAssertEqual(gotSideEffects.count, 1)
+        if case let .file(descriptor) = gotSideEffects.first {
+            XCTAssertEqual(descriptor.path, combinedModuleMapPath)
+            let content = String(data: descriptor.contents!, encoding: .utf8)!
+            let bModuleMapPath = projectBPath.appending(components: "B", "B.module").pathString
+            XCTAssertEqual(content, "extern module B \"\(bModuleMapPath)\"\n")
+        } else {
+            XCTFail("Expected file side effect for combined module map")
+        }
     }
 
     func test_maps_modulemap_flags_to_configurations_that_override_other_swift_flags() throws {
@@ -359,24 +413,24 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         // Then
         let gotTargetA = try XCTUnwrap(gotGraph.projects[projectAPath]?.targets["A"])
 
-        // Base settings should have the module map flags
+        // Base settings should have the combined module map flag
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_SWIFT_FLAGS"],
             .array([
                 "Other",
                 "-Xcc",
-                "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
             ])
         )
 
-        // Debug configuration overrides OTHER_SWIFT_FLAGS and OTHER_CFLAGS, so it should also get the flags
+        // Debug configuration overrides OTHER_SWIFT_FLAGS and OTHER_CFLAGS, so it should also get the flag
         let debugConfiguration = try XCTUnwrap(gotTargetA.settings?.configurations[debugConfig] as? Configuration)
         XCTAssertBetterEqual(
             debugConfiguration.settings["OTHER_SWIFT_FLAGS"],
@@ -386,14 +440,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                 "-D",
                 "FEATURE",
                 "-Xcc",
-                "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
             debugConfiguration.settings["OTHER_CFLAGS"],
             .array([
                 "-DDEBUG",
-                "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
+                "-fmodule-map-file=$(SRCROOT)/Derived/ModuleMaps/A-deps.modulemap",
             ])
         )
 
@@ -404,7 +458,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         XCTAssertNil(releaseConfiguration.settings["OTHER_SWIFT_FLAGS"])
         XCTAssertNil(releaseConfiguration.settings["OTHER_CFLAGS"])
 
-        XCTAssertEqual(gotSideEffects, [])
+        // Verify side effect
+        XCTAssertEqual(gotSideEffects.count, 1)
+        if case let .file(descriptor) = gotSideEffects.first {
+            let combinedModuleMapPath = projectAPath.appending(components: "Derived", "ModuleMaps", "A-deps.modulemap")
+            XCTAssertEqual(descriptor.path, combinedModuleMapPath)
+        } else {
+            XCTFail("Expected file side effect for combined module map")
+        }
     }
 
     func test_external_spm_project_anchors_tuist_derived_paths_on_project_dir() throws {
@@ -482,23 +543,25 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Then — `$(PROJECT_DIR)` for project A resolves to `<scratch>/tuist-derived/Projects/A/`
-        // at build time, so `$(PROJECT_DIR)/../../ModuleMaps/B/B.modulemap` resolves to
-        // `<scratch>/tuist-derived/ModuleMaps/B/B.modulemap` without traversing `<scratch>/checkouts/`.
+        // at build time, so `$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap` resolves to
+        // `<scratch>/tuist-derived/ModuleMaps/A-deps.modulemap` without traversing
+        // `<scratch>/checkouts/`.
         let gotTargetA = try XCTUnwrap(gotGraph.projects[projectAPath]?.targets["A"])
+        let combinedModuleMapPath = derivedRoot.appending(components: "ModuleMaps", "A-deps.modulemap")
 
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_SWIFT_FLAGS"],
             .array([
                 "Other",
                 "-Xcc",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/B/B.modulemap",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/B/B.modulemap",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
@@ -519,6 +582,13 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
             "module-map paths under tuist-derived must not embed `..` segments through `.build/checkouts`"
         )
 
-        XCTAssertEqual(gotSideEffects, [])
+        XCTAssertEqual(gotSideEffects.count, 1)
+        if case let .file(descriptor) = gotSideEffects.first {
+            XCTAssertEqual(descriptor.path, combinedModuleMapPath)
+            let content = try XCTUnwrap(String(data: try XCTUnwrap(descriptor.contents), encoding: .utf8))
+            XCTAssertEqual(content, "extern module B \"\(moduleMapPath.pathString)\"\n")
+        } else {
+            XCTFail("Expected file side effect for combined module map")
+        }
     }
 }

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -533,25 +533,26 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Then — `$(PROJECT_DIR)` for project A resolves to `<scratch>/tuist-derived/Projects/A/`
-        // at build time, so `$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap` resolves to
-        // `<scratch>/tuist-derived/ModuleMaps/A-deps.modulemap` without traversing
-        // `<scratch>/checkouts/`.
+        // at build time, so `$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap` resolves to
+        // `<scratch>/tuist-derived/ModuleMaps/A/A-deps.modulemap` without traversing
+        // `<scratch>/checkouts/`. The project-name namespace keeps same-named targets in
+        // different SwiftPM packages from clobbering each other's combined module maps.
         let gotTargetA = try XCTUnwrap(gotGraph.projects[projectAPath]?.targets["A"])
-        let combinedModuleMapPath = derivedRoot.appending(components: "ModuleMaps", "A-deps.modulemap")
+        let combinedModuleMapPath = derivedRoot.appending(components: "ModuleMaps", "A", "A-deps.modulemap")
 
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_SWIFT_FLAGS"],
             .array([
                 "Other",
                 "-Xcc",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
             gotTargetA.settings?.base["OTHER_CFLAGS"],
             .array([
                 "Other",
-                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A-deps.modulemap",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/A/A-deps.modulemap",
             ])
         )
         XCTAssertBetterEqual(
@@ -580,5 +581,147 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         } else {
             XCTFail("Expected file side effect for combined module map")
         }
+    }
+
+    func test_external_spm_projects_with_same_target_name_use_distinct_combined_module_maps() throws {
+        let workspace = Workspace.test()
+        let scratch = try temporaryPath().appending(component: ".build")
+        let derivedRoot = scratch.appending(component: "tuist-derived")
+
+        let packageAPath = scratch.appending(components: "checkouts", "PackageA")
+        let packageAXcodeProj = scratch.appending(components: "tuist-derived", "Projects", "PackageA", "PackageA.xcodeproj")
+        let depAPath = scratch.appending(components: "checkouts", "DepA")
+        let depAXcodeProj = scratch.appending(components: "tuist-derived", "Projects", "DepA", "DepA.xcodeproj")
+        let depAModuleMapPath = derivedRoot.appending(components: "ModuleMaps", "DepA", "DepA.modulemap")
+        let depAHeaderSearchPath = derivedRoot.appending(components: "ModuleMaps", "DepA")
+
+        let packageBPath = scratch.appending(components: "checkouts", "PackageB")
+        let packageBXcodeProj = scratch.appending(components: "tuist-derived", "Projects", "PackageB", "PackageB.xcodeproj")
+        let depBPath = scratch.appending(components: "checkouts", "DepB")
+        let depBXcodeProj = scratch.appending(components: "tuist-derived", "Projects", "DepB", "DepB.xcodeproj")
+        let depBModuleMapPath = derivedRoot.appending(components: "ModuleMaps", "DepB", "DepB.modulemap")
+        let depBHeaderSearchPath = derivedRoot.appending(components: "ModuleMaps", "DepB")
+
+        let coreA = Target.test(
+            name: "Core",
+            settings: .test(base: [
+                "OTHER_SWIFT_FLAGS": "Other",
+                "OTHER_CFLAGS": ["Other"],
+            ]),
+            dependencies: [
+                .project(target: "DepA", path: depAPath),
+            ]
+        )
+        let packageA = Project.test(
+            path: packageAPath,
+            xcodeProjPath: packageAXcodeProj,
+            name: "PackageA",
+            targets: [coreA],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratch
+        )
+        let depA = Project.test(
+            path: depAPath,
+            xcodeProjPath: depAXcodeProj,
+            name: "DepA",
+            targets: [
+                Target.test(
+                    name: "DepA",
+                    settings: .test(base: [
+                        "MODULEMAP_FILE": .string(depAModuleMapPath.pathString),
+                        "HEADER_SEARCH_PATHS": .array([depAHeaderSearchPath.pathString]),
+                    ])
+                ),
+            ],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratch
+        )
+
+        let coreB = Target.test(
+            name: "Core",
+            settings: .test(base: [
+                "OTHER_SWIFT_FLAGS": "Other",
+                "OTHER_CFLAGS": ["Other"],
+            ]),
+            dependencies: [
+                .project(target: "DepB", path: depBPath),
+            ]
+        )
+        let packageB = Project.test(
+            path: packageBPath,
+            xcodeProjPath: packageBXcodeProj,
+            name: "PackageB",
+            targets: [coreB],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratch
+        )
+        let depB = Project.test(
+            path: depBPath,
+            xcodeProjPath: depBXcodeProj,
+            name: "DepB",
+            targets: [
+                Target.test(
+                    name: "DepB",
+                    settings: .test(base: [
+                        "MODULEMAP_FILE": .string(depBModuleMapPath.pathString),
+                        "HEADER_SEARCH_PATHS": .array([depBHeaderSearchPath.pathString]),
+                    ])
+                ),
+            ],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratch
+        )
+
+        let (gotGraph, gotSideEffects, _) = try subject.map(
+            graph: .test(
+                workspace: workspace,
+                projects: [
+                    packageAPath: packageA,
+                    depAPath: depA,
+                    packageBPath: packageB,
+                    depBPath: depB,
+                ],
+                dependencies: [
+                    .target(name: coreA.name, path: packageAPath): [
+                        .target(name: "DepA", path: depAPath),
+                    ],
+                    .target(name: coreB.name, path: packageBPath): [
+                        .target(name: "DepB", path: depBPath),
+                    ],
+                ]
+            ),
+            environment: MapperEnvironment()
+        )
+
+        let gotCoreA = try XCTUnwrap(gotGraph.projects[packageAPath]?.targets["Core"])
+        XCTAssertBetterEqual(
+            gotCoreA.settings?.base["OTHER_CFLAGS"],
+            .array([
+                "Other",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/PackageA/Core-deps.modulemap",
+            ])
+        )
+
+        let gotCoreB = try XCTUnwrap(gotGraph.projects[packageBPath]?.targets["Core"])
+        XCTAssertBetterEqual(
+            gotCoreB.settings?.base["OTHER_CFLAGS"],
+            .array([
+                "Other",
+                "-fmodule-map-file=$(PROJECT_DIR)/../../ModuleMaps/PackageB/Core-deps.modulemap",
+            ])
+        )
+
+        let sideEffectPaths = gotSideEffects.compactMap { sideEffect -> AbsolutePath? in
+            if case let .file(descriptor) = sideEffect { return descriptor.path }
+            return nil
+        }
+
+        XCTAssertEqual(
+            Set(sideEffectPaths),
+            [
+                derivedRoot.appending(components: "ModuleMaps", "PackageA", "Core-deps.modulemap"),
+                derivedRoot.appending(components: "ModuleMaps", "PackageB", "Core-deps.modulemap"),
+            ]
+        )
     }
 }

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -175,39 +175,24 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Verify side effects: combined module map files for A and B1
-        let sideEffectPaths = gotSideEffects.compactMap { sideEffect -> AbsolutePath? in
-            if case let .file(descriptor) = sideEffect { return descriptor.path }
-            return nil
-        }.sorted()
-        XCTAssertEqual(sideEffectPaths, [combinedModuleMapPathA, combinedModuleMapPathB1].sorted())
+        let b1ModuleMapPath = projectBPath.appending(components: "B1", "B1.module").pathString
+        let b2ModuleMapPath = projectBPath.appending(components: "B2", "B2.module").pathString
 
-        // Verify combined module map content for target A (has B1 and B2 module maps)
-        let sideEffectA = gotSideEffects.first { sideEffect in
-            if case let .file(descriptor) = sideEffect { return descriptor.path == combinedModuleMapPathA }
-            return false
-        }
-        if case let .file(descriptorA) = sideEffectA {
-            let contentA = String(data: descriptorA.contents!, encoding: .utf8)!
-            let b1ModuleMapPath = projectBPath.appending(components: "B1", "B1.module").pathString
-            let b2ModuleMapPath = projectBPath.appending(components: "B2", "B2.module").pathString
-            XCTAssertTrue(contentA.contains("extern module B1 \"\(b1ModuleMapPath)\""))
-            XCTAssertTrue(contentA.contains("extern module B2 \"\(b2ModuleMapPath)\""))
-        } else {
-            XCTFail("Expected file side effect for target A combined module map")
-        }
-
-        // Verify combined module map content for target B1 (has only B2 module map)
-        let sideEffectB1 = gotSideEffects.first { sideEffect in
-            if case let .file(descriptor) = sideEffect { return descriptor.path == combinedModuleMapPathB1 }
-            return false
-        }
-        if case let .file(descriptorB1) = sideEffectB1 {
-            let contentB1 = String(data: descriptorB1.contents!, encoding: .utf8)!
-            let b2ModuleMapPath = projectBPath.appending(components: "B2", "B2.module").pathString
-            XCTAssertEqual(contentB1, "extern module B2 \"\(b2ModuleMapPath)\"\n")
-        } else {
-            XCTFail("Expected file side effect for target B1 combined module map")
-        }
+        XCTAssertBetterEqual(
+            gotSideEffects.sorted(by: { $0.description < $1.description }),
+            [
+                .file(FileDescriptor(
+                    path: combinedModuleMapPathA,
+                    contents: Data(
+                        "extern module B1 \"\(b1ModuleMapPath)\"\nextern module B2 \"\(b2ModuleMapPath)\"\n".utf8
+                    )
+                )),
+                .file(FileDescriptor(
+                    path: combinedModuleMapPathB1,
+                    contents: Data("extern module B2 \"\(b2ModuleMapPath)\"\n".utf8)
+                )),
+            ].sorted(by: { $0.description < $1.description })
+        )
     }
 
     func test_maps_modulemap_build_flag_to_target_with_empty_settings() throws {
@@ -329,15 +314,16 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         )
 
         // Verify side effect: combined module map for A
-        XCTAssertEqual(gotSideEffects.count, 1)
-        if case let .file(descriptor) = gotSideEffects.first {
-            XCTAssertEqual(descriptor.path, combinedModuleMapPath)
-            let content = String(data: descriptor.contents!, encoding: .utf8)!
-            let bModuleMapPath = projectBPath.appending(components: "B", "B.module").pathString
-            XCTAssertEqual(content, "extern module B \"\(bModuleMapPath)\"\n")
-        } else {
-            XCTFail("Expected file side effect for combined module map")
-        }
+        let bModuleMapPath = projectBPath.appending(components: "B", "B.module").pathString
+        XCTAssertBetterEqual(
+            gotSideEffects,
+            [
+                .file(FileDescriptor(
+                    path: combinedModuleMapPath,
+                    contents: Data("extern module B \"\(bModuleMapPath)\"\n".utf8)
+                )),
+            ]
+        )
     }
 
     func test_maps_modulemap_flags_to_configurations_that_override_other_swift_flags() throws {
@@ -459,13 +445,17 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
         XCTAssertNil(releaseConfiguration.settings["OTHER_CFLAGS"])
 
         // Verify side effect
-        XCTAssertEqual(gotSideEffects.count, 1)
-        if case let .file(descriptor) = gotSideEffects.first {
-            let combinedModuleMapPath = projectAPath.appending(components: "Derived", "ModuleMaps", "A-deps.modulemap")
-            XCTAssertEqual(descriptor.path, combinedModuleMapPath)
-        } else {
-            XCTFail("Expected file side effect for combined module map")
-        }
+        let combinedModuleMapPath = projectAPath.appending(components: "Derived", "ModuleMaps", "A-deps.modulemap")
+        let bModuleMapPath = projectBPath.appending(components: "B", "B.module").pathString
+        XCTAssertBetterEqual(
+            gotSideEffects,
+            [
+                .file(FileDescriptor(
+                    path: combinedModuleMapPath,
+                    contents: Data("extern module B \"\(bModuleMapPath)\"\n".utf8)
+                )),
+            ]
+        )
     }
 
     func test_external_spm_project_anchors_tuist_derived_paths_on_project_dir() throws {


### PR DESCRIPTION
## Summary

Fixes "Argument list too long" (E2BIG) errors during `tuist cache` and `tuist test` for targets with many transitive dependencies.

There are two sources of argument list bloat, addressed by two commits:

### 1. Combined module map (commit b279d26)

- The `ModuleMapMapper` previously added individual `-fmodule-map-file=<path>` flags for each transitive dependency's module map. For large dependency graphs, this produced 300+ build setting entries in `OTHER_C_FLAGS` and `OTHER_SWIFT_FLAGS`
- Now generates a single combined module map file per target using clang's `extern module` declarations, referenced by one `-fmodule-map-file` flag. Reduces flag count from O(N) to O(1)

### 2. Framework search paths response file (commit d6df2bf)

- When cached targets are replaced with xcframeworks, each xcframework lives in its own hash-based directory (`~/.cache/tuist/Binaries/<hash>/`). The `LinkGenerator` added each as a `FRAMEWORK_SEARCH_PATHS` entry, producing 100+ unique `-F` flags
- Swift compilation handles this fine (uses `.resp` response files), but C/ObjC compilation (e.g. `_vers.c`, `.m` files) receives all flags directly on the command line, exceeding `ARG_MAX`
- When a target has 20+ precompiled framework search paths, they are now written to a `Derived/FrameworkSearchPaths/<TargetName>.resp` file and referenced via `@file` in `OTHER_CFLAGS`, `OTHER_SWIFT_FLAGS`, and `OTHER_LDFLAGS`. Clang and ld natively support `@file` expansion
- Below the threshold, behavior is unchanged

## Test plan

- [x] `ModuleMapMapperTests` pass (3 existing tests updated + side effect assertions)
- [x] `LinkGeneratorTests` pass (33 tests including new `test_setupFrameworkSearchPath_consolidatesIntoResponseFile_whenManyPrecompiledPaths`)
- [x] Full workspace build succeeds (`xcodebuild build -scheme Tuist-Workspace`)

### E2E verification with 800-module fixture

Created a fixture project with 800 framework targets + one "GodModule" that depends on all 800 (with an ObjC source file to trigger C compilation):

1. `tuist cache` to cache all 801 targets as xcframeworks
2. Invalidate GodModule's cache
3. `tuist cache --generate-only` to regenerate with 800 cached xcframework dependencies

**Before fix** (tuist 4.176.4):
- `FRAMEWORK_SEARCH_PATHS` for GodModule: 800 entries pointing to `~/.cache/tuist/Binaries/<hash>`
- All expanded as `-F` flags on the C compiler command line

**After fix**:
- `FRAMEWORK_SEARCH_PATHS`: empty (cache paths removed)
- `OTHER_CFLAGS`: `@$(SRCROOT)/Derived/FrameworkSearchPaths/GodModule.resp`
- Response file: 800 `-F<path>` lines, read by clang via `@file` (bypasses ARG_MAX)
- `xcodebuild build -scheme GodModule` succeeds (including ObjC compilation)

Could not reproduce the actual E2BIG error locally because ARG_MAX is 1MB and local env is ~12KB (vs 200KB+ on CI), but the fix demonstrably moves all framework search paths out of the command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)