### PR TITLE
fix(cli): link test runs to builds and fix command event metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ Examples:
 - Do not add one-line comments unless you think they are really useful.
 
 ## Workflow
-- The Xcode project is generated with Tuist running `tuist generate --no-open`
-- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift build`
+- For faster builds, generate only the required targets: `tuist generate tuist ProjectDescription --no-open`
+- When compiling Swift changes, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift build`
 - When testing Swift changes, use `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing MyTests/SuiteTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` instead of `swift test`.
 - Prefer running test suites or individual test cases, and not the whole test target, for performance
 - When using `swift build`, `swift test`, or `swift package resolve` always include `--replace-scm-with-registry` to avoid switching packages from registry to source control resolution

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -16,6 +16,11 @@ This node covers the Tuist CLI workspace under `cli/`. Follow downlinks for subs
 - `cli/Sources/TuistKit` - Monolithic command wiring; new commands should be added to feature-specific modules.
 - `cli/Sources/TuistGenerator` - Monolithic generation pipeline; new generation logic should be added to smaller, focused modules.
 
+## Building
+- To generate the Xcode project for a faster build, run `tuist generate tuist ProjectDescription --no-open` (generates only the required targets instead of the full workspace).
+- To compile, use `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
+- Prefer the `tuist` scheme over `Tuist-Workspace` for faster iteration.
+
 ## Code Style
 - Do not add one-line comments unless they are truly useful.
 

--- a/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
@@ -144,6 +144,7 @@
                 resultBundlePath: resolvedResultBundlePath,
                 config: config,
                 quarantinedTests: [],
+                buildRunId: nil,
                 shardPlanId: nil,
                 shardIndex: nil
             )

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -160,15 +160,15 @@ public class TrackableCommand {
                     serverURL: serverURL,
                     sessionDirectory: sessionDirectory
                 )
-                if let buildRunURL {
-                    Logger.current
-                        .info(
-                            "Build uploaded for processing. You can view the build report at: \(buildRunURL.absoluteString)"
-                        )
-                } else if let testRunURL = serverCommandEvent.testRunURL {
+                if let testRunURL = serverCommandEvent.testRunURL {
                     Logger.current
                         .info(
                             "You can view a detailed test report at: \(testRunURL.absoluteString)"
+                        )
+                } else if let buildRunURL {
+                    Logger.current
+                        .info(
+                            "Build uploaded for processing. You can view the build report at: \(buildRunURL.absoluteString)"
                         )
                 } else {
                     Logger.current

--- a/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
+++ b/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
@@ -44,6 +44,7 @@ public protocol UploadResultBundleServicing {
         resultBundlePath: AbsolutePath,
         config: Tuist,
         quarantinedTests: [TestIdentifier],
+        buildRunId: String?,
         shardPlanId: String?,
         shardIndex: Int?
     ) async throws -> Components.Schemas.RunsTest
@@ -164,6 +165,7 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
         resultBundlePath: AbsolutePath,
         config: Tuist,
         quarantinedTests: [TestIdentifier] = [],
+        buildRunId: String? = nil,
         shardPlanId: String? = nil,
         shardIndex: Int? = nil
     ) async throws -> Components.Schemas.RunsTest {
@@ -206,7 +208,7 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
                 duration: 0,
                 testModules: []
             ),
-            buildRunId: nil,
+            buildRunId: buildRunId,
             gitBranch: gitInfo.branch,
             gitCommitSHA: gitInfo.sha,
             gitRef: gitInfo.ref,

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -15,6 +15,7 @@ import TuistLogging
 import TuistRootDirectoryLocator
 import TuistServer
 import TuistSupport
+import TuistXCActivityLog
 import TuistXCResultService
 import XcodeGraph
 import XCResultParser
@@ -113,6 +114,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
     private let shardPlanService: ShardPlanServicing
     private let shardMatrixOutputService: ShardMatrixOutputServicing
     private let shardService: ShardServicing
+    private let xcActivityLogController: XCActivityLogControlling
+    private let uploadBuildRunService: UploadBuildRunServicing?
 
     public init(
         generatorFactory: GeneratorFactorying,
@@ -150,7 +153,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testQuarantineService: TestQuarantineServicing = TestQuarantineService(),
         shardPlanService: ShardPlanServicing = ShardPlanService(),
         shardMatrixOutputService: ShardMatrixOutputServicing = ShardMatrixOutputService(),
-        shardService: ShardServicing = ShardService()
+        shardService: ShardServicing = ShardService(),
+        xcActivityLogController: XCActivityLogControlling = XCActivityLogController(),
+        uploadBuildRunService: UploadBuildRunServicing? = UploadBuildRunService()
     ) {
         self.generatorFactory = generatorFactory
         self.cacheStorageFactory = cacheStorageFactory
@@ -175,6 +180,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         self.shardPlanService = shardPlanService
         self.shardMatrixOutputService = shardMatrixOutputService
         self.shardService = shardService
+        self.xcActivityLogController = xcActivityLogController
+        self.uploadBuildRunService = uploadBuildRunService
     }
 
     public static func validateParameters(
@@ -1428,6 +1435,13 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
             )
         } catch {
+            await uploadBuildRunIfNeeded(
+                projectDerivedDataDirectory: projectDerivedDataDirectory,
+                projectPath: graphTraverser.workspace.xcWorkspacePath,
+                config: config,
+                scheme: scheme.name,
+                configuration: configuration
+            )
             let summary = mode == .local
                 ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
                 : nil
@@ -1443,6 +1457,13 @@ public struct TestService { // swiftlint:disable:this type_body_length
             throw error
         }
 
+        await uploadBuildRunIfNeeded(
+            projectDerivedDataDirectory: projectDerivedDataDirectory,
+            projectPath: graphTraverser.workspace.xcWorkspacePath,
+            config: config,
+            scheme: scheme.name,
+            configuration: configuration
+        )
         let summary = mode == .local
             ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: quarantinedTests)
             : nil
@@ -1466,6 +1487,36 @@ public struct TestService { // swiftlint:disable:this type_body_length
               let parsed = try? await xcResultService.parse(path: resultBundlePath, rootDirectory: rootDir)
         else { return nil }
         return testQuarantineService.markQuarantinedTests(testSummary: parsed, quarantinedTests: quarantinedTests)
+    }
+
+    private func uploadBuildRunIfNeeded(
+        projectDerivedDataDirectory: AbsolutePath?,
+        projectPath: AbsolutePath,
+        config: Tuist,
+        scheme: String?,
+        configuration: String?
+    ) async {
+        guard config.fullHandle != nil,
+              let projectDerivedDataDirectory,
+              let mostRecentActivityLogFile = try? await xcActivityLogController.mostRecentActivityLogFile(
+                  projectDerivedDataDirectory: projectDerivedDataDirectory
+              )
+        else { return }
+
+        await RunMetadataStorage.current.update(buildRunId: mostRecentActivityLogFile.path.basenameWithoutExt)
+
+        guard let uploadBuildRunService else { return }
+        do {
+            try await uploadBuildRunService.uploadBuildRun(
+                activityLogPath: mostRecentActivityLogFile.path,
+                projectPath: projectPath,
+                config: config,
+                scheme: scheme,
+                configuration: configuration
+            )
+        } catch {
+            AlertController.current.warning(.alert("Failed to upload build: \(error.localizedDescription)"))
+        }
     }
 
     private func uploadResultBundleIfNeeded(
@@ -1495,13 +1546,16 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
             case .remote:
                 guard let resultBundlePath else { return }
+                let buildRunId = await RunMetadataStorage.current.buildRunId
                 let test = try await uploadResultBundleService.uploadResultBundle(
                     resultBundlePath: resultBundlePath,
                     config: config,
                     quarantinedTests: quarantinedTests,
+                    buildRunId: buildRunId,
                     shardPlanId: shardPlanId,
                     shardIndex: shardIndex
                 )
+                await RunMetadataStorage.current.update(testRunId: test.id)
                 AlertController.current.success(
                     .alert("Result bundle uploaded for processing. View at \(test.url)")
                 )

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -348,13 +348,16 @@ struct XcodeBuildTestCommandService {
                 )
             case .remote:
                 guard let resultBundlePath else { return }
+                let buildRunId = await RunMetadataStorage.current.buildRunId
                 let test = try await uploadResultBundleService.uploadResultBundle(
                     resultBundlePath: resultBundlePath,
                     config: config,
                     quarantinedTests: quarantinedTests,
+                    buildRunId: buildRunId,
                     shardPlanId: shardPlanId,
                     shardIndex: shardIndex
                 )
+                await RunMetadataStorage.current.update(testRunId: test.id)
                 AlertController.current.success(
                     .alert("Result bundle uploaded for processing. View at \(test.url)")
                 )

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -49,6 +49,7 @@
         public static var configuration: CommandConfiguration {
             CommandConfiguration(
                 commandName: "run",
+                _superCommandName: "test",
                 abstract: "Tests a project",
                 usage:
                 "tuist test [<options>] [<scheme>] -- [<passthrough-xcode-build-arguments> ...]",

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -14,6 +14,7 @@ import TuistGit
 import TuistLoader
 import TuistServer
 import TuistSupport
+import TuistXCActivityLog
 import TuistXCResultService
 import XcodeGraph
 import XCResultParser
@@ -49,6 +50,8 @@ final class TestServiceTests: TuistUnitTestCase {
     private var shardPlanService: MockShardPlanServicing!
     private var shardMatrixOutputService: MockShardMatrixOutputServicing!
     private var shardService: MockShardServicing!
+    private var xcActivityLogController: MockXCActivityLogControlling!
+    private var uploadBuildRunService: MockUploadBuildRunServicing!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -73,6 +76,12 @@ final class TestServiceTests: TuistUnitTestCase {
         shardPlanService = .init()
         shardMatrixOutputService = .init()
         shardService = .init()
+        xcActivityLogController = .init()
+        uploadBuildRunService = .init()
+
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .any, filter: .any)
+            .willReturn(nil)
 
         cacheStorageFactory = MockCacheStorageFactorying()
         given(cacheStorageFactory)
@@ -190,7 +199,9 @@ final class TestServiceTests: TuistUnitTestCase {
             testQuarantineService: testQuarantineService,
             shardPlanService: shardPlanService,
             shardMatrixOutputService: shardMatrixOutputService,
-            shardService: shardService
+            shardService: shardService,
+            xcActivityLogController: xcActivityLogController,
+            uploadBuildRunService: uploadBuildRunService
         )
 
         given(simulatorController)

--- a/server/assets/app/css/pages/run_detail.css
+++ b/server/assets/app/css/pages/run_detail.css
@@ -18,7 +18,6 @@
     & > [data-part="title"] {
       display: flex;
       flex-direction: row;
-      justify-content: space-between;
       align-items: center;
       gap: var(--noora-spacing-4);
 
@@ -56,6 +55,12 @@
         color: var(--noora-surface-label-primary);
         font: var(--noora-font-weight-medium) var(--noora-font-heading-large);
       }
+    }
+
+    & > [data-part="actions"] {
+      display: flex;
+      flex-direction: row;
+      gap: var(--noora-spacing-4);
     }
   }
 

--- a/server/lib/tuist_web/live/run_detail_live.html.heex
+++ b/server/lib/tuist_web/live/run_detail_live.html.heex
@@ -55,28 +55,30 @@
         {"tuist #{@run.name}" <> if @run.subcommand, do: " #{@run.subcommand}", else: ""}
       </h1>
     </div>
-    <.button
-      :if={@has_result_bundle.ok? && @has_result_bundle.result}
-      href={
-        ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@run.id}/download"
-      }
-      label={dgettext("dashboard_builds", "Download result")}
-      variant="secondary"
-      size="medium"
-    >
-      <:icon_left><.download /></:icon_left>
-    </.button>
-    <.button
-      :if={@has_session.ok? && @has_session.result}
-      href={
-        ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@run.id}/download_session"
-      }
-      label={dgettext("dashboard_builds", "Download session")}
-      variant="secondary"
-      size="medium"
-    >
-      <:icon_left><.download /></:icon_left>
-    </.button>
+    <div data-part="actions">
+      <.button
+        :if={@has_result_bundle.ok? && @has_result_bundle.result}
+        href={
+          ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@run.id}/download"
+        }
+        label={dgettext("dashboard_builds", "Download result")}
+        variant="secondary"
+        size="medium"
+      >
+        <:icon_left><.download /></:icon_left>
+      </.button>
+      <.button
+        :if={@has_session.ok? && @has_session.result}
+        href={
+          ~p"/#{@selected_project.account.name}/#{@selected_project.name}/runs/#{@run.id}/download_session"
+        }
+        label={dgettext("dashboard_builds", "Download session")}
+        variant="secondary"
+        size="medium"
+      >
+        <:icon_left><.download /></:icon_left>
+      </.button>
+    </div>
   </div>
   <.tab_menu_horizontal>
     <.tab_menu_horizontal_item


### PR DESCRIPTION
## Summary

- Fix `tuist test` command events showing "tuist run" instead of "tuist test" by adding `_superCommandName` to `TestRunCommand`
- Store `testRunId` in `RunMetadataStorage` during remote xcresult upload so CLI outputs the test run URL instead of the generic run URL
- Upload build runs from `TestService` so processed test runs are associated with their builds on the server
- Pass `buildRunId` through `uploadResultBundle` to link test runs to builds in ClickHouse
- Prefer test run URL over build URL in CLI output for test commands
- Fix run detail page: wrap download buttons in actions container, fix CSS layout

## Test plan

- [ ] Run `tuist test --no-selective-testing` on a sample project and verify:
  - CLI output shows test run URL (not build URL or generic run URL)
  - Run detail page shows "tuist test" (not "tuist run")
  - Download result and Download session buttons are both on the right
  - Processed test run is associated with the build
  - Processed test run shows command details
- [ ] Run `tuist xcodebuild build` and verify build URL is still shown
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)