### PR TITLE
fix(server): refresh account JWTs without crashing on preload

### DIFF
--- a/server/lib/tuist/authentication.ex
+++ b/server/lib/tuist/authentication.ex
@@ -4,6 +4,7 @@ defmodule Tuist.Authentication do
   """
   alias Tuist.Accounts
   alias Tuist.Accounts.AuthenticatedAccount
+  alias Tuist.Accounts.User
   alias Tuist.Projects
 
   def authenticated_subject(token) do
@@ -64,25 +65,33 @@ defmodule Tuist.Authentication do
 
   """
   def refresh(old_token, opts) do
-    with {:ok, user, old_claims} <- Tuist.Guardian.resource_from_token(old_token, %{}, opts),
-         {:ok, {:user, user}} when user != nil <-
-           {:ok, {:user, Tuist.Repo.preload(user, :account)}},
-         preferred_username = user.account.name,
+    with {:ok, resource, old_claims} <- Tuist.Guardian.resource_from_token(old_token, %{}, opts),
+         {:ok, {:resource, resource}} when resource != nil <-
+           {:ok, {:resource, preload_account(resource)}},
+         {preferred_username, subject} <- refresh_subject(resource),
          new_claims =
            old_claims
            |> Map.drop(["jti", "iss", "iat", "nbf", "exp"])
            |> Map.put("preferred_username", preferred_username),
-         {:ok, new_token, new_claims} <- __MODULE__.encode_and_sign(user, new_claims, opts) do
+         {:ok, new_token, new_claims} <- __MODULE__.encode_and_sign(subject, new_claims, opts) do
       Tuist.Guardian.on_revoke(old_claims, old_token)
       {:ok, {old_token, old_claims}, {new_token, new_claims}}
     else
       {:error, reason} ->
         {:error, reason}
 
-      {:ok, {:user, nil}} ->
+      {:ok, {:resource, nil}} ->
         {:error, "The token user doesn't exist"}
     end
   end
+
+  defp preload_account(%User{} = user), do: Tuist.Repo.preload(user, :account)
+  defp preload_account(%AuthenticatedAccount{} = resource), do: resource
+  defp preload_account(_), do: nil
+
+  defp refresh_subject(%User{account: %{name: name}} = user), do: {name, user}
+
+  defp refresh_subject(%AuthenticatedAccount{account: %{name: name} = account}), do: {name, account}
 
   def exchange(old_token, from_type, to_type, options) do
     Tuist.Guardian.exchange(old_token, from_type, to_type, options)

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -100,7 +100,7 @@ defmodule Tuist.AuthenticationTest do
     assert account_id == account.id
   end
 
-  test "refresh/2 refreshes an account JWT without crashing" do
+  test "refresh/2 refreshes an account JWT" do
     # Given
     account = AccountsFixtures.organization_fixture(preload: [:account]).account
 

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -100,6 +100,36 @@ defmodule Tuist.AuthenticationTest do
     assert account_id == account.id
   end
 
+  test "refresh/2 refreshes an account JWT without crashing" do
+    # Given
+    account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+    {:ok, refresh_token, _claims} =
+      Authentication.encode_and_sign(
+        account,
+        %{
+          "type" => "account",
+          "scopes" => ["preview_create"]
+        },
+        token_type: :refresh,
+        ttl: {60, :minute}
+      )
+
+    # When
+    {:ok, _old, {new_refresh_token, new_claims}} =
+      Authentication.refresh(refresh_token, ttl: {60, :minute})
+
+    # Then
+    assert new_claims["preferred_username"] == account.name
+    assert new_claims["type"] == "account"
+    assert new_claims["scopes"] == ["preview_create"]
+
+    {:ok, %AuthenticatedAccount{account: %Account{id: refreshed_account_id}}, _} =
+      Tuist.Guardian.resource_from_token(new_refresh_token)
+
+    assert refreshed_account_id == account.id
+  end
+
   test "refresh/2 refreshes the account handle" do
     # Given
     %User{id: id, account: %{name: name}} =

--- a/server/test/tuist_web/controllers/api/auth_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/auth_controller_test.exs
@@ -169,6 +169,39 @@ defmodule TuistWeb.API.AuthControllerTest do
              })
     end
 
+    test "returns refreshed tokens when the refresh token resolves to an AuthenticatedAccount",
+         %{conn: conn} do
+      # Given
+      account = AccountsFixtures.organization_fixture(preload: [:account]).account
+
+      {:ok, refresh_token, _opts} =
+        Tuist.Authentication.encode_and_sign(
+          account,
+          %{"type" => "account", "scopes" => ["preview_create"]},
+          token_type: :refresh,
+          ttl: {4, :weeks}
+        )
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/auth/refresh_token", %{refresh_token: refresh_token})
+
+      # Then
+      response = json_response(conn, :ok)
+
+      assert Tuist.Authentication.decode_and_verify(response["access_token"], %{
+               "typ" => "access",
+               "sub" => to_string(account.id)
+             })
+
+      assert Tuist.Authentication.decode_and_verify(response["refresh_token"], %{
+               "typ" => "refresh",
+               "sub" => to_string(account.id)
+             })
+    end
+
     test "returns unautheticated if the refresh token is expired", %{conn: conn} do
       # Given
       refresh_token = "refresh_token"


### PR DESCRIPTION
## Summary
- `Tuist.Authentication.refresh/2` unconditionally called `Tuist.Repo.preload(resource, :account)`. For account JWTs (`type: "account"`), `resource_from_claims/1` returns an `AuthenticatedAccount` — a plain struct, not an Ecto schema — so `preload/2` crashed in `__schema__/2`, producing ~54k Sentry errors on `/api/auth/refresh_token` (Sentry [TUIST-74](https://tuist.sentry.io/issues/101114955/)).
- Route the refresh through the underlying `User` or `Account` depending on the resolved resource. `AuthenticatedAccount` already ships with a loaded `account`, so we skip the preload and re-encode via the raw `Account` to satisfy `Guardian.subject_for_token/2`, preserving existing claims (`type`, `scopes`, `project_ids`, etc.) so the next decode still returns an `AuthenticatedAccount`.

Fixes TUIST-74

## Test plan
- [x] `mix test test/tuist/authentication_test.exs` — added regression covering account-JWT refresh (loads the resource back and verifies `account.id`, `type`, and `scopes` round-trip).
- [x] `mix test test/tuist_web/controllers/api/auth_controller_test.exs` — added controller-level test asserting `POST /api/auth/refresh_token` with an account JWT returns new access/refresh tokens whose `sub` matches the account id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)