### PR TITLE
fix(cli): resolve relative -testProductsPath when writing selective testing graph

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -507,7 +507,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         if action == .build {
             if let testProductsPath = try? await resolveTestProductsPath(
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
-                derivedDataPath: derivedDataPath
+                derivedDataPath: derivedDataPath,
+                relativeTo: path
             ) {
                 let selectiveTestingGraph = computeSelectiveTestingGraph(
                     mapperEnvironment: mapperEnvironment,
@@ -853,12 +854,14 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
     private func resolveTestProductsPath(
         passthroughXcodeBuildArguments: [String],
-        derivedDataPath: AbsolutePath?
+        derivedDataPath: AbsolutePath?,
+        relativeTo path: AbsolutePath
     ) async throws -> AbsolutePath {
-        if let index = passthroughXcodeBuildArguments.firstIndex(of: "-testProductsPath"),
-           passthroughXcodeBuildArguments.indices.contains(index + 1)
-        {
-            return try AbsolutePath(validating: passthroughXcodeBuildArguments[index + 1])
+        if let testProductsPath = testProductsPathFromArguments(
+            passthroughXcodeBuildArguments,
+            relativeTo: path
+        ) {
+            return testProductsPath
         }
 
         guard let derivedDataPath else {

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -3530,6 +3530,71 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_build_writesSelectiveTestingGraph_whenTestProductsPathIsRelative() async throws {
+        // Given
+        givenGenerator()
+        let path = try temporaryPath()
+        let bundleName = "MyApp.xctestproducts"
+        let testProductsPath = path.appending(component: bundleName)
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let projectPath = path.appending(component: "Project")
+        let scheme = Scheme.test(name: "TestScheme")
+        let graph: Graph = .test(
+            workspace: .test(schemes: [.test(name: "App-Workspace")]),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [.test(name: "TargetA")],
+                    schemes: [scheme]
+                ),
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraph = graph
+        environment.targetTestHashes = [projectPath: ["TargetA": "hash-a"]]
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, graph, environment)
+            }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willProduce { scheme, _, _, _, _, _ in
+                GraphTarget.test(target: Target.test(name: scheme.name))
+            }
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When
+        try await testRun(
+            schemeName: "TestScheme",
+            path: path,
+            action: .build,
+            passthroughXcodeBuildArguments: ["-testProductsPath", bundleName]
+        )
+
+        // Then — the selective testing graph should have been written into the bundle
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        let exists = try await fileSystem.exists(graphPath)
+        XCTAssertTrue(exists, "Expected selective testing graph at \(graphPath.pathString)")
+    }
+
     fileprivate func testRun(
         runId: String = "run-id",
         schemeName: String? = nil,


### PR DESCRIPTION
## Summary

Follow-up to #9987.

`resolveTestProductsPath` only validated `-testProductsPath` as an absolute path, so passing a relative value (e.g. `tuist test --build-only -- -testProductsPath App.xctestproducts ...`) made `AbsolutePath(validating:)` throw. The error was swallowed by `try?` at the call site, silently skipping the embedded `selective-testing-graph.json` write — which is the very thing #9987 added.

The result: an absolute path like `\$(pwd)/App.xctestproducts` worked and produced a bundle containing `selective-testing-graph.json`, but the equivalent relative path `App.xctestproducts` produced a bundle without it, breaking the fast `--without-building` path on the next stage.

### Fix

Reuse the existing `testProductsPathFromArguments(_:relativeTo:)` helper inside `resolveTestProductsPath` and pass the working directory `path` from `run()` so relative `-testProductsPath` values are resolved against the current working directory — matching how the consumer side at `cli/Sources/TuistKit/Services/TestService.swift:264` already does it.

## Test plan

- [x] Added regression test `test_run_build_writesSelectiveTestingGraph_whenTestProductsPathIsRelative` that runs `action: .build` with a relative `-testProductsPath` and asserts `selective-testing-graph.json` is written into the bundle.
- [ ] Manual E2E from `examples/xcode/generated_app_with_framework_and_tests`:
  ```
  tuist test --build-only --platform ios -- \
    -testProductsPath App.xctestproducts \
    -destination "platform=iOS Simulator,name=iPhone 17 Pro"
  ls App.xctestproducts   # expect selective-testing-graph.json present
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)