### PR TITLE
fix(cli): ignore .DS_Store files when hashing buildable folders

### DIFF
--- a/cli/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
+++ b/cli/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
@@ -1,16 +1,16 @@
 import Path
 
-struct HashingFilesFilter: Sendable {
+public struct HashingFilesFilter: Sendable {
     /// an array of filters, which should return if a path should be included in hashing calculations or not.
     private let filters: [@Sendable (AbsolutePath) -> Bool]
 
-    init() {
+    public init() {
         filters = [
             { $0.basename.uppercased() != ".DS_STORE" },
         ]
     }
 
-    func callAsFunction(_ path: AbsolutePath) -> Bool {
+    public func callAsFunction(_ path: AbsolutePath) -> Bool {
         !filters.contains(where: { $0(path) == false })
     }
 }

--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -218,12 +218,12 @@ public struct TargetContentHasher: TargetContentHashing {
                 []
             }
 
-        let buildableFolderIgnoredFileNames = Set([".ds_store"])
+        let hashingFilesFilter = HashingFilesFilter()
         let buildableFolderHashes = try await graphTarget.target
             .buildableFolders.sorted(by: { $0.path < $1.path })
             .map { buildableFolder in
                 let resolvedFiles = buildableFolder.resolvedFiles
-                    .filter { !buildableFolderIgnoredFileNames.contains($0.path.basename.lowercased()) }
+                    .filter { hashingFilesFilter($0.path) }
                     .sorted(by: { $0.path < $1.path })
 
                 return (buildableFolder, resolvedFiles)

--- a/cli/Sources/TuistHasher/TargetContentHasher.swift
+++ b/cli/Sources/TuistHasher/TargetContentHasher.swift
@@ -218,9 +218,16 @@ public struct TargetContentHasher: TargetContentHashing {
                 []
             }
 
+        let buildableFolderIgnoredFileNames = Set([".ds_store"])
         let buildableFolderHashes = try await graphTarget.target
             .buildableFolders.sorted(by: { $0.path < $1.path })
-            .map { ($0, $0.resolvedFiles.sorted(by: { $0.path < $1.path })) }
+            .map { buildableFolder in
+                let resolvedFiles = buildableFolder.resolvedFiles
+                    .filter { !buildableFolderIgnoredFileNames.contains($0.path.basename.lowercased()) }
+                    .sorted(by: { $0.path < $1.path })
+
+                return (buildableFolder, resolvedFiles)
+            }
             .concurrentFlatMap {
                 (buildableFolder: BuildableFolder, buildableFiles: [BuildableFolderFile]) in
                 let publicHeaders = buildableFolder.exceptions.flatMap(\.publicHeaders)

--- a/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/TargetContentHasherTests.swift
@@ -268,6 +268,64 @@ struct TargetContentHasherTests {
         )
     }
 
+    @Test func hash_with_buildable_folders_ignores_ds_store_files() async throws {
+        // Given
+        let targetWithDSStore = GraphTarget.test(target: .test(buildableFolders: [
+            BuildableFolder(
+                path: try AbsolutePath(validating: "/test/Sources"),
+                exceptions: BuildableFolderExceptions(exceptions: []),
+                resolvedFiles: [
+                    BuildableFolderFile(
+                        path: try AbsolutePath(validating: "/test/Sources/.DS_Store"),
+                        compilerFlags: nil
+                    ),
+                    BuildableFolderFile(
+                        path: try AbsolutePath(validating: "/test/Sources/File.swift"),
+                        compilerFlags: nil
+                    ),
+                ]
+            ),
+        ]), project: .test())
+        let targetWithoutDSStore = GraphTarget.test(target: .test(buildableFolders: [
+            BuildableFolder(
+                path: try AbsolutePath(validating: "/test/Sources"),
+                exceptions: BuildableFolderExceptions(exceptions: []),
+                resolvedFiles: [
+                    BuildableFolderFile(
+                        path: try AbsolutePath(validating: "/test/Sources/File.swift"),
+                        compilerFlags: nil
+                    ),
+                ]
+            ),
+        ]), project: .test())
+
+        // When
+        let gotWithDSStore = try await subject.contentHash(
+            for: targetWithDSStore,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: .test(
+                device: .test(name: "iPhone 16"),
+                runtime: .test(name: "iOS-16")
+            ),
+            additionalStrings: []
+        )
+        let gotWithoutDSStore = try await subject.contentHash(
+            for: targetWithoutDSStore,
+            hashedTargets: [:],
+            hashedPaths: [:],
+            destination: .test(
+                device: .test(name: "iPhone 16"),
+                runtime: .test(name: "iOS-16")
+            ),
+            additionalStrings: []
+        )
+
+        // Then
+        #expect(gotWithDSStore.hash == gotWithoutDSStore.hash)
+        #expect(gotWithDSStore.subhashes == gotWithoutDSStore.subhashes)
+    }
+
     @Test func hash_with_destination() async throws {
         // Given
         let target = GraphTarget.test(


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/8842>

This PR ignores `.DS_Store` files when hashing buildable folders so Finder metadata files do not affect module cache and selective testing hashes.

It also adds a regression unit test covering buildable folders with and without `.DS_Store`.

### How to test locally

```bash
xcodebuild test \
  -workspace Tuist.xcworkspace \
  -scheme TuistUnitTests \
  -destination 'platform=macOS' \
  -only-testing:TuistHasherTests/TargetContentHasherTests
