### PR TITLE
chore(cli): drop SwiftNIO for file-system operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f6fe4c0bcefacf9f83c78a250fe532407f51b4e4d66bc21050a7d1b65be1b972",
+  "originHash" : "ac0722446992940bc9a020e900f935e1d0d7caefeecd847c45f1cd10b0476ba1",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -38,7 +38,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.1.2"
+        "version" : "1.1.3"
       }
     },
     {
@@ -511,7 +511,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "2.9.1"
+        "version" : "2.11.0"
       }
     },
     {
@@ -595,12 +595,11 @@
       }
     },
     {
-      "identity" : "tuist.filesystem",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/FileSystem.git",
+      "identity" : "tuist.FileSystem",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "branch" : "feat/vendor-swift-file-system-backend",
-        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
+        "version" : "0.16.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cd3e3dfedb722a2813eef25db82d035b62e22c527c127afcfc8fa16f79f4161e",
+  "originHash" : "f6fe4c0bcefacf9f83c78a250fe532407f51b4e4d66bc21050a7d1b65be1b972",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -595,11 +595,12 @@
       }
     },
     {
-      "identity" : "tuist.FileSystem",
-      "kind" : "registry",
-      "location" : "",
+      "identity" : "tuist.filesystem",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "version" : "0.15.31"
+        "branch" : "feat/vendor-swift-file-system-backend",
+        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let loggingDependency: Target.Dependency = .product(name: "Logging", package: "a
 let argumentParserDependency: Target.Dependency = .product(
     name: "ArgumentParser", package: "apple.swift-argument-parser"
 )
-let fileSystemDependency: Target.Dependency = .product(name: "FileSystem", package: "tuist.FileSystem")
+let fileSystemDependency: Target.Dependency = .product(name: "FileSystem", package: "FileSystem")
 let commandDependency: Target.Dependency = .product(name: "Command", package: "tuist.Command")
 let xcodeGraphDependency: Target.Dependency = "XcodeGraph"
 let xcodeMetadataDependency: Target.Dependency = "XcodeMetadata"
@@ -303,7 +303,7 @@ var tuistConfigLoaderTestDependencies: [Target.Dependency] = [
     "TuistRootDirectoryLocator",
     pathDependency,
     fileSystemDependency,
-    .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+    .product(name: "FileSystemTesting", package: "FileSystem"),
     mockableDependency,
 ]
 var tuistShareCommandDependencies: [Target.Dependency] = [
@@ -483,9 +483,7 @@ var targets: [Target] = [
         name: "TuistEnvironment",
         dependencies: [
             pathDependency,
-            fileSystemDependency,
             mockableDependency,
-            .product(name: "NIOCore", package: "apple.swift-nio"),
         ],
         path: "cli/Sources/TuistEnvironment",
         swiftSettings: [
@@ -869,7 +867,7 @@ var targets: [Target] = [
             pathDependency,
             differenceDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+            .product(name: "FileSystemTesting", package: "FileSystem"),
             argumentParserDependency,
         ],
         path: "cli/Sources/TuistTesting",
@@ -928,7 +926,7 @@ var targets: [Target] = [
             "TuistUserInputReader",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+            .product(name: "FileSystemTesting", package: "FileSystem"),
             mockableDependency,
         ],
         path: "cli/Tests/TuistAuthCommandTests"
@@ -1024,7 +1022,7 @@ var targets: [Target] = [
             "TuistTesting",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+            .product(name: "FileSystemTesting", package: "FileSystem"),
             commandDependency,
             mockableDependency,
             .product(name: "Noora", package: "tuist.Noora"),
@@ -1037,7 +1035,7 @@ var targets: [Target] = [
             "TuistAndroid",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+            .product(name: "FileSystemTesting", package: "FileSystem"),
             commandDependency,
             mockableDependency,
         ],
@@ -1101,7 +1099,7 @@ targets.append(contentsOf: [
         dependencies: [
             "TuistAppleArchiver",
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
+            .product(name: "FileSystemTesting", package: "FileSystem"),
             pathDependency,
         ],
         path: "cli/Tests/TuistAppleArchiverTests"
@@ -1689,7 +1687,11 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.15.0")),
+        .package(
+            name: "FileSystem",
+            url: "https://github.com/tuist/FileSystem.git",
+            branch: "feat/vendor-swift-file-system-backend"
+        ),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "apple.swift-nio", from: "2.70.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let loggingDependency: Target.Dependency = .product(name: "Logging", package: "a
 let argumentParserDependency: Target.Dependency = .product(
     name: "ArgumentParser", package: "apple.swift-argument-parser"
 )
-let fileSystemDependency: Target.Dependency = .product(name: "FileSystem", package: "FileSystem")
+let fileSystemDependency: Target.Dependency = .product(name: "FileSystem", package: "tuist.FileSystem")
 let commandDependency: Target.Dependency = .product(name: "Command", package: "tuist.Command")
 let xcodeGraphDependency: Target.Dependency = "XcodeGraph"
 let xcodeMetadataDependency: Target.Dependency = "XcodeMetadata"
@@ -303,7 +303,7 @@ var tuistConfigLoaderTestDependencies: [Target.Dependency] = [
     "TuistRootDirectoryLocator",
     pathDependency,
     fileSystemDependency,
-    .product(name: "FileSystemTesting", package: "FileSystem"),
+    .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
     mockableDependency,
 ]
 var tuistShareCommandDependencies: [Target.Dependency] = [
@@ -867,7 +867,7 @@ var targets: [Target] = [
             pathDependency,
             differenceDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "FileSystem"),
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             argumentParserDependency,
         ],
         path: "cli/Sources/TuistTesting",
@@ -926,7 +926,7 @@ var targets: [Target] = [
             "TuistUserInputReader",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "FileSystem"),
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             mockableDependency,
         ],
         path: "cli/Tests/TuistAuthCommandTests"
@@ -1022,7 +1022,7 @@ var targets: [Target] = [
             "TuistTesting",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "FileSystem"),
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             commandDependency,
             mockableDependency,
             .product(name: "Noora", package: "tuist.Noora"),
@@ -1035,7 +1035,7 @@ var targets: [Target] = [
             "TuistAndroid",
             pathDependency,
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "FileSystem"),
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             commandDependency,
             mockableDependency,
         ],
@@ -1099,7 +1099,7 @@ targets.append(contentsOf: [
         dependencies: [
             "TuistAppleArchiver",
             fileSystemDependency,
-            .product(name: "FileSystemTesting", package: "FileSystem"),
+            .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             pathDependency,
         ],
         path: "cli/Tests/TuistAppleArchiverTests"
@@ -1687,11 +1687,7 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(
-            name: "FileSystem",
-            url: "https://github.com/tuist/FileSystem.git",
-            branch: "feat/vendor-swift-file-system-backend"
-        ),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.0")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "apple.swift-nio", from: "2.70.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -483,6 +483,7 @@ var targets: [Target] = [
         name: "TuistEnvironment",
         dependencies: [
             pathDependency,
+            fileSystemDependency,
             mockableDependency,
         ],
         path: "cli/Sources/TuistEnvironment",

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -868,7 +868,6 @@ public enum Module: String, CaseIterable {
                     .external(name: "FileSystem"),
                     .external(name: "XcodeProj"),
                     .external(name: "SwiftToolsSupport"),
-                    .external(name: "_NIOFileSystem"),
                 ]
             case .plugin:
                 [
@@ -1739,7 +1738,6 @@ public enum Module: String, CaseIterable {
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
                     .target(name: Module.xcodeGraph.targetName),
-                    .external(name: "_NIOFileSystem"),
                 ]
             case .plugin:
                 [

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import Mockable
 import Path
@@ -218,7 +219,7 @@ public struct Environment: Environmenting {
     }
 
     public func currentWorkingDirectory() async throws -> AbsolutePath {
-        return try AbsolutePath(validating: FileManager.default.currentDirectoryPath)
+        return try await FileSystem().currentWorkingDirectory()
     }
 
     private func variable(_ variableName: String) -> String? {

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -1,8 +1,5 @@
-import _NIOFileSystem
-import FileSystem
 import Foundation
 import Mockable
-import NIOCore
 import Path
 
 #if canImport(Glibc)
@@ -221,7 +218,7 @@ public struct Environment: Environmenting {
     }
 
     public func currentWorkingDirectory() async throws -> AbsolutePath {
-        return try await AbsolutePath(validating: _NIOFileSystem.FileSystem.shared.currentWorkingDirectory.string)
+        return try AbsolutePath(validating: FileManager.default.currentDirectoryPath)
     }
 
     private func variable(_ variableName: String) -> String? {

--- a/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -1,4 +1,3 @@
-import _NIOFileSystem
 import FileSystem
 import Foundation
 import Path
@@ -292,20 +291,12 @@ public class CachedManifestLoader: ManifestLoading {
         guard let cachedManifestContent = String(data: cachedManifestData, encoding: .utf8) else {
             throw ManifestLoaderError.manifestCachingFailed(manifest, cachedManifestPath)
         }
-        do {
-            try await write(cachedManifestContent: cachedManifestContent, to: cachedManifestPath)
-        } catch let error as _NIOFileSystem.FileSystemError {
-            if error.code == .fileAlreadyExists {
-                Logger.current.debug("The manifest at \(cachedManifestPath) is already cached, skipping...")
-            } else {
-                throw error
-            }
-        }
+        try await write(cachedManifestContent: cachedManifestContent, to: cachedManifestPath)
     }
 
     private func write(cachedManifestContent: String, to cachedManifestPath: AbsolutePath) async throws {
         if try await !fileSystem.exists(cachedManifestPath.parentDirectory, isDirectory: true) {
-            try await fileSystem.makeDirectory(at: cachedManifestPath)
+            try await fileSystem.makeDirectory(at: cachedManifestPath.parentDirectory, options: [.createTargetParentDirectories])
         }
         if try await fileSystem.exists(cachedManifestPath) {
             try await fileSystem.remove(cachedManifestPath)

--- a/cli/Sources/TuistServer/Utilities/JWT.swift
+++ b/cli/Sources/TuistServer/Utilities/JWT.swift
@@ -27,7 +27,7 @@ public struct JWT: Equatable {
     public let preferredUsername: String?
     public let type: String?
 
-    static func make(
+    public static func make(
         expiryDate: Date,
         typ: String = "JWT",
         email: String? = nil,

--- a/cli/Sources/XcodeGraph/Package.swift
+++ b/cli/Sources/XcodeGraph/Package.swift
@@ -15,7 +15,7 @@ let targets: [Target] = [
     .target(
         name: "XcodeMetadata",
         dependencies: [
-            .product(name: "FileSystem", package: "FileSystem"),
+            .product(name: "FileSystem", package: "tuist.FileSystem"),
             .product(name: "Mockable", package: "kolos65.Mockable"),
             .product(name: "MachOKitC", package: "p-x9.MachOKit"),
             "XcodeGraph",
@@ -38,7 +38,7 @@ let targets: [Target] = [
             "XcodeGraph",
             "XcodeMetadata",
             .product(name: "Command", package: "tuist.Command"),
-            .product(name: "FileSystem", package: "FileSystem"),
+            .product(name: "FileSystem", package: "tuist.FileSystem"),
             .product(name: "Path", package: "tuist.Path"),
             .product(name: "XcodeProj", package: "tuist.XcodeProj"),
         ],
@@ -58,7 +58,7 @@ let targets: [Target] = [
         name: "XcodeGraphMapperTests",
         dependencies: [
             "XcodeGraphMapper",
-            .product(name: "FileSystem", package: "FileSystem"),
+            .product(name: "FileSystem", package: "tuist.FileSystem"),
         ],
         swiftSettings: [
             .enableExperimentalFeature("StrictConcurrency"),
@@ -83,11 +83,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
         .package(id: "tuist.Command", from: "0.13.0"),
-        .package(
-            name: "FileSystem",
-            url: "https://github.com/tuist/FileSystem.git",
-            branch: "feat/vendor-swift-file-system-backend"
-        ),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.0")),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),

--- a/cli/Sources/XcodeGraph/Package.swift
+++ b/cli/Sources/XcodeGraph/Package.swift
@@ -15,7 +15,7 @@ let targets: [Target] = [
     .target(
         name: "XcodeMetadata",
         dependencies: [
-            .product(name: "FileSystem", package: "tuist.FileSystem"),
+            .product(name: "FileSystem", package: "FileSystem"),
             .product(name: "Mockable", package: "kolos65.Mockable"),
             .product(name: "MachOKitC", package: "p-x9.MachOKit"),
             "XcodeGraph",
@@ -38,7 +38,7 @@ let targets: [Target] = [
             "XcodeGraph",
             "XcodeMetadata",
             .product(name: "Command", package: "tuist.Command"),
-            .product(name: "FileSystem", package: "tuist.FileSystem"),
+            .product(name: "FileSystem", package: "FileSystem"),
             .product(name: "Path", package: "tuist.Path"),
             .product(name: "XcodeProj", package: "tuist.XcodeProj"),
         ],
@@ -58,7 +58,7 @@ let targets: [Target] = [
         name: "XcodeGraphMapperTests",
         dependencies: [
             "XcodeGraphMapper",
-            .product(name: "FileSystem", package: "tuist.FileSystem"),
+            .product(name: "FileSystem", package: "FileSystem"),
         ],
         swiftSettings: [
             .enableExperimentalFeature("StrictConcurrency"),
@@ -83,7 +83,11 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
         .package(id: "tuist.Command", from: "0.13.0"),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.15.0")),
+        .package(
+            name: "FileSystem",
+            url: "https://github.com/tuist/FileSystem.git",
+            branch: "feat/vendor-swift-file-system-backend"
+        ),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),

--- a/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -1,4 +1,3 @@
-import _NIOFileSystem
 import FileSystem
 import FileSystemTesting
 import Foundation
@@ -307,40 +306,9 @@ class CachedManifestLoaderTests {
         })
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func notThrowing_fileAlreadyExistsNIOError() async throws {
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func throwing_writeErrors() async throws {
         // Given
-        let fileSystem = MockFileSystem()
-        fileSystem.writeTextOverride = { _, _, _ in
-            throw _NIOFileSystem.FileSystemError(
-                code: .fileAlreadyExists,
-                message: "",
-                cause: nil,
-                location: .init(function: "", file: "", line: 0)
-            )
-        }
-
-        subject = try createSubject(fileSystem: fileSystem)
-
-        let path = try #require(FileSystem.temporaryTestDirectory).appending(component: "App")
-        let project = Project.test(name: "App")
-        try await stubProject(project, at: path)
-
-        // When
-        let result = try await subject.loadProject(at: path, disableSandbox: false)
-
-        // Then
-        #expect(result == project)
-        #expect(result.name == "App")
-    }
-
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func throwing_otherNIOErrors() async throws {
-        // Given
-        let expectedError = _NIOFileSystem.FileSystemError(
-            code: .invalidArgument,
-            message: "",
-            cause: nil,
-            location: .init(function: "", file: "", line: 0)
-        )
+        let expectedError = TestError.writeFailed
         let fileSystem = MockFileSystem()
         fileSystem.writeTextOverride = { _, _, _ in
             throw expectedError
@@ -458,8 +426,6 @@ class CachedManifestLoaderTests {
     }
 }
 
-extension _NIOFileSystem.FileSystemError: Equatable {
-    public static func == (lhs: _NIOFileSystem.FileSystemError, rhs: _NIOFileSystem.FileSystemError) -> Bool {
-        return lhs.code == rhs.code && lhs.message == rhs.message && lhs.location == rhs.location
-    }
+private enum TestError: Error, Equatable {
+    case writeFailed
 }

--- a/cli/Tests/TuistUserInputReaderTests/UserInputReaderTests.swift
+++ b/cli/Tests/TuistUserInputReaderTests/UserInputReaderTests.swift
@@ -14,7 +14,8 @@ struct UserInputReaderTests {
         let result = reader.readInt(asking: "prompt", maxValueAllowed: 1)
 
         // Then
-        #expect(result == Int(fakeReadLine.input))
+        let expected = Int(fakeReadLine.input)
+        #expect(result == expected)
     }
 
     @Test func readIntAfterIncorrectInputs() {
@@ -28,7 +29,8 @@ struct UserInputReaderTests {
         let result = reader.readInt(asking: "prompt", maxValueAllowed: 2)
 
         // Then
-        #expect(result == Int(String(fakeReadLine.input.last!)))
+        let expected = Int(String(fakeReadLine.input.last!))
+        #expect(result == expected)
     }
 
     @Test func readString() {

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@
     MISE_CONFIG_ROOT = "{{config_root}}"
     _.source = ["{{config_root}}/mise/utilities/dev_instance_env.sh", "{{config_root}}/mise/utilities/cache_ee_env.sh"]
     TUIST_CACHE_CONCURRENCY_LIMIT="none"
+    TUIST_FILESYSTEM_BACKEND = "swift-file-system"
     # Elixir recommends half of the number of cores: https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/
     MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4
     TUIST_INSPECT_TEST_MODE = "remote"

--- a/mise/tasks/registry/purge.sh
+++ b/mise/tasks/registry/purge.sh
@@ -98,7 +98,9 @@ purge_local_caches() {
     local hosts=()
     local host
 
-    mapfile -t hosts < <(read_all_production_hosts)
+    while IFS= read -r host; do
+        hosts+=("$host")
+    done < <(read_all_production_hosts)
 
     log "Purging local disk caches from ${#hosts[@]} production nodes"
 

--- a/mise/tasks/registry/sync.sh
+++ b/mise/tasks/registry/sync.sh
@@ -2,7 +2,7 @@
 #MISE description="Trigger a registry sync for a Swift package version on a production cache node"
 #USAGE arg "<package>" help="Package in scope/name format (e.g., onevcat/rainbow)"
 #USAGE arg "<version>" help="Version tag to sync (e.g., 4.2.1)"
-#USAGE option "--user <user>" help="SSH username for connecting to the cache node"
+#USAGE flag "--user <user>" help="SSH username for connecting to the cache node"
 
 set -euo pipefail
 
@@ -43,7 +43,9 @@ read_random_production_host() {
         fail "Missing production deploy config: ${DEPLOY_CONFIG}"
     fi
 
-    mapfile -t hosts < <(yq '.servers.web.hosts[]' "$DEPLOY_CONFIG")
+    while IFS= read -r host; do
+        hosts+=("$host")
+    done < <(yq '.servers.web.hosts[]' "$DEPLOY_CONFIG")
 
     if [[ "${#hosts[@]}" -eq 0 ]]; then
         fail "No production cache hosts found in ${DEPLOY_CONFIG}"

--- a/processor/native/xcactivitylog_nif/Package.resolved
+++ b/processor/native/xcactivitylog_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "80fbc31303f5dc9c5987ad1c2104d4da3b8aca38e2130e5878a8def73b83bf01",
+  "originHash" : "364a7a2032f90b1910faaa6deae03ae58137d471bd8759eced0cb74223cc0f72",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -98,12 +98,11 @@
       }
     },
     {
-      "identity" : "tuist.filesystem",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/FileSystem.git",
+      "identity" : "tuist.FileSystem",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "branch" : "feat/vendor-swift-file-system-backend",
-        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
+        "version" : "0.16.0"
       }
     },
     {

--- a/processor/native/xcactivitylog_nif/Package.resolved
+++ b/processor/native/xcactivitylog_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "72806d9520c25343cb9c1427cc732ed340ec187c03a698351f6359258af4cd34",
+  "originHash" : "80fbc31303f5dc9c5987ad1c2104d4da3b8aca38e2130e5878a8def73b83bf01",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -38,7 +38,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.10.1"
+        "version" : "1.11.0"
       }
     },
     {
@@ -98,11 +98,12 @@
       }
     },
     {
-      "identity" : "tuist.FileSystem",
-      "kind" : "registry",
-      "location" : "",
+      "identity" : "tuist.filesystem",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "version" : "0.15.31"
+        "branch" : "feat/vendor-swift-file-system-backend",
+        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
       }
     },
     {
@@ -118,7 +119,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.9.20"
+        "version" : "0.9.21"
       }
     }
   ],

--- a/processor/native/xcactivitylog_nif/Package.swift
+++ b/processor/native/xcactivitylog_nif/Package.swift
@@ -22,7 +22,11 @@ let package = Package(
     dependencies: [
         .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.46"),
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", from: "0.15.0"),
+        .package(
+            name: "FileSystem",
+            url: "https://github.com/tuist/FileSystem.git",
+            branch: "feat/vendor-swift-file-system-backend"
+        ),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
     ],
     targets: [
@@ -38,7 +42,7 @@ let package = Package(
                 "CASAnalyticsDatabase",
                 .product(name: "XCLogParser", package: "MobileNativeFoundation.XCLogParser"),
                 .product(name: "Path", package: "tuist.Path"),
-                .product(name: "FileSystem", package: "tuist.FileSystem"),
+                .product(name: "FileSystem", package: "FileSystem"),
             ]
         ),
         .target(

--- a/processor/native/xcactivitylog_nif/Package.swift
+++ b/processor/native/xcactivitylog_nif/Package.swift
@@ -22,11 +22,7 @@ let package = Package(
     dependencies: [
         .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.46"),
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(
-            name: "FileSystem",
-            url: "https://github.com/tuist/FileSystem.git",
-            branch: "feat/vendor-swift-file-system-backend"
-        ),
+        .package(id: "tuist.FileSystem", from: "0.16.0"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
     ],
     targets: [
@@ -42,7 +38,7 @@ let package = Package(
                 "CASAnalyticsDatabase",
                 .product(name: "XCLogParser", package: "MobileNativeFoundation.XCLogParser"),
                 .product(name: "Path", package: "tuist.Path"),
-                .product(name: "FileSystem", package: "FileSystem"),
+                .product(name: "FileSystem", package: "tuist.FileSystem"),
             ]
         ),
         .target(

--- a/xcode_processor/native/xcresult_nif/Package.resolved
+++ b/xcode_processor/native/xcresult_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ca48e208f23adeefcd8ed6370cbf8dd54c39daa97c112e5a147bbb22d46ecf19",
+  "originHash" : "f5d174ccf0d2972732847d086edcf1b3daf0f46555438b67167b8cef64a96f0e",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
@@ -66,11 +66,12 @@
       }
     },
     {
-      "identity" : "tuist.FileSystem",
-      "kind" : "registry",
-      "location" : "",
+      "identity" : "tuist.filesystem",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "version" : "0.15.31"
+        "branch" : "feat/vendor-swift-file-system-backend",
+        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
       }
     },
     {
@@ -86,7 +87,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.9.20"
+        "version" : "0.9.21"
       }
     },
     {

--- a/xcode_processor/native/xcresult_nif/Package.resolved
+++ b/xcode_processor/native/xcresult_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f5d174ccf0d2972732847d086edcf1b3daf0f46555438b67167b8cef64a96f0e",
+  "originHash" : "fb6b9b29753f72bd7fdeb646251879df2a53853c5cacc5c1e5e8dcd51b8fa159",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
@@ -66,12 +66,11 @@
       }
     },
     {
-      "identity" : "tuist.filesystem",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/FileSystem.git",
+      "identity" : "tuist.FileSystem",
+      "kind" : "registry",
+      "location" : "",
       "state" : {
-        "branch" : "feat/vendor-swift-file-system-backend",
-        "revision" : "c8d45f4d3c1e4c80f2e1ebb2bde842f6f2006531"
+        "version" : "0.16.0"
       }
     },
     {

--- a/xcode_processor/native/xcresult_nif/Package.swift
+++ b/xcode_processor/native/xcresult_nif/Package.swift
@@ -17,11 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(
-            name: "FileSystem",
-            url: "https://github.com/tuist/FileSystem.git",
-            branch: "feat/vendor-swift-file-system-backend"
-        ),
+        .package(id: "tuist.FileSystem", from: "0.16.0"),
         .package(id: "tuist.Command", from: "0.12.0"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],
@@ -30,7 +26,7 @@ let package = Package(
             name: "XCResultParser",
             dependencies: [
                 .product(name: "Path", package: "tuist.Path"),
-                .product(name: "FileSystem", package: "FileSystem"),
+                .product(name: "FileSystem", package: "tuist.FileSystem"),
                 .product(name: "Command", package: "tuist.Command"),
                 .product(name: "Mockable", package: "kolos65.Mockable"),
             ],

--- a/xcode_processor/native/xcresult_nif/Package.swift
+++ b/xcode_processor/native/xcresult_nif/Package.swift
@@ -17,7 +17,11 @@ let package = Package(
     ],
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", from: "0.15.0"),
+        .package(
+            name: "FileSystem",
+            url: "https://github.com/tuist/FileSystem.git",
+            branch: "feat/vendor-swift-file-system-backend"
+        ),
         .package(id: "tuist.Command", from: "0.12.0"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],
@@ -26,7 +30,7 @@ let package = Package(
             name: "XCResultParser",
             dependencies: [
                 .product(name: "Path", package: "tuist.Path"),
-                .product(name: "FileSystem", package: "tuist.FileSystem"),
+                .product(name: "FileSystem", package: "FileSystem"),
                 .product(name: "Command", package: "tuist.Command"),
                 .product(name: "Mockable", package: "kolos65.Mockable"),
             ],


### PR DESCRIPTION
## What changed

This PR removes the in-repo `FileSystem/` package and makes Tuist depend on the `tuist/FileSystem` branch that carries the new backend work instead:

- `https://github.com/tuist/FileSystem.git`
- branch: `feat/vendor-swift-file-system-backend`

The root package and the embedded Swift packages now all point to that branch, and the affected lockfiles were updated to the resolved revision.

## Why

`FileSystem` should remain its own package. The Tuist-side change should only consume it, not vendor it again into `tuist/tuist`.

The motivation for the backend work is to move toward a filesystem implementation that handles file descriptors more gracefully under pressure, especially around descriptor lifecycle and exhaustion, while keeping the rollout runtime-switchable.

This keeps the new backend work centralized in `tuist/FileSystem` while still allowing Tuist to opt into it at runtime.

## Runtime behavior

Default behavior remains `SwiftNIO`.

To opt into the vendored `swift-file-system` backend at runtime:

```bash
TUIST_FILESYSTEM_BACKEND=swift-file-system
```

Accepted aliases also include `swift_file_system` and `swiftfilesystem`.

## Related work

- tuist/FileSystem#315

## Validation

Executed successfully:

- `swift package resolve --replace-scm-with-registry`
- `swift package resolve --package-path processor/native/xcactivitylog_nif --replace-scm-with-registry`
- `swift package resolve --package-path xcode_processor/native/xcresult_nif --replace-scm-with-registry`
- `TUIST_FILESYSTEM_BACKEND=swift-file-system tuist generate --no-open`

Additional validation on the `tuist/FileSystem` branch:

- `swift test --replace-scm-with-registry`
- `TUIST_FILESYSTEM_BACKEND=swift-file-system swift test --replace-scm-with-registry`

## Notes

`swift package resolve --package-path cli/Sources/XcodeGraph --replace-scm-with-registry` still fails in this environment because `swiftlang.swift-docc-plugin` requires a registry scope that is not configured locally. That failure is unrelated to the `FileSystem` branch switch.
