### PR TITLE
fix(server): include test_case_run_argument_id when building attachment rows

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1305,6 +1305,7 @@ defmodule Tuist.Tests do
       %{
         id: Map.get(att_attrs, :attachment_id) || UUIDv7.generate(),
         test_case_run_id: test_case_run_id,
+        test_case_run_argument_id: Map.get(att_attrs, :test_case_run_argument_id),
         test_run_id: test_run_id,
         file_name: Map.get(att_attrs, :file_name),
         repetition_number: Map.get(att_attrs, :repetition_number),

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1413,6 +1413,57 @@ defmodule Tuist.TestsTest do
       assert failure.line_number == 42
       assert failure.issue_type == "assertion"
     end
+
+    test "creates a test with attachments" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      attachment_id = UUIDv7.generate()
+
+      test_attrs = %{
+        id: UUIDv7.generate(),
+        project_id: project.id,
+        account_id: account.id,
+        duration: 1000,
+        status: "success",
+        model_identifier: "Mac15,6",
+        macos_version: "14.0",
+        xcode_version: "15.0",
+        git_branch: "main",
+        git_commit_sha: "abc123",
+        ran_at: NaiveDateTime.utc_now(),
+        is_ci: true,
+        test_modules: [
+          %{
+            name: "AttachmentsTestModule",
+            status: "success",
+            duration: 1000,
+            test_cases: [
+              %{
+                name: "testWithAttachment",
+                status: "success",
+                duration: 500,
+                attachments: [
+                  %{
+                    attachment_id: attachment_id,
+                    file_name: "screenshot.png",
+                    repetition_number: nil
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      # When
+      {:ok, _test} = Tests.create_test(test_attrs)
+
+      # Then
+      IngestRepo.query!("OPTIMIZE TABLE test_case_run_attachments FINAL", [])
+      {:ok, attachment} = Tests.get_attachment_by_id(attachment_id)
+      assert attachment.file_name == "screenshot.png"
+    end
   end
 
   describe "create_test/1 with sharding" do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1460,7 +1460,6 @@ defmodule Tuist.TestsTest do
       {:ok, _test} = Tests.create_test(test_attrs)
 
       # Then
-      IngestRepo.query!("OPTIMIZE TABLE test_case_run_attachments FINAL", [])
       {:ok, attachment} = Tests.get_attachment_by_id(attachment_id)
       assert attachment.file_name == "screenshot.png"
     end


### PR DESCRIPTION
## Summary

- `Tuist.Tests.build_attachments/3` was missing the `test_case_run_argument_id` key on the maps it produces. The parameterized test support commit (f9857ca598) added that field to the `TestCaseRunAttachment` schema and updated `build_failures`/`build_repetitions`, but missed `build_attachments`.
- When `TestCaseRunAttachment.Buffer.insert_all/1` iterates schema fields via `Map.fetch!/2`, it crashed with `KeyError: key :test_case_run_argument_id not found` once an xcresult upload flowed through `create_test/1`.
- Fix: set `test_case_run_argument_id: Map.get(att_attrs, :test_case_run_argument_id)` in the attachment map so top-level attachments default to `nil` and argument-scoped attachments keep their id.

Fixes TUIST-AV (https://tuist.sentry.io/issues/111300679/).

## Test plan

- [x] New regression test `create_test/1 creates a test with attachments` in `server/test/tuist/tests_test.exs` — fails without the fix with the exact Sentry `KeyError`, passes with the fix.
- [x] `mix test test/tuist/tests_test.exs` (192 tests, 0 failures)
- [x] `mix test test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist_web/controllers/api/test_case_run_attachments_controller_test.exs` (27 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)