### PR TITLE
feat(cli): process test insights remotely

### DIFF
--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -38,7 +38,7 @@
 
         @Option(
             name: .long,
-            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
+            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var mode: TestProcessingMode?

--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -2,6 +2,7 @@
     import ArgumentParser
     import Foundation
     import TuistEnvKey
+    import TuistKit
     import TuistNooraExtension
 
     struct InspectTestCommand: AsyncParsableCommand, NooraReadyCommand {
@@ -10,11 +11,6 @@
                 commandName: "test",
                 abstract: "Inspects the latest test results."
             )
-        }
-
-        enum ProcessingMode: String, ExpressibleByArgument, CaseIterable {
-            case local
-            case remote
         }
 
         @Option(
@@ -42,10 +38,10 @@
 
         @Option(
             name: .long,
-            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing.",
+            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
             envKey: .inspectTestMode
         )
-        var mode: ProcessingMode = .local
+        var mode: TestProcessingMode?
 
         var jsonThroughNoora: Bool = false
 

--- a/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
@@ -66,7 +66,7 @@
             path: String?,
             derivedDataPath: String? = nil,
             resultBundlePath: String? = nil,
-            mode: InspectTestCommand.ProcessingMode = .local
+            mode: TestProcessingMode? = nil
         ) async throws {
             if Environment.current.variables["TUIST_INSPECT_TEST_WAIT"] != "YES",
                Environment.current.workspacePath != nil
@@ -94,7 +94,9 @@
             let projectPath = try await xcodeProjectOrWorkspacePathLocator.locate(from: path)
             let config = try await configLoader.loadConfig(path: projectPath)
 
-            switch mode {
+            let resolvedMode = mode ?? TestProcessingMode.default(for: config.url)
+
+            switch resolvedMode {
             case .local:
                 try await runLocal(
                     resolvedResultBundlePath: resolvedResultBundlePath,

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -43,10 +43,10 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
         envKey: .inspectTestMode
     )
-    var inspectMode: TestProcessingMode = .local
+    var inspectMode: TestProcessingMode?
 
     public func run() async throws {
         let shardArchivePath = try await { () async throws -> AbsolutePath? in

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -43,7 +43,7 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -45,7 +45,7 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -45,10 +45,10 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
         envKey: .inspectTestMode
     )
-    var inspectMode: TestProcessingMode = .local
+    var inspectMode: TestProcessingMode?
 
     public func run() async throws {
         let shardArchivePath = try await { () async throws -> AbsolutePath? in

--- a/cli/Sources/TuistKit/Services/TestProcessingMode.swift
+++ b/cli/Sources/TuistKit/Services/TestProcessingMode.swift
@@ -7,17 +7,16 @@ public enum TestProcessingMode: String, Sendable, CaseIterable, ExpressibleByArg
 
     /// Returns the default processing mode for the given Tuist server URL.
     ///
-    /// Defaults to `.remote` for the official Tuist hosts (`tuist.dev`, `staging.tuist.dev`,
-    /// `canary.tuist.dev`) and for `localhost`. All other URLs default to `.local` so
-    /// self-hosted instances continue to parse xcresults locally unless explicitly opted in.
+    /// Defaults to `.remote` for tuist-hosted instances and `.local` for self-hosted ones,
+    /// so self-hosted servers keep parsing xcresults locally unless they explicitly opt in.
     public static func `default`(for url: URL) -> TestProcessingMode {
-        let knownRemoteHosts: Set<String> = [
+        let tuistHostedHosts: Set<String> = [
             "tuist.dev",
             "staging.tuist.dev",
             "canary.tuist.dev",
             "localhost",
         ]
-        if let host = url.host, knownRemoteHosts.contains(host) {
+        if let host = url.host, tuistHostedHosts.contains(host) {
             return .remote
         }
         return .local

--- a/cli/Sources/TuistKit/Services/TestProcessingMode.swift
+++ b/cli/Sources/TuistKit/Services/TestProcessingMode.swift
@@ -1,6 +1,25 @@
 import ArgumentParser
+import Foundation
 
 public enum TestProcessingMode: String, Sendable, CaseIterable, ExpressibleByArgument {
     case local
     case remote
+
+    /// Returns the default processing mode for the given Tuist server URL.
+    ///
+    /// Defaults to `.remote` for the official Tuist hosts (`tuist.dev`, `staging.tuist.dev`,
+    /// `canary.tuist.dev`) and for `localhost`. All other URLs default to `.local` so
+    /// self-hosted instances continue to parse xcresults locally unless explicitly opted in.
+    public static func `default`(for url: URL) -> TestProcessingMode {
+        let knownRemoteHosts: Set<String> = [
+            "tuist.dev",
+            "staging.tuist.dev",
+            "canary.tuist.dev",
+            "localhost",
+        ]
+        if let host = url.host, knownRemoteHosts.contains(host) {
+            return .remote
+        }
+        return .local
+    }
 }

--- a/cli/Sources/TuistKit/Services/TestProcessingMode.swift
+++ b/cli/Sources/TuistKit/Services/TestProcessingMode.swift
@@ -10,13 +10,8 @@ public enum TestProcessingMode: String, Sendable, CaseIterable, ExpressibleByArg
     /// Defaults to `.remote` for tuist-hosted instances and `.local` for self-hosted ones,
     /// so self-hosted servers keep parsing xcresults locally unless they explicitly opt in.
     public static func `default`(for url: URL) -> TestProcessingMode {
-        let tuistHostedHosts: Set<String> = [
-            "tuist.dev",
-            "staging.tuist.dev",
-            "canary.tuist.dev",
-            "localhost",
-        ]
-        if let host = url.host, tuistHostedHosts.contains(host) {
+        guard let host = url.host else { return .local }
+        if host.hasSuffix("tuist.dev") || host == "localhost" {
             return .remote
         }
         return .local

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -231,7 +231,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         shardIndex: Int? = nil,
         shardSkipUpload: Bool = false,
         shardArchivePath: AbsolutePath? = nil,
-        mode: TestProcessingMode = .local
+        mode: TestProcessingMode? = nil
     ) async throws {
         if validateTestTargetsParameters {
             try Self.validateParameters(
@@ -245,6 +245,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 errorMessageOverride:
                 "The 'tuist test' command is for generated projects or Swift packages. Please use 'tuist xcodebuild test' instead."
             )
+
+        let mode = mode ?? TestProcessingMode.default(for: config.url)
 
         if let shardIndex, action == .testWithoutBuilding {
             try await runShard(

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -71,7 +71,7 @@ struct XcodeBuildTestCommandService {
         skipQuarantine: Bool = false,
         shardIndex: Int? = nil,
         shardArchivePath: AbsolutePath? = nil,
-        mode: TestProcessingMode = .local
+        mode: TestProcessingMode? = nil
     ) async throws {
         var passthroughXcodebuildArguments = passthroughXcodebuildArguments
         try await passthroughXcodebuildArguments.append(
@@ -80,6 +80,7 @@ struct XcodeBuildTestCommandService {
 
         let path = try await path(passthroughXcodebuildArguments: passthroughXcodebuildArguments)
         let config = try await configLoader.loadConfig(path: path)
+        let mode = mode ?? TestProcessingMode.default(for: config.url)
 
         var shardPlanId: String?
         var shardTestProductsPath: AbsolutePath?

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -317,7 +317,7 @@
 
         @Option(
             name: .long,
-            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
+            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -317,10 +317,10 @@
 
         @Option(
             name: .long,
-            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing.",
+            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist.dev hosts (and localhost) and 'local' otherwise.",
             envKey: .inspectTestMode
         )
-        var inspectMode: TestProcessingMode = .local
+        var inspectMode: TestProcessingMode?
 
         @Argument(
             parsing: .postTerminator,

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectTestCommandServiceTests.swift
@@ -42,7 +42,7 @@ struct InspectTestCommandServiceTests {
 
         given(configLoader)
             .loadConfig(path: .any)
-            .willReturn(.test(fullHandle: "tuist/tuist"))
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://example.com")!))
 
         given(xcResultService)
             .parse(path: .any, rootDirectory: .any)
@@ -239,6 +239,111 @@ struct InspectTestCommandServiceTests {
             .uploadTestSummary(
                 testSummary: .any,
                 projectDerivedDataDirectory: .value(derivedDataPath),
+                config: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func run_defaults_to_remote_for_tuist_dev_url() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let resultBundlePath = temporaryDirectory.appending(component: "Test.xcresult")
+        try await fileSystem.makeDirectory(at: resultBundlePath)
+
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.variables["TUIST_INSPECT_TEST_WAIT"] = "YES"
+
+        given(xcodeProjectOrWorkspacePathLocator)
+            .locate(from: .value(temporaryDirectory))
+            .willReturn(temporaryDirectory.appending(component: "App.xcodeproj"))
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://tuist.dev")!))
+
+        given(uploadResultBundleService)
+            .uploadResultBundle(
+                resultBundlePath: .any,
+                config: .any,
+                quarantinedTests: .any,
+                buildRunId: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .willReturn(
+                Components.Schemas.RunsTest(
+                    duration: 1000,
+                    id: "test-id",
+                    project_id: 1,
+                    test_case_runs: [],
+                    _type: .test,
+                    url: "https://tuist.dev/tuist/tuist/runs/test-id"
+                )
+            )
+
+        // When
+        try await subject.run(
+            path: temporaryDirectory.pathString,
+            resultBundlePath: resultBundlePath.pathString
+        )
+
+        // Then
+        verify(uploadResultBundleService)
+            .uploadResultBundle(
+                resultBundlePath: .value(resultBundlePath),
+                config: .any,
+                quarantinedTests: .any,
+                buildRunId: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(1)
+        verify(uploadResultBundleService)
+            .uploadTestSummary(
+                testSummary: .any,
+                projectDerivedDataDirectory: .any,
+                config: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(0)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func run_explicit_local_mode_overrides_url_default() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let resultBundlePath = temporaryDirectory.appending(component: "Test.xcresult")
+        try await fileSystem.makeDirectory(at: resultBundlePath)
+
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.variables["TUIST_INSPECT_TEST_WAIT"] = "YES"
+
+        given(xcodeProjectOrWorkspacePathLocator)
+            .locate(from: .value(temporaryDirectory))
+            .willReturn(temporaryDirectory.appending(component: "App.xcodeproj"))
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://tuist.dev")!))
+
+        // When
+        try await subject.run(
+            path: temporaryDirectory.pathString,
+            resultBundlePath: resultBundlePath.pathString,
+            mode: .local
+        )
+
+        // Then
+        verify(uploadResultBundleService)
+            .uploadTestSummary(
+                testSummary: .any,
+                projectDerivedDataDirectory: .value(nil),
                 config: .any,
                 shardPlanId: .any,
                 shardIndex: .any

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -2879,7 +2879,8 @@ final class TestServiceTests: TuistUnitTestCase {
                 .willReturn(
                     .test(
                         project: .testGeneratedProject(),
-                        fullHandle: "tuist/tuist"
+                        fullHandle: "tuist/tuist",
+                        url: URL(string: "https://example.com")!
                     )
                 )
 
@@ -3625,7 +3626,8 @@ final class TestServiceTests: TuistUnitTestCase {
         shardMaxDuration: Int? = nil,
         shardIndex: Int? = nil,
         shardSkipUpload: Bool = false,
-        shardArchivePath: AbsolutePath? = nil
+        shardArchivePath: AbsolutePath? = nil,
+        mode: TestProcessingMode? = .local
     ) async throws {
         try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
             try await subject.run(
@@ -3660,7 +3662,8 @@ final class TestServiceTests: TuistUnitTestCase {
                 shardMaxDuration: shardMaxDuration,
                 shardIndex: shardIndex,
                 shardSkipUpload: shardSkipUpload,
-                shardArchivePath: shardArchivePath
+                shardArchivePath: shardArchivePath,
+                mode: mode
             )
         }
     }

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -188,7 +188,7 @@ struct XcodeBuildTestCommandServiceTests {
 
             given(configLoader)
                 .loadConfig(path: .any)
-                .willReturn(.test(fullHandle: "tuist/tuist"))
+                .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://example.com")!))
 
             xcResultService.reset()
             given(xcResultService)
@@ -251,7 +251,7 @@ struct XcodeBuildTestCommandServiceTests {
 
         given(configLoader)
             .loadConfig(path: .any)
-            .willReturn(.test(fullHandle: "tuist/tuist"))
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://example.com")!))
 
         given(serverEnvironmentService)
             .url(configServerURL: .any)


### PR DESCRIPTION
## Summary
- `tuist inspect test`, `tuist test`, and `tuist xcodebuild test` now default `--mode`/`--inspect-mode` to `remote` for tuist-hosted instances and to `local` for self-hosted ones, so the default matches where it's cheapest to process the xcresult.
- The default is resolved after the config is loaded, so passing `--mode`/`--inspect-mode` explicitly always wins.
- `InspectTestCommand`'s inner `ProcessingMode` enum is replaced by the shared `TestProcessingMode` to avoid duplication.

## Test plan
- [x] `xcsiftbuild build -workspace Tuist.xcworkspace -scheme Tuist-Workspace`
- [x] `TuistKitTests/InspectTestCommandServiceTests` (incl. new `run_defaults_to_remote_for_tuist_dev_url` and `run_explicit_local_mode_overrides_url_default`)
- [x] `TuistKitTests/XcodeBuildTestCommandServiceTests`
- [x] `TuistKitTests/TestServiceTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)