### PR TITLE
chore(server): drop unused okta columns from organizations

### DIFF
--- a/server/priv/repo/migrations/20260412100000_drop_okta_columns_from_organizations.exs
+++ b/server/priv/repo/migrations/20260412100000_drop_okta_columns_from_organizations.exs
@@ -1,0 +1,29 @@
+defmodule Tuist.Repo.Migrations.DropOktaColumnsFromOrganizations do
+  # credo:disable-for-this-file ExcellentMigrations.CredoCheck.MigrationsSafety
+  use Ecto.Migration
+
+  # The data was already copied to oauth2_client_id and
+  # oauth2_encrypted_client_secret in migration 20260324103000.
+  # These columns have been unused since the custom OAuth2 SSO PR landed.
+
+  def up do
+    alter table(:organizations) do
+      remove :okta_client_id
+      remove :okta_encrypted_client_secret
+    end
+  end
+
+  def down do
+    alter table(:organizations) do
+      add :okta_client_id, :string
+      add :okta_encrypted_client_secret, :binary
+    end
+
+    execute """
+    UPDATE organizations
+    SET okta_client_id = oauth2_client_id,
+        okta_encrypted_client_secret = oauth2_encrypted_client_secret
+    WHERE sso_provider = 1
+    """
+  end
+end


### PR DESCRIPTION
## Summary
- Drops `okta_client_id` and `okta_encrypted_client_secret` from the organizations table
- The data was already copied to the unified `oauth2_*` fields in #9982
- These columns have been unused since the custom OAuth2 SSO PR landed

**Do not merge until #9982 is validated in production.**

## Test plan
- [ ] Verify #9982 is deployed and Okta SSO still works
- [ ] Run this migration on staging first
- [ ] Confirm no code references the old columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)