### PR TITLE
fix(cli): keep xcstrings in Resources phase for static framework stale detection

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -393,7 +393,7 @@ class ProjectFileElements {
     ) throws {
         guard products[targetName] == nil else { return }
         let fileType = try RelativePath(validating: productName).extension.flatMap {
-            Self.filetype(extension: $0)
+            Xcode.filetype(extension: $0)
         }
         let fileReference = PBXFileReference(
             sourceTree: .buildProductsDir,
@@ -613,7 +613,7 @@ class ProjectFileElements {
         pbxproj: PBXProj
     ) {
         let localizedFilePath = localizedFile.relative(to: localizedContainer.parentDirectory)
-        let lastKnownFileType = localizedFile.extension.flatMap { Self.filetype(extension: $0) }
+        let lastKnownFileType = localizedFile.extension.flatMap { Xcode.filetype(extension: $0) }
         let language = localizedContainer.basenameWithoutExt
         let localizedFileReference = PBXFileReference(
             sourceTree: .group,
@@ -690,7 +690,7 @@ class ProjectFileElements {
         toGroup: PBXGroup,
         pbxproj: PBXProj
     ) {
-        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Self.filetype(extension: $0) }
+        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .group,
             name: name,
@@ -714,7 +714,7 @@ class ProjectFileElements {
         toGroup: PBXGroup,
         pbxproj: PBXProj
     ) -> PBXFileReference {
-        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Self.filetype(extension: $0) }
+        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .absolute,
             name: name,
@@ -756,7 +756,7 @@ class ProjectFileElements {
         // swiftlint:disable:next force_try
         let sdkPath = sdkNodePath.relative(to: try! AbsolutePath(validating: "/")) // SDK paths are relative
 
-        let lastKnownFileType = sdkPath.extension.flatMap { Self.filetype(extension: $0) }
+        let lastKnownFileType = sdkPath.extension.flatMap { Xcode.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .developerDir,
             name: sdkPath.basename,
@@ -867,24 +867,11 @@ class ProjectFileElements {
         case "xcdatamodeld":
             return "wrapper.xcdatamodel"
         case let fileExtension?:
-            return Self.filetype(extension: fileExtension)
+            return Xcode.filetype(extension: fileExtension)
         default:
             return nil
         }
     }
-
-    /// Returns the Xcode file type for a given extension, supplementing XcodeProj's
-    /// built-in mapping with types it doesn't yet know about.
-    static func filetype(extension ext: String) -> String? {
-        if let known = Xcode.filetype(extension: ext) {
-            return known
-        }
-        return additionalFileTypes[ext]
-    }
-
-    private static let additionalFileTypes: [String: String] = [
-        "xcstrings": "text.json.xcstrings",
-    ]
 
     /// Finds and returns the gpx files used by the Run Action for all schemes.
     func gpxFilesForRunAction(in schemes: [Scheme], filesGroup: ProjectGroup) -> [GroupFileElement] {

--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -393,7 +393,7 @@ class ProjectFileElements {
     ) throws {
         guard products[targetName] == nil else { return }
         let fileType = try RelativePath(validating: productName).extension.flatMap {
-            Xcode.filetype(extension: $0)
+            Self.filetype(extension: $0)
         }
         let fileReference = PBXFileReference(
             sourceTree: .buildProductsDir,
@@ -613,7 +613,7 @@ class ProjectFileElements {
         pbxproj: PBXProj
     ) {
         let localizedFilePath = localizedFile.relative(to: localizedContainer.parentDirectory)
-        let lastKnownFileType = localizedFile.extension.flatMap { Xcode.filetype(extension: $0) }
+        let lastKnownFileType = localizedFile.extension.flatMap { Self.filetype(extension: $0) }
         let language = localizedContainer.basenameWithoutExt
         let localizedFileReference = PBXFileReference(
             sourceTree: .group,
@@ -690,7 +690,7 @@ class ProjectFileElements {
         toGroup: PBXGroup,
         pbxproj: PBXProj
     ) {
-        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
+        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Self.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .group,
             name: name,
@@ -714,7 +714,7 @@ class ProjectFileElements {
         toGroup: PBXGroup,
         pbxproj: PBXProj
     ) -> PBXFileReference {
-        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
+        let lastKnownFileType = fileAbsolutePath.extension.flatMap { Self.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .absolute,
             name: name,
@@ -756,7 +756,7 @@ class ProjectFileElements {
         // swiftlint:disable:next force_try
         let sdkPath = sdkNodePath.relative(to: try! AbsolutePath(validating: "/")) // SDK paths are relative
 
-        let lastKnownFileType = sdkPath.extension.flatMap { Xcode.filetype(extension: $0) }
+        let lastKnownFileType = sdkPath.extension.flatMap { Self.filetype(extension: $0) }
         let file = PBXFileReference(
             sourceTree: .developerDir,
             name: sdkPath.basename,
@@ -867,11 +867,24 @@ class ProjectFileElements {
         case "xcdatamodeld":
             return "wrapper.xcdatamodel"
         case let fileExtension?:
-            return Xcode.filetype(extension: fileExtension)
+            return Self.filetype(extension: fileExtension)
         default:
             return nil
         }
     }
+
+    /// Returns the Xcode file type for a given extension, supplementing XcodeProj's
+    /// built-in mapping with types it doesn't yet know about.
+    static func filetype(extension ext: String) -> String? {
+        if let known = Xcode.filetype(extension: ext) {
+            return known
+        }
+        return additionalFileTypes[ext]
+    }
+
+    private static let additionalFileTypes: [String: String] = [
+        "xcstrings": "text.json.xcstrings",
+    ]
 
     /// Finds and returns the gpx files used by the Run Action for all schemes.
     func gpxFilesForRunAction(in schemes: [Scheme], filesGroup: ProjectGroup) -> [GroupFileElement] {

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -90,22 +90,27 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 buildableFolders: resourceBuildableFolders
             )
             modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
-            // Asset catalogs and string catalogs are added to the main target's Sources build
-            // phase so Xcode generates typed symbols. This mirrors SwiftPM's PIF builder:
+            // Asset catalogs are added to the main target's Sources build phase so Xcode
+            // generates typed asset symbols. This mirrors SwiftPM's PIF builder:
             //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L345-L360
-            // Both are also compiled into the companion resource bundle via its Resources phase.
-            // The companion bundle declares PACKAGE_RESOURCE_TARGET_KIND = "resource" (above)
-            // so Xcode treats it as a pure resource container and skips string extraction.
-            // The main target carries PACKAGE_RESOURCE_TARGET_KIND = "regular" (below) so Xcode
-            // runs extraction here where the Swift source references live.
-            let codeGeneratingResourceExtensions: Set<String> = ["xcassets", "xcstrings"]
+            // They are also compiled into the companion resource bundle via its Resources phase.
+            //
+            // String catalogs (.xcstrings) are kept in the main target's Resources build phase
+            // (NOT Sources) so Xcode correctly runs string extraction in the context of this
+            // target's Swift sources. Adding xcstrings to the Sources phase does not trigger
+            // extraction in a regular xcodeproj (unlike PIF-based SPM builds). Combined with
+            // PACKAGE_RESOURCE_TARGET_KIND = "regular" (below), Xcode performs extraction here
+            // where the Swift source references live. The companion bundle declares
+            // PACKAGE_RESOURCE_TARGET_KIND = "resource" (above) so extraction is skipped there.
+            let codeGeneratingResourceExtensions: Set<String> = ["xcassets"]
             for resource in target.resources.resources {
                 if let ext = resource.path.extension, codeGeneratingResourceExtensions.contains(ext) {
                     modifiedTarget.sources.append(SourceFile(path: resource.path))
                 }
             }
-            modifiedTarget.resources.resources = []
+            modifiedTarget.resources.resources = target.resources.resources.filter {
+                $0.path.extension == "xcstrings"
+            }
             modifiedTarget.copyFiles = []
             modifiedTarget.buildableFolders = remainingBuildableFolders
             modifiedTarget.dependencies.append(.target(

--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -82,7 +82,9 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                     configurations: [:]
                 ),
                 sources: target.sources.filter { $0.path.extension == "metal" },
-                resources: target.resources,
+                resources: ResourceFileElements(
+                    target.resources.resources.filter { $0.path.extension != "xcstrings" }
+                ),
                 copyFiles: target.copyFiles,
                 coreDataModels: target.coreDataModels,
                 filesGroup: target.filesGroup,
@@ -97,11 +99,14 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
             //
             // String catalogs (.xcstrings) are kept in the main target's Resources build phase
             // (NOT Sources) so Xcode correctly runs string extraction in the context of this
-            // target's Swift sources. Adding xcstrings to the Sources phase does not trigger
-            // extraction in a regular xcodeproj (unlike PIF-based SPM builds). Combined with
-            // PACKAGE_RESOURCE_TARGET_KIND = "regular" (below), Xcode performs extraction here
-            // where the Swift source references live. The companion bundle declares
-            // PACKAGE_RESOURCE_TARGET_KIND = "resource" (above) so extraction is skipped there.
+            // target's Swift sources. They are excluded from the companion bundle to prevent
+            // duplicate compilation — the companion bundle has no Swift sources, so extraction
+            // there would incorrectly mark all strings as stale.
+            //
+            // IMPORTANT: PACKAGE_RESOURCE_BUNDLE_NAME is NOT set on the main target because
+            // swift-build's XCStringsCompiler.shouldCompileCatalog() skips xcstrings compilation
+            // when that setting is present, which breaks stale-string detection entirely.
+            // See: https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
             let codeGeneratingResourceExtensions: Set<String> = ["xcassets"]
             for resource in target.resources.resources {
                 if let ext = resource.path.extension, codeGeneratingResourceExtensions.contains(ext) {
@@ -118,22 +123,6 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 status: .required,
                 condition: .when(target.dependencyPlatformFilters)
             ))
-            // PACKAGE_RESOURCE_BUNDLE_NAME tells Xcode that a companion bundle target owns the
-            // compiled asset catalogs, which suppresses LinkAssetCatalog on this target while
-            // preserving GenerateAssetSymbols for typed resource accessors. Without this,
-            // xcodebuild archive fails for static targets because LinkAssetCatalog references
-            // an UninstalledProducts path that doesn't exist during archiving.
-            //
-            // PACKAGE_RESOURCE_TARGET_KIND = "regular" tells Xcode this is a normal compilation
-            // target (not a resource bundle) so string extraction runs here where the Swift
-            // source references live. This mirrors SwiftPM's PIF builder:
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L642
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder%2BModules.swift#L524
-            var base = modifiedTarget.settings?.base ?? SettingsDictionary()
-            base["PACKAGE_RESOURCE_BUNDLE_NAME"] = .string(bundleName)
-            base["PACKAGE_RESOURCE_TARGET_KIND"] = .string("regular")
-            modifiedTarget.settings = modifiedTarget.settings?.with(base: base)
-                ?? Settings(base: base, configurations: [:])
             additionalTargets.append(resourcesTarget)
         }
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1008,11 +1008,14 @@ struct ResourcesProjectMapperTests {
 
         let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
         #expect(resourcesTarget.product == .bundle)
-        #expect(resourcesTarget.resources.resources == resources)
+        let companionXcstrings = resourcesTarget.resources.resources.filter { $0.path.extension == "xcstrings" }
+        #expect(companionXcstrings.isEmpty)
+        let companionOtherResources = resourcesTarget.resources.resources.filter { $0.path.extension != "xcstrings" }
+        #expect(companionOtherResources.count == 1)
     }
 
     @Test
-    func mapWhenStaticTargetHasResourcesSetsPackageResourceBuildSettings() async throws {
+    func mapWhenStaticTargetHasResourcesDoesNotSetPackageResourceBuildSettings() async throws {
         // Given
         let resources: [ResourceFileElement] = [
             .file(path: "/Resources/Assets.xcassets"),
@@ -1027,11 +1030,10 @@ struct ResourcesProjectMapperTests {
 
         // Then
         let gotTarget = try #require(gotProject.targets.values.sorted().last)
-        let expectedBundleName = "\(project.name)_\(target.name)"
         let bundleNameSetting = gotTarget.settings?.base["PACKAGE_RESOURCE_BUNDLE_NAME"]
-        #expect(bundleNameSetting == .string(expectedBundleName))
+        #expect(bundleNameSetting == nil)
         let targetKindSetting = gotTarget.settings?.base["PACKAGE_RESOURCE_TARGET_KIND"]
-        #expect(targetKindSetting == .string("regular"))
+        #expect(targetKindSetting == nil)
     }
 
     // MARK: - Helpers

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -983,7 +983,7 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
-    func mapWhenStaticTargetHasXcstringsAddsThemToSources() async throws {
+    func mapWhenStaticTargetHasXcstringsKeepsThemInResources() async throws {
         // Given
         let resources: [ResourceFileElement] = [
             .file(path: "/Resources/Localizable.xcstrings"),
@@ -1000,11 +1000,11 @@ struct ResourcesProjectMapperTests {
         // Then
         let gotTarget = try #require(gotProject.targets.values.sorted().last)
         let xcstringsSources = gotTarget.sources.filter { $0.path.extension == "xcstrings" }
-        #expect(xcstringsSources.count == 1)
-        let expectedXcstringsPath = try AbsolutePath(validating: "/Resources/Localizable.xcstrings")
-        #expect(xcstringsSources.first?.path == expectedXcstringsPath)
+        #expect(xcstringsSources.isEmpty)
         let xcstringsResources = gotTarget.resources.resources.filter { $0.path.extension == "xcstrings" }
-        #expect(xcstringsResources.isEmpty)
+        #expect(xcstringsResources.count == 1)
+        let expectedXcstringsPath = try AbsolutePath(validating: "/Resources/Localizable.xcstrings")
+        #expect(xcstringsResources.first?.path == expectedXcstringsPath)
 
         let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
         #expect(resourcesTarget.product == .bundle)


### PR DESCRIPTION
## Summary

Fixes xcstrings stale-string detection for static frameworks (both single-platform and multiplatform). The root cause was threefold:

1. **`PACKAGE_RESOURCE_BUNDLE_NAME`** on the main target causes swift-build's `XCStringsCompiler.shouldCompileCatalog()` to return false, delegating xcstrings compilation to the companion bundle — which has no Swift sources, so all strings appear stale
2. **xcstrings in Sources build phase** doesn't trigger `XCStringsCompiler` in regular xcodeproj builds (only works through PIF/SPM)
3. **xcstrings in the companion bundle** caused conflicting extraction since the companion has no Swift sources

### Changes:
- Keep `.xcstrings` in the main target's **Resources** build phase (not Sources)
- **Exclude** `.xcstrings` from the companion bundle's Resources
- **Remove** `PACKAGE_RESOURCE_BUNDLE_NAME` and `PACKAGE_RESOURCE_TARGET_KIND` from the main target so `XCStringsCompiler` processes the catalog there

## Test plan

- [x] Build compiles successfully
- [x] Manually verified: dynamic framework with multiplatform destinations — `unused_string` correctly marked STALE, used strings not marked
- [x] Manually verified: static framework with multiplatform destinations and patched pbxproj — `unused_string` correctly marked STALE, used strings not marked
- [x] Verified `xcodebuild archive` succeeds for static framework with both xcassets and xcstrings (no regression from removing PACKAGE_RESOURCE_BUNDLE_NAME)


🤖 Generated with [Claude Code](https://claude.com/claude-code)