### PR TITLE
fix(server): increase processor worker max attempts to survive deployments

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   @moduledoc false
-  use Oban.Worker, queue: :default, max_attempts: 3
+  use Oban.Worker, queue: :default, max_attempts: 5
 
   alias Tuist.Accounts
   alias Tuist.Builds

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   @moduledoc false
-  use Oban.Worker, queue: :default, max_attempts: 3, unique: [keys: [:test_run_id]]
+  use Oban.Worker, queue: :default, max_attempts: 5, unique: [keys: [:test_run_id]]
 
   alias Tuist.Accounts
   alias Tuist.Storage


### PR DESCRIPTION
## Summary
- Increases `max_attempts` from 3 to 5 on `ProcessBuildWorker` and `ProcessXcresultWorker`
- Oban's default exponential backoff (`attempt^4 + 2` seconds) with 3 attempts only covers ~100s, which isn't enough to survive a processor service deployment on Render
- With 5 attempts the retry window extends to ~16 minutes, giving plenty of headroom for deployments

Fixes TUIST-B0

## Test plan
- [x] Verified the change is limited to `max_attempts` on both workers
- [ ] Monitor Sentry after next processor deployment to confirm no more `econnrefused` failures exhaust retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)