### PR TITLE
fix(cache): strip registry symlinks outside package root

### DIFF
--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -227,7 +227,7 @@ defmodule Cache.Registry.ReleaseWorker do
     parent_dir = Path.dirname(directory)
     base_name = Path.basename(directory)
 
-    with :ok <- ensure_symlinks_within_root(directory),
+    with :ok <- remove_symlinks_outside_root(directory),
          :ok <- resolve_symlinks(directory) do
       case System.cmd("zip", ["-r", archive_path, base_name], cd: parent_dir) do
         {_, 0} -> :ok
@@ -359,46 +359,54 @@ defmodule Cache.Registry.ReleaseWorker do
     end
   end
 
-  defp ensure_symlinks_within_root(root_directory) do
+  defp remove_symlinks_outside_root(root_directory) do
     expanded_root_directory = Path.expand(root_directory)
-    validate_symlinks_within_root([expanded_root_directory], expanded_root_directory)
+    prune_symlinks_outside_root([expanded_root_directory], expanded_root_directory)
   end
 
-  defp validate_symlinks_within_root([], _root_directory), do: :ok
+  defp prune_symlinks_outside_root([], _root_directory), do: :ok
 
-  defp validate_symlinks_within_root([path | rest], root_directory) do
+  defp prune_symlinks_outside_root([path | rest], root_directory) do
     case File.lstat(path) do
       {:ok, stat} ->
-        validate_symlink_path(stat, path, rest, root_directory)
+        prune_symlink_path(stat, path, rest, root_directory)
 
       {:error, reason} ->
         {:error, {:path_lstat_failed, path, reason}}
     end
   end
 
-  defp validate_symlink_path(%File.Stat{type: :symlink}, path, rest, root_directory) do
-    with {:ok, target} <- File.read_link(path),
-         :ok <- ensure_symlink_target_within_root(path, target, root_directory) do
-      validate_symlinks_within_root(rest, root_directory)
-    else
-      {:error, reason} -> {:error, {:symlink_read_failed, path, reason}}
-      {:symlink_outside_root, target} -> {:error, {:symlink_points_outside_root, path, target}}
+  defp prune_symlink_path(%File.Stat{type: :symlink}, path, rest, root_directory) do
+    case File.read_link(path) do
+      {:ok, target} ->
+        case ensure_symlink_target_within_root(path, target, root_directory) do
+          :ok ->
+            prune_symlinks_outside_root(rest, root_directory)
+
+          {:symlink_outside_root, _target} ->
+            Logger.warning("Removing symlink #{path} -> #{target} because it points outside #{root_directory}")
+            File.rm!(path)
+            prune_symlinks_outside_root(rest, root_directory)
+        end
+
+      {:error, reason} ->
+        {:error, {:symlink_read_failed, path, reason}}
     end
   end
 
-  defp validate_symlink_path(%File.Stat{type: :directory}, path, rest, root_directory) do
+  defp prune_symlink_path(%File.Stat{type: :directory}, path, rest, root_directory) do
     case File.ls(path) do
       {:ok, entries} ->
         next_paths = Enum.map(entries, &Path.join(path, &1))
-        validate_symlinks_within_root(next_paths ++ rest, root_directory)
+        prune_symlinks_outside_root(next_paths ++ rest, root_directory)
 
       {:error, reason} ->
         {:error, {:directory_list_failed, path, reason}}
     end
   end
 
-  defp validate_symlink_path(_stat, _path, rest, root_directory) do
-    validate_symlinks_within_root(rest, root_directory)
+  defp prune_symlink_path(_stat, _path, rest, root_directory) do
+    prune_symlinks_outside_root(rest, root_directory)
   end
 
   defp ensure_symlink_target_within_root(path, target, root_directory) do

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -316,7 +316,7 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       refute Enum.any?(lines, &String.contains?(&1, "broken"))
     end
 
-    test "zip_directory rejects symlinks that point outside root" do
+    test "zip_directory removes symlinks that point outside root" do
       root = Briefly.create!(directory: true)
       source_dir = Path.join(root, "repo")
       outside_path = Path.join(root, "outside.txt")
@@ -326,8 +326,11 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       File.write!(outside_path, "secret")
       File.ln_s!("../outside.txt", Path.join(source_dir, "escaped.md"))
 
-      assert {:error, {:symlink_points_outside_root, _path, "../outside.txt"}} =
-               ReleaseWorker.zip_directory(source_dir, archive_path)
+      assert :ok = ReleaseWorker.zip_directory(source_dir, archive_path)
+
+      {output, 0} = System.cmd("unzip", ["-Z", archive_path])
+      refute String.contains?(output, "escaped.md")
+      refute String.contains?(output, "outside.txt")
     end
 
     test "resolves symlinks in downloaded zipball" do
@@ -349,6 +352,54 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {output, 0} = System.cmd("unzip", ["-Z", path])
         refute Enum.any?(String.split(output, "\n"), &String.starts_with?(&1, "l"))
         assert File.read!(path) != original_bytes
+        [File.read!(path)]
+      end)
+
+      expect(ExAws.S3, :upload, fn _stream, _bucket, key, _opts ->
+        assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+        %S3{http_method: :put, bucket: "test", path: key}
+      end)
+
+      expect(ExAws, :request, 2, fn _op ->
+        {:ok, %{status_code: 200, body: ""}}
+      end)
+
+      expect_manifest_fetch(@default_manifest_content)
+      expect_metadata_update_success()
+
+      assert :ok =
+               ReleaseWorker.perform(%Oban.Job{
+                 args: %{
+                   "scope" => "apple",
+                   "name" => "swift-argument-parser",
+                   "repository_full_handle" => "apple/swift-argument-parser",
+                   "tag" => "v1.0.0"
+                 }
+               })
+    end
+
+    test "removes symlinks outside root from downloaded zipball" do
+      expect_release_sync_prerequisites()
+
+      expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser",
+                                                       "token",
+                                                       "v1.0.0",
+                                                       archive_path,
+                                                       _ ->
+        tmp = Path.join(Path.dirname(archive_path), "zipball_content")
+        top_dir = Path.join(tmp, "repo-v1.0.0")
+        File.mkdir_p!(Path.join(top_dir, "Fixtures/symlinks"))
+        File.write!(Path.join(top_dir, "Package.swift"), @default_manifest_content)
+        File.ln_s!("/usr/bin/swift", Path.join(top_dir, "Fixtures/symlinks/swift"))
+        {_, 0} = System.cmd("zip", ["--symlinks", "-r", archive_path, "repo-v1.0.0"], cd: tmp)
+        File.rm_rf!(tmp)
+        :ok
+      end)
+
+      expect(Upload, :stream_file, fn path ->
+        {output, 0} = System.cmd("unzip", ["-Z", path])
+        refute String.contains?(output, "Fixtures/symlinks/swift")
+        refute Enum.any?(String.split(output, "\n"), &String.starts_with?(&1, "l"))
         [File.read!(path)]
       end)
 


### PR DESCRIPTION
## Summary
- remove registry package symlinks whose targets resolve outside the extracted package root
- keep repacking archives so in-root symlinks are still flattened for SwiftPM
- cover the new behavior in release worker tests

## Validation
- nix shell nixpkgs#elixir_1_19 nixpkgs#erlang_28 --command mix format --check-formatted
- nix shell nixpkgs#elixir_1_19 nixpkgs#erlang_28 --command mix credo --strict
- nix shell nixpkgs#elixir_1_19 nixpkgs#erlang_28 nixpkgs#zip nixpkgs#unzip --command env MIX_ENV=test mix test --warnings-as-errors

Fixes CACHE-4K
Fixes CACHE-4M