### PR TITLE
fix(server): handle inactive Slack report installations

### DIFF
--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -13,19 +13,22 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   alias Tuist.Projects
   alias Tuist.Projects.Project
   alias Tuist.Repo
+  alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
   alias Tuist.Slack.Reports
 
+  require Logger
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"project_id" => project_id}}) do
-    project = Projects.get_project_by_id(project_id)
+    case Projects.get_project_by_id(project_id) do
+      nil ->
+        :ok
 
-    if project do
-      project = Repo.preload(project, account: :slack_installation)
-      :ok = send_report(project)
+      project ->
+        project = Repo.preload(project, account: :slack_installation)
+        send_report(project)
     end
-
-    :ok
   end
 
   def perform(_job) do
@@ -72,7 +75,22 @@ defmodule Tuist.Slack.Workers.ReportWorker do
     if slack_installation && project.slack_channel_id do
       last_report_at = get_last_report_time(project.id)
       blocks = Reports.report(project, last_report_at: last_report_at)
-      SlackClient.post_message(slack_installation.access_token, project.slack_channel_id, blocks)
+
+      case SlackClient.post_message(slack_installation.access_token, project.slack_channel_id, blocks) do
+        :ok ->
+          :ok
+
+        {:error, "account_inactive"} ->
+          Logger.warning("Deleting inactive Slack installation for account #{project.account_id}")
+
+          case Slack.delete_installation(slack_installation) do
+            {:ok, _installation} -> {:discard, :account_inactive}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     else
       :ok
     end

--- a/server/test/support/tuist_test_support/fixtures/accounts_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/accounts_fixtures.ex
@@ -4,6 +4,9 @@ defmodule TuistTestSupport.Fixtures.AccountsFixtures do
   alias Tuist.Accounts
 
   def user_fixture(opts \\ []) do
+    email = Keyword.get(opts, :email, unique_user_email())
+    handle = Keyword.get(opts, :handle, handle_from_email(email))
+
     create_opts =
       [
         password: Keyword.get(opts, :password, valid_user_password()),
@@ -13,17 +16,9 @@ defmodule TuistTestSupport.Fixtures.AccountsFixtures do
         setup_billing: Keyword.get(opts, :setup_billing, false),
         current_month_remote_cache_hits_count: Keyword.get(opts, :current_month_remote_cache_hits_count, 0),
         current_month_remote_cache_hits_count_updated_at:
-          Keyword.get(opts, :current_month_remote_cache_hits_count_updated_at)
+          Keyword.get(opts, :current_month_remote_cache_hits_count_updated_at),
+        handle: handle
       ]
-
-    create_opts =
-      if Keyword.has_key?(opts, :handle) do
-        Keyword.put(create_opts, :handle, Keyword.get(opts, :handle))
-      else
-        create_opts
-      end
-
-    email = Keyword.get(opts, :email, unique_user_email())
 
     {:ok, user} =
       Accounts.create_user(email, create_opts)
@@ -88,6 +83,16 @@ defmodule TuistTestSupport.Fixtures.AccountsFixtures do
 
   def unique_user_email, do: "#{TuistTestSupport.Utilities.unique_integer(6)}@tuist.io"
   def valid_user_password, do: "hello world!"
+
+  defp handle_from_email(email) do
+    email
+    |> String.split("@")
+    |> List.first()
+    |> String.replace(".", "-")
+    |> String.replace("_", "-")
+    |> String.replace(~r/[^a-zA-Z0-9-]/, "")
+    |> String.downcase()
+  end
 
   def valid_user_attributes(attrs \\ %{}) do
     Enum.into(attrs, %{

--- a/server/test/tuist/slack/workers/report_worker_test.exs
+++ b/server/test/tuist/slack/workers/report_worker_test.exs
@@ -1,10 +1,12 @@
 defmodule Tuist.Slack.Workers.ReportWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, async: false
   use Mimic
 
   alias Tuist.Builds.Analytics, as: BuildsAnalytics
   alias Tuist.Projects
+  alias Tuist.Repo
   alias Tuist.Slack.Client
+  alias Tuist.Slack.Installation
   alias Tuist.Slack.Workers.ReportWorker
   alias Tuist.Tests.Analytics, as: TestsAnalytics
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -12,13 +14,167 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
   alias TuistTestSupport.Fixtures.SlackFixtures
 
   setup do
-    user = %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
+    unique_value = TuistTestSupport.Utilities.unique_integer(6)
+
+    user =
+      %{account: account} =
+      AccountsFixtures.user_fixture(
+        email: "#{unique_value}@tuist.io",
+        handle: "account-#{unique_value}",
+        preload: [:account]
+      )
+
     slack_installation = SlackFixtures.slack_installation_fixture(account_id: account.id)
     project = ProjectsFixtures.project_fixture(account_id: account.id)
     %{user: user, project: project, account: account, slack_installation: slack_installation}
   end
 
   describe "perform/1" do
+    test "deletes the slack installation when Slack returns account_inactive", %{
+      project: project,
+      slack_installation: slack_installation
+    } do
+      now = ~U[2025-01-15 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-15])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_message, fn access_token, channel_id, blocks ->
+        assert access_token == slack_installation.access_token
+        assert channel_id == "C123456"
+        assert is_list(blocks)
+        {:error, "account_inactive"}
+      end)
+
+      assert {:discard, :account_inactive} = ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
+      assert Repo.get(Installation, slack_installation.id) == nil
+
+      updated_project = Projects.get_project_by_id(project.id)
+      assert updated_project.slack_channel_id == nil
+      assert updated_project.slack_channel_name == nil
+    end
+
+    test "marks account_inactive cleanup jobs as discarded", %{
+      project: project,
+      slack_installation: slack_installation
+    } do
+      now = ~U[2025-01-15 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-15])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_message, fn access_token, channel_id, blocks ->
+        assert access_token == slack_installation.access_token
+        assert channel_id == "C123456"
+        assert is_list(blocks)
+        {:error, "account_inactive"}
+      end)
+
+      {:ok, job} =
+        %{project_id: project.id}
+        |> ReportWorker.new()
+        |> Oban.insert()
+
+      Oban.drain_queue(queue: :default)
+
+      persisted_job = Repo.get!(Oban.Job, job.id)
+
+      assert persisted_job.state == "discarded"
+      assert persisted_job.discarded_at
+      assert persisted_job.completed_at == nil
+    end
+
+    test "does not advance the report window for discarded cleanup jobs", %{
+      project: project,
+      slack_installation: slack_installation
+    } do
+      previous_report_at = ~U[2025-01-14 09:00:00Z]
+      discarded_at = ~U[2025-01-15 09:00:00Z]
+      now = ~U[2025-01-16 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-16])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      insert_report_job(project.id,
+        state: "completed",
+        completed_at: previous_report_at,
+        inserted_at: previous_report_at,
+        scheduled_at: previous_report_at
+      )
+
+      insert_report_job(project.id,
+        state: "discarded",
+        discarded_at: discarded_at,
+        inserted_at: discarded_at,
+        scheduled_at: discarded_at
+      )
+
+      assert Repo.aggregate(Oban.Job, :count, :id) == 2
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_message, fn access_token, channel_id, blocks ->
+        assert access_token == slack_installation.access_token
+        assert channel_id == "C123456"
+
+        context_block = Enum.at(blocks, 1)
+
+        assert hd(context_block.elements).text ==
+                 report_period_text(previous_report_at, now)
+
+        :ok
+      end)
+
+      assert :ok = ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
+    end
+
+    test "returns an error when sending the report fails transiently", %{project: project} do
+      now = ~U[2025-01-15 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-15])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_message, fn _access_token, _channel_id, _blocks ->
+        {:error, "timeout"}
+      end)
+
+      assert {:error, "timeout"} = ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
+    end
+
     test "sends reports for projects with matching schedule", %{project: project, slack_installation: slack_installation} do
       now = ~U[2025-01-15 09:00:00Z]
       day_of_week = Date.day_of_week(~D[2025-01-15])
@@ -33,27 +189,7 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
           report_timezone: "Etc/UTC"
         })
 
-      stub(DateTime, :utc_now, fn -> now end)
-
-      stub(BuildsAnalytics, :build_duration_analytics, fn _project_id, _opts ->
-        %{total_average_duration: 1000, trend: nil}
-      end)
-
-      stub(TestsAnalytics, :test_run_duration_analytics, fn _project_id, _opts ->
-        %{total_average_duration: 500, trend: nil}
-      end)
-
-      stub(Tuist.Cache.Analytics, :cache_hit_rate_analytics, fn _opts ->
-        %{cache_hit_rate: 0.8, trend: nil}
-      end)
-
-      stub(BuildsAnalytics, :selective_testing_analytics, fn _opts ->
-        %{hit_rate: 0, trend: nil}
-      end)
-
-      stub(Tuist.Bundles, :last_project_bundle, fn _project, _opts ->
-        nil
-      end)
+      stub_report_metrics(now)
 
       expect(Client, :post_message, fn access_token, channel_id, blocks ->
         assert access_token == slack_installation.access_token
@@ -171,5 +307,68 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
 
       assert :ok = ReportWorker.perform(%Oban.Job{args: %{}})
     end
+  end
+
+  defp stub_report_metrics(now) do
+    stub(DateTime, :utc_now, fn -> now end)
+
+    stub(BuildsAnalytics, :build_duration_analytics, fn _project_id, _opts ->
+      %{total_average_duration: 1000, trend: nil}
+    end)
+
+    stub(TestsAnalytics, :test_run_duration_analytics, fn _project_id, _opts ->
+      %{total_average_duration: 500, trend: nil}
+    end)
+
+    stub(Tuist.Cache.Analytics, :cache_hit_rate_analytics, fn _opts ->
+      %{cache_hit_rate: 0.8, trend: nil}
+    end)
+
+    stub(BuildsAnalytics, :selective_testing_analytics, fn _opts ->
+      %{hit_rate: 0, trend: nil}
+    end)
+
+    stub(Tuist.Bundles, :last_project_bundle, fn _project, _opts ->
+      nil
+    end)
+  end
+
+  defp insert_report_job(project_id, attrs) do
+    Repo.insert!(%Oban.Job{
+      state: Keyword.fetch!(attrs, :state),
+      queue: "default",
+      worker: to_string(Keyword.get(attrs, :worker, ReportWorker)),
+      args: %{"project_id" => project_id},
+      meta: %{},
+      tags: [],
+      errors: [],
+      attempt: 0,
+      max_attempts: 20,
+      priority: 0,
+      completed_at: truncate_datetime(Keyword.get(attrs, :completed_at)),
+      discarded_at: truncate_datetime(Keyword.get(attrs, :discarded_at)),
+      inserted_at: truncate_datetime(Keyword.fetch!(attrs, :inserted_at)),
+      scheduled_at: truncate_datetime(Keyword.fetch!(attrs, :scheduled_at))
+    })
+  end
+
+  defp truncate_datetime(nil), do: nil
+
+  defp truncate_datetime(datetime) do
+    %{DateTime.truncate(datetime, :microsecond) | microsecond: {elem(datetime.microsecond, 0), 6}}
+  end
+
+  defp report_period_text(current_period_start, current_period_end) do
+    period_duration = DateTime.diff(current_period_end, current_period_start, :second)
+    previous_period_start = DateTime.add(current_period_start, -period_duration, :second)
+
+    "Report period: #{format_datetime(current_period_start)} - #{format_datetime(current_period_end)}\n" <>
+      "Previous period: #{format_datetime(previous_period_start)} - #{format_datetime(current_period_start)}"
+  end
+
+  defp format_datetime(datetime) do
+    timestamp = DateTime.to_unix(datetime)
+    fallback = Calendar.strftime(datetime, "%b %d, %H:%M")
+    "<!date^#{timestamp}^{date_short} {time}|#{fallback}>"
   end
 end


### PR DESCRIPTION
Resolves https://tuist.sentry.io/issues/TUIST-B5

This fixes the `MatchError` reported in Sentry when `Tuist.Slack.Workers.ReportWorker` tries to send a scheduled Slack report for an installation that Slack has already marked as inactive.

Previously, the worker expected `SlackClient.post_message/3` to return `:ok`, so a response like `{:error, "account_inactive"}` crashed the job on the pattern match and kept retrying the same invalid installation.

This PR updates the worker to:

- handle `{:error, "account_inactive"}` explicitly instead of crashing
- delete the inactive Slack installation and clear the associated project Slack channel configuration
- return `{:discard, :account_inactive}` so Oban discards the cleanup job instead of retrying it
- keep the report window anchored to the last *completed* report job, so discarded cleanup jobs do not affect the next report period
- add regression coverage for inactive installations, discarded jobs, transient failures, and the report period behavior

It also makes the account fixture derive a valid handle from the provided email so these tests can create stable account data without collisions.

### How to test locally

- cd server
- mix test test/tuist/slack/workers/report_worker_test.exs