### PR TITLE
fix(cli): resolve directory casing mismatch for tuist-derived dependencies

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -903,6 +903,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.support.targetName),
                     .target(name: Module.constants.targetName),
                     .target(name: Module.xcodeGraph.targetName),
+                    .external(name: "FileSystem"),
                     .external(name: "Logging"),
                 ]
             case .automation:

--- a/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -1,15 +1,24 @@
+import FileSystem
 import Foundation
+import Path
 import TuistConstants
 import TuistCore
 import TuistSupport
 import XcodeGraph
 
 public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
-    public init() {}
+    private let fileSystem: FileSysteming
 
-    public func map(workspace: WorkspaceWithProjects) throws -> (WorkspaceWithProjects, [SideEffectDescriptor]) {
+    public init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    public func map(workspace: WorkspaceWithProjects) async throws -> (WorkspaceWithProjects, [SideEffectDescriptor]) {
         var workspace = workspace
-        let mappedProjects = try workspace.projects.map(map(project:))
+        var mappedProjects: [(Project, [SideEffectDescriptor])] = []
+        for project in workspace.projects {
+            mappedProjects.append(try await map(project: project))
+        }
         workspace.projects = mappedProjects.map(\.0)
         return (
             workspace,
@@ -19,7 +28,7 @@ public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
 
     // MARK: - Helpers
 
-    private func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+    private func map(project: Project) async throws -> (Project, [SideEffectDescriptor]) {
         guard case .external = project.type,
               // We don't want to update local packages (which are defined outside the `checkouts` directory in `.build`
               project.path.parentDirectory.parentDirectory.basename == Constants.SwiftPackageManager.packageBuildDirectoryName
@@ -33,6 +42,12 @@ public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
                 project.name,
             ]
         )
+        // Remove any stale derived directory so it is recreated with the correct casing.
+        // On case-insensitive filesystems (macOS), a leftover directory from a previous run
+        // may have different casing, which Xcode 26+ flags as an error.
+        if try await fileSystem.exists(derivedDirectory, isDirectory: true) {
+            try await fileSystem.remove(derivedDirectory)
+        }
         project.xcodeProjPath = derivedDirectory.appending(component: xcodeProjBasename)
 
         var base = project.settings.base

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -1,3 +1,4 @@
+import FileSystem
 import Foundation
 import TuistConstants
 import TuistCore
@@ -21,7 +22,7 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_map() throws {
+    func test_map() async throws {
         // Given
         let projectPath = try temporaryPath()
         let project = Project.test(
@@ -52,7 +53,7 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
         )
 
         // When
-        let (gotWorkspaceWithProjects, _) = try subject.map(
+        let (gotWorkspaceWithProjects, _) = try await subject.map(
             workspace: WorkspaceWithProjects(
                 workspace: workspace,
                 projects: [
@@ -98,7 +99,60 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
         )
     }
 
-    func test_map_namespacesExternalProjectsToAvoidCollidingWithTargetDerivedDirectories() throws {
+    func test_map_removesStaleDirectoryWithMismatchedCasing() async throws {
+        // Given: A tuist-derived directory exists with "SwiftyMocky" casing (e.g., from a previous run)
+        // but the project name uses "swiftymocky" casing (from Package.swift)
+        let externalProjectBasePath = try temporaryPath()
+            .appending(component: Constants.SwiftPackageManager.packageBuildDirectoryName)
+
+        let derivedDir = externalProjectBasePath.appending(
+            components: [
+                Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                Constants.DerivedDirectory.dependenciesProjectDirectory,
+            ]
+        )
+        let oldCasingDir = derivedDir.appending(component: "SwiftyMocky")
+        let fileSystem = FileSystem()
+        try await fileSystem.makeDirectory(at: oldCasingDir)
+
+        let externalProjectPath = externalProjectBasePath.appending(
+            components: ["checkouts", "SwiftyMocky"]
+        )
+        let externalProject = Project.test(
+            path: externalProjectPath,
+            sourceRootPath: externalProjectPath,
+            xcodeProjPath: externalProjectPath.appending(component: "swiftymocky.xcodeproj"),
+            name: "swiftymocky",
+            type: .external(hash: nil)
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try await subject.map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then: The stale directory should be removed so XcodeProj.write recreates it with correct casing
+        let entries = try await fileSystem.glob(directory: derivedDir, include: ["*"]).collect().map(\.basename)
+        XCTAssertFalse(entries.contains("SwiftyMocky"), "Stale directory 'SwiftyMocky' should have been removed")
+
+        // The xcodeproj path should use the lowercase name
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            externalProjectBasePath.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesProjectDirectory,
+                    "swiftymocky",
+                    "swiftymocky.xcodeproj",
+                ]
+            )
+        )
+    }
+
+    func test_map_namespacesExternalProjectsToAvoidCollidingWithTargetDerivedDirectories() async throws {
         // Given
         let externalProjectBasePath = try temporaryPath()
             .appending(component: Constants.SwiftPackageManager.packageBuildDirectoryName)
@@ -117,7 +171,7 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
         )
 
         // When
-        let (gotWorkspaceWithProjects, _) = try subject.map(
+        let (gotWorkspaceWithProjects, _) = try await subject.map(
             workspace: WorkspaceWithProjects(
                 workspace: .test(name: "A"),
                 projects: [externalProject]


### PR DESCRIPTION
## Summary
- On macOS's case-insensitive APFS, a tuist-derived project directory could persist with stale casing from a previous `tuist generate` run (e.g., `SwiftyMocky/` from a git URL) while the workspace FileRef uses different casing from `Package.swift` (e.g., `swiftymocky/`). Xcode 26+ now flags this as an error.
- In `ExternalDependencyPathWorkspaceMapper`, remove any stale derived directory before setting the xcodeproj path, so `XcodeProj.write` recreates it with the correct casing.

## Test plan
- [x] Added `test_map_removesStaleDirectoryWithMismatchedCasing` to `ExternalDependencyPathWorkspaceMapperTests`
- [ ] Verify with a project that has a dependency where the git repo name casing differs from the `Package.swift` name (e.g., SwiftyMocky)
- [ ] Confirm Xcode 26+ no longer shows the casing mismatch warning after running `tuist generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)