### PR TITLE
fix(cache): handle inaccessible submodules during registry sync

### DIFF
--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -18,6 +18,20 @@ defmodule Cache.Registry.ReleaseWorker do
   @alternate_manifest_regex ~r/\APackage@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?\.swift\z/
   @lock_ttl_seconds 1_800
   @metadata_lock_ttl_seconds 300
+  @skippable_submodule_failure_markers [
+    "no url found for submodule path",
+    "transport 'file' not allowed",
+    "url using bad/illegal format or missing url",
+    "repository not found",
+    "does not appear to be a git repository",
+    "the requested url returned error: 404",
+    "fatal: could not read username for",
+    "not our ref",
+    "did not contain",
+    "unable to find current revision in submodule path",
+    "reference is not a tree",
+    "needed a single revision"
+  ]
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -67,10 +81,11 @@ defmodule Cache.Registry.ReleaseWorker do
     {:ok, tmp_dir} = Briefly.create(directory: true)
     archive_path = Path.join(tmp_dir, "source_archive.zip")
 
-    with :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
+    with {:ok, manifest_payloads} <- fetch_manifests(full_handle, tag, token),
+         :ok <- fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path),
          {:ok, checksum} <- checksum_for_file(archive_path),
          :ok <- upload_source_archive(scope, name, version, archive_path),
-         {:ok, manifests} <- fetch_and_upload_manifests(scope, name, version, full_handle, tag, token) do
+         {:ok, manifests} <- upload_manifests(scope, name, version, manifest_payloads) do
       update_metadata_with_release(scope, name, full_handle, version, checksum, manifests)
     else
       {:error, reason} ->
@@ -80,10 +95,14 @@ defmodule Cache.Registry.ReleaseWorker do
   end
 
   defp fetch_source_archive(full_handle, tag, token, tmp_dir, archive_path) do
-    if has_submodules?(full_handle, tag, token) do
-      build_archive_from_clone(full_handle, tag, token, tmp_dir, archive_path)
-    else
-      build_archive_from_zipball(full_handle, tag, token, tmp_dir, archive_path)
+    with {:ok, submodule_paths} <- fetch_submodule_paths(full_handle, tag, token) do
+      case submodule_paths do
+        [] ->
+          build_archive_from_zipball(full_handle, tag, token, tmp_dir, archive_path)
+
+        _submodule_paths ->
+          build_archive_from_clone(full_handle, tag, token, tmp_dir, archive_path)
+      end
     end
   end
 
@@ -95,7 +114,7 @@ defmodule Cache.Registry.ReleaseWorker do
 
   defp build_archive_from_zipball(full_handle, tag, token, tmp_dir, archive_path) do
     with :ok <- TuistCommon.GitHub.download_zipball(full_handle, token, tag, archive_path, @github_opts) do
-      ensure_archive_without_symlinks(tmp_dir, archive_path)
+      normalize_archive(tmp_dir, archive_path)
     end
   end
 
@@ -103,20 +122,36 @@ defmodule Cache.Registry.ReleaseWorker do
   # packages that contain them (e.g. CLAUDE.md -> AGENTS.md symlinks).
   # This workaround resolves symlinks by repacking the archive before upload.
   # Upstream fix: https://github.com/swiftlang/swift-package-manager/pull/9411
-  defp ensure_archive_without_symlinks(tmp_dir, archive_path) do
+  defp normalize_archive(tmp_dir, archive_path) do
     case archive_has_symlinks?(archive_path) do
-      {:ok, true} -> resolve_symlinks_in_archive(tmp_dir, archive_path)
-      {:ok, false} -> :ok
-      {:error, reason} -> {:error, reason}
+      {:ok, has_symlinks} ->
+        if has_symlinks do
+          repackage_archive(tmp_dir, archive_path)
+        else
+          :ok
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp has_submodules?(full_handle, tag, token) do
+  defp fetch_submodule_paths(full_handle, tag, token) do
     case TuistCommon.GitHub.get_file_content(full_handle, token, ".gitmodules", tag, @github_opts) do
-      {:ok, content} -> content != ""
-      {:error, :not_found} -> false
-      {:error, _reason} -> false
+      {:ok, content} -> {:ok, parse_gitmodules_paths(content)}
+      {:error, :not_found} -> {:ok, []}
+      {:error, reason} -> {:error, {:gitmodules_fetch_failed, reason}}
     end
+  end
+
+  defp parse_gitmodules_paths(content) do
+    ~r/^\s*path\s*=\s*(.+?)\s*$/m
+    |> Regex.scan(content, capture: :all_but_first)
+    |> Enum.map(fn [path] -> String.trim(path) end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(&normalize_package_relative_path/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
   end
 
   defp clone_with_submodules(full_handle, tag, token, tmp_dir) do
@@ -140,7 +175,11 @@ defmodule Cache.Registry.ReleaseWorker do
            stderr_to_stdout: true
          ) do
       {_, 0} ->
-        case update_submodules(%{destination: clone_dest, repository_full_handle: full_handle, tag: tag}) do
+        case update_submodules(%{
+               destination: clone_dest,
+               repository_full_handle: full_handle,
+               tag: tag
+             }) do
           :ok ->
             remove_git_metadata(clone_dest)
             {:ok, clone_dest}
@@ -154,62 +193,125 @@ defmodule Cache.Registry.ReleaseWorker do
     end
   end
 
-  defp update_submodules(%{destination: destination, repository_full_handle: full_handle, tag: tag}) do
-    destination
-    |> submodule_paths()
-    |> Enum.reduce_while(:ok, fn submodule_path, :ok ->
-      case System.cmd(
-             "git",
-             [
-               "-c",
-               "url.https://github.com/.insteadOf=git@github.com:",
-               "-C",
-               destination,
-               "submodule",
-               "update",
-               "--init",
-               "--recursive",
-               "--depth",
-               "1",
-               submodule_path
-             ],
-             stderr_to_stdout: true
-           ) do
-        {_, 0} ->
-          {:cont, :ok}
-
-        {output, status} ->
-          if private_submodule_error?(output) do
-            Logger.info("Skipping private submodule #{submodule_path} for #{full_handle}@#{tag}")
+  @doc false
+  def update_submodules(%{destination: destination, repository_full_handle: full_handle, tag: tag}) do
+    with {:ok, submodule_paths} <- submodule_paths(destination) do
+      Enum.reduce_while(submodule_paths, :ok, fn submodule_path, :ok ->
+        case update_submodule(destination, submodule_path) do
+          :ok ->
             {:cont, :ok}
-          else
-            {:halt, {:error, {:git_submodule_failed, status, output}}}
+
+          {:skip, output} ->
+            case remove_failed_submodule_contents(destination, submodule_path) do
+              :ok ->
+                Logger.warning(
+                  "Skipping submodule #{submodule_path} for #{full_handle}@#{tag} after permanent git submodule update failure: #{output}"
+                )
+
+                {:cont, :ok}
+
+              {:error, reason} ->
+                {:halt, {:error, reason}}
+            end
+
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
+      end)
+    end
+  end
+
+  defp update_submodule(destination, submodule_path) do
+    case System.cmd(
+           "git",
+           [
+             "-c",
+             "url.https://github.com/.insteadOf=git@github.com:",
+             "-C",
+             destination,
+             "submodule",
+             "update",
+             "--init",
+             "--recursive",
+             "--depth",
+             "1",
+             submodule_path
+           ],
+           stderr_to_stdout: true
+         ) do
+      {_, 0} ->
+        :ok
+
+      {output, status} ->
+        output =
+          output
+          |> String.trim()
+          |> case do
+            "" -> "(no output)"
+            trimmed -> trimmed
           end
-      end
-    end)
+
+        nested_submodule_path = nested_submodule_path(output)
+
+        cond do
+          nested_submodule_failure?(output, submodule_path, nested_submodule_path) ->
+            {:error, {:nested_git_submodule_update_failed, submodule_path, nested_submodule_path, status, output}}
+
+          skippable_submodule_failure?(output) ->
+            {:skip, output}
+
+          true ->
+            {:error, {:git_submodule_update_failed, submodule_path, status, output}}
+        end
+    end
+  end
+
+  defp nested_submodule_path(output) do
+    case Regex.run(~r/registered for path '([^']+)'/, output, capture: :all_but_first) ||
+           Regex.run(~r/submodule path '([^']+)'/, output, capture: :all_but_first) do
+      [nested_submodule_path] -> nested_submodule_path
+      _ -> nil
+    end
+  end
+
+  defp nested_submodule_failure?(output, submodule_path, nested_submodule_path) do
+    output =~ "Failed to recurse into submodule path '#{submodule_path}'" and
+      is_binary(nested_submodule_path) and
+      nested_submodule_path != submodule_path and
+      String.starts_with?(nested_submodule_path, submodule_path <> "/")
+  end
+
+  defp skippable_submodule_failure?(output) do
+    Enum.any?(@skippable_submodule_failure_markers, &(output |> String.downcase() |> String.contains?(&1)))
+  end
+
+  defp remove_failed_submodule_contents(destination, submodule_path) do
+    case File.rm_rf(Path.join(destination, submodule_path)) do
+      {:ok, _removed_paths} -> :ok
+      {:error, reason, path} -> {:error, {:remove_failed_submodule_contents_failed, path, reason}}
+    end
   end
 
   defp submodule_paths(destination) do
     case System.cmd("git", ["-C", destination, "ls-files", "--stage"], stderr_to_stdout: true) do
       {output, 0} ->
-        output
-        |> String.split("\n", trim: true)
-        |> Enum.filter(&String.starts_with?(&1, "160000"))
-        |> Enum.map(fn line ->
-          case String.split(line, "\t", parts: 2) do
-            [_, path] -> String.trim(path)
-            _ -> nil
-          end
-        end)
-        |> Enum.reject(&is_nil/1)
+        paths =
+          output
+          |> String.split("\n", trim: true)
+          |> Enum.filter(&String.starts_with?(&1, "160000"))
+          |> Enum.map(fn line ->
+            case String.split(line, "\t", parts: 2) do
+              [_, path] -> String.trim(path)
+              _ -> nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
 
-      _ ->
-        []
+        {:ok, paths}
+
+      {output, status} ->
+        {:error, {:git_list_submodules_failed, status, String.trim(output)}}
     end
-  end
-
-  defp private_submodule_error?(output) do
-    String.contains?(output, "fatal: could not read Username for")
   end
 
   defp remove_git_metadata(directory) do
@@ -307,15 +409,27 @@ defmodule Cache.Registry.ReleaseWorker do
     symlink_path == resolved_target or String.starts_with?(symlink_path, resolved_target <> "/")
   end
 
-  defp resolve_symlinks_in_archive(tmp_dir, archive_path) do
+  defp repackage_archive(tmp_dir, archive_path) do
     extract_dir = Path.join(tmp_dir, "extract")
-    Logger.info("Resolving symlinks in source archive at #{archive_path}")
+    Logger.info("Repacking source archive at #{archive_path}")
 
     with :ok <- ensure_extract_directory(extract_dir),
          :ok <- unzip_archive(archive_path, extract_dir),
          {:ok, top_level_directory} <- extract_archive_root_directory(extract_dir),
          :ok <- remove_archive(archive_path) do
       zip_directory(top_level_directory, archive_path)
+    end
+  end
+
+  defp normalize_package_relative_path(path, base_path \\ ".") do
+    package_root = "/package"
+    expanded_base_path = Path.expand(base_path, package_root)
+    expanded_path = Path.expand(path, expanded_base_path)
+
+    cond do
+      expanded_path == package_root -> nil
+      path_within_root?(expanded_path, package_root) -> Path.relative_to(expanded_path, package_root)
+      true -> nil
     end
   end
 
@@ -454,32 +568,54 @@ defmodule Cache.Registry.ReleaseWorker do
     S3.upload_file(key, archive_path, type: :registry, content_type: "application/zip")
   end
 
-  defp fetch_and_upload_manifests(scope, name, version, full_handle, tag, token) do
+  defp fetch_manifests(full_handle, tag, token) do
     with {:ok, contents} <- TuistCommon.GitHub.list_repository_contents(full_handle, token, tag, @github_opts) do
-      manifests =
+      manifest_payloads =
         contents
         |> Enum.map(&Map.get(&1, "path"))
         |> Enum.filter(&manifest_path?/1)
         |> Enum.map(fn path ->
           filename = Path.basename(path)
-          swift_version = manifest_swift_version(filename)
 
-          with {:ok, content} <- TuistCommon.GitHub.get_file_content(full_handle, token, path, tag, @github_opts),
-               :ok <- upload_manifest(scope, name, version, filename, content) do
-            %{
-              "swift_version" => swift_version,
-              "swift_tools_version" => swift_tools_version(content)
-            }
-          else
+          case TuistCommon.GitHub.get_file_content(full_handle, token, path, tag, @github_opts) do
+            {:ok, content} ->
+              %{
+                content: content,
+                filename: filename,
+                path: path,
+                swift_version: manifest_swift_version(filename)
+              }
+
             {:error, reason} ->
-              Logger.warning("Failed to fetch manifest #{path} for #{scope}/#{name}@#{tag}: #{inspect(reason)}")
+              Logger.warning("Failed to fetch manifest #{path} for #{full_handle}@#{tag}: #{inspect(reason)}")
               nil
           end
         end)
         |> Enum.reject(&is_nil/1)
 
-      {:ok, manifests}
+      {:ok, manifest_payloads}
     end
+  end
+
+  defp upload_manifests(scope, name, version, manifest_payloads) do
+    manifests =
+      manifest_payloads
+      |> Enum.map(fn %{content: content, filename: filename, path: path, swift_version: swift_version} ->
+        case upload_manifest(scope, name, version, filename, content) do
+          :ok ->
+            %{
+              "swift_version" => swift_version,
+              "swift_tools_version" => swift_tools_version(content)
+            }
+
+          {:error, reason} ->
+            Logger.warning("Failed to upload manifest #{path} for #{scope}/#{name}@#{version}: #{inspect(reason)}")
+            nil
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    {:ok, manifests}
   end
 
   defp update_metadata_with_release(scope, name, full_handle, version, checksum, manifests) do

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -77,13 +77,12 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       {:error, :not_found}
     end)
 
-    # No submodules
-    expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                     "token",
-                                                     ".gitmodules",
-                                                     "v1.0.0",
-                                                     _ ->
-      {:error, :not_found}
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, @default_manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
     end)
 
     # Download zipball — write a real file so checksum works
@@ -119,15 +118,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
     end)
 
-    # Fetch the manifest content
-    expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                     "token",
-                                                     "Package.swift",
-                                                     "v1.0.0",
-                                                     _ ->
-      {:ok, @default_manifest_content}
-    end)
-
     # Metadata lock for update
     expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
       {:ok, :acquired}
@@ -159,6 +149,236 @@ defmodule Cache.Registry.ReleaseWorkerTest do
                  "tag" => "v1.0.0"
                }
              })
+  end
+
+  test "does not prune archive contents based on Package.swift excludes" do
+    manifest_content = """
+    // swift-tools-version:5.9
+    import PackageDescription
+
+    let package = Package(
+      name: "swift-argument-parser",
+      targets: [
+        .target(
+          name: "ArgumentParser",
+          exclude: ["../../Generator"]
+        )
+      ]
+    )
+    """
+
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser",
+                                                     "token",
+                                                     "v1.0.0",
+                                                     archive_path,
+                                                     _ ->
+      write_zipball_with_generator(archive_path)
+      :ok
+    end)
+
+    expect(Upload, :stream_file, fn path ->
+      {output, 0} = System.cmd("unzip", ["-Z1", path])
+      assert String.contains?(output, "repo-v1.0.0/Generator/")
+      assert String.contains?(output, "repo-v1.0.0/Generator/template.txt")
+      assert String.contains?(output, "repo-v1.0.0/Sources/ArgumentParser/main.swift")
+      [File.read!(path)]
+    end)
+
+    expect(ExAws.S3, :upload, fn _stream, _bucket, key, _opts ->
+      assert key == "registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+      %S3{http_method: :put, bucket: "test", path: key}
+    end)
+
+    expect(ExAws, :request, 2, fn _op ->
+      {:ok, %{status_code: 200, body: ""}}
+    end)
+
+    expect(Lock, :try_acquire, fn {:package, "apple", "swift-argument-parser"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", metadata ->
+      release = metadata["releases"]["1.0.0"]
+      assert is_binary(release["checksum"])
+      assert [%{"swift_version" => nil, "swift_tools_version" => "5.9"}] = release["manifests"]
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
+  test "logs and skips submodules when updates fail" do
+    root = Briefly.create!(directory: true)
+
+    repo = create_gitlink_repo(root, ["Vendor/Required"])
+    submodule_path = "Vendor/Required"
+    stale_file = Path.join([repo, submodule_path, "stale.txt"])
+
+    File.mkdir_p!(Path.dirname(stale_file))
+    File.write!(stale_file, "stale")
+
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 ReleaseWorker.update_submodules(%{
+                   destination: repo,
+                   repository_full_handle: "apple/swift-argument-parser",
+                   tag: "v1.0.0"
+                 })
+      end)
+
+    assert log =~ "Skipping submodule #{submodule_path}"
+    assert log =~ "No url found for submodule path"
+    refute File.exists?(Path.join(repo, submodule_path))
+  end
+
+  test "skips local file submodule URLs during updates" do
+    root = Briefly.create!(directory: true)
+
+    %{clone_dest: clone_dest, required_submodule_path: required_submodule_path} = setup_local_file_submodule_clone(root)
+
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 ReleaseWorker.update_submodules(%{
+                   destination: clone_dest,
+                   repository_full_handle: "apple/swift-argument-parser",
+                   tag: "v1.0.0"
+                 })
+      end)
+
+    assert log =~ "Skipping submodule #{required_submodule_path}"
+    assert log =~ "transport 'file' not allowed"
+    refute File.exists?(Path.join(clone_dest, required_submodule_path))
+  end
+
+  test "returns an error for transient submodule fetch failures" do
+    root = Briefly.create!(directory: true)
+    submodule_path = "Vendor/Required"
+
+    repo =
+      create_gitlink_repo(root, [
+        %{path: submodule_path, url: "ssh://127.0.0.1:1/required.git"}
+      ])
+
+    stale_file = Path.join([repo, submodule_path, "stale.txt"])
+
+    File.mkdir_p!(Path.dirname(stale_file))
+    File.write!(stale_file, "stale")
+
+    assert {:error, {:git_submodule_update_failed, ^submodule_path, _status, output}} =
+             ReleaseWorker.update_submodules(%{
+               destination: repo,
+               repository_full_handle: "apple/swift-argument-parser",
+               tag: "v1.0.0"
+             })
+
+    assert output
+           |> String.downcase()
+           |> then(fn output ->
+             String.contains?(output, "connection refused") or
+               String.contains?(output, "could not read from remote repository") or
+               String.contains?(output, "failed to clone")
+           end)
+
+    assert File.exists?(stale_file)
+  end
+
+  test "fails instead of deleting the required parent when a nested submodule update fails" do
+    root = Briefly.create!(directory: true)
+    required_submodule_directory = Path.join(root, "required-submodule")
+    superproject = Path.join(root, "superproject")
+    clone_dest = Path.join(root, "clone")
+    required_submodule_path = "Vendor/Required"
+    nested_submodule_path = "NestedPrivateDep"
+
+    init_git_repo(required_submodule_directory)
+    File.write!(Path.join(required_submodule_directory, "README.md"), "required")
+    git!(required_submodule_directory, ["add", "README.md"])
+    git!(required_submodule_directory, ["commit", "-m", "initial"])
+
+    File.write!(
+      Path.join(required_submodule_directory, ".gitmodules"),
+      """
+      [submodule \"#{nested_submodule_path}\"]
+      	path = #{nested_submodule_path}
+      	url = ssh://127.0.0.1:1/nested-private-dep.git
+      """
+    )
+
+    git!(required_submodule_directory, ["add", ".gitmodules"])
+
+    git!(required_submodule_directory, [
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,0123456789012345678901234567890123456789,#{nested_submodule_path}"
+    ])
+
+    git!(required_submodule_directory, ["commit", "-m", "add nested submodule"])
+
+    init_git_repo(superproject)
+    File.write!(Path.join(superproject, "Package.swift"), @default_manifest_content)
+    git!(superproject, ["add", "Package.swift"])
+    git!(superproject, ["commit", "-m", "initial"])
+
+    git!(superproject, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      required_submodule_directory,
+      required_submodule_path
+    ])
+
+    git!(superproject, ["commit", "-am", "add submodule"])
+    git!(root, ["-c", "protocol.file.allow=always", "clone", superproject, clone_dest])
+    git!(clone_dest, ["-c", "protocol.file.allow=always", "submodule", "update", "--init", required_submodule_path])
+
+    assert {:error,
+            {:nested_git_submodule_update_failed, ^required_submodule_path, "Vendor/Required/NestedPrivateDep", _status,
+             output}} =
+             ReleaseWorker.update_submodules(%{
+               destination: clone_dest,
+               repository_full_handle: "apple/swift-argument-parser",
+               tag: "v1.0.0"
+             })
+
+    assert output =~ "registered for path 'Vendor/Required/NestedPrivateDep'"
+    assert output =~ "Failed to recurse into submodule path 'Vendor/Required'"
+    assert File.exists?(Path.join(clone_dest, required_submodule_path))
   end
 
   test "downloads, uploads, and updates metadata with alternate manifests" do
@@ -364,7 +584,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:ok, %{status_code: 200, body: ""}}
       end)
 
-      expect_manifest_fetch(@default_manifest_content)
       expect_metadata_update_success()
 
       assert :ok =
@@ -412,7 +631,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:ok, %{status_code: 200, body: ""}}
       end)
 
-      expect_manifest_fetch(@default_manifest_content)
       expect_metadata_update_success()
 
       assert :ok =
@@ -454,7 +672,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:ok, %{status_code: 200, body: ""}}
       end)
 
-      expect_manifest_fetch(@default_manifest_content)
       expect_metadata_update_success()
 
       assert :ok =
@@ -503,7 +720,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:ok, %{status_code: 200, body: ""}}
       end)
 
-      expect_manifest_fetch(@default_manifest_content)
       expect_metadata_update_success()
 
       assert :ok =
@@ -549,7 +765,6 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:ok, %{status_code: 200, body: ""}}
       end)
 
-      expect_manifest_fetch(@default_manifest_content)
       expect_metadata_update_success()
 
       assert :ok =
@@ -572,12 +787,16 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:error, :not_found}
       end)
 
-      expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                       "token",
-                                                       ".gitmodules",
-                                                       "v1.0.0",
-                                                       _ ->
-        {:error, :not_found}
+      expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+        {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+      end)
+
+      expect(TuistCommon.GitHub, :get_file_content, 2, fn
+        "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+          {:ok, @default_manifest_content}
+
+        "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+          {:error, :not_found}
       end)
 
       expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser",
@@ -613,12 +832,16 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         {:error, :not_found}
       end)
 
-      expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                       "token",
-                                                       ".gitmodules",
-                                                       "v1.0.0",
-                                                       _ ->
-        {:error, :not_found}
+      expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+        {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+      end)
+
+      expect(TuistCommon.GitHub, :get_file_content, 2, fn
+        "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+          {:ok, @default_manifest_content}
+
+        "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+          {:error, :not_found}
       end)
 
       expect(TuistCommon.GitHub, :download_zipball, fn "apple/swift-argument-parser",
@@ -666,7 +889,125 @@ defmodule Cache.Registry.ReleaseWorkerTest do
     File.rm_rf!(tmp)
   end
 
-  defp expect_release_sync_prerequisites do
+  defp write_zipball_with_generator(archive_path) do
+    tmp = Path.join(Path.dirname(archive_path), "zipball_content")
+    top_dir = Path.join(tmp, "repo-v1.0.0")
+    sources_dir = Path.join(top_dir, "Sources/ArgumentParser")
+    generator_dir = Path.join(top_dir, "Generator")
+
+    File.mkdir_p!(sources_dir)
+    File.mkdir_p!(generator_dir)
+    File.write!(Path.join(top_dir, "Package.swift"), @default_manifest_content)
+    File.write!(Path.join(sources_dir, "main.swift"), "print(\"hello\")")
+    File.write!(Path.join(generator_dir, "template.txt"), "generator")
+    {_, 0} = System.cmd("zip", ["-r", archive_path, "repo-v1.0.0"], cd: tmp)
+    File.rm_rf!(tmp)
+  end
+
+  defp create_gitlink_repo(root, submodules) do
+    repo = Path.join(root, "repo")
+
+    init_git_repo(repo)
+    File.write!(Path.join(repo, "Package.swift"), @default_manifest_content)
+    git!(repo, ["add", "Package.swift"])
+    git!(repo, ["commit", "-m", "initial"])
+
+    if Enum.any?(submodules, &match?(%{url: _}, &1)) do
+      gitmodules_content =
+        Enum.map_join(submodules, "\n", fn %{path: path, url: url} ->
+          """
+          [submodule \"#{path}\"]
+          	path = #{path}
+          	url = #{url}
+          """
+        end)
+
+      File.write!(Path.join(repo, ".gitmodules"), gitmodules_content)
+      git!(repo, ["add", ".gitmodules"])
+    end
+
+    Enum.each(submodules, fn
+      path when is_binary(path) ->
+        File.mkdir_p!(Path.join([repo, Path.dirname(path)]))
+        git!(repo, ["update-index", "--add", "--cacheinfo", "160000,0123456789012345678901234567890123456789,#{path}"])
+
+      %{path: path} ->
+        File.mkdir_p!(Path.join([repo, Path.dirname(path)]))
+        git!(repo, ["update-index", "--add", "--cacheinfo", "160000,0123456789012345678901234567890123456789,#{path}"])
+    end)
+
+    git!(repo, ["commit", "-m", "add gitlinks"])
+    repo
+  end
+
+  defp setup_local_file_submodule_clone(root) do
+    required_submodule_directory = Path.join(root, "required-submodule")
+    excluded_submodule_directory = Path.join(root, "excluded-submodule")
+    superproject = Path.join(root, "superproject")
+    clone_dest = Path.join(root, "clone")
+    required_submodule_path = "Vendor/Required"
+    excluded_submodule_path = "Vendor/Skipped"
+
+    init_git_repo(required_submodule_directory)
+    File.write!(Path.join(required_submodule_directory, "README.md"), "required")
+    git!(required_submodule_directory, ["add", "README.md"])
+    git!(required_submodule_directory, ["commit", "-m", "initial"])
+
+    init_git_repo(excluded_submodule_directory)
+    File.write!(Path.join(excluded_submodule_directory, "README.md"), "excluded")
+    git!(excluded_submodule_directory, ["add", "README.md"])
+    git!(excluded_submodule_directory, ["commit", "-m", "initial"])
+
+    init_git_repo(superproject)
+    File.write!(Path.join(superproject, "Package.swift"), @default_manifest_content)
+    git!(superproject, ["add", "Package.swift"])
+    git!(superproject, ["commit", "-m", "initial"])
+
+    git!(superproject, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      required_submodule_directory,
+      required_submodule_path
+    ])
+
+    git!(superproject, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      excluded_submodule_directory,
+      excluded_submodule_path
+    ])
+
+    git!(superproject, ["commit", "-am", "add submodules"])
+    git!(root, ["-c", "protocol.file.allow=always", "clone", superproject, clone_dest])
+
+    %{
+      clone_dest: clone_dest,
+      excluded_submodule_directory: excluded_submodule_directory,
+      excluded_submodule_path: excluded_submodule_path,
+      required_submodule_directory: required_submodule_directory,
+      required_submodule_path: required_submodule_path
+    }
+  end
+
+  defp init_git_repo(path) do
+    File.mkdir_p!(path)
+    git!(path, ["init"])
+    git!(path, ["config", "user.name", "Pi Test"])
+    git!(path, ["config", "user.email", "pi@example.com"])
+  end
+
+  defp git!(working_directory, args) do
+    case System.cmd("git", args, cd: working_directory, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed with status #{status}: #{output}")
+    end
+  end
+
+  defp expect_release_sync_prerequisites(manifest_content \\ @default_manifest_content) do
     expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
       {:ok, :acquired}
     end)
@@ -675,26 +1016,16 @@ defmodule Cache.Registry.ReleaseWorkerTest do
       {:error, :not_found}
     end)
 
-    expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                     "token",
-                                                     ".gitmodules",
-                                                     "v1.0.0",
-                                                     _ ->
-      {:error, :not_found}
-    end)
-  end
-
-  defp expect_manifest_fetch(manifest_content) do
     expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
       {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
     end)
 
-    expect(TuistCommon.GitHub, :get_file_content, fn "apple/swift-argument-parser",
-                                                     "token",
-                                                     "Package.swift",
-                                                     "v1.0.0",
-                                                     _ ->
-      {:ok, manifest_content}
+    expect(TuistCommon.GitHub, :get_file_content, 2, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:ok, manifest_content}
+
+      "apple/swift-argument-parser", "token", ".gitmodules", "v1.0.0", _ ->
+        {:error, :not_found}
     end)
   end
 


### PR DESCRIPTION
## Summary
- skip explicitly skippable top-level submodule failures during registry release sync
- fail fast on transient submodule fetch failures so the job can retry instead of publishing incomplete metadata
- fail fast when a nested submodule update fails, instead of deleting the required parent submodule tree

## Testing
- cd cache && mix format --check-formatted
- cd cache && mix credo --strict
- cd cache && MIX_ENV=test mix test --warnings-as-errors