### PR TITLE
fix(server): move SSO button to its own row on login page

### DIFF
--- a/server/assets/app/css/pages/auth.css
+++ b/server/assets/app/css/pages/auth.css
@@ -126,6 +126,13 @@
     }
   }
 
+  & [data-part="oauth-providers"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--noora-spacing-6);
+    width: 100%;
+  }
+
   & [data-part="oauth"] {
     display: grid;
     grid-auto-columns: minmax(0, 1fr);
@@ -135,6 +142,15 @@
 
     &[data-compact] span {
       display: none;
+    }
+  }
+
+  & [data-part="sso"] {
+    display: flex;
+    width: 100%;
+
+    & > .noora-button {
+      width: 100%;
     }
   }
 

--- a/server/lib/tuist_web/live/user_login_live.ex
+++ b/server/lib/tuist_web/live/user_login_live.ex
@@ -50,58 +50,64 @@ defmodule TuistWeb.UserLoginLive do
               {dgettext("dashboard_auth", "Welcome back! Please log in to continue")}
             </span>
           </div>
-          <div
-            :if={oauth_configured?()}
-            data-part="oauth"
-            data-compact={all_oauth_providers_configured?(assigns)}
-          >
-            <.button
-              :if={@github_configured?}
-              href={~p"/users/auth/github"}
-              variant="secondary"
-              size="medium"
-              label="GitHub"
-              icon_only={all_oauth_providers_configured?(assigns)}
+          <div :if={oauth_configured?()} data-part="oauth-providers">
+            <div
+              :if={social_oauth_configured?(assigns)}
+              data-part="oauth"
+              data-compact={all_social_providers_configured?(assigns)}
             >
-              <.brand_github />
-              <:icon_left>
+              <.button
+                :if={@github_configured?}
+                href={~p"/users/auth/github"}
+                variant="secondary"
+                size="medium"
+                label="GitHub"
+                icon_only={all_social_providers_configured?(assigns)}
+              >
                 <.brand_github />
-              </:icon_left>
-            </.button>
-            <.button
-              :if={@google_configured?}
-              href={~p"/users/auth/google"}
-              variant="secondary"
-              size="medium"
-              label="Google"
-              icon_only={all_oauth_providers_configured?(assigns)}
-            >
-              <.brand_google />
-              <:icon_left>
+                <:icon_left>
+                  <.brand_github />
+                </:icon_left>
+              </.button>
+              <.button
+                :if={@google_configured?}
+                href={~p"/users/auth/google"}
+                variant="secondary"
+                size="medium"
+                label="Google"
+                icon_only={all_social_providers_configured?(assigns)}
+              >
                 <.brand_google />
-              </:icon_left>
-            </.button>
-            <.button
-              :if={@apple_configured?}
-              href={~p"/users/auth/apple"}
-              variant="secondary"
-              size="medium"
-              label="Apple"
-              icon_only={all_oauth_providers_configured?(assigns)}
-            >
-              <.brand_apple />
-              <:icon_left>
+                <:icon_left>
+                  <.brand_google />
+                </:icon_left>
+              </.button>
+              <.button
+                :if={@apple_configured?}
+                href={~p"/users/auth/apple"}
+                variant="secondary"
+                size="medium"
+                label="Apple"
+                icon_only={all_social_providers_configured?(assigns)}
+              >
                 <.brand_apple />
-              </:icon_left>
-            </.button>
-            <.button
-              :if={@okta_configured? or @tuist_hosted?}
-              href={~p"/users/log_in/sso"}
-              variant="secondary"
-              size="medium"
-              label={dgettext("dashboard_auth", "SSO")}
-              icon_only={all_oauth_providers_configured?(assigns)}
-            />
+                <:icon_left>
+                  <.brand_apple />
+                </:icon_left>
+              </.button>
+            </div>
+            <div :if={@okta_configured? or @tuist_hosted?} data-part="sso">
+              <.button
+                href={~p"/users/log_in/sso"}
+                variant="secondary"
+                size="medium"
+                label={dgettext("dashboard_auth", "Log in with SSO")}
+              >
+                <:icon_left>
+                  <.lock />
+                </:icon_left>
+              </.button>
+            </div>
           </div>
           <.line_divider :if={oauth_configured?()} text="OR" />
           <.alert
@@ -218,8 +224,11 @@ defmodule TuistWeb.UserLoginLive do
       Environment.tuist_hosted?()
   end
 
-  defp all_oauth_providers_configured?(assigns) do
-    assigns.github_configured? and assigns.google_configured? and
-      (assigns.okta_configured? or assigns.tuist_hosted?) and assigns.apple_configured?
+  defp social_oauth_configured?(assigns) do
+    assigns.github_configured? or assigns.google_configured? or assigns.apple_configured?
+  end
+
+  defp all_social_providers_configured?(assigns) do
+    assigns.github_configured? and assigns.google_configured? and assigns.apple_configured?
   end
 end


### PR DESCRIPTION

<img width="1161" height="797" alt="image" src="https://github.com/user-attachments/assets/030cc1b3-e0fa-4e26-8c11-d41cbea5ab0a" />


## Summary
- Splits the SSO button out of the social OAuth row (GitHub / Google / Apple) into its own full-width row on the login page, matching patterns like Supabase's login.
- Labels the button "Log in with SSO" with a lock icon to make its purpose explicit.
- Wraps both rows in a shared `oauth-providers` container with a tighter gap so they visually group without the outer page-level spacing between them.

## Test plan
- [ ] Visit `/users/log_in` with only GitHub + SSO enabled and confirm SSO is on its own row.
- [ ] Visit `/users/log_in` with GitHub/Google/Apple + SSO all enabled and confirm the social providers collapse to icon-only while SSO stays full-width.
- [ ] Visit `/users/log_in` with no SSO provider configured (Okta off, non-tuist-hosted) and confirm the SSO row is hidden.
- [ ] Click "Log in with SSO" and confirm it routes to `/users/log_in/sso`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)