### PR TITLE
fix(cli): skip token refresh when optionalAuthentication is enabled

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -41,6 +41,8 @@ public enum ServerAuthenticationControllerError: LocalizedError, Equatable {
 @Mockable
 public protocol ServerAuthenticationControlling: Sendable {
     func authenticationToken(serverURL: URL) async throws -> AuthenticationToken?
+    func authenticationToken(serverURL: URL, refreshIfNeeded: Bool) async throws
+        -> AuthenticationToken?
     func refreshToken(serverURL: URL) async throws
     func refreshToken(serverURL: URL, inBackground: Bool, locking: Bool, forceInProcessLock: Bool)
         async throws
@@ -235,17 +237,35 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
     @discardableResult public func authenticationToken(serverURL: URL)
         async throws -> AuthenticationToken?
     {
+        try await authenticationToken(serverURL: serverURL, refreshIfNeeded: true)
+    }
+
+    @discardableResult public func authenticationToken(
+        serverURL: URL,
+        refreshIfNeeded: Bool
+    ) async throws -> AuthenticationToken? {
         #if canImport(TuistSupport)
             if let environmentToken = try await environmentToken() {
                 return environmentToken
-            } else {
-                return try await authenticationTokenRefreshingIfNeeded(
-                    serverURL: serverURL,
-                    forceRefresh: false,
-                    inBackground: ServerAuthenticationConfig.current.backgroundRefresh,
-                    locking: true
-                )
             }
+        #endif
+
+        if !refreshIfNeeded {
+            switch try await tokenStatus(serverURL: serverURL, forceRefresh: false) {
+            case let .valid(token):
+                return token
+            case .expired, .absent:
+                return nil
+            }
+        }
+
+        #if canImport(TuistSupport)
+            return try await authenticationTokenRefreshingIfNeeded(
+                serverURL: serverURL,
+                forceRefresh: false,
+                inBackground: ServerAuthenticationConfig.current.backgroundRefresh,
+                locking: true
+            )
         #else
             return try await authenticationTokenRefreshingIfNeeded(
                 serverURL: serverURL, forceRefresh: false,

--- a/cli/Tests/TuistCacheEETests/Storage/CacheStorageFactoryTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheStorageFactoryTests.swift
@@ -61,7 +61,8 @@ struct CacheStorageFactoryTests {
                 refreshToken: .test(token: "refresh-token")
             )
             given(serverAuthenticationController).authenticationToken(
-                serverURL: .value(Constants.URLs.production)
+                serverURL: .value(Constants.URLs.production),
+                refreshIfNeeded: .any
             ).willReturn(token)
             given(cacheURLStore)
                 .getCacheURL(for: .value(Constants.URLs.production), accountHandle: .value("tuist"))
@@ -91,7 +92,8 @@ struct CacheStorageFactoryTests {
                 refreshToken: .test(token: "refresh-token")
             )
             given(serverAuthenticationController).authenticationToken(
-                serverURL: .value(Constants.URLs.production)
+                serverURL: .value(Constants.URLs.production),
+                refreshIfNeeded: .any
             ).willReturn(token)
 
             // When
@@ -129,7 +131,8 @@ struct CacheStorageFactoryTests {
         // Given
         given(serverEnvironmentService).url(configServerURL: .any).willReturn(Constants.URLs.production)
         given(serverAuthenticationController).authenticationToken(
-            serverURL: .value(Constants.URLs.production)
+            serverURL: .value(Constants.URLs.production),
+            refreshIfNeeded: .any
         ).willReturn(nil)
 
         // When/Then

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -293,6 +293,67 @@ struct ServerAuthenticationControllerTests {
     @Test(
         .withMockedEnvironment(),
         .withMockedDependencies()
+    ) func authenticationToken_without_refresh_returns_nil_for_expired_token() async throws {
+        let date = Date()
+        try await Date.$now.withValue({ date }) {
+            // Given
+            let serverURL: URL = .test()
+            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+60), typ: "refresh")
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
+            )
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+
+            // When
+            let got = try await subject.authenticationToken(serverURL: serverURL, refreshIfNeeded: false)
+
+            // Then
+            #expect(got == nil)
+            verify(refreshAuthTokenService)
+                .refreshTokens(serverURL: .any, refreshToken: .any)
+                .called(0)
+        }
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) func authenticationToken_without_refresh_returns_valid_token() async throws {
+        let date = Date()
+        try await Date.$now.withValue({ date }) {
+            // Given
+            let serverURL: URL = .test()
+            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(+600), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
+            )
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+
+            // When
+            let got = try await subject.authenticationToken(serverURL: serverURL, refreshIfNeeded: false)
+
+            // Then
+            #expect(
+                got == .user(
+                    accessToken: try JWT.parse(accessToken.token),
+                    refreshToken: try JWT.parse(refreshToken.token)
+                )
+            )
+            verify(refreshAuthTokenService)
+                .refreshTokens(serverURL: .any, refreshToken: .any)
+                .called(0)
+        }
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
     ) func executeRefresh_sets_cache_expiration_based_on_access_token() async throws {
         let date = Date(timeIntervalSince1970: TimeInterval(Int(Date().timeIntervalSince1970)))
         try await Date.$now.withValue({ date }) {


### PR DESCRIPTION
## Summary

With `optionalAuthentication: true`, an expired local token could surface as a hard error from the CLI:

```
The refreshing of the access and refresh token pair for the URL https://tuist.dev failed after 5 seconds.
```

Root cause: `CacheStorageFactory` unconditionally called `ServerAuthenticationController.authenticationToken(serverURL:)`, which drives expired tokens through the refresh path. Any failure there — the background `tuist auth refresh-token` subprocess timing out after 5s in `FileSystemLockActor.withLock`, or a 401 on `/api/auth/refresh_token` that wipes credentials and rethrows via `deletingCredentialsOnUnauthorizedError` — escaped the `try await` and bypassed the `optionalAuthentication` warning branch entirely.

### Fix

- New overload `authenticationToken(serverURL:refreshIfNeeded:)` on `ServerAuthenticationControlling`. When `refreshIfNeeded` is `false`, it consults `tokenStatus` directly: valid tokens are returned, expired/absent tokens return nil, no refresh is attempted, nothing throws from the refresh path.
- Env tokens (`TUIST_TOKEN` et al) are still honored.
- `CacheStorageFactory` passes `refreshIfNeeded: !optionalAuthentication`, so stale tokens now fall through to the existing "skipping remote cache" warning.

### Companion PR

Submodule bump points at https://github.com/tuist/TuistCacheEE/pull/56 which carries the `CacheStorageFactory` call-site change.

## Test plan

- [x] `xcodebuild build -scheme tuist` succeeds
- [x] `TuistServerTests/ServerAuthenticationControllerTests` green, including two new cases:
  - `authenticationToken_without_refresh_returns_nil_for_expired_token` — verifies the refresh service is never called
  - `authenticationToken_without_refresh_returns_valid_token` — verifies a non-expired token is still returned
- [ ] Manual: reproduce with an expired local session + `optionalAuthentication: true` and confirm the warning is shown instead of the 5s timeout error
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)