### PR TITLE
chore(cli): make XcodeGraph modules static frameworks so TuistCore is cacheable

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -367,8 +367,6 @@ public enum Module: String, CaseIterable {
         switch self {
         case .tuist, .tuistBenchmark, .tuistFixtureGenerator:
             return .commandLineTool
-        case .xcodeGraph, .xcodeMetadata, .xcodeGraphMapper:
-            return .staticLibrary
         case .projectAutomation, .projectDescription:
             return forceStaticLinking() ? .staticFramework : .framework
         default:


### PR DESCRIPTION
## Summary

- `XcodeGraph`, `XcodeMetadata`, and `XcodeGraphMapper` were vendored as `.staticLibrary` in #9616.
- `.staticLibrary` is not in `CacheGraphContentHasher.cachableProducts` (only `.framework`, `.staticFramework`, `.bundle`, `.macro` are). Because `GraphContentHasher.isHashable` is transitive, any target depending on these — including `TuistCore` and most of the CLI graph — was silently excluded from `tuist hash cache`, making the whole CLI effectively uncacheable.
- Dropping the special case so these modules fall through to the default `.staticFramework` makes them cacheable and restores the transitive hashability of the rest of the graph.

Verified locally: `TuistCore`, `XcodeGraph`, `XcodeGraphMapper`, and `XcodeMetadata` now appear in `tuist hash cache` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)