### PR TITLE
fix(server): size req_llm Finch pool and parallelize l10n translations

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -23,7 +23,7 @@ jobs:
   translate:
     name: Translate
     runs-on: namespace-profile-default-with-volume
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: namespacelabs/nscloud-cache-action@v1

--- a/translate.exs
+++ b/translate.exs
@@ -1,18 +1,20 @@
+# Configure req_llm's internal Finch pool BEFORE Mix.install so the application
+# supervisor reads it at startup. req_llm hardcodes the Finch instance to
+# ReqLLM.Finch in its provider attach steps, so passing :finch via req_http_options
+# is silently overridden — sizing this pool is the only thing that takes effect.
+# HTTP/1 only avoids Finch issue #265 with large request bodies.
+Application.put_env(:req_llm, :finch,
+  name: ReqLLM.Finch,
+  pools: %{
+    default: [protocols: [:http1], size: 1, count: 128]
+  }
+)
+
 Mix.install([
   {:req_llm, "~> 1.9"},
   {:yaml_elixir, "~> 2.11"},
   {:expo, "~> 1.1"}
 ])
-
-case Finch.start_link(
-       name: L10n.Finch,
-       pools: %{
-         default: [protocols: [:http1], size: 25, count: 2]
-       }
-     ) do
-  {:ok, _pid} -> :ok
-  {:error, {:already_started, _pid}} -> :ok
-end
 
 defmodule L10n.Context do
   @moduledoc """
@@ -409,19 +411,24 @@ defmodule L10n.Translator do
 
     resolved_model = resolve_model(model)
 
-    {:ok, response} = ReqLLM.generate_text(resolved_model, messages,
-      max_tokens: 64_000,
-      receive_timeout: timeout,
-      req_http_options: [finch: L10n.Finch]
-    )
+    case ReqLLM.generate_text(resolved_model, messages,
+           max_tokens: 64_000,
+           receive_timeout: timeout
+         ) do
+      {:ok, response} ->
+        text =
+          response
+          |> ReqLLM.Response.text()
+          |> String.trim()
+          |> String.replace(~r/^```[a-z]*\n/, "")
+          |> String.replace(~r/\n```$/, "")
+          |> String.trim()
 
-    text = ReqLLM.Response.text(response)
+        {:ok, text}
 
-    text
-    |> String.trim()
-    |> String.replace(~r/^```[a-z]*\n/, "")
-    |> String.replace(~r/\n```$/, "")
-    |> String.trim()
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
   end
 
   @doc """
@@ -457,44 +464,41 @@ defmodule L10n.Translator do
           {:skipped, locale}
         else
           try do
-            po_content =
-              translate(
-                pot_content,
-                locale,
-                language,
-                context_body,
-                locale_override,
-                model,
-                request_timeout
-              )
+            with {:ok, po_content} <-
+                   translate(
+                     pot_content,
+                     locale,
+                     language,
+                     context_body,
+                     locale_override,
+                     model,
+                     request_timeout
+                   ),
+                 :ok <- L10n.Validator.validate(po_content) do
+              po_filename = Path.basename(pot_relative_path, ".pot") <> ".po"
+              output_path = Path.join([l10n_dir, target["path"], po_filename])
+              output_path |> Path.dirname() |> File.mkdir_p!()
+              File.write!(output_path, po_content <> "\n")
 
-            case L10n.Validator.validate(po_content) do
-              :ok ->
-                po_filename = Path.basename(pot_relative_path, ".pot") <> ".po"
-                output_path = Path.join([l10n_dir, target["path"], po_filename])
-                output_path |> Path.dirname() |> File.mkdir_p!()
-                File.write!(output_path, po_content <> "\n")
+              L10n.Lock.write!(lock_path, %{
+                hash: hash,
+                model: model,
+                source_file: pot_relative_path,
+                source_hash: source_hash,
+                context_files: context_files,
+                locale_override_files: locale_override_files
+              })
 
-                L10n.Lock.write!(lock_path, %{
-                  hash: hash,
-                  model: model,
-                  source_file: pot_relative_path,
-                  source_hash: source_hash,
-                  context_files: context_files,
-                  locale_override_files: locale_override_files
-                })
-
-                {:translated, locale}
-
-              {:error, reason} ->
-                {:error, locale, reason}
+              {:translated, locale}
+            else
+              {:error, reason} -> {:error, locale, reason}
             end
           rescue
             e -> {:error, locale, Exception.message(e)}
           end
         end
       end,
-      max_concurrency: Keyword.get(opts, :max_concurrency, 2),
+      max_concurrency: Keyword.get(opts, :max_concurrency, 7),
       timeout: request_timeout + 30_000,
       on_timeout: :kill_task
     )
@@ -549,8 +553,8 @@ defmodule L10n.CLI do
     * `--force`, `-f` — Re-translate all files, ignoring lock state
     * `--locale`, `-l` — Translate only the specified locale (e.g., `--locale es`)
     * `--model`, `-m` — Override the LLM model from L10N.md (e.g., `--model openai:gpt-4.1`)
-    * `--concurrency`, `-c` — Max parallel translations per locale within one source file (default: 2)
-    * `--pot-concurrency` — Max parallel source files being translated at once (default: 1)
+    * `--concurrency`, `-c` — Max parallel translations per locale within one source file (default: 7)
+    * `--pot-concurrency` — Max parallel source files being translated at once (default: 4)
     * `--timeout`, `-t` — Timeout in ms per translation request (default: 900000)
   """
 
@@ -631,11 +635,11 @@ defmodule L10n.CLI do
             context_files,
             force: Keyword.get(opts, :force, false),
             locale_override_fn: locale_override_fn,
-            max_concurrency: Keyword.get(opts, :concurrency, 2),
+            max_concurrency: Keyword.get(opts, :concurrency, 7),
             timeout: Keyword.get(opts, :timeout, @default_timeout)
           )
         end,
-        max_concurrency: Keyword.get(opts, :pot_concurrency, 1),
+        max_concurrency: Keyword.get(opts, :pot_concurrency, 4),
         timeout: :infinity  # pot-level timeout is infinite; per-locale tasks have their own timeout
       )
       |> Enum.flat_map(fn {:ok, results} -> results end)


### PR DESCRIPTION
## Summary

The L10n workflow has been failing on `main` for two different reasons in sequence — both rooted in how concurrency interacts with `req_llm`'s internal Finch pool. This PR fixes the underlying issue and unlocks throughput so the job actually finishes inside its CI budget.

### What was wrong

1. **Earlier failure mode (Finch pool exhaustion).** `translate.exs` started a custom `L10n.Finch` instance and passed it via `req_http_options: [finch: L10n.Finch]`. But in `req_llm/lib/req_llm/providers/openai.ex:652`, the `attach/3` step hardcodes `finch: ReqLLM.Application.finch_name()` and silently overrides the user-supplied option. The custom pool was never used. Meanwhile, `req_llm` auto-starts its own `ReqLLM.Finch` with default `size: 1, count: 8` (just 8 connections), which was exhausted under any meaningful concurrency, producing:
   ```
   Finch streaming task crashed: Finch was unable to provide a connection within the timeout due to excess queuing for connections.
   Metadata collection failed: ...
   ```
2. **Workaround in #10193 / #10248** dropped `max_concurrency` to `2` and switched from `stream_text` to `generate_text`. That stopped the pool errors, but introduced the **current failure mode**: each `.pot` file is regenerated in full per locale (the largest, `marketing.pot`, is 2371 lines ≈ 30K output tokens), and at 2 locales in parallel the workflow takes >50 minutes total, hitting the job's `timeout-minutes: 30`. The latest run on `main` (24347594657) was cancelled at exactly 30 minutes after only translating ~4 of 15 source files, with no Finch errors at all.

### What this PR changes

- **Configures `req_llm`'s actual Finch pool** via `Application.put_env(:req_llm, :finch, ...)` *before* `Mix.install` so the application supervisor reads it at startup. Sized at `size: 1, count: 128, http1`. This is the only knob that actually takes effect — passing `finch:` through `req_http_options` is silently ignored.
- **Drops the unused `L10n.Finch` indirection** entirely.
- **Bumps default concurrency**:
  - `--concurrency` (locales per file): `2` → `7` (all locales in parallel)
  - `--pot-concurrency` (parallel `.pot` files): `1` → `4`
- **Makes `generate_text` errors graceful.** The strict `{:ok, response} = ...` pattern was crashing the `rescue` with a `no match of right hand side value`. Switched to a proper `case` that returns `{:error, message}`.
- **Bumps workflow `timeout-minutes` from 30 to 60** as a safety margin while we get a baseline on the new throughput.

### Throughput math after the fix

- 15 `.pot` files × 7 locales = 105 calls
- With 4 files in flight × 7 locales each = up to 28 concurrent requests
- 128 connections in the Finch pool comfortably absorbs that
- Wall time should drop from "doesn't finish in 30 min" to "limited by the slowest file" — likely ~10 min for `marketing.pot` end-to-end

## Test plan

- [x] Local syntax check (`elixir -e 'Code.string_to_quoted!(File.read!("translate.exs"))'`)
- [x] Local dry run with a fake `OPENAI_API_KEY` confirms the new error path is graceful (15 errors reported in the summary, no crash, no Finch warnings)
- [ ] Local run with a real `OPENAI_API_KEY` to regenerate translations and include them in this PR
- [ ] Confirm the L10n workflow completes inside the new 60 min budget on this branch

## Note on translations

I wasn't able to regenerate the actual `.po` translations locally because I don't have access to an `OPENAI_API_KEY` in this environment. Two options:

1. **Run locally before merge**: I can re-run `elixir translate.exs --force` if you provide a key (or sign in to `op` so I can fetch it from 1Password), then push the regenerated `.po` and `.l10n` lock files onto this branch.
2. **Merge and let CI regenerate**: with the new pool sizing and concurrency, the L10n workflow on `main` will pick up the existing stale lock files and rewrite all `.po` files in one run.

Happy to go either direction — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)