### PR TITLE
chore(ci): add runner image build workflow and Packer template

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,48 @@
+name: Build Runner Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_image:
+        description: "Base Tart image (e.g. ghcr.io/cirruslabs/macos-tahoe-xcode:26.4)"
+        required: true
+        default: "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4"
+      output_image:
+        description: "Output image name (e.g. tuist-runner-xcode-26.4)"
+        required: true
+        default: "tuist-runner-xcode-26.4"
+      runner_version:
+        description: "GitHub Actions runner version"
+        required: true
+        default: "2.325.0"
+
+jobs:
+  build:
+    runs-on: namespace-profile-default-macos
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Tart
+        run: brew install cirruslabs/cli/tart
+
+      - name: Install Packer
+        run: brew install hashicorp/tap/packer
+
+      - name: Initialize Packer
+        working-directory: infra/runner-images
+        run: packer init runner.pkr.hcl
+
+      - name: Build image
+        working-directory: infra/runner-images
+        run: |
+          packer build \
+            -var "base_image=${{ inputs.base_image }}" \
+            -var "output_image=${{ inputs.output_image }}" \
+            -var "runner_version=${{ inputs.runner_version }}" \
+            runner.pkr.hcl
+
+      - name: Log in to GHCR
+        run: tart login ghcr.io --username tuist-bot --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push image to GHCR
+        run: tart push ${{ inputs.output_image }} ghcr.io/tuist/${{ inputs.output_image }}:latest

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -6,15 +6,12 @@ on:
       base_image:
         description: "Base Tart image (e.g. ghcr.io/cirruslabs/macos-tahoe-xcode:26.4)"
         required: true
-        default: "ghcr.io/cirruslabs/macos-tahoe-xcode:26.4"
       output_image:
         description: "Output image name (e.g. tuist-runner-xcode-26.4)"
         required: true
-        default: "tuist-runner-xcode-26.4"
       runner_version:
-        description: "GitHub Actions runner version"
+        description: "GitHub Actions runner version (e.g. 2.325.0)"
         required: true
-        default: "2.325.0"
 
 jobs:
   build:

--- a/infra/runner-images/runner.pkr.hcl
+++ b/infra/runner-images/runner.pkr.hcl
@@ -1,0 +1,56 @@
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 1.16.0"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+variable "base_image" {
+  type        = string
+  description = "Base Tart image from Cirrus Labs (e.g. ghcr.io/cirruslabs/macos-tahoe-xcode:26.4)"
+}
+
+variable "output_image" {
+  type        = string
+  description = "Name for the output image (e.g. tuist-runner-xcode-26.4)"
+}
+
+variable "runner_version" {
+  type        = string
+  default     = "2.325.0"
+  description = "GitHub Actions runner version to install"
+}
+
+source "tart-cli" "runner" {
+  vm_base_name = var.base_image
+  vm_name      = var.output_image
+  cpu_count    = 4
+  memory_gb    = 8
+  ssh_username = "admin"
+  ssh_password = "admin"
+  ssh_timeout  = "120s"
+  headless     = true
+}
+
+build {
+  sources = ["source.tart-cli.runner"]
+
+  provisioner "shell" {
+    inline = [
+      "echo 'admin' | sudo -S mkdir -p /opt/actions-runner",
+      "echo 'admin' | sudo -S chown admin:staff /opt/actions-runner"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "cd /opt/actions-runner",
+      "curl -sL -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/v${var.runner_version}/actions-runner-osx-arm64-${var.runner_version}.tar.gz",
+      "tar xzf actions-runner.tar.gz",
+      "rm actions-runner.tar.gz",
+      "./config.sh --version"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` GitHub Actions workflow for building Tuist Runner Tart images
- Packer template takes a Cirrus Labs base image, installs the GitHub Actions runner binary, and pushes to `ghcr.io/tuist/`
- Runs on `namespace-profile-default-macos` (Apple Silicon required for Tart)

This needs to be merged to `main` before `workflow_dispatch` can be triggered.

Part of the Tuist Runners feature (#10264).

## Test plan

- [ ] Merge to main, then trigger via Actions > "Build Runner Image" > Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)