### PR TITLE
fix(cli): fix synthesized resource interface generation for numeric target names

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -292,7 +292,7 @@ public struct SynthesizedResourceInterfaceProjectMapper: ProjectMapping { // swi
         if paths.isEmpty {
             renderedInterfaces = []
         } else {
-            let name = target.name.camelized.uppercasingFirst
+            let name = target.name.toValidSwiftIdentifier()
             renderedInterfaces = [
                 (
                     "Tuist\(templateName)+\(name)",
@@ -300,7 +300,7 @@ public struct SynthesizedResourceInterfaceProjectMapper: ProjectMapping { // swi
                         parser: resourceSynthesizer.parser,
                         parserOptions: resourceSynthesizer.parserOptions,
                         templateString: templateString,
-                        name: target.productName.camelized.uppercasingFirst,
+                        name: target.productName.toValidSwiftIdentifier(),
                         bundleName: project.options.disableBundleAccessors ? nil : "Bundle.module",
                         paths: paths
                     )

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -876,6 +876,61 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         XCTAssertTrue(plistNames.value.contains("XML.plist"))
     }
 
+    func testMap_usesValidSwiftIdentifiersForGeneratedResourceInterfaces() async throws {
+        // Given
+        let names = ThreadSafe<[String]>([])
+        synthesizedResourceInterfacesGenerator.renderStub = { _, _, _, name, _, _ in
+            names.mutate { $0.append(name) }
+            return ""
+        }
+        let projectPath = try temporaryPath()
+        let targetPath = projectPath.appending(component: "1Demo")
+        let assetCatalog = targetPath.appending(component: "Assets.xcassets")
+        try await fileSystem.makeDirectory(at: assetCatalog)
+        try await fileSystem.touch(assetCatalog.appending(component: "Contents.json"))
+
+        let target = Target.test(
+            name: "1Demo",
+            resources: .init([.folderReference(path: assetCatalog)])
+        )
+        let project = Project.test(
+            path: projectPath,
+            targets: [target],
+            resourceSynthesizers: [
+                .init(
+                    parser: .assets,
+                    parserOptions: [:],
+                    extensions: ["xcassets"],
+                    template: .defaultTemplate("Assets")
+                ),
+            ]
+        )
+
+        // When
+        let (mappedProject, sideEffects) = try await subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(names.value, ["_1Demo"])
+        XCTAssertEqual(
+            sideEffects,
+            [
+                .file(
+                    FileDescriptor(
+                        path: projectPath
+                            .appending(component: Constants.DerivedDirectory.name)
+                            .appending(component: Constants.DerivedDirectory.sources)
+                            .appending(component: "TuistAssets+_1Demo.swift"),
+                        contents: Data()
+                    )
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            mappedProject.targets[target.name]?.sources.first?.path.basename,
+            "TuistAssets+_1Demo.swift"
+        )
+    }
+
     // MARK: - Helpers
 
     private func stub(file: AbsolutePath) async throws {


### PR DESCRIPTION
## Summary

This fixes synthesized resource interface generation for targets whose names start with a digit, such as `1Demo`.

## Root Cause

`SynthesizedResourceInterfaceProjectMapper` was still feeding raw target and product names into the synthesized resource interface templates and generated filenames. For a target like `1Demo`, that produced invalid Swift identifiers such as `1DemoAsset` and `TuistAssets+1Demo.swift`.

## What Changed

- sanitize the generated resource interface filename suffix with `toValidSwiftIdentifier()`
- sanitize the template `name` parameter with `toValidSwiftIdentifier()` so the rendered Swift types are valid
- add a regression test covering a target named `1Demo`

Closes #7144.

## Validation

- `tuist install`
- `tuist generate run TuistGeneratorTests --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistGeneratorTests/SynthesizedResourceInterfaceProjectMapperTests/testMap_usesValidSwiftIdentifiersForGeneratedResourceInterfaces CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

Notes:
- `tuist install` cleared the earlier missing `FileSystem` dependency issue.
- The focused workspace test resolves `SnapshotTesting` correctly and compiles `SynthesizedResourceInterfaceProjectMapperTests.swift` and the `TuistGeneratorTests` module. The initial workspace build is still broad and slow, so this PR is left as draft pending a full green run in CI.