### PR TITLE
fix(server): pin follow-redirects to 1.16.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
       "dompurify": "3.3.3",
       "flatted": "3.4.2",
       "yaml": "2.8.3",
-      "defu": "6.1.5"
+      "defu": "6.1.5",
+      "follow-redirects": "1.16.0"
     }
   }
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   flatted: 3.4.2
   yaml: 2.8.3
   defu: 6.1.5
+  follow-redirects: 1.16.0
 
 importers:
 
@@ -747,8 +748,8 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2350,7 +2351,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -2483,7 +2484,7 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- pin `follow-redirects` to `1.16.0` in the server pnpm overrides
- update `server/pnpm-lock.yaml` to resolve the vulnerable transitive version
- fix the failing Server > Security workflow caused by Trivy finding `GHSA-r4q5-vmmm-2653`

## Validation
- `cd server && mise exec trivy -- trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps" ./`