### PR TITLE
fix(server): sort dashboard filter options

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -441,6 +441,7 @@ defmodule Tuist.Builds do
         where: b.project_id == ^project.id,
         where: b.scheme != "",
         where: b.inserted_at > ^thirty_days_ago,
+        order_by: [asc: b.scheme],
         distinct: true,
         select: b.scheme
       )
@@ -455,6 +456,7 @@ defmodule Tuist.Builds do
         where: b.project_id == ^project.id,
         where: b.configuration != "",
         where: b.inserted_at > ^thirty_days_ago,
+        order_by: [asc: b.configuration],
         distinct: true,
         select: b.configuration
       )

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -105,6 +105,7 @@ defmodule Tuist.Tests do
         where: t.project_id == ^project.id,
         where: t.scheme != "",
         where: t.ran_at > ^thirty_days_ago,
+        order_by: [asc: t.scheme],
         distinct: true,
         select: t.scheme
       )

--- a/server/lib/tuist_web/live/gradle_builds_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_builds_live.html.heex
@@ -19,18 +19,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_gradle", "Local")}
-          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
-          data-selected={@analytics_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_gradle", "CI")}
           patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_gradle", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>

--- a/server/lib/tuist_web/live/gradle_overview_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_overview_live.html.heex
@@ -19,18 +19,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_gradle", "Local")}
-          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
-          data-selected={@analytics_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_gradle", "CI")}
           patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_gradle", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
@@ -403,18 +403,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_gradle", "Local")}
-          patch={"?#{Query.put(@uri.query, "builds-environment", "local")}"}
-          data-selected={@builds_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_gradle", "CI")}
           patch={"?#{Query.put(@uri.query, "builds-environment", "ci")}"}
           data-selected={@builds_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_gradle", "Local")}
+          patch={"?#{Query.put(@uri.query, "builds-environment", "local")}"}
+          data-selected={@builds_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>

--- a/server/lib/tuist_web/live/tests_live.html.heex
+++ b/server/lib/tuist_web/live/tests_live.html.heex
@@ -38,18 +38,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_tests", "Local")}
-          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
-          data-selected={@analytics_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_tests", "CI")}
           patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_tests", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
@@ -596,18 +596,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_tests", "Local")}
-          patch={"?#{Query.put(@uri.query, "selective_testing_environment", "local")}"}
-          data-selected={@selective_testing_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_tests", "CI")}
           patch={"?#{Query.put(@uri.query, "selective_testing_environment", "ci")}"}
           data-selected={@selective_testing_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_tests", "Local")}
+          patch={"?#{Query.put(@uri.query, "selective_testing_environment", "local")}"}
+          data-selected={@selective_testing_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>

--- a/server/lib/tuist_web/live/xcode_builds_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_builds_live.html.heex
@@ -89,18 +89,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="incremental"
-          label={dgettext("dashboard_builds", "Incremental")}
-          patch={"?#{Query.put(@uri.query, "analytics-build-category", "incremental")}"}
-          data-selected={@analytics_build_category == "incremental"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="clean"
           label={dgettext("dashboard_builds", "Clean")}
           patch={"?#{Query.put(@uri.query, "analytics-build-category", "clean")}"}
           data-selected={@analytics_build_category == "clean"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="incremental"
+          label={dgettext("dashboard_builds", "Incremental")}
+          patch={"?#{Query.put(@uri.query, "analytics-build-category", "incremental")}"}
+          data-selected={@analytics_build_category == "incremental"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
@@ -119,18 +119,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_builds", "Local")}
-          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
-          data-selected={@analytics_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_builds", "CI")}
           patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_builds", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>

--- a/server/lib/tuist_web/live/xcode_overview_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_overview_live.html.heex
@@ -19,18 +19,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_projects", "Local")}
-          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
-          data-selected={@analytics_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_projects", "CI")}
           patch={"?#{Query.put(@uri.query, "analytics-environment", "ci")}"}
           data-selected={@analytics_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_projects", "Local")}
+          patch={"?#{Query.put(@uri.query, "analytics-environment", "local")}"}
+          data-selected={@analytics_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
@@ -759,18 +759,18 @@
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>
         <.dropdown_item
-          value="local"
-          label={dgettext("dashboard_projects", "Local")}
-          patch={"?#{Query.put(@uri.query, "builds-environment", "local")}"}
-          data-selected={@builds_environment == "local"}
-        >
-          <:right_icon><.check /></:right_icon>
-        </.dropdown_item>
-        <.dropdown_item
           value="ci"
           label={dgettext("dashboard_projects", "CI")}
           patch={"?#{Query.put(@uri.query, "builds-environment", "ci")}"}
           data-selected={@builds_environment == "ci"}
+        >
+          <:right_icon><.check /></:right_icon>
+        </.dropdown_item>
+        <.dropdown_item
+          value="local"
+          label={dgettext("dashboard_projects", "Local")}
+          patch={"?#{Query.put(@uri.query, "builds-environment", "local")}"}
+          data-selected={@builds_environment == "local"}
         >
           <:right_icon><.check /></:right_icon>
         </.dropdown_item>

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -500,7 +500,7 @@ defmodule Tuist.BuildsTest do
       schemes = Builds.project_build_schemes(project)
 
       # Then
-      assert Enum.sort(schemes) == ["App", "Framework"]
+      assert schemes == ["App", "Framework"]
     end
 
     test "returns an empty list when no builds exist for the project" do
@@ -582,7 +582,7 @@ defmodule Tuist.BuildsTest do
       configurations = Builds.project_build_configurations(project)
 
       # Then
-      assert Enum.sort(configurations) == ["Debug", "Release"]
+      assert configurations == ["Debug", "Release"]
     end
 
     test "returns an empty list when no builds exist for the project" do

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -7330,7 +7330,7 @@ defmodule Tuist.TestsTest do
       schemes = Tests.project_test_schemes(project)
 
       # Then
-      assert Enum.sort(schemes) == ["App", "Framework"]
+      assert schemes == ["App", "Framework"]
     end
 
     test "returns an empty list when no tests exist for the project" do


### PR DESCRIPTION
## Summary
- sort dynamic scheme and configuration filter values at the source query level for build and test dashboards
- reorder static dashboard dropdown options so categories and environments appear alphabetically across Xcode, Gradle, and overview pages
- update the affected Elixir tests to assert the returned order directly

## Validation
- `cd server && mix test test/tuist/builds_test.exs:450`
- `cd server && mix test test/tuist/builds_test.exs:537`
- `cd server && mix test test/tuist/tests_test.exs:7285`
