### PR TITLE
fix(server): align dashboard scheme filters and search

### DIFF
--- a/server/lib/tuist_web/live/tests_live.html.heex
+++ b/server/lib/tuist_web/live/tests_live.html.heex
@@ -6,6 +6,13 @@
         label={TuistWeb.TestsLive.test_scheme_label(@analytics_test_scheme)}
         secondary_text={dgettext("dashboard_tests", "Scheme:")}
       >
+        <:search>
+          <input
+            type="text"
+            placeholder={dgettext("dashboard_tests", "Search...")}
+            data-part="search-input"
+          />
+        </:search>
         <.dropdown_item
           value="any"
           label={dgettext("dashboard_tests", "Any")}

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -15,9 +15,10 @@ defmodule TuistWeb.XcodeBuildRunsLive do
 
   def assign_mount(socket) do
     project = socket.assigns.selected_project
+    schemes = Builds.project_build_schemes(project)
     configurations = Builds.project_build_configurations(project)
     tags = Builds.project_build_tags(project)
-    assign(socket, :available_filters, define_filters(project, configurations, tags))
+    assign(socket, :available_filters, define_filters(project, schemes, configurations, tags))
   end
 
   def assign_handle_params(socket, params) do
@@ -196,15 +197,18 @@ defmodule TuistWeb.XcodeBuildRunsLive do
     flop_filters ++ ran_by_flop_filters ++ tag_flop_filters
   end
 
-  defp define_filters(project, configurations, tags) do
+  defp define_filters(project, schemes, configurations, tags) do
     base = [
       %Filter.Filter{
         id: "scheme",
         field: :scheme,
         display_name: dgettext("dashboard_builds", "Scheme"),
-        type: :text,
-        operator: :=~,
-        value: ""
+        type: :option,
+        searchable: true,
+        options: schemes,
+        options_display_names: Map.new(schemes, &{&1, &1}),
+        operator: :==,
+        value: nil
       },
       %Filter.Filter{
         id: "configuration",

--- a/server/lib/tuist_web/live/xcode_builds_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_builds_live.html.heex
@@ -34,6 +34,13 @@
         label={TuistWeb.XcodeBuildsLive.build_scheme_label(@analytics_build_scheme)}
         secondary_text={dgettext("dashboard_builds", "Scheme:")}
       >
+        <:search>
+          <input
+            type="text"
+            placeholder={dgettext("dashboard_builds", "Search...")}
+            data-part="search-input"
+          />
+        </:search>
         <.dropdown_item
           value="any"
           label={dgettext("dashboard_builds", "Any")}

--- a/server/test/tuist_web/live/build_runs_live_test.exs
+++ b/server/test/tuist_web/live/build_runs_live_test.exs
@@ -64,4 +64,29 @@ defmodule TuistWeb.BuildRunsLiveTest do
 
     assert has_element?(lv, "span", "App-1")
   end
+
+  test "filters build runs by scheme", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      scheme: "App"
+    )
+
+    RunsFixtures.build_fixture(
+      project_id: project.id,
+      scheme: "Framework"
+    )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs?filter_scheme_op===&filter_scheme_val=App"
+      )
+
+    assert has_element?(lv, "[data-part='build-runs-table'] span", "App")
+    refute has_element?(lv, "[data-part='build-runs-table'] span", "Framework")
+  end
 end

--- a/server/test/tuist_web/live/builds_live_test.exs
+++ b/server/test/tuist_web/live/builds_live_test.exs
@@ -77,4 +77,14 @@ defmodule TuistWeb.BuildsLiveTest do
     assert has_element?(lv, "span", "Build success rate")
     assert has_element?(lv, "span", "66.7%")
   end
+
+  test "renders a searchable scheme dropdown", %{
+    conn: conn,
+    project: project
+  } do
+    {:ok, lv, _html} = live(conn, ~p"/#{project.account.name}/#{project.name}/builds")
+    render_async(lv)
+
+    assert has_element?(lv, "#builds-analytics-scheme-dropdown [data-part='search-input']")
+  end
 end

--- a/server/test/tuist_web/live/tests_live_test.exs
+++ b/server/test/tuist_web/live/tests_live_test.exs
@@ -1,0 +1,18 @@
+defmodule TuistWeb.TestsLiveTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.LiveCase
+  use TuistTestSupport.Cases.StubCase, dashboard_project: true
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  test "renders a searchable scheme dropdown", %{
+    conn: conn,
+    project: project
+  } do
+    {:ok, lv, _html} = live(conn, ~p"/#{project.account.name}/#{project.name}/tests")
+    render_async(lv)
+
+    assert has_element?(lv, "#tests-analytics-scheme-dropdown [data-part='search-input']")
+  end
+end


### PR DESCRIPTION
## Summary
- replace the Build Runs free-text scheme filter with a searchable option filter backed by the project's schemes
- add searchable scheme dropdowns on the dashboard pages that already expose scheme filters
- align shared dropdown search behavior so filtering updates on input, keeps keyboard handling inside the search field, reapplies on open/update, and shows a no-results state

## Validation
- `cd server && mix test test/tuist_web/live/build_runs_live_test.exs`
- `cd server && mix test test/tuist_web/live/builds_live_test.exs`
- `cd server && mix test test/tuist_web/live/tests_live_test.exs`
- `mise run noora:lint`
- `mise run noora:test`
