### PR TITLE
fix(server): preserve build run list state

### DIFF
--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -141,6 +141,10 @@ defmodule TuistWeb.BuildRunLive do
     {:noreply, socket}
   end
 
+  def build_runs_path(%{selected_project: project, uri: uri}) do
+    Query.append(~p"/#{project.account.name}/#{project.name}/builds/build-runs", uri.query)
+  end
+
   @impl true
   def handle_params(_params, uri, %{assigns: %{selected_project: project}} = socket) do
     params = Query.query_params(uri)

--- a/server/lib/tuist_web/live/build_run_live.html.heex
+++ b/server/lib/tuist_web/live/build_run_live.html.heex
@@ -7,9 +7,7 @@
       data-part="back-button"
       variant="secondary"
       size="medium"
-      navigate={
-        ~p"/#{@selected_project.account.name}/#{@selected_project.name}/builds/build-runs"
-      }
+      navigate={TuistWeb.BuildRunLive.build_runs_path(assigns)}
     >
       <:icon_left>
         <.icon name="arrow_left" />

--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -103,6 +103,10 @@ defmodule TuistWeb.GradleBuildLive do
     |> assign_tab_data(selected_tab, params)
   end
 
+  def build_runs_path(%{selected_account: account, selected_project: project, uri: uri}) do
+    Query.append(~p"/#{account.name}/#{project.name}/builds/build-runs", uri.query)
+  end
+
   defp build_run_path(socket) do
     %{selected_account: account, selected_project: project, build: build} = socket.assigns
     "/#{account.name}/#{project.name}/builds/build-runs/#{build.id}"

--- a/server/lib/tuist_web/live/gradle_build_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_build_live.html.heex
@@ -4,7 +4,7 @@
     data-part="back-button"
     variant="secondary"
     size="medium"
-    navigate={~p"/#{@selected_account.name}/#{@selected_project.name}/builds/build-runs"}
+    navigate={TuistWeb.GradleBuildLive.build_runs_path(assigns)}
   >
     <:icon_left>
       <.icon name="arrow_left" />

--- a/server/lib/tuist_web/live/gradle_build_runs_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.ex
@@ -206,6 +206,10 @@ defmodule TuistWeb.GradleBuildRunsLive do
     "?#{URI.encode_query(query_params)}"
   end
 
+  def build_run_path(%{selected_account: account, selected_project: project, uri: uri}, build_run_id) do
+    Query.append(~p"/#{account.name}/#{project.name}/builds/build-runs/#{build_run_id}", uri.query)
+  end
+
   defp define_filters(project) do
     base = [
       %Filter.Filter{

--- a/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_build_runs_live.html.heex
@@ -59,11 +59,7 @@
           id="gradle-build-runs-table"
           rows={@build_runs}
           row_navigate={
-            fn build ->
-              url(
-                ~p"/#{@selected_account.name}/#{@selected_project.name}/builds/build-runs/#{build.id}"
-              )
-            end
+            fn build -> TuistWeb.GradleBuildRunsLive.build_run_path(assigns, build.id) end
           }
         >
           <:col :let={build} label={dgettext("dashboard_gradle", "Project")}>

--- a/server/lib/tuist_web/live/xcode_build_runs_live.ex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.ex
@@ -167,6 +167,10 @@ defmodule TuistWeb.XcodeBuildRunsLive do
     "?#{URI.encode_query(query_params)}"
   end
 
+  def build_run_path(%{selected_project: project, uri: uri}, build_run_id) do
+    Query.append(~p"/#{project.account.name}/#{project.name}/builds/build-runs/#{build_run_id}", uri.query)
+  end
+
   defp build_flop_filters(filters) do
     {ran_by, filters} = Enum.split_with(filters, &(&1.id == "ran_by"))
     {tags_filters, filters} = Enum.split_with(filters, &(&1.id == "custom_tags"))

--- a/server/lib/tuist_web/live/xcode_build_runs_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_build_runs_live.html.heex
@@ -48,11 +48,7 @@
           id="build-runs-table"
           rows={@build_runs}
           row_navigate={
-            fn build_run ->
-              url(
-                ~p"/#{@selected_project.account.name}/#{@selected_project.name}/builds/build-runs/#{build_run.id}"
-              )
-            end
+            fn build_run -> TuistWeb.XcodeBuildRunsLive.build_run_path(assigns, build_run.id) end
           }
         >
           <:col :let={build_run} label={dgettext("dashboard_builds", "Scheme")}>

--- a/server/lib/tuist_web/utilities/query.ex
+++ b/server/lib/tuist_web/utilities/query.ex
@@ -185,4 +185,18 @@ defmodule TuistWeb.Utilities.Query do
   end
 
   def query_params(nil), do: %{}
+
+  @doc """
+  Appends an encoded query string to a path when present.
+
+  ## Examples
+
+      iex> TuistWeb.Utilities.Query.append("/builds", "foo=bar")
+      "/builds?foo=bar"
+
+      iex> TuistWeb.Utilities.Query.append("/builds", "")
+      "/builds"
+  """
+  def append(path, query) when query in [nil, ""], do: path
+  def append(path, query), do: path <> "?" <> query
 end

--- a/server/test/tuist_web/live/build_run_live_test.exs
+++ b/server/test/tuist_web/live/build_run_live_test.exs
@@ -211,4 +211,27 @@ defmodule TuistWeb.BuildRunLiveTest do
     # Then - Check that the Xcode Cache tab is not present in the horizontal tab menu
     refute has_element?(lv, ".noora-tab-menu-horizontal-item", "Xcode Cache")
   end
+
+  test "preserves the build runs query in the back button", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    {:ok, build_run} =
+      RunsFixtures.build_fixture(
+        project_id: project.id,
+        scheme: "App"
+      )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs/#{build_run.id}?filter_scheme_op===&filter_scheme_val=App"
+      )
+
+    assert has_element?(
+             lv,
+             ~s([data-part="back-button"][href="/#{organization.account.name}/#{project.name}/builds/build-runs?filter_scheme_op=%3D%3D&filter_scheme_val=App"])
+           )
+  end
 end

--- a/server/test/tuist_web/live/build_runs_live_test.exs
+++ b/server/test/tuist_web/live/build_runs_live_test.exs
@@ -89,4 +89,27 @@ defmodule TuistWeb.BuildRunsLiveTest do
     assert has_element?(lv, "[data-part='build-runs-table'] span", "App")
     refute has_element?(lv, "[data-part='build-runs-table'] span", "Framework")
   end
+
+  test "preserves the current query in build run links", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    {:ok, build_run} =
+      RunsFixtures.build_fixture(
+        project_id: project.id,
+        scheme: "App"
+      )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs?filter_scheme_op===&filter_scheme_val=App"
+      )
+
+    assert has_element?(
+             lv,
+             ~s([data-part="link"][href="/#{organization.account.name}/#{project.name}/builds/build-runs/#{build_run.id}?filter_scheme_op=%3D%3D&filter_scheme_val=App"])
+           )
+  end
 end

--- a/server/test/tuist_web/live/gradle_build_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_live_test.exs
@@ -84,6 +84,31 @@ defmodule TuistWeb.GradleBuildLiveTest do
     assert has_element?(lv, "td", ":app:assembleDebug")
   end
 
+  test "preserves the build runs query in the back button", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    build_id =
+      GradleFixtures.build_fixture(
+        project_id: project.id,
+        inserted_at: @now,
+        status: "success",
+        root_project_name: "my-android-app"
+      )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs/#{build_id}?filter_status_op===&filter_status_val=success"
+      )
+
+    assert has_element?(
+             lv,
+             ~s([data-part="back-button"][href="/#{organization.account.name}/#{project.name}/builds/build-runs?filter_status_op=%3D%3D&filter_status_val=success"])
+           )
+  end
+
   test "search filters tasks by task path via URL params", %{
     conn: conn,
     organization: organization,

--- a/server/test/tuist_web/live/gradle_build_runs_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_runs_live_test.exs
@@ -43,6 +43,30 @@ defmodule TuistWeb.GradleBuildRunsLiveTest do
     assert has_element?(lv, "span", "my-other-app")
   end
 
+  test "preserves the current query in build run links", %{
+    conn: conn,
+    organization: organization,
+    project: project
+  } do
+    build_id =
+      GradleFixtures.build_fixture(
+        project_id: project.id,
+        root_project_name: "my-android-app",
+        status: "success"
+      )
+
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/builds/build-runs?filter_status_op===&filter_status_val=success"
+      )
+
+    assert has_element?(
+             lv,
+             ~s([data-part="link"][href="/#{organization.account.name}/#{project.name}/builds/build-runs/#{build_id}?filter_status_op=%3D%3D&filter_status_val=success"])
+           )
+  end
+
   test "filters build runs by status", %{
     conn: conn,
     organization: organization,


### PR DESCRIPTION
## Summary
- preserve the current query string when navigating from Xcode and Gradle build run lists into a build run detail page
- keep the same query parameters on the detail-page back actions so returning to the list restores the active filters and pagination state
- add a shared query helper and targeted LiveView coverage for both Xcode and Gradle flows

## Validation
- `cd server && mix test test/tuist_web/live/build_runs_live_test.exs test/tuist_web/live/build_run_live_test.exs test/tuist_web/live/gradle_build_runs_live_test.exs test/tuist_web/live/gradle_build_live_test.exs`
- `cd server && mix format --check-formatted`
- `cd server && mix credo`
