### PR TITLE
fix(cli): preserve original error when test result parsing fails

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1037,7 +1037,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
         } catch {
             guard action != .build, let resultBundlePath else { throw error }
 
-            let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
+            guard let testStatuses = try? await xcResultService.parseTestStatuses(path: resultBundlePath),
+                  !testStatuses.testCases.isEmpty
+            else {
+                throw error
+            }
 
             let testTargets = testActionTargets(
                 for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1037,11 +1037,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
         } catch {
             guard action != .build, let resultBundlePath else { throw error }
 
-            guard let testStatuses = try? await xcResultService.parseTestStatuses(path: resultBundlePath),
-                  !testStatuses.testCases.isEmpty
-            else {
-                throw error
-            }
+            guard try await fileSystem.exists(resultBundlePath) else { throw error }
+
+            let testStatuses = try await xcResultService.parseTestStatuses(path: resultBundlePath)
+            guard !testStatuses.testCases.isEmpty else { throw error }
 
             let testTargets = testActionTargets(
                 for: schemes, testPlanConfiguration: testPlanConfiguration, graph: graph, action: action

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1464,6 +1464,7 @@ final class TestServiceTests: TuistUnitTestCase {
         xcodebuildController.reset()
 
         let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
+        try await fileSystem.makeDirectory(at: xcresultPath)
         given(xcodebuildController)
             .test(
                 .any,
@@ -1584,7 +1585,7 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_run_tests_preserves_original_error_when_parseTestStatuses_throws() async throws {
+    func test_run_tests_preserves_original_error_when_result_bundle_does_not_exist() async throws {
         // Given
         givenGenerator()
 
@@ -1628,14 +1629,6 @@ final class TestServiceTests: TuistUnitTestCase {
                 throw originalError
             }
 
-        xcResultService.reset()
-        given(xcResultService)
-            .parse(path: .any, rootDirectory: .any)
-            .willReturn(nil)
-        given(xcResultService)
-            .parseTestStatuses(path: .any)
-            .willThrow(NSError(domain: "xcresult", code: 1, userInfo: nil))
-
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(.test(project: .testGeneratedProject()))
@@ -1651,6 +1644,9 @@ final class TestServiceTests: TuistUnitTestCase {
             XCTAssertEqual((error as NSError).domain, "xcodebuild")
             XCTAssertEqual((error as NSError).code, 70)
         }
+        verify(xcResultService)
+            .parseTestStatuses(path: .any)
+            .called(0)
     }
 
     func test_run_tests_preserves_original_error_when_no_test_cases_in_result() async throws {
@@ -1680,6 +1676,8 @@ final class TestServiceTests: TuistUnitTestCase {
             .willReturn([])
 
         let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
+        try await fileSystem.makeDirectory(at: xcresultPath)
+
         let originalError = NSError(domain: "xcodebuild", code: 70, userInfo: [
             NSLocalizedDescriptionKey: "Unable to find a device matching the provided destination specifier",
         ])

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -1584,6 +1584,144 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_tests_preserves_original_error_when_parseTestStatuses_throws() async throws {
+        // Given
+        givenGenerator()
+
+        let scheme = Scheme.test(
+            name: "UnitTests",
+            testAction: .test(
+                targets: [
+                    .test(target: .init(projectPath: try temporaryPath(), name: "TargetTests")),
+                ]
+            )
+        )
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+
+        let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
+        let originalError = NSError(domain: "xcodebuild", code: 70, userInfo: [
+            NSLocalizedDescriptionKey: "Unable to find a device matching the provided destination specifier",
+        ])
+
+        xcodebuildController.reset()
+        given(xcodebuildController)
+            .test(
+                .any, scheme: .any, clean: .any, destination: .any, action: .any, rosetta: .any,
+                derivedDataPath: .any, resultBundlePath: .value(xcresultPath), arguments: .any,
+                retryCount: .any, testTargets: .any, skipTestTargets: .any,
+                testPlanConfiguration: .any, passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
+                self.testedSchemes.append(scheme)
+                throw originalError
+            }
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(nil)
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willThrow(NSError(domain: "xcresult", code: 1, userInfo: nil))
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When / Then
+        do {
+            try await testRun(
+                path: try temporaryPath(),
+                resultBundlePath: xcresultPath
+            )
+            XCTFail("Should throw")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "xcodebuild")
+            XCTAssertEqual((error as NSError).code, 70)
+        }
+    }
+
+    func test_run_tests_preserves_original_error_when_no_test_cases_in_result() async throws {
+        // Given
+        givenGenerator()
+
+        let scheme = Scheme.test(
+            name: "UnitTests",
+            testAction: .test(
+                targets: [
+                    .test(target: .init(projectPath: try temporaryPath(), name: "TargetTests")),
+                ]
+            )
+        )
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, .test(), MapperEnvironment())
+            }
+
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+
+        let xcresultPath = try temporaryPath().appending(component: "bundle.xcresult")
+        let originalError = NSError(domain: "xcodebuild", code: 70, userInfo: [
+            NSLocalizedDescriptionKey: "Unable to find a device matching the provided destination specifier",
+        ])
+
+        xcodebuildController.reset()
+        given(xcodebuildController)
+            .test(
+                .any, scheme: .any, clean: .any, destination: .any, action: .any, rosetta: .any,
+                derivedDataPath: .any, resultBundlePath: .value(xcresultPath), arguments: .any,
+                retryCount: .any, testTargets: .any, skipTestTargets: .any,
+                testPlanConfiguration: .any, passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
+                self.testedSchemes.append(scheme)
+                throw originalError
+            }
+
+        xcResultService.reset()
+        given(xcResultService)
+            .parse(path: .any, rootDirectory: .any)
+            .willReturn(nil)
+        given(xcResultService)
+            .parseTestStatuses(path: .any)
+            .willReturn(TestResultStatuses(testCases: []))
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When / Then
+        do {
+            try await testRun(
+                path: try temporaryPath(),
+                resultBundlePath: xcresultPath
+            )
+            XCTFail("Should throw")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "xcodebuild")
+            XCTAssertEqual((error as NSError).code, 70)
+        }
+    }
+
     func test_run_tests_when_part_is_cached_and_scheme_is_passed() async throws {
         try await withMockedDependencies {
             // Given


### PR DESCRIPTION
## Summary
When `xcodebuild test` fails before tests can run (e.g., a simulator runtime isn't installed), the `testSchemes` catch block in `TestService.swift` unconditionally called `parseTestStatuses(path:)` on the result bundle. If parsing threw, the secondary parsing error replaced the primary xcodebuild error, hiding the actionable message from the user.

This PR:
- Checks that the result bundle exists on disk before attempting to parse it
- Short-circuits when the parsed result contains zero test cases (xcodebuild wrote an empty error bundle)
- Preserves the original xcodebuild error in both cases

Genuine parse errors (e.g., corrupted bundle) still propagate as before, so real bugs in the xcresult tooling aren't hidden.

## Context
one of our customer's config pointed at iOS 26.2 simulators that weren't installed on his machine (Apple had auto-updated him to 26.3). The underlying "Unable to find a device matching the provided destination specifier" message from xcodebuild was being swallowed, producing an unhelpful error.

## E2E testing

Minimal iOS project with a test target, tested against the locally built binary containing the fix.

### Test 1: Invalid simulator destination via passthrough args
```
tuist test --result-bundle-path /tmp/results.xcresult -- -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3'
```
**Result:** Original xcodebuild error is surfaced:
```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
    { platform:iOS Simulator, OS:26.3, name:iPhone 17 Pro }
```
Here xcodebuild writes a result bundle with empty `testNodes`. The `!testStatuses.testCases.isEmpty` guard short-circuits, preserving the original error.

### Test 2: Invalid simulator via `--os`
```
tuist test --os 26.3
```
**Result:** Tuist's own simulator resolution catches this before xcodebuild runs:
```
Could not find a suitable device for iOS 26.3.0.
```

### Test 3: Valid simulator, normal test run
```
tuist test -- -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.2'
```
**Result:** Tests pass successfully (happy path unaffected):
```
✔ The project tests ran successfully
```

### Test 4: Result bundle never written
When xcodebuild fails without writing a result bundle, `fileSystem.exists` short-circuits and the original error is re-thrown. Verified via unit test.

## Test plan
- [x] All 58 `TestServiceTests` pass (56 existing + 2 new)
- [x] `test_run_tests_preserves_original_error_when_result_bundle_does_not_exist` -- verifies `parseTestStatuses` isn't called when the bundle is missing, and the original error is re-thrown
- [x] `test_run_tests_preserves_original_error_when_no_test_cases_in_result` -- verifies the original error is preserved when the bundle exists but has no test cases
- [x] E2E: built tuist binary, verified failing destination surfaces the original xcodebuild error
- [x] E2E: built tuist binary, verified successful test run still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)