### PR TITLE
fix(app): coalesce concurrent token refreshes on iOS

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -270,7 +270,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             return try await authenticationTokenRefreshingIfNeeded(
                 serverURL: serverURL, forceRefresh: false,
                 inBackground: ServerAuthenticationConfig.current.backgroundRefresh,
-                locking: false
+                locking: true
             )
         #endif
     }

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -378,4 +378,146 @@ struct ServerAuthenticationControllerTests {
             #expect(expiresAt == date.addingTimeInterval(+600))
         }
     }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func concurrent_refresh_without_locking_races_on_the_refresh_endpoint() async throws {
+        // Regression test reproducing the iOS token refresh race. Before #10276
+        // the iOS branch of `authenticationToken(serverURL:refreshIfNeeded:)`
+        // passed `locking: false`, landing in `case (.expired, false, false)`
+        // which calls `executeRefresh` directly — no cache coalescing, no
+        // locking. In production that let multiple concurrent callers each
+        // hit `/api/auth/refresh_token`; the server rotated the refresh token
+        // on the winner and returned 401 to every loser, whose error path
+        // wiped credentials and surfaced as "You need to be authenticated to
+        // access this resource".
+        let date = Date()
+        let countingRefreshService = CountingRefreshAuthTokenService(
+            tokens: try Self.makeTokens(date: date)
+        )
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: countingRefreshService,
+            cachedValueStore: CachedValueStore()
+        )
+        let serverCredentialsStore = MockServerCredentialsStoring()
+        let serverURL: URL = .test()
+
+        let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+        let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+        let storeCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token
+        )
+
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+        given(serverCredentialsStore).store(credentials: .any, serverURL: .value(serverURL)).willReturn()
+
+        let subjectCopy = subject!
+        try await ServerCredentialsStore.$current.withValue(serverCredentialsStore) {
+            try await Date.$now.withValue({ date }) {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for _ in 0 ..< 10 {
+                        group.addTask {
+                            try await subjectCopy.refreshToken(
+                                serverURL: serverURL,
+                                inBackground: false,
+                                locking: false,
+                                forceInProcessLock: false
+                            )
+                        }
+                    }
+                    try await group.waitForAll()
+                }
+            }
+        }
+
+        let callCount = await countingRefreshService.callCount
+        #expect(callCount > 1, "Expected concurrent callers to race on the refresh endpoint, got \(callCount) calls")
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func concurrent_refresh_with_in_process_locking_coalesces_into_single_request() async throws {
+        // Confirms the fix: routing expired tokens through
+        // `inProcessLockedRefresh` serialises concurrent callers on the
+        // `CachedValueStore` actor, so only a single refresh request reaches
+        // the server regardless of how many API calls fire in parallel. This
+        // is the path the iOS `#else` branch now uses after #10276.
+        let date = Date()
+        let countingRefreshService = CountingRefreshAuthTokenService(
+            tokens: try Self.makeTokens(date: date)
+        )
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: countingRefreshService,
+            cachedValueStore: CachedValueStore()
+        )
+        let serverCredentialsStore = MockServerCredentialsStoring()
+        let serverURL: URL = .test()
+
+        let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+        let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+        let storeCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token
+        )
+
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+        given(serverCredentialsStore).store(credentials: .any, serverURL: .value(serverURL)).willReturn()
+
+        let subjectCopy = subject!
+        try await ServerCredentialsStore.$current.withValue(serverCredentialsStore) {
+            try await Date.$now.withValue({ date }) {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for _ in 0 ..< 10 {
+                        group.addTask {
+                            try await subjectCopy.refreshToken(
+                                serverURL: serverURL,
+                                inBackground: false,
+                                locking: true,
+                                forceInProcessLock: true
+                            )
+                        }
+                    }
+                    try await group.waitForAll()
+                }
+            }
+        }
+
+        let callCount = await countingRefreshService.callCount
+        #expect(callCount == 1, "Expected coalesced callers to issue exactly one refresh, got \(callCount) calls")
+    }
+
+    private static func makeTokens(date: Date) throws -> ServerAuthenticationTokens {
+        let newAccessToken = try JWT.make(expiryDate: date.addingTimeInterval(+600), typ: "access")
+        let newRefreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+7200), typ: "refresh")
+        return ServerAuthenticationTokens(
+            accessToken: newAccessToken.token,
+            refreshToken: newRefreshToken.token
+        )
+    }
+}
+
+private actor CountingRefreshAuthTokenService: RefreshAuthTokenServicing {
+    private let tokens: ServerAuthenticationTokens
+    private(set) var callCount = 0
+
+    init(tokens: ServerAuthenticationTokens) {
+        self.tokens = tokens
+    }
+
+    func refreshTokens(
+        serverURL _: URL,
+        refreshToken _: String
+    ) async throws -> ServerAuthenticationTokens {
+        callCount += 1
+        // Yield and sleep to give every concurrent caller a chance to enter
+        // this method before any of them returns. Without the delay the
+        // unlocked path can still serialise naturally if tasks happen to
+        // resume before others get scheduled.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        return tokens
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the iOS app bug where users see **"You need to be authenticated to access this resource"** on cold start after a day or two, and re-login only works for a few hours before reproducing.

### Root cause

On iOS, `ServerAuthenticationController.authenticationToken(serverURL:refreshIfNeeded:)` takes the `#else` branch (no `TuistSupport`) and calls `authenticationTokenRefreshingIfNeeded` with `locking: false`. With an expired access token that lands in `case (.expired, false, false)` which runs `executeRefresh` directly — **no lock, no cache coalescing**.

When the Previews screen loads on cold start, several requests fire in parallel, the 10-minute access token is expired, and each request independently:

1. Reads the same refresh token from the keychain.
2. POSTs to `/api/auth/refresh_token`.
3. The server's `Authentication.refresh/2` calls `Guardian.on_revoke` on the old refresh token after the first success, deleting it from `guardian_tokens`.
4. The losing requests send a now-revoked refresh token, server returns 401.
5. `deletingCredentialsOnUnauthorizedError` catches the 401 and **wipes every credential from the keychain**, so subsequent requests have no token at all.

Re-login works while usage is serial; the race reproduces again as soon as a cold start coincides with an expired access token.

Prior race-condition fixes (`7650c28295`, `986721a9a7`, `c3bcba3ac4`) added file-system locking inside `canImport(TuistSupport)` branches, so the iOS path never got coverage. The recently merged `RetryMiddleware` (#10233) amplifies the window by wrapping the auth middleware and retrying on any thrown error.

### Fix

Pass `locking: true` in the iOS `#else` branch. That routes expired tokens through the existing `inProcessLockedRefresh` fallback, which uses the `CachedValueStore` actor to coalesce concurrent refresh attempts — only one refresh request reaches the server, and every concurrent caller awaits the same `Task`.

No new code paths; this reuses the actor-serialized fallback that was already there for non-`TuistSupport` builds.

### Follow-ups worth considering (not in this PR)

- `deletingCredentialsOnUnauthorizedError` wipes credentials on any 401 from the refresh endpoint. Even with coalescing, edge cases (e.g. a stale cached token from a crash) can still log a user out globally. Worth reconsidering whether a single 401 should nuke the keychain.
- The server rotates refresh tokens on every refresh. Concurrency-tolerant schemes (e.g. grace window on the previous token) would make the client resilient against any remaining races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)