### PR TITLE
fix(cli): bump FileSystem to 0.16.1 for Musl support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -599,7 +599,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.0"
+        "version" : "0.16.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1688,7 +1688,7 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.1")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "apple.swift-nio", from: "2.70.0"),

--- a/cli/Sources/XcodeGraph/Package.swift
+++ b/cli/Sources/XcodeGraph/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
         .package(id: "tuist.Command", from: "0.13.0"),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.1")),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),

--- a/processor/native/xcactivitylog_nif/Package.resolved
+++ b/processor/native/xcactivitylog_nif/Package.resolved
@@ -102,7 +102,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.0"
+        "version" : "0.16.1"
       }
     },
     {

--- a/processor/native/xcactivitylog_nif/Package.swift
+++ b/processor/native/xcactivitylog_nif/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.46"),
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", from: "0.16.0"),
+        .package(id: "tuist.FileSystem", from: "0.16.1"),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
     ],
     targets: [

--- a/xcode_processor/native/xcresult_nif/Package.resolved
+++ b/xcode_processor/native/xcresult_nif/Package.resolved
@@ -70,7 +70,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.0"
+        "version" : "0.16.1"
       }
     },
     {

--- a/xcode_processor/native/xcresult_nif/Package.swift
+++ b/xcode_processor/native/xcresult_nif/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", from: "0.16.0"),
+        .package(id: "tuist.FileSystem", from: "0.16.1"),
         .package(id: "tuist.Command", from: "0.12.0"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],


### PR DESCRIPTION
## Summary

- Bumps `tuist/FileSystem` from `0.16.0` → `0.16.1` across the CLI, the XcodeGraph vendored package, and the processor/xcode_processor NIFs.
- `0.16.0` introduced POSIX primitives guarded only by `canImport(Darwin)` / `canImport(Glibc)`, which broke the `Release CLI (Linux aarch64)` job because the Swift Static Linux SDK uses Musl. The failure surfaced on main in run [24399740413](https://github.com/tuist/tuist/actions/runs/24399740413).
- `0.16.1` ([tuist/FileSystem#322](https://github.com/tuist/FileSystem/pull/322)) adds the missing Musl branches and gains a `Release build on Static Linux SDK` CI job to catch future regressions.

## Test plan

- [ ] Release workflow: `Release CLI (Linux x86_64)` passes
- [ ] Release workflow: `Release CLI (Linux aarch64)` passes
- [ ] macOS / iOS builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)