### PR TITLE
fix(server,cache): harden NixOS platform (docker liveRestore, drop root SSH, SSH-config-driven deploys)

### DIFF
--- a/cache/platform/configuration.nix
+++ b/cache/platform/configuration.nix
@@ -163,6 +163,7 @@
   virtualisation.docker = {
     enable = true;
     logDriver = "json-file";
+    liveRestore = true;
     daemon.settings = {
       "default-ulimits" = {
         nofile = {

--- a/cache/platform/flake.nix
+++ b/cache/platform/flake.nix
@@ -49,6 +49,11 @@
     mkColmenaNode = diskConfig: hostname: {
       deployment = {
         targetHost = "${hostname}.tuist.dev";
+        # Defer SSH user to the operator's ~/.ssh/config so the flake stays
+        # pure (no --impure / env vars). Privilege escalation via passwordless
+        # sudo for wheel users.
+        targetUser = null;
+        privilegeEscalationCommand = ["sudo" "-H" "--"];
         buildOnTarget = true;
       };
       imports = mkModules diskConfig hostname;

--- a/cache/platform/users.nix
+++ b/cache/platform/users.nix
@@ -1,8 +1,4 @@
 {
-  users.users.root.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/I+/2QT47raegzMIyhwMEPKarJP/+Ox9ewA4ZFJwk/ cschmatzler@tahani"
-  ];
-
   users.users.cschmatzler = {
     isNormalUser = true;
     extraGroups = ["wheel" "docker"];

--- a/handbook/handbook/engineering/cache-infrastructure.md
+++ b/handbook/handbook/engineering/cache-infrastructure.md
@@ -160,14 +160,14 @@ Grafana Alloy configuration for:
 
 3. **Configure secrets**
 
-   After the server reboots, SSH in and set up the 1Password token:
+   After the server reboots, SSH in as your user and set up the 1Password token
+   (stored in 1Password as `OPNIX_SERVICE_ACCOUNT_TOKEN` in the `cache` vault,
+   also mirrored to the `CACHE_OP_SERVICE_ACCOUNT_TOKEN` GitHub repo secret):
 
    ```bash
-   ssh root@cache-new-region.tuist.dev
-
-   # Create the opnix token file (get token from 1Password)
-   echo "YOUR_1PASSWORD_SERVICE_ACCOUNT_TOKEN" > /etc/opnix-token
-   chmod 600 /etc/opnix-token
+   op read "op://cache/OPNIX_SERVICE_ACCOUNT_TOKEN/password" \
+     | ssh <your-username>@cache-new-region.tuist.dev \
+       "sudo tee /etc/opnix-token > /dev/null && sudo chmod 600 /etc/opnix-token"
    ```
 
 4. **Apply the full configuration**
@@ -192,13 +192,23 @@ Grafana Alloy configuration for:
 
 ### Prerequisites
 
-1. SSH access to the target servers (keys configured in `users.nix`)
+1. SSH access to the target servers (keys configured in `users.nix`) — add
+   a `User <your-username>` entry for `*.tuist.dev` to your `~/.ssh/config`
+   so Colmena and plain `ssh` resolve the right user without per-invocation
+   flags:
+   ```
+   Host *.tuist.dev
+     User <your-username>
+   ```
 2. 1Password CLI with access to the `cache` vault
 3. Nix with flakes enabled
 
 ### Deploying NixOS Configuration
 
-NixOS configuration changes are deployed using Colmena:
+NixOS configuration changes are deployed using Colmena. The flake leaves
+`deployment.targetUser = null`, so Colmena defers to your `~/.ssh/config`
+for the SSH user. Privilege escalation uses passwordless sudo (all wheel
+users).
 
 ```bash
 # Deploy to all machines

--- a/processor/platform/configuration.nix
+++ b/processor/platform/configuration.nix
@@ -42,6 +42,7 @@
   virtualisation.docker = {
     enable = true;
     logDriver = "json-file";
+    liveRestore = true;
   };
 
   environment.systemPackages = map lib.lowPrio [

--- a/processor/platform/flake.nix
+++ b/processor/platform/flake.nix
@@ -36,6 +36,11 @@
     mkColmenaNode = hostname: {
       deployment = {
         targetHost = "${hostname}.tuist.dev";
+        # Defer SSH user to the operator's ~/.ssh/config so the flake stays
+        # pure (no --impure / env vars). Privilege escalation via passwordless
+        # sudo for wheel users.
+        targetUser = null;
+        privilegeEscalationCommand = ["sudo" "-H" "--"];
         buildOnTarget = true;
       };
       imports = mkModules hostname;

--- a/processor/platform/users.nix
+++ b/processor/platform/users.nix
@@ -1,8 +1,4 @@
 {
-  users.users.root.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/I+/2QT47raegzMIyhwMEPKarJP/+Ox9ewA4ZFJwk/ cschmatzler@tahani"
-  ];
-
   users.users.cschmatzler = {
     isNormalUser = true;
     extraGroups = ["wheel" "docker"];


### PR DESCRIPTION
## Summary

Three hardening changes to the processor and cache NixOS platforms, prompted by an incident where `colmena switch` on prod killed the processor container and Kamal didn't auto-restart it.

- **Enable `virtualisation.docker.liveRestore = true`** so dockerd restarts (triggered by `colmena switch`) no longer kill running containers. Without this, every NixOS config apply caused ~30–60s of app downtime and left containers in a `hasBeenManuallyStopped=true` state that blocks Kamal auto-restart.
- **Drop the root-only `cschmatzler@tahani` key** from `authorizedKeys`. It was a nixos-anywhere bootstrap artifact that never got rotated. All legitimate operators (mfort, cschmatzler, pedro) are already in `wheel` with passwordless sudo, so Colmena can deploy via any of them.
- **Set `deployment.targetUser = null`** so Colmena defers to each operator's `~/.ssh/config` for the SSH user. Keeps the flake pure (no `--impure`), sudo handles privilege escalation. Operators add a one-liner to their SSH config (see updated handbook).

Already applied live to processor/processor-canary/processor-staging; cache hosts still need `colmena apply` to pick up `liveRestore`. One-time container restart per host is expected when enabling liveRestore; after that, future switches are transparent.

## Test plan

- [x] `colmena apply --on processor-staging` — Live Restore Enabled: true, app healthy
- [x] `colmena apply --on processor-canary` — same
- [x] `colmena apply --on processor` — same
- [ ] Apply to cache hosts (`cache/platform/`) after merge
- [ ] Verify future `colmena switch` on these hosts no longer restarts containers