### PR TITLE
fix(server): size Processor + XcodeProcessor Finch S3 pools to prevent connection starvation

### DIFF
--- a/processor/config/runtime.exs
+++ b/processor/config/runtime.exs
@@ -42,7 +42,14 @@ if config_env() == :prod do
 
   s3_config = if s3_port, do: Keyword.put(s3_config, :port, s3_port), else: s3_config
 
-  config :ex_aws, :req_opts, []
+  config :ex_aws, :req_opts,
+    # Fail individual chunk downloads before ExAws's Task.async_stream 60s
+    # kill so Finch can release connections cleanly. receive_timeout resets
+    # on each data chunk, so it doesn't cap total download time.
+    receive_timeout: to_timeout(second: 30),
+    pool_timeout: to_timeout(second: 5),
+    pool_max_idle_time: :infinity
+
   config :ex_aws, :s3, s3_config
 
   config :ex_aws,

--- a/processor/lib/processor/application.ex
+++ b/processor/lib/processor/application.ex
@@ -12,13 +12,51 @@ defmodule Processor.Application do
 
     children = [
       {Phoenix.PubSub, name: Processor.PubSub},
-      {Finch, name: Processor.Finch},
+      {Finch, name: Processor.Finch, pools: finch_pools()},
       ProcessorWeb.Endpoint,
       Processor.PromEx
     ]
 
     opts = [strategy: :one_for_one, name: Processor.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # ExAws.S3.download_file opens ~8 parallel GET Range requests per download.
+  # The default 50-conn/1-count pool wedges under concurrent build processing:
+  # chunk Task.async_stream timeouts leak in-flight connections faster than
+  # they're released, starving new requests with "excess queuing" errors.
+  # Mirror the server's sizing (size 500, count = schedulers_online, http1).
+  defp finch_pools do
+    s3_endpoint = s3_endpoint()
+    base = %{default: [size: 10]}
+
+    if is_nil(s3_endpoint) do
+      base
+    else
+      Map.put(base, s3_endpoint,
+        size: 500,
+        count: System.schedulers_online(),
+        protocols: [:http1]
+      )
+    end
+  end
+
+  defp s3_endpoint do
+    case Application.get_env(:ex_aws, :s3) do
+      nil ->
+        nil
+
+      s3_config ->
+        scheme = Keyword.get(s3_config, :scheme, "https://")
+        host = Keyword.get(s3_config, :host)
+        port = Keyword.get(s3_config, :port)
+
+        cond do
+          is_nil(host) -> nil
+          is_nil(port) -> "#{scheme}#{host}"
+          true -> "#{scheme}#{host}:#{port}"
+        end
+    end
   end
 
   defp start_sentry_logger do

--- a/processor/lib/processor/application.ex
+++ b/processor/lib/processor/application.ex
@@ -21,41 +21,16 @@ defmodule Processor.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # ExAws.S3.download_file opens ~8 parallel GET Range requests per download.
-  # The default 50-conn/1-count pool wedges under concurrent build processing:
-  # chunk Task.async_stream timeouts leak in-flight connections faster than
-  # they're released, starving new requests with "excess queuing" errors.
-  # Mirror the server's sizing (size 500, count = schedulers_online, http1).
   defp finch_pools do
-    s3_endpoint = s3_endpoint()
     base = %{default: [size: 10]}
 
-    if is_nil(s3_endpoint) do
-      base
-    else
-      Map.put(base, s3_endpoint,
-        size: 500,
-        count: System.schedulers_online(),
-        protocols: [:http1]
-      )
-    end
-  end
-
-  defp s3_endpoint do
-    case Application.get_env(:ex_aws, :s3) do
+    case TuistCommon.FinchPools.s3_endpoint_from_ex_aws_config() do
       nil ->
-        nil
+        base
 
-      s3_config ->
-        scheme = Keyword.get(s3_config, :scheme, "https://")
-        host = Keyword.get(s3_config, :host)
-        port = Keyword.get(s3_config, :port)
-
-        cond do
-          is_nil(host) -> nil
-          is_nil(port) -> "#{scheme}#{host}"
-          true -> "#{scheme}#{host}:#{port}"
-        end
+      endpoint ->
+        {s3_endpoint, s3_pool_opts} = TuistCommon.FinchPools.s3_pool(endpoint: endpoint)
+        Map.put(base, s3_endpoint, s3_pool_opts)
     end
   end
 

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -223,25 +223,20 @@ defmodule Tuist.Application do
     )
   end
 
-  defp s3_ca_cert_opts do
-    case Environment.s3_ca_cert_pem() do
-      nil ->
-        [cacertfile: CAStore.file_path()]
-
-      pem_content ->
-        der_certs =
-          pem_content
-          |> :public_key.pem_decode()
-          |> Enum.map(fn {_, der, _} -> der end)
-
-        [cacerts: der_certs]
-    end
-  end
-
   defp finch_pools do
     if Environment.test?() do
       %{:default => [size: 10]}
     else
+      {s3_endpoint, s3_pool_opts} =
+        TuistCommon.FinchPools.s3_pool(
+          endpoint: Environment.s3_endpoint(),
+          size: Environment.s3_pool_size(),
+          count: Environment.s3_pool_count(),
+          protocols: Environment.s3_protocols(),
+          use_ipv6: Environment.use_ipv6?() in ~w(true 1),
+          ca_cert_pem: Environment.s3_ca_cert_pem()
+        )
+
       base_pools =
         %{
           :default => [size: 10, start_pool_metrics?: true],
@@ -260,21 +255,7 @@ defmodule Tuist.Application do
             protocols: [:http2, :http1],
             start_pool_metrics?: true
           ],
-          Environment.s3_endpoint() => [
-            conn_opts: [
-              log: true,
-              protocols: Environment.s3_protocols(),
-              transport_opts:
-                [
-                  inet6: Environment.use_ipv6?() in ~w(true 1),
-                  verify: :verify_peer
-                ] ++ s3_ca_cert_opts()
-            ],
-            size: Environment.s3_pool_size(),
-            count: Environment.s3_pool_count(),
-            protocols: Environment.s3_protocols(),
-            start_pool_metrics?: true
-          ],
+          s3_endpoint => s3_pool_opts,
           "https://marketing.tuist.dev" => [
             conn_opts: [
               log: true,

--- a/tuist_common/lib/tuist_common/finch_pools.ex
+++ b/tuist_common/lib/tuist_common/finch_pools.ex
@@ -1,0 +1,88 @@
+defmodule TuistCommon.FinchPools do
+  @moduledoc """
+  Shared Finch pool configuration for services that talk to S3 via ExAws.
+
+  `ExAws.S3.download_file/3` opens ~8 parallel GET Range requests per
+  download. A small default pool wedges under concurrent processing: chunk
+  `Task.async_stream` timeouts can leak in-flight connections faster than
+  they're released, eventually starving new requests with "excess queuing"
+  errors. This module centralizes the sizing and TLS defaults used by
+  `server/`, `processor/`, and `xcode_processor/`.
+  """
+
+  @default_size 500
+  @default_protocols [:http1]
+
+  @doc """
+  Builds a `{endpoint, pool_opts}` entry for Finch's `:pools` option.
+
+  ## Options
+    * `:endpoint` — required origin URL, e.g. `"https://s3.example.com"`.
+    * `:size` — pool size (default `#{@default_size}`).
+    * `:count` — pool count (default `System.schedulers_online()`).
+    * `:protocols` — HTTP protocols (default `#{inspect(@default_protocols)}`).
+    * `:use_ipv6` — boolean (default `false`).
+    * `:ca_cert_pem` — PEM-encoded CA bundle. When nil, falls back to
+      `CAStore.file_path/0`.
+    * `:start_pool_metrics` — boolean (default `true`).
+  """
+  def s3_pool(opts) do
+    endpoint = Keyword.fetch!(opts, :endpoint)
+    protocols = Keyword.get(opts, :protocols, @default_protocols)
+
+    transport_opts =
+      [
+        inet6: Keyword.get(opts, :use_ipv6, false),
+        verify: :verify_peer
+      ] ++ ca_cert_opts(Keyword.get(opts, :ca_cert_pem))
+
+    pool_opts = [
+      conn_opts: [
+        log: true,
+        protocols: protocols,
+        transport_opts: transport_opts
+      ],
+      size: Keyword.get(opts, :size, @default_size),
+      count: Keyword.get(opts, :count, System.schedulers_online()),
+      protocols: protocols,
+      start_pool_metrics?: Keyword.get(opts, :start_pool_metrics, true)
+    ]
+
+    {endpoint, pool_opts}
+  end
+
+  @doc """
+  Derives the S3 origin URL from the `:ex_aws, :s3` runtime config.
+
+  Returns `nil` when the config is missing a host, so callers can skip
+  installing an S3 pool in environments that don't talk to S3.
+  """
+  def s3_endpoint_from_ex_aws_config do
+    case Application.get_env(:ex_aws, :s3) do
+      nil ->
+        nil
+
+      s3_config ->
+        scheme = Keyword.get(s3_config, :scheme, "https://")
+        host = Keyword.get(s3_config, :host)
+        port = Keyword.get(s3_config, :port)
+
+        cond do
+          is_nil(host) -> nil
+          is_nil(port) -> "#{scheme}#{host}"
+          true -> "#{scheme}#{host}:#{port}"
+        end
+    end
+  end
+
+  defp ca_cert_opts(nil), do: [cacertfile: CAStore.file_path()]
+
+  defp ca_cert_opts(pem_content) do
+    der_certs =
+      pem_content
+      |> :public_key.pem_decode()
+      |> Enum.map(fn {_, der, _} -> der end)
+
+    [cacerts: der_certs]
+  end
+end

--- a/tuist_common/mix.exs
+++ b/tuist_common/mix.exs
@@ -26,6 +26,7 @@ defmodule TuistCommon.MixProject do
     [
       {:sentry, "~> 11.0.4"},
       {:bandit, "~> 1.0"},
+      {:castore, "~> 1.0.12"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:db_connection, "~> 2.0"},
       {:ecto, "~> 3.13"},

--- a/tuist_common/test/tuist_common/finch_pools_test.exs
+++ b/tuist_common/test/tuist_common/finch_pools_test.exs
@@ -1,0 +1,105 @@
+defmodule TuistCommon.FinchPoolsTest do
+  use ExUnit.Case, async: false
+
+  alias TuistCommon.FinchPools
+
+  describe "s3_pool/1" do
+    test "returns {endpoint, opts} with production defaults" do
+      {endpoint, opts} = FinchPools.s3_pool(endpoint: "https://s3.example.com")
+
+      assert endpoint == "https://s3.example.com"
+      assert Keyword.fetch!(opts, :size) == 500
+      assert Keyword.fetch!(opts, :count) == System.schedulers_online()
+      assert Keyword.fetch!(opts, :protocols) == [:http1]
+      assert Keyword.fetch!(opts, :start_pool_metrics?) == true
+
+      conn_opts = Keyword.fetch!(opts, :conn_opts)
+      assert Keyword.fetch!(conn_opts, :log) == true
+      assert Keyword.fetch!(conn_opts, :protocols) == [:http1]
+
+      transport_opts = Keyword.fetch!(conn_opts, :transport_opts)
+      assert Keyword.fetch!(transport_opts, :inet6) == false
+      assert Keyword.fetch!(transport_opts, :verify) == :verify_peer
+      assert Keyword.has_key?(transport_opts, :cacertfile)
+    end
+
+    test "honours overrides" do
+      {_endpoint, opts} =
+        FinchPools.s3_pool(
+          endpoint: "https://minio.local:9000",
+          size: 42,
+          count: 3,
+          protocols: [:http2, :http1],
+          use_ipv6: true,
+          start_pool_metrics: false
+        )
+
+      assert Keyword.fetch!(opts, :size) == 42
+      assert Keyword.fetch!(opts, :count) == 3
+      assert Keyword.fetch!(opts, :protocols) == [:http2, :http1]
+      assert Keyword.fetch!(opts, :start_pool_metrics?) == false
+
+      transport_opts = opts |> Keyword.fetch!(:conn_opts) |> Keyword.fetch!(:transport_opts)
+      assert Keyword.fetch!(transport_opts, :inet6) == true
+    end
+
+    test "uses supplied CA bundle instead of CAStore" do
+      pem = File.read!(CAStore.file_path())
+
+      {_endpoint, opts} =
+        FinchPools.s3_pool(endpoint: "https://s3.example.com", ca_cert_pem: pem)
+
+      transport_opts = opts |> Keyword.fetch!(:conn_opts) |> Keyword.fetch!(:transport_opts)
+      refute Keyword.has_key?(transport_opts, :cacertfile)
+
+      cacerts = Keyword.fetch!(transport_opts, :cacerts)
+      assert is_list(cacerts) and cacerts != []
+      assert Enum.all?(cacerts, &is_binary/1)
+    end
+
+    test "raises when endpoint is missing" do
+      assert_raise KeyError, fn -> FinchPools.s3_pool([]) end
+    end
+  end
+
+  describe "s3_endpoint_from_ex_aws_config/0" do
+    setup do
+      original = Application.get_env(:ex_aws, :s3)
+      on_exit(fn -> restore_s3_config(original) end)
+      :ok
+    end
+
+    test "returns nil when :s3 config is missing" do
+      Application.delete_env(:ex_aws, :s3)
+      assert FinchPools.s3_endpoint_from_ex_aws_config() == nil
+    end
+
+    test "returns nil when host is missing" do
+      Application.put_env(:ex_aws, :s3, scheme: "https://", port: 443)
+      assert FinchPools.s3_endpoint_from_ex_aws_config() == nil
+    end
+
+    test "returns scheme + host when port is absent" do
+      Application.put_env(:ex_aws, :s3, scheme: "https://", host: "s3.example.com")
+      assert FinchPools.s3_endpoint_from_ex_aws_config() == "https://s3.example.com"
+    end
+
+    test "defaults scheme to https:// when not set" do
+      Application.put_env(:ex_aws, :s3, host: "s3.example.com")
+      assert FinchPools.s3_endpoint_from_ex_aws_config() == "https://s3.example.com"
+    end
+
+    test "includes port when present" do
+      Application.put_env(:ex_aws, :s3,
+        scheme: "http://",
+        host: "localhost",
+        port: 9000
+      )
+
+      assert FinchPools.s3_endpoint_from_ex_aws_config() == "http://localhost:9000"
+    end
+  end
+
+  defp restore_s3_config(nil), do: Application.delete_env(:ex_aws, :s3)
+  defp restore_s3_config(value), do: Application.put_env(:ex_aws, :s3, value)
+end

--- a/xcode_processor/config/runtime.exs
+++ b/xcode_processor/config/runtime.exs
@@ -43,7 +43,14 @@ if config_env() == :prod do
 
   s3_config = if s3_port, do: Keyword.put(s3_config, :port, s3_port), else: s3_config
 
-  config :ex_aws, :req_opts, []
+  config :ex_aws, :req_opts,
+    # Fail individual chunk downloads before ExAws's Task.async_stream 60s
+    # kill so Finch can release connections cleanly. receive_timeout resets
+    # on each data chunk, so it doesn't cap total download time.
+    receive_timeout: to_timeout(second: 30),
+    pool_timeout: to_timeout(second: 5),
+    pool_max_idle_time: :infinity
+
   config :ex_aws, :s3, s3_config
 
   config :ex_aws,

--- a/xcode_processor/lib/xcode_processor/application.ex
+++ b/xcode_processor/lib/xcode_processor/application.ex
@@ -12,13 +12,51 @@ defmodule XcodeProcessor.Application do
 
     children = [
       {Phoenix.PubSub, name: XcodeProcessor.PubSub},
-      {Finch, name: XcodeProcessor.Finch},
+      {Finch, name: XcodeProcessor.Finch, pools: finch_pools()},
       XcodeProcessorWeb.Endpoint,
       XcodeProcessor.PromEx
     ]
 
     opts = [strategy: :one_for_one, name: XcodeProcessor.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # ExAws.S3.download_file opens ~8 parallel GET Range requests per download.
+  # The default 50-conn/1-count pool wedges under concurrent xcresult processing:
+  # chunk Task.async_stream timeouts leak in-flight connections faster than
+  # they're released, starving new requests with "excess queuing" errors.
+  # Mirror the server's sizing (size 500, count = schedulers_online, http1).
+  defp finch_pools do
+    s3_endpoint = s3_endpoint()
+    base = %{default: [size: 10]}
+
+    if is_nil(s3_endpoint) do
+      base
+    else
+      Map.put(base, s3_endpoint,
+        size: 500,
+        count: System.schedulers_online(),
+        protocols: [:http1]
+      )
+    end
+  end
+
+  defp s3_endpoint do
+    case Application.get_env(:ex_aws, :s3) do
+      nil ->
+        nil
+
+      s3_config ->
+        scheme = Keyword.get(s3_config, :scheme, "https://")
+        host = Keyword.get(s3_config, :host)
+        port = Keyword.get(s3_config, :port)
+
+        cond do
+          is_nil(host) -> nil
+          is_nil(port) -> "#{scheme}#{host}"
+          true -> "#{scheme}#{host}:#{port}"
+        end
+    end
   end
 
   defp start_sentry_logger do

--- a/xcode_processor/lib/xcode_processor/application.ex
+++ b/xcode_processor/lib/xcode_processor/application.ex
@@ -21,41 +21,16 @@ defmodule XcodeProcessor.Application do
     Supervisor.start_link(children, opts)
   end
 
-  # ExAws.S3.download_file opens ~8 parallel GET Range requests per download.
-  # The default 50-conn/1-count pool wedges under concurrent xcresult processing:
-  # chunk Task.async_stream timeouts leak in-flight connections faster than
-  # they're released, starving new requests with "excess queuing" errors.
-  # Mirror the server's sizing (size 500, count = schedulers_online, http1).
   defp finch_pools do
-    s3_endpoint = s3_endpoint()
     base = %{default: [size: 10]}
 
-    if is_nil(s3_endpoint) do
-      base
-    else
-      Map.put(base, s3_endpoint,
-        size: 500,
-        count: System.schedulers_online(),
-        protocols: [:http1]
-      )
-    end
-  end
-
-  defp s3_endpoint do
-    case Application.get_env(:ex_aws, :s3) do
+    case TuistCommon.FinchPools.s3_endpoint_from_ex_aws_config() do
       nil ->
-        nil
+        base
 
-      s3_config ->
-        scheme = Keyword.get(s3_config, :scheme, "https://")
-        host = Keyword.get(s3_config, :host)
-        port = Keyword.get(s3_config, :port)
-
-        cond do
-          is_nil(host) -> nil
-          is_nil(port) -> "#{scheme}#{host}"
-          true -> "#{scheme}#{host}:#{port}"
-        end
+      endpoint ->
+        {s3_endpoint, s3_pool_opts} = TuistCommon.FinchPools.s3_pool(endpoint: endpoint)
+        Map.put(base, s3_endpoint, s3_pool_opts)
     end
   end
 


### PR DESCRIPTION
## Summary

`Processor.Finch` (and `XcodeProcessor.Finch` — same pattern) was started with no pool config, defaulting to a single 50-connection pool per origin. Under concurrent build processing, `ExAws.S3.download_file` opens ~8 parallel GET-Range requests per build; when chunk downloads slowed and the ExAws `Task.async_stream` hit its 60s timeout, the in-flight Finch connections weren't always released cleanly. Orphaned connections accumulated until the pool wedged, after which every request failed at checkout with *"Finch was unable to provide a connection within the timeout due to excess queuing"* — bubbling up as HTTP 422 from the webhook and causing server-side `ProcessBuildWorker` jobs to fail indefinitely until a processor restart.

Sentry confirms this matches the incident timeline: `PROCESSOR-7` (`Uncaught exit - {:timeout, {Task.Supervised, :stream, [60000]}}`) fired 132 times with a last-seen right before the processor stopped responding.

## Changes

### Incident fix
- Dedicated S3-endpoint pool in `Processor.Finch` / `XcodeProcessor.Finch` sized `size: 500, count: schedulers_online, protocols: [:http1]` — mirroring the sizing already proven on the server.
- `ex_aws :req_opts` now sets `receive_timeout: 30s` so individual chunk requests fail cleanly **before** ExAws's 60s `Task.async_stream` kill, ensuring Finch releases connections instead of leaking them. `receive_timeout` resets on each data chunk received, so large downloads aren't capped — only genuinely stalled connections fail.

### Shared pool helper
- New `TuistCommon.FinchPools` module centralizes S3 pool construction used by `server/`, `processor/`, and `xcode_processor/`. Exposes `s3_pool/1` (returns `{endpoint, pool_opts}` with size/count/protocols/TLS defaults and `start_pool_metrics?: true`) and `s3_endpoint_from_ex_aws_config/0` (derives the origin URL from `:ex_aws, :s3` runtime config).
- `castore` added to `tuist_common` deps so the helper can fall back to `CAStore.file_path/0` for the CA bundle.
- `server/lib/tuist/application.ex` now calls the helper for its S3 pool (sizing stays env-driven through `Environment.s3_pool_size/count/protocols` + `s3_ca_cert_pem`). The old `s3_ca_cert_opts/0` helper is removed.
- `processor/` and `xcode_processor/` drop ~35 lines of duplicated `finch_pools/0` + `s3_endpoint/0` and now route through the shared helper. Sizing stays hardcoded (500 / `schedulers_online` / `http1`) for this PR; env-driven overrides can be a follow-up.
- Processor and xcode_processor pools now also get `start_pool_metrics?: true` and explicit `verify: :verify_peer` + CAStore TLS — so their Finch metrics flow into the existing dashboards and TLS setup matches the server's.

## Test plan

- [x] `mix compile` clean for `tuist_common`, `processor`, `xcode_processor`, and `server`
- [x] New unit tests in `tuist_common/test/tuist_common/finch_pools_test.exs` (9 cases) cover defaults, overrides, custom CA bundle, missing endpoint, and all four branches of `s3_endpoint_from_ex_aws_config/0`
- [ ] Deploy to processor-staging and xcode-processor-staging, verify downloads still complete under normal load
- [ ] Deploy to canary; monitor `finch_queue_duration_seconds` + `finch_pool_queue_length` and the `ProcessBuildWorker`/xcresult worker success rate during a processing burst
- [ ] Production deploy