### PR TITLE
chore(server): enable PromEx Oban plugin and Grafana dashboard

### DIFF
--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -107,7 +107,7 @@ defmodule Tuist.PromEx do
       # {:prom_ex, "beam.json"},
       # {:prom_ex, "phoenix.json"},
       # {:prom_ex, "ecto.json"},
-      {:prom_ex, "oban.json"},
+      {:prom_ex, "oban.json"}
       # {:prom_ex, "phoenix_live_view.json"},
       # {:prom_ex, "absinthe.json"},
       # {:prom_ex, "broadway.json"},

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -107,7 +107,7 @@ defmodule Tuist.PromEx do
       # {:prom_ex, "beam.json"},
       # {:prom_ex, "phoenix.json"},
       # {:prom_ex, "ecto.json"},
-      {:prom_ex, "oban.json"}
+      # {:prom_ex, "oban.json"},
       # {:prom_ex, "phoenix_live_view.json"},
       # {:prom_ex, "absinthe.json"},
       # {:prom_ex, "broadway.json"},

--- a/server/lib/tuist/prom_ex.ex
+++ b/server/lib/tuist/prom_ex.ex
@@ -59,7 +59,7 @@ defmodule Tuist.PromEx do
     plugins =
       [
         # Plugins.Application,
-        # Plugins.Oban,
+        PromEx.Plugins.Oban,
         # Plugins.PhoenixLiveView,
         # Plugins.Absinthe,
         # Plugins.Broadway,
@@ -107,7 +107,7 @@ defmodule Tuist.PromEx do
       # {:prom_ex, "beam.json"},
       # {:prom_ex, "phoenix.json"},
       # {:prom_ex, "ecto.json"},
-      # {:prom_ex, "oban.json"},
+      {:prom_ex, "oban.json"},
       # {:prom_ex, "phoenix_live_view.json"},
       # {:prom_ex, "absinthe.json"},
       # {:prom_ex, "broadway.json"},


### PR DESCRIPTION
## Summary
- Enables `PromEx.Plugins.Oban` so Oban worker telemetry is exported on the existing `/metrics` endpoint (port 9091).
- Registers the PromEx-bundled `oban.json` Grafana dashboard so queue health, job throughput, latency, and failures are visible.

## Why
We want visibility into Oban worker behaviour on Grafana and the ability to alert on spikes of job failures. PromEx already ships a battle-tested Oban dashboard — this PR just turns it on.

## Follow-up (not in this PR)
- Ensure `TUIST_PROMETHEUS_ENABLED=true` in the environments we want scraped.
- Import the dashboard into `tuist.grafana.net` (either flip `grafana:` to push on boot in `config/runtime.exs`, or export with `mix prom_ex.dashboard.export --module Tuist.PromEx --dashboard oban.json --stdout` and import manually).
- Add a Grafana alert rule on `rate(prom_ex_oban_job_exception_total[5m])`.

## Test plan
- [ ] Boot server with `TUIST_PROMETHEUS_ENABLED=true` and confirm `curl localhost:9091/metrics | grep oban` returns Oban counters/histograms.
- [ ] Import dashboard into Grafana and confirm panels render against the Prometheus datasource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)