### PR TITLE
fix(cli): Add warning for missing xctestplan files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac0722446992940bc9a020e900f935e1d0d7caefeecd847c45f1cd10b0476ba1",
+  "originHash" : "735f756a121ad290a2191f3b0d5aed94b2117e7e8368362187fd74e1114e3d03",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -599,7 +599,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.1"
+        "version" : "0.15.38"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1688,7 +1688,7 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.1")),
+        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "apple.swift-nio", from: "2.70.0"),

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1728,6 +1728,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.support.targetName),
                     .target(name: Module.testing.targetName),
                     .target(name: Module.nooraTesting.targetName),
+                    .target(name: Module.loggerTesting.targetName),
                     .target(name: Module.rootDirectoryLocator.targetName),
                     .target(name: Module.git.targetName),
                     .target(name: Module.constants.targetName),

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1728,7 +1728,6 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.support.targetName),
                     .target(name: Module.testing.targetName),
                     .target(name: Module.nooraTesting.targetName),
-                    .target(name: Module.loggerTesting.targetName),
                     .target(name: Module.rootDirectoryLocator.targetName),
                     .target(name: Module.git.targetName),
                     .target(name: Module.constants.targetName),

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1722,6 +1722,7 @@ public enum Module: String, CaseIterable {
                 ]
             case .loader:
                 [
+                    .target(name: Module.alert.targetName),
                     .target(name: Module.config.targetName),
                     .target(name: Module.projectDescription.targetName),
                     .target(name: Module.core.targetName),

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -291,11 +291,14 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         var preActions: [XCScheme.ExecutionAction] = []
         var postActions: [XCScheme.ExecutionAction] = []
 
-        let testPlans: [XCScheme.TestPlanReference]? = testAction.testPlans?.map {
-            XCScheme.TestPlanReference(
-                reference: "container:\($0.path.relative(to: rootPath))",
-                default: $0.isDefault
-            )
+        let testPlans: [XCScheme.TestPlanReference]? = testAction.testPlans.flatMap { plans in
+            guard !plans.isEmpty else { return nil }
+            return plans.map {
+                XCScheme.TestPlanReference(
+                    reference: "container:\($0.path.relative(to: rootPath))",
+                    default: $0.isDefault
+                )
+            }
         }
 
         let skippedTests =

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Scheme+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Scheme+ManifestMapper.swift
@@ -20,7 +20,8 @@ extension XcodeGraph.Scheme {
         if let manifestTestAction = manifest.testAction {
             testAction = try await XcodeGraph.TestAction.from(
                 manifest: manifestTestAction,
-                generatorPaths: generatorPaths
+                generatorPaths: generatorPaths,
+                schemeName: name
             )
         } else {
             testAction = nil

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -3,6 +3,7 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
+import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -61,13 +62,17 @@ extension XcodeGraph.TestAction {
                     }
                 } else {
                     // Handle as literal path
-                    if try await fileSystem.exists(resolvedPath) && resolvedPath.extension == "xctestplan" {
-                        let testPlan = try await TestPlan.from(
-                            path: resolvedPath,
-                            isDefault: resolvedTestPlans.isEmpty,
-                            generatorPaths: generatorPaths
-                        )
-                        resolvedTestPlans.append(testPlan)
+                    if try await fileSystem.exists(resolvedPath) {
+                        if resolvedPath.extension == "xctestplan" {
+                            let testPlan = try await TestPlan.from(
+                                path: resolvedPath,
+                                isDefault: resolvedTestPlans.isEmpty,
+                                generatorPaths: generatorPaths
+                            )
+                            resolvedTestPlans.append(testPlan)
+                        }
+                    } else {
+                        Logger.current.warning("\(resolvedPath.pathString) does not exist")
                     }
                 }
             }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -3,7 +3,7 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
-import TuistLogging
+import TuistAlert
 import TuistSupport
 import XcodeGraph
 
@@ -13,7 +13,11 @@ extension XcodeGraph.TestAction {
     // - Parameters:
     //   - manifest: Manifest representation of test action model.
     //   - generatorPaths: Generator paths.
-    static func from(manifest: ProjectDescription.TestAction, generatorPaths: GeneratorPaths) async throws -> XcodeGraph
+    static func from(
+        manifest: ProjectDescription.TestAction,
+        generatorPaths: GeneratorPaths,
+        schemeName: String? = nil
+    ) async throws -> XcodeGraph
         .TestAction
     {
         // swiftlint:enable function_body_length
@@ -72,7 +76,10 @@ extension XcodeGraph.TestAction {
                             resolvedTestPlans.append(testPlan)
                         }
                     } else {
-                        Logger.current.warning("\(resolvedPath.pathString) does not exist")
+                        let schemeContext = schemeName.map { " referenced by the scheme '\($0)'" } ?? ""
+                        AlertController.current.warning(
+                            .alert("Test plan \(resolvedPath.basename) does not exist at \(resolvedPath.pathString)\(schemeContext)")
+                        )
                     }
                 }
             }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -2,8 +2,8 @@ import FileSystem
 import Foundation
 import Path
 import ProjectDescription
-import TuistCore
 import TuistAlert
+import TuistCore
 import TuistSupport
 import XcodeGraph
 
@@ -78,13 +78,15 @@ extension XcodeGraph.TestAction {
                     } else {
                         let schemeContext = schemeName.map { " referenced by the scheme '\($0)'" } ?? ""
                         AlertController.current.warning(
-                            .alert("Test plan \(resolvedPath.basename) does not exist at \(resolvedPath.pathString)\(schemeContext)")
+                            .alert(
+                                "Test plan \(resolvedPath.basename) does not exist at \(resolvedPath.pathString)\(schemeContext)"
+                            )
                         )
                     }
                 }
             }
 
-            testPlans = resolvedTestPlans
+            testPlans = resolvedTestPlans.isEmpty ? nil : resolvedTestPlans
 
             // not used when using test plans
             targets = []

--- a/cli/Sources/XcodeGraph/Package.swift
+++ b/cli/Sources/XcodeGraph/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
         .package(id: "tuist.Command", from: "0.13.0"),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.1")),
+        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
@@ -1,10 +1,9 @@
 import FileSystem
 import FileSystemTesting
 import Foundation
-import Logging
 import ProjectDescription
 import Testing
-import TuistLoggerTesting
+import TuistAlert
 import TuistTesting
 import XcodeGraph
 
@@ -189,10 +188,12 @@ struct TestActionManifestMapperTests {
         #expect(testAction.testPlans?.first?.path == testPlanPath)
     }
 
-    @Test(.inTemporaryDirectory, .withMockedLogger()) func action_with_literal_test_plan_missing_file_warns() async throws {
+    @Test(.inTemporaryDirectory, .withScopedAlertController())
+    func action_with_literal_test_plan_missing_file_warns() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let missingPlanPath = temporaryDirectory.appending(component: "MissingPlan.xctestplan")
+        let schemeName = "MyScheme"
 
         let manifest = ProjectDescription.TestAction.testPlans([
             .path(missingPlanPath.pathString),
@@ -202,12 +203,18 @@ struct TestActionManifestMapperTests {
         // When
         let testAction = try await XcodeGraph.TestAction.from(
             manifest: manifest,
-            generatorPaths: generatorPaths
+            generatorPaths: generatorPaths,
+            schemeName: schemeName
         )
 
         // Then
         #expect(testAction.testPlans?.isEmpty == true)
-        TuistTest.expectLogs("\(missingPlanPath.pathString) does not exist")
+        let warnings = AlertController.current.warnings().map(\.message).map { $0.plain() }
+        #expect(
+            warnings == [
+                "Test plan MissingPlan.xctestplan does not exist at \(missingPlanPath.pathString) referenced by the scheme 'MyScheme'",
+            ]
+        )
     }
 }
 

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
@@ -1,8 +1,11 @@
 import FileSystem
 import FileSystemTesting
 import Foundation
+import Logging
 import ProjectDescription
 import Testing
+import TuistLoggerTesting
+import TuistTesting
 import XcodeGraph
 
 @testable import TuistLoader
@@ -184,6 +187,27 @@ struct TestActionManifestMapperTests {
         // Then
         #expect(testAction.testPlans?.count == 1)
         #expect(testAction.testPlans?.first?.path == testPlanPath)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedLogger()) func action_with_literal_test_plan_missing_file_warns() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let missingPlanPath = temporaryDirectory.appending(component: "MissingPlan.xctestplan")
+
+        let manifest = ProjectDescription.TestAction.testPlans([
+            .path(missingPlanPath.pathString),
+        ])
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory, rootDirectory: temporaryDirectory)
+
+        // When
+        let testAction = try await XcodeGraph.TestAction.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths
+        )
+
+        // Then
+        #expect(testAction.testPlans?.isEmpty == true)
+        TuistTest.expectLogs("\(missingPlanPath.pathString) does not exist")
     }
 }
 

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
@@ -160,7 +160,7 @@ struct TestActionManifestMapperTests {
         )
 
         // Then
-        #expect(testAction.testPlans?.isEmpty == true)
+        #expect(testAction.testPlans == nil)
     }
 
     @Test(.inTemporaryDirectory) func action_with_non_xctestplan_files_filtered_out() async throws {
@@ -208,7 +208,7 @@ struct TestActionManifestMapperTests {
         )
 
         // Then
-        #expect(testAction.testPlans?.isEmpty == true)
+        #expect(testAction.testPlans == nil)
         let warnings = AlertController.current.warnings().map(\.message).map { $0.plain() }
         #expect(
             warnings == [

--- a/xcode_processor/native/xcresult_nif/Package.resolved
+++ b/xcode_processor/native/xcresult_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fb6b9b29753f72bd7fdeb646251879df2a53853c5cacc5c1e5e8dcd51b8fa159",
+  "originHash" : "61858bc0736ac345549a59adc833db2ac40f50a6a734281e88519887c1826902",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
@@ -70,7 +70,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.1"
+        "version" : "0.15.38"
       }
     },
     {

--- a/xcode_processor/native/xcresult_nif/Package.swift
+++ b/xcode_processor/native/xcresult_nif/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", from: "0.16.1"),
+        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
         .package(id: "tuist.Command", from: "0.12.0"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],


### PR DESCRIPTION
Was investigating why generated xcschemes didn't turn out the way I wanted to and found that the xctestplan I generate on CI wasn't generated at the correct timing. This would have saved me time.

> Describe here the purpose of your PR.

### How to test locally

1. Run unit tests
2. Create a Project.swift that references an xctestplan that's missing and run tuist generate
