### PR TITLE
fix(server): isolate build/xcresult workers and extend processor timeouts

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -343,7 +343,7 @@ otel_endpoint = Tuist.Environment.get([:otel, :exporter, :otlp, :endpoint])
 
 # Oban
 config :tuist, Oban,
-  queues: [default: 10],
+  queues: [default: 10, process_build: 2, process_xcresult: 2],
   plugins: [
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
     {Oban.Plugins.Lifeline, rescue_after: to_timeout(minute: 30)},

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   @moduledoc false
-  use Oban.Worker, queue: :default, max_attempts: 5
+  use Oban.Worker, queue: :process_build, max_attempts: 5
 
   alias Tuist.Accounts
   alias Tuist.Builds
@@ -101,7 +101,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
                {"content-type", "application/json"},
                {"x-webhook-signature", signature}
              ],
-             receive_timeout: 300_000
+             receive_timeout: 1_200_000
            ) do
         {:ok, %{status: 200, body: parsed_data}} ->
           {:ok, parsed_data}

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
   @moduledoc false
-  use Oban.Worker, queue: :default, max_attempts: 5, unique: [keys: [:test_run_id]]
+  use Oban.Worker, queue: :process_xcresult, max_attempts: 5, unique: [keys: [:test_run_id]]
 
   alias Tuist.Accounts
   alias Tuist.Storage
@@ -94,7 +94,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
                {"content-type", "application/json"},
                {"x-webhook-signature", signature}
              ],
-             receive_timeout: 300_000
+             receive_timeout: 1_200_000
            ) do
         {:ok, %{status: 200, body: parsed_data}} ->
           {:ok, parsed_data}


### PR DESCRIPTION
## Summary
- move Tuist.Builds.Workers.ProcessBuildWorker to a dedicated process_build Oban queue
- move Tuist.Tests.Workers.ProcessXcresultWorker to a dedicated process_xcresult Oban queue
- configure both queues with concurrency 2 in runtime Oban config
- increase processor request receive_timeout to 20 minutes for both workers

## Validation
- mix test test/tuist/builds/workers/process_build_worker_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs
