### PR TITLE
fix(server): improve SSO authentication error messages

### DIFF
--- a/server/lib/tuist_web/controllers/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/auth_controller.ex
@@ -62,14 +62,18 @@ defmodule TuistWeb.AuthController do
           |> put_session(:sso_route_provider, route_provider)
           |> redirect(external: url)
         else
+          {:error, :not_found} ->
+            raise_sso_unauthorized(:organization_not_found)
+
+          {:error, :oauth2_not_configured} ->
+            raise_sso_unauthorized(:sso_not_configured)
+
           _ ->
-            raise UnauthorizedError,
-                  dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+            raise_sso_unauthorized(:sso_request_failed)
         end
 
       _ ->
-        raise UnauthorizedError,
-              dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+        raise_sso_unauthorized(:missing_organization_id)
     end
   end
 
@@ -77,8 +81,7 @@ defmodule TuistWeb.AuthController do
     case {get_session(conn, :sso_organization_id), get_session(conn, :sso_state)} do
       {organization_id, state} when not is_nil(organization_id) and not is_nil(state) ->
         if conn.params["state"] != state do
-          raise UnauthorizedError,
-                dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+          raise_sso_unauthorized(:state_mismatch)
         end
 
         validate_sso_callback_params!(conn.params)
@@ -94,20 +97,22 @@ defmodule TuistWeb.AuthController do
           |> delete_session(:sso_route_provider)
           |> complete_oauth_callback(auth, sso_organization: organization)
         else
+          {:error, :not_found} ->
+            raise_sso_unauthorized(:organization_not_found)
+
+          {:error, :oauth2_not_configured} ->
+            raise_sso_unauthorized(:sso_not_configured)
+
           {:error, reason} ->
             log(:error, "Failed SSO callback: #{inspect(reason)}")
-
-            raise UnauthorizedError,
-                  dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+            raise_sso_unauthorized(reason)
 
           _ ->
-            raise UnauthorizedError,
-                  dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+            raise_sso_unauthorized(:sso_callback_failed)
         end
 
       _ ->
-        raise UnauthorizedError,
-              dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+        raise_sso_unauthorized(:expired_session)
     end
   end
 
@@ -215,8 +220,7 @@ defmodule TuistWeb.AuthController do
         "Refused to link existing user #{existing_user.id} via custom SSO provider #{auth.provider}: user is not a member of the authenticating organization."
       )
 
-      raise UnauthorizedError,
-            dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+      raise_sso_unauthorized(:existing_user_not_member)
     end
   end
 
@@ -298,7 +302,10 @@ defmodule TuistWeb.AuthController do
         message
 
       _ ->
-        dgettext("dashboard", "Failed to authenticate.")
+        dgettext(
+          "dashboard",
+          "Authentication with the identity provider failed. Please try again."
+        )
     end
   end
 
@@ -334,8 +341,7 @@ defmodule TuistWeb.AuthController do
         if(is_binary(description) and description != "", do: " — #{description}", else: "")
     )
 
-    raise UnauthorizedError,
-          dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+    raise_sso_unauthorized({:provider_returned_error, error})
   end
 
   defp validate_sso_callback_params!(%{"code" => code}) when is_binary(code) and code != "" do
@@ -344,9 +350,7 @@ defmodule TuistWeb.AuthController do
 
   defp validate_sso_callback_params!(_params) do
     log(:warning, "SSO callback request is missing both `code` and `error` parameters")
-
-    raise UnauthorizedError,
-          dgettext("dashboard", "Failed to authenticate with the SSO provider.")
+    raise_sso_unauthorized(:missing_authorization_code)
   end
 
   defp validate_sso_urls(config) do
@@ -419,6 +423,136 @@ defmodule TuistWeb.AuthController do
       {seconds, _} -> System.system_time(:second) + seconds
       :error -> nil
     end
+  end
+
+  defp raise_sso_unauthorized(reason) do
+    raise UnauthorizedError, sso_unauthorized_message(reason)
+  end
+
+  defp sso_unauthorized_message(:missing_organization_id) do
+    dgettext(
+      "dashboard",
+      "The SSO request is missing an organization identifier. Please start the sign-in flow again from the login page."
+    )
+  end
+
+  defp sso_unauthorized_message(:organization_not_found) do
+    dgettext(
+      "dashboard",
+      "We couldn't find the organization for this SSO request. Please verify that you are using the correct SSO link."
+    )
+  end
+
+  defp sso_unauthorized_message(:sso_not_configured) do
+    dgettext(
+      "dashboard",
+      "SSO is not fully configured for this organization. Ask an organization admin to review the SSO settings."
+    )
+  end
+
+  defp sso_unauthorized_message(:expired_session) do
+    dgettext(
+      "dashboard",
+      "Your SSO session has expired. Please restart the sign-in flow from the login page."
+    )
+  end
+
+  defp sso_unauthorized_message(:state_mismatch) do
+    dgettext(
+      "dashboard",
+      "The SSO response could not be validated because the request state did not match. Please try again."
+    )
+  end
+
+  defp sso_unauthorized_message({:provider_returned_error, "access_denied"}) do
+    dgettext(
+      "dashboard",
+      "Your identity provider denied access. Please ask your organization admin to assign you to the Tuist application."
+    )
+  end
+
+  defp sso_unauthorized_message({:provider_returned_error, _error}) do
+    dgettext(
+      "dashboard",
+      "Your identity provider returned an authentication error. Please try again or contact your organization admin."
+    )
+  end
+
+  defp sso_unauthorized_message(:missing_authorization_code) do
+    dgettext(
+      "dashboard",
+      "The SSO provider callback is missing an authorization code. Please restart the sign-in flow."
+    )
+  end
+
+  defp sso_unauthorized_message(:unsafe_sso_url) do
+    dgettext(
+      "dashboard",
+      "The configured SSO endpoints are invalid. Ask your organization admin to review the SSO settings."
+    )
+  end
+
+  defp sso_unauthorized_message({:token_exchange_failed, _status, _body}) do
+    dgettext(
+      "dashboard",
+      "Tuist couldn't exchange the authorization code with your identity provider. Ask your organization admin to verify the SSO credentials and callback URL."
+    )
+  end
+
+  defp sso_unauthorized_message({:userinfo_request_failed, _status, _body}) do
+    dgettext(
+      "dashboard",
+      "Tuist couldn't fetch your profile from your identity provider. Ask your organization admin to verify the user info endpoint and configured scopes."
+    )
+  end
+
+  defp sso_unauthorized_message(:invalid_grant) do
+    dgettext(
+      "dashboard",
+      "The SSO authorization code is invalid or expired. Please restart the sign-in flow."
+    )
+  end
+
+  defp sso_unauthorized_message(:missing_user_identifier) do
+    dgettext(
+      "dashboard",
+      "Your identity provider response is missing a stable user identifier. Ask your organization admin to review the user info claims."
+    )
+  end
+
+  defp sso_unauthorized_message(:missing_email) do
+    dgettext(
+      "dashboard",
+      "Your identity provider response is missing an email address. Ask your organization admin to include the email claim."
+    )
+  end
+
+  defp sso_unauthorized_message(:existing_user_not_member) do
+    dgettext(
+      "dashboard",
+      "Your Tuist account already exists, but it isn't a member of this organization. Ask an organization admin to add you, then sign in with SSO again."
+    )
+  end
+
+  defp sso_unauthorized_message(:sso_request_failed) do
+    dgettext(
+      "dashboard",
+      "We couldn't start the SSO flow for this organization. Please verify the SSO configuration and try again."
+    )
+  end
+
+  defp sso_unauthorized_message(:sso_callback_failed) do
+    dgettext(
+      "dashboard",
+      "We couldn't complete the SSO callback for this request. Please try again."
+    )
+  end
+
+  defp sso_unauthorized_message(_reason) do
+    dgettext(
+      "dashboard",
+      "Failed to authenticate with the SSO provider. Please try again."
+    )
   end
 
   defp sso_callback_url(:okta), do: TuistWeb.Endpoint.url() <> ~p"/users/auth/okta/callback"

--- a/server/lib/tuist_web/live/sso_login_live.ex
+++ b/server/lib/tuist_web/live/sso_login_live.ex
@@ -39,7 +39,16 @@ defmodule TuistWeb.SSOLoginLive do
         {:noreply, redirect(socket, to: redirect_url)}
 
       {:error, :not_found} ->
-        socket = put_flash(socket, :error, dgettext("dashboard_auth", "No SSO organization found for this email"))
+        socket =
+          put_flash(
+            socket,
+            :error,
+            dgettext(
+              "dashboard_auth",
+              "No SSO organization is configured for this email. Check the address and ask your organization admin to verify the SSO domain setup."
+            )
+          )
+
         {:noreply, socket}
     end
   end

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Download macOS app"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:37
+#: lib/tuist_web/components/app_layout_components.ex:398
 #, elixir-autogen, elixir-format
 msgid "Emails"
 msgstr ""
@@ -114,12 +114,12 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:51
+#: lib/tuist_web/components/app_layout_components.ex:413
 #, elixir-autogen, elixir-format
 msgid "Errors"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:31
+#: lib/tuist_web/components/app_layout_components.ex:391
 #, elixir-autogen, elixir-format
 msgid "Flags"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:61
+#: lib/tuist_web/components/app_layout_components.ex:421
 #, elixir-autogen, elixir-format
 msgid "Grafana"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Invalid installation request. Please try again."
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:26
+#: lib/tuist_web/components/app_layout_components.ex:385
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:21
+#: lib/tuist_web/components/app_layout_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "LiveDashboard"
 msgstr ""
@@ -223,7 +223,6 @@ msgid "Oops, we couldn't find that page"
 msgstr ""
 
 #: lib/tuist_web/components/account_dropdown.ex:68
-#: lib/tuist_web/components/layouts/ops.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Operations"
 msgstr ""
@@ -283,7 +282,7 @@ msgstr ""
 msgid "Sorry, you made too many requests. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:44
+#: lib/tuist_web/components/app_layout_components.ex:405
 #, elixir-autogen, elixir-format
 msgid "Storage"
 msgstr ""
@@ -374,8 +373,8 @@ msgstr ""
 msgid "Too many requests."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:380
-#: lib/tuist_web/components/app_layout_components.ex:416
+#: lib/tuist_web/components/app_layout_components.ex:446
+#: lib/tuist_web/components/app_layout_components.ex:483
 #, elixir-autogen, elixir-format
 msgid "Tuist Icon"
 msgstr ""
@@ -482,7 +481,8 @@ msgstr ""
 msgid "Create project"
 msgstr ""
 
-#: lib/tuist_web/components/layouts/ops.html.heex:16
+#: lib/tuist_web/components/app_layout_components.ex:373
+#: lib/tuist_web/live/ops_cache_live.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Cache"
 msgstr ""
@@ -502,17 +502,13 @@ msgstr ""
 msgid "Metrics"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:301
-#, elixir-autogen, elixir-format
-msgid "Failed to authenticate."
-msgstr ""
-
 #: lib/tuist_web/controllers/error_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Authentication failed"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:292
+#: lib/tuist_web/controllers/auth_controller.ex:296
+#: lib/tuist_web/controllers/auth_controller.ex:468
 #, elixir-autogen, elixir-format
 msgid "Your identity provider denied access. Please ask your organization admin to assign you to the Tuist application."
 msgstr ""
@@ -523,15 +519,97 @@ msgstr ""
 msgid "Shards"
 msgstr ""
 
-#: lib/tuist_web/controllers/auth_controller.ex:67
-#: lib/tuist_web/controllers/auth_controller.ex:72
-#: lib/tuist_web/controllers/auth_controller.ex:81
-#: lib/tuist_web/controllers/auth_controller.ex:101
-#: lib/tuist_web/controllers/auth_controller.ex:105
-#: lib/tuist_web/controllers/auth_controller.ex:110
-#: lib/tuist_web/controllers/auth_controller.ex:219
-#: lib/tuist_web/controllers/auth_controller.ex:338
-#: lib/tuist_web/controllers/auth_controller.ex:349
+#: lib/tuist_web/controllers/auth_controller.ex:305
 #, elixir-autogen, elixir-format
-msgid "Failed to authenticate with the SSO provider."
+msgid "Authentication with the identity provider failed. Please try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:552
+#, elixir-autogen, elixir-format
+msgid "Failed to authenticate with the SSO provider. Please try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:447
+#, elixir-autogen, elixir-format
+msgid "SSO is not fully configured for this organization. Ask an organization admin to review the SSO settings."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:510
+#, elixir-autogen, elixir-format
+msgid "The SSO authorization code is invalid or expired. Please restart the sign-in flow."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:482
+#, elixir-autogen, elixir-format
+msgid "The SSO provider callback is missing an authorization code. Please restart the sign-in flow."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:433
+#, elixir-autogen, elixir-format
+msgid "The SSO request is missing an organization identifier. Please start the sign-in flow again from the login page."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:461
+#, elixir-autogen, elixir-format
+msgid "The SSO response could not be validated because the request state did not match. Please try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:489
+#, elixir-autogen, elixir-format
+msgid "The configured SSO endpoints are invalid. Ask your organization admin to review the SSO settings."
+msgstr ""
+
+#: lib/tuist_web/components/layouts/ops.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Tuist Ops"
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:496
+#, elixir-autogen, elixir-format
+msgid "Tuist couldn't exchange the authorization code with your identity provider. Ask your organization admin to verify the SSO credentials and callback URL."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:503
+#, elixir-autogen, elixir-format
+msgid "Tuist couldn't fetch your profile from your identity provider. Ask your organization admin to verify the user info endpoint and configured scopes."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:545
+#, elixir-autogen, elixir-format
+msgid "We couldn't complete the SSO callback for this request. Please try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:440
+#, elixir-autogen, elixir-format
+msgid "We couldn't find the organization for this SSO request. Please verify that you are using the correct SSO link."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:538
+#, elixir-autogen, elixir-format
+msgid "We couldn't start the SSO flow for this organization. Please verify the SSO configuration and try again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:454
+#, elixir-autogen, elixir-format
+msgid "Your SSO session has expired. Please restart the sign-in flow from the login page."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:531
+#, elixir-autogen, elixir-format
+msgid "Your Tuist account already exists, but it isn't a member of this organization. Ask an organization admin to add you, then sign in with SSO again."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:517
+#, elixir-autogen, elixir-format
+msgid "Your identity provider response is missing a stable user identifier. Ask your organization admin to review the user info claims."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:524
+#, elixir-autogen, elixir-format
+msgid "Your identity provider response is missing an email address. Ask your organization admin to include the email claim."
+msgstr ""
+
+#: lib/tuist_web/controllers/auth_controller.ex:475
+#, elixir-autogen, elixir-format
+msgid "Your identity provider returned an authentication error. Please try again or contact your organization admin."
 msgstr ""

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -101,7 +101,7 @@ msgstr ""
 msgid "Connection successful"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:96
+#: lib/tuist_web/live/sso_login_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Contact us"
 msgstr ""
@@ -121,14 +121,14 @@ msgstr ""
 msgid "Discover how selective testing is reducing your test time."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:196
+#: lib/tuist_web/live/user_login_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Don't have an account?"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:79
+#: lib/tuist_web/live/sso_login_live.ex:88
 #: lib/tuist_web/live/user_forgot_password_live.ex:54
-#: lib/tuist_web/live/user_login_live.ex:133
+#: lib/tuist_web/live/user_login_live.ex:139
 #: lib/tuist_web/live/user_registration_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Email address"
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Explore how binary caching is enhancing your build times."
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:165
+#: lib/tuist_web/live/user_login_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Forgot password?"
 msgstr ""
@@ -174,31 +174,31 @@ msgstr ""
 msgid "Instantly share your app using a URL."
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:91
+#: lib/tuist_web/live/sso_login_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Interested in SSO?"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:158
+#: lib/tuist_web/live/user_login_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:87
+#: lib/tuist_web/live/sso_login_live.ex:96
 #: lib/tuist_web/live/user_login_live.ex:17
-#: lib/tuist_web/live/user_login_live.ex:171
+#: lib/tuist_web/live/user_login_live.ex:177
 #: lib/tuist_web/live/user_registration_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:62
+#: lib/tuist_web/live/sso_login_live.ex:71
 #: lib/tuist_web/live/user_login_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Log in to Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:64
+#: lib/tuist_web/live/sso_login_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Log in to your enterprise account via SSO"
 msgstr ""
@@ -213,17 +213,12 @@ msgstr ""
 msgid "Next steps"
 msgstr ""
 
-#: lib/tuist_web/live/sso_login_live.ex:42
-#, elixir-autogen, elixir-format
-msgid "No SSO organization found for this email"
-msgstr ""
-
 #: lib/tuist_web/live/connect_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "OR"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:144
+#: lib/tuist_web/live/user_login_live.ex:150
 #: lib/tuist_web/live/user_registration_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Password"
@@ -265,7 +260,7 @@ msgstr ""
 msgid "Selective testing"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:201
+#: lib/tuist_web/live/user_login_live.ex:207
 #: lib/tuist_web/live/user_registration_live.ex:182
 #: lib/tuist_web/live/user_registration_live.ex:265
 #, elixir-autogen, elixir-format
@@ -289,7 +284,7 @@ msgstr ""
 
 #: lib/tuist_web/live/choose_username_live.ex:42
 #: lib/tuist_web/live/device_codes_success_live.ex:28
-#: lib/tuist_web/live/sso_login_live.ex:54
+#: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_live.ex:18
 #: lib/tuist_web/live/user_forgot_password_live.ex:23
 #: lib/tuist_web/live/user_login_live.ex:40
@@ -429,7 +424,7 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:191
+#: lib/tuist_web/live/user_login_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Log in as test user"
 msgstr ""
@@ -439,7 +434,12 @@ msgstr ""
 msgid "Choose a username for your account"
 msgstr ""
 
-#: lib/tuist_web/live/user_login_live.ex:102
+#: lib/tuist_web/live/user_login_live.ex:104
 #, elixir-autogen, elixir-format
-msgid "SSO"
+msgid "Log in with SSO"
+msgstr ""
+
+#: lib/tuist_web/live/sso_login_live.ex:46
+#, elixir-autogen, elixir-format
+msgid "No SSO organization is configured for this email. Check the address and ask your organization admin to verify the SSO domain setup."
 msgstr ""


### PR DESCRIPTION
## Summary
- replace generic SSO unauthorized failures with specific, actionable messages in AuthController
- map callback and provider failures (state mismatch, missing code, token/userinfo failures, existing user not in org, etc.) to clearer copy
- improve the SSO login page error shown when no SSO org is configured for the submitted email
- regenerate affected gettext templates (dashboard.pot, dashboard_auth.pot)

## Testing
- cd server && mix test test/tuist_web/controllers/auth_controller_test.exs