### PR TITLE
fix(cli): use literal string matching in ManifestLoader to fix hang on large output

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -340,8 +340,8 @@ public class ManifestLoader: ManifestLoading {
                 environment: Environment.current.manifestLoadingVariables
             )
 
-            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken),
-                  let endTokenRange = string.range(of: ManifestLoader.endManifestToken)
+            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken, options: .literal),
+                  let endTokenRange = string.range(of: ManifestLoader.endManifestToken, options: [.literal, .backwards])
             else {
                 return string.data(using: .utf8)!
             }


### PR DESCRIPTION
## Problem
 
 When a manifest process produces very large output (~1.1M+ characters),
 ManifestLoader hangs indefinitely on:
 
     let endTokenRange = string.range(of: ManifestLoader.endManifestToken)
 
 Swift's default `String.range(of:)` performs locale-aware Unicode normalisation
 and grapheme cluster analysis on every character. At 1M+ chars this just hangs.
 
 ## Fix
 
 Pass `.literal` to both `range(of:)` calls for a fast byte-level match.
 The tokens (TUIST_MANIFEST_START / TUIST_MANIFEST_END) are plain ASCII so behaviour is identical.
 
 The end token search also uses `.backwards` so it scans from the tail of the output
 (where the token lives) rather than re-scanning the full string from the front.
 
 ## How to test
 
 Reproduce with a manifest that emits large output (e.g. via `print` statements or a
 verbose dependency) and confirm `tuist generate` no longer hangs.