### PR TITLE
fix(server): unflake gradle analytics tests and patch trivy findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -951,6 +951,7 @@ jobs:
             TUIST_HOSTED=0
             TUIST_VERSION=${{ needs.check-releases.outputs.server-next-version-number }}
             MIX_ENV=prod
+            APT_CACHE_BUST=${{ github.sha }}
           tags: |
             ghcr.io/tuist/tuist:${{ needs.check-releases.outputs.server-next-version-number }}
             ghcr.io/tuist/tuist:latest

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -376,6 +376,7 @@ jobs:
             TUIST_HOSTED=0
             TUIST_VERSION=1.24.11.11
             MIX_ENV=prod
+            APT_CACHE_BUST=${{ github.sha }}
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.69.3"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -51,7 +51,12 @@ WORKDIR /app
 # ========================================
 FROM ${BUILDER_IMAGE} AS deps-builder
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
+# APT_CACHE_BUST is passed from CI (e.g. the commit SHA) to invalidate the
+# apt layer so `apt-get upgrade` picks up the latest security patches instead
+# of reusing a stale cached layer.
+ARG APT_CACHE_BUST=0
+RUN : "APT_CACHE_BUST=${APT_CACHE_BUST}" \
+  && apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 WORKDIR /app
@@ -102,7 +107,9 @@ COPY server/lib lib
 RUN mix compile --warnings-as-errors
 
 # Install Chromium for OG image generation (headless, no GPU)
-RUN apt-get update -y && \
+ARG APT_CACHE_BUST=0
+RUN : "APT_CACHE_BUST=${APT_CACHE_BUST}" \
+  && apt-get update -y && apt-get upgrade -y && \
   apt-get install -y --no-install-recommends chromium fonts-noto-cjk fonts-noto-core && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -144,7 +151,12 @@ RUN mkdir -p /app/_build/prod/rel/tuist/lib/processor-0.1.0/priv/native && \
 # ========================================
 FROM ${RUNNER_IMAGE} AS runner-base
 
-RUN apt-get update -y && \
+# APT_CACHE_BUST is passed from CI (e.g. the commit SHA) to invalidate the
+# apt layer so `apt-get upgrade` picks up the latest security patches instead
+# of reusing a stale cached layer.
+ARG APT_CACHE_BUST=0
+RUN : "APT_CACHE_BUST=${APT_CACHE_BUST}" \
+  && apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y curl build-essential gcc wget libvips libstdc++6 openssl libncurses5 locales ca-certificates postgresql-client zip unzip git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -51,12 +51,7 @@ WORKDIR /app
 # ========================================
 FROM ${BUILDER_IMAGE} AS deps-builder
 
-# APT_CACHE_BUST is passed from CI (e.g. the commit SHA) to invalidate the
-# apt layer so `apt-get upgrade` picks up the latest security patches instead
-# of reusing a stale cached layer.
-ARG APT_CACHE_BUST=0
-RUN : "APT_CACHE_BUST=${APT_CACHE_BUST}" \
-  && apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 WORKDIR /app
@@ -107,9 +102,7 @@ COPY server/lib lib
 RUN mix compile --warnings-as-errors
 
 # Install Chromium for OG image generation (headless, no GPU)
-ARG APT_CACHE_BUST=0
-RUN : "APT_CACHE_BUST=${APT_CACHE_BUST}" \
-  && apt-get update -y && apt-get upgrade -y && \
+RUN apt-get update -y && \
   apt-get install -y --no-install-recommends chromium fonts-noto-cjk fonts-noto-core && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
       "axios": "1.15.0",
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
-      "dompurify": "3.3.3",
+      "dompurify": "3.4.0",
       "flatted": "3.4.2",
       "yaml": "2.8.3",
       "defu": "6.1.5",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   axios: 1.15.0
   mdast-util-to-hast: 13.2.1
   ajv: 8.18.0
-  dompurify: 3.3.3
+  dompurify: 3.4.0
   flatted: 3.4.2
   yaml: 2.8.3
   defu: 6.1.5
@@ -685,8 +685,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2430,7 +2430,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3054,7 +3054,7 @@ snapshots:
 
   monaco-editor@0.54.0:
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       marked: 14.0.0
 
   monaco-languageserver-types@0.4.0:
@@ -3142,7 +3142,7 @@ snapshots:
       '@posthog/core': 1.24.1
       '@posthog/types': 1.363.2
       core-js: 3.49.0
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       fflate: 0.4.8
       preact: 10.29.0
       query-selector-shadow-dom: 1.0.1

--- a/server/test/tuist/gradle/analytics_test.exs
+++ b/server/test/tuist/gradle/analytics_test.exs
@@ -5,17 +5,36 @@ defmodule Tuist.Gradle.AnalyticsTest do
   alias TuistTestSupport.Fixtures.GradleFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
-  @now ~N[2026-01-15 10:20:30]
-  @start_datetime ~U[2026-01-13 00:00:00Z]
-  @end_datetime ~U[2026-01-15 23:59:59Z]
+  # ClickHouse gradle tables have a 90-day TTL on inserted_at, so hard-coded
+  # timestamps would silently expire over time. Anchor fixtures to the current
+  # date so the tests stay within the retention window.
+  setup do
+    today = Date.utc_today()
+    end_date = today
+    start_date = Date.add(today, -2)
+
+    end_datetime = DateTime.new!(end_date, ~T[23:59:59.000000], "Etc/UTC")
+    start_datetime = DateTime.new!(start_date, ~T[00:00:00.000000], "Etc/UTC")
+    now = NaiveDateTime.new!(today, ~T[10:20:30])
+
+    {:ok,
+     now: now,
+     start_datetime: start_datetime,
+     end_datetime: end_datetime,
+     expected_dates: [start_date, Date.add(today, -1), end_date]}
+  end
 
   describe "cache_hit_rate/4" do
-    test "calculates cache hit rate from build data" do
+    test "calculates cache hit rate from build data", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true},
           %{task_path: ":app:compileJava", outcome: "local_hit", cacheable: true},
@@ -24,25 +43,29 @@ defmodule Tuist.Gradle.AnalyticsTest do
         ]
       )
 
-      got = Analytics.cache_hit_rate(project.id, @start_datetime, @end_datetime)
+      got = Analytics.cache_hit_rate(project.id, start_datetime, end_datetime)
 
       assert got == 50.0
     end
 
-    test "returns zero when no data exists" do
+    test "returns zero when no data exists", %{start_datetime: start_datetime, end_datetime: end_datetime} do
       project = ProjectsFixtures.project_fixture()
 
-      got = Analytics.cache_hit_rate(project.id, @start_datetime, @end_datetime)
+      got = Analytics.cache_hit_rate(project.id, start_datetime, end_datetime)
 
       assert got == 0.0
     end
 
-    test "only considers cacheable tasks" do
+    test "only considers cacheable tasks", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true},
           %{task_path: ":app:clean", outcome: "executed", cacheable: false},
@@ -50,17 +73,21 @@ defmodule Tuist.Gradle.AnalyticsTest do
         ]
       )
 
-      got = Analytics.cache_hit_rate(project.id, @start_datetime, @end_datetime)
+      got = Analytics.cache_hit_rate(project.id, start_datetime, end_datetime)
 
       assert got == 50.0
     end
 
-    test "aggregates across multiple builds" do
+    test "aggregates across multiple builds", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true}
         ]
@@ -68,25 +95,29 @@ defmodule Tuist.Gradle.AnalyticsTest do
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileJava", outcome: "executed", cacheable: true}
         ]
       )
 
-      got = Analytics.cache_hit_rate(project.id, @start_datetime, @end_datetime)
+      got = Analytics.cache_hit_rate(project.id, start_datetime, end_datetime)
 
       assert got == 50.0
     end
   end
 
   describe "cache_hit_rate_analytics/2" do
-    test "returns analytics with trend and time-series data" do
+    test "returns analytics with trend and time-series data", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true},
           %{task_path: ":app:assembleDebug", outcome: "executed", cacheable: true}
@@ -96,8 +127,8 @@ defmodule Tuist.Gradle.AnalyticsTest do
       got =
         Analytics.cache_hit_rate_analytics(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.avg_hit_rate == 50.0
@@ -106,30 +137,38 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert length(got.values) == 3
     end
 
-    test "returns zero trend and rate when no data exists" do
+    test "returns zero trend and rate when no data exists", %{
+      start_datetime: start_datetime,
+      end_datetime: end_datetime,
+      expected_dates: expected_dates
+    } do
       project = ProjectsFixtures.project_fixture()
 
       got =
         Analytics.cache_hit_rate_analytics(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.avg_hit_rate == 0.0
       assert got.trend == 0.0
-      assert got.dates == [~D[2026-01-13], ~D[2026-01-14], ~D[2026-01-15]]
+      assert got.dates == expected_dates
       assert got.values == [0.0, 0.0, 0.0]
     end
   end
 
   describe "cache_hit_rate_percentile/3" do
-    test "returns percentile analytics" do
+    test "returns percentile analytics", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true},
           %{task_path: ":app:assembleDebug", outcome: "executed", cacheable: true}
@@ -140,8 +179,8 @@ defmodule Tuist.Gradle.AnalyticsTest do
         Analytics.cache_hit_rate_percentile(
           project.id,
           0.5,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert is_number(got.total_percentile_hit_rate)
@@ -150,15 +189,18 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert length(got.values) == 3
     end
 
-    test "returns zero when no data exists" do
+    test "returns zero when no data exists", %{
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       got =
         Analytics.cache_hit_rate_percentile(
           project.id,
           0.99,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.total_percentile_hit_rate == 0.0
@@ -167,13 +209,17 @@ defmodule Tuist.Gradle.AnalyticsTest do
   end
 
   describe "cache_hit_rate_scatter_data/2" do
-    test "returns individual build cache hit rates grouped by environment" do
+    test "returns individual build cache hit rates grouped by environment", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       ci_build_id =
         GradleFixtures.build_fixture(
           project_id: project.id,
-          inserted_at: @now,
+          inserted_at: now,
           is_ci: true,
           root_project_name: "my-app",
           tasks: [
@@ -185,7 +231,7 @@ defmodule Tuist.Gradle.AnalyticsTest do
       local_build_id =
         GradleFixtures.build_fixture(
           project_id: project.id,
-          inserted_at: @now,
+          inserted_at: now,
           is_ci: false,
           root_project_name: "my-app",
           tasks: [
@@ -199,8 +245,8 @@ defmodule Tuist.Gradle.AnalyticsTest do
       got =
         Analytics.cache_hit_rate_scatter_data(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.truncated == false
@@ -227,12 +273,16 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert local_point.id == local_build_id
     end
 
-    test "groups by project name when group_by is :project" do
+    test "groups by project name when group_by is :project", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         root_project_name: "app-one",
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "local_hit", cacheable: true}
@@ -241,7 +291,7 @@ defmodule Tuist.Gradle.AnalyticsTest do
 
       GradleFixtures.build_fixture(
         project_id: project.id,
-        inserted_at: @now,
+        inserted_at: now,
         root_project_name: "app-two",
         tasks: [
           %{task_path: ":app:compileKotlin", outcome: "executed", cacheable: true}
@@ -251,8 +301,8 @@ defmodule Tuist.Gradle.AnalyticsTest do
       got =
         Analytics.cache_hit_rate_scatter_data(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime,
+          start_datetime: start_datetime,
+          end_datetime: end_datetime,
           group_by: :project
         )
 
@@ -265,14 +315,17 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert app_two_series
     end
 
-    test "returns empty series when no builds exist" do
+    test "returns empty series when no builds exist", %{
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       got =
         Analytics.cache_hit_rate_scatter_data(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.series == []
@@ -282,35 +335,39 @@ defmodule Tuist.Gradle.AnalyticsTest do
   end
 
   describe "cache_event_analytics/2" do
-    test "returns upload and download statistics" do
+    test "returns upload and download statistics", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.cache_event_fixture(
         project_id: project.id,
         action: "upload",
         size: 1_000_000,
-        inserted_at: @now
+        inserted_at: now
       )
 
       GradleFixtures.cache_event_fixture(
         project_id: project.id,
         action: "upload",
         size: 2_000_000,
-        inserted_at: @now
+        inserted_at: now
       )
 
       GradleFixtures.cache_event_fixture(
         project_id: project.id,
         action: "download",
         size: 500_000,
-        inserted_at: @now
+        inserted_at: now
       )
 
       got =
         Analytics.cache_event_analytics(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.uploads.total_size == 3_000_000
@@ -319,14 +376,17 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert got.downloads.count == 1
     end
 
-    test "returns zeros when no data exists" do
+    test "returns zeros when no data exists", %{
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       got =
         Analytics.cache_event_analytics(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert got.uploads.total_size == 0
@@ -335,21 +395,25 @@ defmodule Tuist.Gradle.AnalyticsTest do
       assert got.downloads.count == 0
     end
 
-    test "includes trend calculation" do
+    test "includes trend calculation", %{
+      now: now,
+      start_datetime: start_datetime,
+      end_datetime: end_datetime
+    } do
       project = ProjectsFixtures.project_fixture()
 
       GradleFixtures.cache_event_fixture(
         project_id: project.id,
         action: "upload",
         size: 1_000_000,
-        inserted_at: @now
+        inserted_at: now
       )
 
       got =
         Analytics.cache_event_analytics(
           project.id,
-          start_datetime: @start_datetime,
-          end_datetime: @end_datetime
+          start_datetime: start_datetime,
+          end_datetime: end_datetime
         )
 
       assert is_number(got.uploads.trend)


### PR DESCRIPTION
## Summary

Three fixes that together turn the failing server CI green.

### 1. Flaky `Tuist.Gradle.AnalyticsTest` (7 cases)
The tests hard-coded `~N[2026-01-15]` timestamps. ClickHouse gradle tables (`gradle_builds`, `gradle_tasks`, `gradle_cache_events`) carry a `TTL inserted_at + INTERVAL 90 DAY`, so once today's date drifted past that window the just-written rows were silently expired before the analytics queries could read them — every assertion expecting a non-zero hit rate failed. The test now derives `now` / `start_datetime` / `end_datetime` from `Date.utc_today()` via a `setup` block, keeping fixtures inside the retention window indefinitely. Verified locally — 14/14 pass on the originally-failing seed `998936` and a random seed.

### 2. Trivy docker scan: `imagemagick-6-common` / `libmagickcore-6.q16-6` (16 HIGH/CRITICAL CVEs)
`apt-get upgrade` runs in `runner-base`, but the layer was being served from the namespacelabs remote BuildKit cache from before Debian published `+deb12u8`, so the patch never landed and trivy kept seeing `+deb12u7`. The Debian apt repo has the fix; the only blocker was the cached layer.

Options considered:

| Option | Trade-off |
|---|---|
| **Bump base image / float to `bookworm-slim`** | Cleanest if it worked, but `bookworm-slim`, `bookworm`, and `bookworm-20260406-slim` all resolve to the **same** April 7 digest right now — Debian hasn't republished the base image since the patch landed in apt. Doesn't fix the failure today; would also require Renovate (not configured) for ongoing maintenance. |
| **`.trivyignore` the CVEs with an expiry** | Most reproducible, but suppresses a genuine HIGH/CRITICAL finding that we *can* fix today. Reactive — needs follow-up to remove the ignore. |
| **`APT_CACHE_BUST` build arg (chosen)** | Patches flow into the runtime image on every CI run regardless of base-image cadence. Cost is real but bounded: ~1–3 min per server build (apt update+upgrade+install + locale-gen + the `COPY --from=builder` re-execute). The `mix deps.compile` cache in `deps-builder` is untouched, and `builder`'s chromium install is also untouched, so the expensive paths are unaffected. |

The arg is scoped to `runner-base` only — that's the only stage that ships into the scanned runtime image — and is wired through `server.yml` and `release.yml` as `${{ github.sha }}`.

### 3. Trivy fs scan: `dompurify` (GHSA-39q2-94rc-95cp, MEDIUM)
The `pnpm.overrides` pin held `dompurify` at 3.3.3, which trivy now flags (FORBID_TAGS bypass via short-circuit evaluation in ADD_TAGS). Bumped the pin to 3.4.0 (upstream-fixed release) and regenerated `server/pnpm-lock.yaml`.

Fixes the two failures originally reported:
- https://github.com/tuist/tuist/actions/runs/24496760948/job/71593463150
- https://github.com/tuist/tuist/actions/runs/24496760948/job/71593463244

…plus the `Security` job's dompurify finding surfaced in https://github.com/tuist/tuist/actions/runs/24498018469/job/71597525779.

## Test plan
- [x] `mix test test/tuist/gradle/analytics_test.exs` passes locally (multiple seeds)
- [ ] CI Server `Test` job is green
- [ ] CI Server `Security` job is green (dompurify)
- [ ] CI Server `Docker build` → `Scan image for vulnerabilities` trivy step is green (imagemagick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)