### PR TITLE
fix(server): handle duplicate ClickHouse rows in get_command_event_by_*_id

### DIFF
--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -373,6 +373,11 @@ defmodule Tuist.CommandEvents do
     |> Map.new(fn %{project_id: id, last_interacted_at: time} -> {id, time} end)
   end
 
+  # Multiple rows may share the same build_run_id because the ID is derived
+  # from the `.xcactivitylog`, which Xcode can reuse across runs (e.g. a
+  # second `tuist test` that short-circuits before building picks up the
+  # previous log). We return the most recent event until we can source the
+  # build_run_id independently of the activity log.
   def get_command_event_by_build_run_id(build_run_id) do
     query =
       from(e in Event,

--- a/server/lib/tuist/command_events.ex
+++ b/server/lib/tuist/command_events.ex
@@ -374,14 +374,28 @@ defmodule Tuist.CommandEvents do
   end
 
   def get_command_event_by_build_run_id(build_run_id) do
-    case ClickHouseRepo.get_by(Event, build_run_id: build_run_id) do
+    query =
+      from(e in Event,
+        where: e.build_run_id == ^build_run_id,
+        order_by: [desc: e.ran_at, desc: e.created_at],
+        limit: 1
+      )
+
+    case ClickHouseRepo.one(query) do
       nil -> {:error, :not_found}
       event -> {:ok, Event.normalize_enums(event)}
     end
   end
 
   def get_command_event_by_test_run_id(test_run_id) do
-    case ClickHouseRepo.get_by(Event, test_run_id: test_run_id) do
+    query =
+      from(e in Event,
+        where: e.test_run_id == ^test_run_id,
+        order_by: [desc: e.ran_at, desc: e.created_at],
+        limit: 1
+      )
+
+    case ClickHouseRepo.one(query) do
       nil -> {:error, :not_found}
       event -> {:ok, Event.normalize_enums(event)}
     end

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1201,6 +1201,84 @@ defmodule Tuist.CommandEventsTest do
       # Then
       assert got == {:error, :not_found}
     end
+
+    test "returns the most recent event when multiple events share the same test_run_id" do
+      # Given
+      test_run_id = UUIDv7.generate()
+
+      _older =
+        CommandEventsFixtures.command_event_fixture(
+          name: "test",
+          test_run_id: test_run_id,
+          ran_at: ~U[2024-01-01 10:00:00Z]
+        )
+
+      newer =
+        CommandEventsFixtures.command_event_fixture(
+          name: "test",
+          test_run_id: test_run_id,
+          ran_at: ~U[2024-01-02 10:00:00Z]
+        )
+
+      # When
+      got = CommandEvents.get_command_event_by_test_run_id(test_run_id)
+
+      # Then
+      assert {:ok, event} = got
+      assert event.id == newer.id
+    end
+  end
+
+  describe "get_command_event_by_build_run_id/1" do
+    test "returns a command event when build_run_id exists" do
+      # Given
+      build_run_id = UUIDv7.generate()
+
+      command_event =
+        CommandEventsFixtures.command_event_fixture(build_run_id: build_run_id)
+
+      # When
+      got = CommandEvents.get_command_event_by_build_run_id(build_run_id)
+
+      # Then
+      assert {:ok, event} = got
+      assert event.id == command_event.id
+    end
+
+    test "returns {:error, :not_found} when build_run_id does not exist" do
+      # Given
+      non_existent_build_run_id = UUIDv7.generate()
+
+      # When
+      got = CommandEvents.get_command_event_by_build_run_id(non_existent_build_run_id)
+
+      # Then
+      assert got == {:error, :not_found}
+    end
+
+    test "returns the most recent event when multiple events share the same build_run_id" do
+      # Given
+      build_run_id = UUIDv7.generate()
+
+      _older =
+        CommandEventsFixtures.command_event_fixture(
+          build_run_id: build_run_id,
+          ran_at: ~U[2024-01-01 10:00:00Z]
+        )
+
+      newer =
+        CommandEventsFixtures.command_event_fixture(
+          build_run_id: build_run_id,
+          ran_at: ~U[2024-01-02 10:00:00Z]
+        )
+
+      # When
+      got = CommandEvents.get_command_event_by_build_run_id(build_run_id)
+
+      # Then
+      assert {:ok, event} = got
+      assert event.id == newer.id
+    end
   end
 
   describe "cache_hit_rate_period_percentile/4" do


### PR DESCRIPTION
## Summary
- `Tuist.CommandEvents.get_command_event_by_build_run_id/1` and `get_command_event_by_test_run_id/1` used `ClickHouseRepo.get_by/2`, which calls `Repo.one/3`. ClickHouse doesn't enforce uniqueness, so when duplicate `command_events` rows existed for a `build_run_id`, the BuildRun LiveView crashed with `Ecto.MultipleResultsError` (Sentry [TUIST-AR](https://tuist.sentry.io/issues/110101295/), 46 occurrences, 7 users impacted).
- Switched both lookups to `order_by: [desc: ran_at, desc: created_at], limit: 1`, mirroring the existing `Tests.get_latest_test_by_build_run_id/1` pattern.
- Added a "multiple events" regression test for each function.

Fixes TUIST-AR

## Test plan
- [x] `mix test test/tuist/command_events_test.exs --only describe:"get_command_event_by_build_run_id/1" --only describe:"get_command_event_by_test_run_id/1"` (6 tests, 0 failures)
- [ ] Verify in staging that the `/.../builds/build-runs/:id` page loads for a build_run_id with duplicate command_events rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)