### PR TITLE
ci(app): allow manual dispatch of the app workflow

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -22,6 +22,7 @@ on:
       - ".swiftpm/**"
       - "Package.swift"
       - "Package.resolved"
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

The `App` workflow (`.github/workflows/app.yml`) already contains step-level conditionals that reference `github.event_name == 'workflow_dispatch'` — see the `Share TuistApp`, `Bundle iOS app`, `Inspect TuistApp`, and `Share TuistApp` IPA steps. But `workflow_dispatch` was never declared under `on:`, so trying to dispatch it manually fails with:

```
HTTP 422: Workflow does not have 'workflow_dispatch' trigger
```

This PR adds the missing `workflow_dispatch:` trigger. No other changes.

### Why

Fixes in code outside the app's `paths:` filter (e.g. `cli/Sources/TuistServer/**`, which the app links as a local project dependency) can affect what ships in TuistApp but don't naturally trigger the workflow on merge. #10276 is a recent example — it fixed an iOS auth race inside `cli/Sources/TuistServer` but didn't produce a new TuistApp preview because the path filter only watches `app/**`, `Tuist/**`, and the package manifests.

With `workflow_dispatch` wired up, after this PR merges a maintainer can run `gh workflow run App --ref main` to rebuild and re-share the app at current `main`, picking up #10276's fix without needing to either widen the path filter or land a trivial no-op commit.

## Test plan

- [ ] After merge, run `gh workflow run App --ref main --repo tuist/tuist` and confirm the workflow starts successfully (no longer returns HTTP 422).
- [ ] Confirm the dispatched run completes its `Share TuistApp` / `Share build/Tuist.ipa` steps, since those are now gated on `github.event_name == 'workflow_dispatch'` among other triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)