### PR TITLE
fix(cli): Make StringProtocol.range(of:) scan UTF-8 bytes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "735f756a121ad290a2191f3b0d5aed94b2117e7e8368362187fd74e1114e3d03",
+  "originHash" : "1f6d96b59d4ac0c449d7302ca00a15240d8bc98a9c2e8b6100f7ea87bf0ece99",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -599,7 +599,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.15.38"
+        "version" : "0.16.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1688,7 +1688,7 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "apple.swift-nio", from: "2.70.0"),

--- a/cli/Sources/XcodeGraph/Package.swift
+++ b/cli/Sources/XcodeGraph/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "tuist.XcodeProj", .upToNextMajor(from: "9.9.0")),
         .package(id: "tuist.Command", from: "0.13.0"),
-        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "kolos65.Mockable", .upToNextMajor(from: "0.6.1")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "swiftlang.swift-docc-plugin", from: "1.4.6"),

--- a/processor/native/xcactivitylog_nif/Package.resolved
+++ b/processor/native/xcactivitylog_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "645422f24c706264fba79d380e0a70c5eb19750234ea8162bc4dba3d4c315f2e",
+  "originHash" : "7625bf075f2542c819989641fa1cbfca603f0003ba410d4d08a6b4aa8f7d7314",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -102,7 +102,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.15.38"
+        "version" : "0.16.2"
       }
     },
     {

--- a/processor/native/xcactivitylog_nif/Package.swift
+++ b/processor/native/xcactivitylog_nif/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.46"),
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),
     ],
     targets: [

--- a/xcode_processor/native/xcresult_nif/Package.resolved
+++ b/xcode_processor/native/xcresult_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "61858bc0736ac345549a59adc833db2ac40f50a6a734281e88519887c1826902",
+  "originHash" : "8aecb7efffb545661361ba528935d388d595ea06503622713fa85a08b59803c1",
   "pins" : [
     {
       "identity" : "apple.swift-atomics",
@@ -70,7 +70,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.15.38"
+        "version" : "0.16.2"
       }
     },
     {

--- a/xcode_processor/native/xcresult_nif/Package.swift
+++ b/xcode_processor/native/xcresult_nif/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(id: "tuist.Path", from: "0.3.8"),
-        .package(id: "tuist.FileSystem", .upToNextMinor(from: "0.15.0")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "tuist.Command", from: "0.12.0"),
         .package(id: "kolos65.Mockable", from: "0.3.0"),
     ],


### PR DESCRIPTION
## Summary
- Bump `tuist.FileSystem` to 0.16.2 across the root, `cli/Sources/XcodeGraph`, `processor/native/xcactivitylog_nif`, and `xcode_processor/native/xcresult_nif` Swift packages.
- Release notes: https://github.com/tuist/FileSystem/releases/tag/0.16.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)