### PR TITLE
fix(cli): Catalyst should use macosx sdk

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -351,7 +351,7 @@ extension XCFrameworkInfoPlist.Library {
             }
             return "sdk=\(graphPlatform.xcodeSdkRoot)*"
         case .maccatalyst:
-            return "sdk=iphoneos*"
+            return "sdk=macosx*"
         case nil:
             return "sdk=\(graphPlatform.xcodeSdkRoot)*"
         }


### PR DESCRIPTION
There was a mistake in the PR:
https://github.com/tuist/tuist/pull/9902

Since then I've found sourced online that use `macosx` for MacCatalyst. 
Also this fix was need for our project to work.