### PR TITLE
fix(cli): stop excluding transitive deps from cache hashing for positional targets

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: namespace-profile-default-macos
     timeout-minutes: 60
     needs: cli-acceptance-tests-build
-    if: fromJson(needs.cli-acceptance-tests-build.outputs.matrix).shard[0] != null
+    if: toJSON(fromJSON(needs.cli-acceptance-tests-build.outputs.matrix).shard) != '[]'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.cli-acceptance-tests-build.outputs.matrix) }}

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -872,10 +872,6 @@ import XcodeGraph
 
             // Apply the same profile-based filtering used by `tuist generate`.
             // Targets where shouldReplace returns false are excluded from cache warming.
-            // Positional-target filtering (the `targets` argument of `tuist cache`) is applied
-            // earlier by FocusTargetsGraphMappers, which scopes the graph to the requested
-            // targets and their transitive dependencies. Excluding non-requested targets here
-            // would break the transitive hashability check in GraphContentHasher.
             let decider = CacheProfileTargetReplacementDecider(profile: cacheProfile, exceptions: [])
             var excludedTargets = Set<String>()
             for graphTarget in graphTraverser.allTargets() {

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -145,7 +145,6 @@ import XcodeGraph
                 for: graph,
                 configuration: configuration,
                 config: config,
-                includedTargets: targetsToBinaryCache,
                 cacheProfile: profile,
                 cacheStorage: cacheStorage
             )
@@ -866,7 +865,6 @@ import XcodeGraph
             for graph: Graph,
             configuration: String,
             config: Tuist,
-            includedTargets: Set<String>,
             cacheProfile: CacheProfile,
             cacheStorage: CacheStoring
         ) async throws -> [(GraphTarget, String)] {
@@ -874,6 +872,10 @@ import XcodeGraph
 
             // Apply the same profile-based filtering used by `tuist generate`.
             // Targets where shouldReplace returns false are excluded from cache warming.
+            // Positional-target filtering (the `targets` argument of `tuist cache`) is applied
+            // earlier by FocusTargetsGraphMappers, which scopes the graph to the requested
+            // targets and their transitive dependencies. Excluding non-requested targets here
+            // would break the transitive hashability check in GraphContentHasher.
             let decider = CacheProfileTargetReplacementDecider(profile: cacheProfile, exceptions: [])
             var excludedTargets = Set<String>()
             for graphTarget in graphTraverser.allTargets() {
@@ -883,11 +885,6 @@ import XcodeGraph
                 }
             }
 
-            // When explicit targets are specified, exclude any targets not in that set.
-            if !includedTargets.isEmpty {
-                let allTargetNames = Set(graphTraverser.allTargets().map(\.target.name))
-                excludedTargets.formUnion(allTargetNames.subtracting(includedTargets))
-            }
             let hashesByCacheableTarget = try await cacheGraphContentHasher.contentHashes(
                 for: graph,
                 configuration: configuration,

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -293,4 +293,33 @@ struct TuistCacheEEAcceptanceTests {
         try TuistTest.expectContainsTarget("App", inXcodeProj: xcodeprojPath)
         try TuistTest.expectLinked("Framework1.xcframework", by: "App", inXcodeProj: xcodeprojPath)
     }
+
+    // Regression test for https://github.com/tuist/tuist/pull/9946: passing a positional target
+    // whose dependency tree includes internal targets caused the cache command to short-circuit
+    // with "All cacheable targets are already cached" because the dependencies were excluded
+    // from hashing, which in turn made the root target itself fail the transitive-hashability
+    // check in GraphContentHasher.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_ios_app_with_cache_profiles")
+    ) func cache_warm_with_positional_target_hashes_transitive_dependencies() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        try await TuistTest.run(InstallCommand.self, ["--path", fixtureDirectory.pathString])
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            [
+                "--path", fixtureDirectory.pathString,
+                "--cache-profile", "all-possible",
+                "--generate-only",
+                "NonCacheableModule",
+            ]
+        )
+
+        TuistTest.expectLogs("Targets to be cached: ExpensiveModule, NonCacheableModule")
+        TuistTest.doesntExpectLogs("All cacheable targets are already cached")
+    }
 }

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -294,11 +294,6 @@ struct TuistCacheEEAcceptanceTests {
         try TuistTest.expectLinked("Framework1.xcframework", by: "App", inXcodeProj: xcodeprojPath)
     }
 
-    // Regression test for https://github.com/tuist/tuist/pull/9946: passing a positional target
-    // whose dependency tree includes internal targets caused the cache command to short-circuit
-    // with "All cacheable targets are already cached" because the dependencies were excluded
-    // from hashing, which in turn made the root target itself fail the transitive-hashability
-    // check in GraphContentHasher.
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/server/priv/docs/en/guides/features/test-sharding/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-sharding/generated-projects.md
@@ -113,7 +113,7 @@ jobs:
   test:
     name: "Shard #${{ matrix.shard }}"
     needs: build
-    if: fromJson(needs.build.outputs.matrix).shard[0] != null
+    if: toJSON(fromJSON(needs.build.outputs.matrix).shard) != '[]'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -478,7 +478,7 @@ jobs:
   test:
     name: "Shard #${{ matrix.shard }}"
     needs: build
-    if: fromJson(needs.build.outputs.matrix).shard[0] != null
+    if: toJSON(fromJSON(needs.build.outputs.matrix).shard) != '[]'
     runs-on: namespace-profile-default-macos
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Fixes the regression reported in Slack where `tuist cache <Target>` (positional-target form) has been silently no-op'ing since **4.177.0**, printing `All cacheable targets are already cached` even on a fresh project with source edits. Only targets with *no internal dependencies* (leaves) happened to work; path-based caching (`-p Path/To/Target`) was unaffected.

## Root cause

#9946 added a second-pass filter in `CacheWarmCommandService.cacheableTargets(…)` that folded the positional targets into `excludedTargets`:

```swift
if !includedTargets.isEmpty {
    let allTargetNames = Set(graphTraverser.allTargets().map(\.target.name))
    excludedTargets.formUnion(allTargetNames.subtracting(includedTargets))
}
```

`excludedTargets` flows into `GraphContentHasher.isHashable`, which requires **every transitive dependency** to also be hashable (`allSatisfy`). Excluding the requested target's deps therefore made the requested target itself unhashable, and the hash set came back empty → false "already cached" message.

`FocusTargetsGraphMappers` already scopes the graph to the positional targets plus their dependencies before we reach this point, so this filter was both redundant and incorrect. Drop it (and the now-unused `includedTargets` parameter on the private helper). Profile-based filtering via `CacheProfileTargetReplacementDecider` is untouched.

## Test plan

### Swift acceptance test
- [x] `xcodebuild test … -only-testing:TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests/cache_warm_with_positional_target_hashes_transitive_dependencies()` passes with the fix (~5s), fails without it (verified both directions by temporarily re-introducing the buggy block).

### `--generate-only` CLI checks (hashing path only) against `examples/xcode/generated_ios_app_with_cache_profiles`:
- [x] `cache --cache-profile all-possible NonCacheableModule --generate-only` → `Targets to be cached: ExpensiveModule, NonCacheableModule`
- [x] `cache --cache-profile all-possible ExpensiveModule --generate-only` (leaf regression check) → `Targets to be cached: ExpensiveModule`
- [x] `cache --cache-profile all-possible --generate-only` (no positional) → all cacheable targets listed
- [x] `cache --cache-profile only-external --generate-only` → only Alamofire targets listed
- [x] Confirmed stock 4.180.0 still reproduces the bug against the same fixture.

### Full CLI e2e without `--generate-only` (build + store + invalidation cycle):
- [x] Fresh cache + `cache NonCacheableModule` → builds both frameworks, creates XCFrameworks, `2 targets stored: ExpensiveModule, NonCacheableModule`.
- [x] Re-run with no source changes → `All cacheable targets are already cached` (correct no-op).
- [x] Edit `NonCacheable.swift` and re-run → `Targets to be cached: NonCacheableModule` — only the changed target, `ExpensiveModule` correctly stays cached — then stored successfully.
- [x] Post-store re-run → `All cacheable targets are already cached` (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)