### PR TITLE
fix(gradle): stop capturing OkHttpClient in Test task actions

### DIFF
--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
@@ -468,21 +468,15 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
         }
 
         val quarantineEnabled = config.testQuarantineEnabled ?: ciDetector.isCi()
-        val quarantineService = if (quarantineEnabled) {
-            val httpClients = TuistHttpClients()
-            val configProvider = DefaultConfigurationProvider(
-                project = config.project,
-                serverUrl = config.url,
-                projectDir = java.io.File(System.getProperty("user.dir")),
-                httpClients = httpClients
-            )
-            val httpClient = TuistHttpClient(
-                configurationProvider = configProvider,
-                httpClients = httpClients,
-                connectTimeoutMs = 10_000,
-                readTimeoutMs = 10_000
-            )
-            TuistTestQuarantineService(httpClient = httpClient, baseUrl = config.url)
+        val quarantineServiceProvider = if (quarantineEnabled) {
+            project.gradle.sharedServices.registerIfAbsent(
+                "tuistTestQuarantine",
+                TuistTestQuarantineBuildService::class.java
+            ) {
+                parameters.serverUrl.set(config.url)
+                config.project?.let { parameters.tuistProject.set(it) }
+                parameters.projectDir.set(System.getProperty("user.dir"))
+            }
         } else {
             null
         }
@@ -502,11 +496,12 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
                     }
                 })
 
-                if (quarantineService != null) {
+                if (quarantineServiceProvider != null) {
+                    testTask.usesService(quarantineServiceProvider)
                     testTask.ignoreFailures = true
 
                     testTask.doFirst {
-                        val quarantineMap = quarantineService.getQuarantinedTests()
+                        val quarantineMap = quarantineServiceProvider.get().getQuarantinedTests()
                         serviceProvider.get().quarantineMap = quarantineMap
                         val modulePatterns = quarantineMap[moduleName]
                         if (modulePatterns != null) {

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
@@ -3,6 +3,9 @@ package dev.tuist.gradle
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
@@ -107,5 +110,55 @@ class TuistTestQuarantineService(
                 )
             }
         )
+    }
+}
+
+/**
+ * Gradle [BuildService] wrapper around [TuistTestQuarantineService].
+ *
+ * The HTTP plumbing (OkHttp clients, configuration provider, token provider) is
+ * built lazily inside the service rather than captured in task action closures.
+ * This keeps the configuration cache happy: only serializable parameters
+ * (server URL, project handle, working directory) are written to disk — the
+ * non-serializable OkHttp machinery is rebuilt on demand at execution time.
+ */
+abstract class TuistTestQuarantineBuildService :
+    BuildService<TuistTestQuarantineBuildService.Params> {
+
+    interface Params : BuildServiceParameters {
+        val serverUrl: Property<String>
+        val tuistProject: Property<String>
+        val projectDir: Property<String>
+    }
+
+    @Volatile
+    private var delegate: TuistTestQuarantineService? = null
+    private val lock = Any()
+
+    fun getQuarantinedTests(): Map<String, List<TestIdentifier>> = resolveDelegate().getQuarantinedTests()
+
+    private fun resolveDelegate(): TuistTestQuarantineService {
+        delegate?.let { return it }
+        return synchronized(lock) {
+            delegate ?: createDelegate().also { delegate = it }
+        }
+    }
+
+    private fun createDelegate(): TuistTestQuarantineService {
+        val serverUrl = parameters.serverUrl.get()
+        val httpClients = TuistHttpClients()
+        val configProvider = DefaultConfigurationProvider(
+            project = parameters.tuistProject.orNull,
+            serverUrl = serverUrl,
+            projectDir = java.io.File(parameters.projectDir.get()),
+            httpClients = httpClients
+        )
+        val httpClient = TuistHttpClient(
+            configurationProvider = configProvider,
+            httpClients = httpClients,
+            connectTimeoutMs = 10_000,
+            readTimeoutMs = 10_000
+        )
+        return TuistTestQuarantineService(httpClient = httpClient, baseUrl = serverUrl)
     }
 }

--- a/gradle/src/test/kotlin/dev/tuist/gradle/CacheEndpointResolverTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/CacheEndpointResolverTest.kt
@@ -66,8 +66,10 @@ class CacheEndpointResolverTest {
         val fastServer = MockWebServer()
         val slowServer = MockWebServer()
         fastServer.enqueue(MockResponse().setBody("ok"))
-        // Use a large delay to ensure deterministic ordering despite thread scheduling variance
-        slowServer.enqueue(MockResponse().setBody("ok").setBodyDelay(3, TimeUnit.SECONDS))
+        // measureLatency times how long execute() takes, which returns as soon as
+        // response headers arrive — setBodyDelay only delays the body and leaves
+        // headers instant, so we delay headers to make the ordering deterministic.
+        slowServer.enqueue(MockResponse().setBody("ok").setHeadersDelay(3, TimeUnit.SECONDS))
         fastServer.start()
         slowServer.start()
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
@@ -329,6 +329,44 @@ class TuistPluginTest {
     }
 
     @Test
+    fun `quarantine configuration stores no unserializable clients in task actions`() {
+        settingsFile.writeText("""
+            plugins {
+                id("dev.tuist")
+            }
+
+            tuist {
+                project = "test-account/test-project"
+                testQuarantine {
+                    enabled = true
+                }
+                buildCache {
+                    enabled = false
+                }
+            }
+
+            rootProject.name = "test-project"
+        """.trimIndent())
+
+        buildFile.writeText("""
+            plugins { java }
+
+            repositories { mavenCentral() }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("test", "--configuration-cache", "--dry-run")
+            .withPluginClasspath()
+            .build()
+
+        assertTrue(
+            !result.output.contains("Configuration cache state could not be cached"),
+            "Unexpected configuration cache serialization error:\n${result.output}"
+        )
+    }
+
+    @Test
     fun `plugin logs message when build cache is configured`() {
         settingsFile.writeText("""
             plugins {


### PR DESCRIPTION
## Summary

- The proxy auto-detection work (#10261) wired OkHttp-backed `TuistHttpClients` into `TuistTestQuarantineService`, which the test quarantine logic captured inside the `Test` task's `doFirst` lambda. Gradle's configuration cache then tried to serialize `OkHttpClient`'s internal TLS state (`BasicTrustRootIndex` / `X500Principal`) and failed with `Configuration cache state could not be cached`.
- Move the quarantine service behind a Gradle `BuildService` (`TuistTestQuarantineBuildService`) that only carries serializable parameters (server URL, project handle, project dir) and builds the HTTP machinery lazily at execution time. The `doFirst` closure now references only the build service `Provider`, which the configuration cache knows how to serialize.

TDD: added `TuistPluginTest.quarantine configuration stores no unserializable clients in task actions` which runs `test --configuration-cache --dry-run` with quarantine enabled. The test failed before the fix with the exact serialization trace reported on CI and passes after it.

Fixes the failure from https://github.com/tuist/tuist/actions/runs/24524935295/job/71692505703.

## Test plan

- [x] `./gradlew test` (all unit + TestKit tests green)
- [x] New reproduction test fails on `main` with the reported `OkHttpClient` serialization error and passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)