### PR TITLE
fix(cli): use proxy-aware URLSession for cache endpoint latency checks

### DIFF
--- a/cli/Sources/TuistCAS/Services/EndpointLatencyService.swift
+++ b/cli/Sources/TuistCAS/Services/EndpointLatencyService.swift
@@ -3,6 +3,7 @@ import Foundation
     import FoundationNetworking
 #endif
 import Mockable
+import TuistHTTP
 
 @Mockable
 protocol EndpointLatencyServicing: Sendable {
@@ -23,7 +24,7 @@ struct EndpointLatencyService: EndpointLatencyServicing {
             // Use URLSessionTaskMetrics for precise timing on macOS
             return await withCheckedContinuation { continuation in
                 let delegate = MetricsDelegate(continuation: continuation)
-                let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+                let session = URLSession(configuration: tuistURLSessionConfiguration(), delegate: delegate, delegateQueue: nil)
                 delegate.session = session
 
                 Task {
@@ -36,7 +37,7 @@ struct EndpointLatencyService: EndpointLatencyServicing {
             let clock = ContinuousClock()
             let start = clock.now
             do {
-                let (_, response) = try await URLSession.shared.data(for: request)
+                let (_, response) = try await URLSession.tuistShared.data(for: request)
                 let end = clock.now
                 let duration = end - start
                 if let httpResponse = response as? HTTPURLResponse,

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -21,7 +21,7 @@ private func environmentProxyURL() -> URL? {
     return nil
 }
 
-private func tuistURLSessionConfiguration() -> URLSessionConfiguration {
+public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
     configuration.timeoutIntervalForRequest = 120
     configuration.timeoutIntervalForResource = 300


### PR DESCRIPTION
## Summary
  - The endpoint latency service was using the default `URLSession` instead of the proxy-aware configuration
  - This caused cache endpoints to appear unreachable when behind an HTTP proxy (HTTPS_PROXY/HTTP_PROXY)
  - Makes `tuistURLSessionConfiguration()` public so it can be shared with `EndpointLatencyService`

  Follows up on #10261 which added proxy auto-detection but missed the latency check code path.

  ### How to test locally

  Behind a corporate proxy:

  ```bash
  # Before fix - production endpoints unreachable
  [ai-sandbox] changd@changd-H375DJ7 ios % make tuist_sandbox

  ✖ Error
    None of the cache endpoints are reachable.

  # After fix - endpoints reachable via proxy
  [ai-sandbox] changd@changd-H375DJ7 ios % make tuist_dev_sandbox
  ✔ Success
    Project generated.
```