### PR TITLE
fix(cli): handle binary wrapper xcframework name collisions for Singular and Firebase patterns

### DIFF
--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -456,12 +456,19 @@ public struct PackageInfoMapper: PackageInfoMapping {
 
             for dependency in currentTarget.dependencies {
                 let dependencyName: String
+                let isSamePackageDependency: Bool
                 switch dependency {
-                case let .target(name, _), let .byName(name, _), let .product(name, _, _, _):
+                case let .target(name, _), let .byName(name, _):
                     dependencyName = name
+                    isSamePackageDependency = true
+                case let .product(name, _, _, _):
+                    dependencyName = name
+                    isSamePackageDependency = false
                 }
 
-                if dependencyName == productName {
+                // A same-package target already uses the product name, so renaming would collide.
+                // Skip .product deps since those reference external packages and won't collide.
+                if isSamePackageDependency, dependencyName == productName {
                     return true
                 }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -416,11 +416,35 @@ public struct PackageInfoMapper: PackageInfoMapping {
         guard products.count == 1,
               let singleProduct = products.first,
               singleProduct.targets.count == 1,
-              singleProduct.targets.first == targetName,
-              singleProduct.name != targetName,
-              targetName.hasPrefix(singleProduct.name)
+              singleProduct.targets.first == targetName
         else { return targetName }
 
+        let productName = singleProduct.name
+        let wrapsProductFramework = wrapsProductNamedFramework(
+            targetName: targetName, productName: productName, packageTargets: packageTargets
+        )
+
+        if targetName == productName {
+            // Wrapper target already shares its name with the product (e.g. Singular 12.10.1's `Singular` target
+            // wrapping `SingularBinary` at `Singular.xcframework`). Suffix the product name so Xcode doesn't emit
+            // the same `.framework` from both the wrapper target and `ProcessXCFramework`. Users importing the
+            // product name still resolve to the xcframework's module.
+            return wrapsProductFramework ? "\(targetName)Wrapper" : targetName
+        }
+
+        // Target name differs from the product. SwiftPM hoists the product name onto single-target wrappers whose
+        // name has the product as a prefix (e.g. `FirebaseCrashlyticsTarget` becomes `FirebaseCrashlytics`). Skip
+        // the hoist when the rename would collide with a sibling target or the framework a wrapped binary already
+        // emits.
+        guard targetName.hasPrefix(productName) else { return targetName }
+        return wrapsProductFramework ? targetName : productName
+    }
+
+    private static func wrapsProductNamedFramework(
+        targetName: String,
+        productName: String,
+        packageTargets: [PackageInfo.Target]
+    ) -> Bool {
         let targetsByName = Dictionary(uniqueKeysWithValues: packageTargets.map { ($0.name, $0) })
         var visited = Set<String>()
         var queue = [targetName]
@@ -437,29 +461,44 @@ public struct PackageInfoMapper: PackageInfoMapping {
                     dependencyName = name
                 }
 
-                if dependencyName == singleProduct.name {
-                    return targetName
+                if dependencyName == productName {
+                    return true
                 }
 
                 if let depTarget = targetsByName[dependencyName] {
-                    if depTarget.type == .binary {
-                        // Remote binary targets don't expose a local xcframework path here, so we also fall back to
-                        // the binary target name to avoid renaming the wrapper target to a product name that Xcode
-                        // will already emit from ProcessXCFramework.
-                        let matchesProductNameInPath =
-                            depTarget.path.flatMap { try? RelativePath(validating: $0).basenameWithoutExt } == singleProduct.name
-                        let matchesProductNameInTargetName =
-                            depTarget.name == singleProduct.name || depTarget.name.hasPrefix(singleProduct.name)
-                        if matchesProductNameInPath || matchesProductNameInTargetName {
-                            return targetName
-                        }
+                    if depTarget.type == .binary, binaryTargetEmitsProductFramework(
+                        depTarget, productName: productName
+                    ) {
+                        return true
                     }
                     queue.append(dependencyName)
                 }
             }
         }
 
-        return singleProduct.name
+        return false
+    }
+
+    private static func binaryTargetEmitsProductFramework(
+        _ target: PackageInfo.Target,
+        productName: String
+    ) -> Bool {
+        // Prefer a local xcframework path when available since its basename is what Xcode emits verbatim.
+        if let path = target.path,
+           let basename = try? RelativePath(validating: path).basenameWithoutExt,
+           basename == productName
+        {
+            return true
+        }
+
+        // Remote binary targets don't expose a local path, so match on the target name. Some SDKs (e.g.
+        // firebase-ios-sdk-xcframeworks) mark binary targets internal with a leading underscore while the shipped
+        // xcframework still uses the unprefixed product name, so strip leading underscores before comparing.
+        let strippedName = String(target.name.drop(while: { $0 == "_" }))
+        return target.name == productName
+            || target.name.hasPrefix(productName)
+            || strippedName == productName
+            || strippedName.hasPrefix(productName)
     }
 
     // swiftlint:disable:next function_body_length

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -6474,6 +6474,94 @@ struct PackageInfoMapperTests {
 
     @Test(
         .inTemporaryDirectory, .withMockedSwiftVersionProvider
+    ) func map_whenUnderscorePrefixedBinaryTargetMatchesProductName_keepsTargetNameAsProductName() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/FirebaseCrashlyticsTarget"))
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(
+                            name: "FirebaseCrashlytics",
+                            type: .library(.automatic),
+                            targets: ["FirebaseCrashlyticsTarget"]
+                        ),
+                    ],
+                    targets: [
+                        .test(
+                            name: "FirebaseCrashlyticsTarget",
+                            dependencies: [
+                                .target(name: "_FirebaseCrashlytics", condition: nil),
+                            ]
+                        ),
+                        .test(
+                            name: "_FirebaseCrashlytics",
+                            type: .binary,
+                            url: "https://github.com/akaffenberger/firebase-ios-sdk-xcframeworks/releases/download/11.15.0/_FirebaseCrashlytics.xcframework.zip"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let mappedTarget = try #require(project?.targets.first(where: { $0.name == "FirebaseCrashlyticsTarget" }))
+        #expect(mappedTarget.productName == "FirebaseCrashlyticsTarget")
+    }
+
+    @Test(
+        .inTemporaryDirectory, .withMockedSwiftVersionProvider
+    ) func map_whenWrapperTargetSharesProductNameWithBinaryXcframework_suffixesProductName() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "Package/Sources/Singular"))
+        )
+
+        let project = try await subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Singular",
+                    products: [
+                        .init(name: "Singular", type: .library(.automatic), targets: ["Singular"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Singular",
+                            dependencies: [
+                                .target(name: "SingularBinary", condition: nil),
+                            ]
+                        ),
+                        .test(
+                            name: "SingularBinary",
+                            type: .binary,
+                            path: "Singular.xcframework"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        let mappedTarget = try #require(project?.targets.first(where: { $0.name == "Singular" }))
+        #expect(mappedTarget.productName == "SingularWrapper")
+    }
+
+    @Test(
+        .inTemporaryDirectory, .withMockedSwiftVersionProvider
     ) func map_whenTargetNameContainsSpacesAndDefaultPathUsesUnderscores_mapsTargetSources() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
         try await fileSystem.makeDirectory(

--- a/xcode_processor/native/xcresult_nif/Sources/XCResultParser/TestSummary.swift
+++ b/xcode_processor/native/xcresult_nif/Sources/XCResultParser/TestSummary.swift
@@ -23,7 +23,7 @@ public struct TestSummary: Encodable, Sendable {
         status: TestStatus,
         duration: Int?,
         testModules: [TestModule],
-        runDestinations: [RunDestination]
+        runDestinations: [RunDestination] = []
     ) {
         self.testPlanName = testPlanName
         self.status = status


### PR DESCRIPTION
## Summary
- Fixes "Multiple commands produce" build errors when SPM packages use a wrapper target around a binary xcframework and both emit the same `.framework` output
- Handles two patterns that PR #10054 missed:
  - **Singular 12.10.1 shape**: wrapper target name equals the product name (`Singular` wrapping `SingularBinary` at `Singular.xcframework`). The old guard in `effectiveModuleName` exited early when `singleProduct.name == targetName`, never reaching the collision check. Now suffixes the wrapper's productName with `Wrapper`.
  - **Firebase xcframeworks shape (#10146)**: binary targets prefixed with `_` (e.g. `_FirebaseCrashlytics`). Strips leading underscores before comparing to the product name so the collision is detected and the wrapper keeps its own target name as productName.
- Refactors the collision detection into `wrapsProductNamedFramework` and `binaryTargetEmitsProductFramework` helpers for clarity

Closes #10146

## Test plan
- [x] New regression test for Singular pattern: wrapper target with same name as product wrapping a local-path binary xcframework
- [x] New regression test for Firebase pattern: wrapper target depending on underscore-prefixed remote binary target
- [x] All 6 pre-existing collision-related PackageInfoMapperTests still pass (GoogleMaps, FirebaseAnalytics transitive, NMapsMap remote, MySDK path-based, Sharing prefix, same-name product+target)
- [x] End-to-end verified with Singular 12.10.1:
  - Created minimal Tuist project depending on `singular-labs/Singular-iOS-SDK` exact 12.10.1
  - With mise-installed tuist 4.181.0: `BUILD FAILED` with 5 "Multiple commands produce `.../Singular.framework`" errors
  - With source-built tuist containing this fix: `BUILD SUCCEEDED`, 0 errors

### E2E repro steps
```bash
mkdir -p /tmp/singular-repro/Sources

cat > /tmp/singular-repro/Project.swift << 'SWIFT'
import ProjectDescription

let project = Project(
    name: "SingularRepro",
    targets: [
        .target(
            name: "SingularRepro",
            destinations: .iOS,
            product: .app,
            bundleId: "io.tuist.SingularRepro",
            infoPlist: .default,
            sources: ["Sources/**"],
            dependencies: [
                .external(name: "Singular"),
            ]
        ),
    ]
)
SWIFT

cat > /tmp/singular-repro/Tuist/Package.swift << 'SWIFT'
// swift-tools-version: 6.0
import PackageDescription

#if TUIST
    import ProjectDescription

    let packageSettings = PackageSettings()
#endif

let package = Package(
    name: "SingularRepro",
    dependencies: [
        .package(url: "https://github.com/singular-labs/Singular-iOS-SDK", exact: "12.10.1"),
    ]
)
SWIFT

cat > /tmp/singular-repro/Sources/SingularReproApp.swift << 'SWIFT'
import SwiftUI

@main
struct SingularReproApp: App {
    var body: some Scene {
        WindowGroup {
            Text("Hello")
        }
    }
}
SWIFT

cd /tmp/singular-repro
tuist install
tuist generate --no-open
xcodebuild build -workspace SingularRepro.xcworkspace -scheme SingularRepro \
  -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)