### PR TITLE
fix(cli): clear pruned expandVariableFromTarget instead of dropping the scheme

### DIFF
--- a/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift
@@ -171,24 +171,27 @@ public struct TreeShakePrunedTargetsGraphMapper: GraphMapping {
                 }
             }
 
+            // Clear variable-expansion references when their target has been pruned, rather than
+            // dropping the whole scheme. Otherwise, for example, a single cached (and therefore
+            // pruned) test target can take an entire aggregate workspace scheme with it — even
+            // when the scheme still has many other non-cached test targets that should run.
+            if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget,
+               !sourceTargets.contains(expandVariableFromTarget)
+            {
+                scheme.runAction?.expandVariableFromTarget = nil
+            }
+            if let expandVariableFromTarget = scheme.testAction?.expandVariableFromTarget,
+               !sourceTargets.contains(expandVariableFromTarget)
+            {
+                scheme.testAction?.expandVariableFromTarget = nil
+            }
+
             let hasBuildTargets = !(scheme.buildAction?.targets ?? []).isEmpty
             let hasTestTargets = !(scheme.testAction?.targets ?? []).isEmpty
             let hasTestPlans = !(scheme.testAction?.testPlans ?? []).isEmpty
             let runsAFilePathExecutable = scheme.runAction?.filePath != nil
 
             guard hasBuildTargets || hasTestTargets || hasTestPlans || runsAFilePathExecutable else {
-                return nil
-            }
-
-            if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget,
-               !sourceTargets.contains(expandVariableFromTarget)
-            {
-                return nil
-            }
-
-            if let expandVariableFromTarget = scheme.testAction?.expandVariableFromTarget,
-               !sourceTargets.contains(expandVariableFromTarget)
-            {
                 return nil
             }
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/RunAction.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/RunAction.swift
@@ -15,7 +15,7 @@ public struct RunAction: Equatable, Codable, Sendable {
     public let options: RunActionOptions
     public let diagnosticsOptions: SchemeDiagnosticsOptions
     public let metalOptions: MetalOptions?
-    public let expandVariableFromTarget: TargetReference?
+    public var expandVariableFromTarget: TargetReference?
     public let askForAppToLaunch: Bool
     public let launchStyle: LaunchStyle
     public let appClipInvocationURL: URL?

--- a/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -93,7 +93,7 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
     }
 
-    func test_map_removes_project_schemes_with_whose_run_action_expand_variable_from_target_has_been_removed() throws {
+    func test_map_clears_run_action_expand_variable_from_target_when_its_target_is_pruned() throws {
         // Given
         let path = try AbsolutePath(validating: "/project")
         let prunedTarget = Target.test(name: "first", metadata: .metadata(tags: ["tuist:prunable"]))
@@ -118,10 +118,12 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEmpty(gotSideEffects)
         XCTAssertNotEmpty(gotGraph.projects)
-        XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
+        let gotSchemes = gotGraph.projects.values.flatMap(\.schemes)
+        XCTAssertEqual(gotSchemes.count, 1)
+        XCTAssertNil(gotSchemes.first?.runAction?.expandVariableFromTarget)
     }
 
-    func test_map_removes_project_schemes_with_whose_test_action_expand_variable_from_target_has_been_removed() throws {
+    func test_map_clears_test_action_expand_variable_from_target_when_its_target_is_pruned() throws {
         // Given
         let path = try AbsolutePath(validating: "/project")
         let prunedTarget = Target.test(name: "first", metadata: .metadata(tags: ["tuist:prunable"]))
@@ -146,6 +148,44 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEmpty(gotSideEffects)
         XCTAssertNotEmpty(gotGraph.projects)
+        let gotSchemes = gotGraph.projects.values.flatMap(\.schemes)
+        XCTAssertEqual(gotSchemes.count, 1)
+        XCTAssertNil(gotSchemes.first?.testAction?.expandVariableFromTarget)
+    }
+
+    func test_map_drops_scheme_when_clearing_expand_variable_from_target_leaves_it_empty() throws {
+        // Given: a scheme whose only content is a pruned expandVariableFromTarget reference.
+        // Clearing that reference leaves the scheme with no build targets, no test targets, no
+        // test plans, and no run file path — so the scheme is correctly dropped.
+        let path = try AbsolutePath(validating: "/project")
+        let prunedTarget = Target.test(name: "first", metadata: .metadata(tags: ["tuist:prunable"]))
+        let schemes: [Scheme] = [
+            .test(
+                buildAction: .test(targets: []),
+                testAction: .test(
+                    targets: [],
+                    expandVariableFromTarget: .init(projectPath: path, name: prunedTarget.name)
+                ),
+                runAction: .test(
+                    executable: nil,
+                    filePath: nil,
+                    expandVariableFromTarget: .init(projectPath: path, name: prunedTarget.name)
+                )
+            ),
+        ]
+        let project = Project.test(path: path, targets: [prunedTarget], schemes: schemes)
+
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
         XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
     }
 
@@ -260,6 +300,81 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
                     )
                 ),
             ]
+        )
+    }
+
+    func test_map_keeps_workspace_aggregate_scheme_when_expand_variable_target_is_pruned() throws {
+        // Given: an aggregate workspace scheme (e.g. "AllModules") that references test targets
+        // from multiple projects and also sets testAction.expandVariableFromTarget to the
+        // first-alphabetically test target (a pattern some DSL helpers produce). The first
+        // target gets a selective-testing cache hit and is marked prunable, while the other
+        // test targets are non-cached and should still run. The scheme must survive so the
+        // shard plan can enumerate the non-cached tests.
+        let projectAPath = try AbsolutePath(validating: "/ProjectA")
+        let projectBPath = try AbsolutePath(validating: "/ProjectB")
+        let projectCPath = try AbsolutePath(validating: "/ProjectC")
+
+        let aFramework = Target.test(name: "A", product: .framework)
+        let aTests = Target.test(
+            name: "ATests",
+            product: .unitTests,
+            metadata: .metadata(tags: ["tuist:prunable"])
+        )
+        let bFramework = Target.test(name: "B", product: .framework)
+        let bTests = Target.test(name: "BTests", product: .unitTests)
+        let cFramework = Target.test(name: "C", product: .framework)
+        let cTests = Target.test(name: "CTests", product: .unitTests)
+
+        let projectA = Project.test(path: projectAPath, targets: [aFramework, aTests])
+        let projectB = Project.test(path: projectBPath, targets: [bFramework, bTests])
+        let projectC = Project.test(path: projectCPath, targets: [cFramework, cTests])
+
+        let allModulesScheme = Scheme.test(
+            name: "AllModules",
+            testAction: .test(
+                targets: [
+                    TestableTarget(target: .init(projectPath: projectAPath, name: aTests.name)),
+                    TestableTarget(target: .init(projectPath: projectBPath, name: bTests.name)),
+                    TestableTarget(target: .init(projectPath: projectCPath, name: cTests.name)),
+                ],
+                // First-alphabetically test target — this is the exact pattern that triggers
+                // the bug when that target has a selective-testing cache hit.
+                expandVariableFromTarget: .init(projectPath: projectAPath, name: aTests.name)
+            )
+        )
+
+        let workspace = Workspace.test(
+            projects: [projectAPath, projectBPath, projectCPath],
+            schemes: [allModulesScheme]
+        )
+
+        let graph = Graph.test(
+            path: projectAPath,
+            workspace: workspace,
+            projects: [
+                projectAPath: projectA,
+                projectBPath: projectB,
+                projectCPath: projectC,
+            ],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let gotScheme = gotGraph.workspace.schemes.first(where: { $0.name == "AllModules" })
+        XCTAssertNotNil(
+            gotScheme,
+            "AllModules should survive tree-shaking even when its expandVariableFromTarget is pruned"
+        )
+        XCTAssertEqual(
+            gotScheme?.testAction?.targets.map(\.target.name).sorted(),
+            ["BTests", "CTests"]
+        )
+        XCTAssertNil(
+            gotScheme?.testAction?.expandVariableFromTarget,
+            "The expandVariableFromTarget reference should be cleared rather than dropping the scheme"
         )
     }
 


### PR DESCRIPTION
## Summary

A single cached test target can take an entire workspace-level aggregate scheme down with it.

`TreeShakePrunedTargetsGraphMapper` was dropping the whole scheme whenever `testAction.expandVariableFromTarget` (or `runAction.expandVariableFromTarget`) pointed at a pruned target. DSL helpers that build aggregate schemes often set this field to the first-alphabetically test target, so any selective-testing cache hit on that target cascades into the scheme disappearing — along with every other non-cached test target it was enumerating.

Fix: clear the pruned variable-expansion reference instead of dropping the scheme. The subsequent `hasBuildTargets || hasTestTargets || hasTestPlans || runsAFilePathExecutable` emptiness check still drops schemes whose only content was the pruned reference.

## Context

In Pinterest's `Workspace.swift`, `AllModules` references ~482 test targets across projects and sets `testAction.expandVariableFromTarget` to `AIForwardCoreTests` (first alphabetical). A single cache hit on `AIForwardCoreTests` caused the whole `AllModules` scheme to be dropped by tree-shake, which in turn meant `tuist test AllModules --build-only --shard-total N` emitted an empty shard plan — silently skipping all 318 cache-miss test targets.

Verified against Pinterest's `graph.json` that `AllModules.testAction.expandVariableFromTarget = AIForwardCoreTests`, matching exactly the pattern the old logic fails on.

Credit to Irena Lee for pinpointing the root cause.

## Test plan

- [x] `test_map_keeps_workspace_aggregate_scheme_when_expand_variable_target_is_pruned` — new test reproducing the Pinterest scenario: aggregate workspace scheme with three test targets where the first-alphabetical one is marked prunable. Scheme survives with the remaining two tests and the variable-expansion reference cleared.
- [x] `test_map_clears_test_action_expand_variable_from_target_when_its_target_is_pruned` — updates the old "removes scheme" test to the new "clears reference" behavior.
- [x] `test_map_clears_run_action_expand_variable_from_target_when_its_target_is_pruned` — same for `runAction`.
- [x] `test_map_drops_scheme_when_clearing_expand_variable_from_target_leaves_it_empty` — new test confirming the emptiness check still drops schemes whose only content was the pruned variable-expansion reference.
- [x] All other pre-existing `TreeShakePrunedTargetsGraphMapperTests` still pass.

## Notes

- Required making `RunAction.expandVariableFromTarget` a `var` on the `XcodeGraph` model (it was already `var` on `TestAction`). No other code paths mutate it; this is a no-op for producers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)