### PR TITLE
fix(server): use IF NOT EXISTS for test_run_destinations ClickHouse migration

### DIFF
--- a/server/priv/ingest_repo/migrations/20260416080607_create_test_run_destinations_table.exs
+++ b/server/priv/ingest_repo/migrations/20260416080607_create_test_run_destinations_table.exs
@@ -1,19 +1,24 @@
 defmodule Tuist.IngestRepo.Migrations.CreateTestRunDestinationsTable do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up do
-    create table(:test_run_destinations,
-             primary_key: false,
-             engine: "MergeTree",
-             options: "PARTITION BY toYYYYMM(inserted_at) ORDER BY (test_run_id, inserted_at, id)"
-           ) do
-      add :id, :uuid, null: false
-      add :test_run_id, :uuid, null: false
-      add :name, :string, null: false
-      add :platform, :"LowCardinality(String)", null: false
-      add :os_version, :string, null: false
-      add :inserted_at, :"DateTime64(6)", default: fragment("now()")
-    end
+    execute("""
+    CREATE TABLE IF NOT EXISTS test_run_destinations
+    (
+      `id` UUID,
+      `test_run_id` UUID,
+      `name` String,
+      `platform` LowCardinality(String),
+      `os_version` String,
+      `inserted_at` DateTime64(6) DEFAULT now()
+    )
+    ENGINE = MergeTree()
+    PARTITION BY toYYYYMM(inserted_at)
+    ORDER BY (test_run_id, inserted_at, id)
+    """)
   end
 
   def down do


### PR DESCRIPTION
## Summary
- The `test_run_destinations` ClickHouse migration was failing in production with `TABLE_ALREADY_EXISTS` error
- Switched from Ecto's `create table` DSL to raw SQL `CREATE TABLE IF NOT EXISTS`, matching the pattern used by other ClickHouse table migrations (e.g. `build_runs`)
- Added `@disable_ddl_transaction` and `@disable_migration_lock` attributes consistent with other ClickHouse migrations

## Test plan
- [ ] Deploy to staging and verify the migration runs without error
- [ ] Verify the `test_run_destinations` table schema is correct in ClickHouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)