### PR TITLE
fix(cache): harden sqlite maintenance contention handling

### DIFF
--- a/cache/lib/cache/sqlite_helpers.ex
+++ b/cache/lib/cache/sqlite_helpers.ex
@@ -6,10 +6,14 @@ defmodule Cache.SQLiteHelpers do
   require Logger
 
   def busy_error?(%Exqlite.Error{message: message}) when is_binary(message) do
-    String.contains?(message, ["database is locked", "SQLITE_BUSY"])
+    String.contains?(message, ["database is locked", "Database busy", "SQLITE_BUSY"])
   end
 
   def busy_error?(_), do: false
+
+  def contention_error?(error) do
+    busy_error?(error) or match?(%DBConnection.ConnectionError{}, error)
+  end
 
   def db_path(repo, fallback \\ "key_value.sqlite") do
     Application.get_env(:cache, repo)[:database] || fallback
@@ -30,7 +34,7 @@ defmodule Cache.SQLiteHelpers do
     set_busy_timeout!(repo, Config.repo_busy_timeout_ms(repo))
   rescue
     error ->
-      if busy_error?(error) do
+      if contention_error?(error) do
         :ok
       else
         Logger.warning("Failed to restore busy timeout for #{inspect(repo)}: #{inspect(error)}")

--- a/cache/lib/cache/sqlite_maintenance_worker.ex
+++ b/cache/lib/cache/sqlite_maintenance_worker.ex
@@ -2,6 +2,7 @@ defmodule Cache.SQLiteMaintenanceWorker do
   @moduledoc false
   use Oban.Worker, queue: :maintenance, max_attempts: 1
 
+  alias Cache.Config
   alias Cache.KeyValueRepo
   alias Cache.Repo
   alias Cache.SQLiteHelpers
@@ -10,7 +11,9 @@ defmodule Cache.SQLiteMaintenanceWorker do
   def perform(_job) do
     Repo.query("PRAGMA incremental_vacuum(128000)")
 
-    SQLiteHelpers.with_repo_busy_timeout(KeyValueRepo, 0, fn ->
+    timeout_ms = Config.key_value_maintenance_busy_timeout_ms()
+
+    SQLiteHelpers.with_repo_busy_timeout(KeyValueRepo, timeout_ms, fn ->
       SQLiteHelpers.query!(KeyValueRepo, "PRAGMA wal_checkpoint(PASSIVE)")
       SQLiteHelpers.query!(KeyValueRepo, "PRAGMA incremental_vacuum(1000)")
     end)
@@ -18,7 +21,7 @@ defmodule Cache.SQLiteMaintenanceWorker do
     :ok
   rescue
     error ->
-      if SQLiteHelpers.busy_error?(error) do
+      if SQLiteHelpers.contention_error?(error) do
         :ok
       else
         reraise error, __STACKTRACE__

--- a/cache/test/cache/sqlite_helpers_test.exs
+++ b/cache/test/cache/sqlite_helpers_test.exs
@@ -19,6 +19,10 @@ defmodule Cache.SQLiteHelpersTest do
       assert SQLiteHelpers.busy_error?(%Exqlite.Error{message: "error: database is locked (SQLITE_BUSY)"})
     end
 
+    test "returns true for 'Database busy' message" do
+      assert SQLiteHelpers.busy_error?(%Exqlite.Error{message: "Database busy"})
+    end
+
     test "returns false for other Exqlite errors" do
       refute SQLiteHelpers.busy_error?(%Exqlite.Error{message: "disk I/O error"})
     end
@@ -37,6 +41,20 @@ defmodule Cache.SQLiteHelpersTest do
 
     test "returns false for nil" do
       refute SQLiteHelpers.busy_error?(nil)
+    end
+  end
+
+  describe "contention_error?/1" do
+    test "returns true for busy SQLite errors" do
+      assert SQLiteHelpers.contention_error?(%Exqlite.Error{message: "database is locked"})
+    end
+
+    test "returns true for connection checkout errors" do
+      assert SQLiteHelpers.contention_error?(%DBConnection.ConnectionError{message: "connection not available"})
+    end
+
+    test "returns false for unrelated errors" do
+      refute SQLiteHelpers.contention_error?(%RuntimeError{message: "boom"})
     end
   end
 

--- a/cache/test/cache/sqlite_maintenance_worker_test.exs
+++ b/cache/test/cache/sqlite_maintenance_worker_test.exs
@@ -7,16 +7,18 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
   setup :set_mimic_from_context
 
   test "vacuums the primary repo and runs bounded KV maintenance" do
+    maintenance_timeout = Cache.Config.key_value_maintenance_busy_timeout_ms()
+
     expect(Cache.Repo, :query, fn "PRAGMA incremental_vacuum(128000)" -> {:ok, %{rows: []}} end)
 
     expect(Cache.KeyValueRepo, :checkout, fn fun -> fun.() end)
 
     expect(Cache.KeyValueRepo, :query, fn query ->
-      case query do
-        "PRAGMA busy_timeout = 0" -> {:ok, %{rows: []}}
-        "PRAGMA wal_checkpoint(PASSIVE)" -> {:ok, %{rows: [[0, 0, 0]]}}
-        "PRAGMA incremental_vacuum(1000)" -> {:ok, %{rows: []}}
-        "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
+      cond do
+        query == "PRAGMA busy_timeout = #{maintenance_timeout}" -> {:ok, %{rows: []}}
+        query == "PRAGMA wal_checkpoint(PASSIVE)" -> {:ok, %{rows: [[0, 0, 0]]}}
+        query == "PRAGMA incremental_vacuum(1000)" -> {:ok, %{rows: []}}
+        query == "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
       end
     end)
 
@@ -24,15 +26,17 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
   end
 
   test "skips KV maintenance when SQLite is busy" do
+    maintenance_timeout = Cache.Config.key_value_maintenance_busy_timeout_ms()
+
     expect(Cache.Repo, :query, fn "PRAGMA incremental_vacuum(128000)" -> {:ok, %{rows: []}} end)
 
     expect(Cache.KeyValueRepo, :checkout, fn fun -> fun.() end)
 
     expect(Cache.KeyValueRepo, :query, fn query ->
-      case query do
-        "PRAGMA busy_timeout = 0" -> {:ok, %{rows: []}}
-        "PRAGMA wal_checkpoint(PASSIVE)" -> raise %Exqlite.Error{message: "database is locked"}
-        "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
+      cond do
+        query == "PRAGMA busy_timeout = #{maintenance_timeout}" -> {:ok, %{rows: []}}
+        query == "PRAGMA wal_checkpoint(PASSIVE)" -> raise %Exqlite.Error{message: "Database busy"}
+        query == "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
       end
     end)
 

--- a/cache/test/cache/sqlite_maintenance_worker_test.exs
+++ b/cache/test/cache/sqlite_maintenance_worker_test.exs
@@ -8,6 +8,7 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
 
   test "vacuums the primary repo and runs bounded KV maintenance" do
     maintenance_timeout = Cache.Config.key_value_maintenance_busy_timeout_ms()
+    repo_timeout = Cache.Config.repo_busy_timeout_ms(Cache.KeyValueRepo)
 
     expect(Cache.Repo, :query, fn "PRAGMA incremental_vacuum(128000)" -> {:ok, %{rows: []}} end)
 
@@ -18,7 +19,7 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
         query == "PRAGMA busy_timeout = #{maintenance_timeout}" -> {:ok, %{rows: []}}
         query == "PRAGMA wal_checkpoint(PASSIVE)" -> {:ok, %{rows: [[0, 0, 0]]}}
         query == "PRAGMA incremental_vacuum(1000)" -> {:ok, %{rows: []}}
-        query == "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
+        query == "PRAGMA busy_timeout = #{repo_timeout}" -> {:ok, %{rows: []}}
       end
     end)
 
@@ -27,6 +28,7 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
 
   test "skips KV maintenance when SQLite is busy" do
     maintenance_timeout = Cache.Config.key_value_maintenance_busy_timeout_ms()
+    repo_timeout = Cache.Config.repo_busy_timeout_ms(Cache.KeyValueRepo)
 
     expect(Cache.Repo, :query, fn "PRAGMA incremental_vacuum(128000)" -> {:ok, %{rows: []}} end)
 
@@ -36,7 +38,7 @@ defmodule Cache.SQLiteMaintenanceWorkerTest do
       cond do
         query == "PRAGMA busy_timeout = #{maintenance_timeout}" -> {:ok, %{rows: []}}
         query == "PRAGMA wal_checkpoint(PASSIVE)" -> raise %Exqlite.Error{message: "Database busy"}
-        query == "PRAGMA busy_timeout = 30000" -> {:ok, %{rows: []}}
+        query == "PRAGMA busy_timeout = #{repo_timeout}" -> {:ok, %{rows: []}}
       end
     end)
 


### PR DESCRIPTION
## Summary
- use the configured KV maintenance busy timeout in `SQLiteMaintenanceWorker` instead of forcing `busy_timeout = 0`
- treat both SQLite busy errors and DB checkout contention as expected contention in maintenance paths
- recognize the `Database busy` SQLite message variant to avoid re-raising expected lock contention

Fixes CACHE-4Q

## Validation
- `mix test test/cache/sqlite_helpers_test.exs test/cache/sqlite_maintenance_worker_test.exs`
- `mise run test`
- `mise run credo`
