### PR TITLE
fix(app): retry create-dmg on AppleScript Finder timeouts

### DIFF
--- a/mise/tasks/app/bundle.sh
+++ b/mise/tasks/app/bundle.sh
@@ -60,7 +60,21 @@ mkdir -p $BUILD_ARTIFACTS_DIRECTORY
 BUILD_DMG_PATH=$BUILD_ARTIFACTS_DIRECTORY/Tuist.dmg
 
 print_status "Creating DMG..."
-create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"
+# create-dmg uses Finder via AppleScript to style the DMG window, which
+# periodically fails on CI with "AppleEvent timed out. (-1712)". Retry a few
+# times before giving up.
+max_attempts=5
+attempt=1
+until create-dmg --background $MISE_PROJECT_ROOT/assets/dmg-background.png --hide-extension "Tuist.app" --icon "Tuist.app" 139 161 --icon-size 95 --window-size 605 363 --app-drop-link 467 161 --volname "Tuist App" "$BUILD_DMG_PATH" "$BUILD_DIRECTORY_BINARY"; do
+    if [ $attempt -ge $max_attempts ]; then
+        echo "create-dmg failed after $attempt attempts" >&2
+        exit 1
+    fi
+    echo "create-dmg attempt $attempt failed; retrying..." >&2
+    rm -f "$BUILD_DMG_PATH"
+    attempt=$((attempt + 1))
+    sleep 5
+done
 
 codesign --force --timestamp --options runtime --sign "Developer ID Application: Tuist GmbH (U6LC622NKF)" --identifier "dev.tuist.app.tuist-app-dmg" "$BUILD_DMG_PATH"
 


### PR DESCRIPTION
## Summary
- The `Release App` job in the Release workflow has been failing because `create-dmg` hits `Finder got an error: AppleEvent timed out. (-1712)` when driving Finder via AppleScript to style the DMG window (see [run 24566021358](https://github.com/tuist/tuist/actions/runs/24566021358/job/71828709659)).
- Wrap the `create-dmg` call in `mise/tasks/app/bundle.sh` in a retry loop (up to 5 attempts, 5s apart), removing the partial DMG between tries, so transient Finder flakes don't block releases.

## Test plan
- [ ] Re-trigger the Release workflow and confirm `Release App → Bundle macOS app` succeeds.
- [ ] Verify the produced `Tuist.dmg` still has the expected window layout and background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)