### PR TITLE
fix: target self-hosted bare-metal runner for image builds

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -10,36 +10,20 @@ on:
         description: "Output image name (e.g. tuist-runner-xcode-26.4)"
         required: true
       runner_version:
-        description: "GitHub Actions runner version (e.g. 2.325.0)"
+        description: "GitHub Actions runner version (e.g. 2.333.1)"
         required: true
 
 jobs:
   build:
-    runs-on: namespace-profile-default-macos
+    runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Tart
-        run: brew install cirruslabs/cli/tart
-
-      - name: Install Packer
-        run: brew install hashicorp/tap/packer
-
-      - name: Initialize Packer
-        working-directory: infra/runner-images
-        run: packer init runner.pkr.hcl
-
       - name: Build image
-        working-directory: infra/runner-images
-        run: |
-          packer build \
-            -var "base_image=${{ inputs.base_image }}" \
-            -var "output_image=${{ inputs.output_image }}" \
-            -var "runner_version=${{ inputs.runner_version }}" \
-            runner.pkr.hcl
+        run: mise run runner:build-image "${{ inputs.base_image }}" "${{ inputs.output_image }}" "${{ inputs.runner_version }}"
 
       - name: Log in to GHCR
-        run: tart login ghcr.io --username tuist-bot --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io --username tuist-bot --password-stdin
 
       - name: Push image to GHCR
-        run: tart push ${{ inputs.output_image }} ghcr.io/tuist/${{ inputs.output_image }}:latest
+        run: tart push "${{ inputs.output_image }}" "ghcr.io/tuist/${{ inputs.output_image }}:latest"

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -16,11 +16,23 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
+    env:
+      PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     steps:
       - uses: actions/checkout@v4
 
+      - name: Initialize Packer
+        working-directory: infra/runner-images
+        run: packer init runner.pkr.hcl
+
       - name: Build image
-        run: mise run runner:build-image "${{ inputs.base_image }}" "${{ inputs.output_image }}" "${{ inputs.runner_version }}"
+        working-directory: infra/runner-images
+        run: |
+          packer build \
+            -var "base_image=${{ inputs.base_image }}" \
+            -var "output_image=${{ inputs.output_image }}" \
+            -var "runner_version=${{ inputs.runner_version }}" \
+            runner.pkr.hcl
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io --username tuist-bot --password-stdin


### PR DESCRIPTION
## Summary

- Updates the runner image build workflow to target the dedicated Scaleway bare-metal Mac (`vm-image-builder-01`) instead of Namespace runners
- Namespace runners are VMs that don't support nested virtualization, which Tart requires

## Test plan

- [ ] Merge, then trigger via Actions > "Build Runner Image"

🤖 Generated with [Claude Code](https://claude.com/claude-code)