### PR TITLE
fix(processor): classify upload-only Xcode cache keys as misses

### DIFF
--- a/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -297,7 +297,8 @@ public struct XCActivityLogParser: Sendable {
             let cacheStatus: String
             if status.isMiss { cacheStatus = "miss" }
             else if status.hasQuery { cacheStatus = "hit_remote" }
-            else { cacheStatus = "hit_local" }
+            else if status.hasMaterialize { cacheStatus = "hit_local" }
+            else { cacheStatus = "miss" }
 
             let readDuration: Double?
             if cacheStatus == "hit_remote" || cacheStatus == "miss" {

--- a/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -294,11 +294,15 @@ public struct XCActivityLogParser: Sendable {
         let nodeIDs = keyNodeIDs
 
         return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 50) { (key, status) in
+            // A key observed only as an upload (no query or materialize) is a fresh
+            // compile whose result we pushed to the remote CAS — the cache did not
+            // serve that work, so it counts as a miss.
+            let isMiss = status.isMiss || (!status.hasQuery && !status.hasMaterialize)
+
             let cacheStatus: String
-            if status.isMiss { cacheStatus = "miss" }
+            if isMiss { cacheStatus = "miss" }
             else if status.hasQuery { cacheStatus = "hit_remote" }
-            else if status.hasMaterialize { cacheStatus = "hit_local" }
-            else { cacheStatus = "miss" }
+            else { cacheStatus = "hit_local" }
 
             let readDuration: Double?
             if cacheStatus == "hit_remote" || cacheStatus == "miss" {

--- a/processor/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
+++ b/processor/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
@@ -139,6 +139,18 @@ struct XCActivityLogParserTests {
 
         #expect(result.status == "success")
     }
+
+    @Test func buildWithUploads_doesNotClassifyUploadOnlyKeysAsHitLocal() async throws {
+        let result = try await parseFixture("build-with-uploads")
+
+        // A key observed only in `Swift caching upload key ...` — i.e. written to the remote
+        // CAS without a matching materialize/query step — is a fresh compilation that had to
+        // run and push its result. That is a miss, not a local-CAS hit.
+        for task in result.cacheable_tasks where task.write_duration != nil {
+            #expect(task.status != "hit_local",
+                    "Upload-bearing key \(task.key) misclassified as hit_local")
+        }
+    }
 }
 
 enum FixtureError: Error {


### PR DESCRIPTION
## Summary

In the xcactivitylog parser, a cache key observed only in `Swift caching upload key …` activity (no matching `materialize` or `query` step) represents a **fresh compilation whose result was pushed to the remote CAS** — i.e. a cache miss. The previous classifier lumped those into `hit_local`, which inflated the hit rate on any build that produced and uploaded fresh artifacts.

Fix: only classify a key as `hit_local` when there is evidence of a `materialize` step (meaning the `SwiftCachingMaterializeKey` sub-task found it in local CAS and skipped the remote query). Upload-only now falls through to `miss`.

`processor/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift:296-300`

```swift
let cacheStatus: String
if status.isMiss { cacheStatus = "miss" }
else if status.hasQuery { cacheStatus = "hit_remote" }
else if status.hasMaterialize { cacheStatus = "hit_local" }
else { cacheStatus = "miss" }
```

### Impact on a real build

Ran the parser before/after against a real customer xcactivitylog (194 cacheable tasks):

| | Before | After |
|---|---|---|
| hit_remote | 134 | 134 |
| hit_local  | 56  | 0   |
| miss       | 4   | 60  |
| Reported hit rate | 97.9% | 69.1% |

The 56 "local hits" were all upload-bearing keys (`write_duration != nil`) — i.e. fresh compiles whose results got pushed to the proxy. They are now correctly attributed as misses.

## Background — the broader mismatch this came from

Context: a report of an xcactivitylog ending with Xcode's diagnostic note

```
note: 139 hits / 1756 cacheable tasks (8%)
```

while our dashboard for the same run showed `190 hits / 194 cacheable tasks (97.9%)`. This PR addresses one specific miscount (the 56 upload-only mislabeling). The remaining gap — 69.1% vs 8% — is **architectural** and is explained below because it changed my understanding of what the dashboard currently represents.

### What Xcode's "1756 cacheable tasks" actually counts

Per `swiftlang/swift-build` (`Sources/SWBBuildSystem/BuildOperation.swift:628-644`):

```swift
let swiftCacheHits = aggregatedCounters[.swiftCacheHits, default: 0]
let swiftCacheMisses = aggregatedCounters[.swiftCacheMisses, default: 0]
let clangCacheHits = aggregatedCounters[.clangCacheHits, default: 0]
let clangCacheMisses = aggregatedCounters[.clangCacheMisses, default: 0]
cacheHits = swiftCacheHits + clangCacheHits
cacheMisses = swiftCacheMisses + clangCacheMisses
```

So **cacheable tasks = hits + misses**, counters incremented exactly once per task execution:

- `SwiftDriverJobTaskAction.swift:667-675` — one bump per `SwiftDriverJob` (per-file swift-frontend compile, WMO compile, emit-module, merge-module, explicit PCM generation, interface-to-swiftmodule compile).
- `ClangCompileTaskAction.swift:386, 399, 412` — one bump per `CompileC` invocation.

The counter is **not deduped across target variants**. If an app ships N variants (e.g. white-labelled builds sharing source), the same `Foo.swift` compiled for all N bumps the counter N times even though they share one cache key.

### SwiftDriverJobs never talk to the CAS proxy directly

`SwiftDriverJobTaskAction.replayCachedCommand` (`SwiftDriverJobTaskAction.swift:620`) only calls `cas.queryLocalCacheKey(...)` — strictly local. The proxy is only reached by three dynamic sub-tasks that the driver job declares as dependencies:

- `SwiftCachingKeyQueryTaskAction` → `cas.queryCacheKey(key, globally: true)` (proxy lookup)
- `SwiftCachingOutputMaterializerTaskAction` → `cas.download(with: casID)` (proxy download)
- `SwiftCachingKeyUploadTaskAction` → proxy upload

llbuild dedupes those dynamic tasks by task-key, so a single proxy fetch per unique `(cacheKeys array)` populates local CAS, and every subsequent driver job across every variant replays from local CAS and bumps the counter without any network I/O.

### The key finding — two categories of "cacheable task"

This is the crucial piece. `SWBCore/Settings/CASOptions.swift:192-210` makes the remote-cache path strictly conditional:

```swift
if scope.evaluate(BuiltinMacros.COMPILATION_CACHE_ENABLE_PLUGIN) {
    casPath = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH).join("plugin")
    pluginPath = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_PLUGIN_PATH))
    let remoteServicePathSetting = Path(scope.evaluate(BuiltinMacros.COMPILATION_CACHE_REMOTE_SERVICE_PATH))
    if !remoteServicePathSetting.isEmpty && isLanguageSupportedForRemoteCaching() {
        remoteServicePath = remoteServicePathSetting
    } else {
        remoteServicePath = nil
    }
} else {
    // plugin off → no remote cache, only local "builtin" CAS
    casPath = scope.evaluate(BuiltinMacros.COMPILATION_CACHE_CAS_PATH).join("builtin")
    pluginPath = nil
    remoteServicePath = nil
}
```

Remote cache needs three things simultaneously:
1. `SWIFT_ENABLE_COMPILE_CACHE=YES` (otherwise the whole CAS path is skipped — see `SwiftCompiler.swift:1003`)
2. `COMPILATION_CACHE_ENABLE_PLUGIN=YES`
3. `COMPILATION_CACHE_REMOTE_SERVICE_PATH` pointing at the proxy plugin

But the counter-bumping path in `SwiftDriverJobTaskAction.execute` only needs **#1** — it goes through `replayCachedCommand` against the local CAS whether remote is on or not.

That means Xcode's 1756 denominator is a union of two disjoint populations:

**Category A — remote cache fully configured** (#1 + #2 + #3):
- `maybeRequestCachingKeyMaterialization` fires → `SwiftCachingMaterializeKey` → `SwiftCachingKeyQuery` → **proxy round-trip** → emits `Swift caching query key [K]` activity section
- Every replay that succeeds or fails gets surfaced in the xcactivitylog with structured key info
- **This is the only category Tuist's parser sees.** 138 keys in this build → 134 hits + 4 misses on the proxy, plus 60 upload-initiated fresh compiles.

**Category B — local cache only** (#1 on, but plugin disabled or `COMPILATION_CACHE_REMOTE_SERVICE_PATH` empty):
- `maybeRequestCachingKeyMaterialization` returns `false` at line 584 (`guard hasRemoteCache else { return false }`) — no materialize task, no query task
- `replayCachedCommand` still runs against the local "builtin" CAS
- On a cold first build, `queryLocalCacheKey` returns nil → bumps `.swiftCacheMisses` → falls through to `spawn(...)` and compiles fresh
- `upload()` also short-circuits on `!hasRemoteCache`, so nothing gets pushed
- **Zero `Swift caching …` activity sections get emitted for these jobs** — Tuist is blind to them.

### So: do Xcode's misses reach our proxy? Mostly no.

The reported build's 1617 Xcode misses are dominated by Category B: targets where `SWIFT_ENABLE_COMPILE_CACHE=YES` is set but the plugin+remote service isn't configured, or where individual SPM dependencies opt out. Those driver jobs run against an empty local "builtin" CAS, count as misses in Xcode's counter, and never touch our proxy.

Tell-tale signs in this particular log:
- `warning: swift compiler caching requires explicit module build (SWIFT_ENABLE_EXPLICIT_MODULES=YES) (in target 'SwiftSoup')` — caching silently no-ops for that target
- Zero `Clang caching` sections at all → Clang caching fully off
- Six variants × ~300 driver jobs each ≈ 1800, close to the 1756 reported

### Implications for how we frame the metric

Tuist's current dashboard measures **proxy activity** — keys the CAS service actually saw. After this fix, 69.1% accurately reflects the proxy's hit rate among the work that was routed to it. That is a meaningful, correct number — but not the same as Xcode's 8%, which is a **build-wide compile-skip rate** dominated by work that never reached the proxy.

The gap between the two numbers is itself a signal: large gap = most cache-eligible targets are not configured for remote caching. That's a misconfiguration the customer can fix (enable `COMPILATION_CACHE_ENABLE_PLUGIN`, set `COMPILATION_CACHE_REMOTE_SERVICE_PATH`, enable `SWIFT_ENABLE_EXPLICIT_MODULES`) — and once they do, Xcode's denominator shrinks and both percentages converge.

### Follow-up worth considering

1. **Surface the `CompilationCacheMetrics` note on the dashboard** alongside our proxy-centric number. The xcactivitylog's `ruleInfo = "CompilationCacheMetrics"` activity has a diagnostic note with the exact string `"N hits / M cacheable tasks (P%)"` (`BuildOperation.swift:640-648`) — cheap to parse, gives parity with what Xcode prints, and the delta against our proxy rate is a diagnostic signal customers can act on.
2. **Configuration-health check.** Warn when a build emits few/no `Swift caching …` activity sections relative to the `SwiftDriverJob` count — that's a clear "remote cache isn't wired up for most of your targets" signal.
3. **Richer breakdown.** Setting the `EnableCacheMetricsLogs=1` environment variable (it is a Swift Build feature flag, not a build setting — see `SWBFeatureFlag.swift:155`) makes Xcode emit a `RawCacheMetrics` activity with per-counter JSON (`swiftCacheHits`, `swiftCacheMisses`, `clangCacheHits`, `clangCacheMisses`, plus per-task-type breakdown). If the Tuist CLI sets that in the spawned environment, we could ingest a structured breakdown instead of regex-parsing the summary note.

All of the above are out of scope for this PR — filing as follow-ups is probably the right call.

## Test plan

- [x] `swift test --replace-scm-with-registry --filter XCActivityLogParserTests` — all 12 tests pass
- [x] New regression test `buildWithUploads_doesNotClassifyUploadOnlyKeysAsHitLocal` asserts that any task with a `write_duration` is not labelled `hit_local`
- [x] Verified against the reporter's xcactivitylog: 56 hit_local → 60 miss, 134 hit_remote unchanged, 4 → 4 miss preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)