### PR TITLE
fix(ci): abort release when main advances with source changes during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1553,6 +1553,62 @@ jobs:
           name: helm-artifacts
           path: infra/helm
 
+      - name: Verify no source changes since build
+        run: |
+          # The build jobs checked out and compiled from ${{ github.sha }}.
+          # If main has advanced with source changes since then, the binary
+          # would not include those changes. Abort to avoid shipping a stale binary.
+          git fetch origin ${{ github.ref_name }}
+          BUILD_SHA="${{ github.sha }}"
+          CURRENT_SHA=$(git rev-parse "origin/${{ github.ref_name }}")
+
+          if [ "$BUILD_SHA" = "$CURRENT_SHA" ]; then
+            echo "main has not advanced since the build commit, safe to release."
+            exit 0
+          fi
+
+          echo "main has advanced: build=$BUILD_SHA current=$CURRENT_SHA"
+          echo "Checking for source changes that would affect released components..."
+
+          STALE_COMPONENTS=""
+
+          if [ "${{ needs.check-releases.outputs.cli-should-release }}" == "true" ] && [ "${{ needs.release-cli.result }}" == "success" ]; then
+            if git diff --name-only "$BUILD_SHA" "$CURRENT_SHA" -- 'cli/Sources/' 'cli/TuistCacheEE/' | grep -q .; then
+              STALE_COMPONENTS="$STALE_COMPONENTS CLI"
+            fi
+          fi
+
+          if [ "${{ needs.check-releases.outputs.server-should-release }}" == "true" ] && [ "${{ needs.release-server.result }}" == "success" ]; then
+            if git diff --name-only "$BUILD_SHA" "$CURRENT_SHA" -- 'server/lib/' 'server/config/' | grep -q .; then
+              STALE_COMPONENTS="$STALE_COMPONENTS Server"
+            fi
+          fi
+
+          if [ "${{ needs.check-releases.outputs.cache-should-release }}" == "true" ] && [ "${{ needs.release-cache.result }}" == "success" ]; then
+            if git diff --name-only "$BUILD_SHA" "$CURRENT_SHA" -- 'cache/lib/' 'cache/config/' | grep -q .; then
+              STALE_COMPONENTS="$STALE_COMPONENTS Cache"
+            fi
+          fi
+
+          if [ "${{ needs.check-releases.outputs.gradle-should-release }}" == "true" ] && [ "${{ needs.release-gradle.result }}" == "success" ]; then
+            if git diff --name-only "$BUILD_SHA" "$CURRENT_SHA" -- 'gradle/src/' | grep -q .; then
+              STALE_COMPONENTS="$STALE_COMPONENTS Gradle"
+            fi
+          fi
+
+          if [ "${{ needs.check-releases.outputs.app-should-release }}" == "true" ] && [ "${{ needs.release-app.result }}" == "success" ]; then
+            if git diff --name-only "$BUILD_SHA" "$CURRENT_SHA" -- 'app/' | grep -q .; then
+              STALE_COMPONENTS="$STALE_COMPONENTS App"
+            fi
+          fi
+
+          if [ -n "$STALE_COMPONENTS" ]; then
+            echo "::error::Source code changed on main after the build for:$STALE_COMPONENTS. The release binary would be stale. Aborting release -- a new workflow run will pick up the changes."
+            exit 1
+          fi
+
+          echo "No source changes affect released components, safe to proceed."
+
       - name: Create tags for successfully released components
         run: |
           # Create tags for successfully released components


### PR DESCRIPTION
## Summary

- Add a guard step to `commit-and-release` that aborts if `main` has advanced with source changes since the build commit (`$GITHUB_SHA`)

## Context

The 4.181.0 release shipped a binary that did **not** contain the fix from PR #10301, even though the fix commit appears before the release commit in git history. Investigation via binary symbol analysis confirmed the released binary still had the old `cacheableTargets(for:...:includedTargets:...)` signature that was removed by #10301.

**Root cause:** The release workflow builds binaries from `$GITHUB_SHA` (the commit that triggered the workflow). The `commit-and-release` job then runs `git pull --rebase` before pushing, which rebases the release commit on top of any commits merged to `main` in the meantime. This makes it *look* like the release includes those commits, but the binary was compiled from the earlier state.

In this case, #10301 was merged ~1 minute before the release was published. The binary was built from the earlier trigger commit without the fix, but `git pull --rebase` placed the release commit after the fix in git history.

**The fix:** Before creating tags and GitHub releases, fetch `origin/main` and diff source paths for each releasing component against `$GITHUB_SHA`. If any component's sources changed, abort with a clear error. The next workflow run (triggered by the commit that caused the drift) will rebuild from the correct source.

## Test plan

- [ ] Verify the workflow YAML is valid
- [ ] Confirm the guard step would have caught the 4.181.0 case: `cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift` changed between the trigger commit and `origin/main`
- [ ] Verify normal releases (where main hasn't advanced) pass through unblocked


🤖 Generated with [Claude Code](https://claude.com/claude-code)