### PR TITLE
fix(app): run Release App job on GitHub Actions instead of namespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -717,7 +717,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: namespace-profile-default-macos
+    runs-on: macos-15
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch the `release-app` job from `namespace-profile-default-macos` to `macos-15` runners
- The namespace macOS runners fail consistently with `AppleEvent timed out (-1712)` when `create-dmg` uses Finder via AppleScript to style the DMG window
- GitHub Actions `macos-15` runners handle this correctly

## Test plan
- [ ] Trigger a release and verify the DMG is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)