### PR TITLE
feat(cache): support HEAD requests for Registry endpoints

### DIFF
--- a/cache/lib/cache_web/controllers/registry_controller.ex
+++ b/cache/lib/cache_web/controllers/registry_controller.ex
@@ -139,16 +139,37 @@ defmodule CacheWeb.RegistryController do
         |> manifest_candidates()
         |> Enum.reduce_while(:not_found, fn filename, _acc ->
           key =
-            KeyNormalizer.package_object_key(%{scope: scope, name: name}, version: normalized_version, path: filename)
+            KeyNormalizer.package_object_key(%{scope: scope, name: name},
+              version: normalized_version,
+              path: filename
+            )
 
           cond do
             Registry.Disk.exists?(scope, name, normalized_version, filename) ->
               {:halt,
-               {:served, serve_manifest_from_disk(conn, scope, name, normalized_version, filename, swift_version, key)}}
+               {:served,
+                serve_manifest_from_disk(
+                  conn,
+                  scope,
+                  name,
+                  normalized_version,
+                  filename,
+                  swift_version,
+                  key
+                )}}
 
             S3.exists?(key, type: :registry) ->
               {:halt,
-               {:served, serve_manifest_from_s3(conn, scope, name, normalized_version, filename, swift_version, key)}}
+               {:served,
+                serve_manifest_from_s3(
+                  conn,
+                  scope,
+                  name,
+                  normalized_version,
+                  filename,
+                  swift_version,
+                  key
+                )}}
 
             true ->
               {:cont, :not_found}
@@ -237,7 +258,7 @@ defmodule CacheWeb.RegistryController do
       )
 
     if Registry.Disk.exists?(scope, name, normalized_version, "source_archive.zip") do
-      track_registry_download(scope, name, normalized_version, key)
+      maybe_track_registry_download(conn, scope, name, normalized_version, key)
       render_local_archive(conn, scope, name, normalized_version)
     else
       render_remote_archive(conn, scope, name, normalized_version, key)
@@ -245,20 +266,24 @@ defmodule CacheWeb.RegistryController do
   end
 
   defp render_local_archive(conn, scope, name, normalized_version) do
-    local_path = Registry.Disk.local_accel_path(scope, name, normalized_version, "source_archive.zip")
+    local_path =
+      Registry.Disk.local_accel_path(scope, name, normalized_version, "source_archive.zip")
 
     conn
     |> put_resp_header("content-version", "1")
     |> put_resp_header("x-accel-redirect", local_path)
     |> put_resp_content_type("application/zip")
-    |> put_resp_header("content-disposition", "attachment; filename=\"#{name}-#{normalized_version}.zip\"")
+    |> put_resp_header(
+      "content-disposition",
+      "attachment; filename=\"#{name}-#{normalized_version}.zip\""
+    )
     |> send_resp(:ok, "")
   end
 
   defp render_remote_archive(conn, scope, name, normalized_version, key) do
     if S3.exists?(key, type: :registry) do
-      S3Transfers.enqueue_registry_download(key)
-      track_registry_download(scope, name, normalized_version, key)
+      maybe_enqueue_registry_download(conn, key)
+      maybe_track_registry_download(conn, scope, name, normalized_version, key)
 
       case S3.presign_download_url(key, type: :registry) do
         {:ok, url} ->
@@ -266,7 +291,10 @@ defmodule CacheWeb.RegistryController do
           |> put_resp_header("content-version", "1")
           |> put_resp_header("x-accel-redirect", S3.remote_accel_path(url))
           |> put_resp_content_type("application/zip")
-          |> put_resp_header("content-disposition", "attachment; filename=\"#{name}-#{normalized_version}.zip\"")
+          |> put_resp_header(
+            "content-disposition",
+            "attachment; filename=\"#{name}-#{normalized_version}.zip\""
+          )
           |> send_resp(:ok, "")
 
         {:error, _reason} ->
@@ -290,7 +318,7 @@ defmodule CacheWeb.RegistryController do
   end
 
   defp serve_manifest_from_disk(conn, scope, name, version, filename, swift_version, key) do
-    :ok = CacheArtifacts.track_artifact_access(key)
+    maybe_track_artifact_access(conn, key)
     local_path = Registry.Disk.local_accel_path(scope, name, version, filename)
 
     conn
@@ -302,8 +330,8 @@ defmodule CacheWeb.RegistryController do
   end
 
   defp serve_manifest_from_s3(conn, scope, name, version, _filename, swift_version, key) do
-    S3Transfers.enqueue_registry_download(key)
-    :ok = CacheArtifacts.track_artifact_access(key)
+    maybe_enqueue_registry_download(conn, key)
+    maybe_track_artifact_access(conn, key)
 
     case S3.presign_download_url(key, type: :registry) do
       {:ok, url} ->
@@ -373,7 +401,8 @@ defmodule CacheWeb.RegistryController do
       swift_version = manifest["swift_version"]
       swift_tools_version = manifest["swift_tools_version"]
 
-      url = "/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift?swift-version=#{swift_version}"
+      url =
+        "/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift?swift-version=#{swift_version}"
 
       display_version =
         if swift_version |> String.split(".") |> Enum.count() == 1 do
@@ -397,6 +426,28 @@ defmodule CacheWeb.RegistryController do
 
       Enum.join(parts, "; ")
     end)
+  end
+
+  defp maybe_enqueue_registry_download(conn, key) do
+    if not head_request?(conn) do
+      S3Transfers.enqueue_registry_download(key)
+    end
+  end
+
+  defp maybe_track_registry_download(conn, scope, name, normalized_version, key) do
+    if not head_request?(conn) do
+      track_registry_download(scope, name, normalized_version, key)
+    end
+  end
+
+  defp maybe_track_artifact_access(conn, key) do
+    if not head_request?(conn) do
+      :ok = CacheArtifacts.track_artifact_access(key)
+    end
+  end
+
+  defp head_request?(conn) do
+    conn.method == "HEAD"
   end
 
   defp provider_from_repository_url(repository_url) do

--- a/cache/lib/cache_web/router.ex
+++ b/cache/lib/cache_web/router.ex
@@ -76,11 +76,17 @@ defmodule CacheWeb.Router do
     pipe_through [:api_registry_swift]
 
     get "/", RegistryController, :availability
+    head "/", RegistryController, :availability
     get "/availability", RegistryController, :availability
+    head "/availability", RegistryController, :availability
     get "/identifiers", RegistryController, :identifiers
+    head "/identifiers", RegistryController, :identifiers
     post "/login", RegistryController, :login
     get "/:scope/:name", RegistryController, :list_releases
+    head "/:scope/:name", RegistryController, :list_releases
     get "/:scope/:name/:version", RegistryController, :show_release
+    head "/:scope/:name/:version", RegistryController, :show_release
     get "/:scope/:name/:version/Package.swift", RegistryController, :show_manifest
+    head "/:scope/:name/:version/Package.swift", RegistryController, :show_manifest
   end
 end

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -589,7 +589,7 @@ defmodule CacheWeb.RegistryControllerTest do
 
       assert conn.status == 404
       assert get_resp_header(conn, "content-version") == ["1"]
-      assert conn.resp_body == ""    
+      assert conn.resp_body == ""
     end
 
     test "returns 503 when S3 returns an error", %{conn: conn} do

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -30,6 +30,19 @@ defmodule CacheWeb.RegistryControllerTest do
     end
   end
 
+  describe "HEAD /api/registry/swift (availability)" do
+    test "returns 200 OK with content-version header", %{conn: conn} do
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+  end
+
   describe "GET /api/registry/swift/availability" do
     test "returns 200 OK with content-version header", %{conn: conn} do
       conn =
@@ -39,6 +52,19 @@ defmodule CacheWeb.RegistryControllerTest do
 
       assert conn.status == 200
       assert get_resp_header(conn, "content-version") == ["1"]
+    end
+  end
+
+  describe "HEAD /api/registry/swift/availability" do
+    test "returns 200 OK with content-version header", %{conn: conn} do
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/availability")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
     end
   end
 
@@ -129,6 +155,76 @@ defmodule CacheWeb.RegistryControllerTest do
     end
   end
 
+  describe "HEAD /api/registry/swift/identifiers" do
+    test "returns 200 for valid repository url", %{conn: conn} do
+      url = "https://github.com/apple/swift-argument-parser"
+
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:ok, %{}} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/identifiers?url=#{URI.encode_www_form(url)}")
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "returns 400 for invalid repository url", %{conn: conn} do
+      url = "https://github.com/invalid"
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/identifiers?url=#{URI.encode_www_form(url)}")
+
+      assert conn.status == 400
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 for unsupported vcs", %{conn: conn} do
+      url = "https://gitlab.com/tuist/tuist"
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/identifiers?url=#{URI.encode_www_form(url)}")
+
+      assert conn.status == 404
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when package is missing", %{conn: conn} do
+      url = "https://github.com/apple/swift-argument-parser"
+
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:error, :not_found} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/identifiers?url=#{URI.encode_www_form(url)}")
+
+      assert conn.status == 404
+      assert conn.resp_body == ""
+    end
+
+    test "returns 503 when S3 returns an error", %{conn: conn} do
+      url = "https://github.com/apple/swift-argument-parser"
+
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" ->
+        {:error, {:s3_error, :rate_limited}}
+      end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/identifiers?url=#{URI.encode_www_form(url)}")
+
+      assert conn.status == 503
+      assert conn.resp_body == ""
+    end
+  end
+
   describe "GET /api/registry/swift/:scope/:name (list_releases)" do
     test "returns releases when package exists", %{conn: conn} do
       scope = "apple"
@@ -206,6 +302,75 @@ defmodule CacheWeb.RegistryControllerTest do
       assert conn.status == 400
       response = json_response(conn, :bad_request)
       assert response["message"] == "Invalid path parameters."
+    end
+  end
+
+  describe "HEAD /api/registry/swift/:scope/:name (list_releases)" do
+    test "returns releases when package exists", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.0.0" => %{"checksum" => "abc123"},
+          "1.1.0" => %{"checksum" => "def456"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when package not found", %{conn: conn} do
+      scope = "unknown"
+      name = "nonexistent"
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:error, :not_found} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 503 when S3 returns an error", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:error, {:s3_error, :rate_limited}} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}")
+
+      assert conn.status == 503
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 400 when normalized path params are invalid", %{conn: conn} do
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/%2E%2E/swift-argument-parser")
+
+      assert conn.status == 400
+      assert conn.resp_body == ""
     end
   end
 
@@ -336,6 +501,115 @@ defmodule CacheWeb.RegistryControllerTest do
     end
   end
 
+  describe "HEAD /api/registry/swift/:scope/:name/:version (show_release)" do
+    test "returns release info when version exists", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.0.0" => %{"checksum" => "abc123def456"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "normalizes version before lookup", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.0.0" => %{"checksum" => "abc123"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/v1")
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when version not found", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "9.9.9"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.0.0" => %{"checksum" => "abc123"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when package not found", %{conn: conn} do
+      scope = "unknown"
+      name = "nonexistent"
+      version = "1.0.0"
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:error, :not_found} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""    
+    end
+
+    test "returns 503 when S3 returns an error", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:error, {:s3_error, :rate_limited}} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}")
+
+      assert conn.status == 503
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+  end
+
   describe "GET /api/registry/swift/:scope/:name/:version.zip (download_archive)" do
     test "serves from disk when file exists locally", %{conn: conn} do
       scope = "apple"
@@ -429,6 +703,106 @@ defmodule CacheWeb.RegistryControllerTest do
 
       assert conn.status == 404
       assert get_resp_header(conn, "content-version") == ["1"]
+    end
+  end
+
+  describe "HEAD /api/registry/swift/:scope/:name/:version.zip (download_archive)" do
+    test "serves from disk when file exists locally", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> true end)
+
+      expect(Registry.Disk, :local_accel_path, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        "/internal/local/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+      end)
+
+      conn =
+        conn
+        |> registry_zip_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}.zip")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+
+      assert get_resp_header(conn, "x-accel-redirect") == [
+               "/internal/local/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
+             ]
+
+      assert get_resp_header(conn, "content-type") == ["application/zip; charset=utf-8"]
+      assert conn.resp_body == ""
+    end
+
+    test "falls back to S3 when file not on disk", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> true end)
+
+      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+
+      expect(S3, :presign_download_url, fn _key, _opts ->
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
+      end)
+
+      expect(S3, :remote_accel_path, fn _url ->
+        "/internal/remote/https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"
+      end)
+
+      conn =
+        conn
+        |> registry_zip_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}.zip")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when S3 presign fails", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> true end)
+
+      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+
+      expect(S3, :presign_download_url, fn _key, _opts -> {:error, :not_found} end)
+
+      conn =
+        conn
+        |> registry_zip_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}.zip")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when S3 object is missing", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> false end)
+
+      conn =
+        conn
+        |> registry_zip_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}.zip")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
     end
   end
 
@@ -559,6 +933,139 @@ defmodule CacheWeb.RegistryControllerTest do
 
       assert conn.status == 404
       assert get_resp_header(conn, "content-version") == ["1"]
+    end
+  end
+
+  describe "HEAD /api/registry/swift/:scope/:name/:version/Package.swift (show_manifest)" do
+    test "returns 400 when normalized version is invalid", %{conn: conn} do
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> head("/api/registry/swift/apple/swift-argument-parser/%2E%2E/Package.swift")
+
+      assert conn.status == 400
+      assert conn.resp_body == ""
+    end
+
+    test "serves manifest from disk when file exists", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.0.0" => %{
+            "checksum" => "abc123",
+            "manifests" => [
+              %{"swift_version" => nil, "swift_tools_version" => "5.7"},
+              %{"swift_version" => "5.9", "swift_tools_version" => "5.9"}
+            ]
+          }
+        }
+      }
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package.swift" -> true end)
+
+      expect(Registry.Disk, :local_accel_path, fn ^scope, ^name, ^version, "Package.swift" ->
+        "/internal/local/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
+      end)
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+
+      assert get_resp_header(conn, "x-accel-redirect") == [
+               "/internal/local/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
+             ]
+
+      assert get_resp_header(conn, "content-type") == ["text/x-swift; charset=utf-8"]
+
+      [link_header] = get_resp_header(conn, "link")
+      assert link_header =~ "rel=\"alternate\""
+      assert link_header =~ "swift-version=5.9"
+      assert conn.resp_body == ""
+    end
+
+    test "redirects to default manifest when swift-version specified but not found", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package@swift-5.8.swift" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> false end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift?swift-version=5.8")
+
+      assert conn.status == 303
+      assert get_resp_header(conn, "content-version") == ["1"]
+
+      assert get_resp_header(conn, "location") == [
+               "/api/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
+             ]
+      assert conn.resp_body == ""
+    end
+
+    test "falls back to S3 when manifest not on disk", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package.swift" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> true end)
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:error, :not_found} end)
+
+      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+
+      expect(S3, :presign_download_url, fn _key, _opts ->
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
+      end)
+
+      expect(S3, :remote_accel_path, fn _url ->
+        "/internal/remote/https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"
+      end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert get_resp_header(conn, "content-type") == ["text/x-swift; charset=utf-8"]
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 when manifest not found anywhere", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      version = "1.0.0"
+
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package.swift" -> false end)
+
+      expect(S3, :exists?, fn _key, _opts -> false end)
+
+      conn =
+        conn
+        |> registry_swift_conn()
+        |> head("/api/registry/swift/#{scope}/#{name}/#{version}/Package.swift")
+
+      assert conn.status == 404
+      assert get_resp_header(conn, "content-version") == ["1"]
+      assert conn.resp_body == ""
     end
   end
 

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -1014,6 +1014,7 @@ defmodule CacheWeb.RegistryControllerTest do
       assert get_resp_header(conn, "location") == [
                "/api/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift"
              ]
+
       assert conn.resp_body == ""
     end
 

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -14,6 +14,7 @@ defmodule CacheWeb.RegistryControllerTest do
     stub(Cache.Config, :registry_github_token, fn -> "test-token" end)
     stub(Cache.Config, :registry_bucket, fn -> "test-bucket" end)
     stub(Cache.Config, :registry_enabled?, fn -> true end)
+    stub(Cache.Config, :analytics_enabled?, fn -> false end)
     stub(CacheArtifacts, :track_artifact_access, fn _key -> :ok end)
     :ok
   end
@@ -125,7 +126,9 @@ defmodule CacheWeb.RegistryControllerTest do
     test "returns 404 when package is missing", %{conn: conn} do
       url = "https://github.com/apple/swift-argument-parser"
 
-      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:error, :not_found} end)
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" ->
+        {:error, :not_found}
+      end)
 
       conn =
         conn
@@ -642,7 +645,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> true end)
 
@@ -670,7 +675,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> true end)
 
@@ -692,7 +699,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> false end)
 
@@ -718,6 +727,8 @@ defmodule CacheWeb.RegistryControllerTest do
         "/internal/local/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip"
       end)
 
+      reject(CacheArtifacts, :track_artifact_access, 1)
+
       conn =
         conn
         |> registry_zip_conn()
@@ -739,11 +750,11 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> true end)
-
-      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
         {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
@@ -752,6 +763,9 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3, :remote_accel_path, fn _url ->
         "/internal/remote/https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"
       end)
+
+      reject(S3Transfers, :enqueue_registry_download, 1)
+      reject(CacheArtifacts, :track_artifact_access, 1)
 
       conn =
         conn
@@ -768,11 +782,14 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> true end)
 
-      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+      reject(S3Transfers, :enqueue_registry_download, 1)
+      reject(CacheArtifacts, :track_artifact_access, 1)
 
       expect(S3, :presign_download_url, fn _key, _opts -> {:error, :not_found} end)
 
@@ -791,7 +808,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "source_archive.zip" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> false end)
 
@@ -869,7 +888,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package@swift-5.8.swift" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package@swift-5.8.swift" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> false end)
 
@@ -974,6 +995,8 @@ defmodule CacheWeb.RegistryControllerTest do
 
       expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
 
+      reject(CacheArtifacts, :track_artifact_access, 1)
+
       conn =
         conn
         |> registry_swift_conn()
@@ -1029,7 +1052,8 @@ defmodule CacheWeb.RegistryControllerTest do
 
       expect(Metadata, :get_package, fn ^scope, ^name -> {:error, :not_found} end)
 
-      expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
+      reject(S3Transfers, :enqueue_registry_download, 1)
+      reject(CacheArtifacts, :track_artifact_access, 1)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
         {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}


### PR DESCRIPTION
My team is trying to mirror the Tuist registry via Jfrog Artifactory, but are encountering errors. We have determined that this is because Jfrog expects that the various registry endpoints will respond to HEAD requests, which is not currently the case. 

We are advising Jfrog that this is a potentially unsafe assumption since the [relevant registry spec](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/registryserverspecification/#4-Endpoints) only advises that "A server SHOULD also respond to HEAD requests for each of the specified endpoints", rather than "MUST". However, adding HEAD support to registry endpoints which currently respond to GET requests will improve interoperability with other systems which assume the same behavior.

This PR adds support for HEAD requests, and  adds additional test cases to validate that the responses for HEAD requests match the expectations for a GET but have an empty response body. If there's a cleaner or better way to implement and/or test this change, please by all means feel free to scrap any and all of this and proceed accordingly. I just wanted to take a stab at this change to gain a bit of familiarity with the registry implementation, as I haven't worked with Elixir before!
