### PR TITLE
fix(cli): consolidate cached framework search paths into per-target staging directories

### DIFF
--- a/cli/Tests/TuistCacheEETests/Generator/CacheGraphMutatorTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/CacheGraphMutatorTests.swift
@@ -120,7 +120,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -259,7 +259,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -382,7 +382,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -500,7 +500,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -565,7 +565,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: [:], sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -671,7 +671,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -810,7 +810,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -935,7 +935,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1051,7 +1051,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1157,7 +1157,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         )
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1269,7 +1269,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         //        }
         //
         //        // When
-        //        let got = try await subject.map(graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]))
+        //        let (got, _) = try await subject.map(graph: graph, precompiledArtifacts: frameworks, sources: Set(["App"]))
         //
         //        // Then
         //        XCTAssertEqual(
@@ -1339,7 +1339,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: [:], sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1406,7 +1406,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1470,7 +1470,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: false
         )
@@ -1529,7 +1529,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["App"]),
             keepSourceTargets: true
         )
@@ -1610,7 +1610,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         artifactLoader.loadStub = { path in GraphDependency.testXCFramework(path: path) }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph, precompiledArtifacts: xcframeworks, sources: Set(["B"]),
             keepSourceTargets: true
         )
@@ -1726,7 +1726,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph,
             precompiledArtifacts: xcframeworks,
             sources: Set(["SharedCounterTests"]),
@@ -1838,7 +1838,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph,
             precompiledArtifacts: xcframeworks,
             sources: Set(["FeatureTests"]),
@@ -1934,7 +1934,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph,
             precompiledArtifacts: xcframeworks,
             sources: Set(["App", "FeatureTests"]),
@@ -2035,7 +2035,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph,
             precompiledArtifacts: xcframeworks,
             sources: Set(["App", "FeatureTests"]),
@@ -2142,7 +2142,7 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
             }
         }
 
-        let got = try await subject.map(
+        let (got, _) = try await subject.map(
             graph: graph,
             precompiledArtifacts: xcframeworks,
             sources: Set(["Feature", "FeatureTests"]),

--- a/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
@@ -128,7 +128,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                     config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                 )
             )
-            .willReturn(outputGraph)
+            .willReturn((outputGraph, [:]))
 
         // When
         let (got, _, gotEnvironment) = try await subject.map(
@@ -236,7 +236,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                     config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                 )
             )
-            .willReturn(outputGraph)
+            .willReturn((outputGraph, [:]))
         given(cacheStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn([:])
 
         // When
@@ -340,7 +340,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                     config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                 )
             )
-            .willReturn(outputGraph)
+            .willReturn((outputGraph, [:]))
         let bBinaryPath = try temporaryPath().appending(component: "B-Binary")
         let cBinaryPath = try temporaryPath().appending(component: "C-Binary")
         given(cacheStorage).fetch(
@@ -412,7 +412,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                     config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                 )
             )
-            .willReturn(outputGraph)
+            .willReturn((outputGraph, [:]))
 
         given(cacheGraphContentHasher)
             .contentHashes(
@@ -473,7 +473,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                     config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                 )
             )
-            .willReturn(outputGraph)
+            .willReturn((outputGraph, [:]))
 
         given(cacheGraphContentHasher)
             .contentHashes(
@@ -572,7 +572,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
                         config.project.generatedProject?.cacheOptions.keepSourceTargets ?? false
                     )
                 )
-                .willReturn(outputGraph)
+                .willReturn((outputGraph, [:]))
 
             // When
             _ = try await subject.map(graph: inputGraph, environment: MapperEnvironment())


### PR DESCRIPTION
## Summary

Investigation into why module cache builds have slower per-module compilation times than building from source, even with 100% cache hit rates.

**This PR was an experiment that did not pan out. Closing with findings documented for future reference.**

## Investigation

### Setup

Compared two builds of a large iOS project (~700 targets, ~120 test targets):
- **With module cache**: 128 targets generated, 100% cache hit rate, all framework deps served as cached xcframeworks
- **Without module cache**: 707 targets generated, everything built from source

| Metric | Module cache | No cache |
|---|---|---|
| Wall-clock | 268s (4.5 min) | 600s (10.0 min) |
| Total CPU | 1475s | 3852s |
| Parallelism | 5.5x | 6.4x |

### Hypothesis: Framework search paths

Each cached xcframework lives in its own hash directory (\`~/.cache/tuist/Binaries/<hash>/\`), producing 100-200 unique \`-F\` paths per target vs 3 when building from source. We hypothesized this slowed the Swift dependency scanner.

This PR consolidated all cached xcframeworks into a single \`Derived/CachedFrameworks/\` directory with symlinks, reducing \`-F\` paths from 199 to 1.

### Benchmark results

Tested against tuist/tuist (19 source targets compiling against 199 cached xcframeworks, CAS disabled):

| Variant | Mean | Relative |
|---|---|---|
| Unpatched (199 \`-F\` paths) | 56.6s ± 2.4s | 1.00 |
| Patched (1 \`-F\` path) | 60.9s ± 3.8s | 1.07 ± 0.08 |

**No improvement.** The consolidation had no measurable effect (and was slightly slower, likely due to symlink resolution overhead).

### Root cause: per-unit overhead of importing pre-compiled modules

Deeper analysis revealed the actual bottleneck is intrinsic to the Swift compiler. Every phase is slower **per unit** when importing from cached xcframeworks vs modules compiled in the same build:

| Phase | Per-unit with cache | Per-unit no cache | Ratio |
|---|---|---|---|
| Swift file compile | 0.951s | 0.495s | **1.92x** |
| Dependency scan | 0.591s | 0.335s | **1.77x** |
| Module emit | 0.352s | 0.203s | **1.73x** |

The module cache still wins overall (2.6x less total work → 2.2x faster wall-clock), but each unit of work costs ~1.8x more because loading a pre-compiled \`.swiftmodule\` from an xcframework requires disk I/O + deserialization + validation, whereas a module compiled in the same build graph can be shared from the compiler's in-memory cache.

This is a Swift compiler characteristic, not something Tuist controls.

Additionally, there is **no correlation** (R² = 0.012) between the number of loaded modules and the per-target overhead -- targets loading 600 modules have the same average overhead as targets loading 150. The per-unit tax is uniform.

### What actually helps

1. **Persist Xcode compilation cache (CAS) across CI runs** -- warm CAS reduced build time from 57s to 30s in our benchmarks (47% reduction). The \`CompilationCache.noindex\` directory skips re-compilation entirely for unchanged inputs.

2. **Selective testing** -- only build/test targets affected by code changes.

3. **Merge test targets** -- each target has ~3.5s fixed overhead (planning + link + emit). Reducing from 120 test targets to 20 saves ~23% wall-clock.

4. **Generate only what you run** -- pass only the test targets you plan to run to \`tuist generate\`.

5. **Flatten the module graph** -- Interface/Mocks/Implementation splits triple the module count. Merging where possible reduces the per-unit tax across all phases.

## Test plan

- [x] All 21 \`CacheGraphMutatorTests\` pass
- [x] All 7 \`TargetsToCacheBinariesGraphMapperTests\` pass
- [x] Benchmarked against tuist/tuist with hyperfine (no improvement measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)