### PR TITLE
Extend the DB and port scoping to work with worktrees

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -58,7 +58,7 @@ mix test
 
 ## Development
 
-The service uses a clone-local suffix from `.tuist-dev-instance` in development mode through mise shell env. That suffix scopes the cache port and the main server URL it talks to, so one repo clone can run its own paired `server/` and `cache/` instances without colliding with other clones.
+The service uses a checkout-local suffix in development mode through the shared mise shell env. Linked Git worktrees prefer Git's per-worktree metadata and fall back to the existing root `.tuist-dev-instance` file when needed for compatibility, while standalone clones keep their own isolated state as before. That suffix scopes the cache port and the main server URL it talks to, so both multiple clones and multiple linked worktrees can run their own paired `server/` and `cache/` instances without colliding.
 
 ## Architecture
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -58,7 +58,7 @@ mix test
 
 ## Development
 
-The service uses a checkout-local suffix in development mode through the shared mise shell env. Linked Git worktrees prefer Git's per-worktree metadata and fall back to the existing root `.tuist-dev-instance` file when needed for compatibility, while standalone clones keep their own isolated state as before. That suffix scopes the cache port and the main server URL it talks to, so both multiple clones and multiple linked worktrees can run their own paired `server/` and `cache/` instances without colliding.
+The service uses a checkout-local suffix in development mode through the shared mise shell env. Each checkout persists that suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the cache port and the main server URL it talks to, so developers can choose either multiple clones or linked worktrees and still run their own paired `server/` and `cache/` instances without colliding.
 
 ## Architecture
 

--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -8,13 +8,45 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-INSTANCE_FILE="${PROJECT_ROOT}/.tuist-dev-instance"
+ROOT_INSTANCE_FILE="${PROJECT_ROOT}/.tuist-dev-instance"
+
+resolve_instance_file() {
+  local git_path=""
+
+  if command -v git >/dev/null 2>&1 && git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_path="$(
+      git -C "${PROJECT_ROOT}" rev-parse --path-format=absolute --git-path tuist-dev-instance 2>/dev/null ||
+        git -C "${PROJECT_ROOT}" rev-parse --git-path tuist-dev-instance 2>/dev/null ||
+        true
+    )"
+
+    if [[ -n "${git_path}" && "${git_path}" != /* ]]; then
+      git_path="${PROJECT_ROOT}/${git_path#./}"
+    fi
+  fi
+
+  if [[ -n "${git_path}" ]]; then
+    printf '%s' "${git_path}"
+  else
+    printf '%s' "${ROOT_INSTANCE_FILE}"
+  fi
+}
+
+INSTANCE_FILE="$(resolve_instance_file)"
 
 validate_suffix() {
   local suffix="$1"
 
   [[ "$suffix" =~ ^[0-9]+$ ]] || return 1
   (( suffix >= 1 && suffix <= 999 ))
+}
+
+persist_suffix() {
+  local suffix="$1"
+  local target="$2"
+
+  mkdir -p "$(dirname "${target}")" 2>/dev/null || return 1
+  printf '%s' "${suffix}" | tee "${target}" >/dev/null 2>&1
 }
 
 ensure_suffix() {
@@ -24,6 +56,8 @@ ensure_suffix() {
     suffix="${TUIST_DEV_INSTANCE}"
   elif [[ -s "${INSTANCE_FILE}" ]]; then
     suffix="$(tr -d '[:space:]' < "${INSTANCE_FILE}")"
+  elif [[ -s "${ROOT_INSTANCE_FILE}" ]]; then
+    suffix="$(tr -d '[:space:]' < "${ROOT_INSTANCE_FILE}")"
   else
     suffix="$(awk 'BEGIN { srand(); print int(100 + rand() * 900) }')"
   fi
@@ -33,7 +67,16 @@ ensure_suffix() {
     return 1
   }
 
-  printf '%s' "${suffix}" > "${INSTANCE_FILE}"
+  if ! persist_suffix "${suffix}" "${INSTANCE_FILE}"; then
+    if [[ "${INSTANCE_FILE}" != "${ROOT_INSTANCE_FILE}" ]] &&
+      persist_suffix "${suffix}" "${ROOT_INSTANCE_FILE}"; then
+      INSTANCE_FILE="${ROOT_INSTANCE_FILE}"
+    else
+      echo "Failed to persist dev instance suffix '${suffix}'." >&2
+      return 1
+    fi
+  fi
+
   printf '%s' "${suffix}"
 }
 

--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,7 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. Install dependencies: `mise run install`
 1. Create and set up the database: `mise run db:setup`
 1. Run the server: `mise run dev`
-1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix. Git worktrees prefer Git's per-worktree metadata and fall back to the existing root `.tuist-dev-instance` file when needed for compatibility, and standalone clones keep their own isolated state as before. That suffix scopes the local service ports, MinIO ports, and server databases. For example, a suffix of `443` yields `http://localhost:8523`:
+1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`:
 
 ```
 Email: tuistrocks@tuist.dev

--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,7 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. Install dependencies: `mise run install`
 1. Create and set up the database: `mise run db:setup`
 1. Run the server: `mise run dev`
-1. Open the clone-specific local URL in your browser and log in with the pre-made test user account. With `mise activate` enabled, each repo clone persists its own numeric suffix in `.tuist-dev-instance`, which scopes the local service ports, MinIO ports, and server databases. For example, a suffix of `443` yields `http://localhost:8523`:
+1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix. Git worktrees prefer Git's per-worktree metadata and fall back to the existing root `.tuist-dev-instance` file when needed for compatibility, and standalone clones keep their own isolated state as before. That suffix scopes the local service ports, MinIO ports, and server databases. For example, a suffix of `443` yields `http://localhost:8523`:
 
 ```
 Email: tuistrocks@tuist.dev
@@ -36,6 +36,6 @@ Pass: tuistrocks
 #### To run additional features
 1. Clone the repository: `https://github.com/tuist/tuist.git`.
 1. Go to `tuist/examples/xcode/generated_ios_app_with_frameworks`.
-1. Change the url in `Tuist/Config.swift` to the clone-specific local URL, for example `http://localhost:8523`.
+1. Change the url in `Tuist/Config.swift` to the local URL for the current clone or worktree, for example `http://localhost:8523`.
 1. Run `tuist auth` to authenticate.
 1. You are now connected to the local Tuist Server!  You can try running `tuist cache` and see the binaries being uploaded.

--- a/server/README.md
+++ b/server/README.md
@@ -36,6 +36,6 @@ Pass: tuistrocks
 #### To run additional features
 1. Clone the repository: `https://github.com/tuist/tuist.git`.
 1. Go to `tuist/examples/xcode/generated_ios_app_with_frameworks`.
-1. Change the url in `Tuist/Config.swift` to the local URL for the current clone or worktree, for example `http://localhost:8523`.
+1. Change the url in `Tuist.swift` to the local URL for the current clone or worktree, for example `http://localhost:8523`.
 1. Run `tuist auth` to authenticate.
 1. You are now connected to the local Tuist Server!  You can try running `tuist cache` and see the binaries being uploaded.


### PR DESCRIPTION
## What changed
- updated `mise/utilities/dev_instance_env.sh` to persist the dev instance per checkout via Git metadata when available
- kept the root `.tuist-dev-instance` file as a compatibility fallback when the Git metadata path is unavailable or unwritable
- renamed the root-file variable to `ROOT_INSTANCE_FILE` to make the fallback role clearer in the script
- updated the server and cache READMEs to make it explicit that developers can use either standalone clones or linked worktrees

## Why
The local development setup uses a persisted numeric suffix to scope ports and databases. That suffix should stay isolated per checkout regardless of whether a developer prefers multiple clones or a single clone with multiple worktrees.

## Impact
- developers can choose either standalone clones or linked worktrees
- each checkout gets its own persisted dev-instance state, so ports and databases do not collide
- the docs now describe both supported workflows without implying a preference

## Root cause
The persisted suffix was tied only to the checkout-root `.tuist-dev-instance` file, which did not provide a Git-aware checkout-local storage path for linked worktrees.

## Validation
- `bash -n mise/utilities/dev_instance_env.sh`
- `zsh -n mise/utilities/dev_instance_env.sh`
- verified the PR branch was created from `main` and scoped to the intended files
