### PR TITLE
fix(server): return test_case_runs as explicit value on test run upsert

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -150,8 +150,13 @@ defmodule Tuist.Tests do
             {:error, :not_found}
 
           test ->
+            ch_preload_keys = [:build_run, :gradle_build, :shard_plan, :run_destinations, :test_case_runs]
+
             {ch_preloads, pg_preloads} =
-              Enum.split_with(preload, &(&1 in [:build_run, :gradle_build, :shard_plan, :run_destinations]))
+              Enum.split_with(preload, fn
+                key when is_atom(key) -> key in ch_preload_keys
+                {key, _} -> key in ch_preload_keys
+              end)
 
             test =
               test

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -520,7 +520,7 @@ defmodule TuistWeb.API.TestsController do
       |> Map.put(:account, Authentication.authenticated_subject_account(conn))
 
     case get_or_create_test(run_params) do
-      {:ok, test_run, test_case_runs} ->
+      {:ok, test_run} ->
         if test_run.status == "processing" do
           storage_key =
             "#{selected_project.account.name}/#{selected_project.name}/runs/#{test_run.id}/result_bundle.zip"
@@ -575,7 +575,7 @@ defmodule TuistWeb.API.TestsController do
           project_id: test_run.project_id,
           url: url(~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-runs/#{test_run.id}"),
           test_case_runs:
-            Enum.map(test_case_runs, fn run ->
+            Enum.map(test_run.test_case_runs, fn run ->
               result = %{
                 id: run.id,
                 name: run.name,
@@ -709,44 +709,38 @@ defmodule TuistWeb.API.TestsController do
   defp get_or_create_test(params) do
     test_id = Map.get(params, :id, UUIDv7.generate())
 
-    case Tests.get_test(test_id) do
+    case Tests.get_test(test_id, preload: [test_case_runs: :arguments]) do
       {:ok, test_run} ->
-        {:ok, test_run, []}
+        {:ok, test_run}
 
       {:error, :not_found} ->
-        with {:ok, test_run} <- create_test(test_id, params) do
-          {:ok, test_run, test_run.test_case_runs}
-        end
+        Tests.create_test(%{
+          id: test_id,
+          duration: params.duration,
+          macos_version: Map.get(params, :macos_version),
+          xcode_version: Map.get(params, :xcode_version),
+          is_ci: Map.get(params, :is_ci),
+          model_identifier: Map.get(params, :model_identifier),
+          scheme: Map.get(params, :scheme),
+          project_id: params.project.id,
+          account_id: params.account.id,
+          status: Map.get(params, :status),
+          git_branch: Map.get(params, :git_branch),
+          git_commit_sha: Map.get(params, :git_commit_sha),
+          git_ref: Map.get(params, :git_ref),
+          ran_at: Map.get(params, :ran_at, NaiveDateTime.utc_now()),
+          ci_run_id: Map.get(params, :ci_run_id),
+          ci_project_handle: Map.get(params, :ci_project_handle),
+          ci_host: Map.get(params, :ci_host),
+          ci_provider: Map.get(params, :ci_provider),
+          build_system: Map.get(params, :build_system, "xcode"),
+          test_modules: Map.get(params, :test_modules, []),
+          test_cases: Map.get(params, :test_cases, []),
+          build_run_id: Map.get(params, :build_run_id),
+          gradle_build_id: Map.get(params, :gradle_build_id),
+          shard_plan_id: Map.get(params, :shard_plan_id),
+          shard_index: Map.get(params, :shard_index)
+        })
     end
-  end
-
-  defp create_test(test_id, params) do
-    Tests.create_test(%{
-      id: test_id,
-      duration: params.duration,
-      macos_version: Map.get(params, :macos_version),
-      xcode_version: Map.get(params, :xcode_version),
-      is_ci: Map.get(params, :is_ci),
-      model_identifier: Map.get(params, :model_identifier),
-      scheme: Map.get(params, :scheme),
-      project_id: params.project.id,
-      account_id: params.account.id,
-      status: Map.get(params, :status),
-      git_branch: Map.get(params, :git_branch),
-      git_commit_sha: Map.get(params, :git_commit_sha),
-      git_ref: Map.get(params, :git_ref),
-      ran_at: Map.get(params, :ran_at, NaiveDateTime.utc_now()),
-      ci_run_id: Map.get(params, :ci_run_id),
-      ci_project_handle: Map.get(params, :ci_project_handle),
-      ci_host: Map.get(params, :ci_host),
-      ci_provider: Map.get(params, :ci_provider),
-      build_system: Map.get(params, :build_system, "xcode"),
-      test_modules: Map.get(params, :test_modules, []),
-      test_cases: Map.get(params, :test_cases, []),
-      build_run_id: Map.get(params, :build_run_id),
-      gradle_build_id: Map.get(params, :gradle_build_id),
-      shard_plan_id: Map.get(params, :shard_plan_id),
-      shard_index: Map.get(params, :shard_index)
-    })
   end
 end

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -520,7 +520,7 @@ defmodule TuistWeb.API.TestsController do
       |> Map.put(:account, Authentication.authenticated_subject_account(conn))
 
     case get_or_create_test(run_params) do
-      {:ok, test_run} ->
+      {:ok, test_run, test_case_runs} ->
         if test_run.status == "processing" do
           storage_key =
             "#{selected_project.account.name}/#{selected_project.name}/runs/#{test_run.id}/result_bundle.zip"
@@ -575,7 +575,7 @@ defmodule TuistWeb.API.TestsController do
           project_id: test_run.project_id,
           url: url(~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-runs/#{test_run.id}"),
           test_case_runs:
-            Enum.map(test_run.test_case_runs || [], fn run ->
+            Enum.map(test_case_runs, fn run ->
               result = %{
                 id: run.id,
                 name: run.name,
@@ -711,36 +711,42 @@ defmodule TuistWeb.API.TestsController do
 
     case Tests.get_test(test_id) do
       {:ok, test_run} ->
-        {:ok, test_run}
+        {:ok, test_run, []}
 
       {:error, :not_found} ->
-        Tests.create_test(%{
-          id: test_id,
-          duration: params.duration,
-          macos_version: Map.get(params, :macos_version),
-          xcode_version: Map.get(params, :xcode_version),
-          is_ci: Map.get(params, :is_ci),
-          model_identifier: Map.get(params, :model_identifier),
-          scheme: Map.get(params, :scheme),
-          project_id: params.project.id,
-          account_id: params.account.id,
-          status: Map.get(params, :status),
-          git_branch: Map.get(params, :git_branch),
-          git_commit_sha: Map.get(params, :git_commit_sha),
-          git_ref: Map.get(params, :git_ref),
-          ran_at: Map.get(params, :ran_at, NaiveDateTime.utc_now()),
-          ci_run_id: Map.get(params, :ci_run_id),
-          ci_project_handle: Map.get(params, :ci_project_handle),
-          ci_host: Map.get(params, :ci_host),
-          ci_provider: Map.get(params, :ci_provider),
-          build_system: Map.get(params, :build_system, "xcode"),
-          test_modules: Map.get(params, :test_modules, []),
-          test_cases: Map.get(params, :test_cases, []),
-          build_run_id: Map.get(params, :build_run_id),
-          gradle_build_id: Map.get(params, :gradle_build_id),
-          shard_plan_id: Map.get(params, :shard_plan_id),
-          shard_index: Map.get(params, :shard_index)
-        })
+        with {:ok, test_run} <- create_test(test_id, params) do
+          {:ok, test_run, test_run.test_case_runs}
+        end
     end
+  end
+
+  defp create_test(test_id, params) do
+    Tests.create_test(%{
+      id: test_id,
+      duration: params.duration,
+      macos_version: Map.get(params, :macos_version),
+      xcode_version: Map.get(params, :xcode_version),
+      is_ci: Map.get(params, :is_ci),
+      model_identifier: Map.get(params, :model_identifier),
+      scheme: Map.get(params, :scheme),
+      project_id: params.project.id,
+      account_id: params.account.id,
+      status: Map.get(params, :status),
+      git_branch: Map.get(params, :git_branch),
+      git_commit_sha: Map.get(params, :git_commit_sha),
+      git_ref: Map.get(params, :git_ref),
+      ran_at: Map.get(params, :ran_at, NaiveDateTime.utc_now()),
+      ci_run_id: Map.get(params, :ci_run_id),
+      ci_project_handle: Map.get(params, :ci_project_handle),
+      ci_host: Map.get(params, :ci_host),
+      ci_provider: Map.get(params, :ci_provider),
+      build_system: Map.get(params, :build_system, "xcode"),
+      test_modules: Map.get(params, :test_modules, []),
+      test_cases: Map.get(params, :test_cases, []),
+      build_run_id: Map.get(params, :build_run_id),
+      gradle_build_id: Map.get(params, :gradle_build_id),
+      shard_plan_id: Map.get(params, :shard_plan_id),
+      shard_index: Map.get(params, :shard_index)
+    })
   end
 end

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -503,13 +503,16 @@ defmodule TuistWeb.API.TestsControllerTest do
       assert arg2["name"] == ".cardAdmin"
     end
 
-    test "returns empty test_case_runs when existing test has unloaded association", %{
+    test "returns empty test_case_runs when the test already exists", %{
       conn: conn,
       user: user,
       project: project
     } do
       existing_id = UUIDv7.generate()
 
+      # Regression test for the %Ecto.Association.NotLoaded{} crash: the
+      # controller must not read test_run.test_case_runs directly, since
+      # Tests.get_test does not preload the association.
       expect(Tests, :get_test, fn _id ->
         {:ok,
          %Test{

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -242,7 +242,7 @@ defmodule TuistWeb.API.TestsControllerTest do
     end
 
     test "creates a test run with xcode build system by default", %{conn: conn, user: user, project: project} do
-      expect(Tests, :get_test, fn _id -> {:error, :not_found} end)
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
         assert attrs.build_system == "xcode"
@@ -290,7 +290,7 @@ defmodule TuistWeb.API.TestsControllerTest do
     end
 
     test "creates a test run with gradle build system", %{conn: conn, user: user, project: project} do
-      expect(Tests, :get_test, fn _id -> {:error, :not_found} end)
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
         assert attrs.build_system == "gradle"
@@ -364,7 +364,7 @@ defmodule TuistWeb.API.TestsControllerTest do
     end
 
     test "creates a test run without macos_version (not required)", %{conn: conn, user: user, project: project} do
-      expect(Tests, :get_test, fn _id -> {:error, :not_found} end)
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
         assert attrs.build_system == "gradle"
@@ -398,7 +398,7 @@ defmodule TuistWeb.API.TestsControllerTest do
     end
 
     test "creates a test run with parameterized test arguments", %{conn: conn, user: user, project: project} do
-      expect(Tests, :get_test, fn _id -> {:error, :not_found} end)
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
         [module] = attrs.test_modules
@@ -503,23 +503,35 @@ defmodule TuistWeb.API.TestsControllerTest do
       assert arg2["name"] == ".cardAdmin"
     end
 
-    test "returns empty test_case_runs when the test already exists", %{
+    test "returns preloaded test_case_runs when the test already exists", %{
       conn: conn,
       user: user,
       project: project
     } do
       existing_id = UUIDv7.generate()
+      existing_run_id = UUIDv7.generate()
 
-      # Regression test for the %Ecto.Association.NotLoaded{} crash: the
-      # controller must not read test_run.test_case_runs directly, since
-      # Tests.get_test does not preload the association.
-      expect(Tests, :get_test, fn _id ->
+      # Regression test for the %Ecto.Association.NotLoaded{} crash: when
+      # the test already exists, get_test must preload test_case_runs so
+      # the response reflects what is actually stored, not an empty list.
+      expect(Tests, :get_test, fn ^existing_id, opts ->
+        assert opts[:preload] == [test_case_runs: :arguments]
+
         {:ok,
          %Test{
            id: existing_id,
            duration: 1000,
            project_id: project.id,
-           build_system: "xcode"
+           build_system: "xcode",
+           test_case_runs: [
+             %Tuist.Tests.TestCaseRun{
+               id: existing_run_id,
+               name: "testExample",
+               module_name: "MyModule",
+               suite_name: "MyModuleTests",
+               arguments: []
+             }
+           ]
          }}
       end)
 
@@ -539,13 +551,15 @@ defmodule TuistWeb.API.TestsControllerTest do
 
       response = json_response(conn, 200)
       assert response["id"] == existing_id
-      assert response["test_case_runs"] == []
+      assert [run] = response["test_case_runs"]
+      assert run["id"] == existing_run_id
+      assert run["name"] == "testExample"
     end
 
     test "enqueues a VCS pull request comment", %{conn: conn, user: user, project: project} do
       test_pid = self()
 
-      expect(Tests, :get_test, fn _id -> {:error, :not_found} end)
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
 
       expect(Tests, :create_test, fn attrs ->
         {:ok,

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -503,6 +503,42 @@ defmodule TuistWeb.API.TestsControllerTest do
       assert arg2["name"] == ".cardAdmin"
     end
 
+    test "returns empty test_case_runs when existing test has unloaded association", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      existing_id = UUIDv7.generate()
+
+      expect(Tests, :get_test, fn _id ->
+        {:ok,
+         %Test{
+           id: existing_id,
+           duration: 1000,
+           project_id: project.id,
+           build_system: "xcode"
+         }}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/api/projects/#{user.account.name}/#{project.name}/tests",
+          %{
+            id: existing_id,
+            duration: 1000,
+            is_ci: false,
+            status: "success",
+            test_modules: []
+          }
+        )
+
+      response = json_response(conn, 200)
+      assert response["id"] == existing_id
+      assert response["test_case_runs"] == []
+    end
+
     test "enqueues a VCS pull request comment", %{conn: conn, user: user, project: project} do
       test_pid = self()
 


### PR DESCRIPTION
## Summary
- Fixes [TUIST-BE](https://tuist.sentry.io/issues/113467657/): `Protocol.UndefinedError: protocol Enumerable not implemented for Ecto.Association.NotLoaded` when `POST /api/projects/:account/:project/tests` is called with an `id` that already exists.
- **Root cause:** `Tests.get_test` did not preload `test_case_runs`, leaving the `has_many` association at its schema default `%Ecto.Association.NotLoaded{}`. That struct is truthy, so the response builder's `|| []` guard did not kick in and `Enum.map/2` crashed. Returning `[]` on the found branch would "fix" the crash but misrepresent state — the test does have runs, the endpoint just wasn't loading them.
- **Fix:** Teach `Tests.get_test` to route `:test_case_runs` (and keyword-form preloads like `[test_case_runs: :arguments]`) to `ClickHouseRepo`, and have `get_or_create_test/1` call it with `preload: [test_case_runs: :arguments]` on the found branch. The response now reflects what is actually stored for an existing test run instead of an empty list.

## Test plan
- [x] Added a regression test covering the "test already exists" branch that asserts `get_test` is called with the expected preload keyword and that preloaded runs flow through the response. Reproduces the Sentry stacktrace before the fix, passes after.
- [x] Updated existing mocks to the `/2` arity of `Tests.get_test`.
- [x] `mix test test/tuist_web/controllers/api/tests_controller_test.exs` — 17 tests, 0 failures.
- [x] `mix test test/tuist/tests_test.exs` — 198 tests, 0 failures (verifies the new preload routing doesn't regress existing callers).
- [x] `mix format` and `mix credo` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)