### PR TITLE
fix(server): harden ClickHouse test teardown against idle connection drops

### DIFF
--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -44,6 +44,7 @@ config :tuist, Tuist.IngestRepo,
   max_buffer_size: 100_000,
   pool_size: 5,
   sync_writes: true,
+  transport_opts: [keepalive: true],
   # Workaround for ClickHouse lazy materialization bug with projections
   # https://github.com/ClickHouse/ClickHouse/issues/80201
   settings: [query_plan_optimize_lazy_materialization: 0]

--- a/server/lib/tuist/ingest_repo.ex
+++ b/server/lib/tuist/ingest_repo.ex
@@ -12,16 +12,24 @@ defmodule Tuist.IngestRepo do
   defoverridable insert_all: 2, insert_all: 3, insert: 1, insert: 2
 
   def insert_all(schema_or_source, entries, opts \\ []) do
-    retry_on_connection_error(fn -> super(schema_or_source, entries, opts) end)
+    with_retry(fn -> super(schema_or_source, entries, opts) end)
   end
 
   def insert(struct, opts \\ []) do
-    retry_on_connection_error(fn -> super(struct, opts) end)
+    with_retry(fn -> super(struct, opts) end)
   end
 
   @max_retries 3
 
-  defp retry_on_connection_error(fun, retries_left \\ @max_retries) do
+  @doc """
+  Runs `fun` and retries with exponential backoff on transient ClickHouse
+  connection errors (`Mint.TransportError`, `DBConnection.ConnectionError`).
+
+  Use this whenever raw ClickHouse queries are issued outside the overridden
+  `insert`/`insert_all` paths — e.g. test teardown truncates — so that idle
+  pool connections dropped by the server don't fail the caller.
+  """
+  def with_retry(fun, retries_left \\ @max_retries) do
     fun.()
   rescue
     e in [Mint.TransportError, DBConnection.ConnectionError] ->
@@ -33,7 +41,7 @@ defmodule Tuist.IngestRepo do
         )
 
         Process.sleep(delay)
-        retry_on_connection_error(fun, retries_left - 1)
+        with_retry(fun, retries_left - 1)
       else
         reraise e, __STACKTRACE__
       end

--- a/server/test/support/tuist_test_support/utilities.ex
+++ b/server/test/support/tuist_test_support/utilities.ex
@@ -40,30 +40,7 @@ defmodule TuistTestSupport.Utilities do
     ]
 
     for command <- commands do
-      query_with_retry(command)
+      Tuist.IngestRepo.with_retry(fn -> Tuist.IngestRepo.query!(command) end)
     end
-  end
-
-  # ClickHouse occasionally drops idle pool connections under CI load; the Ch
-  # client reestablishes them transparently on the *next* use, but the call in
-  # flight when that happens still raises `Mint.TransportError: socket closed`.
-  # Retry once on that specific error so an `on_exit` TRUNCATE doesn't fail
-  # the test that just finished.
-  defp query_with_retry(command, attempts_left \\ 1) do
-    Tuist.IngestRepo.query!(command)
-  rescue
-    error in DBConnection.ConnectionError ->
-      if attempts_left > 0 and error.reason in [:socket_closed, "socket closed"] do
-        query_with_retry(command, attempts_left - 1)
-      else
-        reraise error, __STACKTRACE__
-      end
-
-    error in Mint.TransportError ->
-      if attempts_left > 0 and error.reason == :closed do
-        query_with_retry(command, attempts_left - 1)
-      else
-        reraise error, __STACKTRACE__
-      end
   end
 end


### PR DESCRIPTION
## Summary

CI has been flaking on tests that complete successfully but raise `Mint.TransportError: socket closed` during `on_exit` TRUNCATEs against `Tuist.IngestRepo`. ClickHouse drops idle pool connections under CI load, and the existing test-side retry helper only retries once — we've seen two stale connections picked up back-to-back, exhausting it mid-teardown.

Two small changes:

- **Unify retry policy.** Promote `Tuist.IngestRepo.retry_on_connection_error/2` to a public `with_retry/2` helper (3 retries, exponential backoff — already proven in prod for `insert`/`insert_all`). Update the test teardown in `TuistTestSupport.Utilities.truncate_clickhouse_tables/0` to use it instead of the bespoke 1-retry `query_with_retry` that's now deleted.
- **Add TCP keepalive to the test IngestRepo.** Prod already has `transport_opts: [keepalive: true]` in `config/runtime.exs`; test config didn't. This reduces the rate at which idle connections are dropped in the first place so retries are rarely needed.

Related recent work on main: #10313 (prod retry for transient ClickHouse errors), #10225 (ClickHouse 25.12 upgrade — likely the source of tighter idle timeouts).

Opening as **draft** for review before merging.

## Test plan

- [x] CI passes (esp. the `Test` job that had been flaking)
- [x] Rerun the failing job a few times to confirm the flake doesn't recur
- [x] `mix credo` and `mix format --check-formatted` still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)