### PR TITLE
fix(server): return forbidden for non-user auth on account endpoints

### DIFF
--- a/server/lib/tuist_web/controllers/api/account_controller.ex
+++ b/server/lib/tuist_web/controllers/api/account_controller.ex
@@ -9,6 +9,7 @@ defmodule TuistWeb.API.AccountController do
   alias TuistWeb.API.Schemas.Account, as: AccountSchema
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.ValidationError
+  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -51,11 +52,13 @@ defmodule TuistWeb.API.AccountController do
   )
 
   def update_account(%{path_params: %{"account_handle" => handle}, body_params: params} = conn, _params) do
+    current_user = Authentication.current_user(conn)
+
     with {:ok, account} <- get_account(handle),
          :ok <-
            Authorization.authorize(
              :organization_update,
-             conn.assigns.current_user,
+             current_user,
              account
            ),
          # The field is called `handle` in the public API, but `name` in our domain.
@@ -89,8 +92,10 @@ defmodule TuistWeb.API.AccountController do
   )
 
   def delete_account(%{path_params: %{"account_handle" => handle}} = conn, _params) do
+    current_user = Authentication.current_user(conn)
+
     with {:ok, account} <- get_account(handle),
-         :ok <- Authorization.authorize(:account_delete, conn.assigns.current_user, account) do
+         :ok <- Authorization.authorize(:account_delete, current_user, account) do
       Accounts.delete_account!(account)
 
       conn

--- a/server/test/tuist_web/controllers/api/account_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/account_controller_test.exs
@@ -3,8 +3,10 @@ defmodule TuistWeb.API.AccountControllerTest do
   use Mimic
 
   import TuistTestSupport.Fixtures.AccountsFixtures
+  import TuistTestSupport.Fixtures.ProjectsFixtures
 
   alias Tuist.Accounts
+  alias Tuist.Accounts.AuthenticatedAccount
   alias Tuist.Repo
 
   describe "PATCH /api/accounts" do
@@ -77,6 +79,35 @@ defmodule TuistWeb.API.AccountControllerTest do
       |> put_req_header("content-type", "application/json")
       |> patch("/api/accounts/#{organization.account.name}", %{handle: new_handle})
       |> json_response(:forbidden)
+    end
+
+    test "returns forbidden for account token subject", %{conn: conn, user: user} do
+      user = Repo.preload(user, :account)
+      new_handle = "test#{System.unique_integer()}"
+
+      response =
+        conn
+        |> assign(:current_subject, %AuthenticatedAccount{account: user.account, scopes: ["project:admin:read"]})
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/accounts/#{user.account.name}", %{handle: new_handle})
+        |> json_response(:forbidden)
+
+      assert response["message"] == "You are not authorized to view this resource."
+    end
+
+    test "returns forbidden for project token subject", %{conn: conn, user: user} do
+      user = Repo.preload(user, :account)
+      project = project_fixture(account_id: user.account.id)
+      new_handle = "test#{System.unique_integer()}"
+
+      response =
+        conn
+        |> assign(:current_project, project)
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/accounts/#{user.account.name}", %{handle: new_handle})
+        |> json_response(:forbidden)
+
+      assert response["message"] == "You are not authorized to view this resource."
     end
 
     test "returns error when handle is invalid", %{conn: conn, user: user} do
@@ -189,6 +220,31 @@ defmodule TuistWeb.API.AccountControllerTest do
       # Then
       assert response == %{}
       assert Accounts.get_organization_by_id(organization.id) == {:error, :not_found}
+    end
+
+    test "returns forbidden for account token subject", %{conn: conn, user: user} do
+      user = Repo.preload(user, :account)
+
+      response =
+        conn
+        |> assign(:current_subject, %AuthenticatedAccount{account: user.account, scopes: ["project:admin:read"]})
+        |> delete("/api/accounts/#{user.account.name}")
+        |> json_response(:forbidden)
+
+      assert response["message"] == "The authenticated subject is not authorized to perform this action"
+    end
+
+    test "returns forbidden for project token subject", %{conn: conn, user: user} do
+      user = Repo.preload(user, :account)
+      project = project_fixture(account_id: user.account.id)
+
+      response =
+        conn
+        |> assign(:current_project, project)
+        |> delete("/api/accounts/#{user.account.name}")
+        |> json_response(:forbidden)
+
+      assert response["message"] == "The authenticated subject is not authorized to perform this action"
     end
   end
 end


### PR DESCRIPTION
## Summary
- avoid `KeyError` in `API.AccountController` by replacing direct `conn.assigns.current_user` access with `Authentication.current_user(conn)`
- keep user-authenticated account update/delete behavior unchanged
- return forbidden (instead of 500) for non-user authenticated subjects (account/project tokens)
- add regression coverage for PATCH/DELETE account endpoints with non-user subjects

## Validation
- `cd server && mix test test/tuist_web/controllers/api/account_controller_test.exs`

Refs: TUIST-BF