### PR TITLE
feat(cli): support config-driven network proxy opt-out

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -301,6 +301,7 @@ var tuistConfigLoaderTestDependencies: [Target.Dependency] = [
     "TuistConfigLoader",
     "TuistConfig",
     "TuistConstants",
+    "TuistHTTP",
     "TuistRootDirectoryLocator",
     pathDependency,
     fileSystemDependency,
@@ -908,6 +909,8 @@ var targets: [Target] = [
         name: "TuistHTTPTests",
         dependencies: [
             "TuistHTTP",
+            "TuistEnvironment",
+            "TuistEnvironmentTesting",
             mockableDependency,
         ],
         path: "cli/Tests/TuistHTTPTests"

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1537,6 +1537,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.config.targetName),
                     .target(name: Module.rootDirectoryLocator.targetName),
                     .target(name: Module.constants.targetName),
+                    .target(name: Module.http.targetName),
                     .target(name: Module.loader.targetName),
                     .target(name: Module.testing.targetName),
                     .target(name: Module.support.targetName),
@@ -1952,6 +1953,8 @@ public enum Module: String, CaseIterable {
                 [
                     .target(name: Module.testing.targetName),
                     .target(name: Module.support.targetName),
+                    .target(name: Module.environment.targetName),
+                    .target(name: Module.environmentTesting.targetName),
                     .external(name: "OpenAPIRuntime"),
                     .external(name: "HTTPTypes"),
                 ]

--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -28,6 +28,19 @@
 public typealias Config = Tuist
 
 public struct Tuist: Codable, Equatable, Sendable {
+    /// Options for configuring the HTTP behavior.
+    public struct HTTP: Codable, Equatable, Sendable {
+        /// When `true` (default), Tuist automatically uses the proxy defined by
+        /// `HTTPS_PROXY`/`HTTP_PROXY` when present in the environment.
+        public let proxy: Bool
+
+        /// Creates HTTP options.
+        /// - Parameter proxy: Whether Tuist should use the proxy defined in the environment. Defaults to `true`.
+        public static func http(proxy: Bool = true) -> Self {
+            HTTP(proxy: proxy)
+        }
+    }
+
     /// Options for configuring the Xcode Cache behavior.
     public struct Cache: Codable, Equatable, Sendable {
         /// When `true` (default), the local proxy uploads artifacts to the remote cache.
@@ -50,6 +63,9 @@ public struct Tuist: Codable, Equatable, Sendable {
 
     /// The options to use when running `tuist inspect`.
     public let inspectOptions: InspectOptions
+
+    /// The HTTP configuration.
+    public let http: HTTP
 
     /// The Xcode Cache configuration.
     public let cache: Cache
@@ -75,6 +91,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         cloud: Cloud? = nil,
         fullHandle: String? = nil,
         url: String = "https://tuist.dev",
+        http: HTTP = .http(),
         swiftVersion _: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: GenerationOptions = .options(),
@@ -96,6 +113,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         )
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.http = http
         cache = .cache()
         self.url = url
         dumpIfNeeded(self)
@@ -104,6 +122,7 @@ public struct Tuist: Codable, Equatable, Sendable {
     public init(
         fullHandle: String? = nil,
         inspectOptions: InspectOptions = .options(),
+        http: HTTP = .http(),
         cache: Cache = .cache(),
         url: String = "https://tuist.dev",
         project: TuistProject
@@ -111,6 +130,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.http = http
         self.cache = cache
         self.url = url
         dumpIfNeeded(self)

--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -28,16 +28,16 @@
 public typealias Config = Tuist
 
 public struct Tuist: Codable, Equatable, Sendable {
-    /// Options for configuring the HTTP behavior.
-    public struct HTTP: Codable, Equatable, Sendable {
+    /// Options for configuring network behavior.
+    public struct Network: Codable, Equatable, Sendable {
         /// When `true` (default), Tuist automatically uses the proxy defined by
         /// `HTTPS_PROXY`/`HTTP_PROXY` when present in the environment.
         public let proxy: Bool
 
-        /// Creates HTTP options.
+        /// Creates network options.
         /// - Parameter proxy: Whether Tuist should use the proxy defined in the environment. Defaults to `true`.
-        public static func http(proxy: Bool = true) -> Self {
-            HTTP(proxy: proxy)
+        public static func network(proxy: Bool = true) -> Self {
+            Network(proxy: proxy)
         }
     }
 
@@ -64,8 +64,8 @@ public struct Tuist: Codable, Equatable, Sendable {
     /// The options to use when running `tuist inspect`.
     public let inspectOptions: InspectOptions
 
-    /// The HTTP configuration.
-    public let http: HTTP
+    /// The network configuration.
+    public let network: Network
 
     /// The Xcode Cache configuration.
     public let cache: Cache
@@ -91,7 +91,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         cloud: Cloud? = nil,
         fullHandle: String? = nil,
         url: String = "https://tuist.dev",
-        http: HTTP = .http(),
+        network: Network = .network(),
         swiftVersion _: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: GenerationOptions = .options(),
@@ -113,7 +113,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         )
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
-        self.http = http
+        self.network = network
         cache = .cache()
         self.url = url
         dumpIfNeeded(self)
@@ -122,15 +122,15 @@ public struct Tuist: Codable, Equatable, Sendable {
     public init(
         fullHandle: String? = nil,
         inspectOptions: InspectOptions = .options(),
-        http: HTTP = .http(),
         cache: Cache = .cache(),
         url: String = "https://tuist.dev",
+        network: Network = .network(),
         project: TuistProject
     ) {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
-        self.http = http
+        self.network = network
         self.cache = cache
         self.url = url
         dumpIfNeeded(self)

--- a/cli/Sources/TuistConfig/Tuist.swift
+++ b/cli/Sources/TuistConfig/Tuist.swift
@@ -13,6 +13,14 @@ public enum TuistConfigError: LocalizedError, Equatable {
 }
 
 public struct Tuist: Equatable, Hashable, Sendable {
+    public struct HTTP: Equatable, Hashable, Sendable {
+        public let proxy: Bool
+
+        public init(proxy: Bool = true) {
+            self.proxy = proxy
+        }
+    }
+
     public struct Cache: Equatable, Hashable, Sendable {
         public let upload: Bool
 
@@ -24,6 +32,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public let project: TuistProject
     public let fullHandle: String?
     public let inspectOptions: InspectOptions
+    public let http: HTTP
     public let cache: Cache
     public let url: URL
 
@@ -32,6 +41,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: .defaultGeneratedProject(),
             fullHandle: nil,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            http: HTTP(),
             cache: Cache(),
             url: Constants.URLs.production
         )
@@ -41,12 +51,14 @@ public struct Tuist: Equatable, Hashable, Sendable {
         project: TuistProject,
         fullHandle: String?,
         inspectOptions: InspectOptions,
+        http: HTTP = HTTP(),
         cache: Cache = Cache(),
         url: URL
     ) {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.http = http
         self.cache = cache
         self.url = url
     }
@@ -54,6 +66,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(project)
         hasher.combine(fullHandle)
+        hasher.combine(http)
         hasher.combine(url)
     }
 
@@ -69,6 +82,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: TuistProject = .testGeneratedProject(),
             fullHandle: String? = nil,
             inspectOptions: InspectOptions = .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            http: HTTP = HTTP(),
             cache: Cache = Cache(),
             url: URL = Constants.URLs.production
         ) -> Self {
@@ -76,6 +90,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
                 project: project,
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
+                http: http,
                 cache: cache,
                 url: url
             )

--- a/cli/Sources/TuistConfig/Tuist.swift
+++ b/cli/Sources/TuistConfig/Tuist.swift
@@ -13,7 +13,7 @@ public enum TuistConfigError: LocalizedError, Equatable {
 }
 
 public struct Tuist: Equatable, Hashable, Sendable {
-    public struct HTTP: Equatable, Hashable, Sendable {
+    public struct Network: Equatable, Hashable, Sendable {
         public let proxy: Bool
 
         public init(proxy: Bool = true) {
@@ -32,7 +32,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public let project: TuistProject
     public let fullHandle: String?
     public let inspectOptions: InspectOptions
-    public let http: HTTP
+    public let network: Network
     public let cache: Cache
     public let url: URL
 
@@ -41,9 +41,9 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: .defaultGeneratedProject(),
             fullHandle: nil,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            http: HTTP(),
             cache: Cache(),
-            url: Constants.URLs.production
+            url: Constants.URLs.production,
+            network: Network()
         )
     }
 
@@ -51,14 +51,14 @@ public struct Tuist: Equatable, Hashable, Sendable {
         project: TuistProject,
         fullHandle: String?,
         inspectOptions: InspectOptions,
-        http: HTTP = HTTP(),
         cache: Cache = Cache(),
-        url: URL
+        url: URL,
+        network: Network = Network()
     ) {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
-        self.http = http
+        self.network = network
         self.cache = cache
         self.url = url
     }
@@ -66,7 +66,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(project)
         hasher.combine(fullHandle)
-        hasher.combine(http)
+        hasher.combine(network)
         hasher.combine(url)
     }
 
@@ -82,17 +82,17 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: TuistProject = .testGeneratedProject(),
             fullHandle: String? = nil,
             inspectOptions: InspectOptions = .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            http: HTTP = HTTP(),
             cache: Cache = Cache(),
-            url: URL = Constants.URLs.production
+            url: URL = Constants.URLs.production,
+            network: Network = Network()
         ) -> Self {
             return Tuist(
                 project: project,
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                http: http,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         }
     #endif

--- a/cli/Sources/TuistConfigLoader/ConfigLoader.swift
+++ b/cli/Sources/TuistConfigLoader/ConfigLoader.swift
@@ -65,12 +65,12 @@ public struct ConfigLoader: ConfigLoading {
             project: .defaultGeneratedProject(),
             fullHandle: tomlConfig.project,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            http: .init(proxy: tomlConfig.http?.proxy ?? true),
-            url: tomlConfig.url ?? Constants.URLs.production
+            url: tomlConfig.url ?? Constants.URLs.production,
+            network: .init(proxy: tomlConfig.http?.proxy ?? true)
         )
     }
 
     private func applyRuntimeSettings(from config: TuistConfig.Tuist) {
-        HTTPSettings.current = .init(useEnvironmentProxy: config.http.proxy)
+        HTTPSettings.current = .init(useEnvironmentProxy: config.network.proxy)
     }
 }

--- a/cli/Sources/TuistConfigLoader/ConfigLoader.swift
+++ b/cli/Sources/TuistConfigLoader/ConfigLoader.swift
@@ -66,7 +66,7 @@ public struct ConfigLoader: ConfigLoading {
             fullHandle: tomlConfig.project,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
             url: tomlConfig.url ?? Constants.URLs.production,
-            network: .init(proxy: tomlConfig.http?.proxy ?? true)
+            network: .init(proxy: tomlConfig.network?.proxy ?? true)
         )
     }
 

--- a/cli/Sources/TuistConfigLoader/ConfigLoader.swift
+++ b/cli/Sources/TuistConfigLoader/ConfigLoader.swift
@@ -5,6 +5,7 @@ import Path
 import TuistConfig
 import TuistConstants
 import TuistEnvironment
+import TuistHTTP
 
 @Mockable
 public protocol ConfigLoading: Sendable {
@@ -43,14 +44,19 @@ public struct ConfigLoader: ConfigLoading {
     public func loadConfig(path: AbsolutePath) async throws -> TuistConfig.Tuist {
         #if os(macOS)
             if let _ = try await swiftConfigLoader.locateConfig(at: path) {
-                return try await swiftConfigLoader.loadConfig(path: path)
+                let config = try await swiftConfigLoader.loadConfig(path: path)
+                applyRuntimeSettings(from: config)
+                return config
             }
         #endif
 
         if let tomlConfig = try await tomlConfigLoader.loadConfig(at: path) {
-            return configFromToml(tomlConfig)
+            let config = configFromToml(tomlConfig)
+            applyRuntimeSettings(from: config)
+            return config
         }
 
+        applyRuntimeSettings(from: .default)
         return .default
     }
 
@@ -59,7 +65,12 @@ public struct ConfigLoader: ConfigLoading {
             project: .defaultGeneratedProject(),
             fullHandle: tomlConfig.project,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            http: .init(proxy: tomlConfig.http?.proxy ?? true),
             url: tomlConfig.url ?? Constants.URLs.production
         )
+    }
+
+    private func applyRuntimeSettings(from config: TuistConfig.Tuist) {
+        HTTPSettings.current = .init(useEnvironmentProxy: config.http.proxy)
     }
 }

--- a/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
+++ b/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
@@ -2,7 +2,7 @@ import Foundation
 import TuistConfig
 
 struct TuistTomlConfig: Equatable, Sendable, Decodable {
-    struct HTTP: Equatable, Sendable, Decodable {
+    struct Network: Equatable, Sendable, Decodable {
         let proxy: Bool?
 
         init(proxy: Bool? = nil) {
@@ -12,22 +12,22 @@ struct TuistTomlConfig: Equatable, Sendable, Decodable {
 
     let project: String?
     let url: URL?
-    let http: HTTP?
+    let network: Network?
 
     init(
         project: String? = nil,
         url: URL? = nil,
-        http: HTTP? = nil
+        network: Network? = nil
     ) {
         self.project = project
         self.url = url
-        self.http = http
+        self.network = network
     }
 
     private enum CodingKeys: String, CodingKey {
         case project
         case url
-        case http
+        case network
     }
 
     init(from decoder: Decoder) throws {
@@ -45,6 +45,6 @@ struct TuistTomlConfig: Equatable, Sendable, Decodable {
         } else {
             url = nil
         }
-        http = try container.decodeIfPresent(HTTP.self, forKey: .http)
+        network = try container.decodeIfPresent(Network.self, forKey: .network)
     }
 }

--- a/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
+++ b/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
@@ -2,25 +2,37 @@ import Foundation
 import TuistConfig
 
 struct TuistTomlConfig: Equatable, Sendable, Decodable {
-    let project: String
+    struct HTTP: Equatable, Sendable, Decodable {
+        let proxy: Bool?
+
+        init(proxy: Bool? = nil) {
+            self.proxy = proxy
+        }
+    }
+
+    let project: String?
     let url: URL?
+    let http: HTTP?
 
     init(
-        project: String,
-        url: URL? = nil
+        project: String? = nil,
+        url: URL? = nil,
+        http: HTTP? = nil
     ) {
         self.project = project
         self.url = url
+        self.http = http
     }
 
     private enum CodingKeys: String, CodingKey {
         case project
         case url
+        case http
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        project = try container.decode(String.self, forKey: .project)
+        project = try container.decodeIfPresent(String.self, forKey: .project)
         if let urlString = try container.decodeIfPresent(String.self, forKey: .url) {
             guard let parsed = URL(string: urlString) else {
                 throw DecodingError.dataCorruptedError(
@@ -33,5 +45,6 @@ struct TuistTomlConfig: Equatable, Sendable, Decodable {
         } else {
             url = nil
         }
+        http = try container.decodeIfPresent(HTTP.self, forKey: .http)
     }
 }

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,4 +17,4 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
-- Shared URL sessions are reused per proxy mode, and the default proxy mode comes from runtime HTTP settings.
+- Default proxy mode comes from runtime HTTP settings, and explicit overrides are resolved when a URL session is created.

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,4 +17,4 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
-- Default proxy mode comes from runtime HTTP settings, and shared sessions are resolved lazily on first network use so config load can set the runtime defaults before HTTP clients talk to the network.
+- Default proxy mode comes from runtime HTTP settings, and the shared session is resolved lazily, reused process-wide, and invalidated when those runtime settings change.

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,4 +17,4 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
-- Default proxy mode comes from runtime HTTP settings, and explicit overrides are resolved when a URL session is created.
+- Default proxy mode comes from runtime HTTP settings, and shared sessions are resolved lazily on first network use so config load can set the runtime defaults before HTTP clients talk to the network.

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,3 +17,4 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
+- Shared URL sessions are reused per proxy mode, and the default proxy mode comes from runtime HTTP settings.

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -58,7 +58,6 @@ import Path
         // MARK: - Attributes
 
         private let session: URLSession?
-        private let deferredSharedSession: DeferredSharedURLSession
         private let fileSystem: FileSysteming
         private let successStatusCodeRange = 200 ..< 300
 
@@ -69,7 +68,6 @@ import Path
             fileSystem: FileSysteming = FileSystem()
         ) {
             self.session = session
-            deferredSharedSession = DeferredSharedURLSession()
             self.fileSystem = fileSystem
         }
 
@@ -149,7 +147,7 @@ import Path
         }
 
         private func resolvedSession() -> URLSession {
-            session ?? deferredSharedSession.resolve()
+            session ?? .tuistShared
         }
 
         // MARK: - HAR Recording

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -57,14 +57,14 @@ import Path
     public struct FileClient: FileClienting {
         // MARK: - Attributes
 
-        let session: URLSession
+        let session: URLSession?
         private let fileSystem: FileSysteming
         private let successStatusCodeRange = 200 ..< 300
 
         // MARK: - Init
 
         public init(
-            session: URLSession = .tuistShared,
+            session: URLSession? = nil,
             fileSystem: FileSysteming = FileSystem()
         ) {
             self.session = session
@@ -74,6 +74,7 @@ import Path
         // MARK: - Public
 
         public func download(url: URL) async throws -> AbsolutePath {
+            let session = session ?? .tuistShared
             let request = URLRequest(url: url)
             do {
                 let (localUrl, response) = try await session.download(for: request)
@@ -101,6 +102,7 @@ import Path
         }
 
         public func upload(file: AbsolutePath, hash _: String, to url: URL) async throws -> Bool {
+            let session = session ?? .tuistShared
             guard let metadata = try await fileSystem.fileMetadata(at: file) else {
                 throw FileClientError.noLocalURL(URLRequest(url: url))
             }

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -57,14 +57,14 @@ import Path
     public struct FileClient: FileClienting {
         // MARK: - Attributes
 
-        let session: URLSession?
+        let session: URLSession
         private let fileSystem: FileSysteming
         private let successStatusCodeRange = 200 ..< 300
 
         // MARK: - Init
 
         public init(
-            session: URLSession? = nil,
+            session: URLSession = .tuistShared,
             fileSystem: FileSysteming = FileSystem()
         ) {
             self.session = session
@@ -74,7 +74,6 @@ import Path
         // MARK: - Public
 
         public func download(url: URL) async throws -> AbsolutePath {
-            let session = session ?? .tuistShared
             let request = URLRequest(url: url)
             do {
                 let (localUrl, response) = try await session.download(for: request)
@@ -102,7 +101,6 @@ import Path
         }
 
         public func upload(file: AbsolutePath, hash _: String, to url: URL) async throws -> Bool {
-            let session = session ?? .tuistShared
             guard let metadata = try await fileSystem.fileMetadata(at: file) else {
                 throw FileClientError.noLocalURL(URLRequest(url: url))
             }

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -57,17 +57,19 @@ import Path
     public struct FileClient: FileClienting {
         // MARK: - Attributes
 
-        let session: URLSession
+        private let session: URLSession?
+        private let deferredSharedSession: DeferredSharedURLSession
         private let fileSystem: FileSysteming
         private let successStatusCodeRange = 200 ..< 300
 
         // MARK: - Init
 
         public init(
-            session: URLSession = .tuistShared,
+            session: URLSession? = nil,
             fileSystem: FileSysteming = FileSystem()
         ) {
             self.session = session
+            deferredSharedSession = DeferredSharedURLSession()
             self.fileSystem = fileSystem
         }
 
@@ -75,6 +77,7 @@ import Path
 
         public func download(url: URL) async throws -> AbsolutePath {
             let request = URLRequest(url: url)
+            let session = resolvedSession()
             do {
                 let (localUrl, response) = try await session.download(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -107,6 +110,7 @@ import Path
             let fileSize = UInt64(metadata.size)
             let fileData = try Data(contentsOf: file.url)
             let request = uploadRequest(url: url, fileSize: fileSize, data: fileData)
+            let session = resolvedSession()
             do {
                 let (_, response) = try await session.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -142,6 +146,10 @@ import Path
             request.setValue("zip", forHTTPHeaderField: "Content-Encoding")
             request.httpBody = data
             return request
+        }
+
+        private func resolvedSession() -> URLSession {
+            session ?? deferredSharedSession.resolve()
         }
 
         // MARK: - HAR Recording

--- a/cli/Sources/TuistHTTP/HTTPSettings.swift
+++ b/cli/Sources/TuistHTTP/HTTPSettings.swift
@@ -20,6 +20,7 @@ public struct HTTPSettings: Sendable {
             lock.lock()
             storedCurrent = newValue
             lock.unlock()
+            invalidateSharedTuistURLSession()
         }
     }
 }

--- a/cli/Sources/TuistHTTP/HTTPSettings.swift
+++ b/cli/Sources/TuistHTTP/HTTPSettings.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct HTTPSettings: Sendable {
+    public var useEnvironmentProxy: Bool
+
+    private static let lock = NSLock()
+    private static var storedCurrent = HTTPSettings()
+
+    public init(useEnvironmentProxy: Bool = true) {
+        self.useEnvironmentProxy = useEnvironmentProxy
+    }
+
+    public static var current: HTTPSettings {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedCurrent
+        }
+        set {
+            lock.lock()
+            storedCurrent = newValue
+            lock.unlock()
+        }
+    }
+}

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -15,9 +15,9 @@ import OpenAPIRuntime
 /// uses `data(for:delegate:)` which triggers the URLSessionTaskDelegate methods including
 /// `didFinishCollecting` for capturing detailed timing metrics.
 public struct TuistURLSessionTransport: ClientTransport {
-    private let session: URLSession
+    private let session: URLSession?
 
-    public init(session: URLSession = .tuistShared) {
+    public init(session: URLSession? = nil) {
         self.session = session
     }
 
@@ -27,6 +27,7 @@ public struct TuistURLSessionTransport: ClientTransport {
         baseURL: URL,
         operationID _: String
     ) async throws -> (HTTPResponse, HTTPBody?) {
+        let session = session ?? .tuistShared
         let urlRequest = try await buildURLRequest(from: request, body: body, baseURL: baseURL)
 
         #if canImport(TuistHAR)

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -16,11 +16,9 @@ import OpenAPIRuntime
 /// `didFinishCollecting` for capturing detailed timing metrics.
 public struct TuistURLSessionTransport: ClientTransport {
     private let session: URLSession?
-    private let deferredSharedSession: DeferredSharedURLSession
 
     public init(session: URLSession? = nil) {
         self.session = session
-        deferredSharedSession = DeferredSharedURLSession()
     }
 
     public func send(
@@ -60,7 +58,7 @@ public struct TuistURLSessionTransport: ClientTransport {
     }
 
     private func resolvedSession() -> URLSession {
-        session ?? deferredSharedSession.resolve()
+        session ?? .tuistShared
     }
 
     private func buildURLRequest(from request: HTTPRequest, body: HTTPBody?, baseURL: URL) async throws -> URLRequest {

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -15,10 +15,12 @@ import OpenAPIRuntime
 /// uses `data(for:delegate:)` which triggers the URLSessionTaskDelegate methods including
 /// `didFinishCollecting` for capturing detailed timing metrics.
 public struct TuistURLSessionTransport: ClientTransport {
-    private let session: URLSession
+    private let session: URLSession?
+    private let deferredSharedSession: DeferredSharedURLSession
 
-    public init(session: URLSession = .tuistShared) {
+    public init(session: URLSession? = nil) {
         self.session = session
+        deferredSharedSession = DeferredSharedURLSession()
     }
 
     public func send(
@@ -28,6 +30,7 @@ public struct TuistURLSessionTransport: ClientTransport {
         operationID _: String
     ) async throws -> (HTTPResponse, HTTPBody?) {
         let urlRequest = try await buildURLRequest(from: request, body: body, baseURL: baseURL)
+        let session = resolvedSession()
 
         #if canImport(TuistHAR)
             let metricsDelegate = TaskMetricsDelegate()
@@ -54,6 +57,10 @@ public struct TuistURLSessionTransport: ClientTransport {
         let responseBody: HTTPBody? = data.isEmpty ? nil : HTTPBody(data)
 
         return (httpResponseObj, responseBody)
+    }
+
+    private func resolvedSession() -> URLSession {
+        session ?? deferredSharedSession.resolve()
     }
 
     private func buildURLRequest(from request: HTTPRequest, body: HTTPBody?, baseURL: URL) async throws -> URLRequest {

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -15,9 +15,9 @@ import OpenAPIRuntime
 /// uses `data(for:delegate:)` which triggers the URLSessionTaskDelegate methods including
 /// `didFinishCollecting` for capturing detailed timing metrics.
 public struct TuistURLSessionTransport: ClientTransport {
-    private let session: URLSession?
+    private let session: URLSession
 
-    public init(session: URLSession? = nil) {
+    public init(session: URLSession = .tuistShared) {
         self.session = session
     }
 
@@ -27,7 +27,6 @@ public struct TuistURLSessionTransport: ClientTransport {
         baseURL: URL,
         operationID _: String
     ) async throws -> (HTTPResponse, HTTPBody?) {
-        let session = session ?? .tuistShared
         let urlRequest = try await buildURLRequest(from: request, body: body, baseURL: baseURL)
 
         #if canImport(TuistHAR)

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -60,27 +60,49 @@ private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
     #endif
 }
 
-final class DeferredSharedURLSession: @unchecked Sendable {
+private final class SharedTuistURLSession: @unchecked Sendable {
     private let lock = NSLock()
+    private var useEnvironmentProxy: Bool?
     private var session: URLSession?
 
-    func resolve() -> URLSession {
+    func resolve(useEnvironmentProxy: Bool) -> URLSession {
+        let sessionToInvalidate: URLSession?
         lock.lock()
-        defer { lock.unlock() }
 
-        if let session {
+        if let session, self.useEnvironmentProxy == useEnvironmentProxy {
+            lock.unlock()
             return session
         }
 
-        let session = URLSession.tuistShared
+        sessionToInvalidate = session
+        let session = makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
+        self.useEnvironmentProxy = useEnvironmentProxy
         self.session = session
+        lock.unlock()
+        sessionToInvalidate?.invalidateAndCancel()
         return session
     }
+
+    func invalidate() {
+        let sessionToInvalidate: URLSession?
+        lock.lock()
+        useEnvironmentProxy = nil
+        sessionToInvalidate = session
+        session = nil
+        lock.unlock()
+        sessionToInvalidate?.invalidateAndCancel()
+    }
+}
+
+private let sharedTuistURLSession = SharedTuistURLSession()
+
+func invalidateSharedTuistURLSession() {
+    sharedTuistURLSession.invalidate()
 }
 
 extension URLSession {
     public static var tuistShared: URLSession {
-        makeTuistURLSession(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
+        sharedTuistURLSession.resolve(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
     }
 
     public static func tuistShared(useEnvironmentProxy: Bool) -> URLSession {

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -8,8 +8,6 @@ import TuistEnvironment
     import TuistHAR
 #endif
 
-private let _tuistURLSession: URLSession = makeTuistURLSession()
-
 private func environmentProxyURL() -> URL? {
     let environment = Environment.current.variables
     let candidates = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]
@@ -21,7 +19,33 @@ private func environmentProxyURL() -> URL? {
     return nil
 }
 
-public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
+private func resolvedUseEnvironmentProxy(_ useEnvironmentProxy: Bool?) -> Bool {
+    useEnvironmentProxy ?? HTTPSettings.current.useEnvironmentProxy
+}
+
+private enum TuistURLSessionCache {
+    private static let lock = NSLock()
+    private static var sessions: [Bool: URLSession] = [:]
+
+    static func session(useEnvironmentProxy: Bool) -> URLSession {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let session = sessions[useEnvironmentProxy] {
+            return session
+        }
+
+        let session = makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
+        sessions[useEnvironmentProxy] = session
+        return session
+    }
+}
+
+public func tuistURLSessionConfiguration(useEnvironmentProxy: Bool? = nil) -> URLSessionConfiguration {
+    tuistURLSessionConfigurationResolved(useEnvironmentProxy: resolvedUseEnvironmentProxy(useEnvironmentProxy))
+}
+
+private func tuistURLSessionConfigurationResolved(useEnvironmentProxy: Bool) -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
     configuration.timeoutIntervalForRequest = 120
     configuration.timeoutIntervalForResource = 300
@@ -32,28 +56,35 @@ public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
         configuration.allowsExpensiveNetworkAccess = true
     #endif
     #if os(macOS)
-        if let proxyURL = environmentProxyURL(), let dictionary = proxyDictionary(for: proxyURL) {
+        if useEnvironmentProxy,
+           let proxyURL = environmentProxyURL(),
+           let dictionary = proxyDictionary(for: proxyURL)
+        {
             configuration.connectionProxyDictionary = dictionary
         }
     #endif
     return configuration
 }
 
-private func makeTuistURLSession() -> URLSession {
+private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
     #if canImport(TuistHAR)
         return URLSession(
-            configuration: tuistURLSessionConfiguration(),
+            configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy),
             delegate: URLSessionMetricsDelegate.shared,
             delegateQueue: nil
         )
     #else
-        return URLSession(configuration: tuistURLSessionConfiguration())
+        return URLSession(configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy))
     #endif
 }
 
 extension URLSession {
     public static var tuistShared: URLSession {
-        _tuistURLSession
+        TuistURLSessionCache.session(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
+    }
+
+    public static func tuistShared(useEnvironmentProxy: Bool) -> URLSession {
+        TuistURLSessionCache.session(useEnvironmentProxy: useEnvironmentProxy)
     }
 }
 

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -60,6 +60,24 @@ private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
     #endif
 }
 
+final class DeferredSharedURLSession: @unchecked Sendable {
+    private let lock = NSLock()
+    private var session: URLSession?
+
+    func resolve() -> URLSession {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let session {
+            return session
+        }
+
+        let session = URLSession.tuistShared
+        self.session = session
+        return session
+    }
+}
+
 extension URLSession {
     public static var tuistShared: URLSession {
         makeTuistURLSession(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -23,24 +23,6 @@ private func resolvedUseEnvironmentProxy(_ useEnvironmentProxy: Bool?) -> Bool {
     useEnvironmentProxy ?? HTTPSettings.current.useEnvironmentProxy
 }
 
-private enum TuistURLSessionCache {
-    private static let lock = NSLock()
-    private static var sessions: [Bool: URLSession] = [:]
-
-    static func session(useEnvironmentProxy: Bool) -> URLSession {
-        lock.lock()
-        defer { lock.unlock() }
-
-        if let session = sessions[useEnvironmentProxy] {
-            return session
-        }
-
-        let session = makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
-        sessions[useEnvironmentProxy] = session
-        return session
-    }
-}
-
 public func tuistURLSessionConfiguration(useEnvironmentProxy: Bool? = nil) -> URLSessionConfiguration {
     tuistURLSessionConfigurationResolved(useEnvironmentProxy: resolvedUseEnvironmentProxy(useEnvironmentProxy))
 }
@@ -80,11 +62,11 @@ private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
 
 extension URLSession {
     public static var tuistShared: URLSession {
-        TuistURLSessionCache.session(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
+        makeTuistURLSession(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
     }
 
     public static func tuistShared(useEnvironmentProxy: Bool) -> URLSession {
-        TuistURLSessionCache.session(useEnvironmentProxy: useEnvironmentProxy)
+        makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
     }
 }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -38,6 +38,7 @@ extension TuistConfig.Tuist {
     ) async throws -> TuistConfig.Tuist {
         let fullHandle = manifest.fullHandle
         let inspectOptions = InspectOptions.from(manifest: manifest.inspectOptions)
+        let http = TuistConfig.Tuist.HTTP(proxy: manifest.http.proxy)
         let cache = TuistConfig.Tuist.Cache(upload: manifest.cache.upload)
         let urlString = manifest.url
 
@@ -80,6 +81,7 @@ extension TuistConfig.Tuist {
                 ),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
+                http: http,
                 cache: cache,
                 url: url
             )
@@ -88,6 +90,7 @@ extension TuistConfig.Tuist {
                 project: .xcode(TuistXcodeProjectOptions()),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
+                http: http,
                 cache: cache,
                 url: url
             )

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -38,7 +38,7 @@ extension TuistConfig.Tuist {
     ) async throws -> TuistConfig.Tuist {
         let fullHandle = manifest.fullHandle
         let inspectOptions = InspectOptions.from(manifest: manifest.inspectOptions)
-        let http = TuistConfig.Tuist.HTTP(proxy: manifest.http.proxy)
+        let network = TuistConfig.Tuist.Network(proxy: manifest.network.proxy)
         let cache = TuistConfig.Tuist.Cache(upload: manifest.cache.upload)
         let urlString = manifest.url
 
@@ -81,18 +81,18 @@ extension TuistConfig.Tuist {
                 ),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                http: http,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         case .xcode:
             return TuistConfig.Tuist(
                 project: .xcode(TuistXcodeProjectOptions()),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                http: http,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         }
     }

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -9,14 +9,14 @@ import TuistSupport
         public static func test(
             fullHandle: String? = nil,
             url: String = Constants.URLs.production.absoluteString,
-            http: Config.HTTP = .http(),
+            network: Config.Network = .network(),
             generationOptions: Config.GenerationOptions = .options(),
             plugins: [PluginLocation] = []
         ) -> Config {
             Config(
                 fullHandle: fullHandle,
                 url: url,
-                http: http,
+                network: network,
                 plugins: plugins,
                 generationOptions: generationOptions
             )

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -9,12 +9,14 @@ import TuistSupport
         public static func test(
             fullHandle: String? = nil,
             url: String = Constants.URLs.production.absoluteString,
+            http: Config.HTTP = .http(),
             generationOptions: Config.GenerationOptions = .options(),
             plugins: [PluginLocation] = []
         ) -> Config {
             Config(
                 fullHandle: fullHandle,
                 url: url,
+                http: http,
                 plugins: plugins,
                 generationOptions: generationOptions
             )

--- a/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
@@ -46,12 +46,12 @@ enum CreateTestCaseRunAttachmentServiceError: LocalizedError {
 public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentServicing {
     private let fileSystem: FileSystem
     private let fullHandleService: FullHandleServicing
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init(
         fileSystem: FileSystem = FileSystem(),
         fullHandleService: FullHandleServicing = FullHandleService(),
-        urlSession: URLSession = .tuistShared
+        urlSession: URLSession? = nil
     ) {
         self.fileSystem = fileSystem
         self.fullHandleService = fullHandleService
@@ -69,6 +69,7 @@ public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentSer
     ) async throws -> String {
         let client = Client.authenticated(serverURL: serverURL)
         let handles = try fullHandleService.parse(fullHandle)
+        let urlSession = urlSession ?? .tuistShared
 
         let response = try await client.createTestCaseRunAttachment(
             .init(

--- a/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
@@ -46,12 +46,12 @@ enum CreateTestCaseRunAttachmentServiceError: LocalizedError {
 public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentServicing {
     private let fileSystem: FileSystem
     private let fullHandleService: FullHandleServicing
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init(
         fileSystem: FileSystem = FileSystem(),
         fullHandleService: FullHandleServicing = FullHandleService(),
-        urlSession: URLSession = .tuistShared
+        urlSession: URLSession? = nil
     ) {
         self.fileSystem = fileSystem
         self.fullHandleService = fullHandleService
@@ -99,6 +99,7 @@ public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentSer
                 request.setValue(Self.contentType(for: fileName), forHTTPHeaderField: "Content-Type")
                 request.httpBody = try await fileSystem.readFile(at: filePath)
 
+                let urlSession = urlSession ?? .tuistShared
                 let (_, uploadResponse) = try await urlSession.data(for: request)
                 guard let httpResponse = uploadResponse as? HTTPURLResponse,
                       (200 ..< 300).contains(httpResponse.statusCode)

--- a/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
@@ -46,12 +46,12 @@ enum CreateTestCaseRunAttachmentServiceError: LocalizedError {
 public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentServicing {
     private let fileSystem: FileSystem
     private let fullHandleService: FullHandleServicing
-    private let urlSession: URLSession?
+    private let urlSession: URLSession
 
     public init(
         fileSystem: FileSystem = FileSystem(),
         fullHandleService: FullHandleServicing = FullHandleService(),
-        urlSession: URLSession? = nil
+        urlSession: URLSession = .tuistShared
     ) {
         self.fileSystem = fileSystem
         self.fullHandleService = fullHandleService
@@ -69,7 +69,6 @@ public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentSer
     ) async throws -> String {
         let client = Client.authenticated(serverURL: serverURL)
         let handles = try fullHandleService.parse(fullHandle)
-        let urlSession = urlSession ?? .tuistShared
 
         let response = try await client.createTestCaseRunAttachment(
             .init(

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -61,12 +61,12 @@ public protocol MultipartUploadArtifactServicing {
 }
 
 public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
     private let fileSystem: FileSysteming
     private let retryProvider: RetryProviding
 
     public init(
-        urlSession: URLSession = .tuistShared,
+        urlSession: URLSession? = nil,
         fileSystem: FileSysteming = FileSystem(),
         retryProvider: RetryProviding = RetryProvider()
     ) {
@@ -132,6 +132,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     }
 
     private func upload(for request: URLRequest) async throws -> String {
+        let urlSession = urlSession ?? .tuistShared
         let (data, response) = try await urlSession.data(for: request)
         guard let urlResponse = response as? HTTPURLResponse else {
             throw MultipartUploadArtifactServiceError.noURLResponse(request.url)

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -60,12 +60,12 @@ public protocol MultipartUploadArtifactServicing {
 }
 
 public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
     private let fileSystem: FileSysteming
     private let retryProvider: RetryProviding
 
     public init(
-        urlSession: URLSession = .tuistShared,
+        urlSession: URLSession? = nil,
         fileSystem: FileSysteming = FileSystem(),
         retryProvider: RetryProviding = RetryProvider()
     ) {
@@ -79,6 +79,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
         generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
         updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)] {
+        let urlSession = urlSession ?? .tuistShared
         let partSize = 10 * 1024 * 1024
         guard let inputStream = InputStream(url: URL(fileURLWithPath: artifactPath.pathString)) else {
             throw MultipartUploadArtifactServiceError.cannotCreateInputStream(artifactPath)
@@ -115,7 +116,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
                             }
 
                             let request = uploadRequest(url: url, fileSize: UInt64(bytesRead), data: partData)
-                            let etag = try await upload(for: request)
+                            let etag = try await upload(for: request, urlSession: urlSession)
                             uploadedParts.mutate { $0.append((etag: etag, partNumber: currentPartNumber)) }
                             updateProgress(Double(uploadedParts.value.count) / Double(numberOfParts))
                         }
@@ -130,7 +131,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
             .sorted(by: { $0.partNumber < $1.partNumber })
     }
 
-    private func upload(for request: URLRequest) async throws -> String {
+    private func upload(for request: URLRequest, urlSession: URLSession) async throws -> String {
         let (data, response) = try await urlSession.data(for: request)
         guard let urlResponse = response as? HTTPURLResponse else {
             throw MultipartUploadArtifactServiceError.noURLResponse(request.url)

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -5,6 +5,7 @@ import FileSystem
 import Foundation
 import Mockable
 import Path
+import TuistHTTP
 import TuistThreadSafe
 
 public struct MultipartUploadArtifactPart {
@@ -60,12 +61,12 @@ public protocol MultipartUploadArtifactServicing {
 }
 
 public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
-    private let urlSession: URLSession?
+    private let urlSession: URLSession
     private let fileSystem: FileSysteming
     private let retryProvider: RetryProviding
 
     public init(
-        urlSession: URLSession? = nil,
+        urlSession: URLSession = .tuistShared,
         fileSystem: FileSysteming = FileSystem(),
         retryProvider: RetryProviding = RetryProvider()
     ) {
@@ -79,7 +80,6 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
         generateUploadURL: @escaping (MultipartUploadArtifactPart) async throws -> String,
         updateProgress: @escaping (Double) -> Void
     ) async throws -> [(etag: String, partNumber: Int)] {
-        let urlSession = urlSession ?? .tuistShared
         let partSize = 10 * 1024 * 1024
         guard let inputStream = InputStream(url: URL(fileURLWithPath: artifactPath.pathString)) else {
             throw MultipartUploadArtifactServiceError.cannotCreateInputStream(artifactPath)
@@ -116,7 +116,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
                             }
 
                             let request = uploadRequest(url: url, fileSize: UInt64(bytesRead), data: partData)
-                            let etag = try await upload(for: request, urlSession: urlSession)
+                            let etag = try await upload(for: request)
                             uploadedParts.mutate { $0.append((etag: etag, partNumber: currentPartNumber)) }
                             updateProgress(Double(uploadedParts.value.count) / Double(numberOfParts))
                         }
@@ -131,7 +131,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
             .sorted(by: { $0.partNumber < $1.partNumber })
     }
 
-    private func upload(for request: URLRequest, urlSession: URLSession) async throws -> String {
+    private func upload(for request: URLRequest) async throws -> String {
         let (data, response) = try await urlSession.data(for: request)
         guard let urlResponse = response as? HTTPURLResponse else {
             throw MultipartUploadArtifactServiceError.noURLResponse(request.url)

--- a/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
+++ b/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
@@ -40,20 +40,20 @@ enum UploadPreviewIconServiceError: LocalizedError {
 public struct UploadPreviewIconService: UploadPreviewIconServicing {
     private let fullHandleService: FullHandleServicing
     private let fileSystem: FileSysteming
-    private let urlSession: URLSession?
+    private let urlSession: URLSession
 
     public init() {
         self.init(
             fullHandleService: FullHandleService(),
             fileSystem: FileSystem(),
-            urlSession: nil
+            urlSession: .tuistShared
         )
     }
 
     init(
         fullHandleService: FullHandleServicing,
         fileSystem: FileSysteming,
-        urlSession: URLSession?
+        urlSession: URLSession
     ) {
         self.fullHandleService = fullHandleService
         self.fileSystem = fileSystem
@@ -67,7 +67,6 @@ public struct UploadPreviewIconService: UploadPreviewIconServicing {
         fullHandle: String
     ) async throws {
         let client = Client.authenticated(serverURL: serverURL)
-        let urlSession = urlSession ?? .tuistShared
 
         let handles = try fullHandleService.parse(fullHandle)
 

--- a/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
+++ b/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
@@ -40,20 +40,20 @@ enum UploadPreviewIconServiceError: LocalizedError {
 public struct UploadPreviewIconService: UploadPreviewIconServicing {
     private let fullHandleService: FullHandleServicing
     private let fileSystem: FileSysteming
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init() {
         self.init(
             fullHandleService: FullHandleService(),
             fileSystem: FileSystem(),
-            urlSession: .tuistShared
+            urlSession: nil
         )
     }
 
     init(
         fullHandleService: FullHandleServicing,
         fileSystem: FileSysteming,
-        urlSession: URLSession
+        urlSession: URLSession? = nil
     ) {
         self.fullHandleService = fullHandleService
         self.fileSystem = fileSystem
@@ -86,6 +86,7 @@ public struct UploadPreviewIconService: UploadPreviewIconServicing {
                 let data = try await fileSystem.readFile(at: icon)
                 let fileSize = try await fileSystem.fileSizeInBytes(at: icon)
                 guard let url = URL(string: json.url) else { fatalError() }
+                let urlSession = urlSession ?? .tuistShared
                 let (_, response) = try await urlSession.data(
                     for: uploadRequest(
                         url: url,

--- a/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
+++ b/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
@@ -40,20 +40,20 @@ enum UploadPreviewIconServiceError: LocalizedError {
 public struct UploadPreviewIconService: UploadPreviewIconServicing {
     private let fullHandleService: FullHandleServicing
     private let fileSystem: FileSysteming
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init() {
         self.init(
             fullHandleService: FullHandleService(),
             fileSystem: FileSystem(),
-            urlSession: .tuistShared
+            urlSession: nil
         )
     }
 
     init(
         fullHandleService: FullHandleServicing,
         fileSystem: FileSysteming,
-        urlSession: URLSession
+        urlSession: URLSession?
     ) {
         self.fullHandleService = fullHandleService
         self.fileSystem = fileSystem
@@ -67,6 +67,7 @@ public struct UploadPreviewIconService: UploadPreviewIconServicing {
         fullHandle: String
     ) async throws {
         let client = Client.authenticated(serverURL: serverURL)
+        let urlSession = urlSession ?? .tuistShared
 
         let handles = try fullHandleService.parse(fullHandle)
 

--- a/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
@@ -24,7 +24,7 @@ struct ConfigLoaderTests {
             .willReturn(TuistTomlConfig(
                 project: "tuist/tuist",
                 url: URL(string: "https://custom.tuist.dev")!,
-                http: .init(proxy: false)
+                network: .init(proxy: false)
             ))
 
         let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
@@ -59,7 +59,7 @@ struct ConfigLoaderTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func loadConfig_returns_toml_http_config_without_project() async throws {
+    func loadConfig_returns_toml_network_config_without_project() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlConfigLoader = MockTuistTomlConfigLoading()
         let previousSettings = HTTPSettings.current
@@ -67,7 +67,7 @@ struct ConfigLoaderTests {
 
         given(tomlConfigLoader)
             .loadConfig(at: .any)
-            .willReturn(TuistTomlConfig(http: .init(proxy: false)))
+            .willReturn(TuistTomlConfig(network: .init(proxy: false)))
 
         let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
 

--- a/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
@@ -33,7 +33,7 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "tuist/tuist")
         #expect(config.url == URL(string: "https://custom.tuist.dev")!)
-        #expect(config.http.proxy == false)
+        #expect(config.network.proxy == false)
         #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
@@ -54,7 +54,7 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "org/project")
         #expect(config.url == Constants.URLs.production)
-        #expect(config.http.proxy == true)
+        #expect(config.network.proxy == true)
         #expect(HTTPSettings.current.useEnvironmentProxy == true)
     }
 
@@ -75,7 +75,7 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == nil)
         #expect(config.url == Constants.URLs.production)
-        #expect(config.http.proxy == false)
+        #expect(config.network.proxy == false)
         #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 

--- a/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
@@ -6,18 +6,26 @@ import Path
 import Testing
 import TuistConfig
 import TuistConstants
+import TuistHTTP
 
 @testable import TuistConfigLoader
 
+@Suite(.serialized)
 struct ConfigLoaderTests {
     @Test(.inTemporaryDirectory)
     func loadConfig_returns_toml_config_when_toml_exists() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
 
         given(tomlConfigLoader)
             .loadConfig(at: .any)
-            .willReturn(TuistTomlConfig(project: "tuist/tuist", url: URL(string: "https://custom.tuist.dev")!))
+            .willReturn(TuistTomlConfig(
+                project: "tuist/tuist",
+                url: URL(string: "https://custom.tuist.dev")!,
+                http: .init(proxy: false)
+            ))
 
         let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
 
@@ -25,12 +33,16 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "tuist/tuist")
         #expect(config.url == URL(string: "https://custom.tuist.dev")!)
+        #expect(config.http.proxy == false)
+        #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
     @Test(.inTemporaryDirectory)
     func loadConfig_uses_production_url_when_toml_has_no_url() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
 
         given(tomlConfigLoader)
             .loadConfig(at: .any)
@@ -42,6 +54,29 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "org/project")
         #expect(config.url == Constants.URLs.production)
+        #expect(config.http.proxy == true)
+        #expect(HTTPSettings.current.useEnvironmentProxy == true)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func loadConfig_returns_toml_http_config_without_project() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
+
+        given(tomlConfigLoader)
+            .loadConfig(at: .any)
+            .willReturn(TuistTomlConfig(http: .init(proxy: false)))
+
+        let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
+
+        let config = try await subject.loadConfig(path: temporaryDirectory)
+
+        #expect(config.fullHandle == nil)
+        #expect(config.url == Constants.URLs.production)
+        #expect(config.http.proxy == false)
+        #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
     private func makeConfigLoader(tomlConfigLoader: TuistTomlConfigLoading) -> ConfigLoader {

--- a/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
@@ -181,7 +181,7 @@
                 .test(
                     fullHandle: "tuist/tuist",
                     url: "https://test.tuist.io",
-                    http: .http(proxy: false)
+                    network: .network(proxy: false)
                 ),
                 at: configPath.parentDirectory
             )
@@ -203,8 +203,8 @@
                 )),
                 fullHandle: "tuist/tuist",
                 inspectOptions: .test(),
-                http: .init(proxy: false),
-                url: expectedURL
+                url: expectedURL,
+                network: .init(proxy: false)
             ))
         }
 

--- a/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
@@ -180,7 +180,8 @@
             stubConfig(
                 .test(
                     fullHandle: "tuist/tuist",
-                    url: "https://test.tuist.io"
+                    url: "https://test.tuist.io",
+                    http: .http(proxy: false)
                 ),
                 at: configPath.parentDirectory
             )
@@ -202,6 +203,7 @@
                 )),
                 fullHandle: "tuist/tuist",
                 inspectOptions: .test(),
+                http: .init(proxy: false),
                 url: expectedURL
             ))
         }

--- a/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
@@ -20,6 +20,9 @@ struct TuistTomlConfigLoaderTests {
             """
             project = "tuist/tuist"
             url = "https://custom.tuist.dev"
+
+            [http]
+            proxy = false
             """,
             at: tomlPath
         )
@@ -35,6 +38,7 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "tuist/tuist")
         #expect(config?.url == URL(string: "https://custom.tuist.dev")!)
+        #expect(config?.http?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)
@@ -59,6 +63,33 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "org/project")
         #expect(config?.url == nil)
+        #expect(config?.http == nil)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func loadConfig_returns_config_with_http_only() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlPath = temporaryDirectory.appending(component: Constants.tuistTomlFileName)
+        try await fileSystem.writeText(
+            """
+            [http]
+            proxy = false
+            """,
+            at: tomlPath
+        )
+
+        let rootDirectoryLocator = MockRootDirectoryLocating()
+        given(rootDirectoryLocator).locate(from: .any).willReturn(temporaryDirectory)
+
+        let subject = TuistTomlConfigLoader(
+            fileSystem: fileSystem,
+            rootDirectoryLocator: rootDirectoryLocator
+        )
+        let config = try await subject.loadConfig(at: temporaryDirectory)
+
+        #expect(config?.project == nil)
+        #expect(config?.url == nil)
+        #expect(config?.http?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
@@ -21,7 +21,7 @@ struct TuistTomlConfigLoaderTests {
             project = "tuist/tuist"
             url = "https://custom.tuist.dev"
 
-            [http]
+            [network]
             proxy = false
             """,
             at: tomlPath
@@ -38,7 +38,7 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "tuist/tuist")
         #expect(config?.url == URL(string: "https://custom.tuist.dev")!)
-        #expect(config?.http?.proxy == false)
+        #expect(config?.network?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)
@@ -63,16 +63,16 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "org/project")
         #expect(config?.url == nil)
-        #expect(config?.http == nil)
+        #expect(config?.network == nil)
     }
 
     @Test(.inTemporaryDirectory)
-    func loadConfig_returns_config_with_http_only() async throws {
+    func loadConfig_returns_config_with_network_only() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlPath = temporaryDirectory.appending(component: Constants.tuistTomlFileName)
         try await fileSystem.writeText(
             """
-            [http]
+            [network]
             proxy = false
             """,
             at: tomlPath
@@ -89,7 +89,7 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == nil)
         #expect(config?.url == nil)
-        #expect(config?.http?.proxy == false)
+        #expect(config?.network?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -63,5 +63,41 @@
                     == "proxy.tuist.dev"
             )
         }
+
+        @Test(.withMockedEnvironment())
+        func deferredSharedURLSession_resolves_runtime_settings_on_first_use() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            defer { HTTPSettings.current = previousSettings }
+
+            let deferredSession = DeferredSharedURLSession()
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+
+            let resolvedSession = deferredSession.resolve()
+
+            #expect(resolvedSession.configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test(.withMockedEnvironment())
+        func deferredSharedURLSession_reuses_the_first_resolved_session() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            defer { HTTPSettings.current = previousSettings }
+
+            let deferredSession = DeferredSharedURLSession()
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            let firstSession = deferredSession.resolve()
+
+            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            let secondSession = deferredSession.resolve()
+
+            #expect(firstSession === secondSession)
+            #expect(secondSession.configuration.connectionProxyDictionary == nil)
+        }
     }
 #endif

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -45,19 +45,23 @@
             #expect(configuration.connectionProxyDictionary == nil)
         }
 
-        @Test
-        func tuistShared_reuses_sessions_per_proxy_mode() async {
+        @Test(.withMockedEnvironment())
+        func tuistShared_resolves_proxy_mode_from_runtime_settings() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
             let previousSettings = HTTPSettings.current
             HTTPSettings.current = .init(useEnvironmentProxy: false)
             defer { HTTPSettings.current = previousSettings }
 
-            let proxied = URLSession.tuistShared(useEnvironmentProxy: true)
-            let nonProxied = URLSession.tuistShared(useEnvironmentProxy: false)
-            let defaultNonProxied = URLSession.tuistShared
+            let defaultSession = URLSession.tuistShared
+            let explicitProxiedSession = URLSession.tuistShared(useEnvironmentProxy: true)
 
-            #expect(ObjectIdentifier(proxied) == ObjectIdentifier(URLSession.tuistShared(useEnvironmentProxy: true)))
-            #expect(ObjectIdentifier(nonProxied) == ObjectIdentifier(defaultNonProxied))
-            #expect(ObjectIdentifier(proxied) != ObjectIdentifier(nonProxied))
+            #expect(defaultSession.configuration.connectionProxyDictionary == nil)
+            #expect(
+                explicitProxiedSession.configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+                    == "proxy.tuist.dev"
+            )
         }
     }
 #endif

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -65,39 +65,41 @@
         }
 
         @Test(.withMockedEnvironment())
-        func deferredSharedURLSession_resolves_runtime_settings_on_first_use() async throws {
+        func tuistShared_reuses_the_process_shared_session() async throws {
             let environment = try #require(Environment.mocked)
             environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
 
             let previousSettings = HTTPSettings.current
-            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
             defer { HTTPSettings.current = previousSettings }
 
-            let deferredSession = DeferredSharedURLSession()
-            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            let firstSession = URLSession.tuistShared
+            let secondSession = URLSession.tuistShared
 
-            let resolvedSession = deferredSession.resolve()
-
-            #expect(resolvedSession.configuration.connectionProxyDictionary == nil)
+            #expect(firstSession === secondSession)
+            #expect(firstSession.configuration.connectionProxyDictionary == nil)
         }
 
         @Test(.withMockedEnvironment())
-        func deferredSharedURLSession_reuses_the_first_resolved_session() async throws {
+        func tuistShared_recreates_the_shared_session_when_runtime_settings_change() async throws {
             let environment = try #require(Environment.mocked)
             environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
 
             let previousSettings = HTTPSettings.current
             defer { HTTPSettings.current = previousSettings }
 
-            let deferredSession = DeferredSharedURLSession()
             HTTPSettings.current = .init(useEnvironmentProxy: false)
-            let firstSession = deferredSession.resolve()
+            let firstSession = URLSession.tuistShared
 
             HTTPSettings.current = .init(useEnvironmentProxy: true)
-            let secondSession = deferredSession.resolve()
+            let secondSession = URLSession.tuistShared
 
-            #expect(firstSession === secondSession)
-            #expect(secondSession.configuration.connectionProxyDictionary == nil)
+            #expect(firstSession !== secondSession)
+            #expect(firstSession.configuration.connectionProxyDictionary == nil)
+            #expect(
+                secondSession.configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+                    == "proxy.tuist.dev"
+            )
         }
     }
 #endif

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -1,0 +1,63 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+    import TuistEnvironment
+    import TuistEnvironmentTesting
+
+    @testable import TuistHTTP
+
+    @Suite(.serialized)
+    struct URLSessionTuistTests {
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_uses_environment_proxy_when_enabled() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let configuration = tuistURLSessionConfiguration(useEnvironmentProxy: true)
+            let proxyHost = configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+            let proxyPort = configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPPort as String] as? Int
+
+            #expect(proxyHost == "proxy.tuist.dev")
+            #expect(proxyPort == 8080)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_skips_environment_proxy_when_disabled() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let configuration = tuistURLSessionConfiguration(useEnvironmentProxy: false)
+
+            #expect(configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_uses_current_http_settings_by_default() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            defer { HTTPSettings.current = previousSettings }
+
+            let configuration = tuistURLSessionConfiguration()
+
+            #expect(configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test
+        func tuistShared_reuses_sessions_per_proxy_mode() async {
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            defer { HTTPSettings.current = previousSettings }
+
+            let proxied = URLSession.tuistShared(useEnvironmentProxy: true)
+            let nonProxied = URLSession.tuistShared(useEnvironmentProxy: false)
+            let defaultNonProxied = URLSession.tuistShared
+
+            #expect(ObjectIdentifier(proxied) == ObjectIdentifier(URLSession.tuistShared(useEnvironmentProxy: true)))
+            #expect(ObjectIdentifier(nonProxied) == ObjectIdentifier(defaultNonProxied))
+            #expect(ObjectIdentifier(proxied) != ObjectIdentifier(nonProxied))
+        }
+    }
+#endif

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -195,6 +195,9 @@ final class DumpServiceTests: TuistTestCase {
                   ]
                 }
               },
+              "network": {
+                "proxy": true
+              },
               "project": {
                 "tuist": {
                   "cacheOptions": {

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -91,3 +91,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+}

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
@@ -7,10 +7,10 @@ import java.io.File
 data class TomlConfig(
     val project: String?,
     val url: String?,
-    val http: TomlHttpConfig?
+    val network: TomlNetworkConfig?
 )
 
-data class TomlHttpConfig(
+data class TomlNetworkConfig(
     val proxy: Boolean?
 )
 
@@ -29,7 +29,7 @@ object TomlParser {
             TomlConfig(
                 project = result.getString("project"),
                 url = result.getString("url"),
-                http = result.getBoolean("http.proxy")?.let { TomlHttpConfig(proxy = it) }
+                network = result.getBoolean("network.proxy")?.let { TomlNetworkConfig(proxy = it) }
             )
         } catch (e: Exception) {
             logger.warn("Tuist: Failed to parse {}: {}", file, e.message)
@@ -44,7 +44,7 @@ object EnvironmentProxyResolver {
 
         if (projectDir != null) {
             ServerUrlResolver.findTomlFile(projectDir)?.let { tomlFile ->
-                TomlParser.parse(tomlFile)?.http?.proxy?.let { return it }
+                TomlParser.parse(tomlFile)?.network?.proxy?.let { return it }
             }
         }
 

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
@@ -6,7 +6,12 @@ import java.io.File
 
 data class TomlConfig(
     val project: String?,
-    val url: String?
+    val url: String?,
+    val http: TomlHttpConfig?
+)
+
+data class TomlHttpConfig(
+    val proxy: Boolean?
 )
 
 object TomlParser {
@@ -23,11 +28,26 @@ object TomlParser {
             }
             TomlConfig(
                 project = result.getString("project"),
-                url = result.getString("url")
+                url = result.getString("url"),
+                http = result.getBoolean("http.proxy")?.let { TomlHttpConfig(proxy = it) }
             )
         } catch (e: Exception) {
             logger.warn("Tuist: Failed to parse {}: {}", file, e.message)
             null
         }
+    }
+}
+
+object EnvironmentProxyResolver {
+    fun resolve(extensionProxy: Boolean?, projectDir: File?): Boolean {
+        extensionProxy?.let { return it }
+
+        if (projectDir != null) {
+            ServerUrlResolver.findTomlFile(projectDir)?.let { tomlFile ->
+                TomlParser.parse(tomlFile)?.http?.proxy?.let { return it }
+            }
+        }
+
+        return true
     }
 }

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
@@ -23,6 +23,8 @@ open class TuistBuildCache : AbstractBuildCache() {
     @Deprecated("No longer used. The plugin resolves auth natively.")
     var executablePath: String? = null
     var url: String? = null
+    lateinit var projectDir: String
+    var useEnvironmentProxy: Boolean = true
     var allowInsecureProtocol: Boolean = false
 }
 
@@ -39,8 +41,8 @@ class TuistBuildCacheServiceFactory : BuildCacheServiceFactory<TuistBuildCache> 
             .type("Tuist")
             .config("project", configuration.project ?: "(from tuist.toml)")
 
-        val projectDir = java.io.File(System.getProperty("user.dir"))
-        val httpClients = TuistHttpClients()
+        val projectDir = java.io.File(configuration.projectDir)
+        val httpClients = TuistHttpClients(useEnvironmentProxy = configuration.useEnvironmentProxy)
         val configurationProvider = DefaultConfigurationProvider(
             project = configuration.project,
             serverUrl = configuration.url ?: "https://tuist.dev",

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.GradleInternal
@@ -111,8 +112,10 @@ abstract class TuistBuildInsightsService :
     interface Params : BuildServiceParameters {
         val url: Property<String>
         val project: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
         val gradleVersion: Property<String>
         val rootProjectName: Property<String>
+        val projectDir: DirectoryProperty
     }
 
     private val logger = Logging.getLogger(TuistBuildInsightsService::class.java)
@@ -145,10 +148,7 @@ abstract class TuistBuildInsightsService :
 
     override fun started(buildOperation: BuildOperationDescriptor, startEvent: OperationStartEvent) {
         val opId = buildOperation.id ?: return
-        val parentId = buildOperation.parentId
-        if (parentId != null) {
-            operationParents[opId] = parentId
-        }
+        buildOperation.parentId?.let { operationParents[opId] = it }
 
         val details = buildOperation.details
         if (details is ExecuteTaskBuildOperationType.Details) {
@@ -221,12 +221,11 @@ abstract class TuistBuildInsightsService :
      * the cache load op up to the task op and returns `:app:compileKotlin`.
      */
     private fun findTaskPathForOperation(opId: OperationIdentifier): String? {
-        var currentId: OperationIdentifier? = opId
-        while (currentId != null) {
+        var currentId = opId
+        while (true) {
             operationTaskPaths[currentId]?.let { return it }
-            currentId = operationParents[currentId]
+            currentId = operationParents[currentId] ?: return null
         }
-        return null
     }
 
     override fun onFinish(event: FinishEvent) {
@@ -312,8 +311,8 @@ abstract class TuistBuildInsightsService :
 
     private fun sendReport(machineMetrics: List<MachineMetricSample>) {
         val projectValue = parameters.project.orNull
-        val httpClients = TuistHttpClients()
-        val projectDir = java.io.File(System.getProperty("user.dir"))
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
+        val projectDir = parameters.projectDir.asFile.get()
 
         val configProvider = DefaultConfigurationProvider(
             project = projectValue,
@@ -347,7 +346,7 @@ abstract class TuistBuildInsightsService :
         val response = httpClient.execute { config ->
             val resolvedUrl = ServerUrlResolver.resolve(
                 extensionUrl = parameters.url.get(),
-                projectDir = java.io.File(System.getProperty("user.dir"))
+                projectDir = projectDir
             )
             val url = URI(resolvedUrl).resolve("/api/projects/${config.accountHandle}/${config.projectHandle}/gradle/builds")
             val connection = httpClient.openConnection(url, config)
@@ -458,8 +457,10 @@ internal abstract class TuistBuildInsightsPlugin @Inject constructor(
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
+            parameters.useEnvironmentProxy.set(config.http.proxy)
             parameters.gradleVersion.set(project.gradle.gradleVersion)
             parameters.rootProjectName.set(project.rootProject.name)
+            parameters.projectDir.set(project.rootProject.layout.projectDirectory)
         }
 
         eventsListenerRegistry.onTaskCompletion(serviceProvider)

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
@@ -457,7 +457,7 @@ internal abstract class TuistBuildInsightsPlugin @Inject constructor(
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
-            parameters.useEnvironmentProxy.set(config.http.proxy)
+            parameters.useEnvironmentProxy.set(config.network.proxy)
             parameters.gradleVersion.set(project.gradle.gradleVersion)
             parameters.rootProjectName.set(project.rootProject.name)
             parameters.projectDir.set(project.rootProject.layout.projectDirectory)

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistHttpClients.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistHttpClients.kt
@@ -17,14 +17,19 @@ import java.util.concurrent.TimeUnit
  * pool is shared.
  *
  * When the `HTTPS_PROXY` or `HTTP_PROXY` environment variable is set, the
- * clients automatically route requests through it; otherwise they use direct
- * connections. No explicit configuration is exposed to users.
+ * clients automatically route requests through it by default; otherwise they use
+ * direct connections. Callers can opt out by setting [useEnvironmentProxy] to
+ * `false`.
  */
 open class TuistHttpClients(
+    private val useEnvironmentProxy: Boolean = true,
+    private val proxyURLProvider: () -> String? = { environmentProxyURL() },
     private val environmentVariables: Map<String, String> = System.getenv()
 ) {
 
-    val javaProxy: java.net.Proxy? by lazy { environmentProxy() }
+    val javaProxy: java.net.Proxy? by lazy {
+        if (useEnvironmentProxy) environmentProxy() else null
+    }
 
     open val okHttp: OkHttpClient by lazy {
         OkHttpClient.Builder()
@@ -93,23 +98,28 @@ open class TuistHttpClients(
 
         private val PROXY_ENV_VARS = listOf("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
 
-        private fun environmentProxy(): java.net.Proxy? {
+        private fun environmentProxyURL(): String? {
             for (name in PROXY_ENV_VARS) {
                 val value = System.getenv(name)
-                if (!value.isNullOrBlank()) {
-                    val uri = runCatching { URI(value) }.getOrNull() ?: continue
-                    val host = uri.host ?: continue
-                    val port = if (uri.port != -1) uri.port else defaultProxyPort(uri.scheme)
-                    return java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress(host, port))
-                }
+                if (!value.isNullOrBlank()) return value
             }
             return null
         }
+    }
 
-        private fun defaultProxyPort(scheme: String?): Int = when (scheme?.lowercase()) {
-            "https" -> 443
-            "http" -> 80
-            else -> 8080
-        }
+    private fun environmentProxy(): java.net.Proxy? {
+        val value = proxyURLProvider()
+        if (value.isNullOrBlank()) return null
+
+        val uri = runCatching { URI(value) }.getOrNull() ?: return null
+        val host = uri.host ?: return null
+        val port = if (uri.port != -1) uri.port else defaultProxyPort(uri.scheme)
+        return java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress(host, port))
+    }
+
+    private fun defaultProxyPort(scheme: String?): Int = when (scheme?.lowercase()) {
+        "https" -> 443
+        "http" -> 80
+        else -> 8080
     }
 }

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
@@ -24,7 +24,7 @@ import org.gradle.api.logging.Logging
  *
  *     uploadInBackground = true // default: true locally, false on CI
  *
- *     http {
+ *     network {
  *         proxy = false
  *     }
  *
@@ -42,11 +42,11 @@ import org.gradle.api.logging.Logging
 data class TuistGradleConfig(
     val url: String,
     val project: String?,
-    val http: Http,
+    val network: Network,
     val uploadInBackground: Boolean? = null,
     val testQuarantineEnabled: Boolean? = null
 ) {
-    data class Http(val proxy: Boolean)
+    data class Network(val proxy: Boolean)
 
     companion object {
         internal const val EXTRA_PROPERTY_KEY = "tuist.config"
@@ -55,9 +55,9 @@ data class TuistGradleConfig(
             TuistGradleConfig(
                 url = extension.url,
                 project = extension.project.ifBlank { null },
-                http = Http(
+                network = Network(
                     proxy = EnvironmentProxyResolver.resolve(
-                        extensionProxy = extension.http.proxy,
+                        extensionProxy = extension.network.proxy,
                         projectDir = settings.settingsDir
                     )
                 ),
@@ -138,7 +138,7 @@ class TuistPlugin : Plugin<Settings> {
                 this.project = config.project
                 this.url = config.url
                 this.projectDir = settings.settingsDir.absolutePath
-                this.useEnvironmentProxy = config.http.proxy
+                this.useEnvironmentProxy = config.network.proxy
                 isPush = buildCacheConfig.push
                 this.allowInsecureProtocol = buildCacheConfig.allowInsecureProtocol
             }
@@ -177,15 +177,15 @@ open class TuistExtension {
     var uploadInBackground: Boolean? = null
 
     /**
-     * HTTP configuration.
+     * Network configuration.
      */
-    val http: HttpSettings = HttpSettings()
+    val network: NetworkSettings = NetworkSettings()
 
     /**
-     * Configure HTTP settings.
+     * Configure network settings.
      */
-    fun http(action: Action<HttpSettings>) {
-        action.execute(http)
+    fun network(action: Action<NetworkSettings>) {
+        action.execute(network)
     }
 
     /**
@@ -234,12 +234,12 @@ open class BuildCacheExtension {
 }
 
 /**
- * Configuration for Tuist's HTTP behavior.
+ * Configuration for Tuist's network behavior.
  */
-open class HttpSettings {
+open class NetworkSettings {
     /**
      * Whether the plugin should use the proxy defined by `HTTPS_PROXY`/`HTTP_PROXY`.
-     * When null (default), the plugin reads `[http].proxy` from `tuist.toml`
+     * When null (default), the plugin reads `[network].proxy` from `tuist.toml`
      * and otherwise falls back to `true`.
      */
     var proxy: Boolean? = null

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
@@ -24,6 +24,10 @@ import org.gradle.api.logging.Logging
  *
  *     uploadInBackground = true // default: true locally, false on CI
  *
+ *     http {
+ *         proxy = false
+ *     }
+ *
  *     buildCache {
  *         enabled = true
  *         push = true
@@ -38,9 +42,12 @@ import org.gradle.api.logging.Logging
 data class TuistGradleConfig(
     val url: String,
     val project: String?,
+    val http: Http,
     val uploadInBackground: Boolean? = null,
     val testQuarantineEnabled: Boolean? = null
 ) {
+    data class Http(val proxy: Boolean)
+
     companion object {
         internal const val EXTRA_PROPERTY_KEY = "tuist.config"
 
@@ -48,6 +55,12 @@ data class TuistGradleConfig(
             TuistGradleConfig(
                 url = extension.url,
                 project = extension.project.ifBlank { null },
+                http = Http(
+                    proxy = EnvironmentProxyResolver.resolve(
+                        extensionProxy = extension.http.proxy,
+                        projectDir = settings.settingsDir
+                    )
+                ),
                 uploadInBackground = extension.uploadInBackground,
                 testQuarantineEnabled = extension.testQuarantine.enabled
             )
@@ -124,6 +137,8 @@ class TuistPlugin : Plugin<Settings> {
             remote(TuistBuildCache::class.java) {
                 this.project = config.project
                 this.url = config.url
+                this.projectDir = settings.settingsDir.absolutePath
+                this.useEnvironmentProxy = config.http.proxy
                 isPush = buildCacheConfig.push
                 this.allowInsecureProtocol = buildCacheConfig.allowInsecureProtocol
             }
@@ -160,6 +175,18 @@ open class TuistExtension {
      * to ensure it completes before ephemeral agents exit.
      */
     var uploadInBackground: Boolean? = null
+
+    /**
+     * HTTP configuration.
+     */
+    val http: HttpSettings = HttpSettings()
+
+    /**
+     * Configure HTTP settings.
+     */
+    fun http(action: Action<HttpSettings>) {
+        action.execute(http)
+    }
 
     /**
      * Build cache configuration.
@@ -204,6 +231,18 @@ open class BuildCacheExtension {
      * Whether to allow insecure HTTP connections. Defaults to false.
      */
     var allowInsecureProtocol: Boolean = false
+}
+
+/**
+ * Configuration for Tuist's HTTP behavior.
+ */
+open class HttpSettings {
+    /**
+     * Whether the plugin should use the proxy defined by `HTTPS_PROXY`/`HTTP_PROXY`.
+     * When null (default), the plugin reads `[http].proxy` from `tuist.toml`
+     * and otherwise falls back to `true`.
+     */
+    var proxy: Boolean? = null
 }
 
 /**

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
@@ -468,7 +468,7 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
-            parameters.useEnvironmentProxy.set(config.http.proxy)
+            parameters.useEnvironmentProxy.set(config.network.proxy)
             parameters.rootProjectName.set(project.rootProject.name)
             parameters.projectDir.set(project.rootProject.layout.projectDirectory)
         }
@@ -481,7 +481,7 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
             ) {
                 parameters.serverUrl.set(config.url)
                 config.project?.let { parameters.tuistProject.set(it) }
-                parameters.useEnvironmentProxy.set(config.http.proxy)
+                parameters.useEnvironmentProxy.set(config.network.proxy)
                 parameters.projectDir.set(project.rootProject.layout.projectDirectory)
             }
         } else {

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
@@ -288,7 +289,9 @@ abstract class TuistTestInsightsService :
     interface Params : BuildServiceParameters {
         val url: Property<String>
         val project: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
         val rootProjectName: Property<String>
+        val projectDir: DirectoryProperty
     }
 
     private val logger = Logging.getLogger(TuistTestInsightsService::class.java)
@@ -372,12 +375,13 @@ abstract class TuistTestInsightsService :
 
     private fun sendReport() {
         val projectValue = parameters.project.orNull
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
+        val projectDir = parameters.projectDir.asFile.get()
 
         val configProvider = DefaultConfigurationProvider(
             project = projectValue,
             serverUrl = parameters.url.get(),
-            projectDir = java.io.File(System.getProperty("user.dir")),
+            projectDir = projectDir,
             httpClients = httpClients
         )
 
@@ -464,7 +468,9 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
+            parameters.useEnvironmentProxy.set(config.http.proxy)
             parameters.rootProjectName.set(project.rootProject.name)
+            parameters.projectDir.set(project.rootProject.layout.projectDirectory)
         }
 
         val quarantineEnabled = config.testQuarantineEnabled ?: ciDetector.isCi()
@@ -475,7 +481,8 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
             ) {
                 parameters.serverUrl.set(config.url)
                 config.project?.let { parameters.tuistProject.set(it) }
-                parameters.projectDir.set(System.getProperty("user.dir"))
+                parameters.useEnvironmentProxy.set(config.http.proxy)
+                parameters.projectDir.set(project.rootProject.layout.projectDirectory)
             }
         } else {
             null

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
@@ -128,7 +129,8 @@ abstract class TuistTestQuarantineBuildService :
     interface Params : BuildServiceParameters {
         val serverUrl: Property<String>
         val tuistProject: Property<String>
-        val projectDir: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
+        val projectDir: DirectoryProperty
     }
 
     @Volatile
@@ -146,11 +148,11 @@ abstract class TuistTestQuarantineBuildService :
 
     private fun createDelegate(): TuistTestQuarantineService {
         val serverUrl = parameters.serverUrl.get()
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
         val configProvider = DefaultConfigurationProvider(
             project = parameters.tuistProject.orNull,
             serverUrl = serverUrl,
-            projectDir = java.io.File(parameters.projectDir.get()),
+            projectDir = parameters.projectDir.asFile.get(),
             httpClients = httpClients
         )
         val httpClient = TuistHttpClient(

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
@@ -338,7 +338,7 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             description = "Build test classes, discover test suites, and create a shard plan on the Tuist server"
             serverUrl = config.url
             tuistProject = config.project
-            useEnvironmentProxy = config.http.proxy
+            useEnvironmentProxy = config.network.proxy
             compiledTestClassDirectories.from(testClassDirectories)
 
             providers.gradleProperty("tuistShardMax").orNull?.toIntOrNull()?.let { shardMax = it }
@@ -360,7 +360,7 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             return
         }
 
-        val httpClients = TuistHttpClients(useEnvironmentProxy = config.http.proxy)
+        val httpClients = TuistHttpClients(useEnvironmentProxy = config.network.proxy)
         val configProvider = DefaultConfigurationProvider(
             project = config.project,
             serverUrl = config.url,

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
@@ -174,6 +174,9 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
     @get:Internal
     var tuistProject: String? = null
 
+    @get:Input
+    var useEnvironmentProxy: Boolean = true
+
     @TaskAction
     fun execute() {
         val shardingService = createShardingService()
@@ -293,7 +296,7 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
     }
 
     private fun createShardingService(): TuistTestShardingService {
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = useEnvironmentProxy)
         val configProvider = DefaultConfigurationProvider(
             project = tuistProject,
             serverUrl = serverUrl,
@@ -327,6 +330,7 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             description = "Build test classes, discover test suites, and create a shard plan on the Tuist server"
             serverUrl = config.url
             tuistProject = config.project
+            useEnvironmentProxy = config.http.proxy
 
             project.findProperty("tuistShardMax")?.toString()?.toIntOrNull()?.let { shardMax = it }
             project.findProperty("tuistShardMin")?.toString()?.toIntOrNull()?.let { shardMin = it }
@@ -351,11 +355,11 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             return
         }
 
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = config.http.proxy)
         val configProvider = DefaultConfigurationProvider(
             project = config.project,
             serverUrl = config.url,
-            projectDir = java.io.File(System.getProperty("user.dir")),
+            projectDir = project.rootProject.projectDir,
             httpClients = httpClients
         )
         val cacheConfig = configProvider.getConfiguration()

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
@@ -9,10 +9,16 @@ import okhttp3.OkHttpClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.Test
 import retrofit2.Retrofit
@@ -110,13 +116,6 @@ private fun createShardsApi(
         .create(ShardsApi::class.java)
 }
 
-fun discoverTestSuites(project: Project): List<String> {
-    val classDirs = project.allprojects.flatMap { subproject ->
-        subproject.tasks.withType(Test::class.java).flatMap { it.testClassesDirs.files }
-    }
-    return discoverTestSuitesFromDirs(classDirs)
-}
-
 fun discoverTestSuitesFromDirs(classDirs: List<java.io.File>): List<String> {
     val testSuites = mutableSetOf<String>()
     for (dir in classDirs) {
@@ -177,6 +176,12 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
     @get:Input
     var useEnvironmentProxy: Boolean = true
 
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    @get:IgnoreEmptyDirectories
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val compiledTestClassDirectories: ConfigurableFileCollection
+
     @TaskAction
     fun execute() {
         val shardingService = createShardingService()
@@ -187,7 +192,7 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
                 "Could not derive shard reference. Set TUIST_SHARD_REFERENCE or run in a supported CI environment."
             )
 
-        val testSuites = discoverTestSuites(project)
+        val testSuites = discoverTestSuitesFromDirs(compiledTestClassDirectories.files.toList())
         if (testSuites.isEmpty()) {
             throw org.gradle.api.GradleException("No test classes found in compiled test output.")
         }
@@ -324,31 +329,31 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
         if (project !== project.rootProject) return
 
         val config = TuistGradleConfig.from(project) ?: return
+        val providers = project.providers
+        val testClassDirectories = project.objects.fileCollection()
 
-        project.tasks.register("tuistPrepareTestShards", TuistPrepareTestShardsTask::class.java).configure {
+        val prepareTestShards = project.tasks.register("tuistPrepareTestShards", TuistPrepareTestShardsTask::class.java)
+        prepareTestShards.configure {
             group = "tuist"
             description = "Build test classes, discover test suites, and create a shard plan on the Tuist server"
             serverUrl = config.url
             tuistProject = config.project
             useEnvironmentProxy = config.http.proxy
+            compiledTestClassDirectories.from(testClassDirectories)
 
-            project.findProperty("tuistShardMax")?.toString()?.toIntOrNull()?.let { shardMax = it }
-            project.findProperty("tuistShardMin")?.toString()?.toIntOrNull()?.let { shardMin = it }
-            project.findProperty("tuistShardMaxDuration")?.toString()?.toIntOrNull()?.let { shardMaxDuration = it }
+            providers.gradleProperty("tuistShardMax").orNull?.toIntOrNull()?.let { shardMax = it }
+            providers.gradleProperty("tuistShardMin").orNull?.toIntOrNull()?.let { shardMin = it }
+            providers.gradleProperty("tuistShardMaxDuration").orNull?.toIntOrNull()?.let { shardMaxDuration = it }
+            providers.environmentVariable("TUIST_SHARD_REFERENCE").orNull?.let { shardReference = it }
+        }
 
-            System.getenv("TUIST_SHARD_REFERENCE")?.let { shardReference = it }
-
-            // Depend on whatever tasks produce the compiled test classes.
-            // This works for both standard JVM projects (testClasses) and Android
-            // projects (compileDebugUnitTestSources, etc.).
-            project.allprojects.forEach { subproject ->
-                subproject.tasks.withType(Test::class.java).forEach { testTask ->
-                    dependsOn(testTask.testClassesDirs.buildDependencies)
-                }
+        project.allprojects.forEach { subproject ->
+            subproject.tasks.withType(Test::class.java).configureEach {
+                testClassDirectories.from(testClassesDirs)
             }
         }
 
-        val shardIndexStr = System.getenv("TUIST_SHARD_INDEX") ?: return
+        val shardIndexStr = providers.environmentVariable("TUIST_SHARD_INDEX").orNull ?: return
         val shardIndex = shardIndexStr.toIntOrNull()
         if (shardIndex == null) {
             logger.warn("Tuist: TUIST_SHARD_INDEX is not a valid integer: $shardIndexStr")
@@ -371,7 +376,7 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             httpClients = httpClients
         )
 
-        val reference = System.getenv("TUIST_SHARD_REFERENCE") ?: shardingService.deriveReference()
+        val reference = providers.environmentVariable("TUIST_SHARD_REFERENCE").orNull ?: shardingService.deriveReference()
             ?: throw org.gradle.api.GradleException(
                 "Could not derive shard reference. Set TUIST_SHARD_REFERENCE or run in a supported CI environment."
             )

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
@@ -370,6 +370,7 @@ class TuistBuildCacheTest {
 
     private class TestBuildCacheKey(private val hash: String) : BuildCacheKey {
         override fun getHashCode(): String = hash
+        override fun getDisplayName(): String = hash
         override fun toByteArray(): ByteArray = hash.toByteArray()
     }
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
@@ -370,7 +370,6 @@ class TuistBuildCacheTest {
 
     private class TestBuildCacheKey(private val hash: String) : BuildCacheKey {
         override fun getHashCode(): String = hash
-        override fun getDisplayName(): String = hash
         override fun toByteArray(): ByteArray = hash.toByteArray()
     }
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
@@ -18,7 +18,7 @@ class TomlParserTest {
             project = "my-org/my-project"
             url = "https://custom.server.dev"
 
-            [http]
+            [network]
             proxy = false
         """.trimIndent())
 
@@ -26,7 +26,7 @@ class TomlParserTest {
 
         assertEquals("my-org/my-project", config?.project)
         assertEquals("https://custom.server.dev", config?.url)
-        assertEquals(false, config?.http?.proxy)
+        assertEquals(false, config?.network?.proxy)
     }
 
     @Test
@@ -72,16 +72,16 @@ class TomlParserTest {
     }
 
     @Test
-    fun `parse handles http proxy only`() {
+    fun `parse handles network proxy only`() {
         val toml = File(tempDir, "tuist.toml")
         toml.writeText("""
-            [http]
+            [network]
             proxy = false
         """.trimIndent())
 
         val config = TomlParser.parse(toml)
 
-        assertEquals(false, config?.http?.proxy)
+        assertEquals(false, config?.network?.proxy)
     }
 
 }
@@ -169,7 +169,7 @@ class EnvironmentProxyResolverTest {
     @Test
     fun `resolve returns extension value when set`() {
         File(tempDir, "tuist.toml").writeText("""
-            [http]
+            [network]
             proxy = false
         """.trimIndent())
 
@@ -181,7 +181,7 @@ class EnvironmentProxyResolverTest {
     @Test
     fun `resolve reads from tuist toml when extension value is not set`() {
         File(tempDir, "tuist.toml").writeText("""
-            [http]
+            [network]
             proxy = false
         """.trimIndent())
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
@@ -17,12 +17,16 @@ class TomlParserTest {
         toml.writeText("""
             project = "my-org/my-project"
             url = "https://custom.server.dev"
+
+            [http]
+            proxy = false
         """.trimIndent())
 
         val config = TomlParser.parse(toml)
 
         assertEquals("my-org/my-project", config?.project)
         assertEquals("https://custom.server.dev", config?.url)
+        assertEquals(false, config?.http?.proxy)
     }
 
     @Test
@@ -65,6 +69,19 @@ class TomlParserTest {
 
         val config = TomlParser.parse(toml)
         assertEquals("spaced/project", config?.project)
+    }
+
+    @Test
+    fun `parse handles http proxy only`() {
+        val toml = File(tempDir, "tuist.toml")
+        toml.writeText("""
+            [http]
+            proxy = false
+        """.trimIndent())
+
+        val config = TomlParser.parse(toml)
+
+        assertEquals(false, config?.http?.proxy)
     }
 
 }
@@ -141,5 +158,42 @@ class ServerUrlResolverFindTomlTest {
         nested.mkdirs()
 
         assertNull(ServerUrlResolver.findTomlFile(nested))
+    }
+}
+
+class EnvironmentProxyResolverTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `resolve returns extension value when set`() {
+        File(tempDir, "tuist.toml").writeText("""
+            [http]
+            proxy = false
+        """.trimIndent())
+
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = true, projectDir = tempDir)
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `resolve reads from tuist toml when extension value is not set`() {
+        File(tempDir, "tuist.toml").writeText("""
+            [http]
+            proxy = false
+        """.trimIndent())
+
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = null, projectDir = tempDir)
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `resolve defaults to true when nothing is configured`() {
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = null, projectDir = tempDir)
+
+        assertEquals(true, result)
     }
 }

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
@@ -35,6 +35,26 @@ class TuistHttpClientsTest {
     }
 
     @Test
+    fun `does not create proxy when environment proxy usage is disabled`() {
+        val httpClients = TuistHttpClients(
+            useEnvironmentProxy = false,
+            proxyURLProvider = { "http://proxy.tuist.dev:8080" }
+        )
+
+        assertNull(httpClients.javaProxy)
+    }
+
+    @Test
+    fun `creates proxy from environment when enabled`() {
+        val httpClients = TuistHttpClients(
+            useEnvironmentProxy = true,
+            proxyURLProvider = { "http://proxy.tuist.dev:8080" }
+        )
+
+        assertNotNull(httpClients.javaProxy)
+    }
+
+    @Test
     fun `unauthenticatedRetrofit reaches the target server when no proxy env var is set`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"access_token":"at","refresh_token":"rt"}"""))
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
@@ -293,6 +293,46 @@ class TuistPluginTest {
     }
 
     @Test
+    fun `plugin reads http proxy from tuist toml`() {
+        File(testProjectDir, "tuist.toml").writeText("""
+            project = "test-account/test-project"
+
+            [http]
+            proxy = false
+        """.trimIndent())
+
+        settingsFile.writeText("""
+            import dev.tuist.gradle.TuistGradleConfig
+
+            plugins {
+                id("dev.tuist")
+            }
+
+            rootProject.name = "test-project"
+        """.trimIndent())
+
+        buildFile.writeText("""
+            import dev.tuist.gradle.TuistGradleConfig
+
+            tasks.register("printProxyConfig") {
+                doLast {
+                    val config = project.extensions.extraProperties["tuist.config"] as TuistGradleConfig
+                    println("proxy=${'$'}{config.http.proxy}")
+                }
+            }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("printProxyConfig")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":printProxyConfig")?.outcome)
+        assertTrue(result.output.contains("proxy=false"))
+    }
+
+    @Test
     fun `build insights logs message when configured`() {
         settingsFile.writeText("""
             plugins {

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
@@ -293,11 +293,11 @@ class TuistPluginTest {
     }
 
     @Test
-    fun `plugin reads http proxy from tuist toml`() {
+    fun `plugin reads network proxy from tuist toml`() {
         File(testProjectDir, "tuist.toml").writeText("""
             project = "test-account/test-project"
 
-            [http]
+            [network]
             proxy = false
         """.trimIndent())
 
@@ -317,7 +317,7 @@ class TuistPluginTest {
             tasks.register("printProxyConfig") {
                 doLast {
                     val config = project.extensions.extraProperties["tuist.config"] as TuistGradleConfig
-                    println("proxy=${'$'}{config.http.proxy}")
+                    println("proxy=${'$'}{config.network.proxy}")
                 }
             }
         """.trimIndent())

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistTestShardingTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistTestShardingTest.kt
@@ -46,7 +46,7 @@ class TuistTestShardingTest {
         val project = org.gradle.testfixtures.ProjectBuilder.builder()
             .withProjectDir(projectDir)
             .build()
-        return project.tasks.create("testShards", TuistPrepareTestShardsTask::class.java)
+        return project.tasks.register("testShards", TuistPrepareTestShardsTask::class.java).get()
     }
 
     private fun shardPlan(shardCount: Int = 2) = ShardPlan(


### PR DESCRIPTION
## Summary
- add `network.proxy` to `Tuist.swift`, `tuist.toml`, and the Gradle plugin, and map it into shared runtime HTTP settings
- resolve proxy mode at config and plugin load time so shared HTTP sessions and clients can pick it up without threading proxy flags through service layers
- add focused Swift and Gradle coverage for the new configuration path and keep Gradle verification aligned with the current toolchain

## Why
The earlier iteration widened the diff by passing proxy configuration through several services. This version keeps proxy selection at the configuration boundary and lets the shared HTTP layer pick it up from runtime settings, which keeps the service layer largely unchanged and makes the PR easier to review.

## Testing
- `xcodebuild -quiet build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild -quiet test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistHTTPTests/URLSessionTuistTests -only-testing:TuistConfigLoaderTests/ConfigLoaderTests -only-testing:TuistConfigLoaderTests/SwiftConfigLoaderTests -only-testing:TuistConfigLoaderTests/TuistTomlConfigLoaderTests -only-testing:TuistKitTests/DumpServiceTests/test_prints_the_manifest_when_config_manifest CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `cd gradle && JAVA_HOME=~/.local/share/mise/installs/java/21.0.2 PATH=~/.local/share/mise/installs/gradle/8.12.1/gradle-8.12.1/bin:$JAVA_HOME/bin:$PATH gradle test --tests dev.tuist.gradle.TomlParserTest --tests dev.tuist.gradle.EnvironmentProxyResolverTest --tests dev.tuist.gradle.TuistHttpClientsTest --tests dev.tuist.gradle.TuistPluginTest --tests dev.tuist.gradle.TuistTestShardingTest`