### PR TITLE
fix(server): bootstrap install in fresh worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,10 @@ Tuist Server is an Elixir/Phoenix web application that extends the functionality
 
 **Setup Commands:**
 ```bash
-mise install                    # Install system dependencies
 brew install postgresql@16      # Make sure `postgresql@16` is installed locally via Homebrew
 brew services start postgresql@16
 mise run clickhouse:start      # Start ClickHouse
-mise run db:create             # Create database
-mise run db:load               # Load database schema
-mise run db:seed               # Seed with development data
+mise install                   # Install dependencies and bootstrap the local development database
 mise run dev                   # Start development server
 ```
 
@@ -248,7 +245,7 @@ The application deploys to Render with different environments:
 ## Important Notes
 
 - Always run `mix ecto.migrate` after pulling database migrations
-- Use `mise run install` after pulling dependency changes
+- Use `mise run install` after pulling dependency changes or when bootstrapping a fresh worktree
 - Local development connects to `http://localhost:8080` for Tuist CLI integration
 
 # Tuist Handbook

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -34,13 +34,10 @@ Tuist Server is an Elixir/Phoenix web application that extends the Tuist CLI. It
 
 **Setup Commands**
 ```bash
-mise install
 brew install postgresql@16
 brew services start postgresql@16
 mise run clickhouse:start
-mise run db:create
-mise run db:load
-mise run db:seed
+mise install
 mise run dev
 ```
 
@@ -114,7 +111,7 @@ mise run dev
 
 ## Important Notes
 - Run `mix ecto.migrate` after pulling migrations.
-- Use `mise run install` after dependency changes.
+- Use `mise run install` after dependency changes or when bootstrapping a fresh worktree.
 - Local development connects to `http://localhost:8080` for Tuist CLI integration.
 
 ## Data Export Documentation

--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -3,6 +3,14 @@
 
 set -euo pipefail
 
+postgres_database_exists() {
+  psql -Atqc "SELECT 1 FROM pg_database WHERE datname = '${TUIST_SERVER_POSTGRES_DB}'" postgres | grep -qx 1
+}
+
+clickhouse_database_exists() {
+  curl -fsS http://localhost:8123 --data-binary "EXISTS DATABASE ${TUIST_SERVER_CLICKHOUSE_DB}" | grep -qx 1
+}
+
 mix deps.get
 pnpm install --ignore-workspace
 pushd .. >/dev/null
@@ -13,6 +21,12 @@ pnpm run build
 popd >/dev/null
 
 if [ -z "${CI:-}" ]; then
+  # Fresh worktrees use isolated database names and need the schema dump loaded before later migrations run.
+  if ! postgres_database_exists || ! clickhouse_database_exists; then
+    mise run db:create
+    mise run db:load
+  fi
+
   mise run db:migrate
   mise run db:seed
 fi

--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -11,6 +11,16 @@ clickhouse_database_exists() {
   curl -fsS http://localhost:8123 --data-binary "EXISTS DATABASE ${TUIST_SERVER_CLICKHOUSE_DB}" | grep -qx 1
 }
 
+bootstrap_postgres_database() {
+  mix ecto.create -r Tuist.Repo
+  mix ecto.load -r Tuist.Repo
+}
+
+bootstrap_clickhouse_database() {
+  mix ecto.create -r Tuist.IngestRepo
+  mix ecto.load -r Tuist.IngestRepo
+}
+
 mix deps.get
 pnpm install --ignore-workspace
 pushd .. >/dev/null
@@ -21,10 +31,13 @@ pnpm run build
 popd >/dev/null
 
 if [ -z "${CI:-}" ]; then
-  # Fresh worktrees use isolated database names and need the schema dump loaded before later migrations run.
-  if ! postgres_database_exists || ! clickhouse_database_exists; then
-    mise run db:create
-    mise run db:load
+  # Fresh worktrees use isolated database names, so bootstrap missing repos independently.
+  if ! postgres_database_exists; then
+    bootstrap_postgres_database
+  fi
+
+  if ! clickhouse_database_exists; then
+    bootstrap_clickhouse_database
   fi
 
   mise run db:migrate


### PR DESCRIPTION
## Summary
- bootstrap `server` installs in fresh worktrees by checking whether the per-worktree Postgres and ClickHouse databases already exist
- load the schema dumps before running migrations when those databases are missing
- update the root and server AGENTS setup notes so they match the actual bootstrap flow

## Root Cause
Fresh worktrees derive unique database names from the dev-instance suffix. `server/mise/tasks/install.sh` went straight to `db:migrate` and `db:seed`, which fails on a brand-new worktree because the databases do not exist yet. After creating them, a second issue appears: this repo also expects `db:load` to run before later migrations on an empty database.

## Impact
`mise run install` now succeeds in a newly created worktree without requiring manual database setup first, while preserving the existing fast path for already-bootstrapped environments.

## Validation
- ran `mise run install` in `server` from a fresh `origin/main`-based worktree and verified it completed successfully
