### PR TITLE
fix(server): allow non-localhost dev instance binding

### DIFF
--- a/mise/tasks/local-proxy-setup.sh
+++ b/mise/tasks/local-proxy-setup.sh
@@ -8,6 +8,30 @@ if [[ -z "${TUIST_SERVER_HOSTNAME:-}" || -z "${TUIST_SERVER_PORT:-}" ]]; then
   exit 1
 fi
 
+proxy_target_host="${TUIST_SERVER_BIND_HOST:-localhost}"
+
+case "${proxy_target_host}" in
+  "")
+    echo "Error: TUIST_SERVER_BIND_HOST must not be empty." >&2
+    exit 1
+    ;;
+  localhost)
+    proxy_target="localhost:${TUIST_SERVER_PORT}"
+    ;;
+  0.0.0.0)
+    proxy_target="127.0.0.1:${TUIST_SERVER_PORT}"
+    ;;
+  ::)
+    proxy_target="[::1]:${TUIST_SERVER_PORT}"
+    ;;
+  *:*)
+    proxy_target="[${proxy_target_host}]:${TUIST_SERVER_PORT}"
+    ;;
+  *)
+    proxy_target="${proxy_target_host}:${TUIST_SERVER_PORT}"
+    ;;
+esac
+
 CADDY_SITES_DIR="${HOME}/.config/caddy/sites"
 CADDY_MAIN="${HOME}/.config/caddy/Caddyfile"
 CADDY_SITE_FILE="${CADDY_SITES_DIR}/${TUIST_SERVER_HOSTNAME%.localhost}.caddy"
@@ -32,7 +56,7 @@ if [[ ! -f "${CADDY_MAIN}" ]] || ! grep -qF "output file" "${CADDY_MAIN}"; then
 fi
 
 # Write per-project site config (idempotent)
-CADDY_EXPECTED="$(printf 'http://%s {\n\treverse_proxy localhost:%s\n}\n' "${TUIST_SERVER_HOSTNAME}" "${TUIST_SERVER_PORT}")"
+CADDY_EXPECTED="$(printf 'http://%s {\n\treverse_proxy %s\n}\n' "${TUIST_SERVER_HOSTNAME}" "${proxy_target}")"
 if [[ ! -f "${CADDY_SITE_FILE}" ]] || [[ "$(cat "${CADDY_SITE_FILE}")" != "${CADDY_EXPECTED}" ]]; then
   printf '%s\n' "${CADDY_EXPECTED}" > "${CADDY_SITE_FILE}"
   echo "Wrote Caddy config: ${CADDY_SITE_FILE}"
@@ -61,4 +85,4 @@ else
 fi
 
 echo ""
-echo "http://${TUIST_SERVER_HOSTNAME} -> localhost:${TUIST_SERVER_PORT}"
+echo "http://${TUIST_SERVER_HOSTNAME} -> ${proxy_target}"

--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -82,6 +82,7 @@ ensure_suffix() {
 
 suffix="$(ensure_suffix)"
 test_partition="${MIX_TEST_PARTITION:-}"
+server_bind_host="${TUIST_SERVER_BIND_HOST:-localhost}"
 
 # Derive a hostname from the project root directory basename
 project_basename="$(basename "${PROJECT_ROOT}")"
@@ -90,8 +91,9 @@ project_hostname="$(printf '%s' "${project_basename}" | tr '[:upper:]' '[:lower:
 
 export TUIST_DEV_INSTANCE="${suffix}"
 export TUIST_SERVER_PORT="$((8080 + suffix))"
+export TUIST_SERVER_BIND_HOST="${server_bind_host}"
 export TUIST_SERVER_HOSTNAME="${project_hostname}.localhost"
-export TUIST_SERVER_URL="http://localhost:${TUIST_SERVER_PORT}"
+export TUIST_SERVER_URL="http://${TUIST_SERVER_BIND_HOST}:${TUIST_SERVER_PORT}"
 export TUIST_SERVER_POSTGRES_DB="tuist_development_${suffix}"
 export TUIST_SERVER_CLICKHOUSE_DB="tuist_development_${suffix}"
 export TUIST_CACHE_PORT="$((8087 + suffix))"

--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -83,6 +83,31 @@ ensure_suffix() {
 suffix="$(ensure_suffix)"
 test_partition="${MIX_TEST_PARTITION:-}"
 server_bind_host="${TUIST_SERVER_BIND_HOST:-localhost}"
+server_public_host="${TUIST_SERVER_PUBLIC_HOST:-${server_bind_host}}"
+
+case "${server_bind_host}" in
+  "")
+    echo "TUIST_SERVER_BIND_HOST must not be empty." >&2
+    return 1
+    ;;
+  0.0.0.0 | ::)
+    if [[ -z "${TUIST_SERVER_PUBLIC_HOST:-}" ]]; then
+      echo "TUIST_SERVER_BIND_HOST='${server_bind_host}' requires TUIST_SERVER_PUBLIC_HOST to build TUIST_SERVER_URL." >&2
+      return 1
+    fi
+    ;;
+esac
+
+case "${server_public_host}" in
+  "")
+    echo "TUIST_SERVER_PUBLIC_HOST must not be empty." >&2
+    return 1
+    ;;
+  0.0.0.0 | ::)
+    echo "TUIST_SERVER_PUBLIC_HOST must not be ${server_public_host}." >&2
+    return 1
+    ;;
+esac
 
 # Derive a hostname from the project root directory basename
 project_basename="$(basename "${PROJECT_ROOT}")"
@@ -92,8 +117,14 @@ project_hostname="$(printf '%s' "${project_basename}" | tr '[:upper:]' '[:lower:
 export TUIST_DEV_INSTANCE="${suffix}"
 export TUIST_SERVER_PORT="$((8080 + suffix))"
 export TUIST_SERVER_BIND_HOST="${server_bind_host}"
+export TUIST_SERVER_PUBLIC_HOST="${server_public_host}"
 export TUIST_SERVER_HOSTNAME="${project_hostname}.localhost"
-export TUIST_SERVER_URL="http://${TUIST_SERVER_BIND_HOST}:${TUIST_SERVER_PORT}"
+
+case "${TUIST_SERVER_PUBLIC_HOST}" in
+  *:*) export TUIST_SERVER_URL="http://[${TUIST_SERVER_PUBLIC_HOST}]:${TUIST_SERVER_PORT}" ;;
+  *) export TUIST_SERVER_URL="http://${TUIST_SERVER_PUBLIC_HOST}:${TUIST_SERVER_PORT}" ;;
+esac
+
 export TUIST_SERVER_POSTGRES_DB="tuist_development_${suffix}"
 export TUIST_SERVER_CLICKHOUSE_DB="tuist_development_${suffix}"
 export TUIST_CACHE_PORT="$((8087 + suffix))"

--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,10 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. Install dependencies: `mise run install`
 1. Create and set up the database: `mise run db:setup`
 1. Run the server: `mise run dev`
-1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`. If you need the dev server to be reachable from another machine, export `TUIST_SERVER_BIND_HOST=<hostname-or-ip>` before `mise activate`; the generated `TUIST_SERVER_URL` will then use that host instead of `localhost`:
+1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`. If you need the dev server to be reachable from another machine, set `TUIST_SERVER_BIND_HOST` to the interface or address the server should listen on before `mise activate`. When you bind to all interfaces with `0.0.0.0` or `::`, also set `TUIST_SERVER_PUBLIC_HOST` so generated absolute URLs and OAuth callbacks use a reachable host:
+
+   - `TUIST_SERVER_BIND_HOST=192.168.1.10 mise activate`
+   - `TUIST_SERVER_BIND_HOST=0.0.0.0 TUIST_SERVER_PUBLIC_HOST=192.168.1.10 mise activate`
 
 ```
 Email: tuistrocks@tuist.dev

--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,7 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. Install dependencies: `mise run install`
 1. Create and set up the database: `mise run db:setup`
 1. Run the server: `mise run dev`
-1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`:
+1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`. If you need the dev server to be reachable from another machine, export `TUIST_SERVER_BIND_HOST=<hostname-or-ip>` before `mise activate`; the generated `TUIST_SERVER_URL` will then use that host instead of `localhost`:
 
 ```
 Email: tuistrocks@tuist.dev

--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -161,8 +161,8 @@ config :tuist, Tuist.Repo,
   pool_size: 10
 
 config :tuist, TuistWeb.Endpoint,
-  # Binding to loopback ipv4 address prevents access from other machines.
-  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  # Runtime config keeps the default dev listener on loopback unless
+  # TUIST_SERVER_BIND_HOST overrides it.
   http: [ip: {127, 0, 0, 1}, port: 8080],
   check_origin: false,
   code_reloader: true,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -194,12 +194,35 @@ if Enum.member?([:prod, :stag, :can, :dev], env) do
   app_url = Tuist.Environment.app_url([route_type: :app], secrets)
   %{host: app_url_host, port: app_url_port, scheme: app_url_scheme} = URI.parse(app_url)
 
+  if env == :dev and app_url_host in ["0.0.0.0", "::"] do
+    raise "TUIST_SERVER_URL must use a reachable host in development. Set TUIST_SERVER_PUBLIC_HOST when binding to #{app_url_host}."
+  end
+
+  bind_host = System.get_env("TUIST_SERVER_BIND_HOST") || "localhost"
+
   http_ip =
-    case {env, app_url_host} do
-      {:dev, "localhost"} -> {127, 0, 0, 1}
-      {:dev, _host} -> {0, 0, 0, 0}
+    case {env, bind_host} do
+      {:dev, "localhost"} ->
+        {127, 0, 0, 1}
+
+      {:dev, "0.0.0.0"} ->
+        {0, 0, 0, 0}
+
+      {:dev, "::"} ->
+        {0, 0, 0, 0, 0, 0, 0, 0}
+
+      {:dev, bind_host} ->
+        case :inet.parse_address(String.to_charlist(bind_host)) do
+          {:ok, ip} ->
+            ip
+
+          {:error, _reason} ->
+            raise "TUIST_SERVER_BIND_HOST must be localhost, 0.0.0.0, ::, or a literal IP address in development. Got: #{inspect(bind_host)}"
+        end
+
       # Enable IPv6 and bind on all interfaces.
-      {_env, _host} -> {0, 0, 0, 0, 0, 0, 0, 0}
+      _env ->
+        {0, 0, 0, 0, 0, 0, 0, 0}
     end
 
   check_origin = if env == :dev, do: false, else: [app_url]


### PR DESCRIPTION
> Allow `mise/utilities/dev_instance_env.sh` to use `TUIST_SERVER_BIND_HOST` when generating `TUIST_SERVER_URL`, while keeping `localhost` as the default. This lets local dev instances bind beyond loopback when needed and documents the workflow in `server/README.md`.

### How to test locally

1. Run `source mise/utilities/dev_instance_env.sh` and verify `echo "$TUIST_SERVER_URL"` still points at `http://localhost:<port>` by default.
2. Run `TUIST_SERVER_BIND_HOST=192.0.2.10 bash -lc 'source mise/utilities/dev_instance_env.sh && echo "$TUIST_SERVER_URL"'` and verify the configured host is used in the URL.
3. Start the server with `mise run dev` after exporting `TUIST_SERVER_BIND_HOST=<hostname-or-ip>` and verify it is reachable through that host.

### Validation

- `bash -n mise/utilities/dev_instance_env.sh mise/tasks/local-proxy-setup.sh`
- `source mise/utilities/dev_instance_env.sh` smoke test for default and overridden `TUIST_SERVER_BIND_HOST`
- `mise run lint` is currently blocked in this environment because the `mise`-installed `swiftlint` binary cannot run on this NixOS host (`stub-ld` dynamic linker failure)
