### PR TITLE
refactor(server): Builds.get_build/1 returns {:ok, build} | {:error, :not_found}

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -37,9 +37,15 @@ defmodule Tuist.Builds do
   end
 
   def get_build(id) do
-    Build
-    |> from(hints: ["FINAL"], where: [id: ^id])
-    |> ClickHouseRepo.one()
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} ->
+        Build
+        |> from(hints: ["FINAL"], where: [id: ^uuid])
+        |> ClickHouseRepo.one()
+
+      :error ->
+        nil
+    end
   end
 
   def create_build(attrs) do

--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -37,14 +37,14 @@ defmodule Tuist.Builds do
   end
 
   def get_build(id) do
-    case Ecto.UUID.cast(id) do
-      {:ok, uuid} ->
-        Build
-        |> from(hints: ["FINAL"], where: [id: ^uuid])
-        |> ClickHouseRepo.one()
-
-      :error ->
-        nil
+    with {:ok, uuid} <- Ecto.UUID.cast(id),
+         build when not is_nil(build) <-
+           Build
+           |> from(hints: ["FINAL"], where: [id: ^uuid])
+           |> ClickHouseRepo.one() do
+      {:ok, build}
+    else
+      _ -> {:error, :not_found}
     end
   end
 

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -151,13 +151,13 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
 
   defp base_build_attrs(build_id, account_id, build_metadata) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         Map.merge(
           %{id: build_id, account_id: account_id, is_ci: false},
           atomize_keys(build_metadata)
         )
 
-      existing_build ->
+      {:ok, existing_build} ->
         existing_build
         |> Map.from_struct()
         |> Map.drop([

--- a/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
+++ b/server/lib/tuist/mcp/components/tools/get_xcode_build.ex
@@ -30,7 +30,7 @@ defmodule Tuist.MCP.Components.Tools.GetXcodeBuild do
 
     with {:ok, build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -56,13 +56,6 @@ defmodule Tuist.MCP.Components.Tools.GetXcodeBuild do
          cacheable_task_remote_hits_count: build.cacheable_task_remote_hits_count,
          inserted_at: Formatter.iso8601(build.inserted_at, naive: :utc)
        }}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 end

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
@@ -45,7 +45,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -89,13 +89,6 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
            end),
          pagination_metadata: MCPTool.pagination_metadata(meta)
        }}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 end

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cas_outputs.ex
@@ -45,7 +45,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -89,13 +89,6 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCASOutputs do
            end),
          pagination_metadata: MCPTool.pagination_metadata(meta)
        }}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 end

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_files.ex
@@ -49,7 +49,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildFiles do
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -97,13 +97,6 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildFiles do
            end),
          pagination_metadata: MCPTool.pagination_metadata(meta)
        }}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 end

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_issues.ex
@@ -41,7 +41,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -72,13 +72,6 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildIssues do
            ending_column: issue.ending_column
          }
        end)}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_targets.ex
@@ -41,7 +41,7 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildTargets do
 
     with {:ok, _build, _project} <-
            MCPTool.load_and_authorize(
-             get_build(build_run_id),
+             Builds.get_build(build_run_id),
              conn.assigns,
              :read,
              :build,
@@ -81,13 +81,6 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildTargets do
            end),
          pagination_metadata: MCPTool.pagination_metadata(meta)
        }}
-    end
-  end
-
-  defp get_build(id) do
-    case Builds.get_build(id) do
-      nil -> {:error, :not_found}
-      build -> {:ok, build}
     end
   end
 end

--- a/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
@@ -126,12 +126,12 @@ defmodule TuistWeb.API.BuildCacheTasksController do
         _params
       ) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      %{project_id: project_id} when project_id == selected_project.id ->
+      {:ok, %{project_id: project_id}} when project_id == selected_project.id ->
         filters = build_filters(build_id, params)
 
         {tasks, meta} =
@@ -166,7 +166,7 @@ defmodule TuistWeb.API.BuildCacheTasksController do
           }
         })
 
-      _build ->
+      {:ok, _build} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})

--- a/server/lib/tuist_web/controllers/api/build_cas_outputs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_cas_outputs_controller.ex
@@ -123,12 +123,12 @@ defmodule TuistWeb.API.BuildCASOutputsController do
         _params
       ) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      %{project_id: project_id} when project_id == selected_project.id ->
+      {:ok, %{project_id: project_id}} when project_id == selected_project.id ->
         filters = build_filters(build_id, params)
 
         {outputs, meta} =
@@ -163,7 +163,7 @@ defmodule TuistWeb.API.BuildCASOutputsController do
           }
         })
 
-      _build ->
+      {:ok, _build} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})

--- a/server/lib/tuist_web/controllers/api/build_files_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_files_controller.ex
@@ -122,12 +122,12 @@ defmodule TuistWeb.API.BuildFilesController do
         _params
       ) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      %{project_id: project_id} when project_id == selected_project.id ->
+      {:ok, %{project_id: project_id}} when project_id == selected_project.id ->
         filters = build_filters(build_id, params)
 
         {order_by, order_directions} =
@@ -166,7 +166,7 @@ defmodule TuistWeb.API.BuildFilesController do
           }
         })
 
-      _build ->
+      {:ok, _build} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})

--- a/server/lib/tuist_web/controllers/api/build_issues_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_issues_controller.ex
@@ -135,12 +135,12 @@ defmodule TuistWeb.API.BuildIssuesController do
         _params
       ) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      build ->
+      {:ok, build} ->
         if build.project_id == selected_project.id do
           filters = [%{field: :build_run_id, op: :==, value: build_id}]
 

--- a/server/lib/tuist_web/controllers/api/build_targets_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_targets_controller.ex
@@ -107,12 +107,12 @@ defmodule TuistWeb.API.BuildTargetsController do
         _params
       ) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      %{project_id: project_id} when project_id == selected_project.id ->
+      {:ok, %{project_id: project_id}} when project_id == selected_project.id ->
         filters = [%{field: :build_run_id, op: :==, value: build_id}]
 
         filters =
@@ -152,7 +152,7 @@ defmodule TuistWeb.API.BuildTargetsController do
           }
         })
 
-      _build ->
+      {:ok, _build} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -328,12 +328,12 @@ defmodule TuistWeb.API.BuildsController do
 
   def show(%{assigns: %{selected_project: selected_project}, params: %{build_id: build_id}} = conn, _params) do
     case Builds.get_build(build_id) do
-      nil ->
+      {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> json(%{message: "Build not found."})
 
-      build ->
+      {:ok, build} ->
         if build.project_id == selected_project.id do
           json(conn, %{
             id: build.id,
@@ -883,10 +883,10 @@ defmodule TuistWeb.API.BuildsController do
 
   defp get_or_create_build(params) do
     case Builds.get_build(params.id) do
-      %Tuist.Builds.Build{} = build ->
+      {:ok, build} ->
         {:ok, build}
 
-      nil ->
+      {:error, :not_found} ->
         custom_metadata = Map.get(params, :custom_metadata, %{})
 
         build_attrs = %{
@@ -975,8 +975,8 @@ defmodule TuistWeb.API.BuildsController do
   defp handle_build_creation_result({:error, changeset}, build_id) do
     if Keyword.has_key?(changeset.errors, :id) do
       case Builds.get_build(build_id) do
-        %Tuist.Builds.Build{} = build -> {:ok, build}
-        nil -> {:error, :creation_failed}
+        {:ok, build} -> {:ok, build}
+        {:error, :not_found} -> {:error, :creation_failed}
       end
     else
       {:error, changeset}

--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -835,10 +835,10 @@ defmodule TuistWeb.API.RunsController do
 
   defp get_or_create_build(params) do
     case Builds.get_build(params.id) do
-      %Tuist.Builds.Build{} = build ->
+      {:ok, build} ->
         {:ok, build}
 
-      nil ->
+      {:error, :not_found} ->
         custom_metadata = Map.get(params, :custom_metadata, %{})
 
         build_attrs = %{
@@ -881,8 +881,8 @@ defmodule TuistWeb.API.RunsController do
   defp handle_build_creation_result({:error, changeset}, build_id) do
     if Keyword.has_key?(changeset.errors, :id) do
       case Builds.get_build(build_id) do
-        %Tuist.Builds.Build{} = build -> {:ok, build}
-        nil -> {:error, :creation_failed}
+        {:ok, build} -> {:ok, build}
+        {:error, :not_found} -> {:error, :creation_failed}
       end
     else
       {:error, changeset}

--- a/server/lib/tuist_web/controllers/build_controller.ex
+++ b/server/lib/tuist_web/controllers/build_controller.ex
@@ -14,7 +14,7 @@ defmodule TuistWeb.BuildController do
     with {:ok, project} <-
            Projects.get_project_by_slug("#{account_handle}/#{project_handle}", preload: [:account]),
          :ok <- Authorization.authorize(:build_read, user, project),
-         %Builds.Build{} = build <- Builds.get_build(build_id),
+         {:ok, build} <- Builds.get_build(build_id),
          true <- build.project_id == project.id do
       storage_key = Builds.build_storage_key(account_handle, project_handle, build_id)
       url = Storage.generate_download_url(storage_key, project.account)

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -37,11 +37,11 @@ defmodule TuistWeb.BuildRunLive do
   defp mount_xcode(params, _session, %{assigns: %{selected_project: project}} = socket) do
     run =
       case Builds.get_build(params["build_run_id"]) do
-        nil ->
-          raise NotFoundError, dgettext("dashboard_builds", "Build not found.")
-
-        run ->
+        {:ok, run} ->
           run
+
+        {:error, :not_found} ->
+          raise NotFoundError, dgettext("dashboard_builds", "Build not found.")
       end
 
     slug = Projects.get_project_slug_from_id(project.id)
@@ -125,9 +125,10 @@ defmodule TuistWeb.BuildRunLive do
   @impl true
   def handle_info({:xcode_build_created, build}, socket) do
     if build.id == socket.assigns.run.id do
+      {:ok, run} = Builds.get_build(build.id)
+
       run =
-        build.id
-        |> Builds.get_build()
+        run
         |> Tuist.Repo.preload([:ran_by_account, project: :vcs_connection])
         |> Tuist.ClickHouseRepo.preload([:issues])
 
@@ -218,9 +219,10 @@ defmodule TuistWeb.BuildRunLive do
 
   @impl true
   def handle_event("refresh_build", _params, %{assigns: %{run: run}} = socket) do
+    {:ok, refreshed_run} = Builds.get_build(run.id)
+
     refreshed_run =
-      run.id
-      |> Builds.get_build()
+      refreshed_run
       |> Tuist.Repo.preload([:ran_by_account, project: :vcs_connection])
       |> Tuist.ClickHouseRepo.preload([:issues, :machine_metrics])
 

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -492,7 +492,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
         "git_commit_sha" => "abc123"
       }
 
-      expect(Tuist.Builds, :get_build, fn ^non_existent_build_id -> nil end)
+      expect(Tuist.Builds, :get_build, fn ^non_existent_build_id -> {:error, :not_found} end)
 
       expect(Tuist.Builds, :create_build, fn attrs ->
         assert attrs.status == "failed_processing"

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -197,7 +197,7 @@ defmodule Tuist.BuildsTest do
   end
 
   describe "get_build/1" do
-    test "returns build" do
+    test "returns {:ok, build}" do
       # Given
       {:ok, build} =
         RunsFixtures.build_fixture()
@@ -205,29 +205,26 @@ defmodule Tuist.BuildsTest do
       build_id = build.id
 
       # When
-      build = Builds.get_build(build_id)
+      {:ok, got} = Builds.get_build(build_id)
 
       # Then
-      assert build.id == build_id
+      assert got.id == build_id
     end
 
-    test "returns nil when build does not exist" do
+    test "returns {:error, :not_found} when build does not exist" do
       # Given
       non_existent_build_id = UUIDv7.generate()
 
-      # When
-      build = Builds.get_build(non_existent_build_id)
-
-      # Then
-      assert build == nil
+      # When / Then
+      assert Builds.get_build(non_existent_build_id) == {:error, :not_found}
     end
 
-    test "returns nil when id is nil" do
-      assert Builds.get_build(nil) == nil
+    test "returns {:error, :not_found} when id is nil" do
+      assert Builds.get_build(nil) == {:error, :not_found}
     end
 
-    test "returns nil when id is not a valid UUID" do
-      assert Builds.get_build("not-a-uuid") == nil
+    test "returns {:error, :not_found} when id is not a valid UUID" do
+      assert Builds.get_build("not-a-uuid") == {:error, :not_found}
     end
   end
 

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -221,6 +221,14 @@ defmodule Tuist.BuildsTest do
       # Then
       assert build == nil
     end
+
+    test "returns nil when id is nil" do
+      assert Builds.get_build(nil) == nil
+    end
+
+    test "returns nil when id is not a valid UUID" do
+      assert Builds.get_build("not-a-uuid") == nil
+    end
   end
 
   describe "project_build_tags/1" do

--- a/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
@@ -87,26 +87,27 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
       project = %{id: 1, name: "app"}
 
       stub(Builds, :get_build, fn "build-1" ->
-        %{
-          id: "build-1",
-          duration: 5000,
-          status: "success",
-          category: "clean",
-          scheme: "App",
-          configuration: "Debug",
-          xcode_version: "15.0",
-          macos_version: "14.0",
-          model_identifier: "MacBookPro18,1",
-          is_ci: false,
-          git_branch: "main",
-          git_commit_sha: "abc123",
-          git_ref: "refs/heads/main",
-          cacheable_tasks_count: 10,
-          cacheable_task_local_hits_count: 5,
-          cacheable_task_remote_hits_count: 3,
-          project_id: 1,
-          inserted_at: ~N[2024-01-01 12:00:00]
-        }
+        {:ok,
+         %{
+           id: "build-1",
+           duration: 5000,
+           status: "success",
+           category: "clean",
+           scheme: "App",
+           configuration: "Debug",
+           xcode_version: "15.0",
+           macos_version: "14.0",
+           model_identifier: "MacBookPro18,1",
+           is_ci: false,
+           git_branch: "main",
+           git_commit_sha: "abc123",
+           git_ref: "refs/heads/main",
+           cacheable_tasks_count: 10,
+           cacheable_task_local_hits_count: 5,
+           cacheable_task_remote_hits_count: 3,
+           project_id: 1,
+           inserted_at: ~N[2024-01-01 12:00:00]
+         }}
       end)
 
       stub(Projects, :get_project_by_id, fn 1 -> project end)
@@ -127,7 +128,7 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
       project = %{id: 1, name: "app"}
 
       stub(Builds, :get_build, fn "build-1" ->
-        %{id: "build-1", project_id: 1}
+        {:ok, %{id: "build-1", project_id: 1}}
       end)
 
       stub(Projects, :get_project_by_id, fn 1 -> project end)
@@ -167,7 +168,7 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
     test "returns build files" do
       project = %{id: 1, name: "app"}
 
-      stub(Builds, :get_build, fn "build-1" -> %{id: "build-1", project_id: 1} end)
+      stub(Builds, :get_build, fn "build-1" -> {:ok, %{id: "build-1", project_id: 1}} end)
       stub(Projects, :get_project_by_id, fn 1 -> project end)
       stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
 
@@ -204,7 +205,7 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
     test "returns build issues" do
       project = %{id: 1, name: "app"}
 
-      stub(Builds, :get_build, fn "build-1" -> %{id: "build-1", project_id: 1} end)
+      stub(Builds, :get_build, fn "build-1" -> {:ok, %{id: "build-1", project_id: 1}} end)
       stub(Projects, :get_project_by_id, fn 1 -> project end)
       stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
 
@@ -240,7 +241,7 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
     test "returns cache tasks" do
       project = %{id: 1, name: "app"}
 
-      stub(Builds, :get_build, fn "build-1" -> %{id: "build-1", project_id: 1} end)
+      stub(Builds, :get_build, fn "build-1" -> {:ok, %{id: "build-1", project_id: 1}} end)
       stub(Projects, :get_project_by_id, fn 1 -> project end)
       stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
 
@@ -279,7 +280,7 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
     test "returns CAS outputs" do
       project = %{id: 1, name: "app"}
 
-      stub(Builds, :get_build, fn "build-1" -> %{id: "build-1", project_id: 1} end)
+      stub(Builds, :get_build, fn "build-1" -> {:ok, %{id: "build-1", project_id: 1}} end)
       stub(Projects, :get_project_by_id, fn 1 -> project end)
       stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
 

--- a/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     test "returns an empty list when there are no cache tasks", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cacheable_tasks, fn _attrs ->
         {[],
@@ -51,7 +51,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     test "returns cache tasks for the build", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cacheable_tasks, fn _attrs ->
         {[
@@ -93,7 +93,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     test "filters cache tasks by status", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cacheable_tasks, fn attrs ->
         assert %{field: :status, op: :==, value: "miss"} in attrs.filters
@@ -133,7 +133,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     test "filters cache tasks by type", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cacheable_tasks, fn attrs ->
         assert %{field: :type, op: :==, value: "clang"} in attrs.filters
@@ -173,7 +173,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     test "supports pagination", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cacheable_tasks, fn attrs ->
         assert attrs.page == 2
@@ -215,7 +215,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
     end
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       conn =
         get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}/cache-tasks")
@@ -227,7 +227,7 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       {:ok, build} = RunsFixtures.build_fixture(project_id: other_project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/cache-tasks")
 

--- a/server/test/tuist_web/controllers/api/build_cas_outputs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_cas_outputs_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     test "returns an empty list when there are no CAS outputs", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cas_outputs, fn _attrs ->
         {[],
@@ -51,7 +51,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     test "returns CAS outputs for the build", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cas_outputs, fn _attrs ->
         {[
@@ -93,7 +93,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     test "filters CAS outputs by operation", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cas_outputs, fn attrs ->
         assert %{field: :operation, op: :==, value: "upload"} in attrs.filters
@@ -133,7 +133,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     test "filters CAS outputs by type", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cas_outputs, fn attrs ->
         assert %{field: :type, op: :==, value: "swift"} in attrs.filters
@@ -173,7 +173,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     test "supports pagination", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_cas_outputs, fn attrs ->
         assert attrs.page == 2
@@ -215,7 +215,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
     end
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       conn =
         get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}/cas-outputs")
@@ -227,7 +227,7 @@ defmodule TuistWeb.API.BuildCASOutputsControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       {:ok, build} = RunsFixtures.build_fixture(project_id: other_project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/cas-outputs")
 

--- a/server/test/tuist_web/controllers/api/build_files_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_files_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     test "returns an empty list when there are no files", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_files, fn _attrs ->
         {[],
@@ -51,7 +51,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     test "returns files for the build", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_files, fn _attrs ->
         {[
@@ -89,7 +89,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     test "filters files by target", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_files, fn attrs ->
         assert %{field: :target, op: :==, value: "MyTarget"} in attrs.filters
@@ -127,7 +127,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     test "filters files by type", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_files, fn attrs ->
         assert %{field: :type, op: :==, value: "swift"} in attrs.filters
@@ -164,7 +164,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     test "supports pagination", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_files, fn attrs ->
         assert attrs.page == 2
@@ -204,7 +204,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
     end
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}/files")
 
@@ -215,7 +215,7 @@ defmodule TuistWeb.API.BuildFilesControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       {:ok, build} = RunsFixtures.build_fixture(project_id: other_project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/files")
 

--- a/server/test/tuist_web/controllers/api/build_issues_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_issues_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     test "returns an empty list when there are no issues", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_issues_paginated, fn _attrs ->
         {[],
@@ -51,7 +51,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     test "returns issues for the build", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_issues_paginated, fn _attrs ->
         {[
@@ -103,7 +103,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     test "filters issues by type", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_issues_paginated, fn attrs ->
         assert %{field: :type, op: :==, value: "error"} in attrs.filters
@@ -148,7 +148,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     test "filters issues by target", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_issues_paginated, fn attrs ->
         assert %{field: :target, op: :==, value: "MyTarget"} in attrs.filters
@@ -193,7 +193,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     test "supports pagination", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_issues_paginated, fn attrs ->
         assert attrs.page == 2
@@ -240,7 +240,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
     end
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}/issues")
 
@@ -251,7 +251,7 @@ defmodule TuistWeb.API.BuildIssuesControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       {:ok, build} = RunsFixtures.build_fixture(project_id: other_project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/issues")
 

--- a/server/test/tuist_web/controllers/api/build_targets_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_targets_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
     test "returns an empty list when there are no targets", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_targets, fn _attrs ->
         {[],
@@ -51,7 +51,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
     test "returns targets for the build", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_build_targets, fn _attrs ->
         {[
@@ -89,7 +89,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
     test "filters targets by status", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_targets, fn attrs ->
         assert %{field: :status, op: :==, value: "failure"} in attrs.filters
@@ -127,7 +127,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
     test "supports pagination", %{conn: conn, user: user, project: project} do
       {:ok, build} = RunsFixtures.build_fixture(project_id: project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       expect(Builds, :list_build_targets, fn attrs ->
         assert attrs.page == 2
@@ -159,7 +159,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
     end
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}/targets")
 
@@ -170,7 +170,7 @@ defmodule TuistWeb.API.BuildTargetsControllerTest do
       other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       {:ok, build} = RunsFixtures.build_fixture(project_id: other_project.id, user_id: user.account.id)
 
-      stub(Builds, :get_build, fn _id -> build end)
+      stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/targets")
 

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -331,7 +331,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
         )
 
       stub(Builds, :get_build, fn _id ->
-        build
+        {:ok, build}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}")
@@ -351,7 +351,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
 
     test "returns 404 when build is not found", %{conn: conn, user: user, project: project} do
       stub(Builds, :get_build, fn _id ->
-        nil
+        {:error, :not_found}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{UUIDv7.generate()}")
@@ -369,7 +369,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
         )
 
       stub(Builds, :get_build, fn _id ->
-        build
+        {:ok, build}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}")
@@ -396,7 +396,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
         )
 
       stub(Builds, :get_build, fn _id ->
-        build
+        {:ok, build}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}")
@@ -460,7 +460,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
         )
 
       stub(Builds, :get_build, fn _id ->
-        build
+        {:ok, build}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/builds/#{build.id}")
@@ -483,7 +483,7 @@ defmodule TuistWeb.API.BuildsControllerTest do
     test "creates a build using the deprecated route", %{conn: conn, user: user, project: project} do
       build_id = UUIDv7.generate()
 
-      stub(Builds, :get_build, fn _id -> nil end)
+      stub(Builds, :get_build, fn _id -> {:error, :not_found} end)
 
       stub(Builds, :create_build, fn _attrs ->
         {:ok,

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -511,7 +511,7 @@ defmodule TuistWeb.API.RunsControllerTest do
       stub(Builds, :get_build, fn ^id ->
         count = :counters.get(get_build_call_count, 1)
         :counters.add(get_build_call_count, 1, 1)
-        if count == 0, do: nil, else: existing_build
+        if count == 0, do: {:error, :not_found}, else: {:ok, existing_build}
       end)
 
       error_changeset = %Ecto.Changeset{

--- a/server/test/tuist_web/controllers/build_controller_test.exs
+++ b/server/test/tuist_web/controllers/build_controller_test.exs
@@ -19,10 +19,11 @@ defmodule TuistWeb.BuildControllerTest do
       build_id = UUIDv7.generate()
 
       stub(Builds, :get_build, fn ^build_id ->
-        %Builds.Build{
-          id: build_id,
-          project_id: project.id
-        }
+        {:ok,
+         %Builds.Build{
+           id: build_id,
+           project_id: project.id
+         }}
       end)
 
       stub(Storage, :generate_download_url, fn _storage_key, _account ->
@@ -47,7 +48,7 @@ defmodule TuistWeb.BuildControllerTest do
       project = ProjectsFixtures.project_fixture(account_id: user.account.id)
       build_id = UUIDv7.generate()
 
-      stub(Builds, :get_build, fn ^build_id -> nil end)
+      stub(Builds, :get_build, fn ^build_id -> {:error, :not_found} end)
 
       # When/Then
       assert_error_sent 404, fn ->
@@ -86,10 +87,11 @@ defmodule TuistWeb.BuildControllerTest do
       build_id = UUIDv7.generate()
 
       stub(Builds, :get_build, fn ^build_id ->
-        %Builds.Build{
-          id: build_id,
-          project_id: other_project.id
-        }
+        {:ok,
+         %Builds.Build{
+           id: build_id,
+           project_id: other_project.id
+         }}
       end)
 
       # When/Then


### PR DESCRIPTION
Fixes [TUIST-BG](https://tuist.sentry.io/issues/113608987/).

### Summary

The `get_xcode_build` MCP tool called `Tuist.Builds.get_build/1` with a `nil` `build_run_id`, raising an Ecto `ArgumentError` ("nil given for `id`. comparison with nil is forbidden…") inside the Ecto query builder — the Sentry stack trace pointed straight at `lib/tuist/builds.ex:41`.

Rather than just guarding `get_build/1` against `nil`, this PR takes the opportunity to normalize its return shape. `get_build/1` now returns `{:ok, build}` on success and `{:error, :not_found}` when the id is missing, malformed, or doesn't resolve to a build — the same convention already used elsewhere in the codebase (e.g. `CommandEvents.get_command_event_by_id/1`).

### What changed

- `Tuist.Builds.get_build/1` casts the id through `Ecto.UUID.cast/1` and returns a tagged tuple.
- All 16 lib/ call sites were migrated:
  - API controllers (`builds`, `build_files`, `build_targets`, `build_issues`, `build_cache_tasks`, `build_cas_outputs`, `runs`, `build`)
  - `TuistWeb.Live.BuildRunLive`
  - `Tuist.Builds.Workers.ProcessBuildWorker`
  - All six MCP `get_*` / `list_xcode_build_*` tools. The private `get_build` wrappers those tools used to own are gone — `Builds.get_build/1` now directly produces the shape `MCPTool.load_and_authorize/5` expects.
- All ~50 Mimic stubs/expects in the test suite were updated to return the new shape.
- Added regression tests in `test/tuist/builds_test.exs` for `nil` and non-UUID input; both previously raised and now return `{:error, :not_found}`.

### How to test locally

```bash
cd server
mix test test/tuist/builds_test.exs --only describe:"get_build/1"
mix test test/tuist/mcp/components/tools/xcode_build_tools_test.exs
mix test test/tuist/builds/workers/process_build_worker_test.exs
mix test test/tuist_web/controllers/build_controller_test.exs
mix test test/tuist_web/live/build_run_live_test.exs
```

All 102 tests across the impacted, non-environment-bound suites pass. (The `runs_controller_test`/`builds_controller_test` license-expired errors observed locally reproduce against `main` as well and are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)