### PR TITLE
perf(server): route flaky runs lookup through test_case_runs_by_test_run MV

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -2106,14 +2106,7 @@ defmodule Tuist.Tests do
   Returns a list of groups, each containing runs with their failures.
   """
   def get_flaky_runs_for_test_run(test_run_id) do
-    flaky_runs_query =
-      from(tcr in TestCaseRun,
-        where: tcr.test_run_id == ^test_run_id,
-        where: tcr.is_flaky == true,
-        order_by: [desc: tcr.ran_at]
-      )
-
-    current_flaky_runs = ClickHouseRepo.all(flaky_runs_query)
+    current_flaky_runs = fetch_flaky_runs_for_test_run(test_run_id)
 
     cross_run_counterparts =
       get_cross_run_flaky_runs(test_run_id, current_flaky_runs)
@@ -2161,6 +2154,21 @@ defmodule Tuist.Tests do
       }
     end)
     |> Enum.sort_by(& &1.latest_ran_at, {:desc, NaiveDateTime})
+  end
+
+  defp fetch_flaky_runs_for_test_run(test_run_id) do
+    slim_query =
+      from(mv in TestCaseRunByTestRun,
+        hints: ["FINAL"],
+        where: mv.test_run_id == ^test_run_id and mv.is_flaky == true,
+        order_by: [desc: mv.ran_at]
+      )
+
+    slim_results = ClickHouseRepo.all(slim_query)
+    ids = Enum.map(slim_results, & &1.id)
+    full_results = fetch_full_test_case_runs(slim_results)
+    ordered_by_id = Map.new(full_results, &{&1.id, &1})
+    ids |> Enum.map(&Map.get(ordered_by_id, &1)) |> Enum.reject(&is_nil/1)
   end
 
   defp get_cross_run_flaky_runs(_test_run_id, []), do: []


### PR DESCRIPTION
> Reduces p90 latency and rows-read on the slow ClickHouse query normalized hash 4525249810012193648 (filtering `test_case_runs` by `test_run_id` + `is_flaky`).

### The query being fixed

```sql
SELECT <all columns>
FROM test_case_runs
WHERE test_run_id = ?
  AND is_flaky = 1
ORDER BY ran_at DESC
```

Issued from `Tests.get_flaky_runs_for_test_run/1` (`server/lib/tuist/tests.ex`), which prior to this PR built it as:

```elixir
from(tcr in TestCaseRun,
  where: tcr.test_run_id == ^test_run_id,
  where: tcr.is_flaky == true,
  order_by: [desc: tcr.ran_at]
)
```

### What changed
`Tests.get_flaky_runs_for_test_run/1` no longer scans the main `test_case_runs` table via the coarse `idx_test_run_id` bloom filter. It now:
1. Queries the existing `test_case_runs_by_test_run` materialized view (ordered `(test_run_id, ran_at, id)`, `ReplacingMergeTree(inserted_at)`) with `FINAL` for a tight prefix scan on `test_run_id + is_flaky`.
2. Hydrates full rows from the main table via `(project_id, test_case_id, id)` — the main table's primary-key prefix — using the existing `fetch_full_test_case_runs/1` helper.

This is the same two-step pattern already used by `list_test_case_runs_via_test_run_mv/2`.

### Why
The previous query filtered on `test_run_id`, which is not part of the main table's primary key `(project_id, test_case_id, ran_at, id)`. The only index hit was `INDEX idx_test_run_id ... TYPE bloom_filter GRANULARITY 4`, which is coarse enough that every execution scanned ~3.3–3.9M rows on the ~863M-row production table (1.4–6.4 s p90, spiking under CI bursts).

The MV path has a prefix key on `test_run_id`, so the slim read is O(rows per run) regardless of table size. No new migration, no new MV, no app-side API change.

### How to test locally

1. Apply this branch and run `mix ecto.migrate --repo Tuist.IngestRepo` if the local ClickHouse isn't already on migration `20260409120004` (converts the MV to `ReplacingMergeTree`, required for the `FINAL` hint).
2. Seed/OPTIMIZE enough data so both tables are materially populated:
   ```
   OPTIMIZE TABLE test_case_runs FINAL;
   OPTIMIZE TABLE test_case_runs_by_test_run FINAL;
   ```
3. Unit tests: `mix test test/tuist/tests_test.exs:4999` (the full `get_flaky_runs_for_test_run/1` describe block — 9 tests) plus the VCS + LiveView call-sites:
   ```
   mix test test/tuist/tests_test.exs:4999 test/tuist/vcs_test.exs test/tuist_web/live/test_run_live_test.exs
   ```

### Local benchmark (117M-row synthetic table, 6.66 GiB, 3 partitions — same schema as prod)

ClickHouse-side rows read / elapsed (cold mark+uncompressed caches):

| Scenario | OLD (direct scan) | NEW slim MV | NEW hydrate |
|---|---|---|---|
| 18 flaky rows | 40 K / ~14 ms | 16 K / ~4 ms | — (point lookup) |
| 885 flaky rows | 655 K / ~120 ms | 98 K / ~15 ms | 655 K / ~145 ms |

The slim MV step reads **3–6× fewer rows** than the OLD scan and runs in near-constant time regardless of table size. At production scale (57 GB, 863 M rows, cold partitions, high concurrency) the savings compound — the bloom-filter cost scales with table size, the MV prefix scan does not.

End-to-end Elixir latency (5 runs, includes HTTP + Ecto):

| Scenario | OLD | NEW |
|---|---|---|
| 885 flaky | 192 ms avg (σ=23) | 171 ms avg (σ=4) |
| 18 flaky | 23.7 ms avg | 37.8 ms avg |

Small test-runs regress slightly in wall-clock (two round trips vs one) but they aren't the ones showing up in slow logs. Big runs — the ones that page — get modestly faster and much more consistent on warm synthetic data; the larger wins come from prod's cold storage and CI-burst concurrency, which local benchmarking can't fully reproduce.