### PR TITLE
chore(gradle): bump gradle plugin references to 0.9.2

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
 rootProject.name = "Tuist"
 
 plugins {
-    id("dev.tuist") version "0.9.1"
+    id("dev.tuist") version "0.9.2"
 }
 
 buildCache {

--- a/cli/Sources/TuistConstants/Constants.swift
+++ b/cli/Sources/TuistConstants/Constants.swift
@@ -28,7 +28,7 @@ public enum Constants {
 
     public static let tuistManifestFileName = "Tuist.swift"
     public static let tuistTomlFileName = "tuist.toml"
-    public static let gradlePluginVersion = "0.9.1"
+    public static let gradlePluginVersion = "0.9.2"
 
     /// The cache version.
     /// This should change only when it changes the logic to map a `XcodeGraph.Target` to a cached build artifact.

--- a/gradle/CHANGELOG.md
+++ b/gradle/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## What's Changed in gradle@0.9.1<!-- RELEASE NOTES START -->
+## What's Changed in gradle@0.9.2<!-- RELEASE NOTES START -->
+
+### 🐛 Bug Fixes
+
+* stop capturing OkHttpClient in Test task actions by [@pepicrft](https://github.com/pepicrft) in [#10304](https://github.com/tuist/tuist/pull/10304)
+
+
+
+**Full Changelog**: https://github.com/tuist/tuist/compare/gradle@0.9.1...gradle@0.9.2
+
+## What's Changed in gradle@0.9.1
 
 ### 🐛 Bug Fixes
 

--- a/gradle/settings.gradle.kts
+++ b/gradle/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "tuist-gradle-plugin"
 
 plugins {
-    id("dev.tuist") version "0.9.1"
+    id("dev.tuist") version "0.9.2"
 }
 
 buildCache {


### PR DESCRIPTION
### Purpose

Unblocks the Android CI, which has been failing since April 17 on a configuration cache serialization error (OkHttpClient captured in Test task actions).

### Why main was stuck on 0.9.1

The gradle plugin **0.9.2 was already published** to the Gradle Plugin Portal on April 17 at 11:24 UTC (run [24562314393](https://github.com/tuist/tuist/actions/runs/24562314393)) — it contains the OkHttpClient fix from #10304. However, that release workflow was **cancelled four minutes later** by a concurrent push to main, which killed the "Commit and Release" step. That step is what pushes the version-reference updates back to main (see the \`sed\` at release.yml:1724-1725 and the downloads/commits that follow).

Result: the portal has 0.9.2, but \`android/settings.gradle.kts\`, \`gradle/settings.gradle.kts\`, \`cli/Sources/TuistConstants/Constants.swift\`, and \`gradle/CHANGELOG.md\` were left pinned to 0.9.1 — so Android CI kept resolving the broken plugin version.

This PR applies the bookkeeping changes the cancelled job would have pushed.

### How to test locally

- Verify \`0.9.2\` is resolvable from the portal: \`curl -sI https://plugins.gradle.org/m2/dev/tuist/dev.tuist.gradle.plugin/0.9.2/dev.tuist.gradle.plugin-0.9.2.pom\` (returns 200).
- After merge, the Android workflow should pass \`./gradlew testDebugUnitTest\` (previously failed with \`Configuration cache state could not be cached: ... BasicTrustRootIndex ... latencyClient$delegate\`).

### Note on recurrence

This drift will happen again whenever a new push cancels a release mid-publish (because \`cancel-in-progress: true\` on the Release workflow). Out of scope for this PR — worth addressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)