### PR TITLE
fix(server): bump protobufjs to 7.5.5 for CVE-2026-41242

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
       "flatted": "3.4.2",
       "yaml": "2.8.3",
       "defu": "6.1.5",
-      "follow-redirects": "1.16.0"
+      "follow-redirects": "1.16.0",
+      "protobufjs": "7.5.5"
     }
   }
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   yaml: 2.8.3
   defu: 6.1.5
   follow-redirects: 1.16.0
+  protobufjs: 7.5.5
 
 importers:
 
@@ -1203,8 +1204,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -1749,7 +1750,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -3171,7 +3172,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
### Purpose

The Security Check CI job was failing because `trivy fs` flagged `protobufjs@7.5.4` for [CVE-2026-41242](https://avd.aquasec.com/nvd/cve-2026-41242) (arbitrary code execution, CRITICAL), fixed in 7.5.5 / 8.0.1. The dep is pulled in transitively via `@opentelemetry/otlp-transformer`.

This adds a `protobufjs: "7.5.5"` pnpm override in `server/package.json` and regenerates `server/pnpm-lock.yaml` so trivy sees the patched version.

### How to test locally

From `server/`:

```bash
trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps" ./
```

Should report 0 vulnerabilities (previously: 1 CRITICAL for `protobufjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)