### PR TITLE
chore(ci): disable remaining processor + xcode-processor deploys pending k8s migration

### DIFF
--- a/.github/workflows/processor-deploy.yml
+++ b/.github/workflows/processor-deploy.yml
@@ -1,78 +1,77 @@
 name: Processor Deploy
 
-# NOTE: Production deploy is disabled pending migration to Kubernetes. Kamal
-# auto-deploys to the current prod infrastructure have been unreliable. The
-# canary deploy below still runs on pushes to `main` so we keep exercising
-# the build and deploy path. Re-enable the production job once the service
-# runs on k8s.
+# NOTE: Canary and production deploys are disabled pending migration to
+# Kubernetes. Kamal auto-deploys to the current infrastructure have been
+# unreliable. Staging continues to deploy via processor-staging-deploy.yml.
+# Re-enable by uncommenting the blocks below once the service runs on k8s.
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - processor/**
-      - tuist_common/**
-      - .github/workflows/processor-deploy.yml
-
-concurrency:
-  group: processor-deploy
-  cancel-in-progress: false
-
-permissions:
-  contents: read
-
-defaults:
-  run:
-    working-directory: processor
-
-env:
-  MISE_VERSION: "2026.4.18"
-  MISE_GITHUB_TOKEN: ${{ github.token }}
-
-jobs:
-  deploy-canary:
-    runs-on: namespace-profile-default
-    timeout-minutes: 45
-    environment: processor-canary
-    steps:
-      - uses: actions/checkout@v4
-      - uses: 1password/install-cli-action@v2
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-          working_directory: processor
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.CACHE_SSH_PRIVATE_KEY }}
-      - name: Deploy with Kamal
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          mise run deploy canary
-  # deploy-production:
-  #   runs-on: namespace-profile-default
-  #   timeout-minutes: 45
-  #   needs: deploy-canary
-  #   if: ${{ needs.deploy-canary.result == 'success' }}
-  #   environment: processor-production
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: 1password/install-cli-action@v2
-  #     - uses: jdx/mise-action@v4.0.1
-  #       with:
-  #         version: ${{ env.MISE_VERSION }}
-  #         cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-  #         working_directory: processor
-  #     - name: Setup SSH
-  #       uses: webfactory/ssh-agent@v0.9.1
-  #       with:
-  #         ssh-private-key: ${{ secrets.CACHE_SSH_PRIVATE_KEY }}
-  #     - name: Deploy with Kamal
-  #       env:
-  #         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-  #       run: |
-  #         mise run deploy production
+# on:
+#   workflow_dispatch:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - processor/**
+#       - tuist_common/**
+#       - .github/workflows/processor-deploy.yml
+#
+# concurrency:
+#   group: processor-deploy
+#   cancel-in-progress: false
+#
+# permissions:
+#   contents: read
+#
+# defaults:
+#   run:
+#     working-directory: processor
+#
+# env:
+#   MISE_VERSION: "2026.4.18"
+#   MISE_GITHUB_TOKEN: ${{ github.token }}
+#
+# jobs:
+#   deploy-canary:
+#     runs-on: namespace-profile-default
+#     timeout-minutes: 45
+#     environment: processor-canary
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: 1password/install-cli-action@v2
+#       - uses: jdx/mise-action@v4.0.1
+#         with:
+#           version: ${{ env.MISE_VERSION }}
+#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+#           working_directory: processor
+#       - name: Setup SSH
+#         uses: webfactory/ssh-agent@v0.9.1
+#         with:
+#           ssh-private-key: ${{ secrets.CACHE_SSH_PRIVATE_KEY }}
+#       - name: Deploy with Kamal
+#         env:
+#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+#         run: |
+#           mise run deploy canary
+#   deploy-production:
+#     runs-on: namespace-profile-default
+#     timeout-minutes: 45
+#     needs: deploy-canary
+#     if: ${{ needs.deploy-canary.result == 'success' }}
+#     environment: processor-production
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: 1password/install-cli-action@v2
+#       - uses: jdx/mise-action@v4.0.1
+#         with:
+#           version: ${{ env.MISE_VERSION }}
+#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+#           working_directory: processor
+#       - name: Setup SSH
+#         uses: webfactory/ssh-agent@v0.9.1
+#         with:
+#           ssh-private-key: ${{ secrets.CACHE_SSH_PRIVATE_KEY }}
+#       - name: Deploy with Kamal
+#         env:
+#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+#         run: |
+#           mise run deploy production

--- a/.github/workflows/xcode-processor-staging-deploy.yml
+++ b/.github/workflows/xcode-processor-staging-deploy.yml
@@ -1,54 +1,59 @@
 name: Xcode Processor Staging Deploy
 
-permissions:
-  contents: read
+# NOTE: Disabled pending migration to Kubernetes. Staging targets the same
+# Scaleway Mac mini infrastructure as production and shares its reliability
+# issues. Re-enable by uncommenting the blocks below once the service runs
+# on k8s.
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Sha of the commit to be deployed
-        required: true
-
-defaults:
-  run:
-    working-directory: xcode_processor
-
-env:
-  MISE_VERSION: "2026.4.18"
-  MISE_GITHUB_TOKEN: ${{ github.token }}
-
-jobs:
-  deploy:
-    runs-on: namespace-profile-default-macos
-    timeout-minutes: 45
-    environment: xcode-processor-staging
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.commit_sha }}
-      - uses: 1password/install-cli-action@v2
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "erlang elixir"
-          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-          working_directory: xcode_processor
-      - name: Load secrets from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-          op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-          echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
-          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
-      - name: Deploy
-        env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-        run: |
-          mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging
+# permissions:
+#   contents: read
+#
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       commit_sha:
+#         description: Sha of the commit to be deployed
+#         required: true
+#
+# defaults:
+#   run:
+#     working-directory: xcode_processor
+#
+# env:
+#   MISE_VERSION: "2026.4.18"
+#   MISE_GITHUB_TOKEN: ${{ github.token }}
+#
+# jobs:
+#   deploy:
+#     runs-on: namespace-profile-default-macos
+#     timeout-minutes: 45
+#     environment: xcode-processor-staging
+#     steps:
+#       - uses: actions/checkout@v4
+#         with:
+#           ref: ${{ github.event.inputs.commit_sha }}
+#       - uses: 1password/install-cli-action@v2
+#       - uses: jdx/mise-action@v4.0.1
+#         with:
+#           version: ${{ env.MISE_VERSION }}
+#           install_args: "erlang elixir"
+#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+#           working_directory: xcode_processor
+#       - name: Load secrets from 1Password
+#         env:
+#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+#         run: |
+#           echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
+#           op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
+#           echo "EOF" >> $GITHUB_ENV
+#           echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
+#           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+#       - name: Setup SSH
+#         uses: webfactory/ssh-agent@v0.9.1
+#         with:
+#           ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
+#       - name: Deploy
+#         env:
+#           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+#         run: |
+#           mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging


### PR DESCRIPTION
## Summary

Follow-up to [#10345](https://github.com/tuist/tuist/pull/10345), disabling the remaining workflow-driven deploys for both services until we move to Kubernetes.

- `processor-deploy.yml` — comments out the `deploy-canary` job and the `on:` triggers. After this merges, no Processor Deploy job auto-runs on pushes to `main`.
- `xcode-processor-staging-deploy.yml` — xcode-processor has no canary tier, so the equivalent "remaining pre-prod deploy" is staging. Body moves under `#`, matching the shape of the already-disabled `xcode-processor-deploy.yml` on `main`.
- `processor-staging-deploy.yml` is intentionally left as-is so staging remains manually dispatchable for the build processor.

With this merged, neither processor has any workflow-driven deploy path on GitHub Actions. Manual deploys via `mise run deploy` from a developer machine remain possible for break-glass scenarios.

## Test plan

- [ ] After merge: pushes to `main` touching `processor/**` or `tuist_common/**` no longer queue `Processor Deploy`.
- [ ] `Xcode Processor Staging Deploy` no longer appears in the manual-dispatch list on the Actions tab.
- [ ] `Processor Staging Deploy` remains available for manual dispatch.
- [ ] After the k8s migration lands: revert this PR (plus [#10345](https://github.com/tuist/tuist/pull/10345)) — each a single uncomment per file — to restore full deploy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)