### PR TITLE
chore(ci): disable xcode-processor staging deploy pending k8s migration

### DIFF
--- a/.github/workflows/xcode-processor-staging-deploy.yml
+++ b/.github/workflows/xcode-processor-staging-deploy.yml
@@ -1,54 +1,59 @@
 name: Xcode Processor Staging Deploy
 
-permissions:
-  contents: read
+# NOTE: Disabled pending migration to Kubernetes. Staging targets the same
+# Scaleway Mac mini infrastructure as production and shares its reliability
+# issues. Re-enable by uncommenting the blocks below once the service runs
+# on k8s.
 
-on:
-  workflow_dispatch:
-    inputs:
-      commit_sha:
-        description: Sha of the commit to be deployed
-        required: true
-
-defaults:
-  run:
-    working-directory: xcode_processor
-
-env:
-  MISE_VERSION: "2026.4.18"
-  MISE_GITHUB_TOKEN: ${{ github.token }}
-
-jobs:
-  deploy:
-    runs-on: namespace-profile-default-macos
-    timeout-minutes: 45
-    environment: xcode-processor-staging
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.commit_sha }}
-      - uses: 1password/install-cli-action@v2
-      - uses: jdx/mise-action@v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-          install_args: "erlang elixir"
-          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-          working_directory: xcode_processor
-      - name: Load secrets from 1Password
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-          op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-          echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
-          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
-      - name: Deploy
-        env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-        run: |
-          mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging
+# permissions:
+#   contents: read
+#
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       commit_sha:
+#         description: Sha of the commit to be deployed
+#         required: true
+#
+# defaults:
+#   run:
+#     working-directory: xcode_processor
+#
+# env:
+#   MISE_VERSION: "2026.4.18"
+#   MISE_GITHUB_TOKEN: ${{ github.token }}
+#
+# jobs:
+#   deploy:
+#     runs-on: namespace-profile-default-macos
+#     timeout-minutes: 45
+#     environment: xcode-processor-staging
+#     steps:
+#       - uses: actions/checkout@v4
+#         with:
+#           ref: ${{ github.event.inputs.commit_sha }}
+#       - uses: 1password/install-cli-action@v2
+#       - uses: jdx/mise-action@v4.0.1
+#         with:
+#           version: ${{ env.MISE_VERSION }}
+#           install_args: "erlang elixir"
+#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+#           working_directory: xcode_processor
+#       - name: Load secrets from 1Password
+#         env:
+#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+#         run: |
+#           echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
+#           op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
+#           echo "EOF" >> $GITHUB_ENV
+#           echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
+#           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+#       - name: Setup SSH
+#         uses: webfactory/ssh-agent@v0.9.1
+#         with:
+#           ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
+#       - name: Deploy
+#         env:
+#           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+#         run: |
+#           mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging


### PR DESCRIPTION
## Summary

- Mirrors [#10348](https://github.com/tuist/tuist/pull/10348) for xcode-processor: since the xcode-processor has no canary tier, the "remaining pre-prod deploy" to disable is staging.
- Comments out `xcode-processor-staging-deploy.yml` — its `on:` / `jobs:` / `env:` blocks all move under `#`, leaving only `name:` and a disabled banner. This is the same shape as the already-disabled `xcode-processor-deploy.yml` on \`main\`.
- With this merged, the xcode-processor has no workflow-driven deploy path on GitHub Actions until the service is on Kubernetes. Manual deploys from a developer machine via \`mise run deploy\` remain possible if needed.

## Test plan

- [ ] After merge: confirm that `Xcode Processor Staging Deploy` no longer appears in the manual-dispatch list on the Actions tab.
- [ ] After the k8s migration lands: revert this PR (plus [#10345](https://github.com/tuist/tuist/pull/10345) and [#10348](https://github.com/tuist/tuist/pull/10348)) — each is a single uncomment — to restore full deploy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)