### PR TITLE
feat(cache): Fix cache read atomicity and treat corrupt Gradle entries as misses

### DIFF
--- a/cache/lib/cache/s3.ex
+++ b/cache/lib/cache/s3.ex
@@ -178,6 +178,7 @@ defmodule Cache.S3 do
 
   defp download_from_bucket(key, bucket) do
     local_path = Cache.Disk.artifact_path(key)
+    tmp_path = tmp_download_path(local_path)
 
     case head_object_status(bucket, key) do
       :exists ->
@@ -186,21 +187,31 @@ defmodule Cache.S3 do
         {dl_duration, dl_result} =
           :timer.tc(fn ->
             bucket
-            |> ExAws.S3.download_file(key, local_path)
+            |> ExAws.S3.download_file(key, tmp_path)
             |> ExAws.request()
           end)
 
         case dl_result do
           {:ok, :done} ->
-            :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :ok})
-            {:ok, :hit}
+            case publish_download(tmp_path, local_path) do
+              :ok ->
+                :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :ok})
+                {:ok, :hit}
+
+              {:error, reason} ->
+                :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
+                Logger.error("Failed to publish S3 download for artifact #{key}: #{inspect(reason)}")
+                {:error, reason}
+            end
 
           {:error, {:http_error, 429, _}} ->
+            cleanup_tmp_download(tmp_path)
             :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :rate_limited})
             Logger.warning("S3 download rate limited for artifact: #{key}")
             {:error, :rate_limited}
 
           {:error, reason} ->
+            cleanup_tmp_download(tmp_path)
             :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
             Logger.error("S3 download failed for artifact #{key}: #{inspect(reason)}")
             {:error, reason}
@@ -216,6 +227,36 @@ defmodule Cache.S3 do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp publish_download(tmp_path, local_path) do
+    case Cache.Disk.move_file(tmp_path, local_path) do
+      :ok ->
+        :ok
+
+      {:error, :exists} ->
+        cleanup_tmp_download(tmp_path)
+        :ok
+
+      {:error, reason} ->
+        cleanup_tmp_download(tmp_path)
+        {:error, reason}
+    end
+  end
+
+  defp cleanup_tmp_download(tmp_path) do
+    case File.rm(tmp_path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp tmp_download_path(local_path) do
+    dir = Path.dirname(local_path)
+    filename = Path.basename(local_path)
+    suffix = [:positive] |> System.unique_integer() |> Integer.to_string()
+    Path.join(dir, ".tmp.#{filename}.#{suffix}")
   end
 
   @doc """

--- a/cache/lib/cache/s3.ex
+++ b/cache/lib/cache/s3.ex
@@ -178,44 +178,10 @@ defmodule Cache.S3 do
 
   defp download_from_bucket(key, bucket) do
     local_path = Cache.Disk.artifact_path(key)
-    tmp_path = tmp_download_path(local_path)
 
     case head_object_status(bucket, key) do
       :exists ->
-        local_path |> Path.dirname() |> File.mkdir_p!()
-
-        {dl_duration, dl_result} =
-          :timer.tc(fn ->
-            bucket
-            |> ExAws.S3.download_file(key, tmp_path)
-            |> ExAws.request()
-          end)
-
-        case dl_result do
-          {:ok, :done} ->
-            case publish_download(tmp_path, local_path) do
-              :ok ->
-                :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :ok})
-                {:ok, :hit}
-
-              {:error, reason} ->
-                :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
-                Logger.error("Failed to publish S3 download for artifact #{key}: #{inspect(reason)}")
-                {:error, reason}
-            end
-
-          {:error, {:http_error, 429, _}} ->
-            cleanup_tmp_download(tmp_path)
-            :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :rate_limited})
-            Logger.warning("S3 download rate limited for artifact: #{key}")
-            {:error, :rate_limited}
-
-          {:error, reason} ->
-            cleanup_tmp_download(tmp_path)
-            :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
-            Logger.error("S3 download failed for artifact #{key}: #{inspect(reason)}")
-            {:error, reason}
-        end
+        download_existing_object(key, bucket, local_path)
 
       :not_found ->
         {:ok, :miss}
@@ -227,6 +193,48 @@ defmodule Cache.S3 do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp download_existing_object(key, bucket, local_path) do
+    tmp_path = tmp_download_path(local_path)
+
+    local_path |> Path.dirname() |> File.mkdir_p!()
+
+    {dl_duration, dl_result} =
+      :timer.tc(fn ->
+        bucket
+        |> ExAws.S3.download_file(key, tmp_path)
+        |> ExAws.request()
+      end)
+
+    handle_download_result(key, local_path, tmp_path, dl_duration, dl_result)
+  end
+
+  defp handle_download_result(key, local_path, tmp_path, dl_duration, {:ok, :done}) do
+    case publish_download(tmp_path, local_path) do
+      :ok ->
+        :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :ok})
+        {:ok, :hit}
+
+      {:error, reason} ->
+        :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
+        Logger.error("Failed to publish S3 download for artifact #{key}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp handle_download_result(key, _local_path, tmp_path, dl_duration, {:error, {:http_error, 429, _}}) do
+    cleanup_tmp_download(tmp_path)
+    :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :rate_limited})
+    Logger.warning("S3 download rate limited for artifact: #{key}")
+    {:error, :rate_limited}
+  end
+
+  defp handle_download_result(key, _local_path, tmp_path, dl_duration, {:error, reason}) do
+    cleanup_tmp_download(tmp_path)
+    :telemetry.execute([:cache, :s3, :download], %{duration: dl_duration}, %{result: :error})
+    Logger.error("S3 download failed for artifact #{key}: #{inspect(reason)}")
+    {:error, reason}
   end
 
   defp publish_download(tmp_path, local_path) do

--- a/cache/test/cache/s3_test.exs
+++ b/cache/test/cache/s3_test.exs
@@ -307,18 +307,23 @@ defmodule Cache.S3Test do
 
       expect(Cache.Disk, :artifact_path, fn ^key -> local_path end)
 
-      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, ^local_path ->
-        {:download_operation, "test-bucket", key, local_path}
+      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, tmp_path ->
+        assert Path.dirname(tmp_path) == tmp_dir
+        assert Path.basename(tmp_path) =~ ".tmp.test_hash."
+        {:download_operation, "test-bucket", key, tmp_path}
       end)
 
-      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, ^local_path} ->
-        File.write!(local_path, "downloaded content")
+      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, tmp_path} ->
+        File.write!(tmp_path, "downloaded content")
         {:ok, :done}
       end)
 
       capture_log(fn ->
         assert {:ok, :hit} = S3.download(key)
       end)
+
+      assert File.read!(local_path) == "downloaded content"
+      assert File.ls!(tmp_dir) == ["test_hash"]
     end
 
     test "returns {:ok, :miss} when file does not exist in S3" do
@@ -348,17 +353,21 @@ defmodule Cache.S3Test do
 
       expect(Cache.Disk, :artifact_path, fn ^key -> local_path end)
 
-      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, ^local_path ->
-        {:download_operation, "test-bucket", key, local_path}
+      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, tmp_path ->
+        {:download_operation, "test-bucket", key, tmp_path}
       end)
 
-      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, ^local_path} ->
+      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, tmp_path} ->
+        File.write!(tmp_path, "partial content")
         {:error, :timeout}
       end)
 
       capture_log(fn ->
         assert {:error, :timeout} = S3.download(key)
       end)
+
+      refute File.exists?(local_path)
+      assert File.ls!(tmp_dir) == []
     end
 
     test "returns :rate_limited error on 429 during exists check" do
@@ -390,17 +399,53 @@ defmodule Cache.S3Test do
 
       expect(Cache.Disk, :artifact_path, fn ^key -> local_path end)
 
-      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, ^local_path ->
-        {:download_operation, "test-bucket", key, local_path}
+      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, tmp_path ->
+        {:download_operation, "test-bucket", key, tmp_path}
       end)
 
-      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, ^local_path} ->
+      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, tmp_path} ->
+        File.write!(tmp_path, "partial content")
         {:error, {:http_error, 429, %{body: "Too many requests"}}}
       end)
 
       capture_log(fn ->
         assert {:error, :rate_limited} = S3.download(key)
       end)
+
+      refute File.exists?(local_path)
+      assert File.ls!(tmp_dir) == []
+    end
+
+    test "treats a finished download as success when another process published the artifact first" do
+      key = "test_account/test_project/xcode/TE/ST/test_hash"
+      {:ok, tmp_dir} = Briefly.create(directory: true)
+      local_path = Path.join(tmp_dir, "test_hash")
+
+      File.write!(local_path, "already there")
+
+      expect(ExAws.S3, :head_object, fn "test-bucket", ^key ->
+        %ExAws.Operation.S3{bucket: "test-bucket", path: key}
+      end)
+
+      expect(ExAws, :request, fn %ExAws.Operation.S3{}, _opts -> {:ok, %{status_code: 200}} end)
+
+      expect(Cache.Disk, :artifact_path, fn ^key -> local_path end)
+
+      expect(ExAws.S3, :download_file, fn "test-bucket", ^key, tmp_path ->
+        {:download_operation, "test-bucket", key, tmp_path}
+      end)
+
+      expect(ExAws, :request, fn {:download_operation, "test-bucket", ^key, tmp_path} ->
+        File.write!(tmp_path, "new content")
+        {:ok, :done}
+      end)
+
+      capture_log(fn ->
+        assert {:ok, :hit} = S3.download(key)
+      end)
+
+      assert File.read!(local_path) == "already there"
+      assert File.ls!(tmp_dir) == ["test_hash"]
     end
 
     test "xcode_cache download from primary bucket returns {:ok, :hit}" do
@@ -416,18 +461,23 @@ defmodule Cache.S3Test do
 
       expect(Cache.Disk, :artifact_path, fn ^key -> local_path end)
 
-      expect(ExAws.S3, :download_file, fn "test-xcode-cache-bucket", ^key, ^local_path ->
-        {:download_operation, "test-xcode-cache-bucket", key, local_path}
+      expect(ExAws.S3, :download_file, fn "test-xcode-cache-bucket", ^key, tmp_path ->
+        assert Path.dirname(tmp_path) == tmp_dir
+        assert Path.basename(tmp_path) =~ ".tmp.test_hash."
+        {:download_operation, "test-xcode-cache-bucket", key, tmp_path}
       end)
 
-      expect(ExAws, :request, fn {:download_operation, "test-xcode-cache-bucket", ^key, ^local_path} ->
-        File.write!(local_path, "downloaded content")
+      expect(ExAws, :request, fn {:download_operation, "test-xcode-cache-bucket", ^key, tmp_path} ->
+        File.write!(tmp_path, "downloaded content")
         {:ok, :done}
       end)
 
       capture_log(fn ->
         assert {:ok, :hit} = S3.download(key, type: :xcode_cache)
       end)
+
+      assert File.read!(local_path) == "downloaded content"
+      assert File.ls!(tmp_dir) == ["test_hash"]
     end
 
     test "xcode_cache download returns {:ok, :miss} when not in dedicated bucket" do

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
@@ -7,9 +7,12 @@ import org.gradle.caching.BuildCacheKey
 import org.gradle.caching.BuildCacheService
 import org.gradle.caching.BuildCacheServiceFactory
 import org.gradle.caching.configuration.AbstractBuildCache
+import org.slf4j.LoggerFactory
+import java.io.EOFException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URI
+import java.util.zip.ZipException
 
 /**
  * Build cache configuration type for Tuist.
@@ -169,15 +172,20 @@ class TuistBuildCacheService(
                 HttpURLConnection.HTTP_OK -> {
                     try {
                         connection.inputStream.use { input -> reader.readFrom(input) }
+                        true
                     } catch (e: Throwable) {
-                        throw cacheFailure(
-                            "load", cacheKey, url,
-                            "Failed to read cache entry body (Content-Length=${connection.contentLengthLong})",
-                            cause = e,
-                            status = responseCode
-                        )
+                        if (looksLikeInvalidCompressedCacheEntry(e)) {
+                            logCorruptCacheEntry(url, cacheKey, connection, e)
+                            false
+                        } else {
+                            throw cacheFailure(
+                                "load", cacheKey, url,
+                                "Failed to read cache entry body (Content-Length=${connection.contentLengthLong})",
+                                cause = e,
+                                status = responseCode
+                            )
+                        }
                     }
-                    true
                 }
                 HttpURLConnection.HTTP_NOT_FOUND -> false
                 HttpURLConnection.HTTP_UNAUTHORIZED -> throw TokenExpiredException()
@@ -256,6 +264,18 @@ class TuistBuildCacheService(
 
     companion object {
         private const val ERROR_BODY_MAX_BYTES = 1024
+        private val logger = LoggerFactory.getLogger(TuistBuildCacheService::class.java)
+        private val invalidCompressionMessageHints = listOf(
+            "unexpected end of zlib input stream",
+            "not in gzip format",
+            "invalid stored block lengths",
+            "invalid distance too far back",
+            "invalid entry compressed size",
+            "end of central directory",
+            "invalid code lengths set",
+            "invalid literal/lengths set",
+            "corrupt gzip trailer"
+        )
 
         internal fun cacheFailure(
             operation: String,
@@ -298,6 +318,40 @@ class TuistBuildCacheService(
                 null
             }
         }
+
+        internal fun looksLikeInvalidCompressedCacheEntry(error: Throwable): Boolean {
+            return causalChain(error).any { candidate ->
+                candidate is ZipException ||
+                    candidate is EOFException ||
+                    candidate.message
+                        ?.lowercase()
+                        ?.let { message -> invalidCompressionMessageHints.any(message::contains) }
+                        ?: false
+            }
+        }
+
+        private fun logCorruptCacheEntry(
+            url: URI,
+            cacheKey: String,
+            connection: HttpURLConnection,
+            error: Throwable
+        ) {
+            val rootCause = causalChain(error).last()
+            logger.warn(
+                "Tuist: Treating remote cache entry {} as a miss because it appears invalid while reading from {} " +
+                    "(Content-Length={}, ETag={}, Last-Modified={}): {}: {}",
+                cacheKey,
+                "${url.host ?: "<unknown>"}${url.rawPath ?: ""}",
+                connection.contentLengthLong,
+                connection.getHeaderField("ETag") ?: "<none>",
+                connection.getHeaderField("Last-Modified") ?: "<none>",
+                rootCause.javaClass.name,
+                rootCause.message ?: "(no message)"
+            )
+        }
+
+        private fun causalChain(error: Throwable): Sequence<Throwable> =
+            generateSequence(error) { current -> current.cause }
     }
 }
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistBuildCacheTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.zip.ZipException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -177,6 +178,28 @@ class TuistBuildCacheTest {
             "expected underlying cause in message, got: $message"
         )
         assertEquals("truncated body", exception.cause?.message)
+    }
+
+    @Test
+    fun `load treats invalid compressed cache entries as cache misses`() {
+        mockServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("anything")
+                .addHeader("ETag", "\"bad-entry\"")
+                .addHeader("Last-Modified", "Tue, 21 Apr 2026 00:47:30 GMT")
+        )
+
+        val service = createService()
+        val reader = object : BuildCacheEntryReader {
+            override fun readFrom(input: InputStream) {
+                throw ZipException("Unexpected end of ZLIB input stream")
+            }
+        }
+
+        val result = service.load(TestBuildCacheKey("corrupt-entry"), reader)
+
+        assertFalse(result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Make S3 read-through downloads atomic by writing to a temp file and publishing only after the transfer completes.
- Treat invalid compressed Gradle cache payloads as cache misses instead of build failures.
- Log corrupt cache reads with cache key, host/path, content length, ETag, and Last-Modified for tracing.

## Testing
- Ran cache service unit tests for S3 download behavior.
- Ran the targeted Gradle build cache unit test suite.
- Both targeted test runs passed locally.