### PR TITLE
fix(ci): surface homebrew dispatch failures and fix curl invocation

### DIFF
--- a/mise/tasks/app/release/homebrew-cask.sh
+++ b/mise/tasks/app/release/homebrew-cask.sh
@@ -33,7 +33,7 @@ REPO="homebrew-tuist"
 WORKFLOW_ID="130356792"
 
 # Trigger the workflow
-curl -v X POST \
+curl --fail-with-body -v -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_ID/dispatches" \

--- a/mise/tasks/cli/release/homebrew-formula.sh
+++ b/mise/tasks/cli/release/homebrew-formula.sh
@@ -33,7 +33,7 @@ REPO="homebrew-tuist"
 WORKFLOW_ID="90129194"
 
 # Trigger the workflow
-curl -v X POST \
+curl --fail-with-body -v -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_ID/dispatches" \


### PR DESCRIPTION
## Summary
- `mise/tasks/cli/release/homebrew-formula.sh` and `mise/tasks/app/release/homebrew-cask.sh` were invoking `curl -v X POST`, which parsed `X` and `POST` as URLs instead of supplying `-X POST`. The real dispatch URL still got a request, but the invocation was clearly wrong and surfaced `Could not resolve host: X` / `...POST` lines in every release log.
- Neither script used `--fail`, so when the homebrew dispatch started returning HTTP 403 (`Resource not accessible by personal access token`) after [#10223](https://github.com/tuist/tuist/pull/10223) split the PAT, the step exited 0 and CLI releases 4.177.0 → 4.183.0 never updated `tuist/homebrew-tuist` (last tap release: 4.176.4, right before the PAT split merged).

This PR changes the invocation to `curl --fail-with-body -v -X POST`. It does not fix the PAT itself — `TUIST_RELEASE_GITHUB_TOKEN` still needs `actions:write` on `tuist/homebrew-tuist` — but it ensures any future 4xx from the dispatch call fails the release step loudly instead of silently.

## Test plan
- [ ] Next CLI release after merging: confirm the "Trigger Homebrew Formula Update" step either succeeds (tap repo gets the new formula) or fails visibly if the PAT still isn't authorized.
- [ ] Backfill the missing formulas (4.177.0 → 4.183.0) via `mise run --no-deps cli:release:homebrew-formula` or manual `workflow_dispatch` on homebrew-tuist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)