### PR TITLE
fix(server): return structured errors from list_cacheable_tasks

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -285,7 +285,10 @@ defmodule Tuist.Builds do
   end
 
   def list_cacheable_tasks(attrs) do
-    ClickHouseFlop.validate_and_run!(CacheableTask, attrs, for: CacheableTask)
+    case ClickHouseFlop.validate_and_run(CacheableTask, attrs, for: CacheableTask) do
+      {:ok, result} -> {:ok, result}
+      {:error, %Flop.Meta{errors: errors}} -> {:error, errors}
+    end
   end
 
   def list_cas_outputs(attrs) do

--- a/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
+++ b/server/lib/tuist/mcp/components/tools/list_xcode_build_cache_tasks.ex
@@ -14,10 +14,12 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
         },
         "status" => %{
           "type" => "string",
+          "enum" => ["hit_local", "hit_remote", "miss"],
           "description" => "Filter by cache status: hit_local, hit_remote, or miss."
         },
         "type" => %{
           "type" => "string",
+          "enum" => ["clang", "swift"],
           "description" => "Filter by task type: clang or swift."
         },
         "page" => %{
@@ -51,44 +53,42 @@ defmodule Tuist.MCP.Components.Tools.ListXcodeBuildCacheTasks do
              :build,
              "Build not found: #{build_run_id}"
            ) do
-      filters = [%{field: :build_run_id, op: :==, value: build_run_id}]
-
-      filters =
-        Enum.reduce([:status, :type], filters, fn field, acc ->
-          case Map.get(args, to_string(field)) do
-            nil -> acc
-            value -> acc ++ [%{field: field, op: :==, value: value}]
-          end
-        end)
-
-      page = MCPTool.page(args)
-      page_size = MCPTool.page_size(args)
-
-      {tasks, meta} =
-        Builds.list_cacheable_tasks(%{
-          filters: filters,
-          order_by: [:inserted_at],
-          order_directions: [:desc],
-          page: page,
-          page_size: page_size
-        })
-
-      {:ok,
-       %{
-         tasks:
-           Enum.map(tasks, fn task ->
-             %{
-               type: to_string(task.type),
-               status: to_string(task.status),
-               key: task.key,
-               read_duration: task.read_duration,
-               write_duration: task.write_duration,
-               description: task.description,
-               cas_output_node_ids: task.cas_output_node_ids
-             }
-           end),
-         pagination_metadata: MCPTool.pagination_metadata(meta)
-       }}
+      with {:ok, {tasks, meta}} <-
+             Builds.list_cacheable_tasks(%{
+               filters: build_filters(build_run_id, args),
+               order_by: [:inserted_at],
+               order_directions: [:desc],
+               page: MCPTool.page(args),
+               page_size: MCPTool.page_size(args)
+             }) do
+        {:ok,
+         %{
+           tasks:
+             Enum.map(tasks, fn task ->
+               %{
+                 type: to_string(task.type),
+                 status: to_string(task.status),
+                 key: task.key,
+                 read_duration: task.read_duration,
+                 write_duration: task.write_duration,
+                 description: task.description,
+                 cas_output_node_ids: task.cas_output_node_ids
+               }
+             end),
+           pagination_metadata: MCPTool.pagination_metadata(meta)
+         }}
+      end
     end
+  end
+
+  defp build_filters(build_run_id, args) do
+    base = [%{field: :build_run_id, op: :==, value: build_run_id}]
+
+    Enum.reduce([:status, :type], base, fn field, acc ->
+      case Map.get(args, to_string(field)) do
+        nil -> acc
+        value -> acc ++ [%{field: field, op: :==, value: value}]
+      end
+    end)
   end
 end

--- a/server/lib/tuist/mcp/tool.ex
+++ b/server/lib/tuist/mcp/tool.ex
@@ -58,7 +58,8 @@ defmodule Tuist.MCP.Tool do
   # --- Call dispatchers ---
 
   def respond({:ok, data}), do: json_response(data)
-  def respond({:error, message}), do: EMCP.Tool.error(message)
+  def respond({:error, message}) when is_binary(message), do: EMCP.Tool.error(message)
+  def respond({:error, other}), do: EMCP.Tool.error(inspect(other))
 
   def call_with_project(conn, args, action, category, execute_fn) do
     case resolve_and_authorize_project(args, conn.assigns, action, category) do

--- a/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
@@ -134,7 +134,7 @@ defmodule TuistWeb.API.BuildCacheTasksController do
       {:ok, %{project_id: project_id}} when project_id == selected_project.id ->
         filters = build_filters(build_id, params)
 
-        {tasks, meta} =
+        {:ok, {tasks, meta}} =
           Builds.list_cacheable_tasks(%{
             filters: filters,
             order_by: [:inserted_at],

--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -967,7 +967,7 @@ defmodule TuistWeb.BuildRunLive do
       order_directions: order_directions
     }
 
-    {tasks, tasks_meta} = Builds.list_cacheable_tasks(options)
+    {:ok, {tasks, tasks_meta}} = Builds.list_cacheable_tasks(options)
 
     # Fetch CAS outputs for all tasks on the current page
     all_node_ids =

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -861,7 +861,7 @@ defmodule Tuist.BuildsTest do
         )
 
       # When
-      {tasks, meta} =
+      {:ok, {tasks, meta}} =
         Builds.list_cacheable_tasks(%{
           page_size: 2,
           filters: [%{field: :build_run_id, op: :==, value: build.id}]
@@ -885,7 +885,7 @@ defmodule Tuist.BuildsTest do
         )
 
       # When - filter by type
-      {swift_tasks, _meta} =
+      {:ok, {swift_tasks, _meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [
             %{field: :build_run_id, op: :==, value: build.id},
@@ -910,7 +910,7 @@ defmodule Tuist.BuildsTest do
         )
 
       # When
-      {tasks, _meta} =
+      {:ok, {tasks, _meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [%{field: :build_run_id, op: :==, value: build.id}],
           order_by: [:key],
@@ -927,7 +927,7 @@ defmodule Tuist.BuildsTest do
       {:ok, build} = RunsFixtures.build_fixture(cacheable_tasks: [])
 
       # When
-      {tasks, meta} =
+      {:ok, {tasks, meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [%{field: :build_run_id, op: :==, value: build.id}]
         })
@@ -935,6 +935,21 @@ defmodule Tuist.BuildsTest do
       # Then
       assert tasks == []
       assert meta.total_count == 0
+    end
+
+    test "returns {:error, errors} when a filter value is invalid" do
+      # When
+      result =
+        Builds.list_cacheable_tasks(%{
+          filters: [
+            %{field: :build_run_id, op: :==, value: "00000000-0000-0000-0000-000000000000"},
+            %{field: :status, op: :==, value: "hit"}
+          ]
+        })
+
+      # Then
+      assert {:error, errors} = result
+      assert Keyword.has_key?(errors, :filters)
     end
   end
 

--- a/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/xcode_build_tools_test.exs
@@ -246,25 +246,26 @@ defmodule Tuist.MCP.Components.Tools.XcodeBuildToolsTest do
       stub(Tuist.Authorization, :authorize, fn :build_read, :subject, ^project -> :ok end)
 
       stub(Builds, :list_cacheable_tasks, fn _attrs ->
-        {[
-           %{
-             type: "swift",
-             status: "hit_remote",
-             key: "abc123",
-             read_duration: 50.0,
-             write_duration: nil,
-             description: "AppTarget",
-             cas_output_node_ids: ["node-1"]
-           }
-         ],
-         %{
-           has_next_page?: false,
-           has_previous_page?: false,
-           total_count: 1,
-           total_pages: 1,
-           current_page: 1,
-           page_size: 20
-         }}
+        {:ok,
+         {[
+            %{
+              type: "swift",
+              status: "hit_remote",
+              key: "abc123",
+              read_duration: 50.0,
+              write_duration: nil,
+              description: "AppTarget",
+              cas_output_node_ids: ["node-1"]
+            }
+          ],
+          %{
+            has_next_page?: false,
+            has_previous_page?: false,
+            total_count: 1,
+            total_pages: 1,
+            current_page: 1,
+            page_size: 20
+          }}}
       end)
 
       result = ListXcodeBuildCacheTasks.call(conn_with_subject(), %{"build_run_id" => "build-1"})

--- a/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
@@ -22,15 +22,16 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
       stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cacheable_tasks, fn _attrs ->
-        {[],
-         %{
-           has_next_page?: false,
-           has_previous_page?: false,
-           current_page: 1,
-           page_size: 20,
-           total_count: 0,
-           total_pages: 0
-         }}
+        {:ok,
+         {[],
+          %{
+            has_next_page?: false,
+            has_previous_page?: false,
+            current_page: 1,
+            page_size: 20,
+            total_count: 0,
+            total_pages: 0
+          }}}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/cache-tasks")
@@ -54,25 +55,26 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
       stub(Builds, :get_build, fn _id -> {:ok, build} end)
 
       stub(Builds, :list_cacheable_tasks, fn _attrs ->
-        {[
-           %{
-             type: :swift,
-             status: :hit_remote,
-             key: "abc123",
-             read_duration: 250.5,
-             write_duration: nil,
-             description: "MyModule",
-             cas_output_node_ids: ["node1", "node2"]
-           }
-         ],
-         %{
-           has_next_page?: false,
-           has_previous_page?: false,
-           current_page: 1,
-           page_size: 20,
-           total_count: 1,
-           total_pages: 1
-         }}
+        {:ok,
+         {[
+            %{
+              type: :swift,
+              status: :hit_remote,
+              key: "abc123",
+              read_duration: 250.5,
+              write_duration: nil,
+              description: "MyModule",
+              cas_output_node_ids: ["node1", "node2"]
+            }
+          ],
+          %{
+            has_next_page?: false,
+            has_previous_page?: false,
+            current_page: 1,
+            page_size: 20,
+            total_count: 1,
+            total_pages: 1
+          }}}
       end)
 
       conn = get(conn, "/api/projects/#{user.account.name}/#{project.name}/xcode/builds/#{build.id}/cache-tasks")
@@ -98,25 +100,26 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
       expect(Builds, :list_cacheable_tasks, fn attrs ->
         assert %{field: :status, op: :==, value: "miss"} in attrs.filters
 
-        {[
-           %{
-             type: :swift,
-             status: :miss,
-             key: "abc123",
-             read_duration: nil,
-             write_duration: 500.0,
-             description: nil,
-             cas_output_node_ids: []
-           }
-         ],
-         %{
-           has_next_page?: false,
-           has_previous_page?: false,
-           current_page: 1,
-           page_size: 20,
-           total_count: 1,
-           total_pages: 1
-         }}
+        {:ok,
+         {[
+            %{
+              type: :swift,
+              status: :miss,
+              key: "abc123",
+              read_duration: nil,
+              write_duration: 500.0,
+              description: nil,
+              cas_output_node_ids: []
+            }
+          ],
+          %{
+            has_next_page?: false,
+            has_previous_page?: false,
+            current_page: 1,
+            page_size: 20,
+            total_count: 1,
+            total_pages: 1
+          }}}
       end)
 
       conn =
@@ -138,25 +141,26 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
       expect(Builds, :list_cacheable_tasks, fn attrs ->
         assert %{field: :type, op: :==, value: "clang"} in attrs.filters
 
-        {[
-           %{
-             type: :clang,
-             status: :hit_local,
-             key: "def456",
-             read_duration: 100.0,
-             write_duration: nil,
-             description: nil,
-             cas_output_node_ids: []
-           }
-         ],
-         %{
-           has_next_page?: false,
-           has_previous_page?: false,
-           current_page: 1,
-           page_size: 20,
-           total_count: 1,
-           total_pages: 1
-         }}
+        {:ok,
+         {[
+            %{
+              type: :clang,
+              status: :hit_local,
+              key: "def456",
+              read_duration: 100.0,
+              write_duration: nil,
+              description: nil,
+              cas_output_node_ids: []
+            }
+          ],
+          %{
+            has_next_page?: false,
+            has_previous_page?: false,
+            current_page: 1,
+            page_size: 20,
+            total_count: 1,
+            total_pages: 1
+          }}}
       end)
 
       conn =
@@ -179,25 +183,26 @@ defmodule TuistWeb.API.BuildCacheTasksControllerTest do
         assert attrs.page == 2
         assert attrs.page_size == 10
 
-        {[
-           %{
-             type: :swift,
-             status: :hit_remote,
-             key: "abc123",
-             read_duration: 250.5,
-             write_duration: nil,
-             description: nil,
-             cas_output_node_ids: []
-           }
-         ],
-         %{
-           has_next_page?: false,
-           has_previous_page?: true,
-           current_page: 2,
-           page_size: 10,
-           total_count: 11,
-           total_pages: 2
-         }}
+        {:ok,
+         {[
+            %{
+              type: :swift,
+              status: :hit_remote,
+              key: "abc123",
+              read_duration: 250.5,
+              write_duration: nil,
+              description: nil,
+              cas_output_node_ids: []
+            }
+          ],
+          %{
+            has_next_page?: false,
+            has_previous_page?: true,
+            current_page: 2,
+            page_size: 10,
+            total_count: 11,
+            total_pages: 2
+          }}}
       end)
 
       conn =

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -725,7 +725,7 @@ defmodule TuistWeb.API.RunsControllerTest do
       assert build.cacheable_task_local_hits_count == 2
       assert build.cacheable_task_remote_hits_count == 2
 
-      {cacheable_tasks, _meta} =
+      {:ok, {cacheable_tasks, _meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [%{field: :build_run_id, op: :==, value: build.id}],
           order_by: [:key],
@@ -782,7 +782,7 @@ defmodule TuistWeb.API.RunsControllerTest do
       assert build.cacheable_task_remote_hits_count == 0
 
       # Verify no cacheable tasks are created in ClickHouse
-      {cacheable_tasks, _meta} =
+      {:ok, {cacheable_tasks, _meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [%{field: :build_run_id, op: :==, value: build.id}]
         })
@@ -1038,7 +1038,7 @@ defmodule TuistWeb.API.RunsControllerTest do
       Buffer.flush()
       [build] = get_builds_for_project(project.id)
 
-      {cacheable_tasks, _meta} =
+      {:ok, {cacheable_tasks, _meta}} =
         Builds.list_cacheable_tasks(%{
           filters: [%{field: :build_run_id, op: :==, value: build.id}],
           order_by: [:key],


### PR DESCRIPTION
## Summary

- Fixes Sentry issue [TUIST-BJ](https://tuist.sentry.io/issues/113957997/) — the MCP `list_xcode_build_cache_tasks` tool crashed with an uncaught `Flop.InvalidParamsError` when an LLM passed an invalid `status` value (e.g. `"hit"` instead of `hit_local`/`hit_remote`/`miss`), returning a 500.
- Switched `Builds.list_cacheable_tasks/1` from `Flop.validate_and_run!/3` (bang) to `Flop.validate_and_run/3`. It now returns `{:ok, {tasks, meta}} | {:error, errors}` where `errors` is the Flop validation keyword list. Updated the API controller, LiveView, and MCP tool callers to match.
- `MCPTool.respond/1` now handles non-binary errors by `inspect`ing them, so MCP tools can pass structured errors straight through without formatting.
- Added `enum` constraints to the MCP tool's JSON Schema for `status` and `type` so LLM clients see the allowed values upfront.

## Why

Flop was an implementation detail that leaked out as an uncaught exception. The fix keeps Flop inside `Builds` while giving callers a contract they can actually pattern-match on (`{:ok, _}` / `{:error, _}`).

### How to test locally

- [ ] `mix test test/tuist/builds_test.exs test/tuist/mcp/components/tools/xcode_build_tools_test.exs` — 72 tests green.
- [ ] `mix format --check-formatted` and `mix credo` clean on the touched files.
- [ ] Manually: call the `list_xcode_build_cache_tasks` MCP tool with `status: "hit"` — should return `isError: true` with the structured Flop errors `inspect`ed, instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)