### PR TITLE
chore(server): Make our ClickHouse development setup work with worktrees

### DIFF
--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -9,14 +9,17 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_INSTANCE_FILE="${PROJECT_ROOT}/.tuist-dev-instance"
+CLICKHOUSE_STATE_ROOT="${XDG_STATE_HOME:-${HOME}/.local/state}/tuist"
 
-resolve_instance_file() {
+resolve_git_path() {
+  local target_name="$1"
+  local fallback_path="$2"
   local git_path=""
 
   if command -v git >/dev/null 2>&1 && git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git_path="$(
-      git -C "${PROJECT_ROOT}" rev-parse --path-format=absolute --git-path tuist-dev-instance 2>/dev/null ||
-        git -C "${PROJECT_ROOT}" rev-parse --git-path tuist-dev-instance 2>/dev/null ||
+      git -C "${PROJECT_ROOT}" rev-parse --path-format=absolute --git-path "${target_name}" 2>/dev/null ||
+        git -C "${PROJECT_ROOT}" rev-parse --git-path "${target_name}" 2>/dev/null ||
         true
     )"
 
@@ -28,11 +31,11 @@ resolve_instance_file() {
   if [[ -n "${git_path}" ]]; then
     printf '%s' "${git_path}"
   else
-    printf '%s' "${ROOT_INSTANCE_FILE}"
+    printf '%s' "${fallback_path}"
   fi
 }
 
-INSTANCE_FILE="$(resolve_instance_file)"
+INSTANCE_FILE="$(resolve_git_path "tuist-dev-instance" "${ROOT_INSTANCE_FILE}")"
 
 validate_suffix() {
   local suffix="$1"
@@ -94,6 +97,13 @@ export TUIST_SERVER_HOSTNAME="${project_hostname}.localhost"
 export TUIST_SERVER_URL="http://localhost:${TUIST_SERVER_PORT}"
 export TUIST_SERVER_POSTGRES_DB="tuist_development_${suffix}"
 export TUIST_SERVER_CLICKHOUSE_DB="tuist_development_${suffix}"
+export TUIST_SERVER_CLICKHOUSE_RUNTIME_DIR="${CLICKHOUSE_STATE_ROOT}/clickhouse"
+export TUIST_SERVER_CLICKHOUSE_HTTP_PORT="8123"
+export TUIST_SERVER_CLICKHOUSE_NATIVE_PORT="9000"
+export TUIST_SERVER_CLICKHOUSE_INTERSERVER_HTTP_PORT="9009"
+export TUIST_SERVER_CLICKHOUSE_MYSQL_PORT="9004"
+export TUIST_SERVER_CLICKHOUSE_POSTGRESQL_PORT="9005"
+export TUIST_SERVER_CLICKHOUSE_HTTP_URL="http://127.0.0.1:${TUIST_SERVER_CLICKHOUSE_HTTP_PORT}"
 export TUIST_CACHE_PORT="$((8087 + suffix))"
 export TUIST_CACHE_SERVER_URL="${TUIST_SERVER_URL}"
 export TUIST_MINIO_API_PORT="$((9095 + suffix))"

--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,7 @@ Contributions to the Tuist Server require signing a Contributor License Agreemen
 1. Install dependencies: `mise run install`
 1. Create and set up the database: `mise run db:setup`
 1. Run the server: `mise run dev`
-1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and server databases, so developers can choose either standalone clones or linked worktrees. For example, a suffix of `443` yields `http://localhost:8523`:
+1. Open the local URL for your current clone or worktree in your browser and log in with the pre-made test user account. With `mise activate` enabled, each checkout persists its own numeric suffix through Git metadata when available, while keeping the existing root `.tuist-dev-instance` file as a compatibility fallback. That suffix scopes the local service ports, MinIO ports, and the PostgreSQL and ClickHouse database names, while the local ClickHouse daemon itself stays shared across checkouts. For example, a suffix of `443` yields `http://localhost:8523`:
 
 ```
 Email: tuistrocks@tuist.dev

--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -136,15 +136,11 @@ config :phoenix_live_reload,
 config :phoenix_live_view, :debug_heex_annotations, true
 
 config :tuist, Tuist.ClickHouseRepo,
-  hostname: "localhost",
-  port: 8123,
-  database: "tuist_development",
+  hostname: "127.0.0.1",
   settings: [readonly: 1]
 
 config :tuist, Tuist.IngestRepo,
-  hostname: "localhost",
-  port: 8123,
-  database: "tuist_development",
+  hostname: "127.0.0.1",
   flush_interval_ms: 5000,
   # Bytes
   max_buffer_size: 100_000,
@@ -155,15 +151,11 @@ config :tuist, Tuist.Mailer, adapter: Bamboo.LocalAdapter
 # Configure your database
 config :tuist, Tuist.Repo,
   hostname: "localhost",
-  database: "tuist_development",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 
 config :tuist, TuistWeb.Endpoint,
-  # Binding to loopback ipv4 address prevents access from other machines.
-  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 8080],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -136,11 +136,15 @@ config :phoenix_live_reload,
 config :phoenix_live_view, :debug_heex_annotations, true
 
 config :tuist, Tuist.ClickHouseRepo,
-  hostname: "127.0.0.1",
+  hostname: "localhost",
+  port: 8123,
+  database: "tuist_development",
   settings: [readonly: 1]
 
 config :tuist, Tuist.IngestRepo,
-  hostname: "127.0.0.1",
+  hostname: "localhost",
+  port: 8123,
+  database: "tuist_development",
   flush_interval_ms: 5000,
   # Bytes
   max_buffer_size: 100_000,
@@ -151,11 +155,15 @@ config :tuist, Tuist.Mailer, adapter: Bamboo.LocalAdapter
 # Configure your database
 config :tuist, Tuist.Repo,
   hostname: "localhost",
+  database: "tuist_development",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 
 config :tuist, TuistWeb.Endpoint,
+  # Binding to loopback ipv4 address prevents access from other machines.
+  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  http: [ip: {127, 0, 0, 1}, port: 8080],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -165,6 +165,9 @@ if Enum.member?([:prod, :stag, :can], env) do
 end
 
 if env == :dev do
+  clickhouse_http_port =
+    String.to_integer(System.get_env("TUIST_SERVER_CLICKHOUSE_HTTP_PORT") || "8123")
+
   dev_db_config =
     for {env_var, key} <- [
           {"DATABASE_USERNAME", :username},
@@ -175,12 +178,45 @@ if env == :dev do
         value = System.get_env(env_var),
         do: {key, value}
 
-  config :tuist, Tuist.Repo, dev_db_config
+  config :tuist, Tuist.Repo, Keyword.put_new(dev_db_config, :database, "tuist_development")
 
-  if clickhouse_database = System.get_env("TUIST_SERVER_CLICKHOUSE_DB") do
-    config :tuist, Tuist.ClickHouseRepo, database: clickhouse_database
-    config :tuist, Tuist.IngestRepo, database: clickhouse_database
-  end
+  clickhouse_dev_config = [
+    hostname: "127.0.0.1",
+    port: clickhouse_http_port,
+    database: System.get_env("TUIST_SERVER_CLICKHOUSE_DB") || "tuist_development"
+  ]
+
+  config :tuist, Tuist.ClickHouseRepo, clickhouse_dev_config
+  config :tuist, Tuist.IngestRepo, clickhouse_dev_config
+end
+
+if env == :test do
+  test_postgres_db =
+    System.get_env("TUIST_SERVER_TEST_POSTGRES_DB") ||
+      "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
+
+  test_clickhouse_db =
+    System.get_env("TUIST_SERVER_TEST_CLICKHOUSE_DB") ||
+      "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
+
+  test_port = String.to_integer(System.get_env("TUIST_SERVER_TEST_PORT") || "4002")
+  clickhouse_http_port =
+    String.to_integer(System.get_env("TUIST_SERVER_CLICKHOUSE_HTTP_PORT") || "8123")
+
+  config :tuist, Tuist.Repo, database: test_postgres_db
+
+  config :tuist, Tuist.ClickHouseRepo,
+    hostname: "127.0.0.1",
+    port: clickhouse_http_port,
+    database: test_clickhouse_db
+
+  config :tuist, Tuist.IngestRepo,
+    hostname: "127.0.0.1",
+    port: clickhouse_http_port,
+    database: test_clickhouse_db
+
+  config :tuist, TuistWeb.Endpoint,
+    http: [ip: {127, 0, 0, 1}, port: test_port]
 end
 
 if Enum.member?([:prod, :stag, :can, :dev], env) do

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -178,8 +178,6 @@ if env == :dev do
         value = System.get_env(env_var),
         do: {key, value}
 
-  config :tuist, Tuist.Repo, Keyword.put_new(dev_db_config, :database, "tuist_development")
-
   clickhouse_dev_config = [
     hostname: "127.0.0.1",
     port: clickhouse_http_port,
@@ -188,6 +186,7 @@ if env == :dev do
 
   config :tuist, Tuist.ClickHouseRepo, clickhouse_dev_config
   config :tuist, Tuist.IngestRepo, clickhouse_dev_config
+  config :tuist, Tuist.Repo, Keyword.put_new(dev_db_config, :database, "tuist_development")
 end
 
 if env == :test do
@@ -200,10 +199,9 @@ if env == :test do
       "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
 
   test_port = String.to_integer(System.get_env("TUIST_SERVER_TEST_PORT") || "4002")
+
   clickhouse_http_port =
     String.to_integer(System.get_env("TUIST_SERVER_CLICKHOUSE_HTTP_PORT") || "8123")
-
-  config :tuist, Tuist.Repo, database: test_postgres_db
 
   config :tuist, Tuist.ClickHouseRepo,
     hostname: "127.0.0.1",
@@ -215,8 +213,8 @@ if env == :test do
     port: clickhouse_http_port,
     database: test_clickhouse_db
 
-  config :tuist, TuistWeb.Endpoint,
-    http: [ip: {127, 0, 0, 1}, port: test_port]
+  config :tuist, Tuist.Repo, database: test_postgres_db
+  config :tuist, TuistWeb.Endpoint, http: [ip: {127, 0, 0, 1}, port: test_port]
 end
 
 if Enum.member?([:prod, :stag, :can, :dev], env) do

--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -1,12 +1,5 @@
 import Config
 
-test_postgres_db = System.get_env("TUIST_SERVER_TEST_POSTGRES_DB") || "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
-
-test_clickhouse_db =
-  System.get_env("TUIST_SERVER_TEST_CLICKHOUSE_DB") || "tuist_test#{System.get_env("MIX_TEST_PARTITION")}"
-
-test_port = String.to_integer(System.get_env("TUIST_SERVER_TEST_PORT") || "4002")
-
 # Only in tests, remove the complexity from the password hashing algorithm
 config :bcrypt_elixir, :log_rounds, 1
 
@@ -29,17 +22,13 @@ config :sentry, dsn: nil
 config :tuist, Oban, testing: :manual
 
 config :tuist, Tuist.ClickHouseRepo,
-  hostname: "localhost",
-  port: 8123,
-  database: test_clickhouse_db,
+  hostname: "127.0.0.1",
   # Workaround for ClickHouse lazy materialization bug with projections
   # https://github.com/ClickHouse/ClickHouse/issues/80201
   settings: [readonly: 1, query_plan_optimize_lazy_materialization: 0]
 
 config :tuist, Tuist.IngestRepo,
-  hostname: "localhost",
-  port: 8123,
-  database: test_clickhouse_db,
+  hostname: "127.0.0.1",
   flush_interval_ms: 5000,
   max_buffer_size: 100_000,
   pool_size: 5,
@@ -60,7 +49,6 @@ config :tuist, Tuist.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: test_postgres_db,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2,
   queue_target: 5000,
@@ -71,7 +59,6 @@ config :tuist, Tuist.Tasks, sync: true
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :tuist, TuistWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: test_port],
   secret_key_base: "pbaHQK0N946e06chs5G1/RUJnkI//2QshGgUvJQkADTV3AiQHV/dXlLdjnaQxtxx",
   server: false
 

--- a/server/config/test.exs
+++ b/server/config/test.exs
@@ -22,13 +22,17 @@ config :sentry, dsn: nil
 config :tuist, Oban, testing: :manual
 
 config :tuist, Tuist.ClickHouseRepo,
-  hostname: "127.0.0.1",
+  hostname: "localhost",
+  port: 8123,
+  database: "tuist_test#{System.get_env("MIX_TEST_PARTITION")}",
   # Workaround for ClickHouse lazy materialization bug with projections
   # https://github.com/ClickHouse/ClickHouse/issues/80201
   settings: [readonly: 1, query_plan_optimize_lazy_materialization: 0]
 
 config :tuist, Tuist.IngestRepo,
-  hostname: "127.0.0.1",
+  hostname: "localhost",
+  port: 8123,
+  database: "tuist_test#{System.get_env("MIX_TEST_PARTITION")}",
   flush_interval_ms: 5000,
   max_buffer_size: 100_000,
   pool_size: 5,
@@ -49,6 +53,7 @@ config :tuist, Tuist.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
+  database: "tuist_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2,
   queue_target: 5000,
@@ -59,6 +64,7 @@ config :tuist, Tuist.Tasks, sync: true
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :tuist, TuistWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "pbaHQK0N946e06chs5G1/RUJnkI//2QshGgUvJQkADTV3AiQHV/dXlLdjnaQxtxx",
   server: false
 

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -4,6 +4,7 @@ TUIST_SECRET_KEY_BASE = "rpux4+W/oBey0drSFOctyIbppOG2A9VUUuTMC1WaM8xZgYxA6gg4yry
 
 [hooks]
   postinstall = "{{config_root}}/mise/tasks/install.sh"
+  enter = { task = "clickhouse:start" }
 
 [tools]
   pnpm = "10.17.1"

--- a/server/mise/tasks/clickhouse/start.sh
+++ b/server/mise/tasks/clickhouse/start.sh
@@ -3,9 +3,29 @@
 
 set -euo pipefail
 
+CLICKHOUSE_RUNTIME_DIR="${TUIST_SERVER_CLICKHOUSE_RUNTIME_DIR:-${XDG_STATE_HOME:-${HOME}/.local/state}/tuist/clickhouse}"
+CLICKHOUSE_HTTP_PORT="${TUIST_SERVER_CLICKHOUSE_HTTP_PORT:-8123}"
+CLICKHOUSE_NATIVE_PORT="${TUIST_SERVER_CLICKHOUSE_NATIVE_PORT:-9000}"
+CLICKHOUSE_INTERSERVER_HTTP_PORT="${TUIST_SERVER_CLICKHOUSE_INTERSERVER_HTTP_PORT:-9009}"
+CLICKHOUSE_MYSQL_PORT="${TUIST_SERVER_CLICKHOUSE_MYSQL_PORT:-9004}"
+CLICKHOUSE_POSTGRESQL_PORT="${TUIST_SERVER_CLICKHOUSE_POSTGRESQL_PORT:-9005}"
+CLICKHOUSE_HTTP_URL="${TUIST_SERVER_CLICKHOUSE_HTTP_URL:-http://127.0.0.1:${CLICKHOUSE_HTTP_PORT}}"
+
+CONFIG_DIR="${CLICKHOUSE_RUNTIME_DIR}/config.d"
+DATA_DIR="${CLICKHOUSE_RUNTIME_DIR}/data"
+TMP_DIR="${CLICKHOUSE_RUNTIME_DIR}/tmp"
+USER_FILES_DIR="${CLICKHOUSE_RUNTIME_DIR}/user_files"
+FORMAT_SCHEMA_DIR="${CLICKHOUSE_RUNTIME_DIR}/format_schemas"
+LOG_DIR="${CLICKHOUSE_RUNTIME_DIR}/log"
+PID_FILE="${CLICKHOUSE_RUNTIME_DIR}/clickhouse.pid"
+STARTUP_LOG="${LOG_DIR}/startup.log"
+SERVER_LOG="${LOG_DIR}/server.log"
+ERROR_LOG="${LOG_DIR}/error.log"
+
+mkdir -p "${CONFIG_DIR}" "${DATA_DIR}" "${TMP_DIR}" "${USER_FILES_DIR}" "${FORMAT_SCHEMA_DIR}" "${LOG_DIR}"
+
 # Create config.d with query_log enabled (ClickHouse merges this with embedded defaults)
-mkdir -p config.d
-cat > config.d/query_log.xml << 'EOF'
+cat > "${CONFIG_DIR}/query_log.xml" << 'EOF'
 <clickhouse>
     <query_log>
         <database>system</database>
@@ -14,8 +34,61 @@ cat > config.d/query_log.xml << 'EOF'
 </clickhouse>
 EOF
 
+if curl -sf "${CLICKHOUSE_HTTP_URL}/ping" >/dev/null 2>&1; then
+  echo "ClickHouse already running at ${CLICKHOUSE_HTTP_URL}"
+  exit 0
+fi
+
+if [[ -f "${PID_FILE}" ]]; then
+  pid="$(tr -d '[:space:]' < "${PID_FILE}")"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
+    for _ in $(seq 1 60); do
+      if curl -sf "${CLICKHOUSE_HTTP_URL}/ping" >/dev/null 2>&1; then
+        echo "ClickHouse already running at ${CLICKHOUSE_HTTP_URL}"
+        exit 0
+      fi
+      sleep 1
+    done
+
+    echo "ClickHouse process ${pid} is running but did not become ready." >&2
+    exit 1
+  else
+    rm -f "${PID_FILE}"
+  fi
+fi
+
 # Start ClickHouse in background (--daemon flag doesn't pick up config.d correctly).
 # Set keep_alive_timeout high enough to cover idle gaps in the Elixir connection
 # pool; otherwise the server drops sockets mid-suite and TRUNCATE queries from
 # ExUnit `on_exit` handlers fail with `Mint.TransportError: socket closed`.
-TZ=UTC nohup clickhouse server -- --keep_alive_timeout=300 > /dev/null 2>&1 &
+(
+  cd "${CLICKHOUSE_RUNTIME_DIR}"
+  TZ=UTC nohup clickhouse server \
+    -L "${SERVER_LOG}" \
+    -E "${ERROR_LOG}" \
+    -P "${PID_FILE}" \
+    -- \
+    --path="${DATA_DIR}/" \
+    --tmp_path="${TMP_DIR}/" \
+    --user_files_path="${USER_FILES_DIR}/" \
+    --format_schema_path="${FORMAT_SCHEMA_DIR}/" \
+    --listen_host=127.0.0.1 \
+    --http_port="${CLICKHOUSE_HTTP_PORT}" \
+    --tcp_port="${CLICKHOUSE_NATIVE_PORT}" \
+    --interserver_http_port="${CLICKHOUSE_INTERSERVER_HTTP_PORT}" \
+    --mysql_port="${CLICKHOUSE_MYSQL_PORT}" \
+    --postgresql_port="${CLICKHOUSE_POSTGRESQL_PORT}" \
+    --keep_alive_timeout=300 \
+    >"${STARTUP_LOG}" 2>&1 &
+)
+
+for _ in $(seq 1 60); do
+  if curl -sf "${CLICKHOUSE_HTTP_URL}/ping" >/dev/null 2>&1; then
+    echo "ClickHouse ready at ${CLICKHOUSE_HTTP_URL}"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ClickHouse failed to start. Check ${STARTUP_LOG} and ${ERROR_LOG} for details." >&2
+exit 1

--- a/server/mise/tasks/clickhouse/stop.sh
+++ b/server/mise/tasks/clickhouse/stop.sh
@@ -3,8 +3,39 @@
 
 set -euo pipefail
 
-if clickhouse client --query "SYSTEM SHUTDOWN" >/dev/null 2>&1; then
+CLICKHOUSE_RUNTIME_DIR="${TUIST_SERVER_CLICKHOUSE_RUNTIME_DIR:-${XDG_STATE_HOME:-${HOME}/.local/state}/tuist/clickhouse}"
+CLICKHOUSE_NATIVE_PORT="${TUIST_SERVER_CLICKHOUSE_NATIVE_PORT:-9000}"
+PID_FILE="${CLICKHOUSE_RUNTIME_DIR}/clickhouse.pid"
+
+if [[ ! -f "${PID_FILE}" ]]; then
+  echo "ClickHouse is managed externally"
+  exit 0
+fi
+
+pid="$(tr -d '[:space:]' < "${PID_FILE}")"
+if [[ -z "${pid}" ]] || ! kill -0 "${pid}" >/dev/null 2>&1; then
+  rm -f "${PID_FILE}"
+  echo "ClickHouse is managed externally"
+  exit 0
+fi
+
+if clickhouse client --host 127.0.0.1 --port "${CLICKHOUSE_NATIVE_PORT}" --query "SYSTEM SHUTDOWN" >/dev/null 2>&1; then
+  if [[ -f "${PID_FILE}" ]]; then
+    for _ in $(seq 1 30); do
+      if [[ -z "${pid}" ]] || ! kill -0 "${pid}" >/dev/null 2>&1; then
+        rm -f "${PID_FILE}"
+        echo "ClickHouse stopped"
+        exit 0
+      fi
+      sleep 1
+    done
+  fi
+
   echo "ClickHouse stopped"
 else
+  if [[ -n "${pid}" ]] && ! kill -0 "${pid}" >/dev/null 2>&1; then
+    rm -f "${PID_FILE}"
+  fi
+
   echo "ClickHouse is not running"
 fi

--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -3,12 +3,14 @@
 
 set -euo pipefail
 
+CLICKHOUSE_HTTP_URL="${TUIST_SERVER_CLICKHOUSE_HTTP_URL:-http://127.0.0.1:${TUIST_SERVER_CLICKHOUSE_HTTP_PORT:-8123}}"
+
 postgres_database_exists() {
   psql -Atqc "SELECT 1 FROM pg_database WHERE datname = '${TUIST_SERVER_POSTGRES_DB}'" postgres | grep -qx 1
 }
 
 clickhouse_database_exists() {
-  curl -fsS http://localhost:8123 --data-binary "EXISTS DATABASE ${TUIST_SERVER_CLICKHOUSE_DB}" | grep -qx 1
+  curl -fsS "${CLICKHOUSE_HTTP_URL}" --data-binary "EXISTS DATABASE ${TUIST_SERVER_CLICKHOUSE_DB}" | grep -qx 1
 }
 
 bootstrap_postgres_database() {


### PR DESCRIPTION
Our current setup is incompatible with worktrees. We are currently treating ClickHouse as a global process through an assigned port, while configuring it from each worktree to persist its data in a directory scoped to the worktree. This PR changes that by making it truly global, with its storage being globally in the system, while scoping each worktree to a DB whose name is bound to the worktree.

## Summary
- Move dev and test ClickHouse port and database selection into `runtime.exs`
- Keep the local ClickHouse daemon shared across checkouts while retaining per-worktree database names
- Simplify the compile-time config files so they only hold static settings

## Testing
- Verified `Config.Reader.read!` loads `runtime.exs` successfully
- Verified the updated shell scripts still parse with `bash -n`
- Performed a local ClickHouse start/stop smoke check against the shared daemon path