### PR TITLE
fix(cli): map static library dependencies in XcodeGraph

### DIFF
--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXFrameworksBuildPhaseMapper.swift
@@ -64,28 +64,21 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
             )
         )
         if let path = fileRef.path {
-            let name = path.replacingOccurrences(of: ".framework", with: "")
             let linkingStatus: LinkingStatus = buildFile.attributes?
                 .contains("Weak") == true ? .optional : .required
             switch fileRef.sourceTree {
             case .buildProductsDir:
-                if let target = xcodeProj.pbxproj.targets(named: name).first {
-                    return .target(
-                        name: target.name,
-                        status: linkingStatus,
-                        condition: nil
-                    )
-                } else if let projectNativeTarget = projectNativeTargets[name] {
-                    return .project(
-                        target: projectNativeTarget.nativeTarget.name,
-                        path: projectNativeTarget.project.projectPath.parentDirectory,
-                        status: linkingStatus,
-                        condition: nil
-                    )
+                if let targetDependency = mapBuildProductDependency(
+                    path: path,
+                    linkingStatus: linkingStatus,
+                    xcodeProj: xcodeProj,
+                    projectNativeTargets: projectNativeTargets
+                ) {
+                    return targetDependency
                 }
             case .sdkRoot, .developerDir:
                 return .sdk(
-                    name: name,
+                    name: productName(from: path),
                     status: linkingStatus,
                     condition: nil
                 )
@@ -98,6 +91,48 @@ struct PBXFrameworksBuildPhaseMapper: PBXFrameworksBuildPhaseMapping {
 
         let absolutePath = try AbsolutePath(validating: filePathString)
         return try pathMapper.map(path: absolutePath, expectedSignature: nil, condition: nil)
+    }
+
+    private func mapBuildProductDependency(
+        path: String,
+        linkingStatus: LinkingStatus,
+        xcodeProj: XcodeProj,
+        projectNativeTargets: [String: ProjectNativeTarget]
+    ) -> TargetDependency? {
+        let target = xcodeProj.pbxproj.nativeTargets
+            .filter { $0.product?.path == path }
+            .first
+            ?? xcodeProj.pbxproj.targets(named: productName(from: path)).first
+        if let target {
+            return .target(
+                name: target.name,
+                status: linkingStatus,
+                condition: nil
+            )
+        }
+
+        let projectNativeTarget = projectNativeTargets.values
+            .filter { $0.nativeTarget.product?.path == path }
+            .first
+            ?? projectNativeTargets[productName(from: path)]
+        if let projectNativeTarget {
+            return .project(
+                target: projectNativeTarget.nativeTarget.name,
+                path: projectNativeTarget.project.projectPath.parentDirectory,
+                status: linkingStatus,
+                condition: nil
+            )
+        }
+
+        return nil
+    }
+
+    private func productName(from path: String) -> String {
+        if path.hasPrefix("lib"), path.hasSuffix(".a") {
+            return String(path.dropFirst(3).dropLast(2))
+        }
+
+        return path.replacingOccurrences(of: ".framework", with: "")
     }
 }
 

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/xcode_project_with_static_library_graph/Sources/App/main.swift
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/xcode_project_with_static_library_graph/Sources/App/main.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+print(greeting())

--- a/cli/Sources/XcodeGraph/Tests/Fixtures/xcode_project_with_static_library_graph/Sources/StaticLibrary/StaticLibrary.swift
+++ b/cli/Sources/XcodeGraph/Tests/Fixtures/xcode_project_with_static_library_graph/Sources/StaticLibrary/StaticLibrary.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public func greeting() -> String {
+    "Hello, graph"
+}

--- a/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
+++ b/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Graph/XcodeGraphMapperTests.swift
@@ -164,6 +164,22 @@ struct XcodeGraphMapperTests {
             .called(1)
     }
 
+    @Test("Maps an Xcode project with a static library dependency")
+    func projectWithStaticLibraryDependency() async throws {
+        // Given
+        let fixturePath = AssertionsTesting.fixturePath(
+            path: try RelativePath(validating: "xcode_project_with_static_library_graph")
+        )
+        let mapper = XcodeGraphMapper()
+
+        // When
+        let graph = try await mapper.map(at: fixturePath)
+
+        // Then
+        let project = try #require(graph.projects.values.first)
+        #expect(Set(project.targets.keys) == Set(["App", "StaticLibrary"]))
+    }
+
     @Test("Maps a workspace with multiple projects into a single graph")
     func workspaceGraphMultipleProjects() async throws {
         // Given

--- a/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXFrameworksBuildPhaseMapperTests.swift
+++ b/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXFrameworksBuildPhaseMapperTests.swift
@@ -196,4 +196,63 @@ struct PBXFrameworksBuildPhaseMapperTests {
             ]
         )
     }
+
+    @Test("Maps static library build products from frameworks phase")
+    func mapStaticLibraryBuildProducts() async throws {
+        // Given
+        let xcodeProj = try await XcodeProj.test()
+        let pbxProj = xcodeProj.pbxproj
+
+        let staticLibraryRef = PBXFileReference(
+            sourceTree: .buildProductsDir,
+            explicitFileType: "archive.ar",
+            path: "libStaticLibrary.a"
+        )
+        let staticLibraryBuildFile = PBXBuildFile(file: staticLibraryRef).add(to: pbxProj)
+
+        let frameworksPhase = PBXFrameworksBuildPhase(
+            files: [staticLibraryBuildFile]
+        ).add(to: pbxProj)
+
+        try PBXNativeTarget(
+            name: "App",
+            buildPhases: [frameworksPhase],
+            productType: .application
+        )
+        .add(to: pbxProj)
+        .add(to: pbxProj.rootObject)
+
+        PBXNativeTarget.test(
+            name: "StaticLibrary",
+            productType: .staticLibrary,
+            product: PBXFileReference.test(
+                sourceTree: .buildProductsDir,
+                explicitFileType: "archive.ar",
+                path: "libStaticLibrary.a",
+                lastKnownFileType: nil,
+                includeInIndex: false
+            )
+        )
+        .add(to: pbxProj)
+
+        let mapper = PBXFrameworksBuildPhaseMapper()
+
+        // When
+        let frameworks = try mapper.map(
+            frameworksPhase,
+            xcodeProj: xcodeProj,
+            projectNativeTargets: [:]
+        )
+
+        // Then
+        #expect(
+            frameworks == [
+                .target(
+                    name: "StaticLibrary",
+                    status: .required,
+                    condition: nil
+                ),
+            ]
+        )
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/10350

## Summary
- Resolve build product dependencies for static libraries by matching the product path before falling back to target name lookup
- Normalize product names for both frameworks and static libraries
- Add coverage for static library build phases and a project fixture with a static library dependency

## Testing
- Added unit tests for `PBXFrameworksBuildPhaseMapper`
- Added graph mapping coverage for an Xcode project that includes a static library