### PR TITLE
fix(server): restore scheme dropdown search and fix recent builds timing race

### DIFF
--- a/server/lib/tuist_web/live/gradle_builds_live.ex
+++ b/server/lib/tuist_web/live/gradle_builds_live.ex
@@ -261,7 +261,7 @@ defmodule TuistWeb.GradleBuildsLive do
       filters ++
         [
           %{field: :inserted_at, op: :>=, value: start_datetime},
-          %{field: :inserted_at, op: :<=, value: end_datetime}
+          %{field: :inserted_at, op: :<=, value: DateTime.add(end_datetime, 1, :second)}
         ]
 
     {builds, _meta} = Gradle.list_builds(project.id, %{page_size: @recent_builds_page_size, filters: filters})

--- a/server/lib/tuist_web/live/xcode_builds_live.ex
+++ b/server/lib/tuist_web/live/xcode_builds_live.ex
@@ -361,7 +361,7 @@ defmodule TuistWeb.XcodeBuildsLive do
     |> maybe_add_tag_filter(assigns.analytics_build_tag)
     |> Kernel.++([
       %{field: :inserted_at, op: :>=, value: start_datetime},
-      %{field: :inserted_at, op: :<=, value: end_datetime}
+      %{field: :inserted_at, op: :<=, value: DateTime.add(end_datetime, 1, :second)}
     ])
   end
 

--- a/server/lib/tuist_web/live/xcode_builds_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_builds_live.html.heex
@@ -29,6 +29,13 @@
       label={TuistWeb.XcodeBuildsLive.build_scheme_label(@analytics_build_scheme)}
       secondary_text={dgettext("dashboard_builds", "Scheme:")}
     >
+      <:search>
+        <input
+          type="text"
+          placeholder={dgettext("dashboard_builds", "Search...")}
+          data-part="search-input"
+        />
+      </:search>
       <.dropdown_item
         value="any"
         label={dgettext("dashboard_builds", "Any")}

--- a/server/test/tuist/gradle/analytics_test.exs
+++ b/server/test/tuist/gradle/analytics_test.exs
@@ -335,7 +335,7 @@ defmodule Tuist.Gradle.AnalyticsTest do
   end
 
   describe "build_duration_analytics_by_category/3" do
-    test "filters by is_ci", %{start_datetime: start_datetime, now: now} do
+    test "filters by is_ci", %{start_datetime: start_datetime} do
       project = ProjectsFixtures.project_fixture()
       inserted_at = NaiveDateTime.new!(Date.add(Date.utc_today(), -1), ~T[10:00:00])
 


### PR DESCRIPTION
## Summary

Fixes two failures in [BuildsLiveTest](server/test/tuist_web/live/builds_live_test.exs) that were introduced by [#10199](https://github.com/tuist/tuist/pull/10199) (page level filters):

- **\`renders a searchable scheme dropdown\`** — the \`<:search>\` slot that [#10272](https://github.com/tuist/tuist/pull/10272) added to the builds analytics scheme dropdown was accidentally dropped during the filter rewrite. Restored it to match the pattern used in [tests_live.html.heex](server/lib/tuist_web/live/tests_live.html.heex).
- **\`lists latest builds\`** — \`recent_builds_filters\` applies \`inserted_at <= end_datetime\`, but \`end_datetime\` is truncated to seconds (see [DatePicker.period_for_preset](server/lib/tuist_web/helpers/date_picker.ex)) while builds are stored with microsecond precision in the ClickHouse \`build_runs\` table (\`DateTime64(6)\`). When the dashboard mounts in the same wall-clock second the fixture was created, \`16:43:08.123456 <= 16:43:08.000000\` is false and the freshly-inserted build is filtered out. Buffering the upper bound by one second closes the window. Applied the same buffer to the Gradle equivalent since it shares the pattern.

See the failing run: https://github.com/tuist/tuist/actions/runs/24734114640/job/72356251537

## Test plan

- [x] \`mix test test/tuist_web/live/builds_live_test.exs\` (5 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)