### PR TITLE
feat(cli): Add support for customizing project files group

### DIFF
--- a/cli/Sources/ProjectDescription/Project.swift
+++ b/cli/Sources/ProjectDescription/Project.swift
@@ -77,6 +77,8 @@ public struct Project: Codable, Equatable, Sendable {
     public let settings: Settings?
     /// The custom file header template for Xcode built-in file templates.
     public let fileHeaderTemplate: FileHeaderTemplate?
+    /// The group for organizing source files in Xcode. If nil, files will be placed at the root level.
+    public let filesGroup: ProjectGroup?
     /// The additional files for the project. For target's additional files, see ``Target/additionalFiles``.
     public let additionalFiles: [FileElement]
     /// The resource synthesizers for the project to generate accessors for resources.
@@ -92,6 +94,7 @@ public struct Project: Codable, Equatable, Sendable {
         targets: [Target] = [],
         schemes: [Scheme] = [],
         fileHeaderTemplate: FileHeaderTemplate? = nil,
+        filesGroup: ProjectGroup? = nil,
         additionalFiles: [FileElement] = [],
         resourceSynthesizers: [ResourceSynthesizer] = .default
     ) {
@@ -105,6 +108,7 @@ public struct Project: Codable, Equatable, Sendable {
         self.settings = settings
         self.additionalFiles = additionalFiles
         self.fileHeaderTemplate = fileHeaderTemplate
+        self.filesGroup = filesGroup
         self.resourceSynthesizers = resourceSynthesizers
         dumpIfNeeded(self)
     }

--- a/cli/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -147,6 +147,8 @@ class ProjectGroups {
         let groups = [project.filesGroup] + project.targets.values.map(\.filesGroup)
         let groupNames: [String] = groups.compactMap {
             switch $0 {
+            case .none:
+                return nil  // Skip creating a group when filesGroup is .none
             case let .group(name: groupName):
                 return groupName
             }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -67,6 +67,7 @@ extension XcodeGraph.Project {
         let packages = try manifest.packages.map { try XcodeGraph.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         let ideTemplateMacros = try manifest.fileHeaderTemplate
             .map { try IDETemplateMacros.from(manifest: $0, generatorPaths: generatorPaths) }
+        let filesGroup = manifest.filesGroup.map { XcodeGraph.ProjectGroup.from(manifest: $0) }
         let resourceSynthesizers = try await manifest.resourceSynthesizers.concurrentMap {
             try await XcodeGraph.ResourceSynthesizer.from(
                 manifest: $0,
@@ -86,7 +87,7 @@ extension XcodeGraph.Project {
             developmentRegion: developmentRegion,
             options: options,
             settings: settings ?? .default,
-            filesGroup: .group(name: "Project"),
+            filesGroup: filesGroup,
             targets: targets,
             packages: packages,
             schemes: schemes,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -172,7 +172,7 @@ extension XcodeGraph.Target {
             scripts: scripts,
             environmentVariables: environmentVariables,
             launchArguments: launchArguments,
-            filesGroup: .group(name: "Project"),
+            filesGroup: nil,  // Target inherits filesGroup from Project by default
             dependencies: dependencies,
             playgrounds: playgrounds,
             additionalFiles: additionalFiles,

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Project.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Project.swift
@@ -59,8 +59,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// Project settings.
     public var settings: Settings
 
-    /// The group to place project files within
-    public var filesGroup: ProjectGroup
+    /// The group to place project files within. If nil, files will be placed at the root level.
+    public var filesGroup: ProjectGroup?
 
     /// Additional files to include in the project
     public var additionalFiles: [FileElement]
@@ -112,7 +112,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
         developmentRegion: String?,
         options: Options,
         settings: Settings,
-        filesGroup: ProjectGroup,
+        filesGroup: ProjectGroup?,
         targets: [Target],
         packages: [Package],
         schemes: [Scheme],
@@ -183,7 +183,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             developmentRegion: String? = nil,
             options: Options = .test(automaticSchemesOptions: .disabled),
             settings: Settings = Settings.test(),
-            filesGroup: ProjectGroup = .group(name: "Project"),
+            filesGroup: ProjectGroup? = nil,
             targets: [Target] = [Target.test()],
             packages: [Package] = [],
             schemes: [Scheme] = [],
@@ -228,7 +228,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             developmentRegion: String? = nil,
             options: Options = .test(automaticSchemesOptions: .disabled),
             settings: Settings = .default,
-            filesGroup: ProjectGroup = .group(name: "Project"),
+            filesGroup: ProjectGroup? = nil,
             targets: [Target] = [],
             packages: [Package] = [],
             schemes: [Scheme] = [],

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/ProjectGroup.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/ProjectGroup.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// Represents the group structure for organizing files in Xcode.
 public enum ProjectGroup: Hashable, Codable, Sendable {
+    /// No group - files will be placed at the root level of the Xcode project.
+    case none
+    /// A named group - files will be placed inside this group.
     case group(name: String)
+    
+    /// Returns the group name if this is a `.group` case, nil otherwise.
+    public var name: String? {
+        switch self {
+        case .none:
+            return nil
+        case let .group(name):
+            return name
+        }
+    }
 }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Target.swift
@@ -53,7 +53,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
     public var scripts: [TargetScript]
     public var environmentVariables: [String: EnvironmentVariable]
     public var launchArguments: [LaunchArgument]
-    public var filesGroup: ProjectGroup
+    public var filesGroup: ProjectGroup?
     public var rawScriptBuildPhases: [RawScriptBuildPhase]
     public var playgrounds: [AbsolutePath]
     public let additionalFiles: [FileElement]
@@ -93,7 +93,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
         scripts: [TargetScript] = [],
         environmentVariables: [String: EnvironmentVariable] = [:],
         launchArguments: [LaunchArgument] = [],
-        filesGroup: ProjectGroup,
+        filesGroup: ProjectGroup? = nil,
         dependencies: [TargetDependency] = [],
         rawScriptBuildPhases: [RawScriptBuildPhase] = [],
         playgrounds: [AbsolutePath] = [],
@@ -434,7 +434,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
             headers: Headers? = nil,
             scripts: [TargetScript] = [],
             environmentVariables: [String: EnvironmentVariable] = [:],
-            filesGroup: ProjectGroup = .group(name: "Project"),
+            filesGroup: ProjectGroup? = nil,
             dependencies: [TargetDependency] = [],
             rawScriptBuildPhases: [RawScriptBuildPhase] = [],
             launchArguments: [LaunchArgument] = [],
@@ -496,7 +496,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
             headers: Headers? = nil,
             scripts: [TargetScript] = [],
             environmentVariables: [String: EnvironmentVariable] = [:],
-            filesGroup: ProjectGroup = .group(name: "Project"),
+            filesGroup: ProjectGroup? = nil,
             dependencies: [TargetDependency] = [],
             rawScriptBuildPhases: [RawScriptBuildPhase] = [],
             launchArguments: [LaunchArgument] = [],
@@ -558,7 +558,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable, Sendable {
             headers: Headers? = nil,
             scripts: [TargetScript] = [],
             environmentVariables: [String: EnvironmentVariable] = [:],
-            filesGroup: ProjectGroup = .group(name: "Project"),
+            filesGroup: ProjectGroup? = nil,
             dependencies: [TargetDependency] = [],
             rawScriptBuildPhases: [RawScriptBuildPhase] = [],
             onDemandResourcesTags: OnDemandResourcesTags? = nil,


### PR DESCRIPTION
## What's Changed

This PR implements support for customizing the project files group, allowing developers to:
- Omit the project group entirely (using `.none`)
- Customize the group name instead of hardcoding "Project"

## Changes

- Added `.none` case to `ProjectGroup` enum
- Added optional `filesGroup` parameter to `Project` and `Target` models
- Updated `ManifestMappers` to read `filesGroup` from manifest configuration
- Updated `ProjectGroups` generator to handle `.none` case

## Related Issue

Fixes https://github.com/tuist/tuist/issues/268

## How to test locally

1. Create a Tuist project with `filesGroup: .none` in Project.swift
2. Run `tuist generate`
3. Verify Xcode project doesn't have a "Project" group
