### PR TITLE
fix(cli): preserve scheme buildAction targets in `tuist test <scheme>` focus

### DIFF
--- a/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
+++ b/cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift
@@ -62,9 +62,16 @@ public struct FocusTargetsGraphMappers: GraphMapping {
         let sourceTargets: Set<GraphTarget>
 
         if let schemeName, !hasExplicitFilters {
+            let scheme = graphTraverser.schemes().first(where: { $0.name == schemeName })
             let schemeTestTargets = graphTraverser.testTargets(for: schemeName)
-            if !schemeTestTargets.isEmpty {
-                sourceTargets = schemeTestTargets
+            let schemeBuildTargets: Set<GraphTarget> = Set(
+                (scheme?.buildAction?.targets ?? []).compactMap {
+                    graphTraverser.target(path: $0.projectPath, name: $0.name)
+                }
+            )
+            let schemeTargets = schemeTestTargets.union(schemeBuildTargets)
+            if !schemeTargets.isEmpty {
+                sourceTargets = schemeTargets
             } else if !includedProducts.isEmpty {
                 sourceTargets = graphTraverser.allTargets().filter { includedProducts.contains($0.target.product) }
             } else {

--- a/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/FocusTargetsGraphMappersTests.swift
@@ -647,6 +647,62 @@ final class FocusTargetsGraphMappersTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_when_scheme_has_test_plan_preserves_scheme_build_action_targets() throws {
+        // Given: a scheme whose buildAction is the App, whose testAction uses a test plan
+        // listing only framework tests that do NOT depend on the App. Without preserving the
+        // scheme's buildAction targets as focus sources, the App gets pruned and xcodebuild
+        // fails with "Supported platforms for the buildables in the current scheme is empty".
+        let appTarget = Target.test(name: "App", product: .app)
+        let kitLib = Target.test(name: "KitLib", product: .framework)
+        let kitLibTests = Target.test(name: "KitLibTests", product: .unitTests)
+        let unrelatedTests = Target.test(name: "UnrelatedTests", product: .unitTests)
+        let path = try temporaryPath()
+        let testPlan = TestPlan(
+            path: path.appending(component: "Plan.xctestplan"),
+            testTargets: [
+                .test(target: TargetReference(projectPath: path, name: "KitLibTests")),
+            ],
+            isDefault: true
+        )
+        let project = Project.test(
+            path: path,
+            targets: [appTarget, kitLib, kitLibTests, unrelatedTests],
+            schemes: [
+                .test(
+                    name: "AppScheme",
+                    buildAction: .test(targets: [TargetReference(projectPath: path, name: "App")]),
+                    testAction: .test(targets: [], testPlans: [testPlan])
+                ),
+            ]
+        )
+        let subject = FocusTargetsGraphMappers(
+            schemeName: "AppScheme",
+            includedTargets: Set(),
+            includedProducts: [.unitTests, .uiTests]
+        )
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: kitLibTests.name, path: path): [
+                    .target(name: kitLib.name, path: path),
+                ],
+            ]
+        )
+
+        // When
+        let (gotGraph, _, _) = try subject.map(graph: graph, environment: MapperEnvironment())
+        let prunedNames = gotGraph.projects.values.flatMap(\.targets.values)
+            .filter { $0.metadata.tags.contains("tuist:prunable") }
+            .map(\.name)
+            .sorted()
+
+        // Then — App must survive so the scheme's BuildAction isn't empty; UnrelatedTests is pruned
+        XCTAssertFalse(prunedNames.contains("App"))
+        XCTAssertFalse(prunedNames.contains("KitLib"))
+        XCTAssertFalse(prunedNames.contains("KitLibTests"))
+        XCTAssertTrue(prunedNames.contains("UnrelatedTests"))
+    }
+
     func test_map_when_scheme_name_not_found_falls_back_to_included_products() throws {
         // Given
         let framework = Target.test(name: "Framework")


### PR DESCRIPTION
## Summary

Follow-up to [#10339](https://github.com/tuist/tuist/pull/10339). That PR taught [`GraphTraverser.testTargets(for:)`](cli/Sources/TuistCore/Graph/GraphTraverser.swift#L117-L130) to return test plan targets, but the focus path in [`FocusTargetsGraphMappers.map(graph:environment:)`](cli/Sources/TuistKit/Mappers/FocusTargetsGraphMappers.swift#L64-L72) still seeded `sourceTargets` with only the scheme's test targets. When those test targets don't transitively depend on the scheme's `buildAction` targets — common for framework-based test plans where `KitTests` depends on `Kit`, not the app — the app is never pulled into `filteredTargets`. [`TreeShakePrunedTargetsGraphMapper.treeShake(schemes:sourceTargets:)`](cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift#L158-L160) then filters `scheme.buildAction.targets` down to empty. The scheme survives its own pruning check ([line 191](cli/Sources/TuistKit/Mappers/TreeShakePrunedTargetsGraphMapper.swift#L191)) because `hasTestPlans` is true, and xcodebuild fails at runtime:

```
IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
Unable to find a destination matching the provided destination specifier: { id:<UDID> }
```

This is what users are reporting on 4.183.0 after #10339 shipped.

### Fix

Include the scheme's `buildAction.targets` alongside its test targets as source targets, so the topological sort pulls in the app (and its dependencies) and tree-shake preserves the scheme's `<BuildAction>`.

## Reproduction

Minimal fixture: `App` + `KitLib` (framework) + `KitLibTests` (unit test depending on `KitLib`, **not** `App`); scheme with `buildAction.targets = [App]` and `testAction.testPlans = [Plan]` listing only `KitLibTests`.

**Before** (4.183.0 / pre-fix on this branch):

```xml
<BuildAction ...>
   <BuildActionEntries>
   </BuildActionEntries>
</BuildAction>
```

`App` absent from `project.pbxproj` entirely.

**After** this change:

```xml
<BuildAction ...>
   <BuildActionEntries>
      <BuildableReference BlueprintName = "App" ...>
      </BuildableReference>
   </BuildActionEntries>
</BuildAction>
```

## Unit test

`FocusTargetsGraphMappersTests.test_map_when_scheme_has_test_plan_preserves_scheme_build_action_targets` constructs the exact topology above and asserts `App` is **not** pruned, while `UnrelatedTests` (not in the plan) still is.

- Before fix: fails — `App` is tagged `tuist:prunable`.
- After fix: passes.
- All 19 existing `FocusTargetsGraphMappersTests`, all 154 `GraphTraverserTests`, and all 15 `TreeShakePrunedTargetsGraphMapperTests` continue to pass.

## Test plan

- [x] Repro fixture at `/tmp/tuist-focus-repro` confirms the scheme's `<BuildAction>` now contains `App` after `tuist test --generate-only AppScheme`.
- [x] `xcsiftbuild test ... -only-testing TuistKitTests/FocusTargetsGraphMappersTests`
- [x] `xcsiftbuild test ... -only-testing TuistCoreTests/GraphTraverserTests`
- [x] `xcsiftbuild test ... -only-testing TuistKitTests/TreeShakePrunedTargetsGraphMapperTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)