### PR TITLE
fix(cache): persist skipped registry releases

### DIFF
--- a/cache/lib/cache/registry/metadata.ex
+++ b/cache/lib/cache/registry/metadata.ex
@@ -23,6 +23,11 @@ defmodule Cache.Registry.Metadata do
         ]
       }
     },
+    "skipped_releases": {
+      "<version>": {
+        "reason": "string"
+      }
+    },
     "updated_at": "ISO8601 timestamp"
   }
   ```
@@ -37,6 +42,8 @@ defmodule Cache.Registry.Metadata do
   * `releases.<version>.manifests` - List of Package.swift variants for this release
   * `releases.<version>.manifests[].swift_version` - Swift version suffix (e.g., "5.9") or null for default
   * `releases.<version>.manifests[].swift_tools_version` - Swift tools version from manifest or null
+  * `skipped_releases` - Optional map of normalized version strings to permanent skip reasons
+  * `skipped_releases.<version>.reason` - Machine-readable reason code for not mirroring a release
   * `updated_at` - ISO8601 timestamp of last sync (for staleness detection)
 
   ## Example
@@ -158,6 +165,7 @@ defmodule Cache.Registry.Metadata do
 
       {:error, {:http_error, 429, _}} ->
         :telemetry.execute([:cache, :s3, :upload], %{duration: duration}, %{result: :rate_limited})
+
         Logger.warning("S3 rate limited writing metadata for #{scope}/#{name}")
         {:error, {:s3_error, :rate_limited}}
 
@@ -189,16 +197,23 @@ defmodule Cache.Registry.Metadata do
     case result do
       {:ok, _response} ->
         :telemetry.execute([:cache, :s3, :delete], %{duration: duration, count: 1}, %{result: :ok})
+
         Cachex.del(cache_name, cache_key(scope, name))
         :ok
 
       {:error, {:http_error, 429, _}} ->
-        :telemetry.execute([:cache, :s3, :delete], %{duration: duration, count: 0}, %{result: :rate_limited})
+        :telemetry.execute([:cache, :s3, :delete], %{duration: duration, count: 0}, %{
+          result: :rate_limited
+        })
+
         Logger.warning("S3 rate limited deleting metadata for #{scope}/#{name}")
         {:error, {:s3_error, :rate_limited}}
 
       {:error, reason} ->
-        :telemetry.execute([:cache, :s3, :delete], %{duration: duration, count: 0}, %{result: :error})
+        :telemetry.execute([:cache, :s3, :delete], %{duration: duration, count: 0}, %{
+          result: :error
+        })
+
         Logger.error("Failed to delete metadata from S3 for #{scope}/#{name}: #{inspect(reason)}")
         {:error, reason}
     end

--- a/cache/lib/cache/registry/release_worker.ex
+++ b/cache/lib/cache/registry/release_worker.ex
@@ -64,8 +64,10 @@ defmodule Cache.Registry.ReleaseWorker do
         case Metadata.get_package(scope, name, fresh: true) do
           {:ok, metadata} ->
             releases = Map.get(metadata, "releases", %{})
+            skipped_releases = Map.get(metadata, "skipped_releases", %{})
 
-            if Map.has_key?(releases, normalized_version) do
+            if Map.has_key?(releases, normalized_version) or
+                 Map.has_key?(skipped_releases, normalized_version) do
               :ok
             else
               sync_release(scope, name, full_handle, tag, normalized_version, token)
@@ -89,8 +91,20 @@ defmodule Cache.Registry.ReleaseWorker do
       update_metadata_with_release(scope, name, full_handle, version, checksum, manifests)
     else
       {:error, reason} ->
-        Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
-        {:error, reason}
+        case maybe_skip_release(scope, name, full_handle, version, reason) do
+          :ok ->
+            :ok
+
+          :not_skipped ->
+            Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
+            {:error, reason}
+
+          {:error, skip_reason} ->
+            Logger.warning("Failed to record skipped release #{scope}/#{name}@#{tag}: #{inspect(skip_reason)}")
+
+            Logger.warning("Failed to sync release #{scope}/#{name}@#{tag}: #{inspect(reason)}")
+            {:error, reason}
+        end
     end
   end
 
@@ -113,7 +127,14 @@ defmodule Cache.Registry.ReleaseWorker do
   end
 
   defp build_archive_from_zipball(full_handle, tag, token, tmp_dir, archive_path) do
-    with :ok <- TuistCommon.GitHub.download_zipball(full_handle, token, tag, archive_path, @github_opts) do
+    with :ok <-
+           TuistCommon.GitHub.download_zipball(
+             full_handle,
+             token,
+             tag,
+             archive_path,
+             @github_opts
+           ) do
       normalize_archive(tmp_dir, archive_path)
     end
   end
@@ -282,7 +303,10 @@ defmodule Cache.Registry.ReleaseWorker do
   end
 
   defp skippable_submodule_failure?(output) do
-    Enum.any?(@skippable_submodule_failure_markers, &(output |> String.downcase() |> String.contains?(&1)))
+    Enum.any?(
+      @skippable_submodule_failure_markers,
+      &(output |> String.downcase() |> String.contains?(&1))
+    )
   end
 
   defp remove_failed_submodule_contents(destination, submodule_path) do
@@ -427,9 +451,14 @@ defmodule Cache.Registry.ReleaseWorker do
     expanded_path = Path.expand(path, expanded_base_path)
 
     cond do
-      expanded_path == package_root -> nil
-      path_within_root?(expanded_path, package_root) -> Path.relative_to(expanded_path, package_root)
-      true -> nil
+      expanded_path == package_root ->
+        nil
+
+      path_within_root?(expanded_path, package_root) ->
+        Path.relative_to(expanded_path, package_root)
+
+      true ->
+        nil
     end
   end
 
@@ -499,6 +528,7 @@ defmodule Cache.Registry.ReleaseWorker do
 
           {:symlink_outside_root, _target} ->
             Logger.warning("Removing symlink #{path} -> #{target} because it points outside #{root_directory}")
+
             File.rm!(path)
             prune_symlinks_outside_root(rest, root_directory)
         end
@@ -564,12 +594,18 @@ defmodule Cache.Registry.ReleaseWorker do
   end
 
   defp upload_source_archive(scope, name, version, archive_path) do
-    key = KeyNormalizer.package_object_key(%{scope: scope, name: name}, version: version, path: "source_archive.zip")
+    key =
+      KeyNormalizer.package_object_key(%{scope: scope, name: name},
+        version: version,
+        path: "source_archive.zip"
+      )
+
     S3.upload_file(key, archive_path, type: :registry, content_type: "application/zip")
   end
 
   defp fetch_manifests(full_handle, tag, token) do
-    with {:ok, contents} <- TuistCommon.GitHub.list_repository_contents(full_handle, token, tag, @github_opts) do
+    with {:ok, contents} <-
+           TuistCommon.GitHub.list_repository_contents(full_handle, token, tag, @github_opts) do
       manifest_payloads =
         contents
         |> Enum.map(&Map.get(&1, "path"))
@@ -588,19 +624,28 @@ defmodule Cache.Registry.ReleaseWorker do
 
             {:error, reason} ->
               Logger.warning("Failed to fetch manifest #{path} for #{full_handle}@#{tag}: #{inspect(reason)}")
+
               nil
           end
         end)
         |> Enum.reject(&is_nil/1)
 
-      {:ok, manifest_payloads}
+      case manifest_payloads do
+        [] -> {:error, {:missing_manifests, full_handle, tag}}
+        _ -> {:ok, manifest_payloads}
+      end
     end
   end
 
   defp upload_manifests(scope, name, version, manifest_payloads) do
     manifests =
       manifest_payloads
-      |> Enum.map(fn %{content: content, filename: filename, path: path, swift_version: swift_version} ->
+      |> Enum.map(fn %{
+                       content: content,
+                       filename: filename,
+                       path: path,
+                       swift_version: swift_version
+                     } ->
         case upload_manifest(scope, name, version, filename, content) do
           :ok ->
             %{
@@ -610,6 +655,7 @@ defmodule Cache.Registry.ReleaseWorker do
 
           {:error, reason} ->
             Logger.warning("Failed to upload manifest #{path} for #{scope}/#{name}@#{version}: #{inspect(reason)}")
+
             nil
         end
       end)
@@ -625,7 +671,17 @@ defmodule Cache.Registry.ReleaseWorker do
       {:ok, :acquired} ->
         try do
           with {:ok, metadata} <- get_or_create_metadata(scope, name, full_handle) do
-            updated_metadata = build_updated_metadata(metadata, scope, name, full_handle, version, checksum, manifests)
+            updated_metadata =
+              build_updated_metadata(
+                metadata,
+                scope,
+                name,
+                full_handle,
+                version,
+                checksum,
+                manifests
+              )
+
             Metadata.put_package(scope, name, updated_metadata)
           end
         after
@@ -634,7 +690,50 @@ defmodule Cache.Registry.ReleaseWorker do
 
       {:error, :already_locked} ->
         Logger.info("Metadata update skipped for #{scope}/#{name}@#{version}: lock held by another node")
+
         :ok
+    end
+  end
+
+  defp maybe_skip_release(scope, name, full_handle, version, {:missing_manifests, failed_full_handle, tag}) do
+    Logger.warning(
+      "Skipping registry release #{scope}/#{name}@#{tag} for #{failed_full_handle}: no root Package.swift manifest was found"
+    )
+
+    update_metadata_with_skipped_release(scope, name, full_handle, version, "missing_manifests")
+  end
+
+  defp maybe_skip_release(_scope, _name, _full_handle, _version, _reason), do: :not_skipped
+
+  defp update_metadata_with_skipped_release(scope, name, full_handle, version, reason) do
+    lock_key = {:package, scope, name}
+
+    case Lock.try_acquire(lock_key, @metadata_lock_ttl_seconds) do
+      {:ok, :acquired} ->
+        try do
+          with {:ok, metadata} <- get_or_create_metadata(scope, name, full_handle) do
+            updated_metadata =
+              build_updated_metadata_with_skipped_release(
+                metadata,
+                scope,
+                name,
+                full_handle,
+                version,
+                reason
+              )
+
+            Metadata.put_package(scope, name, updated_metadata)
+          end
+        after
+          Lock.release(lock_key)
+        end
+
+      {:error, :already_locked} ->
+        Logger.warning(
+          "Skipped release metadata update deferred for #{scope}/#{name}@#{version}: lock held by another node"
+        )
+
+        {:error, {:skipped_release_metadata_locked, scope, name, version}}
     end
   end
 
@@ -644,7 +743,13 @@ defmodule Cache.Registry.ReleaseWorker do
         {:ok, metadata}
 
       {:error, :not_found} ->
-        {:ok, %{"scope" => scope, "name" => name, "repository_full_handle" => full_handle, "releases" => %{}}}
+        {:ok,
+         %{
+           "scope" => scope,
+           "name" => name,
+           "repository_full_handle" => full_handle,
+           "releases" => %{}
+         }}
 
       {:error, reason} ->
         {:error, reason}
@@ -656,7 +761,10 @@ defmodule Cache.Registry.ReleaseWorker do
     |> Map.put_new("scope", scope)
     |> Map.put_new("name", name)
     |> Map.put("repository_full_handle", full_handle)
-    |> Map.put("updated_at", DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601())
+    |> Map.put(
+      "updated_at",
+      DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    )
     |> Map.update(
       "releases",
       %{version => %{"checksum" => checksum, "manifests" => manifests}},
@@ -669,13 +777,38 @@ defmodule Cache.Registry.ReleaseWorker do
     )
   end
 
+  defp build_updated_metadata_with_skipped_release(metadata, scope, name, full_handle, version, reason) do
+    metadata
+    |> Map.put_new("scope", scope)
+    |> Map.put_new("name", name)
+    |> Map.put("repository_full_handle", full_handle)
+    |> Map.put(
+      "updated_at",
+      DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    )
+    |> Map.update(
+      "skipped_releases",
+      %{version => %{"reason" => reason}},
+      fn skipped_releases ->
+        Map.put(skipped_releases || %{}, version, %{"reason" => reason})
+      end
+    )
+  end
+
   defp upload_manifest(scope, name, version, filename, content) do
-    key = KeyNormalizer.package_object_key(%{scope: scope, name: name}, version: version, path: filename)
+    key =
+      KeyNormalizer.package_object_key(%{scope: scope, name: name},
+        version: version,
+        path: filename
+      )
+
     S3.upload_content(key, content, type: :registry, content_type: "text/x-swift")
   end
 
   defp manifest_path?("Package.swift"), do: true
+
   defp manifest_path?(path) when is_binary(path), do: Regex.match?(@alternate_manifest_regex, Path.basename(path))
+
   defp manifest_path?(_), do: false
 
   defp manifest_swift_version("Package.swift"), do: nil

--- a/cache/lib/cache/registry/sync_worker.ex
+++ b/cache/lib/cache/registry/sync_worker.ex
@@ -105,6 +105,8 @@ defmodule Cache.Registry.SyncWorker do
 
   defp missing_versions(tags, metadata) do
     releases = Map.get(metadata, "releases", %{})
+    skipped_releases = Map.get(metadata, "skipped_releases", %{})
+    known_versions = Map.keys(releases) ++ Map.keys(skipped_releases)
 
     tags
     |> Enum.filter(&valid_semver?/1)
@@ -112,7 +114,7 @@ defmodule Cache.Registry.SyncWorker do
     |> Enum.uniq_by(&KeyNormalizer.normalize_version/1)
     |> Enum.filter(fn tag ->
       normalized = KeyNormalizer.normalize_version(tag)
-      not Map.has_key?(releases, normalized)
+      normalized not in known_versions
     end)
   end
 
@@ -130,7 +132,10 @@ defmodule Cache.Registry.SyncWorker do
     |> Map.put_new("name", name)
     |> Map.put("repository_full_handle", full_handle)
     |> Map.put_new("releases", %{})
-    |> Map.put("updated_at", DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601())
+    |> Map.put(
+      "updated_at",
+      DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    )
   end
 
   defp empty_metadata(scope, name, full_handle) do

--- a/cache/test/cache/registry/release_worker_test.exs
+++ b/cache/test/cache/registry/release_worker_test.exs
@@ -27,15 +27,25 @@ defmodule Cache.Registry.ReleaseWorkerTest do
   end
 
   test "skips when release already exists" do
-    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ -> {:ok, :acquired} end)
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
 
     expect(Metadata, :get_package, fn "apple", "swift-argument-parser", _opts ->
       {:ok, %{"releases" => %{"1.0.0" => %{"checksum" => "abc", "manifests" => []}}}}
     end)
 
-    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
-    stub(TuistCommon.GitHub, :list_repository_contents, fn _, _, _, _ -> flunk("unexpected contents request") end)
-    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ -> flunk("unexpected file request") end)
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ ->
+      flunk("unexpected zipball download")
+    end)
+
+    stub(TuistCommon.GitHub, :list_repository_contents, fn _, _, _, _ ->
+      flunk("unexpected contents request")
+    end)
+
+    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ ->
+      flunk("unexpected file request")
+    end)
 
     assert :ok =
              ReleaseWorker.perform(%Oban.Job{
@@ -267,7 +277,8 @@ defmodule Cache.Registry.ReleaseWorkerTest do
   test "skips local file submodule URLs during updates" do
     root = Briefly.create!(directory: true)
 
-    %{clone_dest: clone_dest, required_submodule_path: required_submodule_path} = setup_local_file_submodule_clone(root)
+    %{clone_dest: clone_dest, required_submodule_path: required_submodule_path} =
+      setup_local_file_submodule_clone(root)
 
     log =
       capture_log(fn ->
@@ -365,7 +376,15 @@ defmodule Cache.Registry.ReleaseWorkerTest do
 
     git!(superproject, ["commit", "-am", "add submodule"])
     git!(root, ["-c", "protocol.file.allow=always", "clone", superproject, clone_dest])
-    git!(clone_dest, ["-c", "protocol.file.allow=always", "submodule", "update", "--init", required_submodule_path])
+
+    git!(clone_dest, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "update",
+      "--init",
+      required_submodule_path
+    ])
 
     assert {:error,
             {:nested_git_submodule_update_failed, ^required_submodule_path, "Vendor/Required/NestedPrivateDep", _status,
@@ -465,6 +484,93 @@ defmodule Cache.Registry.ReleaseWorkerTest do
                  "tag" => "v1.0.0"
                }
              })
+  end
+
+  test "marks releases without root manifests as skipped" do
+    expect(Lock, :try_acquire, 2, fn
+      {:release, "newrelic", "newrelic-ios-agent-spm", "7.0.0"}, _ -> {:ok, :acquired}
+      {:package, "newrelic", "newrelic-ios-agent-spm"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, 2, fn "newrelic", "newrelic-ios-agent-spm", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "newrelic/newrelic-ios-agent-spm", "token", "7.0.0", _ ->
+      {:ok, [%{"path" => ".gitmodules", "type" => "file"}, %{"path" => "Agent", "type" => "dir"}]}
+    end)
+
+    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ ->
+      flunk("unexpected file request")
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ ->
+      flunk("unexpected zipball download")
+    end)
+
+    stub(Upload, :stream_file, fn _ -> flunk("unexpected upload stream") end)
+    stub(ExAws.S3, :upload, fn _, _, _, _ -> flunk("unexpected S3 upload") end)
+    stub(ExAws, :request, fn _ -> flunk("unexpected AWS request") end)
+
+    expect(Metadata, :put_package, fn "newrelic", "newrelic-ios-agent-spm", metadata ->
+      assert metadata["releases"] == %{}
+      assert metadata["skipped_releases"] == %{"7.0.0" => %{"reason" => "missing_manifests"}}
+      :ok
+    end)
+
+    assert :ok =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "newrelic",
+                 "name" => "newrelic-ios-agent-spm",
+                 "repository_full_handle" => "newrelic/newrelic-ios-agent-spm",
+                 "tag" => "7.0.0"
+               }
+             })
+  end
+
+  test "retries missing-manifest releases when the skipped-release metadata lock is held" do
+    expect(Lock, :try_acquire, 2, fn
+      {:release, "newrelic", "newrelic-ios-agent-spm", "7.0.0"}, _ -> {:ok, :acquired}
+      {:package, "newrelic", "newrelic-ios-agent-spm"}, _ -> {:error, :already_locked}
+    end)
+
+    expect(Metadata, :get_package, fn "newrelic", "newrelic-ios-agent-spm", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "newrelic/newrelic-ios-agent-spm", "token", "7.0.0", _ ->
+      {:ok, [%{"path" => ".gitmodules", "type" => "file"}, %{"path" => "Agent", "type" => "dir"}]}
+    end)
+
+    stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ ->
+      flunk("unexpected file request")
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ ->
+      flunk("unexpected zipball download")
+    end)
+
+    stub(Upload, :stream_file, fn _ -> flunk("unexpected upload stream") end)
+    stub(ExAws.S3, :upload, fn _, _, _, _ -> flunk("unexpected S3 upload") end)
+    stub(ExAws, :request, fn _ -> flunk("unexpected AWS request") end)
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected metadata write") end)
+
+    log =
+      capture_log([level: :info], fn ->
+        assert {:error, {:missing_manifests, "newrelic/newrelic-ios-agent-spm", "7.0.0"}} =
+                 ReleaseWorker.perform(%Oban.Job{
+                   args: %{
+                     "scope" => "newrelic",
+                     "name" => "newrelic-ios-agent-spm",
+                     "repository_full_handle" => "newrelic/newrelic-ios-agent-spm",
+                     "tag" => "7.0.0"
+                   }
+                 })
+      end)
+
+    assert log =~ "Skipped release metadata update deferred for newrelic/newrelic-ios-agent-spm@7.0.0"
+    assert log =~ "Failed to record skipped release newrelic/newrelic-ios-agent-spm@7.0.0"
   end
 
   describe "symlink resolution" do
@@ -858,7 +964,10 @@ defmodule Cache.Registry.ReleaseWorkerTest do
         File.write!(Path.join(first_dir, "target.md"), "content")
         File.ln_s!("target.md", Path.join(first_dir, "link.md"))
         File.write!(Path.join(second_dir, "Package.swift"), manifest_content)
-        {_, 0} = System.cmd("zip", ["--symlinks", "-r", archive_path, "repo-v1.0.0", "repo-v1.0.1"], cd: tmp)
+
+        {_, 0} =
+          System.cmd("zip", ["--symlinks", "-r", archive_path, "repo-v1.0.0", "repo-v1.0.1"], cd: tmp)
+
         File.rm_rf!(tmp)
         :ok
       end)
@@ -929,11 +1038,23 @@ defmodule Cache.Registry.ReleaseWorkerTest do
     Enum.each(submodules, fn
       path when is_binary(path) ->
         File.mkdir_p!(Path.join([repo, Path.dirname(path)]))
-        git!(repo, ["update-index", "--add", "--cacheinfo", "160000,0123456789012345678901234567890123456789,#{path}"])
+
+        git!(repo, [
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          "160000,0123456789012345678901234567890123456789,#{path}"
+        ])
 
       %{path: path} ->
         File.mkdir_p!(Path.join([repo, Path.dirname(path)]))
-        git!(repo, ["update-index", "--add", "--cacheinfo", "160000,0123456789012345678901234567890123456789,#{path}"])
+
+        git!(repo, [
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          "160000,0123456789012345678901234567890123456789,#{path}"
+        ])
     end)
 
     git!(repo, ["commit", "-m", "add gitlinks"])
@@ -1002,8 +1123,11 @@ defmodule Cache.Registry.ReleaseWorkerTest do
 
   defp git!(working_directory, args) do
     case System.cmd("git", args, cd: working_directory, stderr_to_stdout: true) do
-      {_, 0} -> :ok
-      {output, status} -> flunk("git #{Enum.join(args, " ")} failed with status #{status}: #{output}")
+      {_, 0} ->
+        :ok
+
+      {output, status} ->
+        flunk("git #{Enum.join(args, " ")} failed with status #{status}: #{output}")
     end
   end
 

--- a/cache/test/cache/registry/sync_worker_test.exs
+++ b/cache/test/cache/registry/sync_worker_test.exs
@@ -37,15 +37,26 @@ defmodule Cache.Registry.SyncWorkerTest do
     end)
 
     expect(SwiftPackageIndex, :list_packages, fn "token" ->
-      {:ok, [%{scope: "apple", name: "swift-argument-parser", repository_full_handle: "apple/swift-argument-parser"}]}
+      {:ok,
+       [
+         %{
+           scope: "apple",
+           name: "swift-argument-parser",
+           repository_full_handle: "apple/swift-argument-parser"
+         }
+       ]}
     end)
 
     expect(SyncCursor, :get, fn -> 0 end)
     expect(SyncCursor, :put, fn 0 -> :ok end)
 
     expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:error, :not_found} end)
+
     expect(Metadata, :put_package, fn "apple", "swift-argument-parser", _metadata -> :ok end)
-    expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-argument-parser", "token", _ -> {:ok, ["v1.2.3"]} end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-argument-parser", "token", _ ->
+      {:ok, ["v1.2.3"]}
+    end)
 
     assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
 
@@ -58,6 +69,47 @@ defmodule Cache.Registry.SyncWorkerTest do
         "tag" => "v1.2.3"
       }
     )
+  end
+
+  test "does not enqueue release workers for skipped versions" do
+    expect(Lock, :try_acquire, 2, fn
+      :sync, _ -> {:ok, :acquired}
+      {:package, "newrelic", "newrelic-ios-agent-spm"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(SwiftPackageIndex, :list_packages, fn "token" ->
+      {:ok,
+       [
+         %{
+           scope: "newrelic",
+           name: "newrelic-ios-agent-spm",
+           repository_full_handle: "newrelic/newrelic-ios-agent-spm"
+         }
+       ]}
+    end)
+
+    expect(SyncCursor, :get, fn -> 0 end)
+    expect(SyncCursor, :put, fn 0 -> :ok end)
+
+    expect(Metadata, :get_package, fn "newrelic", "newrelic-ios-agent-spm" ->
+      {:ok,
+       %{
+         "releases" => %{},
+         "skipped_releases" => %{"7.0.0" => %{"reason" => "missing_manifests"}}
+       }}
+    end)
+
+    expect(Metadata, :put_package, fn "newrelic", "newrelic-ios-agent-spm", metadata ->
+      assert metadata["skipped_releases"] == %{"7.0.0" => %{"reason" => "missing_manifests"}}
+      :ok
+    end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "newrelic/newrelic-ios-agent-spm", "token", _ ->
+      {:ok, ["7.0.0"]}
+    end)
+
+    assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
+    refute_enqueued(worker: ReleaseWorker)
   end
 
   @tag capture_log: true


### PR DESCRIPTION
Fixes: https://tuist.sentry.io/issues/CACHE-4W

## Summary
- Persist permanently invalid registry releases in `skipped_releases` so sync does not keep re-enqueueing them.
- Treat missing root `Package.swift` as a permanent skip for registry mirroring.
- Return a retryable error if the skipped-release metadata lock is contended, so the skip marker is not lost.
- Update registry sync logic to respect skipped versions when deciding what to enqueue.

## Testing
- Added a regression test for marking missing-manifest releases as skipped.
- Added a regression test for retrying when skipped-release metadata cannot be written due to lock contention.
- Ran focused cache registry tests successfully: `release_worker_test.exs` and `sync_worker_test.exs`.