### PR TITLE
fix(cli): ensure package product dependencies are initialized

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -690,6 +690,9 @@ extension PBXTarget {
             buildFile.applyCondition(condition, applicableTo: target)
             pbxproj.add(object: buildFile)
 
+            if packageProductDependencies == nil {
+                packageProductDependencies = []
+            }
             packageProductDependencies?.append(productDependency)
 
             // Link the product

--- a/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -417,6 +417,35 @@ final class LinkGeneratorTests: XCTestCase {
         ])
     }
 
+    func test_generatePackages_initializesPackageProductDependencies() throws {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            product: .framework,
+            dependencies: [
+                .package(product: "OrderedCollections", type: .runtime),
+            ]
+        )
+        let pbxproj = PBXProj()
+        let pbxTarget = PBXNativeTarget(name: target.name)
+        pbxproj.add(object: pbxTarget)
+
+        let frameworksBuildPhase = PBXFrameworksBuildPhase()
+        pbxproj.add(object: frameworksBuildPhase)
+        pbxTarget.buildPhases.append(frameworksBuildPhase)
+
+        // When
+        try subject.generatePackages(
+            target: target,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertEqual(pbxTarget.packageProductDependencies?.map(\.productName), ["OrderedCollections"])
+        XCTAssertEqual(try pbxTarget.frameworksBuildPhase()?.files?.map(\.product?.productName), ["OrderedCollections"])
+    }
+
     func test_generateEmbedPhase_setupEmbedFrameworksBuildPhase_whenPackageProductIsPresent() throws {
         // Given
         var dependencies: Set<GraphDependencyReference> = []


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/10338

## Summary
- Initialize `packageProductDependencies` before appending Swift package products in `PBXTarget`
- Add a regression test covering package products linked through `generatePackages`

## Testing
- Added a focused unit test for `LinkGenerator`
- Built the `TuistGenerator` product locally