### PR TITLE
feat(cli): Generate Objective-C resource accessors for internal targets

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -137,8 +137,11 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
             sideEffects.append(sideEffect)
         }
 
-        if case .external = project.type,
-           target.sources.containsObjcFiles,
+        // Generate Objective-C resource accessor for targets with Objective-C sources and bundle-accessed resources.
+        // This applies to both external and internal targets.
+        // Note: We no longer set GCC_PREFIX_HEADER to avoid overriding user-defined prefix headers (.pch files).
+        // The generated header is only needed by the generated implementation file, which imports it directly.
+        if target.sources.containsObjcFiles,
            target.resources.containsBundleAccessedResources,
            !target.supportsResources || target.product == .staticFramework
         {
@@ -147,11 +150,6 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
             let headerHash = try headerData.map(contentHasher.hash)
             let headerFile = SourceFile(path: headerFilePath, contentHash: headerHash)
             let headerSideEffect = SideEffectDescriptor.file(.init(path: headerFilePath, contents: headerData, state: .present))
-
-            let gccPrefixHeader = "$(SRCROOT)/\(headerFile.path.relative(to: project.path).pathString)"
-            var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
-            settings["GCC_PREFIX_HEADER"] = .string(gccPrefixHeader)
-            modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)
 
             sideEffects.append(headerSideEffect)
 

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -137,6 +137,28 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
+    func mapWhenInternalObjcStaticFrameworkHasResources() async throws {
+        // Given
+        let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let target = Target.test(product: .staticFramework, sources: ["/Absolute/File.m"], resources: .init(resources))
+        let project = Project.test(targets: [target], type: .local) // Internal target (not external)
+        given(buildableFolderChecker).containsResources(.value([])).willReturn(false)
+        given(buildableFolderChecker).containsSources(.value([])).willReturn(false)
+
+        // When
+        let (gotProject, gotSideEffects) = try await subject.map(project: project)
+
+        // Then
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+        verifyObjcBundleAccessor(
+            for: target,
+            gotTarget: gotTarget,
+            gotSideEffects: gotSideEffects,
+            project: project
+        )
+    }
+
+    @Test
     func mapWhenDisableBundleAccessorsIsTrueDoesNotGenerateAccessors() async throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
@@ -1075,12 +1097,8 @@ struct ResourcesProjectMapperTests {
         gotSideEffects: [SideEffectDescriptor],
         project: Project
     ) {
-        #expect(
-            gotTarget.settings?.base["GCC_PREFIX_HEADER"] ==
-                .string(
-                    "$(SRCROOT)/\(Constants.DerivedDirectory.name)/\(Constants.DerivedDirectory.sources)/TuistBundle+\(target.name).h"
-                )
-        )
+        // Verify GCC_PREFIX_HEADER is NOT set (we no longer override user's prefix header)
+        #expect(gotTarget.settings?.base["GCC_PREFIX_HEADER"] == nil)
         #expect(gotTarget.sources.count == 2)
         #expect(gotSideEffects.count == 2)
         let generatedFiles = gotSideEffects.compactMap {


### PR DESCRIPTION
Fixes #6456

## What
- Remove `.external` project type restriction for ObjC accessor generation
- No longer set `GCC_PREFIX_HEADER` to avoid overriding user-defined prefix headers (.pch files)
- Generated header is still created and directly imported by the implementation file

## Why
Previously, internal targets with Objective-C sources couldn't access resource bundles because Tuist only generated accessors for `.external` projects. The `GCC_PREFIX_HEADER` setting was overriding user-defined prefix headers, causing regressions.

## Solution
1. Remove `.external` restriction - generate accessors for both external and internal targets
2. Don't set `GCC_PREFIX_HEADER` - the generated header is only needed by the generated implementation file, which imports it directly
3. Add test case for internal targets with Objective-C sources

## Testing
- Added `mapWhenInternalObjcStaticFrameworkHasResources` test case
- Updated `verifyObjcBundleAccessor` to verify GCC_PREFIX_HEADER is NOT set
- Existing tests pass

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Commit message follows conventional commits
- [x] Self-review completed