### PR TITLE
refactor(server): polish ops accounts dashboard — new-tab Stripe, 0 seats, cancel status

### DIFF
--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -224,9 +224,11 @@ defmodule Tuist.Billing do
     available_prices = Tuist.Environment.stripe_prices()
     key = if cadence == "yearly", do: "flat_yearly", else: "flat_monthly"
 
+    # Enterprise is negotiated per-deal; start the subscription with 0 seats
+    # so sales can fill in the actual quantity on Stripe without us guessing.
     (available_prices["enterprise"][key] || [])
     |> Enum.take(1)
-    |> Enum.map(&%{price: &1, quantity: 1})
+    |> Enum.map(&%{price: &1, quantity: 0})
   end
 
   @doc """
@@ -276,7 +278,8 @@ defmodule Tuist.Billing do
           status: subscription.status,
           account_id: account.id,
           default_payment_method: subscription.default_payment_method,
-          trial_end: trial_end
+          trial_end: trial_end,
+          cancel_at_period_end: Map.get(subscription, :cancel_at_period_end, false) || false
         })
         |> Repo.insert!()
 
@@ -286,7 +289,8 @@ defmodule Tuist.Billing do
           plan: plan,
           status: subscription.status,
           default_payment_method: subscription.default_payment_method,
-          trial_end: trial_end
+          trial_end: trial_end,
+          cancel_at_period_end: Map.get(subscription, :cancel_at_period_end, false) || false
         })
         |> Repo.update!()
     end

--- a/server/lib/tuist/billing/subscription.ex
+++ b/server/lib/tuist/billing/subscription.ex
@@ -14,6 +14,7 @@ defmodule Tuist.Billing.Subscription do
     field :status, :string
     field :default_payment_method, :string
     field :trial_end, :utc_datetime
+    field :cancel_at_period_end, :boolean, default: false
 
     belongs_to :account, Account
 
@@ -30,6 +31,7 @@ defmodule Tuist.Billing.Subscription do
       :status,
       :default_payment_method,
       :trial_end,
+      :cancel_at_period_end,
       :inserted_at
     ])
     |> validate_required([:plan, :subscription_id, :account_id, :status])
@@ -43,7 +45,7 @@ defmodule Tuist.Billing.Subscription do
 
   def update_changeset(account, attrs) do
     account
-    |> cast(attrs, [:plan, :status, :default_payment_method, :trial_end])
+    |> cast(attrs, [:plan, :status, :default_payment_method, :trial_end, :cancel_at_period_end])
     |> validate_plan()
   end
 end

--- a/server/lib/tuist_web/controllers/ops_controller.ex
+++ b/server/lib/tuist_web/controllers/ops_controller.ex
@@ -1,0 +1,23 @@
+defmodule TuistWeb.OpsController do
+  @moduledoc """
+  Controllers for ops-only endpoints that don't fit the LiveView model —
+  currently just the Stripe billing portal handoff, which needs to run as a
+  regular GET so the browser can open it in a new tab via `target="_blank"`.
+  """
+  use TuistWeb, :controller
+
+  alias Tuist.Accounts
+  alias Tuist.Billing
+
+  def stripe_session(conn, %{"id" => id}) do
+    case Accounts.get_account_by_id(String.to_integer(id)) do
+      {:ok, account} ->
+        account = Accounts.create_customer_when_absent(account)
+        session = Billing.create_session(account.customer_id)
+        conn |> redirect(external: session.url) |> halt()
+
+      {:error, :not_found} ->
+        raise TuistWeb.Errors.NotFoundError, "Account not found."
+    end
+  end
+end

--- a/server/lib/tuist_web/live/ops_accounts_live.ex
+++ b/server/lib/tuist_web/live/ops_accounts_live.ex
@@ -73,19 +73,6 @@ defmodule TuistWeb.OpsAccountsLive do
   end
 
   @impl true
-  def handle_event("manage", %{"id" => id}, socket) do
-    case Accounts.get_account_by_id(String.to_integer(id)) do
-      {:ok, account} ->
-        account = Accounts.create_customer_when_absent(account)
-        session = Billing.create_session(account.customer_id)
-        {:noreply, redirect(socket, external: session.url)}
-
-      {:error, :not_found} ->
-        {:noreply, put_flash(socket, :error, "Account not found.")}
-    end
-  end
-
-  @impl true
   def handle_event("initiate_enterprise_upgrade", %{"id" => id}, socket) do
     case Accounts.get_account_by_id(String.to_integer(id)) do
       {:ok, account} ->
@@ -230,6 +217,22 @@ defmodule TuistWeb.OpsAccountsLive do
   def plan_color(:enterprise), do: "success"
   def plan_color(:open_source), do: "information"
   def plan_color(_), do: "neutral"
+
+  # `cancel_at_period_end` takes priority — a subscription flagged for
+  # cancellation still reports `status: "active"` until the period ends.
+  # Accounts without a subscription are on the Air plan, which is always
+  # active (there's nothing to cancel).
+  def subscription_status(%Account{subscriptions: [%{cancel_at_period_end: true} | _]}), do: :canceling
+  def subscription_status(%Account{subscriptions: [%{status: "trialing"} | _]}), do: :trialing
+  def subscription_status(_), do: :active
+
+  def status_label(:active), do: "Active"
+  def status_label(:trialing), do: "Trialing"
+  def status_label(:canceling), do: "Canceling"
+
+  def status_color(:active), do: "success"
+  def status_color(:trialing), do: "information"
+  def status_color(:canceling), do: "warning"
 
   # ISO 3166-1 alpha-2 codes for the countries most likely to appear on
   # Enterprise invoices. Extend as needed. Sorted alphabetically by name.

--- a/server/lib/tuist_web/live/ops_accounts_live.ex
+++ b/server/lib/tuist_web/live/ops_accounts_live.ex
@@ -222,17 +222,17 @@ defmodule TuistWeb.OpsAccountsLive do
   # cancellation still reports `status: "active"` until the period ends.
   # Accounts without a subscription are on the Air plan, which is always
   # active (there's nothing to cancel).
-  def subscription_status(%Account{subscriptions: [%{cancel_at_period_end: true} | _]}), do: :canceling
+  def subscription_status(%Account{subscriptions: [%{cancel_at_period_end: true} | _]}), do: :cancelled
   def subscription_status(%Account{subscriptions: [%{status: "trialing"} | _]}), do: :trialing
   def subscription_status(_), do: :active
 
   def status_label(:active), do: "Active"
   def status_label(:trialing), do: "Trialing"
-  def status_label(:canceling), do: "Canceling"
+  def status_label(:cancelled), do: "Cancelled"
 
   def status_color(:active), do: "success"
   def status_color(:trialing), do: "information"
-  def status_color(:canceling), do: "warning"
+  def status_color(:cancelled), do: "warning"
 
   # ISO 3166-1 alpha-2 codes for the countries most likely to appear on
   # Enterprise invoices. Extend as needed. Sorted alphabetically by name.

--- a/server/lib/tuist_web/live/ops_accounts_live.html.heex
+++ b/server/lib/tuist_web/live/ops_accounts_live.html.heex
@@ -70,7 +70,7 @@
             <.dropdown_item
               :if={
                 current_plan(account) in [:pro, :enterprise] and
-                  subscription_status(account) != :canceling
+                  subscription_status(account) != :cancelled
               }
               label="Cancel plan"
               value="cancel"

--- a/server/lib/tuist_web/live/ops_accounts_live.html.heex
+++ b/server/lib/tuist_web/live/ops_accounts_live.html.heex
@@ -33,6 +33,13 @@
             style="light-fill"
           />
         </:col>
+        <:col :let={account} label="Status">
+          <.badge_cell
+            label={status_label(subscription_status(account))}
+            color={status_color(subscription_status(account))}
+            style="light-fill"
+          />
+        </:col>
         <:col :let={account} label="Stripe customer">
           <.text_cell label={account.customer_id || "Not created"} />
         </:col>
@@ -43,8 +50,9 @@
             <.dropdown_item
               label="Manage on Stripe"
               value="manage"
-              phx-click="manage"
-              phx-value-id={account.id}
+              href={~p"/ops/accounts/#{account.id}/stripe-session"}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <:left_icon><.credit_card /></:left_icon>
             </.dropdown_item>
@@ -60,7 +68,10 @@
             </.dropdown_item>
 
             <.dropdown_item
-              :if={current_plan(account) in [:pro, :enterprise]}
+              :if={
+                current_plan(account) in [:pro, :enterprise] and
+                  subscription_status(account) != :canceling
+              }
               label="Cancel plan"
               value="cancel"
               phx-click="cancel_plan"

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -631,6 +631,12 @@ defmodule TuistWeb.Router do
     plug :assign_current_path
   end
 
+  scope "/ops", TuistWeb do
+    pipe_through [:browser_app, :ops]
+
+    get "/accounts/:id/stripe-session", OpsController, :stripe_session
+  end
+
   scope "/ops" do
     pipe_through [:browser_app, :ops]
 

--- a/server/priv/repo/migrations/20260422100000_add_cancel_at_period_end_to_subscriptions.exs
+++ b/server/priv/repo/migrations/20260422100000_add_cancel_at_period_end_to_subscriptions.exs
@@ -1,0 +1,10 @@
+defmodule Tuist.Repo.Migrations.AddCancelAtPeriodEndToSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      # excellent_migrations:safety-assured-for-next-line column_added_with_default
+      add :cancel_at_period_end, :boolean, default: false, null: false
+    end
+  end
+end

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -200,6 +200,27 @@ defmodule Tuist.BillingTest do
       subscription = Billing.get_current_active_subscription(account)
       assert subscription.plan == :air
       assert subscription.default_payment_method == "pm_some-id"
+      refute subscription.cancel_at_period_end
+    end
+
+    test "persists cancel_at_period_end from the Stripe payload" do
+      # Given
+      user = AccountsFixtures.user_fixture(customer_id: "customer_id")
+      account = Accounts.get_account_from_user(user)
+
+      # When
+      Billing.on_subscription_change(%{
+        id: "sub_some-id",
+        status: "active",
+        customer: "customer_id",
+        default_payment_method: "pm_some-id",
+        cancel_at_period_end: true,
+        items: %{data: [%{price: %{id: "pro.usage"}}, %{price: %{id: "pro.flat.monthly"}}]}
+      })
+
+      # Then
+      subscription = Billing.get_current_active_subscription(account)
+      assert subscription.cancel_at_period_end
     end
 
     test "when a user downgrades from the pro to the air plan" do
@@ -730,7 +751,7 @@ defmodule Tuist.BillingTest do
 
       expect(Stripe.Subscription, :create, fn %{
                                                 customer: "customer_id",
-                                                items: [%{price: "enterprise.flat.monthly", quantity: 1}],
+                                                items: [%{price: "enterprise.flat.monthly", quantity: 0}],
                                                 collection_method: "send_invoice",
                                                 days_until_due: 30
                                               } ->
@@ -778,7 +799,7 @@ defmodule Tuist.BillingTest do
                                                 items: [
                                                   %{id: "pro.flat.monthly", deleted: true},
                                                   %{id: "pro.usage", deleted: true},
-                                                  %{price: "enterprise.flat.yearly", quantity: 1}
+                                                  %{price: "enterprise.flat.yearly", quantity: 0}
                                                 ],
                                                 collection_method: "send_invoice",
                                                 days_until_due: 30

--- a/server/test/tuist_web/controllers/ops_controller_test.exs
+++ b/server/test/tuist_web/controllers/ops_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule TuistWeb.OpsControllerTest do
+  use TuistTestSupport.Cases.ConnCase
+  use Mimic
+
+  alias Tuist.Billing
+  alias Tuist.Environment
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  setup :verify_on_exit!
+
+  setup %{conn: conn} do
+    user = AccountsFixtures.user_fixture(preload: [:account])
+    conn = log_in_user(conn, user)
+    Mimic.stub(Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+    %{conn: conn, user: user}
+  end
+
+  test "GET /ops/accounts/:id/stripe-session redirects to the Stripe billing portal", %{
+    conn: conn,
+    user: user
+  } do
+    expect(Billing, :create_session, fn customer_id ->
+      assert customer_id == user.account.customer_id
+      %{url: "https://billing.stripe.test/session"}
+    end)
+
+    conn = get(conn, ~p"/ops/accounts/#{user.account.id}/stripe-session")
+
+    assert redirected_to(conn, 302) == "https://billing.stripe.test/session"
+  end
+end

--- a/server/test/tuist_web/live/ops_accounts_live_test.exs
+++ b/server/test/tuist_web/live/ops_accounts_live_test.exs
@@ -36,6 +36,26 @@ defmodule TuistWeb.OpsAccountsLiveTest do
     assert html =~ "acme"
     assert html =~ "Pro"
     assert html =~ "Air"
+    assert html =~ "Active"
+  end
+
+  test "flags the Canceling status when cancel_at_period_end is set", %{conn: conn} do
+    # Given
+    organization = AccountsFixtures.organization_fixture(name: "acme")
+    org_account = Accounts.get_account_from_organization(organization)
+
+    subscription =
+      BillingFixtures.subscription_fixture(account_id: org_account.id, plan: :pro)
+
+    # Simulate the webhook sync: cancel_at_period_end flipped but status
+    # still "active" until the period actually ends.
+    Tuist.Repo.update!(Ecto.Changeset.change(subscription, cancel_at_period_end: true))
+
+    # When
+    {:ok, _lv, html} = live(conn, ~p"/ops/accounts")
+
+    # Then
+    assert html =~ "Canceling"
   end
 
   test "paginates when there are more accounts than one page", %{conn: conn} do
@@ -82,23 +102,6 @@ defmodule TuistWeb.OpsAccountsLiveTest do
     table_row = html |> Floki.parse_fragment!() |> Floki.find("#ops-accounts-table tbody tr")
     table_html = Floki.raw_html(table_row)
     refute table_html =~ user.account.name
-  end
-
-  test "Manage on Stripe event redirects to Stripe portal", %{conn: conn, user: user} do
-    # Given
-    stub(Billing, :create_session, fn customer_id ->
-      assert customer_id == user.account.customer_id
-      %{url: "https://billing.stripe.test/session"}
-    end)
-
-    {:ok, lv, _html} = live(conn, ~p"/ops/accounts")
-
-    # When — dropdown items live inside a <template> portal, so we dispatch
-    # the event directly rather than clicking through the DOM.
-    result = render_hook(lv, "manage", %{"id" => to_string(user.account.id)})
-
-    # Then
-    assert {:error, {:redirect, %{to: "https://billing.stripe.test/session"}}} = result
   end
 
   test "one-click upgrade when the Stripe customer already has billing details", %{conn: conn, user: user} do

--- a/server/test/tuist_web/live/ops_accounts_live_test.exs
+++ b/server/test/tuist_web/live/ops_accounts_live_test.exs
@@ -39,7 +39,7 @@ defmodule TuistWeb.OpsAccountsLiveTest do
     assert html =~ "Active"
   end
 
-  test "flags the Canceling status when cancel_at_period_end is set", %{conn: conn} do
+  test "flags the Cancelled status when cancel_at_period_end is set", %{conn: conn} do
     # Given
     organization = AccountsFixtures.organization_fixture(name: "acme")
     org_account = Accounts.get_account_from_organization(organization)
@@ -55,7 +55,7 @@ defmodule TuistWeb.OpsAccountsLiveTest do
     {:ok, _lv, html} = live(conn, ~p"/ops/accounts")
 
     # Then
-    assert html =~ "Canceling"
+    assert html =~ "Cancelled"
   end
 
   test "paginates when there are more accounts than one page", %{conn: conn} do


### PR DESCRIPTION
## Summary

Three follow-ups to [#10359](https://github.com/tuist/tuist/pull/10359) based on real usage:

- **Manage on Stripe opens in a new tab.** Replaced the LiveView event with a plain GET endpoint (\`/ops/accounts/:id/stripe-session\` → new \`TuistWeb.OpsController\`) and made the dropdown item a regular \`<a target=\"_blank\" rel=\"noopener noreferrer\">\`. A \`redirect/2\` from inside the LiveView used to tear the ops page out from under whoever was working.
- **Enterprise subscriptions start with quantity 0.** Enterprise is negotiated per-deal; sales fills the actual seat count in Stripe afterwards. Spinning up the subscription with \`quantity: 1\` was billing for a seat the customer hadn't agreed to.
- **Cancellation state surfaced.** Adds \`cancel_at_period_end\` to the \`subscriptions\` table, persists it from the existing webhook payload (\`Billing.on_subscription_change/1\`), and shows a new **Status** column on /ops/accounts:
  - **Cancelled** (warning) — \`cancel_at_period_end: true\`. Stripe keeps the sub active through the end of the paid period; the label reflects that the customer's already pulled the trigger.
  - **Trialing** (info) — Stripe \`status: \"trialing\"\`.
  - **Active** (success) — everything else, including Air. Air can't be cancelled, so it always reads as Active rather than empty.

  The **Cancel plan** dropdown item hides itself once the subscription is already in the cancelled state.

## How to test locally

- [ ] \`mise run db:migrate\` to apply the new column.
- [ ] Log in as an ops user and visit \`/ops/accounts\`. The Status column should show **Active** for everything by default.
- [ ] **Manage on Stripe** opens the Stripe billing portal in a new tab; the ops page stays put.
- [ ] **Upgrade to Enterprise** an account with billing details on file → Stripe subscription is created with the enterprise flat-monthly price at \`quantity: 0\`.
- [ ] **Cancel plan** an active Pro/Enterprise subscription → after the webhook fires (\`stripe listen --forward-to localhost:8080/webhooks/billing\`), the row's status flips to **Cancelled** and the \"Cancel plan\" item disappears.
- [ ] \`mix test test/tuist_web/live/ops_accounts_live_test.exs test/tuist/billing_test.exs test/tuist_web/controllers/ops_controller_test.exs\` — 42 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)