### PR TITLE
fix(cli): cache per-SDK slices for multi-platform resource bundles

### DIFF
--- a/cli/Sources/TuistCache/MultiPlatformBundle.swift
+++ b/cli/Sources/TuistCache/MultiPlatformBundle.swift
@@ -70,10 +70,6 @@ public enum MultiPlatformBundle {
         }
     }
 
-    public static func isMultiPlatformBundle(path: AbsolutePath) -> Bool {
-        path.extension == bundleExtension
-    }
-
     public static func readManifest(
         at wrapperPath: AbsolutePath,
         fileSystem: FileSysteming

--- a/cli/Sources/TuistCache/MultiPlatformBundle.swift
+++ b/cli/Sources/TuistCache/MultiPlatformBundle.swift
@@ -1,0 +1,107 @@
+import FileSystem
+import Foundation
+import Path
+import XcodeGraph
+
+public enum MultiPlatformBundle {
+    public static let bundleExtension = "xcbundle"
+    public static let manifestFileName = "Info.plist"
+
+    public struct Slice: Hashable, Codable {
+        public let libraryIdentifier: String
+        public let supportedPlatforms: [String]
+        public let bundleName: String
+
+        public init(libraryIdentifier: String, supportedPlatforms: [String], bundleName: String) {
+            self.libraryIdentifier = libraryIdentifier
+            self.supportedPlatforms = supportedPlatforms
+            self.bundleName = bundleName
+        }
+
+        public var platformFilters: PlatformFilters {
+            Set(supportedPlatforms.compactMap(PlatformFilter.init(xcodeprojValue:)))
+        }
+
+        public func bundlePath(inside wrapper: AbsolutePath) throws -> AbsolutePath {
+            try wrapper.appending(
+                RelativePath(validating: "\(libraryIdentifier)/\(bundleName)")
+            )
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case libraryIdentifier = "LibraryIdentifier"
+            case supportedPlatforms = "SupportedPlatforms"
+            case bundleName = "BundleName"
+        }
+    }
+
+    public struct Manifest: Codable {
+        public let version: Int
+        public let slices: [Slice]
+
+        public init(slices: [Slice]) {
+            version = 1
+            self.slices = slices
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case version = "TuistMultiPlatformBundleVersion"
+            case slices = "Slices"
+        }
+    }
+
+    public static func libraryIdentifier(for platform: Platform) -> String {
+        switch platform {
+        case .iOS: return "ios"
+        case .macOS: return "macos"
+        case .tvOS: return "tvos"
+        case .watchOS: return "watchos"
+        case .visionOS: return "visionos"
+        }
+    }
+
+    public static func supportedPlatformFilters(for platform: Platform) -> [PlatformFilter] {
+        switch platform {
+        case .iOS: return [.ios, .catalyst]
+        case .macOS: return [.macos]
+        case .tvOS: return [.tvos]
+        case .watchOS: return [.watchos]
+        case .visionOS: return [.visionos]
+        }
+    }
+
+    public static func isMultiPlatformBundle(path: AbsolutePath) -> Bool {
+        path.extension == bundleExtension
+    }
+
+    public static func readManifest(
+        at wrapperPath: AbsolutePath,
+        fileSystem: FileSysteming
+    ) async throws -> Manifest {
+        let plistPath = wrapperPath.appending(component: manifestFileName)
+        return try await fileSystem.readPlistFile(at: plistPath)
+    }
+
+    public static func writeManifest(
+        _ manifest: Manifest,
+        to wrapperPath: AbsolutePath,
+        fileSystem: FileSysteming
+    ) async throws {
+        try await fileSystem.writeAsPlist(manifest, at: wrapperPath.appending(component: manifestFileName))
+    }
+}
+
+extension PlatformFilter {
+    public init?(xcodeprojValue: String) {
+        switch xcodeprojValue {
+        case "ios": self = .ios
+        case "macos": self = .macos
+        case "tvos": self = .tvos
+        case "maccatalyst": self = .catalyst
+        case "driverkit": self = .driverkit
+        case "watchos": self = .watchos
+        case "xros": self = .visionos
+        default: return nil
+        }
+    }
+}

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -883,6 +883,7 @@ public class GraphTraverser: GraphTraversing {
             case .macro: return nil
             case .library: return nil
             case .bundle: return nil
+            case .multiPlatformBundle: return nil
             case .packageProduct: return nil
             case .target: return nil
             case .sdk: return nil
@@ -1116,7 +1117,7 @@ public class GraphTraverser: GraphTraversing {
                         return !precompiledMacroDependencies(dependency).isEmpty
                     case .macro:
                         return true
-                    case .bundle, .library, .framework, .sdk, .target, .packageProduct, .foreignBuildOutput:
+                    case .bundle, .multiPlatformBundle, .library, .framework, .sdk, .target, .packageProduct, .foreignBuildOutput:
                         return false
                     }
                 },
@@ -1124,7 +1125,7 @@ public class GraphTraverser: GraphTraversing {
                     switch dependency {
                     case .macro:
                         return true
-                    case .bundle, .library, .framework, .sdk, .target, .packageProduct, .xcframework, .foreignBuildOutput:
+                    case .bundle, .multiPlatformBundle, .library, .framework, .sdk, .target, .packageProduct, .xcframework, .foreignBuildOutput:
                         return false
                     }
                 }
@@ -1135,7 +1136,7 @@ public class GraphTraverser: GraphTraversing {
                     return Array(precompiledMacroDependencies(dependency))
                 case let .macro(path):
                     return [path]
-                case .bundle, .library, .framework, .sdk, .target, .packageProduct, .foreignBuildOutput:
+                case .bundle, .multiPlatformBundle, .library, .framework, .sdk, .target, .packageProduct, .foreignBuildOutput:
                     return []
                 }
             }
@@ -1454,7 +1455,7 @@ public class GraphTraverser: GraphTraversing {
         switch dependency {
         case .macro:
             return true
-        case .bundle, .framework, .xcframework, .library, .sdk, .target, .packageProduct, .foreignBuildOutput:
+        case .bundle, .multiPlatformBundle, .framework, .xcframework, .library, .sdk, .target, .packageProduct, .foreignBuildOutput:
             return false
         }
     }
@@ -1467,6 +1468,7 @@ public class GraphTraverser: GraphTraversing {
         case .framework: return true
         case .library: return true
         case .bundle: return true
+        case .multiPlatformBundle: return true
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -1481,6 +1483,7 @@ public class GraphTraverser: GraphTraversing {
         case .framework: return true
         case .library: return false
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -1524,6 +1527,7 @@ public class GraphTraverser: GraphTraversing {
              let .library(_, _, linking, _, _):
             return linking == .static
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case let .target(name, path, _):
             guard let target = target(path: path, name: name) else { return false }
@@ -1666,6 +1670,11 @@ public class GraphTraverser: GraphTraversing {
             )
         case let .bundle(path):
             return .bundle(path: path, condition: condition)
+        case .multiPlatformBundle:
+            // The wrapper sentinel is always expanded into per-slice `.bundle` deps by the cache
+            // graph mutator before reaching this point; if it's still here, it has no Xcode-readable
+            // representation.
+            return nil
         case let .packageProduct(_, product, .runtimeEmbedded):
             return .packageProduct(product: product, condition: condition)
         case .packageProduct:
@@ -1699,7 +1708,7 @@ public class GraphTraverser: GraphTraversing {
 
     private func isDependencyResourceBundle(dependency: GraphDependency) -> Bool {
         switch dependency {
-        case .bundle:
+        case .bundle, .multiPlatformBundle:
             return true
         case let .target(name: name, path: path, _):
             return target(path: path, name: name)?.target.product == .bundle
@@ -1728,7 +1737,7 @@ public class GraphTraverser: GraphTraversing {
                 switch dependency {
                 case let .framework(_, _, _, _, linking: linking, _, _):
                     return linking == .static
-                case .xcframework, .library, .bundle, .packageProduct, .target, .sdk, .macro, .foreignBuildOutput:
+                case .xcframework, .library, .bundle, .multiPlatformBundle, .packageProduct, .target, .sdk, .macro, .foreignBuildOutput:
                     return false
                 }
             }
@@ -1769,7 +1778,7 @@ public class GraphTraverser: GraphTraversing {
                 switch dependency {
                 case let .xcframework(xcframework):
                     return xcframework.linking == .static
-                case .framework, .library, .bundle, .packageProduct, .target, .sdk, .macro, .foreignBuildOutput:
+                case .framework, .library, .bundle, .multiPlatformBundle, .packageProduct, .target, .sdk, .macro, .foreignBuildOutput:
                     return false
                 }
             },

--- a/cli/Sources/TuistGenerator/Extensions/Graph+Extras.swift
+++ b/cli/Sources/TuistGenerator/Extensions/Graph+Extras.swift
@@ -68,7 +68,7 @@ extension GraphDependency {
             } else {
                 return false
             }
-        case .framework, .xcframework, .library, .bundle, .packageProduct, .sdk, .macro, .foreignBuildOutput:
+        case .framework, .xcframework, .library, .bundle, .multiPlatformBundle, .packageProduct, .sdk, .macro, .foreignBuildOutput:
             return true
         }
     }

--- a/cli/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/cli/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -91,6 +91,8 @@ extension GraphDependency {
             return path.basenameWithoutExt
         case let .bundle(path):
             return path.basenameWithoutExt
+        case let .multiPlatformBundle(path):
+            return path.basenameWithoutExt
         case let .packageProduct(path: _, product: product, type: _):
             return product
         case let .sdk(

--- a/cli/Sources/TuistGenerator/GraphViz/NodeStyling.swift
+++ b/cli/Sources/TuistGenerator/GraphViz/NodeStyling.swift
@@ -74,6 +74,8 @@ extension GraphDependency {
             return .init(fillColorName: .lightgray, shape: .folder)
         case .bundle:
             return .init(fillColorName: .aliceblue, shape: .box)
+        case .multiPlatformBundle:
+            return .init(fillColorName: .aliceblue, shape: .box)
         case .packageProduct:
             return .init(fillColorName: .tan4, textColorName: .white, shape: .tab)
         case .xcframework:

--- a/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/cli/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -193,6 +193,8 @@ struct StaticProductsGraphLinter: StaticProductsGraphLinting {
             return linking == .static
         case .bundle:
             return true
+        case .multiPlatformBundle:
+            return true
         case let .packageProduct(_, _, type):
             switch type {
             // Swift package products are currently assumed to be static

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -299,6 +299,11 @@ import XcodeGraph
                     temporaryDirectory: temporaryDirectory
                 ))
 
+                artifactsToStore = try await wrapMultiPlatformBundles(
+                    artifactsToStore,
+                    temporaryDirectory: temporaryDirectory
+                )
+
                 Logger.current.info("Storing binaries to speed up workflows", metadata: .section)
 
                 let successfullyStoredTargets = try await store(
@@ -462,10 +467,6 @@ import XcodeGraph
                 ]
             )
 
-            // NOTE: This logic doesn't account for multi-platform bundle targets.
-            // If there's a bundle target for multiple platforms the bundle that we'll end persisting is the one for the last
-            // platform
-            // that we build.
             let bundleProductsDirectory = derivedDataPath
                 .appending(
                     try RelativePath(
@@ -480,7 +481,8 @@ import XcodeGraph
                     graphTarget: bundle.0,
                     hash: bundle.1,
                     path: bundlePath,
-                    metadata: .init()
+                    metadata: .init(),
+                    platform: platform
                 ))
             }
 
@@ -559,6 +561,77 @@ import XcodeGraph
             }
 
             return xcframeworks
+        }
+
+        private func wrapMultiPlatformBundles(
+            _ artifacts: [CacheGraphTargetBuiltArtifact],
+            temporaryDirectory: AbsolutePath
+        ) async throws -> [CacheGraphTargetBuiltArtifact] {
+            var nonBundles: [CacheGraphTargetBuiltArtifact] = []
+            var bundlesByTarget: [CacheStorableTarget: [CacheGraphTargetBuiltArtifact]] = [:]
+            for artifact in artifacts {
+                guard artifact.type == .bundle else {
+                    nonBundles.append(artifact)
+                    continue
+                }
+                let key = CacheStorableTarget(target: artifact.graphTarget, hash: artifact.hash)
+                bundlesByTarget[key, default: []].append(artifact)
+            }
+
+            var result = nonBundles
+            let wrappersRoot = temporaryDirectory.appending(component: "xcbundles")
+
+            for (_, group) in bundlesByTarget {
+                let uniquePlatforms = Set(group.compactMap(\.platform))
+                guard uniquePlatforms.count > 1, let first = group.first else {
+                    result.append(contentsOf: group)
+                    continue
+                }
+
+                let wrapperName = "\(first.graphTarget.target.productName).\(MultiPlatformBundle.bundleExtension)"
+                let wrapperPath = wrappersRoot.appending(component: wrapperName)
+                if try await fileSystem.exists(wrapperPath) {
+                    try await fileSystem.remove(wrapperPath)
+                }
+                try await fileSystem.makeDirectory(at: wrapperPath)
+
+                var slices: [MultiPlatformBundle.Slice] = []
+                for artifact in group {
+                    guard let platform = artifact.platform else { continue }
+                    let identifier = MultiPlatformBundle.libraryIdentifier(for: platform)
+                    let sliceDirectory = wrapperPath.appending(component: identifier)
+                    try await fileSystem.makeDirectory(at: sliceDirectory)
+                    let destination = sliceDirectory.appending(component: artifact.path.basename)
+                    try await fileSystem.copy(artifact.path, to: destination)
+
+                    slices.append(
+                        MultiPlatformBundle.Slice(
+                            libraryIdentifier: identifier,
+                            supportedPlatforms: MultiPlatformBundle.supportedPlatformFilters(for: platform).map(\.xcodeprojValue),
+                            bundleName: artifact.path.basename
+                        )
+                    )
+                }
+
+                try await MultiPlatformBundle.writeManifest(
+                    MultiPlatformBundle.Manifest(slices: slices),
+                    to: wrapperPath,
+                    fileSystem: fileSystem
+                )
+
+                result.append(
+                    CacheGraphTargetBuiltArtifact(
+                        type: .bundle,
+                        graphTarget: first.graphTarget,
+                        hash: first.hash,
+                        path: wrapperPath,
+                        metadata: first.metadata,
+                        platform: nil
+                    )
+                )
+            }
+
+            return result
         }
 
         private func collectForeignBuildArtifacts(

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Graph/GraphDependency.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Graph/GraphDependency.swift
@@ -107,6 +107,11 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     /// A dependency that represents a pre-compiled bundle.
     case bundle(path: AbsolutePath)
 
+    /// A Tuist-internal wrapper around per-SDK slices of a single resource bundle, produced by the
+    /// binary cache for multi-platform bundle targets. Always expanded into per-slice `.bundle`
+    /// dependencies before reaching project generation; never reaches Xcode.
+    case multiPlatformBundle(path: AbsolutePath)
+
     /// A dependency that represents a package product.
     case packageProduct(path: AbsolutePath, product: String, type: PackageProductType)
 
@@ -134,6 +139,9 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case let .bundle(path):
             hasher.combine("bundle")
             hasher.combine(path)
+        case let .multiPlatformBundle(path):
+            hasher.combine("multiPlatformBundle")
+            hasher.combine(path)
         case let .packageProduct(path, product, isPlugin):
             hasher.combine("package")
             hasher.combine(path)
@@ -160,6 +168,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case .framework: return false
         case .library: return false
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case .target: return true
         case .sdk: return false
@@ -176,6 +185,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case let .framework(_, _, _, _, linking, _, _),
              let .library(_, _, linking, _, _): return linking == .static
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -192,6 +202,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case let .framework(_, _, _, _, linking, _, _),
              let .library(_, _, linking, _, _): return linking == .dynamic
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -206,6 +217,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case .framework: return true
         case .library: return true
         case .bundle: return true
+        case .multiPlatformBundle: return true
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -220,6 +232,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case .framework: return true
         case .library: return true
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return true
         case .target: return true
         case .sdk: return true
@@ -234,6 +247,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case .framework: return false
         case .library: return false
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -250,6 +264,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
              let .library(path: _, publicHeaders: _, linking: linking, architectures: _, swiftModuleMap: _):
             return linking == .dynamic
         case .bundle: return false
+        case .multiPlatformBundle: return false
         case .packageProduct(_, _, type: .runtimeEmbedded): return true
         case .packageProduct: return false
         case .target: return false
@@ -284,6 +299,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             return "library '\(name)'"
         case .bundle:
             return "bundle '\(name)'"
+        case .multiPlatformBundle:
+            return "multi-platform bundle '\(name)'"
         case .packageProduct:
             return "package '\(name)'"
         case .target:
@@ -306,6 +323,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case let .library(path, _, _, _, _):
             return path.basename
         case let .bundle(path):
+            return path.basename
+        case let .multiPlatformBundle(path):
             return path.basename
         case let .packageProduct(_, product, _):
             return product

--- a/examples/xcode/generated_app_with_mac_bundle/App/Sources/ContentView.swift
+++ b/examples/xcode/generated_app_with_mac_bundle/App/Sources/ContentView.swift
@@ -6,9 +6,13 @@ public struct ContentView: View {
     public init() {}
 
     public var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Text(ProjectResourcesFramework.ResourcesProvider.greeting())
             Text(ResourcesFramework.ResourcesProvider.greeting())
+            Text("Brand color loaded: \(ProjectResourcesFramework.ResourcesProvider.brandColorIsLoaded ? "YES" : "NO")")
+            Rectangle()
+                .fill(ProjectResourcesFramework.ResourcesProvider.brandColor)
+                .frame(width: 120, height: 60)
         }
         .padding()
     }

--- a/examples/xcode/generated_app_with_mac_bundle/Project.swift
+++ b/examples/xcode/generated_app_with_mac_bundle/Project.swift
@@ -49,7 +49,10 @@ let project = Project(
             bundleId: "ProjectResourcesFramework",
             deploymentTargets: .multiplatform(iOS: "13.0", macOS: "11.0"),
             sources: ["ProjectResourcesFramework/Sources/*.swift"],
-            resources: ["ProjectResourcesFramework/Sources/greeting.txt"]
+            resources: [
+                "ProjectResourcesFramework/Sources/greeting.txt",
+                "ProjectResourcesFramework/Sources/Assets.xcassets",
+            ]
         ),
     ]
 )

--- a/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/Assets.xcassets/BrandColor.colorset/Contents.json
+++ b/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/Assets.xcassets/BrandColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.600",
+          "red" : "0.900"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/Assets.xcassets/Contents.json
+++ b/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/ResourcesProvider.swift
+++ b/examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework/Sources/ResourcesProvider.swift
@@ -1,8 +1,29 @@
 import Foundation
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 public enum ResourcesProvider {
     public static func greeting() -> String {
         let url = Bundle.module.url(forResource: "greeting", withExtension: "txt")!
         return try! String(contentsOf: url, encoding: .utf8)
+    }
+
+    public static var brandColor: Color {
+        Color("BrandColor", bundle: .module)
+    }
+
+    public static var brandColorIsLoaded: Bool {
+        #if canImport(UIKit)
+        return UIColor(named: "BrandColor", in: .module, compatibleWith: nil) != nil
+        #elseif canImport(AppKit)
+        return NSColor(named: "BrandColor", bundle: .module) != nil
+        #else
+        return false
+        #endif
     }
 }


### PR DESCRIPTION
> Fixes the bug where multi-platform `staticFramework` targets with resources cache a single SDK-tagged bundle (whichever platform built last — usually macOS), so iOS apps embed a macOS-compiled `Assets.car` and `Color("…", bundle: .module)` silently fails at runtime. Also surfaced for `RiverstyleFoundations` in a recent user report.

## What changed

**Cache warm** ([CacheWarmCommandService.swift](cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift)):

- `buildBundles` tags each emitted `CacheGraphTargetBuiltArtifact` with the `Platform` it was built for.
- New `wrapMultiPlatformBundles` step groups bundles by `(target, contentHash)`. Groups with ≥2 platforms are packed into a Tuist-internal `Foo.xcbundle/` wrapper containing per-slice subdirs (`ios/Foo.bundle`, `macos/Foo.bundle`, …) plus an `Info.plist` manifest. Single-platform groups keep the existing flat `.bundle` layout.
- Result: `store()`'s dict-keyed reduce no longer drops platforms — each `(target, hash)` ends up with exactly one stored artifact regardless of slice count.

**Shared format** ([MultiPlatformBundle.swift](cli/Sources/TuistCache/MultiPlatformBundle.swift)) — manifest read/write + slice path resolution + `Platform → PlatformFilter` mapping (iOS → `[ios, catalyst]`, preserving the existing convention that iOS bundles serve catalyst consumers).

**Cache consume** (in TuistCacheEE — see [tuist/TuistCacheEE#57](https://github.com/tuist/TuistCacheEE/pull/57)) — `CacheGraphMutator` detects the `.xcbundle` sentinel, reads the manifest, and fans the dependency out into N graph deps each wired with a `PlatformCondition`. The existing `BuildPhaseGenerator.generateResourceBundle` path then emits N `PBXBuildFile` entries with `platformFilters` set, and Xcode picks the matching slice at build time per `$(PLATFORM_NAME)`. No new build-phase scripts, no runtime selection.

**Fixture upgrade** — `examples/xcode/generated_app_with_mac_bundle/ProjectResourcesFramework` gains an `Assets.xcassets` with a `BrandColor`, plus matching `ContentView`/`ResourcesProvider` code that displays the color and reports whether it loaded. This makes the bug (and its fix) reproducible end-to-end with `tuist cache && tuist generate App App-macOS && xcodebuild …`.

## Backward compat

- Old caches with a flat `.bundle` for a multi-platform target keep working (loader treats them as single-slice; behavior is the pre-fix one). Re-warming produces the new wrapper format.
- Single-platform bundle targets unchanged.

## How to test locally

```bash
cd examples/xcode/generated_app_with_mac_bundle
tuist install
tuist cache
tuist generate App App-macOS --no-open

# iOS — should now embed an iOS-compiled bundle
xcodebuild build -workspace App.xcworkspace -scheme App \
  -destination 'platform=iOS Simulator,name=iPhone 16 Pro'

assetutil --info \
  ~/Library/Developer/Xcode/DerivedData/App-*/Build/Products/Debug-iphonesimulator/App.app/App_ProjectResourcesFramework.bundle/Assets.car \
  | grep Platform
# → "Platform" : "ios"

# macOS — should embed a macOS-compiled bundle
xcodebuild build -workspace App.xcworkspace -scheme App-macOS -destination 'platform=macOS'

assetutil --info \
  ~/Library/Developer/Xcode/DerivedData/App-*/Build/Products/Debug/App_macOS.app/Contents/Resources/App_ProjectResourcesFramework.bundle/Contents/Resources/Assets.car \
  | grep Platform
# → "Platform" : "macosx"
```

Boot the iOS app in the simulator: it shows a "Brand color loaded: YES" label and an orange rectangle (was an empty/black square before the fix).

## Verified

- All 21 existing `CacheGraphMutatorTests` pass unchanged.
- iOS app verified at runtime in simulator (color loads, screenshot confirms).
- macOS app verified via `NSColor(named:bundle:)` returning a real catalog color.

## Companion submodule PR

[tuist/TuistCacheEE#57](https://github.com/tuist/TuistCacheEE/pull/57) — required for the consume side. Submodule pointer in this PR already advances to the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)