### PR TITLE
refactor(cli): deprecate unused `swiftVersion` on `TuistProject.tuist(...)`

### DIFF
--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -62,7 +62,6 @@ public struct Tuist: Codable, Equatable, Sendable {
     /// - Parameters:
     ///   - compatibleXcodeVersions: List of Xcode versions the project is compatible with.
     ///   - cloud: Cloud configuration.
-    ///   - swiftVersion: The version of Swift that will be used by Tuist.
     ///   - plugins: A list of plugins to extend Tuist.
     ///   - generationOptions: List of options to use when generating the project.
     ///   - installOptions: List of options to use when running `tuist install`.
@@ -76,7 +75,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         cloud: Cloud? = nil,
         fullHandle: String? = nil,
         url: String = "https://tuist.dev",
-        swiftVersion: Version? = nil,
+        swiftVersion _: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: GenerationOptions = .options(),
         inspectOptions: InspectOptions = .options(),
@@ -91,7 +90,6 @@ public struct Tuist: Codable, Equatable, Sendable {
 
         project = TuistProject.tuist(
             compatibleXcodeVersions: compatibleXcodeVersions,
-            swiftVersion: swiftVersion,
             plugins: plugins,
             generationOptions: generationOptions,
             installOptions: installOptions

--- a/cli/Sources/ProjectDescription/TuistProject.swift
+++ b/cli/Sources/ProjectDescription/TuistProject.swift
@@ -3,18 +3,38 @@ public enum TuistProject: Codable, Equatable, Sendable {
     ///
     /// - Parameters:
     ///   - compatibleXcodeVersions: List of Xcode versions the project is compatible with.
-    ///   - swiftVersion: The version of Swift that will be used by Tuist.
     ///   - plugins: A list of plugins to extend Tuist.
     ///   - generationOptions: List of options to use when generating the project.
     ///   - installOptions: List of options to use when running `tuist install`.
     ///   - cacheOptions: Options to configure the caching functionality.
     case tuist(
         compatibleXcodeVersions: CompatibleXcodeVersions = .all,
-        swiftVersion: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: Tuist.GenerationOptions = .options(),
         installOptions: Tuist.InstallOptions = .options(),
         cacheOptions: Tuist.CacheOptions = .options()
     )
     case xcode(TuistXcodeProjectOptions = TuistXcodeProjectOptions.options())
+
+    @available(
+        *,
+        deprecated,
+        message: "`swiftVersion` is unused and no longer affects generation. Remove it from your configuration."
+    )
+    public static func tuist(
+        compatibleXcodeVersions: CompatibleXcodeVersions = .all,
+        swiftVersion _: Version?,
+        plugins: [PluginLocation] = [],
+        generationOptions: Tuist.GenerationOptions = .options(),
+        installOptions: Tuist.InstallOptions = .options(),
+        cacheOptions: Tuist.CacheOptions = .options()
+    ) -> TuistProject {
+        .tuist(
+            compatibleXcodeVersions: compatibleXcodeVersions,
+            plugins: plugins,
+            generationOptions: generationOptions,
+            installOptions: installOptions,
+            cacheOptions: cacheOptions
+        )
+    }
 }

--- a/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
+++ b/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift
@@ -1,9 +1,7 @@
 import Path
-import TSCUtility
 
 public struct TuistGeneratedProjectOptions: Equatable, Hashable {
     public let compatibleXcodeVersions: CompatibleXcodeVersions
-    public let swiftVersion: Version?
     public let plugins: [PluginLocation]
     public let generationOptions: GenerationOptions
     public let installOptions: InstallOptions
@@ -11,14 +9,12 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
 
     public init(
         compatibleXcodeVersions: CompatibleXcodeVersions,
-        swiftVersion: Version?,
         plugins: [PluginLocation],
         generationOptions: GenerationOptions,
         installOptions: InstallOptions,
         cacheOptions: CacheOptions
     ) {
         self.compatibleXcodeVersions = compatibleXcodeVersions
-        self.swiftVersion = swiftVersion
         self.plugins = plugins
         self.generationOptions = generationOptions
         self.installOptions = installOptions
@@ -27,7 +23,6 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(compatibleXcodeVersions)
-        hasher.combine(swiftVersion)
         hasher.combine(plugins)
         hasher.combine(generationOptions)
         hasher.combine(installOptions)
@@ -37,7 +32,6 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
     public static var `default`: Self {
         TuistGeneratedProjectOptions(
             compatibleXcodeVersions: .all,
-            swiftVersion: nil,
             plugins: [],
             generationOptions: .init(
                 resolveDependenciesWithSystemScm: false,
@@ -211,7 +205,6 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
     #if DEBUG
         public static func test(
             compatibleXcodeVersions: CompatibleXcodeVersions = .all,
-            swiftVersion: Version? = nil,
             plugins: [PluginLocation] = [],
             generationOptions: GenerationOptions = .test(),
             installOptions: InstallOptions = .test(),
@@ -219,7 +212,6 @@ public struct TuistGeneratedProjectOptions: Equatable, Hashable {
         ) -> Self {
             return .init(
                 compatibleXcodeVersions: compatibleXcodeVersions,
-                swiftVersion: swiftVersion,
                 plugins: plugins,
                 generationOptions: generationOptions,
                 installOptions: installOptions,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Path
 import ProjectDescription
-import TSCUtility
 import TuistConfig
 import TuistCore
 import TuistLogging
@@ -49,7 +48,6 @@ extension TuistConfig.Tuist {
         switch manifest.project {
         case let .tuist(
             compatibleXcodeVersions,
-            manifestSwiftVersion,
             plugins,
             generationOptions,
             installOptions,
@@ -65,12 +63,6 @@ extension TuistConfig.Tuist {
 
             let compatibleXcodeVersions = TuistConfig.CompatibleXcodeVersions.from(manifest: compatibleXcodeVersions)
             let plugins = try plugins.map { try PluginLocation.from(manifest: $0, generatorPaths: generatorPaths) }
-            let swiftVersion: TSCUtility.Version?
-            if let configuredVersion = manifestSwiftVersion {
-                swiftVersion = TSCUtility.Version(configuredVersion.major, configuredVersion.minor, configuredVersion.patch)
-            } else {
-                swiftVersion = nil
-            }
 
             let installOptions = TuistConfig.TuistGeneratedProjectOptions.InstallOptions.from(
                 manifest: installOptions
@@ -80,7 +72,6 @@ extension TuistConfig.Tuist {
                 project: .generated(
                     TuistGeneratedProjectOptions(
                         compatibleXcodeVersions: compatibleXcodeVersions,
-                        swiftVersion: swiftVersion,
                         plugins: plugins,
                         generationOptions: generationOptions,
                         installOptions: installOptions,

--- a/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
@@ -53,7 +53,6 @@
             #expect(result == TuistConfig.Tuist(
                 project: .generated(TuistGeneratedProjectOptions(
                     compatibleXcodeVersions: .all,
-                    swiftVersion: nil,
                     plugins: [],
                     generationOptions: .test(),
                     installOptions: .test(),
@@ -81,7 +80,6 @@
             #expect(result == TuistConfig.Tuist(
                 project: .generated(TuistGeneratedProjectOptions(
                     compatibleXcodeVersions: .all,
-                    swiftVersion: nil,
                     plugins: [],
                     generationOptions: .test(),
                     installOptions: .test(),
@@ -160,7 +158,6 @@
             #expect(result == TuistConfig.Tuist(
                 project: .generated(TuistGeneratedProjectOptions(
                     compatibleXcodeVersions: .all,
-                    swiftVersion: nil,
                     plugins: [],
                     generationOptions: .test(),
                     installOptions: .test(),
@@ -195,7 +192,6 @@
             #expect(result == TuistConfig.Tuist(
                 project: .generated(TuistGeneratedProjectOptions(
                     compatibleXcodeVersions: .all,
-                    swiftVersion: nil,
                     plugins: [],
                     generationOptions: .test(
                         buildInsightsDisabled: false,
@@ -230,7 +226,6 @@
             #expect(result == TuistConfig.Tuist(
                 project: .generated(TuistGeneratedProjectOptions(
                     compatibleXcodeVersions: .all,
-                    swiftVersion: nil,
                     plugins: [],
                     generationOptions: .test(
                         buildInsightsDisabled: false,

--- a/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Mockable
-import TSCUtility
 import TuistConfig
 import TuistConfigLoader
 import TuistConstants
@@ -60,11 +59,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .update(at: .any, arguments: .any, printOutput: .any)
             .willReturn()
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
-                .test(project: .generated(.test(swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description))))
+                .test(project: .generated(.test()))
             )
 
         pluginService.fetchRemotePluginsStub = { _ in
@@ -142,11 +140,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .resolve(at: .any, arguments: .any, printOutput: .any)
             .willReturn()
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
-                Tuist.test(project: .generated(.test(swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description))))
+                Tuist.test(project: .generated(.test()))
             )
 
         pluginService.fetchRemotePluginsStub = { _ in }
@@ -193,11 +190,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .resolve(at: .any, arguments: .any, printOutput: .any)
             .willReturn()
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
-                Tuist.test(project: .generated(.test(swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description))))
+                Tuist.test(project: .generated(.test()))
             )
 
         pluginService.fetchRemotePluginsStub = { _ in }
@@ -284,12 +280,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .locatePackageManifest(at: .any)
             .willReturn(stubbedPath.appending(components: "Tuist", "Package.swift"))
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
                 Tuist.test(project: .generated(.test(
-                    swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description),
                     installOptions: .test(
                         passthroughSwiftPackageManagerArguments: ["--replace-scm-with-registry"]
                     )
@@ -334,12 +328,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .locatePackageManifest(at: .any)
             .willReturn(stubbedPath.appending(components: "Tuist", "Package.swift"))
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
                 Tuist.test(project: .generated(.test(
-                    swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description),
                     installOptions: .test(
                         passthroughSwiftPackageManagerArguments: ["--replace-scm-with-registry"]
                     )
@@ -384,12 +376,10 @@ final class InstallServiceTests: TuistUnitTestCase {
             .locatePackageManifest(at: .any)
             .willReturn(stubbedPath.appending(components: "Tuist", "Package.swift"))
 
-        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         given(configLoader)
             .loadConfig(path: .any)
             .willReturn(
                 Tuist.test(project: .generated(.test(
-                    swiftVersion: .init(stringLiteral: stubbedSwiftVersion.description),
                     installOptions: .test(
                         passthroughSwiftPackageManagerArguments: ["--replace-scm-with-registry"]
                     )

--- a/cli/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/cli/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -486,7 +486,6 @@ final class PluginServiceTests: TuistUnitTestCase {
     {
         TuistConfig.TuistGeneratedProjectOptions(
             compatibleXcodeVersions: .all,
-            swiftVersion: nil,
             plugins: plugins,
             generationOptions: .test(),
             installOptions: .test(),


### PR DESCRIPTION
> Deprecates the `swiftVersion` parameter on `TuistProject.tuist(...)` (and the already-deprecated `Config(swiftVersion:)` init), and removes the dead internal plumbing that carried it.

## Why

`swiftVersion` is documented as "the version of Swift that will be used by Tuist," but in the current codebase nothing reads it:

- It's plumbed through the `.tuist(...)` manifest case into [`TuistGeneratedProjectOptions.swiftVersion`](../blob/main/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift) and nothing else.
- Generation, `install`, SPM resolution, `SWIFT_VERSION` build settings, the project-description-helpers hasher, and the editable-project mapper all derive Swift version from `SwiftVersionProvider.current.swiftVersion()` (the system `swift --version`) or from SPM's `swift-tools-version` / `swiftLanguageVersions` — not from the config value.
- #4679 (Aug 2022) already updated the docs to clarify that `Config.swiftVersion` does **not** control `SWIFT_VERSION`. Since then the field has been fully vestigial.

Rather than leave a footgun in the public manifest API, surface a compile-time deprecation warning so users can drop it.

## What changed

**Public API ([`TuistProject.swift`](../blob/main/cli/Sources/ProjectDescription/TuistProject.swift))**
- Removed `swiftVersion` from `case tuist(...)` associated values.
- Added a deprecated `static func tuist(..., swiftVersion: Version?, ...)` overload that forwards to the new case. Users passing `swiftVersion:` in their `Tuist.swift` now get:
  > `swiftVersion` is unused and no longer affects generation. Remove it from your configuration.
- `.tuist()` / `.tuist(compatibleXcodeVersions:, plugins:, ...)` without `swiftVersion:` binds to the new case — no warning, no behavior change.

**Dead-code cleanup**
- [`Tuist.swift`](../blob/main/cli/Sources/ProjectDescription/Tuist.swift) — the already-deprecated `Config(swiftVersion:)` init stops forwarding the ignored value (the init itself stays, still deprecated).
- [`TuistGeneratedProjectOptions`](../blob/main/cli/Sources/TuistConfig/TuistGeneratedProjectOptions.swift) — dropped the `swiftVersion` field, init param, hash contribution, default, and `.test(...)` factory arg.
- [`Tuist+ManifestMapper.swift`](../blob/main/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift) — pattern match and constructor updated; removed the now-dead `Version` conversion and `TSCUtility` import.
- Tests updated to drop the unused `swiftVersion:` arguments.

## Backwards compatibility

Source-compatible: existing `.tuist(swiftVersion: …)` call sites and `Config(swiftVersion: …, …)` call sites still compile — they just emit a deprecation warning and do nothing with the value (which is what they were already doing, silently).

### How to test locally

- `swift build --replace-scm-with-registry` (or build via `xcodebuild` on the Tuist workspace) — passes cleanly.
- Write a `Tuist.swift` manifest containing `let tuist = Tuist(project: .tuist(swiftVersion: "5.10"))` — you should see the deprecation warning at manifest compile time. Remove the `swiftVersion:` argument and the warning goes away; generation behavior is unchanged either way.
- Targeted Swift Testing suite: `swift test --replace-scm-with-registry` — `SwiftConfigLoaderTests` and the rest of the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)