### PR TITLE
fix(cli): respect repo optional auth in command tracking

### DIFF
--- a/cli/Sources/TuistConfig/TuistProject.swift
+++ b/cli/Sources/TuistConfig/TuistProject.swift
@@ -11,6 +11,14 @@ public enum TuistProject: Equatable, Hashable, Sendable {
         }
     }
 
+    public var optionalAuthentication: Bool {
+        switch self {
+        case let .generated(options): return options.generationOptions.optionalAuthentication
+        case .xcode: return false
+        case .swiftPackage: return false
+        }
+    }
+
     public var disableSandbox: Bool {
         switch self {
         case let .generated(options): return options.generationOptions.disableSandbox

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -67,7 +67,8 @@ public class TrackableCommand {
     public func run(
         fullHandle: String?,
         serverURL: URL?,
-        shouldTrackAnalytics: Bool
+        shouldTrackAnalytics: Bool,
+        optionalAuthentication: Bool = false
     ) async throws {
         let timer = clock.startTimer()
         let ranAt = clock.now
@@ -79,37 +80,42 @@ public class TrackableCommand {
         }
         let path = try await Environment.current.pathRelativeToWorkingDirectory(pathArgument)
         let runMetadataStorage = RunMetadataStorage()
-        try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
-            do {
-                if var asyncCommand = command as? AsyncParsableCommand {
-                    try await asyncCommand.run()
-                } else {
-                    try command.run()
+        let usesOptionalAuthentication =
+            optionalAuthentication
+            && (((command as? TrackableParsableCommand)?.analyticsRequired == true) || Environment.current.isCI)
+        try await withServerAuthenticationConfig(optionalAuthentication: usesOptionalAuthentication) {
+            try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
+                do {
+                    if var asyncCommand = command as? AsyncParsableCommand {
+                        try await asyncCommand.run()
+                    } else {
+                        try command.run()
+                    }
+                    if let fullHandle, let serverURL, shouldTrackAnalytics {
+                        try await uploadCommandEvent(
+                            timer: timer,
+                            status: .success,
+                            runId: runMetadataStorage.runId,
+                            path: path,
+                            runMetadataStorage: runMetadataStorage,
+                            fullHandle: fullHandle,
+                            serverURL: serverURL
+                        )
+                    }
+                } catch {
+                    if let fullHandle, let serverURL, shouldTrackAnalytics {
+                        try await uploadCommandEvent(
+                            timer: timer,
+                            status: .failure("\(error)"),
+                            runId: await runMetadataStorage.runId,
+                            path: path,
+                            runMetadataStorage: runMetadataStorage,
+                            fullHandle: fullHandle,
+                            serverURL: serverURL
+                        )
+                    }
+                    throw error
                 }
-                if let fullHandle, let serverURL, shouldTrackAnalytics {
-                    try await uploadCommandEvent(
-                        timer: timer,
-                        status: .success,
-                        runId: runMetadataStorage.runId,
-                        path: path,
-                        runMetadataStorage: runMetadataStorage,
-                        fullHandle: fullHandle,
-                        serverURL: serverURL
-                    )
-                }
-            } catch {
-                if let fullHandle, let serverURL, shouldTrackAnalytics {
-                    try await uploadCommandEvent(
-                        timer: timer,
-                        status: .failure("\(error)"),
-                        runId: await runMetadataStorage.runId,
-                        path: path,
-                        runMetadataStorage: runMetadataStorage,
-                        fullHandle: fullHandle,
-                        serverURL: serverURL
-                    )
-                }
-                throw error
             }
         }
     }
@@ -196,6 +202,24 @@ public class TrackableCommand {
                 ],
                 environment: ProcessInfo.processInfo.environment
             )
+        }
+    }
+
+    private func withServerAuthenticationConfig<T>(
+        optionalAuthentication: Bool,
+        _ action: () async throws -> T
+    ) async throws -> T {
+        guard optionalAuthentication else {
+            return try await action()
+        }
+        let currentConfiguration = ServerAuthenticationConfig.current
+        return try await ServerAuthenticationConfig.$current.withValue(
+            .init(
+                backgroundRefresh: currentConfiguration.backgroundRefresh,
+                optionalAuthentication: true
+            )
+        ) {
+            try await action()
         }
     }
 

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -76,7 +76,7 @@ public class TrackableCommand {
         let runMetadataStorage = RunMetadataStorage()
         let usesOptionalAuthentication =
             optionalAuthentication
-            && (((command as? TrackableParsableCommand)?.analyticsRequired == true) || Environment.current.isCI)
+                && (((command as? TrackableParsableCommand)?.analyticsRequired == true) || Environment.current.isCI)
         try await ServerAuthenticationConfig.withOptionalAuthentication(usesOptionalAuthentication) {
             try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
                 do {

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -72,18 +72,12 @@ public class TrackableCommand {
     ) async throws {
         let timer = clock.startTimer()
         let ranAt = clock.now
-        let pathIndex = commandArguments.firstIndex(of: "--path")
-        let pathArgument: String? = if let pathIndex, commandArguments.endIndex > pathIndex + 1 {
-            commandArguments[pathIndex + 1]
-        } else {
-            nil
-        }
-        let path = try await Environment.current.pathRelativeToWorkingDirectory(pathArgument)
+        let path = try await CommandArguments.path(in: commandArguments)
         let runMetadataStorage = RunMetadataStorage()
         let usesOptionalAuthentication =
             optionalAuthentication
             && (((command as? TrackableParsableCommand)?.analyticsRequired == true) || Environment.current.isCI)
-        try await withServerAuthenticationConfig(optionalAuthentication: usesOptionalAuthentication) {
+        try await ServerAuthenticationConfig.withOptionalAuthentication(usesOptionalAuthentication) {
             try await RunMetadataStorage.$current.withValue(runMetadataStorage) {
                 do {
                     if var asyncCommand = command as? AsyncParsableCommand {
@@ -99,7 +93,8 @@ public class TrackableCommand {
                             path: path,
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
-                            serverURL: serverURL
+                            serverURL: serverURL,
+                            ranAt: ranAt
                         )
                     }
                 } catch {
@@ -111,7 +106,8 @@ public class TrackableCommand {
                             path: path,
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
-                            serverURL: serverURL
+                            serverURL: serverURL,
+                            ranAt: ranAt
                         )
                     }
                     throw error
@@ -127,7 +123,8 @@ public class TrackableCommand {
         path: AbsolutePath,
         runMetadataStorage: RunMetadataStorage,
         fullHandle: String,
-        serverURL: URL
+        serverURL: URL,
+        ranAt: Date
     ) async throws {
         let durationInSeconds = timer.stop()
         let durationInMs = Int(durationInSeconds * 1000)
@@ -147,7 +144,7 @@ public class TrackableCommand {
             targetContentHashSubhashes: runMetadataStorage.targetContentHashSubhashes,
             previewId: runMetadataStorage.previewId,
             resultBundlePath: runMetadataStorage.resultBundlePath,
-            ranAt: Date(),
+            ranAt: ranAt,
             buildRunId: runMetadataStorage.buildRunId,
             testRunId: runMetadataStorage.testRunId,
             cacheEndpoint: runMetadataStorage.cacheEndpoint
@@ -202,24 +199,6 @@ public class TrackableCommand {
                 ],
                 environment: ProcessInfo.processInfo.environment
             )
-        }
-    }
-
-    private func withServerAuthenticationConfig<T>(
-        optionalAuthentication: Bool,
-        _ action: () async throws -> T
-    ) async throws -> T {
-        guard optionalAuthentication else {
-            return try await action()
-        }
-        let currentConfiguration = ServerAuthenticationConfig.current
-        return try await ServerAuthenticationConfig.$current.withValue(
-            .init(
-                backgroundRefresh: currentConfiguration.backgroundRefresh,
-                optionalAuthentication: true
-            )
-        ) {
-            try await action()
         }
     }
 

--- a/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
+++ b/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
@@ -1,8 +1,8 @@
 import FileSystem
 import Foundation
 import Path
-import TuistCore
 import TuistConfigLoader
+import TuistCore
 import TuistServer
 import TuistSupport
 
@@ -63,7 +63,7 @@ struct AnalyticsUploadCommandService {
               let config = try? await configLoader.loadConfig(path: path)
         else { return false }
 
-        return config.project.generatedProject?.generationOptions.optionalAuthentication == true
+        return config.project.optionalAuthentication
     }
 
     private func withCleanup<T>(

--- a/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
+++ b/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import TuistCore
 import TuistConfigLoader
-import TuistEnvironment
 import TuistServer
 import TuistSupport
 
@@ -41,14 +40,14 @@ struct AnalyticsUploadCommandService {
     ) async throws {
         let eventPath = try AbsolutePath(validating: eventFilePath)
         let sessionDirectory = try sessionDirectory.map { try AbsolutePath(validating: $0) }
-        do {
+        try await withCleanup(of: eventPath) {
             guard let url = URL(string: serverURL) else {
                 throw AnalyticsUploadCommandServiceError.invalidServerURL(serverURL)
             }
 
             let commandEvent: CommandEvent = try await fileSystem.readJSONFile(at: eventPath)
             let optionalAuthentication = await resolveOptionalAuthentication(commandArguments: commandEvent.commandArguments)
-            try await withServerAuthenticationConfig(optionalAuthentication: optionalAuthentication) {
+            try await ServerAuthenticationConfig.withOptionalAuthentication(optionalAuthentication) {
                 _ = try await uploadAnalyticsService.upload(
                     commandEvent: commandEvent,
                     fullHandle: fullHandle,
@@ -56,45 +55,30 @@ struct AnalyticsUploadCommandService {
                     sessionDirectory: sessionDirectory
                 )
             }
-        } catch {
-            try? await fileSystem.remove(eventPath)
-            throw error
-        }
-
-        try? await fileSystem.remove(eventPath)
-    }
-
-    private func withServerAuthenticationConfig<T>(
-        optionalAuthentication: Bool,
-        _ action: () async throws -> T
-    ) async throws -> T {
-        guard optionalAuthentication else {
-            return try await action()
-        }
-        let currentConfiguration = ServerAuthenticationConfig.current
-        return try await ServerAuthenticationConfig.$current.withValue(
-            .init(
-                backgroundRefresh: currentConfiguration.backgroundRefresh,
-                optionalAuthentication: true
-            )
-        ) {
-            try await action()
         }
     }
 
     private func resolveOptionalAuthentication(commandArguments: [String]) async -> Bool {
-        let pathIndex = commandArguments.firstIndex(of: "--path")
-        let pathArgument: String? = if let pathIndex, commandArguments.endIndex > pathIndex + 1 {
-            commandArguments[pathIndex + 1]
-        } else {
-            nil
-        }
+        guard let path = try? await CommandArguments.path(in: commandArguments),
+              let config = try? await configLoader.loadConfig(path: path)
+        else { return false }
+
+        return config.project.generatedProject?.generationOptions.optionalAuthentication == true
+    }
+
+    private func withCleanup<T>(
+        of path: AbsolutePath,
+        _ operation: () async throws -> T
+    ) async throws -> T {
+        let result: Result<T, Error>
+
         do {
-            let path = try await Environment.current.pathRelativeToWorkingDirectory(pathArgument)
-            let config = try await configLoader.loadConfig(path: path)
-            return config.project.generatedProject?.generationOptions.optionalAuthentication == true
+            result = .success(try await operation())
         } catch {
-            return false
+            result = .failure(error)
         }
+
+        try? await fileSystem.remove(path)
+        return try result.get()
     }
 }

--- a/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
+++ b/cli/Sources/TuistKit/Services/AnalyticsUploadCommandService.swift
@@ -2,6 +2,8 @@ import FileSystem
 import Foundation
 import Path
 import TuistCore
+import TuistConfigLoader
+import TuistEnvironment
 import TuistServer
 import TuistSupport
 
@@ -19,16 +21,24 @@ enum AnalyticsUploadCommandServiceError: LocalizedError, Equatable {
 struct AnalyticsUploadCommandService {
     private let fileSystem: FileSysteming
     private let uploadAnalyticsService: UploadAnalyticsServicing
+    private let configLoader: ConfigLoading
 
     init(
         fileSystem: FileSysteming = FileSystem(),
-        uploadAnalyticsService: UploadAnalyticsServicing = UploadAnalyticsService()
+        uploadAnalyticsService: UploadAnalyticsServicing = UploadAnalyticsService(),
+        configLoader: ConfigLoading = ConfigLoader()
     ) {
         self.fileSystem = fileSystem
         self.uploadAnalyticsService = uploadAnalyticsService
+        self.configLoader = configLoader
     }
 
-    func run(eventFilePath: String, fullHandle: String, serverURL: String, sessionDirectory: String? = nil) async throws {
+    func run(
+        eventFilePath: String,
+        fullHandle: String,
+        serverURL: String,
+        sessionDirectory: String? = nil
+    ) async throws {
         let eventPath = try AbsolutePath(validating: eventFilePath)
         let sessionDirectory = try sessionDirectory.map { try AbsolutePath(validating: $0) }
         do {
@@ -37,18 +47,54 @@ struct AnalyticsUploadCommandService {
             }
 
             let commandEvent: CommandEvent = try await fileSystem.readJSONFile(at: eventPath)
-
-            _ = try await uploadAnalyticsService.upload(
-                commandEvent: commandEvent,
-                fullHandle: fullHandle,
-                serverURL: url,
-                sessionDirectory: sessionDirectory
-            )
+            let optionalAuthentication = await resolveOptionalAuthentication(commandArguments: commandEvent.commandArguments)
+            try await withServerAuthenticationConfig(optionalAuthentication: optionalAuthentication) {
+                _ = try await uploadAnalyticsService.upload(
+                    commandEvent: commandEvent,
+                    fullHandle: fullHandle,
+                    serverURL: url,
+                    sessionDirectory: sessionDirectory
+                )
+            }
         } catch {
             try? await fileSystem.remove(eventPath)
             throw error
         }
 
         try? await fileSystem.remove(eventPath)
+    }
+
+    private func withServerAuthenticationConfig<T>(
+        optionalAuthentication: Bool,
+        _ action: () async throws -> T
+    ) async throws -> T {
+        guard optionalAuthentication else {
+            return try await action()
+        }
+        let currentConfiguration = ServerAuthenticationConfig.current
+        return try await ServerAuthenticationConfig.$current.withValue(
+            .init(
+                backgroundRefresh: currentConfiguration.backgroundRefresh,
+                optionalAuthentication: true
+            )
+        ) {
+            try await action()
+        }
+    }
+
+    private func resolveOptionalAuthentication(commandArguments: [String]) async -> Bool {
+        let pathIndex = commandArguments.firstIndex(of: "--path")
+        let pathArgument: String? = if let pathIndex, commandArguments.endIndex > pathIndex + 1 {
+            commandArguments[pathIndex + 1]
+        } else {
+            nil
+        }
+        do {
+            let path = try await Environment.current.pathRelativeToWorkingDirectory(pathArgument)
+            let config = try await configLoader.loadConfig(path: path)
+            return config.project.generatedProject?.generationOptions.optionalAuthentication == true
+        } catch {
+            return false
+        }
     }
 }

--- a/cli/Sources/TuistKit/Services/TuistService.swift
+++ b/cli/Sources/TuistKit/Services/TuistService.swift
@@ -37,16 +37,7 @@ public final class TuistService: NSObject {
 
         let commandName = "tuist-\(arguments[0])"
 
-        let currentPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
-        let path: AbsolutePath
-        if let pathOptionIndex = arguments.firstIndex(of: "--path") ?? arguments.firstIndex(of: "--p") {
-            path = try AbsolutePath(
-                validating: arguments[pathOptionIndex + 1],
-                relativeTo: currentPath
-            )
-        } else {
-            path = currentPath
-        }
+        let path = try await CommandArguments.path(in: arguments)
 
         let config = try await configLoader.loadConfig(path: path)
 

--- a/cli/Sources/TuistKit/Utils/CommandArguments.swift
+++ b/cli/Sources/TuistKit/Utils/CommandArguments.swift
@@ -1,8 +1,31 @@
+import Path
 import TuistEnvironment
 
 public enum CommandArguments {
     public static func processArguments(_ arguments: [String]? = nil) -> [String]? {
         let arguments = arguments ?? Array(Environment.current.arguments)
         return arguments.filter { $0 != "--verbose" && $0 != "--quiet" }
+    }
+
+    public static func value(
+        for optionNames: [String],
+        in arguments: [String]
+    ) -> String? {
+        for optionName in optionNames {
+            guard let optionIndex = arguments.firstIndex(of: optionName),
+                  arguments.endIndex > optionIndex + 1
+            else { continue }
+            return arguments[optionIndex + 1]
+        }
+
+        return nil
+    }
+
+    public static func pathArgument(in arguments: [String]) -> String? {
+        value(for: ["--path", "--p"], in: arguments)
+    }
+
+    public static func path(in arguments: [String]) async throws -> AbsolutePath {
+        try await Environment.current.pathRelativeToWorkingDirectory(pathArgument(in: arguments))
     }
 }

--- a/cli/Sources/TuistKit/Utils/CommandArguments.swift
+++ b/cli/Sources/TuistKit/Utils/CommandArguments.swift
@@ -22,7 +22,7 @@ public enum CommandArguments {
     }
 
     public static func pathArgument(in arguments: [String]) -> String? {
-        value(for: ["--path", "--p"], in: arguments)
+        value(for: ["--path", "-p"], in: arguments)
     }
 
     public static func path(in arguments: [String]) async throws -> AbsolutePath {

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
@@ -1,8 +1,13 @@
 public struct ServerAuthenticationConfig {
     @TaskLocal public static var current: ServerAuthenticationConfig = .init(backgroundRefresh: false)
     public let backgroundRefresh: Bool
+    public let optionalAuthentication: Bool
 
-    public init(backgroundRefresh: Bool = false) {
+    public init(
+        backgroundRefresh: Bool = false,
+        optionalAuthentication: Bool = false
+    ) {
         self.backgroundRefresh = backgroundRefresh
+        self.optionalAuthentication = optionalAuthentication
     }
 }

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
@@ -10,4 +10,24 @@ public struct ServerAuthenticationConfig {
         self.backgroundRefresh = backgroundRefresh
         self.optionalAuthentication = optionalAuthentication
     }
+
+    public func enablingOptionalAuthentication() -> Self {
+        .init(
+            backgroundRefresh: backgroundRefresh,
+            optionalAuthentication: true
+        )
+    }
+
+    public static func withOptionalAuthentication<T>(
+        _ isEnabled: Bool,
+        _ operation: () async throws -> T
+    ) async throws -> T {
+        guard isEnabled else {
+            return try await operation()
+        }
+
+        return try await Self.$current.withValue(current.enablingOptionalAuthentication()) {
+            try await operation()
+        }
+    }
 }

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationConfig.swift
@@ -26,7 +26,7 @@ public struct ServerAuthenticationConfig {
             return try await operation()
         }
 
-        return try await Self.$current.withValue(current.enablingOptionalAuthentication()) {
+        return try await $current.withValue(current.enablingOptionalAuthentication()) {
             try await operation()
         }
     }

--- a/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -38,10 +38,15 @@ struct ServerClientAuthenticationMiddleware: ClientMiddleware {
         var request = request
 
         let urlForAuthentication = authenticationURL ?? baseURL
+        let config = ServerAuthenticationConfig.current
         guard let token = try await serverAuthenticationController.authenticationToken(
-            serverURL: urlForAuthentication
+            serverURL: urlForAuthentication,
+            refreshIfNeeded: !config.optionalAuthentication
         )
         else {
+            if config.optionalAuthentication {
+                return try await next(request, body, baseURL)
+            }
             throw ClientAuthenticationError.notAuthenticated
         }
         request.headerFields.append(

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -195,7 +195,9 @@ public struct TuistCommand: AsyncParsableCommand {
                                 try await trackableCommand.run(
                                     fullHandle: config.fullHandle,
                                     serverURL: serverURL,
-                                    shouldTrackAnalytics: shouldTrackAnalytics
+                                    shouldTrackAnalytics: shouldTrackAnalytics,
+                                    optionalAuthentication: config.project.generatedProject?.generationOptions.optionalAuthentication
+                                        == true
                                 )
                             }
                         }
@@ -203,7 +205,9 @@ public struct TuistCommand: AsyncParsableCommand {
                         try await trackableCommand.run(
                             fullHandle: config.fullHandle,
                             serverURL: serverURL,
-                            shouldTrackAnalytics: shouldTrackAnalytics
+                            shouldTrackAnalytics: shouldTrackAnalytics,
+                            optionalAuthentication: config.project.generatedProject?.generationOptions.optionalAuthentication
+                                == true
                         )
                     }
                 }

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -148,14 +148,7 @@ public struct TuistCommand: AsyncParsableCommand {
         let processedArguments = Array(processArguments(arguments)?.dropFirst() ?? [])
 
         #if os(macOS)
-            let path: AbsolutePath
-            if let argumentIndex = CommandLine.arguments.firstIndex(of: "--path") {
-                path = try AbsolutePath(
-                    validating: CommandLine.arguments[argumentIndex + 1], relativeTo: .current
-                )
-            } else {
-                path = .current
-            }
+            let path = try await CommandArguments.path(in: processedArguments)
 
             try await CacheDirectoriesProvider.bootstrap()
 
@@ -188,27 +181,25 @@ public struct TuistCommand: AsyncParsableCommand {
                     let shouldTrackAnalytics = processedArguments.prefix(2) != ["inspect", "build"]
                         && processedArguments.prefix(2) != ["auth", "refresh-token"]
                         && processedArguments.first != "analytics-upload"
-                    if let nooraReadyCommand = command as? NooraReadyCommand {
-                        let jsonThroughNoora = nooraReadyCommand.jsonThroughNoora
-                        try await withLoggerForNoora(logFilePath: logFilePath) {
-                            try await Noora.$current.withValue(initNoora(jsonThroughNoora: jsonThroughNoora)) {
-                                try await trackableCommand.run(
-                                    fullHandle: config.fullHandle,
-                                    serverURL: serverURL,
-                                    shouldTrackAnalytics: shouldTrackAnalytics,
-                                    optionalAuthentication: config.project.generatedProject?.generationOptions.optionalAuthentication
-                                        == true
-                                )
-                            }
-                        }
-                    } else {
+                    let optionalAuthentication = config.project.generatedProject?.generationOptions.optionalAuthentication
+                        == true
+                    let runTrackableCommand = {
                         try await trackableCommand.run(
                             fullHandle: config.fullHandle,
                             serverURL: serverURL,
                             shouldTrackAnalytics: shouldTrackAnalytics,
-                            optionalAuthentication: config.project.generatedProject?.generationOptions.optionalAuthentication
-                                == true
+                            optionalAuthentication: optionalAuthentication
                         )
+                    }
+                    if let nooraReadyCommand = command as? NooraReadyCommand {
+                        let jsonThroughNoora = nooraReadyCommand.jsonThroughNoora
+                        try await withLoggerForNoora(logFilePath: logFilePath) {
+                            try await Noora.$current.withValue(initNoora(jsonThroughNoora: jsonThroughNoora)) {
+                                try await runTrackableCommand()
+                            }
+                        }
+                    } else {
+                        try await runTrackableCommand()
                     }
                 }
             } catch {

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -181,8 +181,7 @@ public struct TuistCommand: AsyncParsableCommand {
                     let shouldTrackAnalytics = processedArguments.prefix(2) != ["inspect", "build"]
                         && processedArguments.prefix(2) != ["auth", "refresh-token"]
                         && processedArguments.first != "analytics-upload"
-                    let optionalAuthentication = config.project.generatedProject?.generationOptions.optionalAuthentication
-                        == true
+                    let optionalAuthentication = config.project.optionalAuthentication
                     let runTrackableCommand = {
                         try await trackableCommand.run(
                             fullHandle: config.fullHandle,

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -142,7 +142,9 @@ final class TrackableCommandTests: TuistTestCase {
     func test_whenOptionalAuthenticationIsEnabled_forTrackedCommands_wraps_command_execution() async throws {
         // Given
         let recorder = AuthenticationConfigRecorder()
-        let command = ConfigObservingCommand(recorder: recorder, analyticsRequired: true)
+        ConfigObservingCommandState.recorder = recorder
+        ConfigObservingCommandState.analyticsRequired = true
+        let command = ConfigObservingCommand()
         try makeSubject(command: command)
 
         // When
@@ -194,6 +196,11 @@ private actor AuthenticationConfigRecorder {
     }
 }
 
+private enum ConfigObservingCommandState {
+    static var recorder = AuthenticationConfigRecorder()
+    static var analyticsRequired = false
+}
+
 private struct TestCommand: TrackableParsableCommand, ParsableCommand {
     enum TestError: FatalError, Equatable {
         case commandFailed
@@ -230,10 +237,11 @@ private struct ConfigObservingCommand: TrackableParsableCommand, AsyncParsableCo
         CommandConfiguration(commandName: "observe")
     }
 
-    let recorder: AuthenticationConfigRecorder
-    let analyticsRequired: Bool
+    var analyticsRequired: Bool {
+        ConfigObservingCommandState.analyticsRequired
+    }
 
     func run() async throws {
-        await recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
+        await ConfigObservingCommandState.recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
     }
 }

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -42,6 +42,7 @@ final class TrackableCommandTests: TuistTestCase {
     }
 
     private func makeSubject(
+        command: ParsableCommand? = nil,
         flag: Bool = true,
         shouldFail: Bool = false,
         analyticsRequired: Bool = false,
@@ -49,7 +50,7 @@ final class TrackableCommandTests: TuistTestCase {
     ) throws {
         let temporaryPath = try temporaryPath()
         subject = TrackableCommand(
-            command: TestCommand(
+            command: command ?? TestCommand(
                 flag: flag,
                 shouldFail: shouldFail,
                 analyticsRequired: analyticsRequired
@@ -137,6 +138,60 @@ final class TrackableCommandTests: TuistTestCase {
             .gitInfo(workingDirectory: .any)
             .called(1)
     }
+
+    func test_whenOptionalAuthenticationIsEnabled_forTrackedCommands_wraps_command_execution() async throws {
+        // Given
+        let recorder = AuthenticationConfigRecorder()
+        let command = ConfigObservingCommand(recorder: recorder, analyticsRequired: true)
+        try makeSubject(command: command)
+
+        // When
+        try await subject.run(
+            fullHandle: nil,
+            serverURL: nil,
+            shouldTrackAnalytics: false,
+            optionalAuthentication: true
+        )
+
+        // Then
+        let recordedValues = await recorder.values()
+        XCTAssertEqual(recordedValues, [true])
+    }
+
+    func test_whenOptionalAuthenticationIsEnabled_background_upload_does_not_add_a_flag() async throws {
+        // Given
+        try makeSubject(analyticsRequired: false)
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true,
+            optionalAuthentication: true
+        )
+
+        // Then
+        verify(backgroundProcessRunner)
+            .runInBackground(
+                .matching { arguments in
+                    !arguments.contains("--optional-authentication")
+                },
+                environment: .any
+            )
+            .called(1)
+    }
+}
+
+private actor AuthenticationConfigRecorder {
+    private var recordedValues: [Bool] = []
+
+    func record(_ value: Bool) {
+        recordedValues.append(value)
+    }
+
+    func values() -> [Bool] {
+        recordedValues
+    }
 }
 
 private struct TestCommand: TrackableParsableCommand, ParsableCommand {
@@ -167,5 +222,18 @@ private struct TestCommand: TrackableParsableCommand, ParsableCommand {
         if shouldFail {
             throw TestError.commandFailed
         }
+    }
+}
+
+private struct ConfigObservingCommand: TrackableParsableCommand, AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(commandName: "observe")
+    }
+
+    let recorder: AuthenticationConfigRecorder
+    let analyticsRequired: Bool
+
+    func run() async throws {
+        await recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
     }
 }

--- a/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
@@ -5,6 +5,7 @@ import Mockable
 import Path
 import Testing
 import TuistConfig
+import TuistConfigLoader
 import TuistCore
 import TuistEnvironment
 import TuistEnvironmentTesting

--- a/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
@@ -4,7 +4,10 @@ import Foundation
 import Mockable
 import Path
 import Testing
+import TuistConfig
 import TuistCore
+import TuistEnvironment
+import TuistEnvironmentTesting
 import TuistServer
 import TuistSupport
 
@@ -15,12 +18,17 @@ struct AnalyticsUploadCommandServiceTests {
     private let fullHandle = "tuist-org/tuist"
     private let serverURL = "https://tuist.dev"
     private let uploadAnalyticsService = MockUploadAnalyticsServicing()
+    private let configLoader = MockConfigLoading()
     private let subject: AnalyticsUploadCommandService
 
     init() {
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.default)
         subject = AnalyticsUploadCommandService(
             fileSystem: FileSystem(),
-            uploadAnalyticsService: uploadAnalyticsService
+            uploadAnalyticsService: uploadAnalyticsService,
+            configLoader: configLoader
         )
     }
 
@@ -146,8 +154,111 @@ struct AnalyticsUploadCommandServiceTests {
             )
         }
     }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func run_enables_optional_authentication_from_repo_config() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let eventFilePath = temporaryDirectory.appending(component: "event.json")
+        let mockedEnvironment = try #require(Environment.mocked)
+        let currentWorkingDirectory = try await mockedEnvironment.currentWorkingDirectory()
+        let projectPath = currentWorkingDirectory.appending(component: "Project")
+        let event = CommandEvent.test(commandArguments: ["test", "--path", "Project"])
+        let eventData = try JSONEncoder().encode(event)
+        try eventData.write(to: eventFilePath.url, options: .atomic)
+        let recorder = AuthenticationConfigRecorder()
+        let configLoader = MockConfigLoading()
+        given(configLoader)
+            .loadConfig(path: .value(projectPath))
+            .willReturn(
+                .test(
+                    project: .generated(
+                        .test(
+                            generationOptions: .test(optionalAuthentication: true)
+                        )
+                    )
+                )
+            )
+        let subject = AnalyticsUploadCommandService(
+            fileSystem: FileSystem(),
+            uploadAnalyticsService: RecordingUploadAnalyticsService(recorder: recorder),
+            configLoader: configLoader
+        )
+
+        // When
+        try await subject.run(
+            eventFilePath: eventFilePath.pathString,
+            fullHandle: fullHandle,
+            serverURL: serverURL
+        )
+
+        // Then
+        let values = await recorder.values()
+        #expect(values == [true])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func run_falls_back_to_required_authentication_when_config_loading_fails()
+        async throws
+    {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let eventFilePath = temporaryDirectory.appending(component: "event.json")
+        let mockedEnvironment = try #require(Environment.mocked)
+        let currentWorkingDirectory = try await mockedEnvironment.currentWorkingDirectory()
+        let projectPath = currentWorkingDirectory.appending(component: "Project")
+        let event = CommandEvent.test(commandArguments: ["test", "--path", "Project"])
+        let eventData = try JSONEncoder().encode(event)
+        try eventData.write(to: eventFilePath.url, options: .atomic)
+        let recorder = AuthenticationConfigRecorder()
+        let configLoader = MockConfigLoading()
+        given(configLoader)
+            .loadConfig(path: .value(projectPath))
+            .willThrow(TestError.configLoadFailed)
+        let subject = AnalyticsUploadCommandService(
+            fileSystem: FileSystem(),
+            uploadAnalyticsService: RecordingUploadAnalyticsService(recorder: recorder),
+            configLoader: configLoader
+        )
+
+        // When
+        try await subject.run(
+            eventFilePath: eventFilePath.pathString,
+            fullHandle: fullHandle,
+            serverURL: serverURL
+        )
+
+        // Then
+        let values = await recorder.values()
+        #expect(values == [false])
+    }
 }
 
 private enum TestError: Error {
     case uploadFailed
+    case configLoadFailed
+}
+
+private actor AuthenticationConfigRecorder {
+    private var recordedValues: [Bool] = []
+
+    func record(_ value: Bool) {
+        recordedValues.append(value)
+    }
+
+    func values() -> [Bool] {
+        recordedValues
+    }
+}
+
+private struct RecordingUploadAnalyticsService: UploadAnalyticsServicing {
+    let recorder: AuthenticationConfigRecorder
+
+    func upload(
+        commandEvent _: CommandEvent,
+        fullHandle _: String,
+        serverURL _: URL,
+        sessionDirectory _: AbsolutePath?
+    ) async throws -> ServerCommandEvent {
+        await recorder.record(ServerAuthenticationConfig.current.optionalAuthentication)
+        return .test()
+    }
 }

--- a/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
@@ -155,7 +155,10 @@ struct AnalyticsUploadCommandServiceTests {
         }
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func run_enables_optional_authentication_from_repo_config() async throws {
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment()
+    ) func run_enables_optional_authentication_from_repo_config() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let eventFilePath = temporaryDirectory.appending(component: "event.json")
@@ -196,7 +199,10 @@ struct AnalyticsUploadCommandServiceTests {
         #expect(values == [true])
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func run_falls_back_to_required_authentication_when_config_loading_fails()
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment()
+    ) func run_falls_back_to_required_authentication_when_config_loading_fails()
         async throws
     {
         // Given

--- a/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/AnalyticsUploadCommandServiceTests.swift
@@ -158,14 +158,14 @@ struct AnalyticsUploadCommandServiceTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()
-    ) func run_enables_optional_authentication_from_repo_config() async throws {
+    ) func run_enables_optional_authentication_from_repo_config_when_using_short_path_option() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let eventFilePath = temporaryDirectory.appending(component: "event.json")
         let mockedEnvironment = try #require(Environment.mocked)
         let currentWorkingDirectory = try await mockedEnvironment.currentWorkingDirectory()
         let projectPath = currentWorkingDirectory.appending(component: "Project")
-        let event = CommandEvent.test(commandArguments: ["test", "--path", "Project"])
+        let event = CommandEvent.test(commandArguments: ["test", "-p", "Project"])
         let eventData = try JSONEncoder().encode(event)
         try eventData.write(to: eventFilePath.url, options: .atomic)
         let recorder = AuthenticationConfigRecorder()
@@ -202,7 +202,7 @@ struct AnalyticsUploadCommandServiceTests {
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment()
-    ) func run_falls_back_to_required_authentication_when_config_loading_fails()
+    ) func run_falls_back_to_required_authentication_when_config_loading_fails_with_short_path_option()
         async throws
     {
         // Given
@@ -211,7 +211,7 @@ struct AnalyticsUploadCommandServiceTests {
         let mockedEnvironment = try #require(Environment.mocked)
         let currentWorkingDirectory = try await mockedEnvironment.currentWorkingDirectory()
         let projectPath = currentWorkingDirectory.appending(component: "Project")
-        let event = CommandEvent.test(commandArguments: ["test", "--path", "Project"])
+        let event = CommandEvent.test(commandArguments: ["test", "-p", "Project"])
         let eventData = try JSONEncoder().encode(event)
         try eventData.write(to: eventFilePath.url, options: .atomic)
         let recorder = AuthenticationConfigRecorder()

--- a/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -29,7 +29,7 @@ struct ServerClientAuthenticationMiddlewareTests {
             serverURL: .value(url),
             refreshIfNeeded: .value(true)
         )
-            .willReturn(nil)
+        .willReturn(nil)
 
         // When / Then
         await #expect(throws: ClientAuthenticationError.notAuthenticated, performing: {
@@ -59,7 +59,7 @@ struct ServerClientAuthenticationMiddlewareTests {
             serverURL: .value(url),
             refreshIfNeeded: .value(true)
         )
-            .willReturn(token)
+        .willReturn(token)
         var gotRequest: HTTPRequest!
 
         // When
@@ -105,7 +105,7 @@ struct ServerClientAuthenticationMiddlewareTests {
             serverURL: .value(authenticationURL),
             refreshIfNeeded: .value(true)
         )
-            .willReturn(token)
+        .willReturn(token)
         var gotRequest: HTTPRequest!
 
         // When
@@ -158,7 +158,7 @@ struct ServerClientAuthenticationMiddlewareTests {
             serverURL: .value(baseURL),
             refreshIfNeeded: .value(true)
         )
-            .willReturn(token)
+        .willReturn(token)
         var gotRequest: HTTPRequest!
 
         // When
@@ -199,7 +199,7 @@ struct ServerClientAuthenticationMiddlewareTests {
             serverURL: .value(url),
             refreshIfNeeded: .value(false)
         )
-            .willReturn(nil)
+        .willReturn(nil)
         var gotRequest: HTTPRequest!
 
         // When

--- a/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -25,7 +25,10 @@ struct ServerClientAuthenticationMiddlewareTests {
         let response = HTTPResponse(
             status: 200
         )
-        given(serverAuthenticationController).authenticationToken(serverURL: .value(url))
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
             .willReturn(nil)
 
         // When / Then
@@ -52,7 +55,10 @@ struct ServerClientAuthenticationMiddlewareTests {
             accessToken: .test(token: "access-token"),
             refreshToken: .test(token: "refresh-token")
         )
-        given(serverAuthenticationController).authenticationToken(serverURL: .value(url))
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
             .willReturn(token)
         var gotRequest: HTTPRequest!
 
@@ -95,7 +101,10 @@ struct ServerClientAuthenticationMiddlewareTests {
             authenticationURL: authenticationURL
         )
 
-        given(serverAuthenticationController).authenticationToken(serverURL: .value(authenticationURL))
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(authenticationURL),
+            refreshIfNeeded: .value(true)
+        )
             .willReturn(token)
         var gotRequest: HTTPRequest!
 
@@ -121,7 +130,10 @@ struct ServerClientAuthenticationMiddlewareTests {
 
         // Verify authentication was requested with the custom URL, not the baseURL
         verify(serverAuthenticationController)
-            .authenticationToken(serverURL: .value(authenticationURL))
+            .authenticationToken(
+                serverURL: .value(authenticationURL),
+                refreshIfNeeded: .value(true)
+            )
             .called(1)
     }
 
@@ -142,7 +154,10 @@ struct ServerClientAuthenticationMiddlewareTests {
             authenticationURL: nil
         )
 
-        given(serverAuthenticationController).authenticationToken(serverURL: .value(baseURL))
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(baseURL),
+            refreshIfNeeded: .value(true)
+        )
             .willReturn(token)
         var gotRequest: HTTPRequest!
 
@@ -168,7 +183,42 @@ struct ServerClientAuthenticationMiddlewareTests {
 
         // Verify authentication was requested with the baseURL
         verify(serverAuthenticationController)
-            .authenticationToken(serverURL: .value(baseURL))
+            .authenticationToken(
+                serverURL: .value(baseURL),
+                refreshIfNeeded: .value(true)
+            )
             .called(1)
+    }
+
+    @Test func allows_requests_without_a_token_when_optional_authentication_is_enabled() async throws {
+        // Given
+        let url = URL(string: "https://test.tuist.dev")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
+        let response = HTTPResponse(status: 200)
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(false)
+        )
+            .willReturn(nil)
+        var gotRequest: HTTPRequest!
+
+        // When
+        let (gotResponse, _) = try await ServerAuthenticationConfig.$current.withValue(
+            .init(optionalAuthentication: true)
+        ) {
+            try await subject.intercept(
+                request,
+                body: nil,
+                baseURL: url,
+                operationID: "123"
+            ) { request, body, _ in
+                gotRequest = request
+                return (response, body)
+            }
+        }
+
+        // Then
+        #expect(gotResponse == response)
+        #expect(gotRequest.headerFields == request.headerFields)
     }
 }


### PR DESCRIPTION
## Summary
- Route optional authentication from repo generation options into tracked command execution
- Resolve optional auth for background analytics uploads by reloading config from the recorded command path
- Keep the server middleware tolerant of expired auth when optional authentication is enabled
- Add coverage for tracked-command wrapping, background upload config resolution, and middleware fallback behavior

## Testing
- `swift build --replace-scm-with-registry --target TuistKit --target TuistServer --target tuist` passed
- Added and updated unit tests for CLI tracking, analytics upload behavior, and server authentication middleware