### PR TITLE
Make ClickHouse cleanup opt in at the case level

### DIFF
--- a/server/test/AGENTS.md
+++ b/server/test/AGENTS.md
@@ -7,6 +7,7 @@ This directory contains ExUnit tests for the Tuist Server.
 - Tests run with a clean database.
 - Never modify System environment variables in tests (shared state).
 - Use mocks/stubs/DI for environment-dependent behavior.
+- Tests that touch ClickHouse should opt in at the case level with `clickhouse: true`, for example `use TuistTestSupport.Cases.DataCase, clickhouse: true` or `use TuistTestSupport.Cases.ConnCase, clickhouse: true`. That marks the test with `:clickhouse`, registers ClickHouse cleanup automatically, and must not be combined with `async: true`.
 
 ## Related Context
 - Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/test/support/tuist_test_support/cases/channel_case.ex
+++ b/server/test/support/tuist_test_support/cases/channel_case.ex
@@ -17,23 +17,35 @@ defmodule TuistWeb.ChannelCase do
 
   use ExUnit.CaseTemplate
 
-  using do
-    quote do
+  using options do
+    clickhouse? = Keyword.get(options, :clickhouse, false)
+    async? = Keyword.get(options, :async, false)
+
+    if clickhouse? and async? do
+      raise ArgumentError,
+            "ClickHouse tests cannot be async. Use `use TuistWeb.ChannelCase, clickhouse: true` without `async: true`."
+    end
+
+    quote bind_quoted: [clickhouse?: clickhouse?] do
       # Import conveniences for testing with channels
       import Phoenix.ChannelTest
       import TuistWeb.ChannelCase
 
       # The default endpoint for testing
       @endpoint TuistWeb.Endpoint
+
+      if clickhouse?, do: @moduletag(:clickhouse)
     end
   end
 
   setup tags do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
 
-    on_exit(fn ->
-      TuistTestSupport.Utilities.truncate_clickhouse_tables()
-    end)
+    if tags[:clickhouse] do
+      on_exit(fn ->
+        TuistTestSupport.Utilities.truncate_clickhouse_tables()
+      end)
+    end
 
     :ok
   end

--- a/server/test/support/tuist_test_support/cases/conn_case.ex
+++ b/server/test/support/tuist_test_support/cases/conn_case.ex
@@ -17,8 +17,16 @@ defmodule TuistTestSupport.Cases.ConnCase do
 
   use ExUnit.CaseTemplate
 
-  using do
-    quote do
+  using options do
+    clickhouse? = Keyword.get(options, :clickhouse, false)
+    async? = Keyword.get(options, :async, false)
+
+    if clickhouse? and async? do
+      raise ArgumentError,
+            "ClickHouse tests cannot be async. Use `use TuistTestSupport.Cases.ConnCase, clickhouse: true` without `async: true`."
+    end
+
+    quote bind_quoted: [clickhouse?: clickhouse?] do
       use TuistWeb, :verified_routes
       use Oban.Testing, repo: Tuist.Repo
 
@@ -29,15 +37,19 @@ defmodule TuistTestSupport.Cases.ConnCase do
 
       # The default endpoint for testing
       @endpoint TuistWeb.Endpoint
+
+      if clickhouse?, do: @moduletag(:clickhouse)
     end
   end
 
   setup tags do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
 
-    on_exit(fn ->
-      TuistTestSupport.Utilities.truncate_clickhouse_tables()
-    end)
+    if tags[:clickhouse] do
+      on_exit(fn ->
+        TuistTestSupport.Utilities.truncate_clickhouse_tables()
+      end)
+    end
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end

--- a/server/test/support/tuist_test_support/cases/data_case.ex
+++ b/server/test/support/tuist_test_support/cases/data_case.ex
@@ -19,8 +19,16 @@ defmodule TuistTestSupport.Cases.DataCase do
 
   require File
 
-  using do
-    quote do
+  using options do
+    clickhouse? = Keyword.get(options, :clickhouse, false)
+    async? = Keyword.get(options, :async, false)
+
+    if clickhouse? and async? do
+      raise ArgumentError,
+            "ClickHouse tests cannot be async. Use `use TuistTestSupport.Cases.DataCase, clickhouse: true` without `async: true`."
+    end
+
+    quote bind_quoted: [clickhouse?: clickhouse?] do
       use Oban.Testing, repo: Tuist.Repo
 
       import Ecto
@@ -31,6 +39,8 @@ defmodule TuistTestSupport.Cases.DataCase do
       import TuistTestSupport.Utilities
 
       alias Tuist.Repo
+
+      if clickhouse?, do: @moduletag(:clickhouse)
     end
   end
 
@@ -38,9 +48,11 @@ defmodule TuistTestSupport.Cases.DataCase do
     TuistTestSupport.Cases.DataCase.setup_sandbox(tags)
     Mimic.stub(Tuist.Tasks, :run_async, fn fun -> fun.() end)
 
-    on_exit(fn ->
-      TuistTestSupport.Utilities.truncate_clickhouse_tables()
-    end)
+    if tags[:clickhouse] do
+      on_exit(fn ->
+        TuistTestSupport.Utilities.truncate_clickhouse_tables()
+      end)
+    end
 
     :ok
   end

--- a/server/test/support/tuist_test_support/utilities.ex
+++ b/server/test/support/tuist_test_support/utilities.ex
@@ -39,31 +39,10 @@ defmodule TuistTestSupport.Utilities do
       "TRUNCATE TABLE IF EXISTS gradle_cache_events"
     ]
 
-    for command <- commands do
-      query_with_retry(command)
-    end
-  end
-
-  # ClickHouse occasionally drops idle pool connections under CI load; the Ch
-  # client reestablishes them transparently on the *next* use, but the call in
-  # flight when that happens still raises `Mint.TransportError: socket closed`.
-  # Retry once on that specific error so an `on_exit` TRUNCATE doesn't fail
-  # the test that just finished.
-  defp query_with_retry(command, attempts_left \\ 1) do
-    Tuist.IngestRepo.query!(command)
-  rescue
-    error in DBConnection.ConnectionError ->
-      if attempts_left > 0 and error.reason in [:socket_closed, "socket closed"] do
-        query_with_retry(command, attempts_left - 1)
-      else
-        reraise error, __STACKTRACE__
-      end
-
-    error in Mint.TransportError ->
-      if attempts_left > 0 and error.reason == :closed do
-        query_with_retry(command, attempts_left - 1)
-      else
-        reraise error, __STACKTRACE__
-      end
+    Enum.each(commands, fn command ->
+      Tuist.IngestRepo.with_retry(fn ->
+        Tuist.IngestRepo.query!(command)
+      end)
+    end)
   end
 end

--- a/server/test/tuist/accounts/workers/update_account_usage_worker_test.exs
+++ b/server/test/tuist/accounts/workers/update_account_usage_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.Workers.UpdateAccountUsageWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts.Workers.UpdateAccountUsageWorker

--- a/server/test/tuist/accounts/workers/update_all_accounts_usage_worker_test.exs
+++ b/server/test/tuist/accounts/workers/update_all_accounts_usage_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Accounts.Workers.UpdateAllAccountsUsageWorkerTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts.Workers.UpdateAllAccountsUsageWorker

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AccountsTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use TuistTestSupport.Cases.StubCase, billing: true
   use Mimic
 

--- a/server/test/tuist/alerts/alerts_test.exs
+++ b/server/test/tuist/alerts/alerts_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AlertsTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
 
   alias Tuist.Alerts
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/alerts/workers/flaky_test_alert_worker_test.exs
+++ b/server/test/tuist/alerts/workers/flaky_test_alert_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Alerts.Workers.FlakyTestAlertWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Alerts.Workers.FlakyTestAlertWorker

--- a/server/test/tuist/alerts/workers/flaky_threshold_check_worker_test.exs
+++ b/server/test/tuist/alerts/workers/flaky_threshold_check_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Alerts.Workers.FlakyThresholdCheckWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Alerts.Workers.FlakyTestAlertWorker

--- a/server/test/tuist/app_builds_test.exs
+++ b/server/test/tuist/app_builds_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AppBuildsTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
 
   alias Tuist.AppBuilds
   alias Tuist.AppBuilds.Preview

--- a/server/test/tuist/authentication_test.exs
+++ b/server/test/tuist/authentication_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AuthenticationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist/authorization_test.exs
+++ b/server/test/tuist/authorization_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.AuthorizationTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist/billing/sync_stripe_meters_worker_test.exs
+++ b/server/test/tuist/billing/sync_stripe_meters_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Billing.Workers.SyncStripeMetersWorkerWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Billing.Workers.SyncCustomerStripeMetersWorker

--- a/server/test/tuist/builds/analytics_test.exs
+++ b/server/test/tuist/builds/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Builds.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds.Analytics

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds.Workers.ProcessBuildWorker

--- a/server/test/tuist/builds_test.exs
+++ b/server/test/tuist/builds_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.BuildsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist/cache/analytics_test.exs
+++ b/server/test/tuist/cache/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Cache.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Cache.Analytics

--- a/server/test/tuist/cache_test.exs
+++ b/server/test/tuist/cache_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CacheTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Cache

--- a/server/test/tuist/command_events_test.exs
+++ b/server/test/tuist/command_events_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.CommandEventsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.CommandEvents

--- a/server/test/tuist/gradle/analytics_test.exs
+++ b/server/test/tuist/gradle/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Gradle.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
 
   alias Tuist.Gradle.Analytics
   alias TuistTestSupport.Fixtures.GradleFixtures

--- a/server/test/tuist/gradle_test.exs
+++ b/server/test/tuist/gradle_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.GradleTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
 
   alias Tuist.Gradle
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/mcp/components/tools/gradle_build_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/gradle_build_tools_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.MCP.Components.Tools.GradleBuildToolsTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
 
   alias Tuist.MCP.Components.Tools.GetGradleBuild
   alias Tuist.MCP.Components.Tools.ListGradleBuilds

--- a/server/test/tuist/oauth/token_generator_test.exs
+++ b/server/test/tuist/oauth/token_generator_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.OAuth.TokenGeneratorTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Boruta.Ecto.Token

--- a/server/test/tuist/ops/daily_slack_report_worker_test.exs
+++ b/server/test/tuist/ops/daily_slack_report_worker_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Ops.DailySlackReportWorkerTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist/projects_test.exs
+++ b/server/test/tuist/projects_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.ProjectsTest do
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use TuistTestSupport.Cases.StubCase, billing: true
   use Mimic
 

--- a/server/test/tuist/runs/analytics_test.exs
+++ b/server/test/tuist/runs/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Runs.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Runs.Analytics

--- a/server/test/tuist/shards/analytics_test.exs
+++ b/server/test/tuist/shards/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Shards.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.IngestRepo

--- a/server/test/tuist/shards_test.exs
+++ b/server/test/tuist/shards_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.ShardsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Shards

--- a/server/test/tuist/slack/reports_test.exs
+++ b/server/test/tuist/slack/reports_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Slack.ReportsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Cache.Analytics

--- a/server/test/tuist/tests/analytics_test.exs
+++ b/server/test/tuist/tests/analytics_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Tests.AnalyticsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.IngestRepo

--- a/server/test/tuist/tests/workers/clear_cooled_down_flaky_tests_scheduler_test.exs
+++ b/server/test/tuist/tests/workers/clear_cooled_down_flaky_tests_scheduler_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.Tests.Workers.ClearCooledDownFlakyTestsSchedulerTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Tests.Workers.ClearCooledDownFlakyTestsScheduler

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.TestsTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.ClickHouseRepo

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -1,7 +1,7 @@
 defmodule Tuist.VCSTest do
   use ExUnit.Case, async: false
   use TuistTestSupport.Cases.StubCase, billing: true
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
   use Mimic
 
   alias Tuist.Environment

--- a/server/test/tuist/xcode_test.exs
+++ b/server/test/tuist/xcode_test.exs
@@ -1,5 +1,5 @@
 defmodule Tuist.XcodeTest do
-  use TuistTestSupport.Cases.DataCase
+  use TuistTestSupport.Cases.DataCase, clickhouse: true
 
   import Ecto.Query
 

--- a/server/test/tuist_web/authentication_test.exs
+++ b/server/test/tuist_web/authentication_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.AuthenticationTest do
-  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
 
   import TuistTestSupport.Fixtures.AccountsFixtures
 

--- a/server/test/tuist_web/controllers/analytics_controller_test.exs
+++ b/server/test/tuist_web/controllers/analytics_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.AnalyticsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_cache_tasks_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildCacheTasksControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/build_cas_outputs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_cas_outputs_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildCASOutputsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/build_files_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_files_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildFilesControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/build_issues_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_issues_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildIssuesControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/build_targets_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/build_targets_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildTargetsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/builds_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/builds_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.BuildsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Builds

--- a/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_runs_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.CacheRunsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
 
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.CommandEventsFixtures

--- a/server/test/tuist_web/controllers/api/generations_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/generations_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.GenerationsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
 
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.CommandEventsFixtures

--- a/server/test/tuist_web/controllers/api/gradle_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/gradle_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.GradleControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/controllers/api/gradle_tasks_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/gradle_tasks_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.GradleTasksControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias TuistTestSupport.Fixtures.AccountsFixtures

--- a/server/test/tuist_web/controllers/api/module_cache_targets_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/module_cache_targets_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.ModuleCacheTargetsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Xcode

--- a/server/test/tuist_web/controllers/api/previews_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/previews_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.PreviewsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts

--- a/server/test/tuist_web/controllers/api/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/runs_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.RunsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/controllers/api/selective_testing_targets_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/selective_testing_targets_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.SelectiveTestingTargetsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Tests

--- a/server/test/tuist_web/controllers/api/test_case_run_attachments_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_case_run_attachments_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.TestCaseRunAttachmentsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Storage

--- a/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.TestCaseRunsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Storage

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.API.TestCasesControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Tests

--- a/server/test/tuist_web/controllers/preview_controller_test.exs
+++ b/server/test/tuist_web/controllers/preview_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.PreviewControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: true
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Storage

--- a/server/test/tuist_web/controllers/runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/runs_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.RunsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Storage

--- a/server/test/tuist_web/controllers/test_case_run_attachments_controller_test.exs
+++ b/server/test/tuist_web/controllers/test_case_run_attachments_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.TestCaseRunAttachmentsControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Storage

--- a/server/test/tuist_web/controllers/webhooks/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/cache_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Webhooks.CacheControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/controllers/webhooks/gradle_cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/gradle_cache_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Webhooks.GradleCacheControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/controllers/webhooks/registry_controller_test.exs
+++ b/server/test/tuist_web/controllers/webhooks/registry_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Webhooks.RegistryControllerTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   import Ecto.Query

--- a/server/test/tuist_web/live/build_run_live_test.exs
+++ b/server/test/tuist_web/live/build_run_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.BuildRunLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic
@@ -7,12 +7,14 @@ defmodule TuistWeb.BuildRunLiveTest do
   import Phoenix.LiveViewTest
 
   alias Tuist.CommandEvents
+  alias Tuist.Storage
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.RunsFixtures
 
   setup %{conn: conn} do
     user = AccountsFixtures.user_fixture()
     stub(CommandEvents, :has_result_bundle?, fn _ -> false end)
+    stub(Storage, :object_exists?, fn _, _ -> false end)
     %{conn: conn, user: user}
   end
 

--- a/server/test/tuist_web/live/build_runs_live_test.exs
+++ b/server/test/tuist_web/live/build_runs_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.BuildRunsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/builds_live_test.exs
+++ b/server/test/tuist_web/live/builds_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.BuildsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/cache_runs_live_test.exs
+++ b/server/test/tuist_web/live/cache_runs_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.CacheRunsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/flaky_tests_live_test.exs
+++ b/server/test/tuist_web/live/flaky_tests_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.FlakyTestsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/generate_runs_live_test.exs
+++ b/server/test/tuist_web/live/generate_runs_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.GenerateRunsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/gradle_build_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.GradleBuildLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/gradle_build_runs_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_runs_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.GradleBuildRunsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/module_cache_live_test.exs
+++ b/server/test/tuist_web/live/module_cache_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.ModuleCacheLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/overview_live_test.exs
+++ b/server/test/tuist_web/live/overview_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.OverviewLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use Mimic
 

--- a/server/test/tuist_web/live/preview_live_test.exs
+++ b/server/test/tuist_web/live/preview_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.PreviewLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
 

--- a/server/test/tuist_web/live/quarantined_tests_live_test.exs
+++ b/server/test/tuist_web/live/quarantined_tests_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.QuarantinedTestsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/run_detail_live_test.exs
+++ b/server/test/tuist_web/live/run_detail_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.RunDetailLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
 
@@ -13,6 +13,7 @@ defmodule TuistWeb.RunDetailLiveTest do
   setup %{conn: conn} do
     user = AccountsFixtures.user_fixture()
     stub(CommandEvents, :has_result_bundle?, fn _ -> false end)
+    stub(CommandEvents, :has_session?, fn _ -> false end)
     %{conn: conn, user: user}
   end
 

--- a/server/test/tuist_web/live/test_case_live_test.exs
+++ b/server/test/tuist_web/live/test_case_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.TestCaseLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
 
   import Phoenix.LiveViewTest

--- a/server/test/tuist_web/live/test_case_run_live_test.exs
+++ b/server/test/tuist_web/live/test_case_run_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.TestCaseRunLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use Mimic
 

--- a/server/test/tuist_web/live/test_run_live_test.exs
+++ b/server/test/tuist_web/live/test_run_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.TestRunLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.TestRunsLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
   use Mimic

--- a/server/test/tuist_web/live/xcode_cache_live_test.exs
+++ b/server/test/tuist_web/live/xcode_cache_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.XcodeCacheLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
 

--- a/server/test/tuist_web/live/xcode_overview_live_test.exs
+++ b/server/test/tuist_web/live/xcode_overview_live_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.XcodeOverviewLiveTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use TuistTestSupport.Cases.LiveCase
   use TuistTestSupport.Cases.StubCase, dashboard_project: true
 

--- a/server/test/tuist_web/plugs/loader_plug_test.exs
+++ b/server/test/tuist_web/plugs/loader_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule TuistWeb.Plugs.LoaderPlugTest do
-  use TuistTestSupport.Cases.ConnCase, async: false
+  use TuistTestSupport.Cases.ConnCase, clickhouse: true
   use Mimic
 
   alias Tuist.Accounts


### PR DESCRIPTION
## Summary
- Add a `clickhouse: true` option to `DataCase`, `ConnCase`, and `ChannelCase`
- Register ClickHouse teardown only for tagged tests and reject `clickhouse: true` with `async: true`
- Update ClickHouse-dependent tests to opt in explicitly and document the convention in `server/test/AGENTS.md`

## Testing
- Ran targeted ExUnit coverage for ClickHouse and non-ClickHouse tests; all passed
- Verified the async guard raises when `clickhouse: true` is combined with `async: true`