### PR TITLE
feat(cache): reclaim metadata orphans from repo.sqlite

### DIFF
--- a/cache/config/config.exs
+++ b/cache/config/config.exs
@@ -64,6 +64,7 @@ config :cache, Oban,
      crontab: [
        {"*/10 * * * *", Cache.DiskEvictionWorker},
        {"0 * * * *", Cache.OrphanCleanupWorker},
+       {"*/30 * * * *", Cache.CacheArtifactOrphanCleanupWorker},
        {"*/15 * * * *", Cache.KeyValueEvictionWorker},
        {"* * * * *", Cache.S3TransferWorker},
        {"*/10 * * * *", Cache.Registry.SyncWorker},

--- a/cache/lib/cache/cache_artifact_orphan_cleanup_worker.ex
+++ b/cache/lib/cache/cache_artifact_orphan_cleanup_worker.ex
@@ -1,0 +1,174 @@
+defmodule Cache.CacheArtifactOrphanCleanupWorker do
+  @moduledoc """
+  Oban worker that walks `cache_artifacts` rows and deletes those whose
+  on-disk file no longer exists.
+
+  This is the symmetric counterpart to `Cache.OrphanCleanupWorker`:
+
+    * `OrphanCleanupWorker` finds files on disk with no DB row and deletes
+      the files (disk orphans).
+    * This worker finds DB rows with no file on disk and deletes the rows
+      (metadata orphans).
+
+  Metadata orphans accumulate when a file is removed outside the normal
+  eviction path (manual cleanup, partially-failed batch delete, older CLI
+  versions that pruned files directly) or when `CacheArtifacts.delete_by_keys`
+  itself fails. Over time this can grow `repo.sqlite` to tens of GB beyond
+  what the files on disk justify.
+
+  ## Safety
+
+  Only rows whose `updated_at` is older than `@min_age_seconds` are scanned,
+  mirroring `OrphanCleanupWorker`'s rule. This avoids deleting a row for an
+  upload that was just buffered but where the file isn't visible on disk yet
+  for this scanner (e.g., racy fs cache on a different node's view).
+
+  ## Cursor
+
+  The last scanned `id` is held in `Application` env. On restart the scan
+  begins from 0 again — the operation is idempotent and cheap on healthy
+  nodes.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 1,
+    unique: [period: :infinity, states: [:available, :scheduled, :executing, :retryable]]
+
+  import Ecto.Query
+
+  alias Cache.CacheArtifact
+  alias Cache.Disk
+  alias Cache.Repo
+
+  require Logger
+
+  @cursor_key :cache_artifact_orphan_cleanup_cursor
+  @min_age_seconds 3_600
+  @batch_size 1_000
+  @default_max_duration_ms 120_000
+  @default_vacuum_pages 10_000
+  @telemetry_event [:cache, :cache_artifacts, :orphan_cleanup, :complete]
+
+  @impl Oban.Worker
+  def perform(_job) do
+    started_at = System.monotonic_time(:millisecond)
+    deadline_ms = started_at + max_duration_ms()
+    cursor = Application.get_env(:cache, @cursor_key, 0)
+
+    {new_cursor, summary} = scan(cursor, deadline_ms, %{rows_checked: 0, orphans_deleted: 0})
+
+    Application.put_env(:cache, @cursor_key, new_cursor)
+
+    maybe_reclaim_pages(summary)
+    log_summary(summary, new_cursor)
+    emit_telemetry(summary, started_at)
+    :ok
+  end
+
+  defp scan(cursor, deadline_ms, summary) do
+    if deadline_reached?(deadline_ms) do
+      {cursor, summary}
+    else
+      batch = fetch_batch(cursor)
+
+      case batch do
+        [] ->
+          # Reached the end of the table — reset the cursor so the next run
+          # starts over. Avoids burning CPU on a tight wrap-around loop when
+          # the table is small relative to the per-run time budget.
+          {0, summary}
+
+        rows ->
+          {orphans, checked} = classify(rows)
+          :ok = delete_orphans(orphans)
+
+          next_cursor = rows |> List.last() |> Map.fetch!(:id)
+
+          next_summary = %{
+            rows_checked: summary.rows_checked + checked,
+            orphans_deleted: summary.orphans_deleted + length(orphans)
+          }
+
+          scan(next_cursor, deadline_ms, next_summary)
+      end
+    end
+  end
+
+  defp fetch_batch(cursor) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@min_age_seconds, :second)
+
+    Repo.all(
+      from(a in CacheArtifact,
+        where: a.id > ^cursor and a.updated_at < ^cutoff,
+        order_by: [asc: a.id],
+        limit: ^@batch_size,
+        select: %{id: a.id, key: a.key}
+      )
+    )
+  end
+
+  defp classify(rows) do
+    Enum.reduce(rows, {[], 0}, fn %{id: id, key: key}, {orphans, checked} ->
+      if file_exists?(key) do
+        {orphans, checked + 1}
+      else
+        {[id | orphans], checked + 1}
+      end
+    end)
+  end
+
+  defp file_exists?(key) do
+    key |> Disk.artifact_path() |> File.exists?()
+  end
+
+  defp delete_orphans([]), do: :ok
+
+  defp delete_orphans(ids) do
+    {_count, _} = Repo.delete_all(from(a in CacheArtifact, where: a.id in ^ids))
+    :ok
+  end
+
+  defp maybe_reclaim_pages(%{orphans_deleted: 0}), do: :ok
+
+  defp maybe_reclaim_pages(_summary) do
+    pages = Application.get_env(:cache, :cache_artifacts_orphan_cleanup_vacuum_pages, @default_vacuum_pages)
+
+    case Repo.query("PRAGMA incremental_vacuum(#{pages})") do
+      {:ok, _} -> :ok
+      {:error, reason} -> Logger.warning("cache_artifacts vacuum failed: #{inspect(reason)}")
+    end
+  end
+
+  defp log_summary(%{rows_checked: 0}, _cursor) do
+    Logger.info("cache_artifacts orphan scan: no rows in window")
+  end
+
+  defp log_summary(%{rows_checked: checked, orphans_deleted: deleted}, cursor) do
+    Logger.info(
+      "cache_artifacts orphan scan: checked #{checked} rows, deleted #{deleted} orphans, cursor=#{cursor}"
+    )
+  end
+
+  defp emit_telemetry(summary, started_at) do
+    duration_ms = System.monotonic_time(:millisecond) - started_at
+
+    :telemetry.execute(
+      @telemetry_event,
+      %{
+        rows_checked: summary.rows_checked,
+        orphans_deleted: summary.orphans_deleted,
+        duration_ms: duration_ms
+      },
+      %{}
+    )
+  end
+
+  defp max_duration_ms do
+    Application.get_env(:cache, :cache_artifacts_orphan_cleanup_max_duration_ms, @default_max_duration_ms)
+  end
+
+  defp deadline_reached?(deadline_ms) do
+    System.monotonic_time(:millisecond) >= deadline_ms
+  end
+end

--- a/cache/lib/cache/cache_artifact_orphan_cleanup_worker.ex
+++ b/cache/lib/cache/cache_artifact_orphan_cleanup_worker.ex
@@ -48,6 +48,8 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
   @batch_size 1_000
   @default_max_duration_ms 120_000
   @default_vacuum_pages 10_000
+  @default_max_deletes_per_run 10_000
+  @recheck_sleep_ms 50
   @telemetry_event [:cache, :cache_artifacts, :orphan_cleanup, :complete]
 
   @impl Oban.Worker
@@ -55,8 +57,10 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
     started_at = System.monotonic_time(:millisecond)
     deadline_ms = started_at + max_duration_ms()
     cursor = Application.get_env(:cache, @cursor_key, 0)
+    delete_budget = max_deletes_per_run()
 
-    {new_cursor, summary} = scan(cursor, deadline_ms, %{rows_checked: 0, orphans_deleted: 0})
+    {new_cursor, summary, _remaining_budget} =
+      scan(cursor, deadline_ms, delete_budget, %{rows_checked: 0, orphans_deleted: 0})
 
     Application.put_env(:cache, @cursor_key, new_cursor)
 
@@ -66,9 +70,16 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
     :ok
   end
 
-  defp scan(cursor, deadline_ms, summary) do
+  defp scan(cursor, _deadline_ms, 0 = _budget, summary) do
+    # Per-run deletion cap reached; stop but keep the cursor so the next run
+    # picks up from where we left off.
+    Logger.warning("cache_artifacts orphan scan: per-run deletion cap reached")
+    {cursor, summary, 0}
+  end
+
+  defp scan(cursor, deadline_ms, budget, summary) do
     if deadline_reached?(deadline_ms) do
-      {cursor, summary}
+      {cursor, summary, budget}
     else
       batch = fetch_batch(cursor)
 
@@ -77,20 +88,30 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
           # Reached the end of the table — reset the cursor so the next run
           # starts over. Avoids burning CPU on a tight wrap-around loop when
           # the table is small relative to the per-run time budget.
-          {0, summary}
+          {0, summary, budget}
 
         rows ->
           {orphans, checked} = classify(rows)
-          :ok = delete_orphans(orphans)
+          {orphans_to_delete, leftover} = Enum.split(orphans, budget)
+          :ok = delete_orphans(orphans_to_delete)
 
-          next_cursor = rows |> List.last() |> Map.fetch!(:id)
+          next_cursor =
+            if leftover == [] do
+              rows |> List.last() |> Map.fetch!(:id)
+            else
+              # Budget exhausted partway through the batch. Don't advance past
+              # the rows we didn't get to delete — next run needs to revisit them.
+              cursor
+            end
 
           next_summary = %{
             rows_checked: summary.rows_checked + checked,
-            orphans_deleted: summary.orphans_deleted + length(orphans)
+            orphans_deleted: summary.orphans_deleted + length(orphans_to_delete)
           }
 
-          scan(next_cursor, deadline_ms, next_summary)
+          next_budget = budget - length(orphans_to_delete)
+
+          scan(next_cursor, deadline_ms, next_budget, next_summary)
       end
     end
   end
@@ -110,16 +131,26 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
 
   defp classify(rows) do
     Enum.reduce(rows, {[], 0}, fn %{id: id, key: key}, {orphans, checked} ->
-      if file_exists?(key) do
-        {orphans, checked + 1}
-      else
+      if orphan?(key) do
         {[id | orphans], checked + 1}
+      else
+        {orphans, checked + 1}
       end
     end)
   end
 
-  defp file_exists?(key) do
-    key |> Disk.artifact_path() |> File.exists?()
+  # Double-checked: a row is treated as an orphan only if the file is missing
+  # on *both* checks, separated by a small sleep. Protects against transient
+  # ENOENT (e.g., rename in progress, kernel cache weirdness).
+  defp orphan?(key) do
+    path = Disk.artifact_path(key)
+
+    if File.exists?(path) do
+      false
+    else
+      :timer.sleep(@recheck_sleep_ms)
+      not File.exists?(path)
+    end
   end
 
   defp delete_orphans([]), do: :ok
@@ -166,6 +197,10 @@ defmodule Cache.CacheArtifactOrphanCleanupWorker do
 
   defp max_duration_ms do
     Application.get_env(:cache, :cache_artifacts_orphan_cleanup_max_duration_ms, @default_max_duration_ms)
+  end
+
+  defp max_deletes_per_run do
+    Application.get_env(:cache, :cache_artifacts_orphan_cleanup_max_deletes_per_run, @default_max_deletes_per_run)
   end
 
   defp deadline_reached?(deadline_ms) do

--- a/cache/test/cache/cache_artifact_orphan_cleanup_worker_test.exs
+++ b/cache/test/cache/cache_artifact_orphan_cleanup_worker_test.exs
@@ -1,0 +1,86 @@
+defmodule Cache.CacheArtifactOrphanCleanupWorkerTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Ecto.Query
+
+  alias Cache.CacheArtifact
+  alias Cache.CacheArtifactOrphanCleanupWorker
+  alias Cache.Disk
+  alias Cache.Repo
+  alias Ecto.Adapters.SQL.Sandbox
+
+  @cursor_key :cache_artifact_orphan_cleanup_cursor
+
+  setup do
+    :ok = Sandbox.checkout(Repo)
+    Repo.delete_all(CacheArtifact)
+    Application.delete_env(:cache, @cursor_key)
+
+    {:ok, storage_dir} = Briefly.create(directory: true)
+    stub(Disk, :storage_dir, fn -> storage_dir end)
+
+    {:ok, storage_dir: storage_dir}
+  end
+
+  test "deletes rows whose file does not exist on disk", %{storage_dir: storage_dir} do
+    orphan_key = "acct/proj/xcode/AB/CD/orphan"
+    present_key = "acct/proj/xcode/EF/GH/present"
+
+    insert_artifact(orphan_key, old_timestamp())
+    insert_artifact(present_key, old_timestamp())
+
+    write_file(storage_dir, present_key)
+
+    assert :ok = CacheArtifactOrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    assert [^present_key] = Repo.all(from_keys())
+  end
+
+  test "does not delete rows younger than 1 hour", %{storage_dir: _storage_dir} do
+    key = "acct/proj/xcode/IJ/KL/young"
+    insert_artifact(key, DateTime.utc_now() |> DateTime.truncate(:second))
+
+    assert :ok = CacheArtifactOrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    assert [^key] = Repo.all(from_keys())
+  end
+
+  test "advances the cursor so the next run continues from where it left off" do
+    assert Application.get_env(:cache, @cursor_key) in [nil, 0]
+
+    key1 = "acct/proj/xcode/11/11/a"
+    key2 = "acct/proj/xcode/22/22/b"
+    insert_artifact(key1, old_timestamp())
+    insert_artifact(key2, old_timestamp())
+
+    assert :ok = CacheArtifactOrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    assert Application.get_env(:cache, @cursor_key) > 0
+  end
+
+  defp insert_artifact(key, updated_at) do
+    %CacheArtifact{}
+    |> CacheArtifact.changeset(%{key: key, size_bytes: 7, last_accessed_at: updated_at})
+    |> Ecto.Changeset.force_change(:inserted_at, updated_at)
+    |> Ecto.Changeset.force_change(:updated_at, updated_at)
+    |> Repo.insert!()
+  end
+
+  defp write_file(storage_dir, key) do
+    path = Path.join(storage_dir, key)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, "x")
+    path
+  end
+
+  defp old_timestamp do
+    DateTime.utc_now()
+    |> DateTime.add(-2 * 3600, :second)
+    |> DateTime.truncate(:second)
+  end
+
+  defp from_keys do
+    from(a in CacheArtifact, order_by: a.id, select: a.key)
+  end
+end

--- a/cache/test/cache/cache_artifact_orphan_cleanup_worker_test.exs
+++ b/cache/test/cache/cache_artifact_orphan_cleanup_worker_test.exs
@@ -16,6 +16,7 @@ defmodule Cache.CacheArtifactOrphanCleanupWorkerTest do
     :ok = Sandbox.checkout(Repo)
     Repo.delete_all(CacheArtifact)
     Application.delete_env(:cache, @cursor_key)
+    Application.delete_env(:cache, :cache_artifacts_orphan_cleanup_max_deletes_per_run)
 
     {:ok, storage_dir} = Briefly.create(directory: true)
     stub(Disk, :storage_dir, fn -> storage_dir end)
@@ -44,6 +45,29 @@ defmodule Cache.CacheArtifactOrphanCleanupWorkerTest do
     assert :ok = CacheArtifactOrphanCleanupWorker.perform(%Oban.Job{args: %{}})
 
     assert [^key] = Repo.all(from_keys())
+  end
+
+  test "stops at the per-run deletion cap and does not advance past undeleted rows", %{storage_dir: _storage_dir} do
+    Application.put_env(:cache, :cache_artifacts_orphan_cleanup_max_deletes_per_run, 1)
+
+    inserted_ids =
+      Enum.map(1..3, fn i ->
+        %CacheArtifact{}
+        |> CacheArtifact.changeset(%{key: "acct/proj/xcode/ZZ/ZZ/orphan-#{i}", size_bytes: 1, last_accessed_at: old_timestamp()})
+        |> Ecto.Changeset.force_change(:inserted_at, old_timestamp())
+        |> Ecto.Changeset.force_change(:updated_at, old_timestamp())
+        |> Repo.insert!()
+        |> Map.fetch!(:id)
+      end)
+
+    assert :ok = CacheArtifactOrphanCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    remaining = Repo.aggregate(CacheArtifact, :count, :id)
+    # Cap=1, so exactly one orphan deleted and two still present
+    assert remaining == 2
+    # Cursor must not have advanced past the still-present rows, otherwise
+    # the next run would skip them
+    assert Application.get_env(:cache, @cursor_key) < List.last(inserted_ids)
   end
 
   test "advances the cursor so the next run continues from where it left off" do


### PR DESCRIPTION
## Summary

Adds `Cache.CacheArtifactOrphanCleanupWorker` — the symmetric counterpart to the existing `Cache.OrphanCleanupWorker`:

| Worker | What it finds | What it deletes |
|---|---|---|
| `OrphanCleanupWorker` (existing) | Files on disk with **no DB row** | The file |
| `CacheArtifactOrphanCleanupWorker` (new) | DB rows with **no file on disk** | The row |

Runs every 30 min. Cursor-based, batched (1 000 rows), time-budgeted (2 min/run), with a 1-hour age guard to avoid racing with just-buffered uploads. Ends each run with a bounded `PRAGMA incremental_vacuum` on `repo.sqlite` so the freed pages actually return to the filesystem.

## Context

`repo.sqlite` has no size cap and no self-pruning mechanism. It only shrinks indirectly when `DiskEvictionWorker` evicts files on `/cas` and cascades `CacheArtifacts.delete_by_keys`. On prod nodes where `/cas` sits well under the 85 % watermark, the `cache_artifacts` metadata table grows unbounded.

Observed fleet state today:

| Host | repo.sqlite |
|---|---|
| cache-eu-central | **114 GB** |
| cache-us-east | **61 GB** |
| cache-us-east-2 | 9.6 GB |
| (rest) | < 5 GB |

Neither of the two outliers is at ENOSPC risk yet, but the growth trend is unbounded and matches the pattern that caused the `cache-us-west` incident on the KV side.

## Design notes

- **Cursor is held in `Application` env**, not persisted to DB. On restart the scan begins from 0 again — idempotent, self-healing, and avoids a migration.
- **Age guard (1 h)** mirrors `OrphanCleanupWorker`'s `@min_age_seconds` so we never delete a row for an upload whose file hasn't yet flushed onto disk from our scanner's perspective.
- **Wrap behavior**: when we hit the end of the table, we reset the cursor to 0 and exit — the next cron run starts fresh rather than churning in a tight wrap-around loop on small tables.
- **Vacuum page count** (`@default_vacuum_pages 10_000`) is overrideable via `Application` env (`:cache_artifacts_orphan_cleanup_vacuum_pages`) for per-node tuning without a redeploy.

## Not in scope (follow-ups)

- Independent of PR #10390 (KV eviction under load). Both address unbounded growth on different SQLite DBs; they don't conflict.
- A dynamic cap on `/data` volume pressure is still outstanding.

## Test plan

- [ ] `mix test cache/test/cache/cache_artifact_orphan_cleanup_worker_test.exs` passes locally.
- [ ] Deploy to staging / canary. Verify `[:cache, :cache_artifacts, :orphan_cleanup, :complete]` telemetry shows non-zero `orphans_deleted` on a node with metadata-orphan backlog.
- [ ] On a heavy node (cache-eu-central), watch `repo.sqlite` file size trend down over a few days without user-visible latency regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)