### PR TITLE
fix(cli): error instead of silently ignoring mismatched test shard flags

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -33,6 +33,8 @@ public enum TestServiceError: FatalError, Equatable {
     case actionInvalid
     case testProductsNotFound
     case unspecifiedPlatform(target: String, platforms: [String])
+    case shardPlanningRequiresBuildOnly
+    case shardIndexRequiresWithoutBuilding
 
     // Error description
 
@@ -76,6 +78,12 @@ public enum TestServiceError: FatalError, Equatable {
         case let .unspecifiedPlatform(target, platforms):
             return
                 "Only single platform targets supported. The target \(target) specifies multiple supported platforms (\(platforms.joined(separator: ", ")))."
+        case .shardPlanningRequiresBuildOnly:
+            return
+                "Shard planning flags (--shard-min/--shard-max/--shard-total) only apply when building tests for sharding. Pass --build-only to create a shard plan, or remove the shard flag(s) to run tests normally."
+        case .shardIndexRequiresWithoutBuilding:
+            return
+                "--shard-index only applies when executing a previously built shard. Pass --without-building to run the shard, or remove --shard-index to run tests normally."
         }
     }
 
@@ -85,7 +93,8 @@ public enum TestServiceError: FatalError, Equatable {
         switch self {
         case .schemeNotFound, .schemeWithoutTestableTargets, .testPlanNotFound,
              .testIdentifierInvalid, .duplicatedTestTargets,
-             .nothingToSkip, .actionInvalid, .testProductsNotFound, .unspecifiedPlatform:
+             .nothingToSkip, .actionInvalid, .testProductsNotFound, .unspecifiedPlatform,
+             .shardPlanningRequiresBuildOnly, .shardIndexRequiresWithoutBuilding:
             return .abort
         }
     }
@@ -240,6 +249,15 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 skipTestTargets: skipTestTargets
             )
         }
+
+        let isSharding = shardMin != nil || shardMax != nil || shardTotal != nil
+        if isSharding, action != .build {
+            throw TestServiceError.shardPlanningRequiresBuildOnly
+        }
+        if shardIndex != nil, action != .testWithoutBuilding {
+            throw TestServiceError.shardIndexRequiresWithoutBuilding
+        }
+
         // Load config
         let config = try await configLoader.loadConfig(path: path)
             .assertingIsGeneratedProjectOrSwiftPackage(
@@ -363,8 +381,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
             passedResultBundlePath: passedResultBundlePath,
             config: config
         )
-
-        let isSharding = shardMin != nil || shardMax != nil || shardTotal != nil
 
         let schemes: [Scheme]
         if let schemeName {

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -373,6 +373,32 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_throws_when_shard_planning_flags_are_passed_without_build_only() async throws {
+        await XCTAssertThrowsSpecific(
+            {
+                try await testRun(
+                    path: try temporaryPath(),
+                    action: .test,
+                    shardTotal: 5
+                )
+            },
+            TestServiceError.shardPlanningRequiresBuildOnly
+        )
+    }
+
+    func test_throws_when_shard_index_is_passed_without_without_building() async throws {
+        await XCTAssertThrowsSpecific(
+            {
+                try await testRun(
+                    path: try temporaryPath(),
+                    action: .test,
+                    shardIndex: 0
+                )
+            },
+            TestServiceError.shardIndexRequiresWithoutBuilding
+        )
+    }
+
     func test_throws_an_error_when_config_is_not_for_generated_project() async throws {
         // Given
         givenGenerator()

--- a/server/priv/docs/en/guides/features/test-sharding/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-sharding/generated-projects.md
@@ -29,8 +29,10 @@ Test sharding follows a two-phase workflow:
 Generate your project, build your tests, and create a shard plan:
 
 ```sh
-tuist test --shard-total 5
+tuist test --build-only --shard-total 5
 ```
+
+The `--build-only` flag tells Tuist to build the tests without running them. Tuist errors out if you pass shard planning flags (`--shard-min`/`--shard-max`/`--shard-total`) without `--build-only`.
 
 This command:
 1. Generates the Xcode project from your manifests
@@ -57,8 +59,10 @@ This command:
 Each shard runner executes its assigned tests:
 
 ```sh
-tuist test
+tuist test --without-building
 ```
+
+The `--without-building` flag tells Tuist to run the tests using the previously built products instead of rebuilding. Tuist errors out if `TUIST_SHARD_INDEX` / `--shard-index` is set without `--without-building`.
 
 ### Test options {#test-options}
 
@@ -108,7 +112,7 @@ jobs:
       - uses: jdx/mise-action@v2
       - run: tuist auth login
       - id: build
-        run: tuist test --shard-total 5
+        run: tuist test --build-only --shard-total 5
 
   test:
     name: "Shard #${{ matrix.shard }}"
@@ -125,7 +129,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
       - run: tuist auth login
-      - run: tuist test
+      - run: tuist test --without-building
 ```
 
 ### GitLab CI {#gitlab-ci}
@@ -143,7 +147,7 @@ build-shards:
   tags: [macos]
   script:
     - tuist auth login
-    - tuist test --shard-total 5
+    - tuist test --build-only --shard-total 5
   artifacts:
     paths:
       - .tuist-shard-child-pipeline.yml
@@ -164,7 +168,7 @@ test-shards:
   tags: [macos]
   script:
     - tuist auth login
-    - tuist test
+    - tuist test --without-building
 ```
 
 ### CircleCI {#circleci}
@@ -189,7 +193,7 @@ jobs:
           name: Build and plan shards
           command: |
             tuist auth login
-            tuist test --shard-total 5
+            tuist test --build-only --shard-total 5
       - continuation/continue:
           configuration_path: .circleci/continue-config.yml
           parameters: .tuist-shard-continuation.json
@@ -226,7 +230,7 @@ jobs:
           command: |
             export TUIST_SHARD_INDEX=<< parameters.shard-index >>
             tuist auth login
-            tuist test
+            tuist test --without-building
 
 workflows:
   test:
@@ -247,7 +251,7 @@ steps:
   - label: "Build test shards"
     command: |
       tuist auth login
-      tuist test --shard-total 5
+      tuist test --build-only --shard-total 5
       buildkite-agent pipeline upload .tuist-shard-pipeline.yml
     agents:
       queue: macos
@@ -259,7 +263,7 @@ Each generated step has `TUIST_SHARD_INDEX` set in its environment. Add the test
 # .buildkite/shard-step.sh
 #!/bin/bash
 tuist auth login
-tuist test
+tuist test --without-building
 ```
 
 ### Codemagic {#codemagic}
@@ -278,7 +282,7 @@ workflows:
       - name: Build and plan shards
         script: |
           tuist auth login
-          tuist test --shard-total 5
+          tuist test --build-only --shard-total 5
 
   test-shard-0: &shard-workflow
     name: "Shard #0"
@@ -291,7 +295,7 @@ workflows:
       - name: Run shard
         script: |
           tuist auth login
-          tuist test
+          tuist test --without-building
 
   test-shard-1:
     <<: *shard-workflow
@@ -358,7 +362,7 @@ workflows:
           inputs:
             - content: |
                 tuist auth login
-                tuist test --shard-total 5
+                tuist test --build-only --shard-total 5
 
   test-shard-0: &shard-workflow
     envs:
@@ -369,7 +373,7 @@ workflows:
           inputs:
             - content: |
                 tuist auth login
-                tuist test
+                tuist test --without-building
   test-shard-1:
     <<: *shard-workflow
     envs:
@@ -403,6 +407,7 @@ To use shared volumes:
 
 ```sh
 tuist test \
+  --build-only \
   --shard-total 5 \
   --shard-skip-upload \
   -- \
@@ -412,7 +417,7 @@ tuist test \
 2. In the **test phase**, pass the same `-testProductsPath` so Tuist reads the test products locally instead of downloading them:
 
 ```sh
-tuist test -- -testProductsPath /path/to/shared/volume/$UNIQUE_ID/MyScheme.xctestproducts
+tuist test --without-building -- -testProductsPath /path/to/shared/volume/$UNIQUE_ID/MyScheme.xctestproducts
 ```
 
 | Flag | Environment variable | Description |
@@ -427,6 +432,7 @@ If your CI provider already has artifact upload and download steps, you can let 
 
 ```sh
 tuist test \
+  --build-only \
   --shard-total 5 \
   --shard-archive-path /tmp/shards/${UNIQUE_ID}/bundle.aar
 ```
@@ -437,6 +443,7 @@ tuist test \
 
 ```sh
 tuist test \
+  --without-building \
   --shard-archive-path /tmp/shards/${UNIQUE_ID}/bundle.aar
 ```
 
@@ -467,7 +474,7 @@ jobs:
       - uses: jdx/mise-action@v2
       - run: tuist auth login
       - id: build
-        run: tuist test --shard-total 5
+        run: tuist test --build-only --shard-total 5
       - uses: actions/upload-artifact@v4
         with:
           name: test-shard-archive
@@ -494,7 +501,7 @@ jobs:
         with:
           name: test-shard-archive
           path: /tmp/shards/${{ github.run_id }}
-      - run: tuist test
+      - run: tuist test --without-building
       - if: always()
         run: rm -rf /tmp/shards/${{ github.run_id }}
 ```


### PR DESCRIPTION
### Purpose

`tuist test` silently ignored test-sharding flags when the required action flag was missing:

- Passing `--shard-total` / `--shard-min` / `--shard-max` without `--build-only` skipped shard planning and ran the default test action.
- Passing `--shard-index` (or `TUIST_SHARD_INDEX`) without `--without-building` ran the full test suite instead of the assigned shard.

This made the generated-projects test-sharding docs misleading — users who followed the snippets verbatim ended up running the full suite on every shard runner.

### Change

`TestService.run()` now throws early when the shard flags don't match the action, reusing the existing `isSharding` check:

- `shard-min/max/total` set with `action != .build` → `TestServiceError.shardPlanningRequiresBuildOnly`
- `shard-index` set with `action != .testWithoutBuilding` → `TestServiceError.shardIndexRequiresWithoutBuilding`

The `server/priv/docs/en/guides/features/test-sharding/generated-projects.md` snippets (all CI provider examples, shared-volume and self-managed sections) now include the required `--build-only` / `--without-building` flag, and the inline notes describe the new throw-on-mismatch behavior.

### How to test locally

From `cli/`:

```sh
# Should error with a clear message pointing at --build-only:
tuist test --shard-total 5

# Should error with a clear message pointing at --without-building:
TUIST_SHARD_INDEX=0 tuist test

# Should work as before:
tuist test --build-only --shard-total 5
TUIST_SHARD_INDEX=0 tuist test --without-building
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)