### PR TITLE
fix(server): make AddStateToTestCases migration idempotent

### DIFF
--- a/server/priv/ingest_repo/migrations/20260410120000_add_state_to_test_cases.exs
+++ b/server/priv/ingest_repo/migrations/20260410120000_add_state_to_test_cases.exs
@@ -1,19 +1,24 @@
 defmodule Tuist.IngestRepo.Migrations.AddStateToTestCases do
   use Ecto.Migration
 
-  # The is_quarantined column is left in place here so this PR is non-destructive.
-  # A follow-up migration drops it once this change has shipped and soaked.
+  # Uses raw ALTER TABLE ... ADD COLUMN IF NOT EXISTS so the migration is
+  # idempotent. ClickHouse doesn't treat DDL as transactional, so if a prior
+  # run added the column but then failed (network blip, replica out of sync,
+  # schema_migrations never got the insert), re-running the migration needs
+  # to succeed rather than crash with DUPLICATE_COLUMN.
+  #
+  # The legacy `is_quarantined` column is left in place so this migration is
+  # non-destructive. A follow-up migration drops it once this change has
+  # shipped and soaked.
   def up do
-    alter table(:test_cases) do
-      add :state, :"LowCardinality(String)", default: "enabled"
-    end
+    execute(
+      "ALTER TABLE test_cases ADD COLUMN IF NOT EXISTS state LowCardinality(String) DEFAULT 'enabled'"
+    )
 
     execute("ALTER TABLE test_cases UPDATE state = 'muted' WHERE is_quarantined = true")
   end
 
   def down do
-    alter table(:test_cases) do
-      remove :state
-    end
+    execute("ALTER TABLE test_cases DROP COLUMN IF EXISTS state")
   end
 end

--- a/server/priv/ingest_repo/migrations/20260410120001_create_automation_alert_events.exs
+++ b/server/priv/ingest_repo/migrations/20260410120001_create_automation_alert_events.exs
@@ -1,31 +1,34 @@
 defmodule Tuist.IngestRepo.Migrations.CreateAutomationAlertEvents do
   use Ecto.Migration
 
+  # Raw SQL with IF NOT EXISTS so the migration is idempotent — see
+  # 20260410120000_add_state_to_test_cases.exs for the rationale (ClickHouse
+  # DDL is non-transactional, so partial runs must be recoverable).
   def up do
-    create table(:automation_alert_events,
-             primary_key: false,
-             engine: "MergeTree()",
-             options: "ORDER BY (alert_id, test_case_id, inserted_at)"
-           ) do
-      add :id, :uuid, null: false
-      add :alert_id, :uuid, null: false
-      add :test_case_id, :uuid, null: false
-      add :status, :"LowCardinality(String)", null: false, default: "triggered"
-      add :triggered_at, :"DateTime64(6)", null: false
-      add :recovered_at, :"Nullable(DateTime64(6))"
-      add :inserted_at, :"DateTime64(6)", default: fragment("now()")
-    end
+    execute("""
+    CREATE TABLE IF NOT EXISTS automation_alert_events (
+      id UUID,
+      alert_id UUID,
+      test_case_id UUID,
+      status LowCardinality(String) DEFAULT 'triggered',
+      triggered_at DateTime64(6),
+      recovered_at Nullable(DateTime64(6)),
+      inserted_at DateTime64(6) DEFAULT now()
+    )
+    ENGINE = MergeTree()
+    ORDER BY (alert_id, test_case_id, inserted_at)
+    """)
 
     execute(
-      "ALTER TABLE automation_alert_events ADD INDEX idx_alert_id (alert_id) TYPE bloom_filter GRANULARITY 4"
+      "ALTER TABLE automation_alert_events ADD INDEX IF NOT EXISTS idx_alert_id (alert_id) TYPE bloom_filter GRANULARITY 4"
     )
 
     execute(
-      "ALTER TABLE automation_alert_events ADD INDEX idx_test_case_id (test_case_id) TYPE bloom_filter GRANULARITY 4"
+      "ALTER TABLE automation_alert_events ADD INDEX IF NOT EXISTS idx_test_case_id (test_case_id) TYPE bloom_filter GRANULARITY 4"
     )
   end
 
   def down do
-    drop table(:automation_alert_events)
+    execute("DROP TABLE IF EXISTS automation_alert_events")
   end
 end

--- a/server/priv/ingest_repo/migrations/20260422120000_add_denormalized_fields_to_test_module_and_suite_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120000_add_denormalized_fields_to_test_module_and_suite_runs.exs
@@ -8,22 +8,41 @@ defmodule Tuist.IngestRepo.Migrations.AddDenormalizedFieldsToTestModuleAndSuiteR
   from `test_runs` and a follow-up migration marks them non-nullable once
   backfill is verified. Same pattern used for `test_case_runs` in
   20251127103046_add_denormalized_fields_to_test_case_runs.exs.
+
+  Raw `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` instead of the Ecto DSL so
+  the migration is idempotent on re-run. See 20260410120000 for context.
   """
   use Ecto.Migration
 
-  def change do
-    alter table(:test_module_runs) do
-      add :project_id, :"Nullable(Int64)"
-      add :is_ci, :Bool, default: false
-      add :git_branch, :String, default: ""
-      add :ran_at, :"Nullable(DateTime64(6))"
-    end
+  def up do
+    for {table, column, type, default} <- [
+          {"test_module_runs", "project_id", "Nullable(Int64)", nil},
+          {"test_module_runs", "is_ci", "Bool", "false"},
+          {"test_module_runs", "git_branch", "String", "''"},
+          {"test_module_runs", "ran_at", "Nullable(DateTime64(6))", nil},
+          {"test_suite_runs", "project_id", "Nullable(Int64)", nil},
+          {"test_suite_runs", "is_ci", "Bool", "false"},
+          {"test_suite_runs", "git_branch", "String", "''"},
+          {"test_suite_runs", "ran_at", "Nullable(DateTime64(6))", nil}
+        ] do
+      default_clause = if default, do: " DEFAULT #{default}", else: ""
 
-    alter table(:test_suite_runs) do
-      add :project_id, :"Nullable(Int64)"
-      add :is_ci, :Bool, default: false
-      add :git_branch, :String, default: ""
-      add :ran_at, :"Nullable(DateTime64(6))"
+      execute("ALTER TABLE #{table} ADD COLUMN IF NOT EXISTS #{column} #{type}#{default_clause}")
+    end
+  end
+
+  def down do
+    for {table, column} <- [
+          {"test_module_runs", "project_id"},
+          {"test_module_runs", "is_ci"},
+          {"test_module_runs", "git_branch"},
+          {"test_module_runs", "ran_at"},
+          {"test_suite_runs", "project_id"},
+          {"test_suite_runs", "is_ci"},
+          {"test_suite_runs", "git_branch"},
+          {"test_suite_runs", "ran_at"}
+        ] do
+      execute("ALTER TABLE #{table} DROP COLUMN IF EXISTS #{column}")
     end
   end
 end

--- a/server/priv/ingest_repo/migrations/20260422120003_add_project_filter_projection_to_test_module_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120003_add_project_filter_projection_to_test_module_runs.exs
@@ -21,10 +21,12 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectFilterProjectionToTestModuleRuns
     MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
     """
 
+    # IF NOT EXISTS so re-runs are no-ops (CH DDL isn't transactional; see
+    # 20260410120000 for context).
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE test_module_runs
-    ADD PROJECTION proj_by_project_is_ci_branch_ran_at (
+    ADD PROJECTION IF NOT EXISTS proj_by_project_is_ci_branch_ran_at (
       SELECT *
       ORDER BY project_id, is_ci, git_branch, ran_at
     )

--- a/server/priv/ingest_repo/migrations/20260422120005_add_project_filter_projection_to_test_suite_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260422120005_add_project_filter_projection_to_test_suite_runs.exs
@@ -13,10 +13,12 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectFilterProjectionToTestSuiteRuns 
     MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
     """
 
+    # IF NOT EXISTS so re-runs are no-ops (CH DDL isn't transactional; see
+    # 20260410120000 for context).
     # excellent_migrations:safety-assured-for-next-line raw_sql_executed
     execute """
     ALTER TABLE test_suite_runs
-    ADD PROJECTION proj_by_project_is_ci_branch_ran_at (
+    ADD PROJECTION IF NOT EXISTS proj_by_project_is_ci_branch_ran_at (
       SELECT *
       ORDER BY project_id, is_ci, git_branch, ran_at
     )


### PR DESCRIPTION
## Summary

The `20260410120000_add_state_to_test_cases` migration (landed in #10232) crashes on re-run with:

```
** (Ch.Error) Code: 15. DB::Exception: Cannot add column `state`: column with this name already exists. (DUPLICATE_COLUMN)
```

Root cause: the original migration used the Ecto DSL (`alter table ... add :state`) which emits plain `ALTER TABLE ... ADD COLUMN` without `IF NOT EXISTS`. ClickHouse DDL isn't transactional, so if the column gets added but the migration runner never records the row in `schema_migrations` (network blip, replica out of sync, mid-deploy crash), the next run crashes rather than becoming a no-op.

The audit then turned up four more recently-landed ClickHouse migrations with the same pattern — any of which could crash a re-run in the same way — so fixing them together while the reasoning is fresh.

## Migrations covered

1. **`20260410120000_add_state_to_test_cases`** (PR #10232)
   `ALTER TABLE ... ADD COLUMN` → `ADD COLUMN IF NOT EXISTS`; `down` now `DROP COLUMN IF EXISTS`.

2. **`20260410120001_create_automation_alert_events`** (PR #10232)
   `create table(...)` (plain CREATE TABLE) + two `ALTER TABLE ... ADD INDEX` → `CREATE TABLE IF NOT EXISTS` + `ADD INDEX IF NOT EXISTS`; `down` now `DROP TABLE IF EXISTS`.

3. **`20260422120000_add_denormalized_fields_to_test_module_and_suite_runs`** (PR #10383)
   Eight `alter table ... add ...` calls across two tables → `ADD COLUMN IF NOT EXISTS`; `down` now `DROP COLUMN IF EXISTS`.

4. **`20260422120003_add_project_filter_projection_to_test_module_runs`** (PR #10383)
   `ADD PROJECTION` → `ADD PROJECTION IF NOT EXISTS`. The preceding `MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'` is already idempotent.

5. **`20260422120005_add_project_filter_projection_to_test_suite_runs`** (PR #10383)
   Same fix as #4.

## Non-changes

- **Materialize-projection migrations (`20260422120004`, `20260422120006`)** — `MATERIALIZE PROJECTION` is naturally idempotent (re-runs just re-materialize the parts).
- **Backfill migrations (`20260422120001`, `20260422120002`)** — already start with `DROP DICTIONARY IF EXISTS` and the `ALTER TABLE ... UPDATE ... WHERE project_id IS NULL` mutation is idempotent by construction.
- **`20260416080607_create_test_run_destinations_table`** — already uses raw `CREATE TABLE IF NOT EXISTS`.

## Test plan

Reproduced the exact `DUPLICATE_COLUMN` failure against the local dev ClickHouse with plain `ADD COLUMN`, then verified each rewritten statement is a no-op when the target already exists:

- [x] `ADD COLUMN IF NOT EXISTS` — ran against a column that exists → success (0 rows changed)
- [x] `ADD INDEX IF NOT EXISTS` — same → success
- [x] `ADD PROJECTION IF NOT EXISTS` (with `deduplicate_merge_projection_mode = 'rebuild'` set first) — same → success
- [x] `CREATE TABLE IF NOT EXISTS` — same → success
- [x] Fresh `mix ecto.migrate -r Tuist.IngestRepo` from an empty ClickHouse applies the migrations cleanly
- [x] Re-running plain (pre-fix) `ADD COLUMN state ...` reproduces the exact error reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)