### PR TITLE
ci(server): add on-demand Kubernetes deploy workflow for the server

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1,0 +1,186 @@
+name: Server Deployment
+
+# On-demand build + deploy of the Tuist server to a Kubernetes environment.
+#
+# Ships intentionally lean for the migration runway:
+#   - workflow_dispatch only — no push-to-main trigger yet. The existing
+#     Render-based server-{staging,canary,production}-deployment.yml
+#     workflows still handle merges; they'll retire when we cut over.
+#   - No canary → acceptance-tests → production promotion cascade yet;
+#     that lands once the managed Kubernetes setup is validated on
+#     staging.
+#
+# Each environment is its own Kubernetes namespace. The image is rebuilt
+# per env so Mix.env() and the encrypted priv/secrets/<env>.yml.enc baked
+# in match.
+#
+# Required GitHub Environment secrets on server-k8s-{staging,canary,
+# production}:
+#   KUBECONFIG — base64-encoded kubeconfig for that environment's cluster.
+# App secrets live inside the cluster (MASTER_KEY via ESO, DATABASE_URL /
+# ClickHouse / Tigris keys in priv/secrets/<env>.yml.enc baked into the
+# image).
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - canary
+          - production
+      commit_sha:
+        description: Commit SHA to deploy (defaults to the event's SHA)
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/tuist
+  HELM_CHART_PATH: infra/helm/tuist
+  HELM_RELEASE_NAME: tuist
+  DEPLOY_SHA: ${{ inputs.commit_sha || github.sha }}
+
+jobs:
+  plan:
+    name: Plan (${{ inputs.environment }})
+    runs-on: namespace-profile-default
+    outputs:
+      mix_env: ${{ steps.map.outputs.mix_env }}
+      namespace: ${{ steps.map.outputs.namespace }}
+      image_tag: ${{ steps.map.outputs.image_tag }}
+      values_overlay: ${{ steps.map.outputs.values_overlay }}
+      public_host: ${{ steps.map.outputs.public_host }}
+      environment_key: ${{ steps.map.outputs.environment_key }}
+    steps:
+      - id: map
+        env:
+          TARGET_ENV: ${{ inputs.environment }}
+        run: |
+          case "$TARGET_ENV" in
+            staging)
+              env_key=staging
+              mix_env=stag
+              namespace=tuist-staging
+              overlay=values-managed-staging.yaml
+              host=staging.tuist.dev
+              ;;
+            canary)
+              env_key=canary
+              mix_env=can
+              namespace=tuist-canary
+              overlay=values-managed-canary.yaml
+              host=canary.tuist.dev
+              ;;
+            production)
+              env_key=production
+              mix_env=prod
+              namespace=tuist
+              overlay=values-managed-production.yaml
+              host=tuist.dev
+              ;;
+            *)
+              echo "Unknown environment: $TARGET_ENV" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "environment_key=$env_key"
+            echo "mix_env=$mix_env"
+            echo "namespace=$namespace"
+            echo "values_overlay=$overlay"
+            echo "public_host=$host"
+            echo "image_tag=${TARGET_ENV}-sha-${DEPLOY_SHA:0:12}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build + push image (${{ inputs.environment }})
+    needs: plan
+    runs-on: namespace-profile-default-with-volume
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          submodules: false
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile
+          target: runner
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.image_tag }}
+          build-args: |
+            TUIST_HOSTED=1
+            MIX_ENV=${{ needs.plan.outputs.mix_env }}
+            APT_CACHE_BUST=${{ env.DEPLOY_SHA }}
+          # Scope BuildKit cache per Mix env so staging/canary/production
+          # builds don't invalidate each other's layers.
+          cache-from: type=gha,scope=${{ needs.plan.outputs.mix_env }}
+          cache-to: type=gha,mode=max,scope=${{ needs.plan.outputs.mix_env }}
+
+  deploy:
+    name: Deploy to ${{ needs.plan.outputs.namespace }}
+    needs: [plan, build]
+    runs-on: namespace-profile-default
+    environment:
+      name: server-k8s-${{ needs.plan.outputs.environment_key }}
+      url: https://${{ needs.plan.outputs.public_host }}
+    # Serialize deploys targeting the same environment so two concurrent
+    # runs don't race on the Helm release.
+    concurrency:
+      group: server-deploy-${{ needs.plan.outputs.environment_key }}
+      cancel-in-progress: false
+    timeout-minutes: 30
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load kubeconfig
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: helm upgrade --install
+        # App secrets never pass through --set: the chart runs in
+        # `server.managedSecrets: true` mode, which reads DATABASE_URL /
+        # TUIST_CLICKHOUSE_URL / TUIST_S3_* from priv/secrets/<env>.yml.enc
+        # baked into the image and pulls MASTER_KEY from 1Password via an
+        # in-cluster ExternalSecret. Passing secrets through --set would
+        # leak them into `helm get manifest`.
+        run: |
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "${{ needs.plan.outputs.namespace }}" --create-namespace \
+            -f "$HELM_CHART_PATH/values-managed-common.yaml" \
+            -f "$HELM_CHART_PATH/${{ needs.plan.outputs.values_overlay }}" \
+            --set server.image.tag="${{ needs.plan.outputs.image_tag }}" \
+            --atomic --timeout 15m --wait
+      - name: Post-deploy smoke test
+        run: |
+          kubectl -n "${{ needs.plan.outputs.namespace }}" rollout status deploy/tuist-tuist-server --timeout=10m
+          kubectl -n "${{ needs.plan.outputs.namespace }}" run smoke-$RANDOM --rm -i --restart=Never --image=curlimages/curl \
+            --command -- curl -fsS "http://tuist-tuist-server/ready"


### PR DESCRIPTION
## Summary

Ships the build-and-deploy path the Kubernetes migration needs, split out from the larger [#10368](https://github.com/tuist/tuist/pull/10368) so it can land independently.

A single `.github/workflows/server-deployment.yml` with three jobs: **plan → build → deploy**.

- Builds `ghcr.io/tuist/tuist:<env>-sha-<short12>` from the `runner` Dockerfile target with `TUIST_HOSTED=1` and per-env `MIX_ENV` (`staging=stag` / `canary=can` / `production=prod`), so the release decrypts the right `priv/secrets/<env>.yml.enc`.
- Deploys via `helm upgrade --install` against the target GitHub Environment's `KUBECONFIG` secret. App secrets (DATABASE_URL, ClickHouse, Tigris) live inside the image; `MASTER_KEY` syncs from 1Password through ESO — none of them pass through `--set`.

## Why not add it to an existing workflow?

The workflows already on main serve different purposes:

- `server.yml` — PR sanity check, `push: false`
- `release.yml` — builds `runner-selfhosted` with `TUIST_HOSTED=0` / `MIX_ENV=prod` for public Helm users. Different Dockerfile target, different build-args, different tag cadence.
- `server-{staging,canary,production}-deployment.yml` — trigger Render via its CLI; the image never enters GHCR.

None of them build `runner` + `TUIST_HOSTED=1` + per-env `MIX_ENV` + push to GHCR with per-SHA tags.

## Deliberately out of scope

- **No push-to-main trigger.** The Render deploys keep handling merges. They retire in the big migration PR.
- **No canary → acceptance-tests → production cascade.** Lands once we've validated the managed Kubernetes setup end-to-end on staging.
- **No deletions of existing workflows.**

## Test plan

- [ ] After merge, Actions shows "Server Deployment" with a Run workflow button
- [ ] Run workflow → `environment=staging` → job succeeds
- [ ] Image appears at `ghcr.io/tuist/tuist:staging-sha-<short12>`
- [ ] Helm release `tuist` in namespace `tuist-staging` is installed/upgraded on the target cluster (requires `KUBECONFIG` set on the `server-k8s-staging` Environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)