### PR TITLE
fix(server): exercise repeated-header branch in HeadersTest correctly

### DIFF
--- a/server/test/tuist_web/headers_test.exs
+++ b/server/test/tuist_web/headers_test.exs
@@ -41,10 +41,13 @@ defmodule TuistWeb.HeadersTest do
     end
 
     test "returns normalized client feature flags from repeated header values", %{conn: conn} do
+      # `Plug.Conn.put_req_header/3` replaces the existing value for a key, so
+      # we have to write the header tuples onto `req_headers` directly to
+      # simulate the repeated-header case the parser is meant to support.
+      header = Headers.client_feature_flags_header()
+
       conn =
-        conn
-        |> Plug.Conn.put_req_header(Headers.client_feature_flags_header(), "A, b")
-        |> Plug.Conn.put_req_header(Headers.client_feature_flags_header(), " c , a")
+        update_in(conn.req_headers, &(&1 ++ [{header, "A, b"}, {header, " c , a"}]))
 
       assert Headers.get_client_feature_flags(conn) == MapSet.new(["A", "B", "C"])
     end


### PR DESCRIPTION
## Summary

The `get_client_feature_flags/1 returns normalized client feature flags from repeated header values` test has been failing on `main` since [#10382](https://github.com/tuist/tuist/pull/10382) merged:

```
left:  MapSet.new([\"A\", \"C\"])
right: MapSet.new([\"A\", \"B\", \"C\"])
```

Root cause is in the test, not the parser. `Plug.Conn.put_req_header/3` replaces the existing value for a header key — it doesn't append — so the two sequential calls leave the conn with only the second string (`\" c , a\"`). The parser's `is_list` branch never ran, and the expected `\"B\"` was never in the header data to be matched.

Fix by writing the tuples onto `conn.req_headers` directly so the conn actually carries two values under the same header key, matching the `decode_client_feature_flags/1` list-path the test is meant to cover.

## How to test locally

- [ ] `mix test test/tuist_web/headers_test.exs` — 8 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)