### PR TITLE
fix(server): widen bundle size columns to bigint

### DIFF
--- a/server/priv/repo/migrations/20260423151657_widen_bundle_size_columns_to_bigint.exs
+++ b/server/priv/repo/migrations/20260423151657_widen_bundle_size_columns_to_bigint.exs
@@ -1,0 +1,31 @@
+defmodule Tuist.Repo.Migrations.WidenBundleSizeColumnsToBigint do
+  use Ecto.Migration
+
+  def up do
+    alter table(:bundles) do
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :install_size, :bigint, null: false, from: {:integer, null: false}
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :download_size, :bigint, from: :integer
+    end
+
+    alter table(:artifacts) do
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :size, :bigint, null: false, from: {:integer, null: false}
+    end
+  end
+
+  def down do
+    alter table(:artifacts) do
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :size, :integer, null: false, from: {:bigint, null: false}
+    end
+
+    alter table(:bundles) do
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :download_size, :integer, from: :bigint
+      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      modify :install_size, :integer, null: false, from: {:bigint, null: false}
+    end
+  end
+end

--- a/server/priv/repo/migrations/20260423151657_widen_bundle_size_columns_to_bigint.exs
+++ b/server/priv/repo/migrations/20260423151657_widen_bundle_size_columns_to_bigint.exs
@@ -3,28 +3,28 @@ defmodule Tuist.Repo.Migrations.WidenBundleSizeColumnsToBigint do
 
   def up do
     alter table(:bundles) do
-      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      # excellent_migrations:safety-assured-for-next-line column_type_changed not_null_added
       modify :install_size, :bigint, null: false, from: {:integer, null: false}
       # excellent_migrations:safety-assured-for-next-line column_type_changed
       modify :download_size, :bigint, from: :integer
     end
 
     alter table(:artifacts) do
-      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      # excellent_migrations:safety-assured-for-next-line column_type_changed not_null_added
       modify :size, :bigint, null: false, from: {:integer, null: false}
     end
   end
 
   def down do
     alter table(:artifacts) do
-      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      # excellent_migrations:safety-assured-for-next-line column_type_changed not_null_added
       modify :size, :integer, null: false, from: {:bigint, null: false}
     end
 
     alter table(:bundles) do
       # excellent_migrations:safety-assured-for-next-line column_type_changed
       modify :download_size, :integer, from: :bigint
-      # excellent_migrations:safety-assured-for-next-line column_type_changed
+      # excellent_migrations:safety-assured-for-next-line column_type_changed not_null_added
       modify :install_size, :integer, null: false, from: {:bigint, null: false}
     end
   end


### PR DESCRIPTION
## Summary

A customer ([Sentry TUIST-BQ](https://tuist.sentry.io/issues/114539331/)) hit `DBConnection.EncodeError: Postgrex expected an integer in -2147483648..2147483647, got 2472860772` when uploading a ~2.36 GB bundle via `POST /api/projects/:account/:project/bundles`.

The offending byte-size columns have been typed `:integer` (Postgres int4, max 2,147,483,647) since the initial `bundles` migration. Bundles/artifacts larger than 2 GB overflow that range. This widens them to `:bigint`:

- `bundles.install_size`: `integer` → `bigint`
- `bundles.download_size`: `integer` → `bigint`
- `artifacts.size`: `integer` → `bigint`

Ecto's `field :_, :integer` maps to both int4 and int8 transparently, so no schema / code changes outside the migration are needed.

### Operational note

`ALTER COLUMN ... TYPE bigint` rewrites the table and holds `ACCESS EXCLUSIVE` for the duration. `bundles` is small enough this is trivial; `artifacts` has one row per file per bundle and may be larger — worth running during a low-traffic window. If the lock duration is unacceptable, we can switch to an add-new-column / backfill / swap pattern in a follow-up.

### How to test locally

```bash
cd server
mix ecto.migrate
# verify column types
psql $DATABASE_URL -c "\d bundles" | grep -E "install_size|download_size"
psql $DATABASE_URL -c "\d artifacts" | grep " size "
# expect: bigint
mix ecto.rollback
# verify revert to integer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)