### PR TITLE
fix(cli): propagate default-enabled Swift package traits

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -226,7 +226,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         )
 
         let packageInfoDictionaryById = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.id, $0.info) })
-        let enabledTraitsPerPackage = enabledTraits(
+        let enabledTraitsPerPackage = Self.enabledTraits(
             rootPackageInfo: rootPackage,
             packageInfos: packageInfoDictionaryById
         )
@@ -277,7 +277,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         isLocalDependencyKind(kind) ? .local : .remote
     }
 
-    private func enabledTraits(
+    static func enabledTraits(
         rootPackageInfo: PackageInfo,
         packageInfos: [String: PackageInfo]
     ) -> [String: Set<String>] {
@@ -303,7 +303,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         return result
     }
 
-    private func processTraits(
+    private static func processTraits(
         from dependencies: [PackageDependency],
         enabledTraitsForCurrentPackage: Set<String>,
         packageInfos: [String: PackageInfo],
@@ -330,7 +330,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         }
     }
 
-    private func resolvedEnabledTraits(
+    private static func resolvedEnabledTraits(
         _ traitNames: some Collection<String>,
         packageTraits: [PackageTrait]
     ) -> Set<String> {
@@ -345,7 +345,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         return resolvedTraitNames
     }
 
-    private func resolveEnabledTraitNames(
+    private static func resolveEnabledTraitNames(
         _ traitNames: some Collection<String>,
         packageTraits: [PackageTrait],
         into resolvedTraitNames: inout Set<String>

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -277,6 +277,95 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         isLocalDependencyKind(kind) ? .local : .remote
     }
 
+    private func enabledTraits(
+        rootPackageInfo: PackageInfo,
+        packageInfos: [String: PackageInfo]
+    ) -> [String: Set<String>] {
+        var result: [String: Set<String>] = [:]
+
+        processTraits(
+            from: rootPackageInfo.dependencies,
+            enabledTraitsForCurrentPackage: [],
+            packageInfos: packageInfos,
+            result: &result
+        )
+
+        for (packageId, packageInfo) in packageInfos {
+            let enabledForThisPackage = result[packageId] ?? []
+            processTraits(
+                from: packageInfo.dependencies,
+                enabledTraitsForCurrentPackage: enabledForThisPackage,
+                packageInfos: packageInfos,
+                result: &result
+            )
+        }
+
+        return result
+    }
+
+    private func processTraits(
+        from dependencies: [PackageDependency],
+        enabledTraitsForCurrentPackage: Set<String>,
+        packageInfos: [String: PackageInfo],
+        result: inout [String: Set<String>]
+    ) {
+        for dependency in dependencies {
+            let enabledTraits = dependency.traits.reduce(into: Set<String>()) { result, trait in
+                if let condition = trait.condition {
+                    if !condition.isDisjoint(with: enabledTraitsForCurrentPackage) {
+                        result.insert(trait.name)
+                    }
+                } else {
+                    result.insert(trait.name)
+                }
+            }
+
+            let resolvedTraits = resolvedEnabledTraits(
+                enabledTraits,
+                packageTraits: packageInfos[dependency.identity]?.traits ?? []
+            )
+
+            guard !resolvedTraits.isEmpty else { continue }
+            result[dependency.identity, default: []].formUnion(resolvedTraits)
+        }
+    }
+
+    private func resolvedEnabledTraits(
+        _ traitNames: some Collection<String>,
+        packageTraits: [PackageTrait]
+    ) -> Set<String> {
+        var resolvedTraitNames = Set(traitNames)
+
+        resolveEnabledTraitNames(
+            resolvedTraitNames,
+            packageTraits: packageTraits,
+            into: &resolvedTraitNames
+        )
+
+        return resolvedTraitNames
+    }
+
+    private func resolveEnabledTraitNames(
+        _ traitNames: some Collection<String>,
+        packageTraits: [PackageTrait],
+        into resolvedTraitNames: inout Set<String>
+    ) {
+        for traitName in traitNames {
+            guard let trait = packageTraits.first(where: { $0.name == traitName }) else {
+                continue
+            }
+
+            for enabledTrait in trait.enabledTraits {
+                guard resolvedTraitNames.insert(enabledTrait).inserted else { continue }
+                resolveEnabledTraitNames(
+                    [enabledTrait],
+                    packageTraits: packageTraits,
+                    into: &resolvedTraitNames
+                )
+            }
+        }
+    }
+
     private func validatePackageResolved(at path: AbsolutePath) async throws -> [LintingIssue] {
         let savedPackageResolvedPath = path.appending(components: [
             Constants.SwiftPackageManager.packageBuildDirectoryName,
@@ -325,102 +414,6 @@ extension ProjectDescription.Platform {
             return .watchOS
         case .visionOS:
             return .visionOS
-        }
-    }
-}
-
-// MARK: - Trait Processing
-
-/// Extracts the enabled traits for each package dependency from the root package and all packages in the dependency graph.
-/// - Parameters:
-///   - rootPackageInfo: The `PackageInfo` of the root package (the Tuist `Package.swift`)
-///   - packageInfos: All `PackageInfo`s in the dependency graph, keyed by package identity
-/// - Returns: A dictionary where keys are package identities and values are the set of enabled trait names
-func enabledTraits(
-    rootPackageInfo: PackageInfo,
-    packageInfos: [String: PackageInfo]
-) -> [String: Set<String>] {
-    var result: [String: Set<String>] = [:]
-
-    processTraits(
-        from: rootPackageInfo.dependencies,
-        enabledTraitsForCurrentPackage: [],
-        packageInfos: packageInfos,
-        result: &result
-    )
-
-    for (packageId, packageInfo) in packageInfos {
-        let enabledForThisPackage = result[packageId] ?? []
-        processTraits(
-            from: packageInfo.dependencies,
-            enabledTraitsForCurrentPackage: enabledForThisPackage,
-            packageInfos: packageInfos,
-            result: &result
-        )
-    }
-
-    return result
-}
-
-private func processTraits(
-    from dependencies: [PackageDependency],
-    enabledTraitsForCurrentPackage: Set<String>,
-    packageInfos: [String: PackageInfo],
-    result: inout [String: Set<String>]
-) {
-    for dependency in dependencies {
-        let enabledTraits = dependency.traits.reduce(into: Set<String>()) { result, trait in
-            if let condition = trait.condition {
-                if !condition.isDisjoint(with: enabledTraitsForCurrentPackage) {
-                    result.insert(trait.name)
-                }
-            } else {
-                result.insert(trait.name)
-            }
-        }
-
-        let resolvedTraits = resolvedEnabledTraits(
-            enabledTraits,
-            packageTraits: packageInfos[dependency.identity]?.traits ?? []
-        )
-
-        guard !resolvedTraits.isEmpty else { continue }
-        result[dependency.identity, default: []].formUnion(resolvedTraits)
-    }
-}
-
-private func resolvedEnabledTraits(
-    _ traitNames: some Collection<String>,
-    packageTraits: [PackageTrait]
-) -> Set<String> {
-    var resolvedTraitNames = Set(traitNames)
-
-    resolveEnabledTraitNames(
-        resolvedTraitNames,
-        packageTraits: packageTraits,
-        into: &resolvedTraitNames
-    )
-
-    return resolvedTraitNames
-}
-
-private func resolveEnabledTraitNames(
-    _ traitNames: some Collection<String>,
-    packageTraits: [PackageTrait],
-    into resolvedTraitNames: inout Set<String>
-) {
-    for traitName in traitNames {
-        guard let trait = packageTraits.first(where: { $0.name == traitName }) else {
-            continue
-        }
-
-        for enabledTrait in trait.enabledTraits {
-            guard resolvedTraitNames.insert(enabledTrait).inserted else { continue }
-            resolveEnabledTraitNames(
-                [enabledTrait],
-                packageTraits: packageTraits,
-                into: &resolvedTraitNames
-            )
         }
     }
 }

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -345,6 +345,7 @@ func enabledTraits(
     processTraits(
         from: rootPackageInfo.dependencies,
         enabledTraitsForCurrentPackage: [],
+        packageInfos: packageInfos,
         result: &result
     )
 
@@ -353,6 +354,7 @@ func enabledTraits(
         processTraits(
             from: packageInfo.dependencies,
             enabledTraitsForCurrentPackage: enabledForThisPackage,
+            packageInfos: packageInfos,
             result: &result
         )
     }
@@ -363,17 +365,62 @@ func enabledTraits(
 private func processTraits(
     from dependencies: [PackageDependency],
     enabledTraitsForCurrentPackage: Set<String>,
+    packageInfos: [String: PackageInfo],
     result: inout [String: Set<String>]
 ) {
     for dependency in dependencies {
-        for trait in dependency.traits {
+        let enabledTraits = dependency.traits.reduce(into: Set<String>()) { result, trait in
             if let condition = trait.condition {
                 if !condition.isDisjoint(with: enabledTraitsForCurrentPackage) {
-                    result[dependency.identity, default: []].insert(trait.name)
+                    result.insert(trait.name)
                 }
             } else {
-                result[dependency.identity, default: []].insert(trait.name)
+                result.insert(trait.name)
             }
+        }
+
+        let resolvedTraits = resolvedEnabledTraits(
+            enabledTraits,
+            packageTraits: packageInfos[dependency.identity]?.traits ?? []
+        )
+
+        guard !resolvedTraits.isEmpty else { continue }
+        result[dependency.identity, default: []].formUnion(resolvedTraits)
+    }
+}
+
+private func resolvedEnabledTraits(
+    _ traitNames: some Collection<String>,
+    packageTraits: [PackageTrait]
+) -> Set<String> {
+    var resolvedTraitNames = Set(traitNames)
+
+    resolveEnabledTraitNames(
+        resolvedTraitNames,
+        packageTraits: packageTraits,
+        into: &resolvedTraitNames
+    )
+
+    return resolvedTraitNames
+}
+
+private func resolveEnabledTraitNames(
+    _ traitNames: some Collection<String>,
+    packageTraits: [PackageTrait],
+    into resolvedTraitNames: inout Set<String>
+) {
+    for traitName in traitNames {
+        guard let trait = packageTraits.first(where: { $0.name == traitName }) else {
+            continue
+        }
+
+        for enabledTrait in trait.enabledTraits {
+            guard resolvedTraitNames.insert(enabledTrait).inserted else { continue }
+            resolveEnabledTraitNames(
+                [enabledTrait],
+                packageTraits: packageTraits,
+                into: &resolvedTraitNames
+            )
         }
     }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5636,7 +5636,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: [:]
         )
@@ -5655,7 +5655,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: [:]
         )
@@ -5695,7 +5695,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: ["hummingbird": hummingbirdInfo]
         )
@@ -5732,7 +5732,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: ["hummingbird": hummingbirdInfo]
         )
@@ -5769,7 +5769,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: ["dependency-a": dependencyAInfo]
         )
@@ -5808,7 +5808,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: ["dependency-a": dependencyAInfo]
         )
@@ -5838,7 +5838,7 @@ struct PackageInfoMapperTests {
             ]
         )
 
-        let result = enabledTraits(
+        let result = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: [:]
         )
@@ -6010,7 +6010,7 @@ struct PackageInfoMapperTests {
             "hummingbird": hummingbirdInfo,
             "swift-configuration": swiftConfigurationInfo,
         ]
-        let activeTraits = enabledTraits(
+        let activeTraits = SwiftPackageManagerGraphLoader.enabledTraits(
             rootPackageInfo: rootPackageInfo,
             packageInfos: packageInfos
         )

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5938,9 +5938,11 @@ struct PackageInfoMapperTests {
         .withMockedSwiftVersionProvider
     ) func map_whenDependencyUsesDefaultTrait_includesHummingbirdConfigurationDependency() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)
-        try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore")))
+        try await fileSystem
+            .makeDirectory(at: basePath.appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore")))
         try await fileSystem.touch(
-            basePath.appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore/HTTP1Channel+ConfigReader.swift"))
+            basePath
+                .appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore/HTTP1Channel+ConfigReader.swift"))
         )
         try await fileSystem.makeDirectory(
             at: basePath.appending(try RelativePath(validating: "swift-configuration/Sources/Configuration"))

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -5664,6 +5664,83 @@ struct PackageInfoMapperTests {
     }
 
     @Test(.withMockedSwiftVersionProvider)
+    func enabledTraits_whenDependencyUsesDefaultTrait_resolvesUnderlyingTraits() {
+        let rootPackageInfo = PackageInfo.test(
+            name: "RootPackage",
+            products: [],
+            targets: [],
+            dependencies: [
+                PackageDependency(
+                    identity: "hummingbird",
+                    traits: [PackageDependencyTrait(name: "default")]
+                ),
+            ]
+        )
+
+        let hummingbirdInfo = PackageInfo.test(
+            name: "hummingbird",
+            products: [],
+            targets: [],
+            traits: [
+                PackageTrait(
+                    enabledTraits: ["ConfigurationSupport"],
+                    name: "default",
+                    description: "The default traits of this package."
+                ),
+                PackageTrait(
+                    enabledTraits: [],
+                    name: "ConfigurationSupport",
+                    description: "Enable support for swift-configuration package."
+                ),
+            ]
+        )
+
+        let result = enabledTraits(
+            rootPackageInfo: rootPackageInfo,
+            packageInfos: ["hummingbird": hummingbirdInfo]
+        )
+
+        #expect(result["hummingbird"] == Set(["default", "ConfigurationSupport"]))
+    }
+
+    @Test(.withMockedSwiftVersionProvider)
+    func enabledTraits_whenDependencyExplicitlyDisablesTraits_doesNotEnableDefaultTraits() {
+        let rootPackageInfo = PackageInfo.test(
+            name: "RootPackage",
+            products: [],
+            targets: [],
+            dependencies: [
+                PackageDependency(identity: "hummingbird", traits: []),
+            ]
+        )
+
+        let hummingbirdInfo = PackageInfo.test(
+            name: "hummingbird",
+            products: [],
+            targets: [],
+            traits: [
+                PackageTrait(
+                    enabledTraits: ["ConfigurationSupport"],
+                    name: "default",
+                    description: "The default traits of this package."
+                ),
+                PackageTrait(
+                    enabledTraits: [],
+                    name: "ConfigurationSupport",
+                    description: "Enable support for swift-configuration package."
+                ),
+            ]
+        )
+
+        let result = enabledTraits(
+            rootPackageInfo: rootPackageInfo,
+            packageInfos: ["hummingbird": hummingbirdInfo]
+        )
+
+        #expect(result["hummingbird"] == nil)
+    }
+
+    @Test(.withMockedSwiftVersionProvider)
     func enabledTraits_whenConditionalTraitWithMatchingCondition_enablesTrait() {
         let rootPackageInfo = PackageInfo.test(
             name: "RootPackage",
@@ -5854,6 +5931,103 @@ struct PackageInfoMapperTests {
         let swiftConditions = baseSettings?["SWIFT_ACTIVE_COMPILATION_CONDITIONS"]
 
         #expect(swiftConditions == .array(["$(inherited)", "ActualFeature"]))
+    }
+
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func map_whenDependencyUsesDefaultTrait_includesHummingbirdConfigurationDependency() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore")))
+        try await fileSystem.touch(
+            basePath.appending(try RelativePath(validating: "hummingbird/Sources/HummingbirdCore/HTTP1Channel+ConfigReader.swift"))
+        )
+        try await fileSystem.makeDirectory(
+            at: basePath.appending(try RelativePath(validating: "swift-configuration/Sources/Configuration"))
+        )
+        try await fileSystem.touch(
+            basePath.appending(try RelativePath(validating: "swift-configuration/Sources/Configuration/Configuration.swift"))
+        )
+
+        let rootPackageInfo = PackageInfo.test(
+            name: "RootPackage",
+            products: [],
+            targets: [],
+            dependencies: [
+                PackageDependency(
+                    identity: "hummingbird",
+                    traits: [PackageDependencyTrait(name: "default")]
+                ),
+            ]
+        )
+
+        let hummingbirdInfo = PackageInfo.test(
+            name: "hummingbird",
+            products: [
+                .init(name: "Hummingbird", type: .library(.automatic), targets: ["HummingbirdCore"]),
+            ],
+            targets: [
+                .test(
+                    name: "HummingbirdCore",
+                    dependencies: [
+                        .product(
+                            name: "Configuration",
+                            package: "swift-configuration",
+                            moduleAliases: nil,
+                            condition: .init(platformNames: [], config: nil, traits: ["ConfigurationSupport"])
+                        ),
+                    ]
+                ),
+            ],
+            traits: [
+                PackageTrait(
+                    enabledTraits: ["ConfigurationSupport"],
+                    name: "default",
+                    description: "The default traits of this package."
+                ),
+                PackageTrait(
+                    enabledTraits: [],
+                    name: "ConfigurationSupport",
+                    description: "Enable support for swift-configuration package."
+                ),
+            ],
+            platforms: [.ios]
+        )
+        let swiftConfigurationInfo = PackageInfo.test(
+            name: "swift-configuration",
+            products: [
+                .init(name: "Configuration", type: .library(.automatic), targets: ["Configuration"]),
+            ],
+            targets: [
+                .test(name: "Configuration"),
+            ],
+            platforms: [.ios]
+        )
+
+        let packageInfos = [
+            "hummingbird": hummingbirdInfo,
+            "swift-configuration": swiftConfigurationInfo,
+        ]
+        let activeTraits = enabledTraits(
+            rootPackageInfo: rootPackageInfo,
+            packageInfos: packageInfos
+        )
+
+        #expect(activeTraits["hummingbird"] == Set(["default", "ConfigurationSupport"]))
+
+        let project = try await subject.map(
+            package: "hummingbird",
+            basePath: basePath,
+            packageInfos: packageInfos,
+            enabledTraits: activeTraits["hummingbird"] ?? []
+        )
+
+        let target = try #require(project?.targets.first(where: { $0.name == "HummingbirdCore" }))
+        #expect(target.dependencies.count == 1)
+        #expect(target.dependencies.first == .external(name: "Configuration"))
+
+        let swiftConditions = target.settings?.base["SWIFT_ACTIVE_COMPILATION_CONDITIONS"]
+        #expect(swiftConditions == .array(["$(inherited)", "ConfigurationSupport"]))
     }
 
     @Test(


### PR DESCRIPTION
## Summary
- fixes Swift package generation when a dependency enables SwiftPM's default traits
- expands selected default traits to their underlying trait names before filtering trait-gated package dependencies
- keeps generated dependencies and `SWIFT_ACTIVE_COMPILATION_CONDITIONS` aligned for cases like Hummingbird's `ConfigurationSupport`

## Validation
- Added regression tests in `PackageInfoMapperTests` for default trait expansion and explicit `traits: []`.
- `swift build --replace-scm-with-registry --target TuistLoader`
- Red/green external reproduction with a temporary Swift test package that exercises `SwiftPackageManagerGraphLoader.load`:
  - against `origin/main`, the Hummingbird-style reproduction failed because `Configuration` was missing from `HummingbirdCore`
  - against this branch, the same reproduction passed
- `xcodebuild test` is still not usable in the generated workspace because the `Tuist-Workspace` schemes have empty `Testables`.
- `swift test` for the repo still doesn't run these loader tests directly because `TuistLoaderTests` is not part of the current checked-in SwiftPM package graph.
