### PR TITLE
fix(kura): wait for all Prometheus nodes in cluster e2e

### DIFF
--- a/kura/spec/e2e/cluster_spec.sh
+++ b/kura/spec/e2e/cluster_spec.sh
@@ -151,9 +151,11 @@ Describe 'core cluster behaviour'
     The variable grafana_health should include '"database": "ok"'
 
     capture_into prometheus_query \
-      wait_for_contains \
+      wait_for_all_contains \
       "${PROMETHEUS_URL}/api/v1/query?query=kura_node_info" \
-      'eu-west' || return 1
+      'us-east' \
+      'eu-west' \
+      'ap-south' || return 1
     The variable prometheus_query should include 'us-east'
     The variable prometheus_query should include 'eu-west'
     The variable prometheus_query should include 'ap-south'

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -74,6 +74,35 @@ wait_for_contains() {
   return 1
 }
 
+wait_for_all_contains() {
+  local url="$1"
+  shift
+  local attempts=45
+  local sleep_seconds=2
+  local body
+  local needle
+  local matched
+
+  for _ in $(seq 1 "$attempts"); do
+    body="$(curl -fsS "$url" 2>/dev/null || true)"
+    matched=1
+    for needle in "$@"; do
+      if [[ "$body" != *"$needle"* ]]; then
+        matched=0
+        break
+      fi
+    done
+    if [ -n "$body" ] && [ "$matched" -eq 1 ]; then
+      printf '%s' "$body"
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  printf 'Timed out waiting for [%s] in %s\n' "$*" "$url" >&2
+  return 1
+}
+
 new_marker() {
   python3 - <<'PY'
 import secrets


### PR DESCRIPTION
## Summary
- wait for the observability shellspec to see all expected `kura_node_info` regions in one Prometheus response
- add a shared `wait_for_all_contains` helper for multi-label polling in Kura e2e specs

## Root cause
The failing `E2E (cluster)` job returned from `wait_for_contains` as soon as Prometheus exposed `eu-west`. At that point `kura-ap` could already be healthy and exporting `kura_node_info`, but Prometheus had not necessarily scraped that target yet, so the test raced the scrape cycle and failed even though the stack converged moments later.

GitHub Actions failure: https://github.com/tuist/tuist/actions/runs/24843571705/job/72724169078#step:6:71

## Reproduction
```bash
MISE_TRUSTED_CONFIG_PATHS=/Users/pepicrft/.codex/worktrees/9f21/tuist mise exec -- shellspec -f d -E 'keeps the observability stack reachable' spec/e2e/cluster_spec.sh
```

## Validation
```bash
MISE_TRUSTED_CONFIG_PATHS=/Users/pepicrft/.codex/worktrees/9f21/tuist mise exec -- shellspec -f d spec/e2e/cluster_spec.sh
```
