### PR TITLE
fix(cache): filter stale non-semantic registry versions

### DIFF
--- a/cache/lib/cache/registry/key_normalizer.ex
+++ b/cache/lib/cache/registry/key_normalizer.ex
@@ -7,7 +7,7 @@ defmodule Cache.Registry.KeyNormalizer do
   synchronization via S3TransferWorker.
   """
 
-  @semver_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  @semver_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+([.+][0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
 
   @doc """
   Normalizes a scope by downcasing it.

--- a/cache/lib/cache/registry/key_normalizer.ex
+++ b/cache/lib/cache/registry/key_normalizer.ex
@@ -7,7 +7,8 @@ defmodule Cache.Registry.KeyNormalizer do
   synchronization via S3TransferWorker.
   """
 
-  @semver_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+([.+][0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  @source_tag_regex ~r/^v?\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+  @storage_version_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\+[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
 
   @doc """
   Normalizes a scope by downcasing it.
@@ -94,11 +95,17 @@ defmodule Cache.Registry.KeyNormalizer do
   end
 
   @doc """
-  Returns whether a version normalizes to a supported semantic version.
+  Returns whether a raw upstream tag matches the accepted source tag format.
   """
-  def valid_semver?(version) when is_binary(version) do
-    normalized_version = normalize_version(version)
-    Regex.match?(@semver_regex, normalized_version)
+  def valid_source_tag?(version) when is_binary(version) do
+    Regex.match?(@source_tag_regex, version)
+  end
+
+  @doc """
+  Returns whether a normalized registry storage version matches the accepted format.
+  """
+  def valid_storage_version?(version) when is_binary(version) do
+    Regex.match?(@storage_version_regex, version)
   end
 
   defp add_trailing_semantic_version_zeros(version) do

--- a/cache/lib/cache/registry/key_normalizer.ex
+++ b/cache/lib/cache/registry/key_normalizer.ex
@@ -7,6 +7,8 @@ defmodule Cache.Registry.KeyNormalizer do
   synchronization via S3TransferWorker.
   """
 
+  @semver_regex ~r/^\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
+
   @doc """
   Normalizes a scope by downcasing it.
 
@@ -89,6 +91,14 @@ defmodule Cache.Registry.KeyNormalizer do
       _ ->
         add_trailing_semantic_version_zeros(version)
     end
+  end
+
+  @doc """
+  Returns whether a version normalizes to a supported semantic version.
+  """
+  def valid_semver?(version) when is_binary(version) do
+    normalized_version = normalize_version(version)
+    Regex.match?(@semver_regex, normalized_version)
   end
 
   defp add_trailing_semantic_version_zeros(version) do

--- a/cache/lib/cache/registry/metadata.ex
+++ b/cache/lib/cache/registry/metadata.ex
@@ -37,12 +37,12 @@ defmodule Cache.Registry.Metadata do
   * `scope` - The package scope (e.g., "apple" for github.com/apple/...)
   * `name` - The package name (e.g., "swift-argument-parser")
   * `repository_full_handle` - Full GitHub handle (e.g., "apple/swift-argument-parser")
-  * `releases` - Map of version strings to release data
+  * `releases` - Map of normalized registry storage version strings to release data
   * `releases.<version>.checksum` - SHA256 checksum of the source archive (hex, lowercase)
   * `releases.<version>.manifests` - List of Package.swift variants for this release
   * `releases.<version>.manifests[].swift_version` - Swift version suffix (e.g., "5.9") or null for default
   * `releases.<version>.manifests[].swift_tools_version` - Swift tools version from manifest or null
-  * `skipped_releases` - Optional map of normalized version strings to permanent skip reasons
+  * `skipped_releases` - Optional map of normalized registry storage version strings to permanent skip reasons
   * `skipped_releases.<version>.reason` - Machine-readable reason code for not mirroring a release
   * `updated_at` - ISO8601 timestamp of last sync (for staleness detection)
 
@@ -110,7 +110,8 @@ defmodule Cache.Registry.Metadata do
   Fetches package metadata from cache or S3.
 
   Returns `{:ok, metadata_map}` on success, `{:error, :not_found}` if the package
-  doesn't exist in S3.
+  doesn't exist in S3. Returned metadata is sanitized so only valid normalized
+  storage versions remain in `releases` and `skipped_releases`.
 
   ## Options
 
@@ -130,7 +131,9 @@ defmodule Cache.Registry.Metadata do
           fetch_from_s3(scope, name, cache_key, cache_name)
 
         {:ok, %{metadata: metadata} = cached} ->
-          maybe_revalidate(scope, name, cache_key, cached, metadata, cache_name)
+          sanitized_metadata = sanitize_package(metadata)
+          cached = maybe_cache_sanitized_metadata(cache_name, cache_key, cached, sanitized_metadata)
+          maybe_revalidate(scope, name, cache_key, cached, sanitized_metadata, cache_name)
 
         _ ->
           fetch_from_s3(scope, name, cache_key, cache_name)
@@ -141,13 +144,15 @@ defmodule Cache.Registry.Metadata do
   @doc """
   Writes package metadata to S3 and invalidates the cache.
 
-  Returns `:ok` on success, `{:error, reason}` on failure.
+  Returns `:ok` on success, `{:error, reason}` on failure. Metadata is sanitized
+  before writing so stored release keys always use valid normalized storage versions.
   """
   def put_package(scope, name, metadata, opts \\ []) do
     cache_name = Keyword.get(opts, :cache_name, cache_name())
     {scope, name} = KeyNormalizer.normalize_scope_name(scope, name)
     key = s3_key(scope, name)
     bucket = bucket()
+    metadata = sanitize_package(metadata)
     json_body = JSON.encode!(metadata)
 
     {duration, result} =
@@ -255,6 +260,7 @@ defmodule Cache.Registry.Metadata do
 
         case JSON.decode(body) do
           {:ok, metadata} ->
+            metadata = sanitize_package(metadata)
             etag = S3.etag_from_headers(headers)
             Cachex.put(cache_name, cache_key, cache_value(metadata, etag), ttl: @ttl)
             {:ok, metadata}
@@ -354,6 +360,41 @@ defmodule Cache.Registry.Metadata do
       etag: etag,
       checked_at: DateTime.truncate(DateTime.utc_now(), :second)
     }
+  end
+
+  defp sanitize_package(metadata) do
+    metadata
+    |> sanitize_versions("releases")
+    |> sanitize_versions("skipped_releases")
+  end
+
+  defp sanitize_versions(metadata, key) do
+    case Map.fetch(metadata, key) do
+      {:ok, versions} ->
+        filtered_versions =
+          Enum.reduce(versions, %{}, fn {version, value}, acc ->
+            if KeyNormalizer.valid_storage_version?(version) do
+              Map.put(acc, version, value)
+            else
+              acc
+            end
+          end)
+
+        Map.put(metadata, key, filtered_versions)
+
+      :error ->
+        metadata
+    end
+  end
+
+  defp maybe_cache_sanitized_metadata(cache_name, cache_key, cached, sanitized_metadata) do
+    if sanitized_metadata == cached.metadata do
+      cached
+    else
+      sanitized_cached = %{cached | metadata: sanitized_metadata}
+      Cachex.put(cache_name, cache_key, sanitized_cached, ttl: @ttl)
+      sanitized_cached
+    end
   end
 
   defp parse_s3_key(key) do

--- a/cache/lib/cache/registry/sync_worker.ex
+++ b/cache/lib/cache/registry/sync_worker.ex
@@ -88,6 +88,7 @@ defmodule Cache.Registry.SyncWorker do
         {:ok, metadata} -> metadata
         {:error, :not_found} -> empty_metadata(scope, name, full_handle)
       end
+      |> sanitize_metadata()
 
     case TuistCommon.GitHub.list_tags(full_handle, token, @github_opts) do
       {:ok, tags} ->
@@ -109,7 +110,7 @@ defmodule Cache.Registry.SyncWorker do
     known_versions = Map.keys(releases) ++ Map.keys(skipped_releases)
 
     tags
-    |> Enum.filter(&valid_semver?/1)
+    |> Enum.filter(&KeyNormalizer.valid_semver?/1)
     |> Enum.reject(&String.contains?(&1, "-dev"))
     |> Enum.uniq_by(&KeyNormalizer.normalize_version/1)
     |> Enum.filter(fn tag ->
@@ -148,11 +149,29 @@ defmodule Cache.Registry.SyncWorker do
     }
   end
 
-  defp valid_semver?(version) do
-    Regex.match?(
-      ~r/^v?\d+\.\d+(\.\d+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/,
-      version
-    )
+  defp sanitize_metadata(metadata) do
+    metadata
+    |> sanitize_versions("releases")
+    |> sanitize_versions("skipped_releases")
+  end
+
+  defp sanitize_versions(metadata, key) do
+    case Map.fetch(metadata, key) do
+      {:ok, versions} ->
+        filtered_versions =
+          Enum.reduce(versions, %{}, fn {version, value}, acc ->
+            if KeyNormalizer.valid_semver?(version) do
+              Map.put(acc, version, value)
+            else
+              acc
+            end
+          end)
+
+        Map.put(metadata, key, filtered_versions)
+
+      :error ->
+        metadata
+    end
   end
 
   defp apply_allowlist(packages, nil), do: packages

--- a/cache/lib/cache/registry/sync_worker.ex
+++ b/cache/lib/cache/registry/sync_worker.ex
@@ -88,7 +88,6 @@ defmodule Cache.Registry.SyncWorker do
         {:ok, metadata} -> metadata
         {:error, :not_found} -> empty_metadata(scope, name, full_handle)
       end
-      |> sanitize_metadata()
 
     case TuistCommon.GitHub.list_tags(full_handle, token, @github_opts) do
       {:ok, tags} ->
@@ -110,7 +109,7 @@ defmodule Cache.Registry.SyncWorker do
     known_versions = Map.keys(releases) ++ Map.keys(skipped_releases)
 
     tags
-    |> Enum.filter(&KeyNormalizer.valid_semver?/1)
+    |> Enum.filter(&KeyNormalizer.valid_source_tag?/1)
     |> Enum.reject(&String.contains?(&1, "-dev"))
     |> Enum.uniq_by(&KeyNormalizer.normalize_version/1)
     |> Enum.filter(fn tag ->
@@ -147,31 +146,6 @@ defmodule Cache.Registry.SyncWorker do
       "releases" => %{},
       "updated_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
     }
-  end
-
-  defp sanitize_metadata(metadata) do
-    metadata
-    |> sanitize_versions("releases")
-    |> sanitize_versions("skipped_releases")
-  end
-
-  defp sanitize_versions(metadata, key) do
-    case Map.fetch(metadata, key) do
-      {:ok, versions} ->
-        filtered_versions =
-          Enum.reduce(versions, %{}, fn {version, value}, acc ->
-            if KeyNormalizer.valid_semver?(version) do
-              Map.put(acc, version, value)
-            else
-              acc
-            end
-          end)
-
-        Map.put(metadata, key, filtered_versions)
-
-      :error ->
-        metadata
-    end
   end
 
   defp apply_allowlist(packages, nil), do: packages

--- a/cache/lib/cache_web/controllers/registry_controller.ex
+++ b/cache/lib/cache_web/controllers/registry_controller.ex
@@ -13,7 +13,7 @@ defmodule CacheWeb.RegistryController do
   alias Cache.S3Transfers
   alias CacheWeb.API.Schemas.SafePathComponent
 
-  plug :ensure_registry_enabled
+  plug(:ensure_registry_enabled)
 
   defp ensure_registry_enabled(conn, _opts) do
     if Config.registry_enabled?() do
@@ -84,7 +84,7 @@ defmodule CacheWeb.RegistryController do
         case Metadata.get_package(scope, name) do
           {:ok, metadata} ->
             releases =
-              Map.new(metadata["releases"] || %{}, fn {version, _release_data} ->
+              Map.new(valid_releases(metadata), fn {version, _release_data} ->
                 {version, %{url: "/api/registry/swift/#{scope}/#{name}/#{version}"}}
               end)
 
@@ -190,7 +190,9 @@ defmodule CacheWeb.RegistryController do
               conn
               |> put_resp_header("content-version", "1")
               |> put_status(303)
-              |> redirect(to: "/api/registry/swift/#{scope}/#{name}/#{normalized_version}/Package.swift")
+              |> redirect(
+                to: "/api/registry/swift/#{scope}/#{name}/#{normalized_version}/Package.swift"
+              )
             end
         end
 
@@ -228,7 +230,7 @@ defmodule CacheWeb.RegistryController do
   end
 
   defp render_release_response(conn, scope, name, normalized_version, metadata) do
-    releases = metadata["releases"] || %{}
+    releases = valid_releases(metadata)
 
     case Map.get(releases, normalized_version) do
       nil ->
@@ -351,7 +353,8 @@ defmodule CacheWeb.RegistryController do
     end
   end
 
-  defp maybe_put_alternate_manifest_link(conn, _scope, _name, _version, swift_version) when not is_nil(swift_version) do
+  defp maybe_put_alternate_manifest_link(conn, _scope, _name, _version, swift_version)
+       when not is_nil(swift_version) do
     conn
   end
 
@@ -524,11 +527,24 @@ defmodule CacheWeb.RegistryController do
   defp normalize_registry_version(version) do
     normalized_version = KeyNormalizer.normalize_version(version)
 
-    if SafePathComponent.valid?(normalized_version) do
+    if SafePathComponent.valid?(normalized_version) and
+         KeyNormalizer.valid_semver?(normalized_version) do
       {:ok, normalized_version}
     else
       {:error, :invalid_path_params}
     end
+  end
+
+  defp valid_releases(metadata) do
+    metadata
+    |> Map.get("releases", %{})
+    |> Enum.reduce(%{}, fn {version, release_data}, acc ->
+      if KeyNormalizer.valid_semver?(version) do
+        Map.put(acc, version, release_data)
+      else
+        acc
+      end
+    end)
   end
 
   defp scope_name_from_full_handle(repository_full_handle) do

--- a/cache/lib/cache_web/controllers/registry_controller.ex
+++ b/cache/lib/cache_web/controllers/registry_controller.ex
@@ -84,7 +84,7 @@ defmodule CacheWeb.RegistryController do
         case Metadata.get_package(scope, name) do
           {:ok, metadata} ->
             releases =
-              Map.new(valid_releases(metadata), fn {version, _release_data} ->
+              Map.new(metadata["releases"] || %{}, fn {version, _release_data} ->
                 {version, %{url: "/api/registry/swift/#{scope}/#{name}/#{version}"}}
               end)
 
@@ -190,9 +190,7 @@ defmodule CacheWeb.RegistryController do
               conn
               |> put_resp_header("content-version", "1")
               |> put_status(303)
-              |> redirect(
-                to: "/api/registry/swift/#{scope}/#{name}/#{normalized_version}/Package.swift"
-              )
+              |> redirect(to: "/api/registry/swift/#{scope}/#{name}/#{normalized_version}/Package.swift")
             end
         end
 
@@ -230,7 +228,7 @@ defmodule CacheWeb.RegistryController do
   end
 
   defp render_release_response(conn, scope, name, normalized_version, metadata) do
-    releases = valid_releases(metadata)
+    releases = metadata["releases"] || %{}
 
     case Map.get(releases, normalized_version) do
       nil ->
@@ -353,8 +351,7 @@ defmodule CacheWeb.RegistryController do
     end
   end
 
-  defp maybe_put_alternate_manifest_link(conn, _scope, _name, _version, swift_version)
-       when not is_nil(swift_version) do
+  defp maybe_put_alternate_manifest_link(conn, _scope, _name, _version, swift_version) when not is_nil(swift_version) do
     conn
   end
 
@@ -528,23 +525,11 @@ defmodule CacheWeb.RegistryController do
     normalized_version = KeyNormalizer.normalize_version(version)
 
     if SafePathComponent.valid?(normalized_version) and
-         KeyNormalizer.valid_semver?(normalized_version) do
+         KeyNormalizer.valid_storage_version?(normalized_version) do
       {:ok, normalized_version}
     else
       {:error, :invalid_path_params}
     end
-  end
-
-  defp valid_releases(metadata) do
-    metadata
-    |> Map.get("releases", %{})
-    |> Enum.reduce(%{}, fn {version, release_data}, acc ->
-      if KeyNormalizer.valid_semver?(version) do
-        Map.put(acc, version, release_data)
-      else
-        acc
-      end
-    end)
   end
 
   defp scope_name_from_full_handle(repository_full_handle) do

--- a/cache/test/cache/registry/key_normalizer_test.exs
+++ b/cache/test/cache/registry/key_normalizer_test.exs
@@ -96,6 +96,19 @@ defmodule Cache.Registry.KeyNormalizerTest do
     end
   end
 
+  describe "valid_semver?/1" do
+    test "accepts supported semantic versions after normalization" do
+      assert KeyNormalizer.valid_semver?("v1.2.3")
+      assert KeyNormalizer.valid_semver?("1.2")
+      assert KeyNormalizer.valid_semver?("1.0.0-alpha.1")
+    end
+
+    test "rejects non-semantic versions" do
+      refute KeyNormalizer.valid_semver?("0.0.24b")
+      refute KeyNormalizer.valid_semver?("3.2.0.1")
+    end
+  end
+
   describe "package_object_key/2" do
     test "constructs full key with version and path" do
       result =

--- a/cache/test/cache/registry/key_normalizer_test.exs
+++ b/cache/test/cache/registry/key_normalizer_test.exs
@@ -101,6 +101,8 @@ defmodule Cache.Registry.KeyNormalizerTest do
       assert KeyNormalizer.valid_semver?("v1.2.3")
       assert KeyNormalizer.valid_semver?("1.2")
       assert KeyNormalizer.valid_semver?("1.0.0-alpha.1")
+      assert KeyNormalizer.valid_semver?("1.0.0-alpha.1.2")
+      assert KeyNormalizer.valid_semver?("1.0.0-alpha+1+2")
     end
 
     test "rejects non-semantic versions" do

--- a/cache/test/cache/registry/key_normalizer_test.exs
+++ b/cache/test/cache/registry/key_normalizer_test.exs
@@ -96,18 +96,32 @@ defmodule Cache.Registry.KeyNormalizerTest do
     end
   end
 
-  describe "valid_semver?/1" do
-    test "accepts supported semantic versions after normalization" do
-      assert KeyNormalizer.valid_semver?("v1.2.3")
-      assert KeyNormalizer.valid_semver?("1.2")
-      assert KeyNormalizer.valid_semver?("1.0.0-alpha.1")
-      assert KeyNormalizer.valid_semver?("1.0.0-alpha.1.2")
-      assert KeyNormalizer.valid_semver?("1.0.0-alpha+1+2")
+  describe "valid_source_tag?/1" do
+    test "accepts supported source tag formats" do
+      assert KeyNormalizer.valid_source_tag?("v1.2.3")
+      assert KeyNormalizer.valid_source_tag?("1.2")
+      assert KeyNormalizer.valid_source_tag?("1.0.0-alpha.1")
+      assert KeyNormalizer.valid_source_tag?("1.0.0-alpha.1.2")
     end
 
-    test "rejects non-semantic versions" do
-      refute KeyNormalizer.valid_semver?("0.0.24b")
-      refute KeyNormalizer.valid_semver?("3.2.0.1")
+    test "rejects invalid source tag formats" do
+      refute KeyNormalizer.valid_source_tag?("0.0.24b")
+      refute KeyNormalizer.valid_source_tag?("3.2.0.1")
+      refute KeyNormalizer.valid_source_tag?("1.0.0-alpha+1+2")
+    end
+  end
+
+  describe "valid_storage_version?/1" do
+    test "accepts normalized storage version formats" do
+      assert KeyNormalizer.valid_storage_version?("1.2.3")
+      assert KeyNormalizer.valid_storage_version?("1.2.0")
+      assert KeyNormalizer.valid_storage_version?("1.0.0-alpha+1+2")
+    end
+
+    test "rejects invalid storage version formats" do
+      refute KeyNormalizer.valid_storage_version?("v1.2.3")
+      refute KeyNormalizer.valid_storage_version?("1.0.0-alpha.1.2")
+      refute KeyNormalizer.valid_storage_version?("0.0.24b")
     end
   end
 

--- a/cache/test/cache/registry/metadata_test.exs
+++ b/cache/test/cache/registry/metadata_test.exs
@@ -57,6 +57,31 @@ defmodule Cache.Registry.MetadataTest do
       assert metadata == @sample_metadata
     end
 
+    test "sanitizes cached metadata before returning it", %{cache_name: cache_name} do
+      scope = "apple"
+      name = "swift-argument-parser"
+
+      cached_metadata =
+        @sample_metadata
+        |> put_in(["releases", "0.0.24b"], %{"checksum" => "legacy"})
+        |> put_in(["skipped_releases"], %{"0.0.24b" => %{"reason" => "invalid_semver"}})
+
+      cached = %{
+        metadata: cached_metadata,
+        etag: "some-etag",
+        checked_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
+
+      Cachex.put(cache_name, {scope, name}, cached)
+
+      assert {:ok, metadata} = Metadata.get_package(scope, name, cache_name: cache_name)
+      refute Map.has_key?(metadata["releases"], "0.0.24b")
+      refute Map.has_key?(metadata["skipped_releases"], "0.0.24b")
+
+      assert {:ok, sanitized_cached} = Cachex.get(cache_name, {scope, name})
+      refute Map.has_key?(sanitized_cached.metadata["releases"], "0.0.24b")
+    end
+
     test "fetches from S3 and caches when not in cache", %{cache_name: cache_name} do
       scope = "apple"
       name = "swift-argument-parser"
@@ -76,6 +101,29 @@ defmodule Cache.Registry.MetadataTest do
 
       assert {:ok, cached} = Cachex.get(cache_name, {scope, name})
       assert cached.metadata == @sample_metadata
+    end
+
+    test "sanitizes invalid versions fetched from S3", %{cache_name: cache_name} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      s3_key = "registry/metadata/#{scope}/#{name}/index.json"
+
+      dirty_metadata =
+        @sample_metadata
+        |> put_in(["releases", "0.0.24b"], %{"checksum" => "legacy"})
+        |> put_in(["skipped_releases"], %{"0.0.24b" => %{"reason" => "invalid_semver"}})
+
+      expect(ExAws.S3, :get_object, fn "test-registry-bucket", ^s3_key ->
+        %S3{bucket: "test-registry-bucket", path: s3_key}
+      end)
+
+      expect(ExAws, :request, fn %S3{} ->
+        {:ok, %{body: JSON.encode!(dirty_metadata), headers: %{"etag" => "\"etag\""}}}
+      end)
+
+      assert {:ok, metadata} = Metadata.get_package(scope, name, cache_name: cache_name)
+      refute Map.has_key?(metadata["releases"], "0.0.24b")
+      refute Map.has_key?(metadata["skipped_releases"], "0.0.24b")
     end
 
     test "returns :not_found when S3 returns 404", %{cache_name: cache_name} do
@@ -164,6 +212,30 @@ defmodule Cache.Registry.MetadataTest do
       assert :ok = Metadata.put_package(scope, name, @sample_metadata, cache_name: cache_name)
 
       assert {:ok, nil} = Cachex.get(cache_name, {scope, name})
+    end
+
+    test "sanitizes invalid versions before writing metadata", %{cache_name: cache_name} do
+      scope = "apple"
+      name = "swift-argument-parser"
+      s3_key = "registry/metadata/#{scope}/#{name}/index.json"
+
+      dirty_metadata =
+        @sample_metadata
+        |> put_in(["releases", "0.0.24b"], %{"checksum" => "legacy"})
+        |> put_in(["skipped_releases"], %{"0.0.24b" => %{"reason" => "invalid_semver"}})
+
+      expect(ExAws.S3, :put_object, fn "test-registry-bucket", ^s3_key, body, _opts ->
+        written_metadata = JSON.decode!(body)
+        refute Map.has_key?(written_metadata["releases"], "0.0.24b")
+        refute Map.has_key?(written_metadata["skipped_releases"], "0.0.24b")
+        %S3{bucket: "test-registry-bucket", path: s3_key}
+      end)
+
+      expect(ExAws, :request, fn %S3{} ->
+        {:ok, %{status_code: 200}}
+      end)
+
+      assert :ok = Metadata.put_package(scope, name, dirty_metadata, cache_name: cache_name)
     end
 
     test "returns error when S3 write fails", %{cache_name: cache_name} do

--- a/cache/test/cache/registry/sync_worker_test.exs
+++ b/cache/test/cache/registry/sync_worker_test.exs
@@ -153,7 +153,7 @@ defmodule Cache.Registry.SyncWorkerTest do
     refute_enqueued(worker: ReleaseWorker)
   end
 
-  test "removes stale non-semantic versions from metadata during sync" do
+  test "ignores tags that do not match the accepted source format" do
     expect(Lock, :try_acquire, 2, fn
       :sync, _ -> {:ok, :acquired}
       {:package, "realm", "realm-swift"}, _ -> {:ok, :acquired}
@@ -173,30 +173,35 @@ defmodule Cache.Registry.SyncWorkerTest do
     expect(SyncCursor, :get, fn -> 0 end)
     expect(SyncCursor, :put, fn 0 -> :ok end)
 
-    expect(Metadata, :get_package, fn "realm", "realm-swift" ->
-      {:ok,
-       %{
-         "repository_full_handle" => "realm/realm-swift",
-         "releases" => %{
-           "10.28.1" => %{"checksum" => "abc123"},
-           "0.0.24b" => %{"checksum" => "legacy"}
-         },
-         "skipped_releases" => %{"0.0.24b" => %{"reason" => "invalid_semver"}}
-       }}
-    end)
+    expect(Metadata, :get_package, fn "realm", "realm-swift" -> {:error, :not_found} end)
 
-    expect(Metadata, :put_package, fn "realm", "realm-swift", metadata ->
-      assert metadata["releases"] == %{"10.28.1" => %{"checksum" => "abc123"}}
-      assert metadata["skipped_releases"] == %{}
-      :ok
-    end)
+    expect(Metadata, :put_package, fn "realm", "realm-swift", _metadata -> :ok end)
 
     expect(TuistCommon.GitHub, :list_tags, fn "realm/realm-swift", "token", _ ->
-      {:ok, ["10.28.1"]}
+      {:ok, ["10.28.1", "0.0.24b"]}
     end)
 
     assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
-    refute_enqueued(worker: ReleaseWorker)
+
+    assert_enqueued(
+      worker: ReleaseWorker,
+      args: %{
+        "scope" => "realm",
+        "name" => "realm-swift",
+        "repository_full_handle" => "realm/realm-swift",
+        "tag" => "10.28.1"
+      }
+    )
+
+    refute_enqueued(
+      worker: ReleaseWorker,
+      args: %{
+        "scope" => "realm",
+        "name" => "realm-swift",
+        "repository_full_handle" => "realm/realm-swift",
+        "tag" => "0.0.24b"
+      }
+    )
   end
 
   @tag capture_log: true

--- a/cache/test/cache/registry/sync_worker_test.exs
+++ b/cache/test/cache/registry/sync_worker_test.exs
@@ -71,6 +71,47 @@ defmodule Cache.Registry.SyncWorkerTest do
     )
   end
 
+  test "enqueues release workers for multi-segment prereleases" do
+    expect(Lock, :try_acquire, 2, fn
+      :sync, _ -> {:ok, :acquired}
+      {:package, "apple", "swift-argument-parser"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(SwiftPackageIndex, :list_packages, fn "token" ->
+      {:ok,
+       [
+         %{
+           scope: "apple",
+           name: "swift-argument-parser",
+           repository_full_handle: "apple/swift-argument-parser"
+         }
+       ]}
+    end)
+
+    expect(SyncCursor, :get, fn -> 0 end)
+    expect(SyncCursor, :put, fn 0 -> :ok end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:error, :not_found} end)
+
+    expect(Metadata, :put_package, fn "apple", "swift-argument-parser", _metadata -> :ok end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "apple/swift-argument-parser", "token", _ ->
+      {:ok, ["1.2.3-alpha.1.2"]}
+    end)
+
+    assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
+
+    assert_enqueued(
+      worker: ReleaseWorker,
+      args: %{
+        "scope" => "apple",
+        "name" => "swift-argument-parser",
+        "repository_full_handle" => "apple/swift-argument-parser",
+        "tag" => "1.2.3-alpha.1.2"
+      }
+    )
+  end
+
   test "does not enqueue release workers for skipped versions" do
     expect(Lock, :try_acquire, 2, fn
       :sync, _ -> {:ok, :acquired}

--- a/cache/test/cache/registry/sync_worker_test.exs
+++ b/cache/test/cache/registry/sync_worker_test.exs
@@ -112,6 +112,52 @@ defmodule Cache.Registry.SyncWorkerTest do
     refute_enqueued(worker: ReleaseWorker)
   end
 
+  test "removes stale non-semantic versions from metadata during sync" do
+    expect(Lock, :try_acquire, 2, fn
+      :sync, _ -> {:ok, :acquired}
+      {:package, "realm", "realm-swift"}, _ -> {:ok, :acquired}
+    end)
+
+    expect(SwiftPackageIndex, :list_packages, fn "token" ->
+      {:ok,
+       [
+         %{
+           scope: "realm",
+           name: "realm-swift",
+           repository_full_handle: "realm/realm-swift"
+         }
+       ]}
+    end)
+
+    expect(SyncCursor, :get, fn -> 0 end)
+    expect(SyncCursor, :put, fn 0 -> :ok end)
+
+    expect(Metadata, :get_package, fn "realm", "realm-swift" ->
+      {:ok,
+       %{
+         "repository_full_handle" => "realm/realm-swift",
+         "releases" => %{
+           "10.28.1" => %{"checksum" => "abc123"},
+           "0.0.24b" => %{"checksum" => "legacy"}
+         },
+         "skipped_releases" => %{"0.0.24b" => %{"reason" => "invalid_semver"}}
+       }}
+    end)
+
+    expect(Metadata, :put_package, fn "realm", "realm-swift", metadata ->
+      assert metadata["releases"] == %{"10.28.1" => %{"checksum" => "abc123"}}
+      assert metadata["skipped_releases"] == %{}
+      :ok
+    end)
+
+    expect(TuistCommon.GitHub, :list_tags, fn "realm/realm-swift", "token", _ ->
+      {:ok, ["10.28.1"]}
+    end)
+
+    assert :ok = SyncWorker.perform(%Oban.Job{args: %{}})
+    refute_enqueued(worker: ReleaseWorker)
+  end
+
   @tag capture_log: true
   test "skips sync when token is missing" do
     stub(Config, :registry_github_token, fn -> nil end)

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -473,6 +473,31 @@ defmodule CacheWeb.RegistryControllerTest do
       assert response["version"] == "1.0.0"
     end
 
+    test "normalizes multi-segment prereleases before lookup", %{conn: conn} do
+      scope = "apple"
+      name = "swift-argument-parser"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "1.2.3-alpha+1+2" => %{"checksum" => "abc123"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> get("/api/registry/swift/#{scope}/#{name}/1.2.3-alpha.1.2")
+
+      assert conn.status == 200
+
+      response = json_response(conn, :ok)
+      assert response["version"] == "1.2.3-alpha+1+2"
+    end
+
     test "returns 404 when version not found", %{conn: conn} do
       scope = "apple"
       name = "swift-argument-parser"
@@ -698,8 +723,7 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok,
-         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -802,8 +826,7 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3, :exists?, fn _key, _opts -> true end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok,
-         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -969,8 +992,7 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok,
-         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -1238,8 +1260,7 @@ defmodule CacheWeb.RegistryControllerTest do
       reject(CacheArtifacts, :track_artifact_access, 1)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok,
-         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
+        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -263,35 +263,6 @@ defmodule CacheWeb.RegistryControllerTest do
              }
     end
 
-    test "filters stale non-semantic releases from metadata", %{conn: conn} do
-      scope = "realm"
-      name = "realm-swift"
-
-      metadata = %{
-        "scope" => scope,
-        "name" => name,
-        "releases" => %{
-          "10.28.1" => %{"checksum" => "abc123"},
-          "0.0.24b" => %{"checksum" => "legacy"}
-        }
-      }
-
-      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
-
-      conn =
-        conn
-        |> registry_json_conn()
-        |> get("/api/registry/swift/#{scope}/#{name}")
-
-      assert conn.status == 200
-
-      response = json_response(conn, :ok)
-
-      assert response["releases"] == %{
-               "10.28.1" => %{"url" => "/api/registry/swift/realm/realm-swift/10.28.1"}
-             }
-    end
-
     test "returns 404 when package not found", %{conn: conn} do
       scope = "unknown"
       name = "nonexistent"

--- a/cache/test/cache_web/controllers/registry_controller_test.exs
+++ b/cache/test/cache_web/controllers/registry_controller_test.exs
@@ -201,7 +201,9 @@ defmodule CacheWeb.RegistryControllerTest do
     test "returns 404 when package is missing", %{conn: conn} do
       url = "https://github.com/apple/swift-argument-parser"
 
-      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" -> {:error, :not_found} end)
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser" ->
+        {:error, :not_found}
+      end)
 
       conn =
         conn
@@ -258,6 +260,35 @@ defmodule CacheWeb.RegistryControllerTest do
       assert response["releases"] == %{
                "1.0.0" => %{"url" => "/api/registry/swift/apple/swift-argument-parser/1.0.0"},
                "1.1.0" => %{"url" => "/api/registry/swift/apple/swift-argument-parser/1.1.0"}
+             }
+    end
+
+    test "filters stale non-semantic releases from metadata", %{conn: conn} do
+      scope = "realm"
+      name = "realm-swift"
+
+      metadata = %{
+        "scope" => scope,
+        "name" => name,
+        "releases" => %{
+          "10.28.1" => %{"checksum" => "abc123"},
+          "0.0.24b" => %{"checksum" => "legacy"}
+        }
+      }
+
+      expect(Metadata, :get_package, fn ^scope, ^name -> {:ok, metadata} end)
+
+      conn =
+        conn
+        |> registry_json_conn()
+        |> get("/api/registry/swift/#{scope}/#{name}")
+
+      assert conn.status == 200
+
+      response = json_response(conn, :ok)
+
+      assert response["releases"] == %{
+               "10.28.1" => %{"url" => "/api/registry/swift/realm/realm-swift/10.28.1"}
              }
     end
 
@@ -503,6 +534,18 @@ defmodule CacheWeb.RegistryControllerTest do
       response = json_response(conn, :service_unavailable)
       assert response["message"] == "Registry is temporarily unavailable. Please try again later."
     end
+
+    test "returns 400 when version is not semantic", %{conn: conn} do
+      conn =
+        conn
+        |> registry_json_conn()
+        |> get("/api/registry/swift/realm/realm-swift/0.0.24b")
+
+      assert conn.status == 400
+
+      response = json_response(conn, :bad_request)
+      assert response["message"] == "Invalid path parameters."
+    end
   end
 
   describe "HEAD /api/registry/swift/:scope/:name/:version (show_release)" do
@@ -655,7 +698,8 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
+        {:ok,
+         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -758,7 +802,8 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3, :exists?, fn _key, _opts -> true end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
+        {:ok,
+         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/source_archive.zip?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -924,7 +969,8 @@ defmodule CacheWeb.RegistryControllerTest do
       expect(S3Transfers, :enqueue_registry_download, fn _key -> {:ok, %{}} end)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
+        {:ok,
+         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->
@@ -1154,7 +1200,9 @@ defmodule CacheWeb.RegistryControllerTest do
       name = "swift-argument-parser"
       version = "1.0.0"
 
-      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package@swift-5.8.swift" -> false end)
+      expect(Registry.Disk, :exists?, fn ^scope, ^name, ^version, "Package@swift-5.8.swift" ->
+        false
+      end)
 
       expect(S3, :exists?, fn _key, _opts -> false end)
 
@@ -1190,7 +1238,8 @@ defmodule CacheWeb.RegistryControllerTest do
       reject(CacheArtifacts, :track_artifact_access, 1)
 
       expect(S3, :presign_download_url, fn _key, _opts ->
-        {:ok, "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
+        {:ok,
+         "https://s3.example.com/registry/swift/apple/swift-argument-parser/1.0.0/Package.swift?signed=true"}
       end)
 
       expect(S3, :remote_accel_path, fn _url ->


### PR DESCRIPTION
Closes #10404

## Summary
- Filter stale non-semantic versions out of registry responses and versioned lookups
- Sanitize stored package metadata during sync so legacy bad versions are removed on refresh
- Add regression coverage for the `realm/realm-swift` `0.0.24b` case

## Testing
- Targeted cache tests passed: `key_normalizer`, `sync_worker`, and `registry_controller`
- Verified the issue path locally against the live registry behavior before the fix