### PR TITLE
fix(cli): declare TuistServer iOS environment deps

### DIFF
--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -5,6 +5,7 @@ import FileSystem
 import Foundation
 import Mockable
 import Path
+import TuistHTTP
 import TuistThreadSafe
 
 public struct MultipartUploadArtifactPart {

--- a/cli/Tests/TuistCacheEETests/Generator/CacheGraphMutatorTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/CacheGraphMutatorTests.swift
@@ -2178,6 +2178,102 @@ final class CacheGraphMutatorTests: TuistUnitTestCase {
             ]
         )
     }
+
+    /// Twentieth scenario - a source target depends on a cached static framework that
+    /// transitively depends on other cached static frameworks. Those static binaries must
+    /// remain directly visible to the source target so Swift can load the cached modules.
+    ///
+    /// ┌──────────────────┐   ┌──────────────────┐   ┌──────────────────┐
+    /// │ Server          ├──►│ HTTP             ├──►│ Environment      │
+    /// │ (static, source)│   │ (static, cached) │   │ (static, cached) │
+    /// └──────────────────┘   └────────┬─────────┘   └──────────────────┘
+    ///                                 │
+    ///                                 ▼
+    ///                        ┌──────────────────┐
+    ///                        │ Logging          │
+    ///                        │ (static, cached) │
+    ///                        └──────────────────┘
+    func test_map_when_source_target_depends_on_cached_static_framework_with_cached_static_deps() async throws {
+        let path = try temporaryPath()
+
+        let server = Target.test(name: "Server", destinations: [.iPhone], product: .staticFramework)
+        let http = Target.test(name: "HTTP", destinations: [.iPhone], product: .staticFramework)
+        let environment = Target.test(name: "Environment", destinations: [.iPhone], product: .staticFramework)
+        let logging = Target.test(name: "Logging", destinations: [.iPhone], product: .staticFramework)
+
+        let project = Project.test(
+            path: path.appending(component: "Project"),
+            name: "Project",
+            targets: [server, http, environment, logging]
+        )
+
+        let httpGraphTarget = GraphTarget.test(path: project.path, target: http, project: project)
+        let environmentGraphTarget = GraphTarget.test(path: project.path, target: environment, project: project)
+        let loggingGraphTarget = GraphTarget.test(path: project.path, target: logging, project: project)
+
+        let graph = Graph.test(
+            projects: [project.path: project],
+            dependencies: [
+                .target(name: server.name, path: project.path): [
+                    .target(name: http.name, path: project.path),
+                ],
+                .target(name: http.name, path: project.path): [
+                    .target(name: environment.name, path: project.path),
+                    .target(name: logging.name, path: project.path),
+                ],
+            ]
+        )
+
+        let httpXCFrameworkPath = path.appending(component: "HTTP.xcframework")
+        let environmentXCFrameworkPath = path.appending(component: "Environment.xcframework")
+        let loggingXCFrameworkPath = path.appending(component: "Logging.xcframework")
+        let xcframeworks = [
+            httpGraphTarget: httpXCFrameworkPath,
+            environmentGraphTarget: environmentXCFrameworkPath,
+            loggingGraphTarget: loggingXCFrameworkPath,
+        ]
+
+        artifactLoader.loadStub = { path in
+            if path == httpXCFrameworkPath {
+                return GraphDependency.testXCFramework(path: httpXCFrameworkPath, linking: .static)
+            } else if path == environmentXCFrameworkPath {
+                return GraphDependency.testXCFramework(path: environmentXCFrameworkPath, linking: .static)
+            } else if path == loggingXCFrameworkPath {
+                return GraphDependency.testXCFramework(path: loggingXCFrameworkPath, linking: .static)
+            } else {
+                fatalError("Unexpected load call for \(path)")
+            }
+        }
+
+        let got = try await subject.map(
+            graph: graph,
+            precompiledArtifacts: xcframeworks,
+            sources: Set(["Server"]),
+            keepSourceTargets: false
+        )
+
+        XCTAssertEqual(
+            got.dependencies[
+                .target(name: server.name, path: project.path),
+                default: Set()
+            ],
+            [
+                .testXCFramework(path: httpXCFrameworkPath, linking: .static),
+                .testXCFramework(path: environmentXCFrameworkPath, linking: .static),
+                .testXCFramework(path: loggingXCFrameworkPath, linking: .static),
+            ]
+        )
+        XCTAssertEqual(
+            got.dependencies[
+                .testXCFramework(path: httpXCFrameworkPath, linking: .static),
+                default: Set()
+            ],
+            [
+                .testXCFramework(path: environmentXCFrameworkPath, linking: .static),
+                .testXCFramework(path: loggingXCFrameworkPath, linking: .static),
+            ]
+        )
+    }
 }
 
 final class MockArtifactLoader: ArtifactLoading {


### PR DESCRIPTION
## Summary

- declare `TuistEnvironment` and `TuistLogging` as unconditional `TuistServer` target dependencies
- keep `TuistServer` aligned with its actual imports when it is built for the iOS cache scheme

## Root cause

The failing `Binaries-Cache-iOS` build compiles `TuistServer` for iOS Simulator. `TuistServer` imports `TuistEnvironment` directly, and its direct dependencies (`TuistHTTP`, `TuistAndroid`, `TuistOpener`) also require `TuistEnvironment` and `TuistLogging`. But `Module.server` only declared those target dependencies for macOS, so they were missing from the iOS cache build graph.

## Validation

- inspected failing job log: https://github.com/tuist/tuist/actions/runs/24842997103/job/72722020620
- regenerated the project with `tuist generate tuist ProjectDescription --no-open`
- verified the generated target dependency graph now includes explicit `TuistEnvironment` and `TuistLogging` deps under `TuistServer` during `xcodebuild build -project Tuist.xcodeproj -target TuistServer`
- local follow-up build still hits unrelated workspace/toolchain issues (`Mockable` and `Path` resolution in `TuistEnvironment`) before a full end-to-end cache run completes
