### PR TITLE
style(server): enforce deterministic plug declarations

### DIFF
--- a/server/.credo.exs
+++ b/server/.credo.exs
@@ -1,5 +1,6 @@
 alias Credo.Checks.DisallowDirectivesInFunction
 alias Credo.Checks.DisallowGlobalStateMutation
+alias Credo.Checks.DisallowParensInPlug
 alias Credo.Checks.DisallowSpec
 alias Credo.Checks.TimestampsType
 
@@ -24,6 +25,7 @@ alias Credo.Checks.TimestampsType
           {TimestampsType, files: %{included: ["priv/repo/migrations/"]}, allowed_type: :timestamptz},
           {TimestampsType, files: %{included: ["lib/"]}, allowed_type: :utc_datetime},
           {DisallowSpec, []},
+          {DisallowParensInPlug, []},
           {DisallowDirectivesInFunction, files: %{included: ["lib/"]}},
           {ExcellentMigrations.CredoCheck.MigrationsSafety, []},
           {Credo.Checks.UnusedReturnValue, files: %{excluded: ["priv/repo/migrations/"]}},

--- a/server/lib/tuist_web/controllers/api/account_controller.ex
+++ b/server/lib/tuist_web/controllers/api/account_controller.ex
@@ -11,10 +11,9 @@ defmodule TuistWeb.API.AccountController do
   alias TuistWeb.API.Schemas.ValidationError
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags ["Account"]
 

--- a/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
+++ b/server/lib/tuist_web/controllers/api/account_tokens_controller.ex
@@ -10,13 +10,11 @@ defmodule TuistWeb.API.AccountTokensController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.LoaderPlug)
+  plug TuistWeb.Plugs.LoaderPlug
 
-  plug(
-    TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags ["Account tokens"]
 

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -19,34 +19,29 @@ defmodule TuistWeb.API.AnalyticsController do
   alias TuistWeb.Headers
   alias TuistWeb.Plugs.LoaderPlug
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   # We don't want to try and load the run when generating the mulitpart URL as the run might not exist, yet, at this point
-  plug(
-    LoaderPlug,
-    [:project, :account]
-    when action in [
-           :multipart_start_project,
-           :multipart_generate_url_project,
-           :multipart_complete_project,
-           :complete_artifacts_uploads_project
-         ]
-  )
+  plug LoaderPlug,
+       [:project, :account]
+       when action in [
+              :multipart_start_project,
+              :multipart_generate_url_project,
+              :multipart_complete_project,
+              :complete_artifacts_uploads_project
+            ]
 
-  plug(
-    LoaderPlug
-    when action not in [
-           :multipart_start_project,
-           :multipart_generate_url_project,
-           :multipart_complete_project,
-           :complete_artifacts_uploads_project
-         ]
-  )
+  plug LoaderPlug
+       when action not in [
+              :multipart_start_project,
+              :multipart_generate_url_project,
+              :multipart_complete_project,
+              :complete_artifacts_uploads_project
+            ]
 
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :run
   plug :bad_request_when_project_authenticated_from_non_ci_environment when action in [:create]
 
   tags ["Analytics"]

--- a/server/lib/tuist_web/controllers/api/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/api/auth_controller.ex
@@ -9,10 +9,9 @@ defmodule TuistWeb.API.AuthController do
   alias Tuist.Time
   alias TuistWeb.API.Schemas.AuthenticationTokens
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   @refresh_token_ttl {4, :weeks}
   @access_token_ttl {10, :minutes}

--- a/server/lib/tuist_web/controllers/api/automations/alerts_controller.ex
+++ b/server/lib/tuist_web/controllers/api/automations/alerts_controller.ex
@@ -9,13 +9,12 @@ defmodule TuistWeb.API.Automations.AlertsController do
   alias TuistWeb.API.Schemas.AutomationAlertAction
   alias TuistWeb.API.Schemas.Error
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :automation_alert)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :automation_alert
 
   tags ["Automation Alerts"]
 

--- a/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_cache_tasks_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.BuildCacheTasksController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/build_cas_outputs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_cas_outputs_controller.ex
@@ -8,13 +8,12 @@ defmodule TuistWeb.API.BuildCASOutputsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/build_files_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_files_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.BuildFilesController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/build_issues_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_issues_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.BuildIssuesController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/build_targets_controller.ex
+++ b/server/lib/tuist_web/controllers/api/build_targets_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.BuildTargetsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -16,13 +16,12 @@ defmodule TuistWeb.API.BuildsController do
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Builds"]
 

--- a/server/lib/tuist_web/controllers/api/bundle_artifacts_controller.ex
+++ b/server/lib/tuist_web/controllers/api/bundle_artifacts_controller.ex
@@ -6,13 +6,12 @@ defmodule TuistWeb.API.BundleArtifactsController do
   alias Tuist.Bundles
   alias TuistWeb.API.Schemas.Error
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :bundle)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :bundle
 
   tags ["Bundles"]
 

--- a/server/lib/tuist_web/controllers/api/bundles_controller.ex
+++ b/server/lib/tuist_web/controllers/api/bundles_controller.ex
@@ -16,14 +16,12 @@ defmodule TuistWeb.API.BundlesController do
   alias TuistWeb.API.Schemas.ValidationError
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :bundle)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :bundle
 
-  plug(
-    TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags(["Bundles"])
 

--- a/server/lib/tuist_web/controllers/api/cache_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_controller.ex
@@ -14,11 +14,9 @@ defmodule TuistWeb.API.CacheController do
   alias TuistWeb.API.Schemas.CacheCategory
   alias TuistWeb.API.Schemas.Error
 
-  plug(
-    TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   plug TuistWeb.Plugs.LoaderPlug when action not in [:endpoints]
 

--- a/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/cache_runs_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.CacheRunsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :run
 
   tags ["Cache Runs"]
 

--- a/server/lib/tuist_web/controllers/api/crash_reports_controller.ex
+++ b/server/lib/tuist_web/controllers/api/crash_reports_controller.ex
@@ -6,13 +6,12 @@ defmodule TuistWeb.API.CrashReportsController do
   alias Tuist.Tests
   alias TuistWeb.API.Schemas.Error
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/controllers/api/generations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/generations_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.GenerationsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :run
 
   tags ["Generations"]
 

--- a/server/lib/tuist_web/controllers/api/gradle_controller.ex
+++ b/server/lib/tuist_web/controllers/api/gradle_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.GradleController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Gradle"]
 

--- a/server/lib/tuist_web/controllers/api/gradle_tasks_controller.ex
+++ b/server/lib/tuist_web/controllers/api/gradle_tasks_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.GradleTasksController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :build)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :build
 
   tags ["Gradle"]
 

--- a/server/lib/tuist_web/controllers/api/invitations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/invitations_controller.ex
@@ -9,10 +9,9 @@ defmodule TuistWeb.API.InvitationsController do
   alias TuistWeb.API.Schemas.Invitation
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_message: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags ["Invitations"]
 

--- a/server/lib/tuist_web/controllers/api/module_cache_targets_controller.ex
+++ b/server/lib/tuist_web/controllers/api/module_cache_targets_controller.ex
@@ -8,13 +8,12 @@ defmodule TuistWeb.API.ModuleCacheTargetsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :run
 
   tags ["Runs"]
 

--- a/server/lib/tuist_web/controllers/api/oidc_controller.ex
+++ b/server/lib/tuist_web/controllers/api/oidc_controller.ex
@@ -15,11 +15,9 @@ defmodule TuistWeb.API.OIDCController do
   alias Tuist.Projects
   alias TuistWeb.API.Schemas.Error
 
-  plug(
-    TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags(["OIDC Authentication"])
 

--- a/server/lib/tuist_web/controllers/api/organizations_controller.ex
+++ b/server/lib/tuist_web/controllers/api/organizations_controller.ex
@@ -12,10 +12,9 @@ defmodule TuistWeb.API.OrganizationsController do
   alias TuistWeb.API.Schemas.OrganizationUsage
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_message: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags(["Organizations"])
 

--- a/server/lib/tuist_web/controllers/api/previews_controller.ex
+++ b/server/lib/tuist_web/controllers/api/previews_controller.ex
@@ -18,15 +18,14 @@ defmodule TuistWeb.API.PreviewsController do
   alias TuistWeb.API.Schemas.PreviewSupportedPlatform
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.API.TransformQueryArrayParamsPlug, [:supported_platforms])
+  plug TuistWeb.Plugs.API.TransformQueryArrayParamsPlug, [:supported_platforms]
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :preview)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :preview
 
   tags(["Previews"])
 

--- a/server/lib/tuist_web/controllers/api/project_tokens_controller.ex
+++ b/server/lib/tuist_web/controllers/api/project_tokens_controller.ex
@@ -9,11 +9,9 @@ defmodule TuistWeb.API.ProjectTokensController do
   alias TuistWeb.API.Schemas.ProjectToken
   alias TuistWeb.Authentication
 
-  plug(
-    TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags ["Project tokens"]
 

--- a/server/lib/tuist_web/controllers/api/projects_controller.ex
+++ b/server/lib/tuist_web/controllers/api/projects_controller.ex
@@ -11,10 +11,9 @@ defmodule TuistWeb.API.ProjectsController do
   alias TuistWeb.API.Schemas.Project
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
   tags ["Projects"]
 

--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -22,13 +22,12 @@ defmodule TuistWeb.API.RunsController do
   alias TuistWeb.API.Schemas.Tests.Test
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :run)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :run
 
   tags ["Runs"]
 

--- a/server/lib/tuist_web/controllers/api/selective_testing_targets_controller.ex
+++ b/server/lib/tuist_web/controllers/api/selective_testing_targets_controller.ex
@@ -9,13 +9,12 @@ defmodule TuistWeb.API.SelectiveTestingTargetsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/controllers/api/shards_controller.ex
+++ b/server/lib/tuist_web/controllers/api/shards_controller.ex
@@ -8,13 +8,12 @@ defmodule TuistWeb.API.ShardsController do
   alias TuistWeb.API.Schemas.Shards.Shard
   alias TuistWeb.API.Schemas.Shards.ShardPlan
 
-  plug(OpenApiSpex.Plug.CastAndValidate,
+  plug OpenApiSpex.Plug.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags(["Shards"])
 

--- a/server/lib/tuist_web/controllers/api/test_case_run_attachments_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_case_run_attachments_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.TestCaseRunAttachmentsController do
   alias Tuist.Tests
   alias TuistWeb.API.Schemas.Error
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/controllers/api/test_case_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_case_runs_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.TestCaseRunsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.Tests.TestCaseRunsList
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Test Case Runs"]
 

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -9,13 +9,12 @@ defmodule TuistWeb.API.TestCasesController do
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.TestCase
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Test Cases"]
 

--- a/server/lib/tuist_web/controllers/api/test_module_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_module_runs_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.TestModuleRunsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/controllers/api/test_suite_runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_suite_runs_controller.ex
@@ -7,13 +7,12 @@ defmodule TuistWeb.API.TestSuiteRunsController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -10,13 +10,12 @@ defmodule TuistWeb.API.TestsController do
   alias TuistWeb.API.Schemas.Tests.Test
   alias TuistWeb.Authentication
 
-  plug(TuistWeb.Plugs.CastAndValidate,
+  plug TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
     render_error: TuistWeb.RenderAPIErrorPlug
-  )
 
-  plug(TuistWeb.Plugs.LoaderPlug)
-  plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
+  plug TuistWeb.Plugs.LoaderPlug
+  plug TuistWeb.API.Authorization.AuthorizationPlug, :test
 
   tags ["Tests"]
 

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -14,9 +14,9 @@ defmodule TuistWeb.Marketing.MarketingController do
   alias TuistWeb.Helpers.OpenGraph
   alias TuistWeb.Marketing.Localization
 
-  plug(:assign_default_head_tags)
-  plug(:put_resp_header_cache_control)
-  plug(:put_resp_header_server)
+  plug :assign_default_head_tags
+  plug :put_resp_header_cache_control
+  plug :put_resp_header_server
 
   def qa(conn, _params) do
     read_more_posts = Enum.take(Blog.get_posts(), 3)

--- a/server/test/tuist_web/plugs/close_connection_on_error_plug_integration_test.exs
+++ b/server/test/tuist_web/plugs/close_connection_on_error_plug_integration_test.exs
@@ -13,8 +13,8 @@ defmodule TuistWeb.Plugs.CloseConnectionOnErrorPlugIntegrationTest do
   defmodule TestRouter do
     use Plug.Router
 
-    plug(:match)
-    plug(:dispatch)
+    plug :match
+    plug :dispatch
 
     post "/early_error" do
       conn

--- a/tuist_common/credo/checks/disallow_parens_in_plug.ex
+++ b/tuist_common/credo/checks/disallow_parens_in_plug.ex
@@ -1,0 +1,41 @@
+defmodule Credo.Checks.DisallowParensInPlug do
+  @moduledoc """
+  Ensure that local `plug` calls omit parentheses.
+  """
+
+  use Credo.Check,
+    category: :warning,
+    explanations: [
+      check: """
+      `plug` declarations should omit parentheses so they stay visually consistent
+      across controllers, routers, endpoints, and tests.
+      """
+    ]
+
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:plug, meta, _args} = ast, issues, issue_meta) do
+    if Keyword.has_key?(meta, :closing) do
+      {ast, issues ++ [issue_for(meta, issue_meta)]}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(meta, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Omit parentheses in `plug` declarations to keep formatting deterministic.",
+      line_no: meta[:line],
+      column: meta[:column]
+    )
+  end
+end

--- a/tuist_common/test/credo/checks/disallow_parens_in_plug_test.exs
+++ b/tuist_common/test/credo/checks/disallow_parens_in_plug_test.exs
@@ -1,0 +1,52 @@
+defmodule Credo.Checks.DisallowParensInPlugTest do
+  use Credo.Test.Case
+
+  alias Credo.Checks.DisallowParensInPlug
+
+  describe "when plug declarations use parentheses" do
+    test "it reports a violation for single-line calls" do
+      """
+      defmodule Example do
+        use Phoenix.Controller
+
+        plug(MyPlug)
+      end
+      """
+      |> to_source_file()
+      |> run_check(DisallowParensInPlug)
+      |> assert_issue()
+    end
+
+    test "it reports a violation for multiline calls" do
+      """
+      defmodule Example do
+        use Phoenix.Controller
+
+        plug(
+          MyPlug,
+          :show when action in [:show]
+        )
+      end
+      """
+      |> to_source_file()
+      |> run_check(DisallowParensInPlug)
+      |> assert_issue()
+    end
+  end
+
+  describe "when plug declarations omit parentheses" do
+    test "it reports no violations" do
+      """
+      defmodule Example do
+        use Phoenix.Controller
+
+        plug MyPlug
+        plug MyPlug, :show when action in [:show]
+      end
+      """
+      |> to_source_file()
+      |> run_check(DisallowParensInPlug)
+      |> refute_issues()
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared Credo check that flags parenthesized local `plug` declarations
- enable that check in `server/.credo.exs` so the style is enforced during server linting
- normalize existing `server/` `plug(...)` call sites to the no-parens form to remove formatter noise from future diffs

## Why
Elixir's formatter preserves whichever `plug` call style was typed, so `plug ...` and `plug(...)` could drift over time and create review noise. This pins the preferred form in linting and brings existing server declarations into alignment.

## Validation
- `mise x -- mix test test/credo/checks/disallow_parens_in_plug_test.exs` (from `tuist_common/`)
- `mise x -- mix credo suggest --strict --checks DisallowParensInPlug` (from `server/`)
- `rg -n '^\s*plug\(' server -g '*.ex' -g '*.exs'`
