### PR TITLE
fix(server): handle non-integer bundle size analysis page param

### DIFF
--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -891,8 +891,7 @@ defmodule TuistWeb.BundleLive do
     path_hash = :md5 |> :crypto.hash(artifact_path) |> Base.encode16() |> String.slice(0, 8)
     page_param = "bundle-size-analysis-table-page-#{path_hash}"
 
-    bundle_size_analysis_sunburst_chart_table_page =
-      String.to_integer(params[page_param] || "1")
+    bundle_size_analysis_sunburst_chart_table_page = parse_page(params[page_param])
 
     table_page_size = 5
 
@@ -930,6 +929,15 @@ defmodule TuistWeb.BundleLive do
       :bundle_size_analysis_sunburst_chart_table_page_param,
       page_param
     )
+  end
+
+  defp parse_page(nil), do: 1
+
+  defp parse_page(value) do
+    case Integer.parse(to_string(value)) do
+      {page, _} when page > 0 -> page
+      _ -> 1
+    end
   end
 
   defp add_collapsed_to_artifact(artifact, %{assigns: %{artifacts_by_path: artifacts_by_path}} = _socket) do

--- a/server/test/tuist_web/live/bundle_live_test.exs
+++ b/server/test/tuist_web/live/bundle_live_test.exs
@@ -42,4 +42,26 @@ defmodule TuistWeb.BundleLiveTest do
       get(conn, ~p"/tuist/ios_app_with_frameworks/bundles/#{bundle.id}")
     end
   end
+
+  test "falls back to the first page when the bundle-size-analysis-table-page query param is not an integer",
+       %{
+         conn: conn,
+         organization: organization,
+         project: project
+       } do
+    # Given
+    bundle = BundlesFixtures.bundle_fixture(project: project)
+    path_hash = :md5 |> :crypto.hash("App.app") |> Base.encode16() |> String.slice(0, 8)
+    page_param = "bundle-size-analysis-table-page-#{path_hash}"
+
+    # When
+    {:ok, lv, _html} =
+      live(
+        conn,
+        ~p"/#{organization.account.name}/#{project.name}/bundles/#{bundle.id}?#{[{page_param, "not-an-integer"}]}"
+      )
+
+    # Then
+    assert has_element?(lv, "span[data-part='label']", "main")
+  end
 end


### PR DESCRIPTION
Fixes [TUIST-BS](https://tuist.sentry.io/issues/114667988/).

`TuistWeb.BundleLive.assign_table_artifact/3` crashed with `ArgumentError` from `String.to_integer/1` when a request carried the `bundle-size-analysis-table-page-<hash>` query param with a non-integer value (e.g. from a crawler or tampered URL).

### Change

- Added a safe `parse_page/1` helper that uses `Integer.parse/1` and falls back to `1` for nil, non-numeric, or non-positive values — matching the existing pattern in `ops_accounts_live.ex`.
- Replaced the raising `String.to_integer/1` call in `assign_table_artifact/3` with the helper.

### How to test locally

- Run the targeted test: `cd server && mix test test/tuist_web/live/bundle_live_test.exs`.
- The new test `falls back to the first page when the bundle-size-analysis-table-page query param is not an integer` would previously raise `ArgumentError`; it now renders the bundle page and defaults to page 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)