### PR TITLE
feat(cli,xcode-processor): AppleArchive for xcresult upload + respect --inspect-mode remote

### DIFF
--- a/.github/workflows/xcode-processor-deploy.yml
+++ b/.github/workflows/xcode-processor-deploy.yml
@@ -1,75 +1,63 @@
 name: Xcode Processor Deploy
 
-# NOTE: Production deploy is disabled pending migration to Kubernetes.
-# Auto-deploys to the Scaleway Mac mini have been unreliable. There is no
-# canary tier for this service; staging continues to deploy via
-# xcode-processor-staging-deploy.yml. Re-enable by uncommenting the blocks
-# below once the service runs on k8s.
+# NOTE: Auto-deploy on push to main is disabled pending migration to
+# Kubernetes — auto-deploys to the Scaleway Mac mini have been unreliable.
+# Manual deploys via `workflow_dispatch` are still supported so we can roll
+# out coordinated changes (e.g. a new NIF contract before a CLI release).
 
 on:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA to deploy (defaults to the workflow's ref).
+        required: false
+
+concurrency:
+  group: xcode-processor-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: xcode_processor
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
-  disabled:
-    name: Disabled
-    runs-on: ubuntu-latest
+  deploy-production:
+    runs-on: namespace-profile-default-macos
+    timeout-minutes: 45
+    environment: xcode-processor-production
     steps:
-      - run: echo "Xcode processor deploy is intentionally disabled pending the Kubernetes migration."
-
-# on:
-#   workflow_dispatch:
-#   push:
-#     branches:
-#       - main
-#     paths:
-#       - xcode_processor/**
-#       - tuist_common/**
-#       - .github/workflows/xcode-processor-deploy.yml
-#
-# concurrency:
-#   group: xcode-processor-deploy
-#   cancel-in-progress: false
-#
-# permissions:
-#   contents: read
-#
-# defaults:
-#   run:
-#     working-directory: xcode_processor
-#
-# env:
-#   MISE_VERSION: "2026.4.18"
-#   MISE_GITHUB_TOKEN: ${{ github.token }}
-#
-# jobs:
-#   deploy-production:
-#     runs-on: namespace-profile-default-macos
-#     timeout-minutes: 45
-#     environment: xcode-processor-production
-#     steps:
-#       - uses: actions/checkout@v4
-#       - uses: 1password/install-cli-action@v2
-#       - uses: jdx/mise-action@v4.0.1
-#         with:
-#           version: ${{ env.MISE_VERSION }}
-#           install_args: "erlang elixir"
-#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-#           working_directory: xcode_processor
-#       - name: Load secrets from 1Password
-#         env:
-#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-#         run: |
-#           echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-#           op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
-#           echo "EOF" >> $GITHUB_ENV
-#           echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_PRODUCTION/notesPlain')" >> $GITHUB_ENV
-#           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
-#       - name: Setup SSH
-#         uses: webfactory/ssh-agent@v0.9.1
-#         with:
-#           ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
-#       - name: Deploy
-#         env:
-#           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-#         run: |
-#           mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} production
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.sha }}
+      - uses: 1password/install-cli-action@v2
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "erlang elixir"
+          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+          working_directory: xcode_processor
+      - name: Load secrets from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
+          op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_PRODUCTION/notesPlain')" >> $GITHUB_ENV
+          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
+      - name: Deploy
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        run: |
+          mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} production

--- a/.github/workflows/xcode-processor-staging-deploy.yml
+++ b/.github/workflows/xcode-processor-staging-deploy.yml
@@ -1,69 +1,58 @@
 name: Xcode Processor Staging Deploy
 
-# NOTE: Disabled pending migration to Kubernetes. Staging targets the same
-# Scaleway Mac mini infrastructure as production and shares its reliability
-# issues. Re-enable by uncommenting the blocks below once the service runs
-# on k8s.
+# NOTE: Staging targets the same Scaleway Mac mini infrastructure as
+# production. Auto-deploy is intentionally not wired up (reliability
+# issues), but manual dispatches are supported for coordinated rollouts.
+
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Sha of the commit to be deployed
+        required: true
+
+defaults:
+  run:
+    working-directory: xcode_processor
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
-  disabled:
-    name: Disabled
-    runs-on: ubuntu-latest
+  deploy:
+    runs-on: namespace-profile-default-macos
+    timeout-minutes: 45
+    environment: xcode-processor-staging
     steps:
-      - run: echo "Xcode processor staging deploy is intentionally disabled pending the Kubernetes migration."
-
-# permissions:
-#   contents: read
-#
-# on:
-#   workflow_dispatch:
-#     inputs:
-#       commit_sha:
-#         description: Sha of the commit to be deployed
-#         required: true
-#
-# defaults:
-#   run:
-#     working-directory: xcode_processor
-#
-# env:
-#   MISE_VERSION: "2026.4.18"
-#   MISE_GITHUB_TOKEN: ${{ github.token }}
-#
-# jobs:
-#   deploy:
-#     runs-on: namespace-profile-default-macos
-#     timeout-minutes: 45
-#     environment: xcode-processor-staging
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           ref: ${{ github.event.inputs.commit_sha }}
-#       - uses: 1password/install-cli-action@v2
-#       - uses: jdx/mise-action@v4.0.1
-#         with:
-#           version: ${{ env.MISE_VERSION }}
-#           install_args: "erlang elixir"
-#           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
-#           working_directory: xcode_processor
-#       - name: Load secrets from 1Password
-#         env:
-#           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
-#         run: |
-#           echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-#           op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
-#           echo "EOF" >> $GITHUB_ENV
-#           echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
-#           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
-#       - name: Setup SSH
-#         uses: webfactory/ssh-agent@v0.9.1
-#         with:
-#           ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
-#       - name: Deploy
-#         env:
-#           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-#         run: |
-#           mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
+      - uses: 1password/install-cli-action@v2
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "erlang elixir"
+          cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
+          working_directory: xcode_processor
+      - name: Load secrets from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          echo "XCODE_PROCESSOR_SSH_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
+          op read "op://cache/XCODE_PROCESSOR_SSH_PRIVATE_KEY/notesPlain" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "XCODE_PROCESSOR_HOST=$(op read 'op://cache/XCODE_PROCESSOR_HOST_STAGING/notesPlain')" >> $GITHUB_ENV
+          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ env.XCODE_PROCESSOR_SSH_PRIVATE_KEY }}
+      - name: Deploy
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        run: |
+          mise run deploy ${{ env.XCODE_PROCESSOR_HOST }} staging

--- a/Package.swift
+++ b/Package.swift
@@ -375,6 +375,7 @@ tuistServerDependencies.append(contentsOf: [
     "TuistCore", "TuistProcess", "TuistCI",
     "TuistAutomation", "TuistXCActivityLog",
     "TuistXCResultService",
+    .target(name: "TuistAppleArchiver", condition: .when(platforms: [.macOS])),
     xcodeGraphDependency,
 ])
 tuistHTTPDependencies.append(contentsOf: ["TuistSupport", "TuistHAR"])

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -942,6 +942,7 @@ public enum Module: String, CaseIterable {
                     .target(name: "XCResultParser", condition: .when([.macos])),
                     .target(name: Module.machineMetrics.targetName, condition: .when([.macos])),
                     .target(name: Module.simulator.targetName),
+                    .target(name: Module.appleArchiver.targetName, condition: .when([.macos])),
                     .target(name: Module.automation.targetName, condition: .when([.macos])),
                     .target(name: Module.ci.targetName, condition: .when([.macos])),
                     .target(name: Module.process.targetName, condition: .when([.macos])),
@@ -1808,6 +1809,7 @@ public enum Module: String, CaseIterable {
             case .server:
                 [
                     .target(name: Module.android.targetName),
+                    .target(name: Module.appleArchiver.targetName, condition: .when([.macos])),
                     .target(name: Module.support.targetName),
                     .target(name: Module.testing.targetName),
                     .target(name: Module.core.targetName),

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -266,12 +266,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
 
         let mode = mode ?? TestProcessingMode.default(for: config.url)
-        if mode == .remote {
-            let runBundlePath = try cacheDirectoriesProvider
-                .cacheDirectory(for: .runs)
-                .appending(components: runId, "\(Constants.resultBundleName).xcresult")
-            await RunMetadataStorage.current.update(resultBundlePath: runBundlePath)
-        }
 
         if let shardIndex, action == .testWithoutBuilding {
             try await runShard(
@@ -291,7 +285,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 testPlanConfiguration: testPlanConfiguration,
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
                 runId: runId,
-                shardArchivePath: shardArchivePath
+                shardArchivePath: shardArchivePath,
+                mode: mode
             )
             return
         }
@@ -313,7 +308,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 skipTestTargets: skipTestTargets,
                 testPlanConfiguration: testPlanConfiguration,
                 passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,
-                runId: runId
+                runId: runId,
+                mode: mode
             )
             return
         }
@@ -594,7 +590,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         passthroughXcodeBuildArguments: [String],
         runId: String,
-        shardArchivePath: AbsolutePath?
+        shardArchivePath: AbsolutePath?,
+        mode: TestProcessingMode
     ) async throws {
         guard let fullHandle = config.fullHandle else {
             throw TestServiceError.actionInvalid
@@ -659,7 +656,9 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testError = error
         }
 
-        let summary = await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+        let summary = mode == .local
+            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+            : nil
         await uploadResultBundleIfNeeded(
             testSummary: summary,
             resultBundlePath: resultBundlePath,
@@ -667,7 +666,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
             config: config,
             action: .testWithoutBuilding,
             shardPlanId: shard.shardPlanId,
-            shardIndex: shardIndex
+            shardIndex: shardIndex,
+            mode: mode
         )
 
         if let selectiveTestingGraph = shard.selectiveTestingGraph {
@@ -711,7 +711,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
         passthroughXcodeBuildArguments: [String],
-        runId: String
+        runId: String,
+        mode: TestProcessingMode
     ) async throws {
         Logger.current.notice(
             "Skipping project generation, using selective testing graph from .xctestproducts bundle...",
@@ -766,13 +767,16 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testError = error
         }
 
-        let summary = await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+        let summary = mode == .local
+            ? await testSummary(resultBundlePath: resultBundlePath, quarantinedTests: [])
+            : nil
         await uploadResultBundleIfNeeded(
             testSummary: summary,
             resultBundlePath: resultBundlePath,
             projectDerivedDataDirectory: derivedDataPath,
             config: config,
-            action: .testWithoutBuilding
+            action: .testWithoutBuilding,
+            mode: mode
         )
 
         try await storeSuccessfulTestHashesFromGraph(

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -75,9 +75,11 @@ struct XcodeBuildTestCommandService {
         mode: TestProcessingMode? = nil
     ) async throws {
         var passthroughXcodebuildArguments = passthroughXcodebuildArguments
-        try await passthroughXcodebuildArguments.append(
-            contentsOf: resultBundlePathArguments(passthroughXcodebuildArguments: passthroughXcodebuildArguments)
-        )
+        let (
+            resultBundlePathArgs,
+            resolvedResultBundlePath
+        ) = try await resolveResultBundlePath(passthroughXcodebuildArguments: passthroughXcodebuildArguments)
+        passthroughXcodebuildArguments.append(contentsOf: resultBundlePathArgs)
 
         let path = try await path(passthroughXcodebuildArguments: passthroughXcodebuildArguments)
         let config = try await configLoader.loadConfig(path: path)
@@ -129,9 +131,7 @@ struct XcodeBuildTestCommandService {
             }
         }
 
-        let resultBundlePath = await RunMetadataStorage.current.resultBundlePath
-        await RunMetadataStorage.current.update(resultBundlePath: nil)
-
+        let resultBundlePath: AbsolutePath? = resolvedResultBundlePath
         let quarantinedTests = await testQuarantineService.quarantinedTests(config: config, skipQuarantine: skipQuarantine)
 
         do {
@@ -262,27 +262,24 @@ struct XcodeBuildTestCommandService {
         }
     }
 
-    private func resultBundlePathArguments(
+    private func resolveResultBundlePath(
         passthroughXcodebuildArguments: [String]
-    ) async throws -> [String] {
+    ) async throws -> (additionalArguments: [String], resultBundlePath: AbsolutePath) {
         if let resultBundlePathString = passedValue(
             for: "-resultBundlePath",
             arguments: passthroughXcodebuildArguments
         ) {
             let currentWorkingDirectory = try await Environment.current.currentWorkingDirectory()
             let resultBundlePath = try AbsolutePath(validating: resultBundlePathString, relativeTo: currentWorkingDirectory)
-            await RunMetadataStorage.current.update(
-                resultBundlePath: resultBundlePath
-            )
-            return []
+            return (additionalArguments: [], resultBundlePath: resultBundlePath)
         } else {
             let resultBundlePath = try cacheDirectoriesProvider
                 .cacheDirectory(for: .runs)
                 .appending(components: uniqueIDGenerator.uniqueID())
-            await RunMetadataStorage.current.update(
+            return (
+                additionalArguments: ["-resultBundlePath", resultBundlePath.pathString],
                 resultBundlePath: resultBundlePath
             )
-            return ["-resultBundlePath", resultBundlePath.pathString]
         }
     }
 

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -130,9 +130,7 @@ struct XcodeBuildTestCommandService {
         }
 
         let resultBundlePath = await RunMetadataStorage.current.resultBundlePath
-        if mode == .local {
-            await RunMetadataStorage.current.update(resultBundlePath: nil)
-        }
+        await RunMetadataStorage.current.update(resultBundlePath: nil)
 
         let quarantinedTests = await testQuarantineService.quarantinedTests(config: config, skipQuarantine: skipQuarantine)
 

--- a/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -89,7 +89,7 @@
             self.multipartUploadCompleteAnalyticsService = multipartUploadCompleteAnalyticsService
             self.completeAnalyticsArtifactsUploadsService = completeAnalyticsArtifactsUploadsService
             #if canImport(TuistAppleArchiver)
-                self.appleArchiver = AppleArchiver()
+                appleArchiver = AppleArchiver()
             #endif
         }
 

--- a/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
+++ b/cli/Sources/TuistServer/Services/AnalyticsArtifactUploadService.swift
@@ -5,7 +5,11 @@
     import Path
     import TuistCore
     import TuistHTTP
+    import TuistLogging
     import TuistSupport
+    #if canImport(TuistAppleArchiver)
+        import TuistAppleArchiver
+    #endif
 
     @Mockable
     public protocol AnalyticsArtifactUploadServicing {
@@ -44,6 +48,9 @@
         private let multipartUploadArtifactService: MultipartUploadArtifactServicing
         private let multipartUploadCompleteAnalyticsService: MultipartUploadCompleteAnalyticsServicing
         private let completeAnalyticsArtifactsUploadsService: CompleteAnalyticsArtifactsUploadsServicing
+        #if canImport(TuistAppleArchiver)
+            private let appleArchiver: AppleArchiving
+        #endif
 
         public init() {
             self.init(
@@ -81,7 +88,36 @@
             self.multipartUploadArtifactService = multipartUploadArtifactService
             self.multipartUploadCompleteAnalyticsService = multipartUploadCompleteAnalyticsService
             self.completeAnalyticsArtifactsUploadsService = completeAnalyticsArtifactsUploadsService
+            #if canImport(TuistAppleArchiver)
+                self.appleArchiver = AppleArchiver()
+            #endif
         }
+
+        #if canImport(TuistAppleArchiver)
+            init(
+                fileSystem: FileSysteming,
+                xcresultToolController: XCResultToolControlling,
+                fileArchiver: FileArchivingFactorying,
+                fullHandleService: FullHandleServicing,
+                multipartUploadStartAnalyticsService: MultipartUploadStartAnalyticsServicing,
+                multipartUploadGenerateURLAnalyticsService: MultipartUploadGenerateURLAnalyticsServicing,
+                multipartUploadArtifactService: MultipartUploadArtifactServicing,
+                multipartUploadCompleteAnalyticsService: MultipartUploadCompleteAnalyticsServicing,
+                completeAnalyticsArtifactsUploadsService: CompleteAnalyticsArtifactsUploadsServicing,
+                appleArchiver: AppleArchiving
+            ) {
+                self.fileSystem = fileSystem
+                self.xcresultToolController = xcresultToolController
+                self.fileArchiver = fileArchiver
+                self.fullHandleService = fullHandleService
+                self.multipartUploadStartAnalyticsService = multipartUploadStartAnalyticsService
+                self.multipartUploadGenerateURLAnalyticsService = multipartUploadGenerateURLAnalyticsService
+                self.multipartUploadArtifactService = multipartUploadArtifactService
+                self.multipartUploadCompleteAnalyticsService = multipartUploadCompleteAnalyticsService
+                self.completeAnalyticsArtifactsUploadsService = completeAnalyticsArtifactsUploadsService
+                self.appleArchiver = appleArchiver
+            }
+        #endif
 
         public func uploadAndAnalyzeResultBundle(
             _ resultBundle: AbsolutePath,
@@ -90,6 +126,9 @@
             commandEventId: String,
             serverURL: URL
         ) async throws {
+            Logger.current.debug("Starting result bundle upload and analyze for \(resultBundle.pathString)")
+            let totalStart = Date()
+
             try await uploadAnalyticsArtifact(
                 ServerCommandEvent.Artifact(
                     type: .resultBundle
@@ -102,6 +141,7 @@
             )
 
             try await fileSystem.runInTemporaryDirectory(prefix: UUID().uuidString) { temporaryPath in
+                let parseStart = Date()
                 let invocationRecordString = try await xcresultToolController.resultBundleObject(
                     resultBundle
                 )
@@ -112,10 +152,15 @@
                 let invocationRecord = try decoder.decode(
                     InvocationRecord.self, from: invocationRecordString.data(using: .utf8)!
                 )
+                Logger.current.debug(
+                    "Parsed invocation record in \(String(format: "%.2fs", Date().timeIntervalSince(parseStart)))"
+                )
+
                 for testActionRecord in invocationRecord.actions._values
                     .filter({ $0.schemeCommandName._value == "Test" })
                 {
                     guard let id = testActionRecord.actionResult.testsRef?.id._value else { continue }
+                    let actionParseStart = Date()
                     let resultBundleObjectString = try await xcresultToolController.resultBundleObject(
                         resultBundle,
                         id: id
@@ -123,6 +168,9 @@
                     let filename = "\(id).json"
                     let resultBundleObjectPath = temporaryPath.appending(component: filename)
                     try await fileSystem.writeText(resultBundleObjectString, at: resultBundleObjectPath)
+                    Logger.current.debug(
+                        "Parsed result bundle object \(id) in \(String(format: "%.2fs", Date().timeIntervalSince(actionParseStart)))"
+                    )
                     try await uploadAnalyticsArtifact(
                         ServerCommandEvent.Artifact(
                             type: .resultBundleObject,
@@ -154,6 +202,10 @@
                     serverURL: serverURL
                 )
             }
+
+            Logger.current.debug(
+                "Result bundle upload and analyze finished in \(String(format: "%.2fs", Date().timeIntervalSince(totalStart)))"
+            )
         }
 
         public func uploadResultBundle(
@@ -205,18 +257,43 @@
         ) async throws {
             let passedArtifactPath = artifactPath
             let artifactPath: AbsolutePath
+            let artifactLabel = "\(artifact.type)\(artifact.name.map { " (\($0))" } ?? "")"
 
+            let archiveStart = Date()
             switch artifact.type {
             case .resultBundle:
-                artifactPath = try await fileArchiver.makeFileArchiver(for: [passedArtifactPath])
-                    .zip(name: passedArtifactPath.basenameWithoutExt)
+                #if canImport(TuistAppleArchiver)
+                    // AppleArchive (LZFSE) is substantially faster than deflate for xcresult
+                    // bundles and skips the pre-copy the zip path needs. The server-side
+                    // `xcode_processor` sniffs magic bytes to decide between zip and aar.
+                    let archiveDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "tuist-analytics-archive")
+                    let archivePath = archiveDirectory.appending(
+                        component: "\(passedArtifactPath.basenameWithoutExt).aar"
+                    )
+                    try await appleArchiver.compress(
+                        directory: passedArtifactPath,
+                        to: archivePath,
+                        excludePatterns: []
+                    )
+                    artifactPath = archivePath
+                #else
+                    artifactPath = try await fileArchiver.makeFileArchiver(for: [passedArtifactPath])
+                        .zip(name: passedArtifactPath.basenameWithoutExt)
+                #endif
             case .session:
                 artifactPath = try await fileArchiver.makeFileArchiver(for: [passedArtifactPath])
                     .zip(name: "session")
             case .invocationRecord, .resultBundleObject:
                 artifactPath = passedArtifactPath
             }
+            if artifact.type == .resultBundle || artifact.type == .session {
+                let archiveElapsed = Date().timeIntervalSince(archiveStart)
+                Logger.current.debug(
+                    "Archived \(artifactLabel) in \(String(format: "%.2fs", archiveElapsed))"
+                )
+            }
 
+            let uploadStart = Date()
             let uploadId = try await multipartUploadStartAnalyticsService.uploadAnalyticsArtifact(
                 artifact,
                 accountHandle: accountHandle,
@@ -250,6 +327,10 @@
                 uploadId: uploadId,
                 parts: parts,
                 serverURL: serverURL
+            )
+            let uploadElapsed = Date().timeIntervalSince(uploadStart)
+            Logger.current.debug(
+                "Uploaded \(artifactLabel) in \(String(format: "%.2fs", uploadElapsed)) (\(parts.count) parts)"
             )
         }
     }

--- a/cli/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/cli/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Mockable
 import Path
+import TuistLogging
 
 /// An interface to archive files in a zip file.
 @Mockable
@@ -36,10 +37,26 @@ public class FileArchiver: FileArchiving {
         // ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory.
         let pathsDirectoryPath = temporaryDirectory.appending(component: "\(name)-paths")
         try await fileSystem.makeDirectory(at: pathsDirectoryPath)
+
+        Logger.current.debug(
+            "Archiving \(paths.count) path(s) into \(name).zip (staging at \(pathsDirectoryPath.pathString))"
+        )
+
+        let copyStart = Date()
         for path in paths {
             try await fileSystem.copy(path, to: pathsDirectoryPath.appending(component: path.basename))
         }
+        let copyElapsed = Date().timeIntervalSince(copyStart)
+        Logger.current.debug("Staging copy for \(name).zip finished in \(String(format: "%.2fs", copyElapsed))")
+
+        let zipStart = Date()
         try await fileSystem.zipFileOrDirectoryContent(at: pathsDirectoryPath, to: destinationZipPath)
+        let zipElapsed = Date().timeIntervalSince(zipStart)
+        let zipBytes = (try? await fileSystem.fileMetadata(at: destinationZipPath)?.size) ?? 0
+        Logger.current.debug(
+            "Zipped \(name).zip in \(String(format: "%.2fs", zipElapsed)) (output: \(zipBytes) bytes)"
+        )
+
         return destinationZipPath
     }
 

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -118,12 +118,15 @@ struct XcodeBuildTestCommandServiceTests {
         try await subject.run(passthroughXcodebuildArguments: arguments)
 
         // Then
+        let expectedResultBundlePath = temporaryDirectory.appending(components: "cache", uniqueID)
         verify(xcodeBuildController)
-            .run(arguments: .any)
+            .run(arguments: .value([
+                "test",
+                "-scheme", "MyAppTests",
+                "-resultBundlePath", expectedResultBundlePath.pathString,
+            ]))
             .called(1)
 
-        let expectedResultBundlePath = temporaryDirectory.appending(components: "cache", uniqueID)
-        await #expect(RunMetadataStorage.current.resultBundlePath == expectedResultBundlePath)
         await #expect(RunMetadataStorage.current.buildRunId == activityLogPath.basenameWithoutExt)
     }
 
@@ -160,7 +163,10 @@ struct XcodeBuildTestCommandServiceTests {
         // When
         try await subject.run(passthroughXcodebuildArguments: arguments)
 
-        // Then
+        // Then — the user-supplied `-resultBundlePath` arg is forwarded verbatim to
+        // xcodebuild. `RunMetadataStorage.resultBundlePath` is intentionally left `nil`
+        // for test flows: both local (test summary) and remote (uploadResultBundle)
+        // own the bundle handoff without relying on `UploadAnalyticsService`.
         verify(xcodeBuildController)
             .run(
                 arguments: .value([
@@ -170,8 +176,6 @@ struct XcodeBuildTestCommandServiceTests {
                 ])
             )
             .called(1)
-
-        await #expect(RunMetadataStorage.current.resultBundlePath == resultBundlePath)
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())

--- a/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
+++ b/cli/Tests/TuistServerTests/AnalyticsArtifactUploadServiceTests.swift
@@ -1,6 +1,9 @@
 import FileSystem
 import Foundation
 import Mockable
+#if canImport(TuistAppleArchiver)
+    import TuistAppleArchiver
+#endif
 import TuistCore
 import TuistHTTP
 import TuistServer
@@ -22,6 +25,9 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         MockMultipartUploadCompleteAnalyticsServicing!
     private var completeAnalyticsArtifactsUploadsService:
         MockCompleteAnalyticsArtifactsUploadsServicing!
+    #if canImport(TuistAppleArchiver)
+        private var appleArchiver: MockAppleArchiving!
+    #endif
 
     override func setUp() {
         super.setUp()
@@ -34,18 +40,33 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         multipartUploadArtifactService = .init()
         multipartUploadCompleteAnalyticsService = .init()
         completeAnalyticsArtifactsUploadsService = .init()
-
-        subject = AnalyticsArtifactUploadService(
-            fileSystem: fileSystem,
-            xcresultToolController: xcresultToolController,
-            fileArchiver: fileArchiverFactory,
-            fullHandleService: FullHandleService(),
-            multipartUploadStartAnalyticsService: multipartUploadStartAnalyticsService,
-            multipartUploadGenerateURLAnalyticsService: multipartUploadGenerateURLAnalyticsService,
-            multipartUploadArtifactService: multipartUploadArtifactService,
-            multipartUploadCompleteAnalyticsService: multipartUploadCompleteAnalyticsService,
-            completeAnalyticsArtifactsUploadsService: completeAnalyticsArtifactsUploadsService
-        )
+        #if canImport(TuistAppleArchiver)
+            appleArchiver = .init()
+            subject = AnalyticsArtifactUploadService(
+                fileSystem: fileSystem,
+                xcresultToolController: xcresultToolController,
+                fileArchiver: fileArchiverFactory,
+                fullHandleService: FullHandleService(),
+                multipartUploadStartAnalyticsService: multipartUploadStartAnalyticsService,
+                multipartUploadGenerateURLAnalyticsService: multipartUploadGenerateURLAnalyticsService,
+                multipartUploadArtifactService: multipartUploadArtifactService,
+                multipartUploadCompleteAnalyticsService: multipartUploadCompleteAnalyticsService,
+                completeAnalyticsArtifactsUploadsService: completeAnalyticsArtifactsUploadsService,
+                appleArchiver: appleArchiver
+            )
+        #else
+            subject = AnalyticsArtifactUploadService(
+                fileSystem: fileSystem,
+                xcresultToolController: xcresultToolController,
+                fileArchiver: fileArchiverFactory,
+                fullHandleService: FullHandleService(),
+                multipartUploadStartAnalyticsService: multipartUploadStartAnalyticsService,
+                multipartUploadGenerateURLAnalyticsService: multipartUploadGenerateURLAnalyticsService,
+                multipartUploadArtifactService: multipartUploadArtifactService,
+                multipartUploadCompleteAnalyticsService: multipartUploadCompleteAnalyticsService,
+                completeAnalyticsArtifactsUploadsService: completeAnalyticsArtifactsUploadsService
+            )
+        #endif
     }
 
     override func tearDown() {
@@ -70,16 +91,27 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
         let serverURL: URL = .test()
         let commandEventID = UUID().uuidString
 
-        let fileArchiver = MockFileArchiving()
-        given(fileArchiverFactory)
-            .makeFileArchiver(for: .value([resultBundle]))
-            .willReturn(fileArchiver)
+        #if canImport(TuistAppleArchiver)
+            // On macOS the result_bundle path goes through AppleArchive, not the zip
+            // `FileArchiver`. Stub compress to write an .aar file so the downstream
+            // multipart pipeline has a real file to work with.
+            given(appleArchiver)
+                .compress(directory: .value(resultBundle), to: .any, excludePatterns: .value([]))
+                .willProduce { _, archivePath, _ in
+                    try Data("fake-aar".utf8).write(to: archivePath.url)
+                }
+        #else
+            let fileArchiver = MockFileArchiving()
+            given(fileArchiverFactory)
+                .makeFileArchiver(for: .value([resultBundle]))
+                .willReturn(fileArchiver)
 
-        let artifactArchivePath = temporaryDirectory.appending(component: "artifact.zip")
+            let artifactArchivePath = temporaryDirectory.appending(component: "artifact.zip")
 
-        given(fileArchiver)
-            .zip(name: .value("artifact"))
-            .willReturn(artifactArchivePath)
+            given(fileArchiver)
+                .zip(name: .value("artifact"))
+                .willReturn(artifactArchivePath)
+        #endif
 
         given(multipartUploadStartAnalyticsService)
             .uploadAnalyticsArtifact(
@@ -92,16 +124,29 @@ final class AnalyticsArtifactUploadServiceTests: TuistTestCase {
             .willReturn("upload-id")
 
         var generateUploadURLCallback: ((MultipartUploadArtifactPart) async throws -> String)!
-        given(multipartUploadArtifactService)
-            .multipartUploadArtifact(
-                artifactPath: .value(artifactArchivePath),
-                generateUploadURL: .matching { callback in
-                    generateUploadURLCallback = callback
-                    return true
-                },
-                updateProgress: .any
-            )
-            .willReturn([(etag: "etag", partNumber: 1)])
+        #if canImport(TuistAppleArchiver)
+            given(multipartUploadArtifactService)
+                .multipartUploadArtifact(
+                    artifactPath: .matching { $0.extension == "aar" },
+                    generateUploadURL: .matching { callback in
+                        generateUploadURLCallback = callback
+                        return true
+                    },
+                    updateProgress: .any
+                )
+                .willReturn([(etag: "etag", partNumber: 1)])
+        #else
+            given(multipartUploadArtifactService)
+                .multipartUploadArtifact(
+                    artifactPath: .value(artifactArchivePath),
+                    generateUploadURL: .matching { callback in
+                        generateUploadURLCallback = callback
+                        return true
+                    },
+                    updateProgress: .any
+                )
+                .willReturn([(etag: "etag", partNumber: 1)])
+        #endif
 
         given(multipartUploadCompleteAnalyticsService)
             .uploadAnalyticsArtifact(

--- a/xcode_processor/lib/xcode_processor/xcresult_nif.ex
+++ b/xcode_processor/lib/xcode_processor/xcresult_nif.ex
@@ -57,7 +57,20 @@ defmodule XcodeProcessor.XCResultNIF do
     end
   end
 
+  @doc """
+  Extracts an AppleArchive (.aar) payload into `destination_dir` using the
+  native Apple Archive framework. PKZIP archives are not handled here — the
+  caller should dispatch on magic bytes first.
+  """
+  def decompress_archive(source_path, destination_dir) do
+    decompress_archive_nif(source_path, destination_dir)
+  end
+
   defp parse_nif(_xcresult_path, _root_directory) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  defp decompress_archive_nif(_source_path, _destination_dir) do
     :erlang.nif_error(:nif_not_loaded)
   end
 end

--- a/xcode_processor/lib/xcode_processor/xcresult_processor.ex
+++ b/xcode_processor/lib/xcode_processor/xcresult_processor.ex
@@ -3,12 +3,12 @@ defmodule XcodeProcessor.XCResultProcessor do
 
   require Logger
 
-  def process_local(zip_path, opts \\ []) do
+  def process_local(archive_path, opts \\ []) do
     bucket = Keyword.get(opts, :s3_bucket) || XcodeProcessor.Environment.s3_bucket()
     temp_dir = make_temp_dir()
 
     try do
-      result = process_zip(zip_path, temp_dir)
+      result = process_archive(archive_path, temp_dir)
 
       with {:ok, parsed_data} <- result do
         upload_attachments(parsed_data, bucket, opts)
@@ -21,15 +21,15 @@ defmodule XcodeProcessor.XCResultProcessor do
   def process(storage_key, opts \\ []) do
     bucket = XcodeProcessor.Environment.s3_bucket()
     temp_dir = make_temp_dir()
-    zip_path = Path.join(temp_dir, "xcresult.zip")
+    archive_path = Path.join(temp_dir, "xcresult-archive")
 
     try do
       :telemetry.span([:xcode_processor, :xcresult], %{}, fn ->
         download_result =
           :telemetry.span([:xcode_processor, :s3, :download], %{}, fn ->
-            case ExAws.S3.download_file(bucket, storage_key, zip_path) |> ExAws.request() do
+            case ExAws.S3.download_file(bucket, storage_key, archive_path) |> ExAws.request() do
               {:ok, _} ->
-                file_size = File.stat!(zip_path).size
+                file_size = File.stat!(archive_path).size
                 {:ok, %{file_size: file_size}}
 
               {:error, reason} ->
@@ -43,7 +43,7 @@ defmodule XcodeProcessor.XCResultProcessor do
               error
 
             _ ->
-              result = process_zip(zip_path, temp_dir)
+              result = process_archive(archive_path, temp_dir)
 
               with {:ok, parsed_data} <- result do
                 upload_attachments(parsed_data, bucket, opts)
@@ -58,20 +58,40 @@ defmodule XcodeProcessor.XCResultProcessor do
     end
   end
 
-  defp process_zip(zip_path, temp_dir) do
-    {:ok, _} = :zip.unzip(~c"#{zip_path}", [{:cwd, ~c"#{temp_dir}"}])
+  defp process_archive(archive_path, temp_dir) do
+    with :ok <- extract_archive(archive_path, temp_dir),
+         xcresult_path when not is_nil(xcresult_path) <- find_xcresult(temp_dir) do
+      root_dir = Path.dirname(xcresult_path)
 
-    case find_xcresult(temp_dir) do
-      nil ->
-        {:error, :xcresult_not_found}
+      with {:ok, parsed_data} <- parse_xcresult(xcresult_path, root_dir) do
+        quarantined_tests = read_quarantined_tests(xcresult_path)
+        {:ok, apply_quarantine(parsed_data, quarantined_tests)}
+      end
+    else
+      nil -> {:error, :xcresult_not_found}
+      {:error, _} = error -> error
+    end
+  end
 
-      xcresult_path ->
-        root_dir = Path.dirname(xcresult_path)
+  # Callers upload either a PKZIP archive (legacy CLI clients) or an
+  # AppleArchive payload (newer CLI clients — faster via LZFSE). Sniff the
+  # magic bytes and dispatch: Erlang's `:zip` for PKZIP, the Swift NIF
+  # (AppleArchive framework) for everything else.
+  @pkzip_magic <<0x50, 0x4B>>
 
-        with {:ok, parsed_data} <- parse_xcresult(xcresult_path, root_dir) do
-          quarantined_tests = read_quarantined_tests(xcresult_path)
-          {:ok, apply_quarantine(parsed_data, quarantined_tests)}
+  defp extract_archive(archive_path, temp_dir) do
+    case File.open(archive_path, [:read, :binary], fn file -> IO.binread(file, 2) end) do
+      {:ok, @pkzip_magic} ->
+        case :zip.unzip(~c"#{archive_path}", [{:cwd, ~c"#{temp_dir}"}]) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, {:zip_unzip_failed, reason}}
         end
+
+      {:ok, _} ->
+        XcodeProcessor.XCResultNIF.decompress_archive(archive_path, temp_dir)
+
+      {:error, reason} ->
+        {:error, {:archive_read_failed, reason}}
     end
   end
 

--- a/xcode_processor/native/xcresult_nif/Sources/XCResultNIF/ArchiveDecompressor.swift
+++ b/xcode_processor/native/xcresult_nif/Sources/XCResultNIF/ArchiveDecompressor.swift
@@ -1,0 +1,106 @@
+import AppleArchive
+import Foundation
+import System
+
+/// Decompresses an AppleArchive (.aar) file into `destinationDirectory`.
+///
+/// Exposed to the Erlang NIF layer via `@_cdecl("decompress_archive")`. The
+/// Elixir side is responsible for sniffing the magic bytes and only routing
+/// AppleArchive payloads here; ZIP payloads continue to use Erlang's `:zip`.
+@_cdecl("decompress_archive")
+public func decompressArchiveNIF(
+    _ sourcePathPtr: UnsafePointer<CChar>,
+    _ destinationDirPtr: UnsafePointer<CChar>,
+    _ errorPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+    _ errorLen: UnsafeMutablePointer<Int32>
+) -> Int32 {
+    let sourcePath = String(cString: sourcePathPtr)
+    let destinationDir = String(cString: destinationDirPtr)
+
+    do {
+        try ArchiveDecompressor.decompress(
+            archive: sourcePath,
+            into: destinationDir
+        )
+        return 0
+    } catch {
+        writeCString(
+            "{\"error\": \"\(error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\""))\"}",
+            outputPtr: errorPtr,
+            outputLen: errorLen
+        )
+        return 1
+    }
+}
+
+enum ArchiveDecompressorError: LocalizedError {
+    case openStreamFailed(String)
+    case decompressionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .openStreamFailed(detail): return "could not open archive stream: \(detail)"
+        case let .decompressionFailed(detail): return "archive decompression failed: \(detail)"
+        }
+    }
+}
+
+enum ArchiveDecompressor {
+    /// Extracts the entries of an AppleArchive file into `destination`.
+    /// Mirrors `AppleArchiver.decompress` in the CLI so both ends agree on
+    /// the stream pipeline (byte stream → decompression → decode → extract).
+    static func decompress(archive archivePath: String, into destination: String) throws {
+        let source = FilePath(archivePath)
+        let target = FilePath(destination)
+
+        guard let readStream = ArchiveByteStream.fileStream(
+            path: source,
+            mode: .readOnly,
+            options: [],
+            permissions: []
+        ) else {
+            throw ArchiveDecompressorError.openStreamFailed("file stream")
+        }
+        defer { try? readStream.close() }
+
+        guard let decompressStream = ArchiveByteStream.decompressionStream(
+            readingFrom: readStream
+        ) else {
+            throw ArchiveDecompressorError.openStreamFailed("decompression stream")
+        }
+        defer { try? decompressStream.close() }
+
+        guard let decodeStream = ArchiveStream.decodeStream(readingFrom: decompressStream) else {
+            throw ArchiveDecompressorError.openStreamFailed("decode stream")
+        }
+        defer { try? decodeStream.close() }
+
+        guard let extractStream = ArchiveStream.extractStream(
+            extractingTo: target,
+            flags: [.ignoreOperationNotPermitted]
+        ) else {
+            throw ArchiveDecompressorError.openStreamFailed("extract stream")
+        }
+        defer { try? extractStream.close() }
+
+        do {
+            _ = try ArchiveStream.process(readingFrom: decodeStream, writingTo: extractStream)
+        } catch {
+            throw ArchiveDecompressorError.decompressionFailed(error.localizedDescription)
+        }
+    }
+}
+
+private func writeCString(
+    _ string: String,
+    outputPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+    outputLen: UnsafeMutablePointer<Int32>
+) {
+    let data = Array(string.utf8)
+    let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: data.count)
+    for (i, byte) in data.enumerated() {
+        buffer[i] = CChar(bitPattern: byte)
+    }
+    outputPtr.pointee = buffer
+    outputLen.pointee = Int32(data.count)
+}

--- a/xcode_processor/native/xcresult_nif/nif_bridge.c
+++ b/xcode_processor/native/xcresult_nif/nif_bridge.c
@@ -17,6 +17,13 @@ extern int parse_xcresult(
     int *output_len
 );
 
+extern int decompress_archive(
+    const char *source_path,
+    const char *destination_dir,
+    char **error_ptr,
+    int *error_len
+);
+
 static ERL_NIF_TERM parse_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     if (argc != 2) {
@@ -76,8 +83,60 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     );
 }
 
+static ERL_NIF_TERM decompress_archive_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary source_bin;
+    if (!enif_inspect_binary(env, argv[0], &source_bin)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary dest_bin;
+    if (!enif_inspect_binary(env, argv[1], &dest_bin)) {
+        return enif_make_badarg(env);
+    }
+
+    char *source = malloc(source_bin.size + 1);
+    if (!source) return enif_make_badarg(env);
+    memcpy(source, source_bin.data, source_bin.size);
+    source[source_bin.size] = '\0';
+
+    char *destination = malloc(dest_bin.size + 1);
+    if (!destination) { free(source); return enif_make_badarg(env); }
+    memcpy(destination, dest_bin.data, dest_bin.size);
+    destination[dest_bin.size] = '\0';
+
+    char *error_output = NULL;
+    int error_len = 0;
+
+    int result = decompress_archive(source, destination, &error_output, &error_len);
+
+    free(source);
+    free(destination);
+
+    if (result == 0) {
+        if (error_output) free(error_output);
+        return enif_make_atom(env, "ok");
+    }
+
+    ERL_NIF_TERM reason;
+    if (error_output && error_len > 0) {
+        unsigned char *bin_data = enif_make_new_binary(env, error_len, &reason);
+        memcpy(bin_data, error_output, error_len);
+        free(error_output);
+    } else {
+        reason = enif_make_atom(env, "decompress_failed");
+    }
+
+    return enif_make_tuple2(env, enif_make_atom(env, "error"), reason);
+}
+
 static ErlNifFunc nif_funcs[] = {
-    {"parse_nif", 2, parse_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND}
+    {"parse_nif", 2, parse_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"decompress_archive_nif", 2, decompress_archive_nif, ERL_NIF_DIRTY_JOB_IO_BOUND}
 };
 
 ERL_NIF_INIT(Elixir.XcodeProcessor.XCResultNIF, nif_funcs, NULL, NULL, NULL, NULL)

--- a/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
+++ b/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
@@ -228,7 +228,10 @@ defmodule XcodeProcessor.XCResultProcessorTest do
       # AppleArchive LZFSE-compressed streams start with the "bvx" prefix; any
       # non-PKZIP header routes through `XCResultNIF.decompress_archive`.
       fixture_dir =
-        Path.join(System.tmp_dir!(), "xcresult_aar_fixture_#{:erlang.unique_integer([:positive])}")
+        Path.join(
+          System.tmp_dir!(),
+          "xcresult_aar_fixture_#{:erlang.unique_integer([:positive])}"
+        )
 
       File.mkdir_p!(fixture_dir)
       fixture_path = Path.join(fixture_dir, "fixture.aar")
@@ -260,7 +263,10 @@ defmodule XcodeProcessor.XCResultProcessorTest do
 
     test "surfaces NIF decompression failures for AppleArchive payloads" do
       fixture_dir =
-        Path.join(System.tmp_dir!(), "xcresult_aar_failure_#{:erlang.unique_integer([:positive])}")
+        Path.join(
+          System.tmp_dir!(),
+          "xcresult_aar_failure_#{:erlang.unique_integer([:positive])}"
+        )
 
       File.mkdir_p!(fixture_dir)
       fixture_path = Path.join(fixture_dir, "fixture.aar")

--- a/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
+++ b/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
@@ -224,6 +224,63 @@ defmodule XcodeProcessor.XCResultProcessorTest do
       refute Map.has_key?(attachment, "file_path")
     end
 
+    test "dispatches to AppleArchive NIF when the downloaded payload is not PKZIP" do
+      # AppleArchive LZFSE-compressed streams start with the "bvx" prefix; any
+      # non-PKZIP header routes through `XCResultNIF.decompress_archive`.
+      fixture_dir =
+        Path.join(System.tmp_dir!(), "xcresult_aar_fixture_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(fixture_dir)
+      fixture_path = Path.join(fixture_dir, "fixture.aar")
+      File.write!(fixture_path, <<0x62, 0x76, 0x78, 0x32, "fake-aar-body">>)
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      parsed_data = %{"tests" => [%{"name" => "testAar", "status" => "passed"}]}
+
+      stub(ExAws.S3, :download_file, fn _bucket, _key, dest_path ->
+        File.cp!(fixture_path, dest_path)
+        %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}
+      end)
+
+      expect(ExAws, :request, fn _ -> {:ok, :done} end)
+
+      expect(XcodeProcessor.XCResultNIF, :decompress_archive, fn _archive_path, temp_dir ->
+        File.mkdir_p!(Path.join(temp_dir, "Test.xcresult"))
+        File.write!(Path.join([temp_dir, "Test.xcresult", "Info.plist"]), "fake-plist")
+        :ok
+      end)
+
+      expect(XcodeProcessor.XCResultNIF, :parse, fn xcresult_path, _root ->
+        assert String.ends_with?(xcresult_path, "Test.xcresult")
+        {:ok, parsed_data}
+      end)
+
+      assert {:ok, ^parsed_data} = XCResultProcessor.process("some/key.aar")
+    end
+
+    test "surfaces NIF decompression failures for AppleArchive payloads" do
+      fixture_dir =
+        Path.join(System.tmp_dir!(), "xcresult_aar_failure_#{:erlang.unique_integer([:positive])}")
+
+      File.mkdir_p!(fixture_dir)
+      fixture_path = Path.join(fixture_dir, "fixture.aar")
+      File.write!(fixture_path, <<0x62, 0x76, 0x78, 0x32, "fake-aar-body">>)
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      stub(ExAws.S3, :download_file, fn _bucket, _key, dest_path ->
+        File.cp!(fixture_path, dest_path)
+        %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}
+      end)
+
+      expect(ExAws, :request, fn _ -> {:ok, :done} end)
+
+      expect(XcodeProcessor.XCResultNIF, :decompress_archive, fn _archive_path, _temp_dir ->
+        {:error, "decompression failed"}
+      end)
+
+      assert {:error, "decompression failed"} = XCResultProcessor.process("some/key.aar")
+    end
+
     test "cleans up temp directory even when processing fails" do
       stub(ExAws.S3, :download_file, fn _bucket, _key, _dest_path ->
         %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}


### PR DESCRIPTION
## Purpose

Two bugs in the xcresult upload path were combining to add **6–10 minutes** to every remote test run, on top of the actual multipart upload:

1. `--inspect-mode remote` was silently ignored for `tuist test --without-building` runs that take the selective-testing shortcut. Users got local-mode behavior (a ~22 MB `test_modules` JSON inline in `POST /tests`) despite asking for remote processing.
2. The `tuist xcodebuild test` remote path was **double-uploading** the xcresult — once via `UploadResultBundleService` (for server-side processing) and once via `UploadAnalyticsService` in `TrackableCommand`, which also ran `xcresulttool` locally and uploaded ~250 MB of parsed JSON that the server doesn't need.

Separately, zipping the xcresult itself dominated the remote flow: a ~200 MB output zip took ~5 min on CircleCI `VirtualMac2,1` instances because `FileArchiver.zip` pre-copies the whole bundle into a temp directory and then single-threadedly deflates it via ZIPFoundation.

## Approach

- Thread `mode:` through `TestService.runShard` and `TestService.runTestWithoutBuildingFromBundle` so `--inspect-mode remote` actually takes effect.
- Stop registering the xcresult in `RunMetadataStorage.resultBundlePath` for test flows. `XcodeBuildTestCommandService` now unconditionally clears the field after reading it into a local var. Both modes own their upload (`uploadTestSummary` for local, `uploadResultBundle` for remote); leaving the storage field `nil` keeps `UploadAnalyticsService` in `TrackableCommand` from doing a second pass.
- Switch the xcresult archive on macOS to AppleArchive (LZFSE) via `TuistAppleArchiver.AppleArchiver`. No pre-copy, hardware-accelerated on Apple Silicon, and substantially faster than ZIPFoundation. Session uploads stay on the existing zip path.
- Teach `xcode_processor` to accept either payload: the Elixir side sniffs the first two bytes — PKZIP (`PK`) routes through `:zip.unzip` (old CLI clients), anything else routes through a new Swift NIF that uses the `AppleArchive` framework to decompress into a directory. This is backwards-compatible by construction; existing stored `.zip` bundles and older CLI versions keep working.
- Add timing logs around archiving and per-artifact multipart upload in `FileArchiver` and `AnalyticsArtifactUploadService`, so future investigations don't have to infer where the time went.
- Re-enable `workflow_dispatch` on the production and staging `xcode_processor` deploy workflows so we can roll out the new NIF contract ahead of the CLI release. Auto-deploy on push to main remains disabled.

## Rollout

`xcode_processor` must be deployed before (or alongside) this CLI release so the new `decompress_archive` NIF is available when CLI clients start sending AppleArchive payloads. Old CLI clients are unaffected — they continue to upload PKZIP, which the sniff still dispatches to `:zip.unzip`.

1. Merge this PR (puts the updated deploy workflows on `main`).
2. Trigger `Xcode Processor Deploy` (or `Xcode Processor Staging Deploy`) via `workflow_dispatch` from the Actions tab.
3. Cut the CLI release — older CLI clients continue to work through the same PKZIP sniff branch.

## End-to-end validation

Ran against a real, ~629 MB xcresult from a production failed-test run (60k+ test cases across 140+ modules) to exercise the actual wire-format handoff and processor pipeline.

| Step | Observation |
| --- | --- |
| Compress via the same AppleArchive framework `TuistAppleArchiver.compress` uses (`aa archive -a lzfse`) | 629 MB → 133 MB `.aar` in ~27 s on an M-series Mac (multithreaded, hardware-accelerated) |
| First-byte sniff of the `.aar` | `pbze` — correctly routes to the NIF, not to `:zip.unzip` |
| Drive `XCResultNIF.decompress_archive/2` from IEx against the real `.aar` | `:ok` in ~23 s; extracted tree contains the `.xcresult` with `Info.plist`, `database.sqlite3`, and `Data/` intact |
| `XCResultProcessor.process_local/2` (magic-byte sniff → NIF decompress → `xcresulttool` parse) | `{:ok, …}` in ~78 s, returning 142 parsed modules / 60,250 test cases; status + duration match the real run |
| PKZIP fixture | First two bytes `"PK"`, `:zip.unzip` extracts successfully — confirms the backwards-compat branch still works |

For comparison, Alex's HAR earlier this week showed the CLI spending ~5 min just producing a ~200 MB `.zip` on CircleCI's virtualized Mac, before any bytes went over the wire.

### How to test locally

1. In a Tuist-backed project on macOS, run `tuist test --without-building … --inspect-mode remote` (or rely on the `tuist.dev` default). Confirm the `POST /tests` body no longer carries `test_modules` inline and `UploadAnalyticsService` does not re-upload the xcresult (verify via `--verbose` logs or by inspecting network traffic).
2. Confirm the uploaded payload at `result_bundle.zip` is an AppleArchive (first bytes are `bvx…`/`pbze…`). The `xcode_processor` should still decode it successfully end-to-end — run against a staging processor or a locally deployed one with the new NIF.
3. Run `tuist test --inspect-mode local` and confirm the old local-mode behavior still works: parsed `test_modules` in `POST /tests`, no xcresult upload, no processor-side decompression needed.
4. Run an old CLI (pre-this-change) against a processor that has this PR deployed. The processor should detect PKZIP magic and fall back to `:zip.unzip` — i.e. no regression for older clients.
5. `mix test test/xcode_processor/xcresult_processor_test.exs` from `xcode_processor/` — covers the sniff + dispatch path.