### PR TITLE
fix(cli,server): add muted/unmuted test case event types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -926,6 +926,7 @@ var targets: [Target] = [
             "TuistServer",
             "TuistEnvironmentTesting",
             "TuistOIDC",
+            "TuistTesting",
             "TuistUserInputReader",
             pathDependency,
             fileSystemDependency,
@@ -986,6 +987,7 @@ var targets: [Target] = [
             "TuistConfigLoader",
             "TuistEnvironmentTesting",
             "TuistNooraTesting",
+            "TuistTesting",
             mockableDependency,
         ],
         path: "cli/Tests/TuistRegistryCommandTests"

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -15365,6 +15365,8 @@ public enum Operations {
                                 case first_run = "first_run"
                                 case marked_flaky = "marked_flaky"
                                 case unmarked_flaky = "unmarked_flaky"
+                                case muted = "muted"
+                                case unmuted = "unmuted"
                                 case quarantined = "quarantined"
                                 case unquarantined = "unquarantined"
                             }

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -7456,6 +7456,8 @@ paths:
                             - first_run
                             - marked_flaky
                             - unmarked_flaky
+                            - muted
+                            - unmuted
                             - quarantined
                             - unquarantined
                           type: string

--- a/cli/Sources/TuistTestCommand/TestCaseEventsCommandService.swift
+++ b/cli/Sources/TuistTestCommand/TestCaseEventsCommandService.swift
@@ -122,6 +122,8 @@ struct TestCaseEventsCommandService: TestCaseEventsCommandServicing {
         case .first_run: return "First run"
         case .marked_flaky: return "Marked flaky"
         case .unmarked_flaky: return "Unmarked flaky"
+        case .muted: return "Muted"
+        case .unmuted: return "Unmuted"
         case .quarantined: return "Quarantined"
         case .unquarantined: return "Unquarantined"
         }

--- a/cli/Tests/TuistTestCommandTests/Services/TestCaseEventsCommandServiceTests.swift
+++ b/cli/Tests/TuistTestCommandTests/Services/TestCaseEventsCommandServiceTests.swift
@@ -108,13 +108,14 @@ struct TestCaseEventsCommandServiceTests {
         given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
         let eventsResponse = Operations.listTestCaseEvents.Output.Ok.Body.jsonPayload(
             events: [
+                ServerTestCaseEvent.test(eventType: .muted, insertedAt: 1_700_000_001),
                 ServerTestCaseEvent.test(eventType: .quarantined, insertedAt: 1_700_000_000),
             ],
             pagination_metadata: .init(
                 has_next_page: false,
                 has_previous_page: false,
                 page_size: 20,
-                total_count: 1
+                total_count: 2
             )
         )
         given(listTestCaseEventsService).listTestCaseEvents(
@@ -137,6 +138,7 @@ struct TestCaseEventsCommandServiceTests {
 
         // Then
         #expect(ui().contains("Events"))
+        #expect(ui().contains("Muted (automatic)"))
         #expect(ui().contains("Quarantined (automatic)"))
     }
 

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -345,7 +345,15 @@ defmodule TuistWeb.API.TestCasesController do
                  properties: %{
                    event_type: %Schema{
                      type: :string,
-                     enum: ["first_run", "marked_flaky", "unmarked_flaky", "quarantined", "unquarantined"],
+                     enum: [
+                       "first_run",
+                       "marked_flaky",
+                       "unmarked_flaky",
+                       "muted",
+                       "unmuted",
+                       "quarantined",
+                       "unquarantined"
+                     ],
                      description: "The type of event."
                    },
                    inserted_at: %Schema{type: :integer, description: "Unix timestamp of when the event occurred."},


### PR DESCRIPTION
### Summary

The server emits `muted` / `unmuted` test case events (a rename of `quarantined` / `unquarantined`), but the OpenAPI spec's `event_type` enum was never updated to include them. The CLI's generated decoder rejects the response as a result, breaking \`tuist test case events\` end-to-end with:

\`\`\`
✖ Error Client encountered an error invoking the operation 'listTestCaseEvents'
\`\`\`

### Changes

- **server** (\`test_cases_controller.ex\`): add \`muted\` and \`unmuted\` to the \`event_type\` enum. Legacy \`quarantined\` / \`unquarantined\` values are kept so older events still decode.
- **cli** (generated \`server.yml\` + \`Types.swift\`): mirror the two new enum cases. These changes would normally come from running \`mise run generate-api-cli-code\`, but are applied by hand here to keep the diff minimal and avoid pulling in unrelated generated drift.
- **cli** (\`TestCaseEventsCommandService.swift\`): extend the display switch with the new cases.
- **tests**: update \`run_with_text_output\` to also assert \`Muted\` renders, since that's the case this PR unblocks.

### Notes

- While investigating, I noticed \`.github/workflows/server.yml\` contains a full OpenAPI-drift check job (regenerate spec, fail CI if git status is dirty) that is entirely commented out. Re-enabling it would have caught this before release. Happy to open a separate issue/PR for that if useful.
- There's a broader discussion to be had about whether forward-evolving enum fields (event kinds, CI providers, platforms, etc.) should use an extensible-enum pattern so the CLI doesn't hard-fail on unknown server values. Out of scope here; this PR only restores the currently-documented behavior.

### How to test locally

\`\`\`bash
swift test --package-path . --replace-scm-with-registry --filter TestCaseEventsCommandServiceTests
\`\`\`

Running \`tuist test case events <id>\` against a project whose history contains \`muted\` events now succeeds and renders \`Muted (automatic)\`, where previously the decode failed the whole request.