### PR TITLE
fix(cli): make swift-file-system the default filesystem backend

### DIFF
--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -124,6 +124,7 @@ extension Environmenting {
         let value = variables["TUIST_FILESYSTEM_BACKEND"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
+        guard let value else { return true }
         return ["swift-file-system", "swift_file_system", "swiftfilesystem"].contains(value)
     }
 

--- a/cli/Tests/TuistSupportTests/Utils/EnvironmentTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/EnvironmentTests.swift
@@ -6,6 +6,18 @@ import Testing
 @testable import TuistTesting
 
 struct EnvironmentTests {
+    @Test() func isSwiftFileSystemBackendEnabled_isEnabledByDefault() {
+        let subject = Environment(variables: [:])
+
+        #expect(subject.isSwiftFileSystemBackendEnabled)
+    }
+
+    @Test() func isSwiftFileSystemBackendEnabled_isDisabledWhenUsingAnyOtherValue() {
+        let subject = Environment(variables: ["TUIST_FILESYSTEM_BACKEND": "legacy"])
+
+        #expect(!subject.isSwiftFileSystemBackendEnabled)
+    }
+
     // MARK: - Cache Directory Tests
 
     @Test() func cacheDirectory_withTuistXDGCacheHome() throws {


### PR DESCRIPTION
I haven't noticed any issues on our side, file-system related, so I'm confident with putting this out there and reverting if needed.

### Motivation
- Enable the new Swift file system backend by default so Tuist uses `swift-file-system` unless a different backend is explicitly requested via `TUIST_FILESYSTEM_BACKEND`.

### Description
- Change `Environment.isSwiftFileSystemBackendEnabled` to return `true` when `TUIST_FILESYSTEM_BACKEND` is not set while still recognizing the accepted values `"swift-file-system"`, `"swift_file_system"`, and `"swiftfilesystem"` in `cli/Sources/TuistEnvironment/Environment.swift`.
- Add unit tests in `cli/Tests/TuistSupportTests/Utils/EnvironmentTests.swift` that assert the backend is enabled by default and disabled when a non-swift value (e.g. `"legacy"`) is provided.

### Testing
- Attempted to run `swift test --package-path cli --replace-scm-with-registry --filter EnvironmentTests`, but the test execution in this environment failed due to network restrictions while cloning external dependencies (`CONNECT tunnel failed, response 403`).
- New unit tests were added to cover the behavior and should pass in a normal environment/CI where external dependencies can be fetched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea864de8a88321b3e0bb6863da8aa0)