### PR TITLE
feat(server): add link headers for agent discovery

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,6 +57,9 @@ WORKDIR /app
 # ========================================
 FROM ${BUILDER_IMAGE} AS deps-builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
@@ -115,15 +118,20 @@ COPY xcode_processor/lib /xcode_processor/lib
 
 # Cache mount on _build persists compiled dep artifacts across builds, so
 # incremental compilation survives even when this layer is invalidated.
+# Scope the cache by target platform and MIX_ENV so precompiled NIFs don't
+# leak across incompatible targets (for example arm64 vs amd64 Linux builds).
 # The mount masks the image layer, so /app/_build is empty in the committed
 # layer — every subsequent RUN that reads _build must use the same mount id.
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix deps.compile
 
 # ========================================
 # Stage 3: Main application builder
 # ========================================
 FROM deps-builder AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY server/priv priv
 COPY skills/skills priv/static/skills
@@ -145,12 +153,12 @@ RUN apt-get update -y && \
 # All mix steps that read/write _build share the same cache mount id so
 # incremental compilation persists both within this build (across RUNs)
 # and across builds (via BuildKit persistent cache).
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix compile --warnings-as-errors
 
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix docs.gen.og_images
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix marketing.gen.og_images
 
 COPY server/config/runtime.exs config/
@@ -158,13 +166,13 @@ COPY server/rel rel
 
 COPY --from=npm-deps /app/node_modules /app/node_modules
 COPY --from=npm-deps /noora/priv/static /noora/priv/static
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix assets.deploy
 
 # mix release writes into the cache mount, so we copy the release output
 # out to /release (a real image path) in the same RUN. Downstream stages
 # COPY --from=builder /release instead of /app/_build/${MIX_ENV}/rel/tuist.
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
+RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
     mix release && \
     cp -r /app/_build/${MIX_ENV}/rel/tuist /release
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,9 +57,6 @@ WORKDIR /app
 # ========================================
 FROM ${BUILDER_IMAGE} AS deps-builder
 
-ARG TARGETOS
-ARG TARGETARCH
-
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential git \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
@@ -118,20 +115,15 @@ COPY xcode_processor/lib /xcode_processor/lib
 
 # Cache mount on _build persists compiled dep artifacts across builds, so
 # incremental compilation survives even when this layer is invalidated.
-# Scope the cache by target platform and MIX_ENV so precompiled NIFs don't
-# leak across incompatible targets (for example arm64 vs amd64 Linux builds).
 # The mount masks the image layer, so /app/_build is empty in the committed
 # layer — every subsequent RUN that reads _build must use the same mount id.
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix deps.compile
 
 # ========================================
 # Stage 3: Main application builder
 # ========================================
 FROM deps-builder AS builder
-
-ARG TARGETOS
-ARG TARGETARCH
 
 COPY server/priv priv
 COPY skills/skills priv/static/skills
@@ -153,12 +145,12 @@ RUN apt-get update -y && \
 # All mix steps that read/write _build share the same cache mount id so
 # incremental compilation persists both within this build (across RUNs)
 # and across builds (via BuildKit persistent cache).
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix compile --warnings-as-errors
 
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix docs.gen.og_images
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix marketing.gen.og_images
 
 COPY server/config/runtime.exs config/
@@ -166,13 +158,13 @@ COPY server/rel rel
 
 COPY --from=npm-deps /app/node_modules /app/node_modules
 COPY --from=npm-deps /noora/priv/static /noora/priv/static
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix assets.deploy
 
 # mix release writes into the cache mount, so we copy the release output
 # out to /release (a real image path) in the same RUN. Downstream stages
 # COPY --from=builder /release instead of /app/_build/${MIX_ENV}/rel/tuist.
-RUN --mount=type=cache,id=server-mix-build-v2-${TARGETOS}-${TARGETARCH}-${MIX_ENV},target=/app/_build \
+RUN --mount=type=cache,id=mix-build,target=/app/_build \
     mix release && \
     cp -r /app/_build/${MIX_ENV}/rel/tuist /release
 

--- a/server/lib/tuist_web/agent_discovery.ex
+++ b/server/lib/tuist_web/agent_discovery.ex
@@ -1,0 +1,60 @@
+defmodule TuistWeb.AgentDiscovery do
+  @moduledoc false
+
+  @api_base_path "/api"
+  @api_catalog_path "/.well-known/api-catalog"
+  @api_catalog_profile_uri "https://www.rfc-editor.org/info/rfc9727"
+  @service_desc_path "/api/spec"
+  @service_doc_path "/api/docs"
+
+  def homepage_link_header_value do
+    Enum.join(
+      [
+        api_catalog_link_header_value(),
+        link_value(@service_desc_path, "service-desc", type: "application/json"),
+        link_value(@service_doc_path, "service-doc", type: "text/html")
+      ],
+      ", "
+    )
+  end
+
+  def api_catalog_link_header_value do
+    link_value(@api_catalog_path, "api-catalog",
+      type: "application/linkset+json",
+      profile: @api_catalog_profile_uri
+    )
+  end
+
+  def api_catalog_content_type do
+    ~s(application/linkset+json; profile="#{@api_catalog_profile_uri}")
+  end
+
+  def api_catalog(origin) do
+    %{
+      "linkset" => [
+        %{
+          "anchor" => origin <> @api_base_path,
+          "service-desc" => [
+            %{
+              "href" => origin <> @service_desc_path,
+              "type" => "application/json"
+            }
+          ],
+          "service-doc" => [
+            %{
+              "href" => origin <> @service_doc_path,
+              "type" => "text/html"
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  defp link_value(target, relation, attributes) do
+    parameters =
+      [{"rel", relation}] ++ Enum.map(attributes, fn {key, value} -> {Atom.to_string(key), value} end)
+
+    IO.iodata_to_binary(["<#{target}>", Enum.map(parameters, fn {key, value} -> ~s(; #{key}="#{value}") end)])
+  end
+end

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -3,12 +3,23 @@ defmodule TuistWeb.WellKnownController do
 
   alias Tuist.Environment
   alias Tuist.Namespace.JWTToken
+  alias TuistWeb.AgentDiscovery
   alias TuistWeb.RequestOrigin
 
   @mcp_path "/mcp"
   @oauth_token_path "/oauth2/token"
   @oauth_authorize_path "/oauth2/authorize"
   @oauth_registration_path "/oauth2/register"
+
+  def api_catalog(conn, _params) do
+    origin = RequestOrigin.from_conn(conn)
+    catalog = AgentDiscovery.api_catalog(origin)
+
+    conn
+    |> put_resp_header("content-type", AgentDiscovery.api_catalog_content_type())
+    |> put_resp_header("link", AgentDiscovery.api_catalog_link_header_value())
+    |> send_resp(:ok, Jason.encode!(catalog))
+  end
 
   @doc """
   Returns the OpenID configuration for JWT verification.

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -10,13 +10,15 @@ defmodule TuistWeb.Marketing.MarketingController do
   alias Tuist.Marketing.Customers
   alias Tuist.Marketing.Newsletter
   alias Tuist.Marketing.Pages
+  alias TuistWeb.AgentDiscovery
   alias TuistWeb.Errors.NotFoundError
   alias TuistWeb.Helpers.OpenGraph
   alias TuistWeb.Marketing.Localization
 
-  plug(:assign_default_head_tags)
-  plug(:put_resp_header_cache_control)
-  plug(:put_resp_header_server)
+  plug :assign_default_head_tags
+  plug :put_agent_discovery_links when action in [:home]
+  plug :put_resp_header_cache_control
+  plug :put_resp_header_server
 
   def qa(conn, _params) do
     read_more_posts = Enum.take(Blog.get_posts(), 3)
@@ -702,6 +704,10 @@ defmodule TuistWeb.Marketing.MarketingController do
     |> assign(:head_twitter_card, "summary_large_image")
     |> assign(:head_include_blog_rss_and_atom, true)
     |> assign(:head_include_changelog_rss_and_atom, true)
+  end
+
+  defp put_agent_discovery_links(conn, _opts) do
+    put_resp_header(conn, "link", AgentDiscovery.homepage_link_header_value())
   end
 
   defp put_resp_header_cache_control(conn, _opts) do

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -374,6 +374,12 @@ defmodule TuistWeb.Router do
   end
 
   scope "/.well-known", TuistWeb do
+    pipe_through [:open_api]
+
+    get "/api-catalog", WellKnownController, :api_catalog
+  end
+
+  scope "/.well-known", TuistWeb do
     pipe_through [:open_api, :non_authenticated_api]
 
     get "/openid-configuration", WellKnownController, :openid_configuration

--- a/server/priv/gettext/dashboard_cache.pot
+++ b/server/priv/gettext/dashboard_cache.pot
@@ -66,8 +66,8 @@ msgstr ""
 msgid "< 0.1 %"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.html.heex:3
-#: lib/tuist_web/live/xcode_cache_live.html.heex:31
+#: lib/tuist_web/live/module_cache_live.html.heex:86
+#: lib/tuist_web/live/xcode_cache_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Analytics"
 msgstr ""
@@ -76,8 +76,8 @@ msgstr ""
 #: lib/tuist_web/live/bundles_live.html.heex:45
 #: lib/tuist_web/live/bundles_live.html.heex:60
 #: lib/tuist_web/live/bundles_live.html.heex:74
-#: lib/tuist_web/live/module_cache_live.ex:318
-#: lib/tuist_web/live/module_cache_live.html.heex:15
+#: lib/tuist_web/live/module_cache_live.ex:329
+#: lib/tuist_web/live/module_cache_live.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Any"
 msgstr ""
@@ -178,10 +178,10 @@ msgstr ""
 msgid "Bundles"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:320
-#: lib/tuist_web/live/module_cache_live.ex:321
-#: lib/tuist_web/live/module_cache_live.html.heex:31
-#: lib/tuist_web/live/xcode_cache_live.ex:301
+#: lib/tuist_web/live/module_cache_live.ex:331
+#: lib/tuist_web/live/module_cache_live.ex:332
+#: lib/tuist_web/live/module_cache_live.html.heex:26
+#: lib/tuist_web/live/xcode_cache_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "CI"
 msgstr ""
@@ -192,7 +192,7 @@ msgstr ""
 msgid "Cache Runs"
 msgstr ""
 
-#: lib/tuist_web/live/xcode_cache_live.ex:197
+#: lib/tuist_web/live/xcode_cache_live.ex:211
 #: lib/tuist_web/live/xcode_cache_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Cache downloads"
@@ -203,10 +203,10 @@ msgstr ""
 msgid "Cache downloads represents the total size of cache artifacts downloaded from remote storage during the given period."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:295
+#: lib/tuist_web/live/module_cache_live.ex:306
 #: lib/tuist_web/live/module_cache_live.html.heex:103
 #: lib/tuist_web/live/module_cache_live.html.heex:502
-#: lib/tuist_web/live/xcode_cache_live.ex:206
+#: lib/tuist_web/live/xcode_cache_live.ex:220
 #: lib/tuist_web/live/xcode_cache_live.html.heex:101
 #: lib/tuist_web/live/xcode_cache_live.html.heex:522
 #, elixir-autogen, elixir-format
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Cache hit rate represents the percentage of cacheable tasks that were resolved from cache (local or remote) rather than being rebuilt."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:277
+#: lib/tuist_web/live/module_cache_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Cache hits"
 msgstr ""
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Cache hits represents the total count of targets that were resolved from cache (local or remote) during the given period."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:286
+#: lib/tuist_web/live/module_cache_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Cache misses"
 msgstr ""
@@ -243,7 +243,7 @@ msgstr ""
 msgid "Cache misses represents the total count of cacheable targets that had to be rebuilt because they were not found in cache during the given period."
 msgstr ""
 
-#: lib/tuist_web/live/xcode_cache_live.ex:188
+#: lib/tuist_web/live/xcode_cache_live.ex:202
 #: lib/tuist_web/live/xcode_cache_live.html.heex:213
 #, elixir-autogen, elixir-format
 msgid "Cache uploads"
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.html.heex:11
+#: lib/tuist_web/live/module_cache_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Environment:"
 msgstr ""
@@ -334,7 +334,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:51
 #: lib/tuist_web/live/cache_runs_live.html.heex:93
-#: lib/tuist_web/live/xcode_cache_live.ex:308
+#: lib/tuist_web/live/xcode_cache_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -419,10 +419,10 @@ msgstr ""
 msgid "Install size deviation"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:319
-#: lib/tuist_web/live/module_cache_live.ex:322
-#: lib/tuist_web/live/module_cache_live.html.heex:23
-#: lib/tuist_web/live/xcode_cache_live.ex:302
+#: lib/tuist_web/live/module_cache_live.ex:330
+#: lib/tuist_web/live/module_cache_live.ex:333
+#: lib/tuist_web/live/module_cache_live.html.heex:18
+#: lib/tuist_web/live/xcode_cache_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Local"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:50
 #: lib/tuist_web/live/cache_runs_live.html.heex:91
-#: lib/tuist_web/live/xcode_cache_live.ex:307
+#: lib/tuist_web/live/xcode_cache_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
@@ -584,7 +584,7 @@ msgstr ""
 msgid "Run the following command to analyze a bundle."
 msgstr ""
 
-#: lib/tuist_web/live/xcode_cache_live.ex:295
+#: lib/tuist_web/live/xcode_cache_live.ex:313
 #: lib/tuist_web/live/xcode_cache_live.html.heex:257
 #: lib/tuist_web/live/xcode_cache_live.html.heex:595
 #, elixir-autogen, elixir-format
@@ -622,7 +622,7 @@ msgid "Space usage"
 msgstr ""
 
 #: lib/tuist_web/live/cache_runs_live.ex:46
-#: lib/tuist_web/live/xcode_cache_live.ex:296
+#: lib/tuist_web/live/xcode_cache_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/tuist_web/live/bundle_live.html.heex:162
 #: lib/tuist_web/live/bundle_live.html.heex:229
 #: lib/tuist_web/live/bundles_live.ex:388
-#: lib/tuist_web/live/xcode_cache_live.ex:304
+#: lib/tuist_web/live/xcode_cache_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -749,83 +749,83 @@ msgid "p99 hit rate"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.ex:261
-#: lib/tuist_web/live/module_cache_live.ex:316
-#: lib/tuist_web/live/xcode_cache_live.ex:215
+#: lib/tuist_web/live/module_cache_live.ex:327
+#: lib/tuist_web/live/xcode_cache_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "since last month"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.ex:258
-#: lib/tuist_web/live/module_cache_live.ex:313
-#: lib/tuist_web/live/xcode_cache_live.ex:212
+#: lib/tuist_web/live/module_cache_live.ex:324
+#: lib/tuist_web/live/xcode_cache_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "since last week"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.ex:259
-#: lib/tuist_web/live/module_cache_live.ex:314
-#: lib/tuist_web/live/xcode_cache_live.ex:213
+#: lib/tuist_web/live/module_cache_live.ex:325
+#: lib/tuist_web/live/xcode_cache_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "since last year"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:125
-#: lib/tuist_web/live/module_cache_live.html.heex:80
-#: lib/tuist_web/live/xcode_cache_live.html.heex:78
+#: lib/tuist_web/live/module_cache_live.html.heex:75
+#: lib/tuist_web/live/xcode_cache_live.html.heex:73
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:118
-#: lib/tuist_web/live/module_cache_live.html.heex:71
-#: lib/tuist_web/live/xcode_cache_live.html.heex:69
+#: lib/tuist_web/live/module_cache_live.html.heex:66
+#: lib/tuist_web/live/xcode_cache_live.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:109
-#: lib/tuist_web/live/module_cache_live.html.heex:62
-#: lib/tuist_web/live/xcode_cache_live.html.heex:60
+#: lib/tuist_web/live/module_cache_live.html.heex:57
+#: lib/tuist_web/live/xcode_cache_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid "Custom"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:106
-#: lib/tuist_web/live/module_cache_live.html.heex:59
-#: lib/tuist_web/live/xcode_cache_live.html.heex:57
+#: lib/tuist_web/live/module_cache_live.html.heex:54
+#: lib/tuist_web/live/xcode_cache_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Last 12 months"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.html.heex:44
-#: lib/tuist_web/live/xcode_cache_live.html.heex:42
+#: lib/tuist_web/live/module_cache_live.html.heex:39
+#: lib/tuist_web/live/xcode_cache_live.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Last 24 hours"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:101
-#: lib/tuist_web/live/module_cache_live.html.heex:54
-#: lib/tuist_web/live/xcode_cache_live.html.heex:52
+#: lib/tuist_web/live/module_cache_live.html.heex:49
+#: lib/tuist_web/live/xcode_cache_live.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:96
-#: lib/tuist_web/live/module_cache_live.html.heex:49
-#: lib/tuist_web/live/xcode_cache_live.html.heex:47
+#: lib/tuist_web/live/module_cache_live.html.heex:44
+#: lib/tuist_web/live/xcode_cache_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Last 7 days"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.ex:260
-#: lib/tuist_web/live/module_cache_live.ex:315
-#: lib/tuist_web/live/xcode_cache_live.ex:214
+#: lib/tuist_web/live/module_cache_live.ex:326
+#: lib/tuist_web/live/xcode_cache_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "since last period"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:312
-#: lib/tuist_web/live/xcode_cache_live.ex:211
+#: lib/tuist_web/live/module_cache_live.ex:323
+#: lib/tuist_web/live/xcode_cache_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
 msgstr ""
@@ -881,8 +881,8 @@ msgstr ""
 msgid "Package name"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_live.ex:342
-#: lib/tuist_web/live/xcode_cache_live.ex:297
+#: lib/tuist_web/live/module_cache_live.ex:353
+#: lib/tuist_web/live/xcode_cache_live.ex:315
 #: lib/tuist_web/live/xcode_cache_live.html.heex:258
 #, elixir-autogen, elixir-format
 msgid "Environment"

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -140,6 +140,7 @@ msgstr ""
 msgid "Cache effectiveness represents the combined hit rate of both Module cache and Xcode cache, showing the percentage of cacheable items that were resolved from cache rather than being rebuilt."
 msgstr ""
 
+#: lib/tuist_web/live/project_automations_live.html.heex:593
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:190
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:349
 #: lib/tuist_web/live/project_notifications_live.html.heex:168
@@ -270,6 +271,8 @@ msgid "Local"
 msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:86
+#: lib/tuist_web/live/project_automations_live.html.heex:73
+#: lib/tuist_web/live/project_automations_live.html.heex:630
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:107
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:171
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:216
@@ -555,6 +558,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
+#: lib/tuist_web/live/project_automations_live.html.heex:603
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:358
 #: lib/tuist_web/live/project_notifications_live.html.heex:176
 #, elixir-autogen, elixir-format
@@ -656,7 +660,8 @@ msgstr ""
 msgid "Configure your report notifications"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:141
+#: lib/tuist_web/live/project_automations_live.html.heex:244
+#: lib/tuist_web/live/project_automations_live.html.heex:466
 #: lib/tuist_web/live/project_notifications_live.html.heex:206
 #: lib/tuist_web/live/project_notifications_live.html.heex:302
 #: lib/tuist_web/live/project_notifications_live.html.heex:631
@@ -700,8 +705,8 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:150
-#: lib/tuist_web/live/project_automations_live.html.heex:160
+#: lib/tuist_web/live/project_automations_live.html.heex:230
+#: lib/tuist_web/live/project_automations_live.html.heex:452
 #: lib/tuist_web/live/project_notifications_live.html.heex:215
 #: lib/tuist_web/live/project_notifications_live.html.heex:225
 #: lib/tuist_web/live/project_notifications_live.html.heex:506
@@ -711,7 +716,8 @@ msgstr ""
 msgid "Select channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:159
+#: lib/tuist_web/live/project_automations_live.html.heex:229
+#: lib/tuist_web/live/project_automations_live.html.heex:451
 #: lib/tuist_web/live/project_notifications_live.html.heex:224
 #: lib/tuist_web/live/project_notifications_live.html.heex:505
 #: lib/tuist_web/live/project_notifications_live.html.heex:866
@@ -756,6 +762,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
+#: lib/tuist_web/live/project_automations_live.html.heex:604
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:198
 #: lib/tuist_web/live/project_notifications_live.html.heex:533
 #: lib/tuist_web/live/projects_live.ex:391
@@ -810,21 +817,6 @@ msgstr ""
 msgid "No alert rules"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:59
-#, elixir-autogen, elixir-format
-msgid "Auto-mark tests as flaky"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:198
-#, elixir-autogen, elixir-format
-msgid "Auto-quarantine flaky tests"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:181
-#, elixir-autogen, elixir-format
-msgid "Automatically quarantine tests when they are detected as flaky"
-msgstr ""
-
 #: lib/tuist_web/live/project_automations_live.ex:34
 #: lib/tuist_web/live/project_automations_live.html.heex:20
 #: lib/tuist_web/live/project_automations_live.html.heex:32
@@ -833,36 +825,6 @@ msgstr ""
 #: lib/tuist_web/live/project_settings_live.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Automations"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:39
-#, elixir-autogen, elixir-format
-msgid "Flaky test detection"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:42
-#, elixir-autogen, elixir-format
-msgid "Get notified when tests are flagged as flaky"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:71
-#, elixir-autogen, elixir-format
-msgid "Minimum occurrences"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:130
-#, elixir-autogen, elixir-format
-msgid "Slack notifications"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:178
-#, elixir-autogen, elixir-format
-msgid "Test quarantine"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:63
-#, elixir-autogen, elixir-format
-msgid "Tests will be marked as flaky after the specified number of flaky occurrences within the last 30 days"
 msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:98
@@ -1055,16 +1017,6 @@ msgstr ""
 msgid "Connect the Tuist GitHub App to enable bundle size check runs on PRs."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:92
-#, elixir-autogen, elixir-format
-msgid "Number of days without a flaky occurrence before the flaky flag is automatically cleared from a test case"
-msgstr ""
-
-#: lib/tuist_web/live/project_automations_live.html.heex:87
-#, elixir-autogen, elixir-format
-msgid "Cooldown period (days)"
-msgstr ""
-
 #: lib/tuist_web/live/create_project_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Create a Tuist project"
@@ -1078,4 +1030,267 @@ msgstr ""
 #: lib/tuist_web/live/create_project_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Select organization"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Action"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:328
+#, elixir-autogen, elixir-format
+msgid "Add action"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Add automation"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:427
+#, elixir-autogen, elixir-format
+msgid "Add label"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:448
+#, elixir-autogen, elixir-format
+msgid "Add label: %{label}"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:550
+#, elixir-autogen, elixir-format
+msgid "Add recovery action"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:294
+#: lib/tuist_web/live/project_automations_live.html.heex:516
+#, elixir-autogen, elixir-format
+msgid "Available variables:"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:425
+#: lib/tuist_web/live/project_automations_live.html.heex:338
+#: lib/tuist_web/live/project_automations_live.html.heex:560
+#, elixir-autogen, elixir-format
+msgid "Change state"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:186
+#: lib/tuist_web/live/project_automations_live.html.heex:408
+#, elixir-autogen, elixir-format
+msgid "Change state to"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Condition"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Continuously monitor tests and respond with automated actions."
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:53
+#, elixir-autogen, elixir-format
+msgid "Create automation"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:656
+#, elixir-autogen, elixir-format
+msgid "Delete this automation?"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:52
+#, elixir-autogen, elixir-format
+msgid "Edit automation"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:418
+#, elixir-autogen, elixir-format
+msgid "Enable"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:422
+#: lib/tuist_web/live/project_automations_live.html.heex:204
+#: lib/tuist_web/live/project_automations_live.html.heex:417
+#, elixir-autogen, elixir-format
+msgid "Enabled"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:286
+#: lib/tuist_web/live/project_automations_live.html.heex:508
+#, elixir-autogen, elixir-format
+msgid "Enter message template..."
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:413
+#: lib/tuist_web/live/project_automations_live.html.heex:111
+#, elixir-autogen, elixir-format
+msgid "Flakiness rate"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:414
+#: lib/tuist_web/live/project_automations_live.html.heex:119
+#, elixir-autogen, elixir-format
+msgid "Flaky runs"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:130
+#, elixir-autogen, elixir-format
+msgid "Is greater than or equal to (%)"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:350
+#, elixir-autogen, elixir-format
+msgid "Mark as flaky"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:306
+#: lib/tuist_web/live/project_automations_live.html.heex:528
+#, elixir-autogen, elixir-format
+msgid "Mark test as flaky"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:264
+#: lib/tuist_web/live/project_automations_live.html.heex:486
+#, elixir-autogen, elixir-format
+msgid "Message template"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:618
+#, elixir-autogen, elixir-format
+msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:147
+#, elixir-autogen, elixir-format
+msgid "Over the last"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:417
+#, elixir-autogen, elixir-format
+msgid "Quarantine"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:421
+#: lib/tuist_web/live/project_automations_live.html.heex:195
+#: lib/tuist_web/live/project_automations_live.html.heex:426
+#, elixir-autogen, elixir-format
+msgid "Quarantined"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:132
+#, elixir-autogen, elixir-format
+msgid "Reach at least (count)"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:374
+#, elixir-autogen, elixir-format
+msgid "Recovery"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:428
+#, elixir-autogen, elixir-format
+msgid "Remove label"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:451
+#, elixir-autogen, elixir-format
+msgid "Remove label: %{label}"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:377
+#, elixir-autogen, elixir-format
+msgid "Run actions when the conditions no longer hold"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "Run these actions for each test case that meets the condition"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:426
+#: lib/tuist_web/live/project_automations_live.html.heex:217
+#: lib/tuist_web/live/project_automations_live.html.heex:355
+#: lib/tuist_web/live/project_automations_live.html.heex:439
+#: lib/tuist_web/live/project_automations_live.html.heex:577
+#, elixir-autogen, elixir-format
+msgid "Send Slack notification"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:445
+#, elixir-autogen, elixir-format
+msgid "Slack: not configured"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:267
+#: lib/tuist_web/live/project_automations_live.html.heex:489
+#, elixir-autogen, elixir-format
+msgid "Supports Slack"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Test case automations"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:633
+#, elixir-autogen, elixir-format
+msgid "Trigger"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:94
+#, elixir-autogen, elixir-format
+msgid "Trigger the automation when this condition is met"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:415
+#: lib/tuist_web/live/project_automations_live.ex:419
+#: lib/tuist_web/live/project_automations_live.ex:423
+#: lib/tuist_web/live/project_automations_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Unknown"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:572
+#, elixir-autogen, elixir-format
+msgid "Unmark as flaky"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:310
+#: lib/tuist_web/live/project_automations_live.html.heex:532
+#, elixir-autogen, elixir-format
+msgid "Unmark test as flaky"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:103
+#, elixir-autogen, elixir-format
+msgid "When"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:459
+#, elixir-autogen, elixir-format
+msgid "When flakiness rate ≥ %{threshold}% over %{window}"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "When flaky runs ≥ %{threshold} over %{window}"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:387
+#, elixir-autogen, elixir-format
+msgid "Without trigger for"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "e.g. Auto-quarantine flaky tests"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.html.heex:275
+#: lib/tuist_web/live/project_automations_live.html.heex:497
+#, elixir-autogen, elixir-format
+msgid "formatting."
 msgstr ""

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -7,7 +7,7 @@
 ## date. Leave "msgstr"s empty as changing them here has no
 ## effect: edit them in PO (.po) files instead.
 #
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:125
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:127
 #, elixir-autogen, elixir-format
 msgid "\"We could solve our immediate problems and do so while maintaining a familiar"
 msgstr ""
@@ -47,7 +47,7 @@ msgstr ""
 msgid "9+"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:610
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:612
 #, elixir-autogen, elixir-format
 msgid "<p>Our commitment to open-source and our core values shape our unique approach to pricing. Unlike many models that try to extract every dollar from you with \"contact sales\" calls, limited demos, and other sales tactics, we believe in fairness and transparency. We treat everyone equally and set prices that are fair for all. By choosing our services, you are not only getting a great product but also supporting the development of more open-source projects. We see building a thriving business as a long-term journey, not a short-term sprint filled with shady practices. You can %{read_more}  about our philosophy.</p>\n<p>By supporting Tuist, you are also supporting the development of more open-source software for the Swift ecosystem.</p>\n"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex:187
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:70
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:243
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:245
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:193
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:267
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:476
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:557
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:559
 #: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_blog_live.html.heex:13
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:52
@@ -303,7 +303,7 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:653
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:655
 #, elixir-autogen, elixir-format
 msgid "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
 msgstr ""
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Do you offer annual billing discounts?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:628
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:630
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "Do you offer discounts for non-profits and open-source?"
@@ -488,7 +488,7 @@ msgstr ""
 msgid "How can I estimate the cost for my project?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:618
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:620
 #, elixir-autogen, elixir-format
 msgid "How can I estimate the cost of my project?"
 msgstr ""
@@ -523,7 +523,7 @@ msgstr ""
 msgid "Instantly share your app using a URL"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:380
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:382
 #, elixir-autogen, elixir-format
 msgid "Invalid verification link. Please try signing up again."
 msgstr ""
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Is there a free trial for paid plans?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:623
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:625
 #, elixir-autogen, elixir-format
 msgid "Is there a free trial on paid plans?"
 msgstr ""
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Join the community on Slack"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:130
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "Jonathan Crooke, Bumble"
 msgstr ""
@@ -643,8 +643,8 @@ msgstr ""
 msgid "Newsletter"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:370
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:389
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:372
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:391
 #, elixir-autogen, elixir-format
 msgid "Newsletter Verification Failed"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:318
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:320
 #, elixir-autogen, elixir-format
 msgid "Please check your email to confirm your subscription."
 msgstr ""
@@ -739,7 +739,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:187
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:260
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:471
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:648
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:650
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
@@ -851,8 +851,8 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:141
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:182
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:143
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:184
 #, elixir-autogen, elixir-format
 msgid "Since adopting Tuist in our iOS project, we've seen major improvements in scalability and productivity. Overall, it has made our development process faster and more efficient, allowing the team to focus on building features without being slowed down by tool limitations."
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Socials"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:327
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:329
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
@@ -946,7 +946,7 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:338
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:340
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Successfully Subscribed!"
@@ -957,14 +957,14 @@ msgstr ""
 msgid "Supercharge your app development"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:265
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:267
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:214
 #: lib/tuist_web/marketing/controllers/marketing_html/support.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Support"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:287
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:289
 #, elixir-autogen, elixir-format
 msgid "Swift Stories Newsletter"
 msgstr ""
@@ -1002,12 +1002,12 @@ msgstr ""
 msgid "That's why Tuist exists—to restore the joy of development at any scale. We enhance Apple's native tooling by bringing innovative ideas from across the development ecosystem, so teams can focus on creating exceptional apps instead of fighting their build system."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:424
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:426
 #, elixir-autogen, elixir-format
 msgid "The newsletter issue %{issue_number} was not found."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:416
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:418
 #, elixir-autogen, elixir-format
 msgid "The newsletter issue number %{issue_number} is not a valid number."
 msgstr ""
@@ -1037,13 +1037,13 @@ msgstr ""
 msgid "Trusted by the world's best developer teams"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:242
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:264
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:286
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:556
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:592
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:647
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:688
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:244
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:266
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:288
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:558
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:594
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:649
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:690
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Tuist"
@@ -1066,7 +1066,7 @@ msgstr ""
 msgid "Tuist Digest"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:297
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:299
 #, elixir-autogen, elixir-format
 msgid "Tuist Digest Newsletter"
 msgstr ""
@@ -1087,17 +1087,17 @@ msgstr ""
 msgid "Tuist bridges the gaps in Apple's tooling that prevent teams from moving fast. We solve the build complexity, workflow friction, and collaboration challenges—so you can deliver exceptional apps at speed."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:221
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tuist has allowed us to migrate our existing monolythic codebase to a modular one. We extracted our different domains into specific modules. It allowed us to remove extra dependencies, ease testability and made our development cycles faster than ever. It even allowed us to bring up 'Test Apps' for speeding up our development on each module."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:155
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:157
 #, elixir-autogen, elixir-format
 msgid "Tuist has been a game-changer for our large codebase, where multiple engineers collaborate simultaneously. I've been using it since version 1, and it's been incredible to see how the product has evolved and expanded with new features over time."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:170
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:172
 #, elixir-autogen, elixir-format
 msgid "Tuist has revolutionized our iOS development workflow at DraftKings. Its automation capabilities have streamlined project generation, build settings, and dependency management. Highly recommended for iOS teams seeking workflow optimization."
 msgstr ""
@@ -1168,17 +1168,17 @@ msgstr ""
 msgid "Usage/seat based pricing"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:194
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:196
 #, elixir-autogen, elixir-format
 msgid "Using Tuist in our current project has been a game-changer. It has significantly de-stressed our build times and reduced conflicts within the team, allowing us to focus more on development and less on configuration issues. We're confident that it will continue to enhance our productivity and collaboration in future projects."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:362
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:364
 #, elixir-autogen, elixir-format
 msgid "Verification failed. Please try signing up again."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:399
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:401
 #, elixir-autogen, elixir-format
 msgid "Verification link expired or invalid. Please try signing up again."
 msgstr ""
@@ -1219,7 +1219,7 @@ msgstr ""
 msgid "We embrace standards for long-term success while respecting freedom of choice."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:624
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:626
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:664
 #, elixir-autogen, elixir-format
 msgid "We have a generous free tier on every paid plan so you can try out the features before paying any money."
@@ -1275,12 +1275,12 @@ msgstr ""
 msgid "What we believe in"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:606
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:608
 #, elixir-autogen, elixir-format
 msgid "Why is your pricing model more accessible compared to traditional enterprise models?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:209
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:211
 #, elixir-autogen, elixir-format
 msgid "With macros, external SDKs, and many SPM modules (fully modularized app) Xcode was constantly slow or stuck on my M1 device. SPM kept resolving, code completion didn't work, and swift-syntax compiled forever. It's not just for big teams with big apps. Tuist gave me back my productivity as indie developer for my side projects."
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Yes, we do. Please reach out to contact@tuist.dev for more information."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:629
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:631
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please reach out to oss@tuist.io for more information."
 msgstr ""
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "You can set up the Air plan and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:619
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:621
 #, elixir-autogen, elixir-format
 msgid "You can set up the Air plan, and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Your platform team, as a service"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:129
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:131
 #, elixir-autogen, elixir-format
 msgid "core development experience\""
 msgstr ""
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "pay as you go"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:616
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:618
 #, elixir-autogen, elixir-format
 msgid "read more"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex:196
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:106
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:593
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:595
 #: lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_customers_live.ex:69
 #: lib/tuist_web/marketing/live/marketing_customers_live.html.heex:17
@@ -2355,7 +2355,7 @@ msgstr ""
 msgid "as a service"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:42
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:44
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Let us be your virtual companion that continuously optimizes and observes your setup, so you can focus on shipping"

--- a/server/test/tuist_web/agent_discovery_test.exs
+++ b/server/test/tuist_web/agent_discovery_test.exs
@@ -1,0 +1,42 @@
+defmodule TuistWeb.AgentDiscoveryTest do
+  use ExUnit.Case, async: true
+
+  alias TuistWeb.AgentDiscovery
+
+  test "returns the homepage link header value" do
+    assert AgentDiscovery.homepage_link_header_value() ==
+             ~s(</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727", </api/spec>; rel="service-desc"; type="application/json", </api/docs>; rel="service-doc"; type="text/html")
+  end
+
+  test "returns the api catalog link header value" do
+    assert AgentDiscovery.api_catalog_link_header_value() ==
+             ~s(</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727")
+  end
+
+  test "returns the api catalog content type" do
+    assert AgentDiscovery.api_catalog_content_type() ==
+             ~s(application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727")
+  end
+
+  test "returns the api catalog body" do
+    assert AgentDiscovery.api_catalog("https://tuist.dev") == %{
+             "linkset" => [
+               %{
+                 "anchor" => "https://tuist.dev/api",
+                 "service-desc" => [
+                   %{
+                     "href" => "https://tuist.dev/api/spec",
+                     "type" => "application/json"
+                   }
+                 ],
+                 "service-doc" => [
+                   %{
+                     "href" => "https://tuist.dev/api/docs",
+                     "type" => "text/html"
+                   }
+                 ]
+               }
+             ]
+           }
+  end
+end

--- a/server/test/tuist_web/controllers/marketing_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_controller_test.exs
@@ -4,6 +4,20 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
   alias Tuist.Loops
 
+  describe "GET /" do
+    test "includes agent discovery link headers on the homepage", %{conn: conn} do
+      conn = get(conn, "/")
+
+      assert html_response(conn, 200)
+      assert [link_header] = get_resp_header(conn, "link")
+      assert link_header =~ ~s(</.well-known/api-catalog>; rel="api-catalog")
+      assert link_header =~ ~s(type="application/linkset+json")
+      assert link_header =~ ~s(profile="https://www.rfc-editor.org/info/rfc9727")
+      assert link_header =~ ~s(</api/spec>; rel="service-desc"; type="application/json")
+      assert link_header =~ ~s(</api/docs>; rel="service-doc"; type="text/html")
+    end
+  end
+
   describe "POST /newsletter" do
     test "successfully sends confirmation email", %{conn: conn} do
       # Given

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -5,6 +5,55 @@ defmodule TuistWeb.WellKnownControllerTest do
   alias Tuist.Environment
   alias Tuist.Namespace.JWTToken
 
+  describe "GET /.well-known/api-catalog" do
+    test "returns a linkset API catalog", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "application/linkset+json")
+        |> get("/.well-known/api-catalog")
+
+      assert response(conn, 200)
+
+      assert get_resp_header(conn, "content-type") == [
+               ~s(application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727")
+             ]
+
+      assert get_resp_header(conn, "link") == [
+               ~s(</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727")
+             ]
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "linkset" => [
+                 %{
+                   "anchor" => "http://www.example.com/api",
+                   "service-desc" => [
+                     %{
+                       "href" => "http://www.example.com/api/spec",
+                       "type" => "application/json"
+                     }
+                   ],
+                   "service-doc" => [
+                     %{
+                       "href" => "http://www.example.com/api/docs",
+                       "type" => "text/html"
+                     }
+                   ]
+                 }
+               ]
+             }
+    end
+
+    test "includes an api-catalog link header on HEAD requests", %{conn: conn} do
+      conn = head(conn, "/.well-known/api-catalog")
+
+      assert response(conn, 200) == ""
+
+      assert get_resp_header(conn, "link") == [
+               ~s(</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727")
+             ]
+    end
+  end
+
   describe "GET /.well-known/openid_configuration" do
     test "returns the OpenID configuration", %{conn: conn} do
       issuer = "https://test.example.com"


### PR DESCRIPTION
AI Engine Optimization will likely be a mystery like SEO, but I'd aim at aligning us with best practices. Cloudflare released [this website](https://isitagentready.com/tuist.dev) to check if a website is ready for agents and it detected some issues that are easy to fix, so I'm going to go through them and address the ones that make sense in our particular case. This addresses:

<img width="849" height="483" alt="image" src="https://github.com/user-attachments/assets/ac22d9a4-15f4-4eee-8381-29964902c269" />

## Summary
- Add `Link` headers on the homepage for `api-catalog`, `service-desc`, and `service-doc` discovery.
- Expose `/.well-known/api-catalog` as a Linkset JSON document with matching discovery metadata.
- Add controller coverage for the homepage headers, the API catalog response, and `HEAD` requests.

## Testing
- `mise x -- mix test test/tuist_web/controllers/marketing_controller_test.exs test/tuist_web/controllers/well_known_controller_test.exs`