### PR TITLE
fix(cli): skip xcodebuild when -skip-testing clears selective tests

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -460,7 +460,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testPlanConfiguration: testPlanConfiguration,
             mapperEnvironment: mapperEnvironment,
             graph: graph,
-            action: action
+            action: action,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         ), action == .build {
             try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
             return
@@ -1018,7 +1019,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
             testPlanConfiguration: testPlanConfiguration,
             mapperEnvironment: mapperEnvironment,
             graph: graph,
-            action: action
+            action: action,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         ) {
             if action != .build {
                 try await uploadSkippedTestSummary(
@@ -1182,7 +1184,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         mapperEnvironment: MapperEnvironment,
         graph: Graph,
-        action: XcodeBuildTestAction
+        action: XcodeBuildTestAction,
+        passthroughXcodeBuildArguments: [String] = []
     ) -> Bool {
         let testActionTargets = testActionTargets(
             for: schemes,
@@ -1224,7 +1227,19 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
         }
 
-        let testedTargetNames = testActionTargets.map(\.name).sorted()
+        let passthroughSkippedTargetNames = passthroughSkippedTestTargetNames(passthroughXcodeBuildArguments)
+        let targetsAfterPassthroughSkip = testActionTargets
+            .filter { !passthroughSkippedTargetNames.contains($0.name) }
+
+        if targetsAfterPassthroughSkip.isEmpty, !testActionTargets.isEmpty {
+            Logger.current
+                .notice(
+                    "All test targets selected by selective testing are excluded by -skip-testing in the xcodebuild passthrough arguments, finishing early"
+                )
+            return false
+        }
+
+        let testedTargetNames = targetsAfterPassthroughSkip.map(\.name).sorted()
         if !testedTargetNames.isEmpty {
             Logger.current
                 .notice(
@@ -1233,6 +1248,34 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         return true
+    }
+
+    private func passthroughSkippedTestTargetNames(_ arguments: [String]) -> Set<String> {
+        var names: Set<String> = []
+        var index = arguments.startIndex
+        while index < arguments.endIndex {
+            let argument = arguments[index]
+            let value: String?
+            if argument == "-skip-testing",
+               arguments.index(after: index) < arguments.endIndex
+            {
+                value = arguments[arguments.index(after: index)]
+                index = arguments.index(index, offsetBy: 2)
+            } else if argument.hasPrefix("-skip-testing:") {
+                value = String(argument.dropFirst("-skip-testing:".count))
+                index = arguments.index(after: index)
+            } else {
+                index = arguments.index(after: index)
+                continue
+            }
+            guard let identifier = value else { continue }
+            // Only whole-target skips (no `/Class` or `/Class/Method` suffix) remove a target entirely.
+            let components = identifier.split(separator: "/", omittingEmptySubsequences: false)
+            if components.count == 1, !components[0].isEmpty {
+                names.insert(String(components[0]))
+            }
+        }
+        return names
     }
 
     private func initialTestTargets(

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1251,31 +1251,24 @@ public struct TestService { // swiftlint:disable:this type_body_length
     }
 
     private func passthroughSkippedTestTargetNames(_ arguments: [String]) -> Set<String> {
-        var names: Set<String> = []
-        var index = arguments.startIndex
-        while index < arguments.endIndex {
-            let argument = arguments[index]
-            let value: String?
-            if argument == "-skip-testing",
-               arguments.index(after: index) < arguments.endIndex
-            {
-                value = arguments[arguments.index(after: index)]
-                index = arguments.index(index, offsetBy: 2)
+        passthroughSkipTestingValues(arguments)
+            .compactMap { try? TestIdentifier(string: $0) }
+            // Only whole-target skips (no `/Class` or `/Class/Method`) remove a target entirely.
+            .filter { $0.class == nil && $0.method == nil }
+            .reduce(into: Set<String>()) { $0.insert($1.target) }
+    }
+
+    private func passthroughSkipTestingValues(_ arguments: [String]) -> [String] {
+        var values: [String] = []
+        var iterator = arguments.makeIterator()
+        while let argument = iterator.next() {
+            if argument == "-skip-testing", let value = iterator.next() {
+                values.append(value)
             } else if argument.hasPrefix("-skip-testing:") {
-                value = String(argument.dropFirst("-skip-testing:".count))
-                index = arguments.index(after: index)
-            } else {
-                index = arguments.index(after: index)
-                continue
-            }
-            guard let identifier = value else { continue }
-            // Only whole-target skips (no `/Class` or `/Class/Method` suffix) remove a target entirely.
-            let components = identifier.split(separator: "/", omittingEmptySubsequences: false)
-            if components.count == 1, !components[0].isEmpty {
-                names.insert(String(components[0]))
+                values.append(String(argument.dropFirst("-skip-testing:".count)))
             }
         }
-        return names
+        return values
     }
 
     private func initialTestTargets(

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -2047,6 +2047,206 @@ final class TestServiceTests: TuistUnitTestCase {
         XCTAssertEqual(capturedTestTargets, [try TestIdentifier(target: "TargetA", class: nil)])
     }
 
+    func test_run_skips_xcodebuild_when_passthrough_skip_testing_removes_all_selective_targets() async throws {
+        // Given — selective testing has filtered the graph so that only "SkippedTarget"
+        // remains in the scheme. The user also passes `-skip-testing:SkippedTarget` as a
+        // passthrough xcodebuild argument, which would leave xcodebuild with nothing to
+        // test (exit code 2). tuist should short-circuit and NOT invoke xcodebuild.
+        let projectPath = try temporaryPath().appending(component: "Project")
+        let filteredScheme = Scheme.test(
+            name: "App-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPath, name: "SkippedTarget")),
+                ]
+            )
+        )
+        let initialScheme = Scheme.test(
+            name: "App-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPath, name: "CleanTarget")),
+                    .test(target: TargetReference(projectPath: projectPath, name: "SkippedTarget")),
+                ]
+            )
+        )
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+
+        var environment = MapperEnvironment()
+        environment.initialGraph = .test(
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "CleanTarget", product: .unitTests, bundleId: "dev.tuist.Clean"),
+                        .test(name: "SkippedTarget", product: .unitTests, bundleId: "dev.tuist.Skipped"),
+                    ],
+                    schemes: [initialScheme]
+                ),
+            ]
+        )
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path,
+                    .test(
+                        projects: [
+                            projectPath: .test(
+                                path: projectPath,
+                                targets: [
+                                    .test(name: "SkippedTarget", product: .unitTests, bundleId: "dev.tuist.Skipped"),
+                                ],
+                                schemes: [filteredScheme]
+                            ),
+                        ]
+                    ),
+                    environment
+                )
+            }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([filteredScheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test())
+
+        xcodebuildController.reset()
+        given(xcodebuildController)
+            .test(
+                .any,
+                scheme: .any,
+                clean: .any,
+                destination: .any,
+                action: .any,
+                rosetta: .any,
+                derivedDataPath: .any,
+                resultBundlePath: .any,
+                arguments: .any,
+                retryCount: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                testPlanConfiguration: .any,
+                passthroughXcodeBuildArguments: .any
+            )
+            .willProduce { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
+                self.testedSchemes.append(scheme)
+            }
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            passthroughXcodeBuildArguments: ["-skip-testing:SkippedTarget"]
+        )
+
+        // Then — xcodebuild should NOT have been invoked (would otherwise exit 2).
+        XCTAssertEmpty(testedSchemes)
+    }
+
+    func test_run_invokes_xcodebuild_when_passthrough_skip_testing_targets_a_class_within_remaining_target() async throws {
+        // Given — selective testing has filtered the graph so only "TargetA" remains,
+        // and the user passes `-skip-testing:TargetA/SomeClass` (a scoped skip). The
+        // target still has tests to run, so xcodebuild should still be invoked.
+        let projectPath = try temporaryPath().appending(component: "Project")
+        let scheme = Scheme.test(
+            name: "App-Workspace",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                ]
+            )
+        )
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+        given(generatorFactory)
+            .testing(
+                config: .any,
+                testPlan: .any,
+                includedTargets: .any,
+                excludedTargets: .any,
+                skipUITests: .any,
+                skipUnitTests: .any,
+                configuration: .any,
+                ignoreBinaryCache: .any,
+                ignoreSelectiveTesting: .any,
+                cacheStorage: .any,
+                destination: .any,
+                schemeName: .any
+            )
+            .willReturn(generator)
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path,
+                    .test(
+                        projects: [
+                            projectPath: .test(
+                                path: projectPath,
+                                targets: [.test(name: "TargetA", product: .unitTests)],
+                                schemes: [scheme]
+                            ),
+                        ]
+                    ),
+                    MapperEnvironment()
+                )
+            }
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test())
+
+        // When
+        try await testRun(
+            path: try temporaryPath(),
+            passthroughXcodeBuildArguments: ["-skip-testing:TargetA/SomeClass"]
+        )
+
+        // Then — xcodebuild SHOULD be invoked; a scoped skip does not remove the whole target.
+        XCTAssertEqual(testedSchemes, ["App-Workspace"])
+    }
+
     func test_run_tests_all_project_schemes_when_fails() async throws {
         // Given
         givenGenerator()


### PR DESCRIPTION
## Summary
- `tuist test` with selective testing filters the graph so the scheme only contains targets that need to be retested. If a user also passes `-skip-testing:<Target>` as an xcodebuild passthrough argument (via `-- -skip-testing:...`) and that skip covers every remaining selective-testing target, xcodebuild is still invoked against a scheme with nothing to run and exits with code 2, failing CI.
- This commonly surfaces with a target that's always excluded via `-skip-testing:` on every CI run — its success hash is never stored, so selective testing always considers it dirty while every other target gets cached as clean. Once everything else is clean, the filtered scheme contains only the always-skipped target, and xcodebuild's `-skip-testing` removes it.
- Fix: in `TestService.shouldRunTest`, parse `-skip-testing` values from the passthrough xcodebuild arguments (supporting both `-skip-testing:Target` and `-skip-testing Target` forms). When those skips cover every remaining selective-testing target, short-circuit with a clear log message instead of invoking xcodebuild. Only whole-target skips trigger the short-circuit; scoped `-skip-testing:Target/Class[/Method]` entries still run the target.

## Test plan
- [x] New regression test `test_run_skips_xcodebuild_when_passthrough_skip_testing_removes_all_selective_targets` — fails on the unfixed code (xcodebuild gets invoked) and passes on the fixed code
- [x] New edge-case test `test_run_invokes_xcodebuild_when_passthrough_skip_testing_targets_a_class_within_remaining_target` — confirms scoped `Target/Class` skips still invoke xcodebuild
- [x] Existing `test_run_filters_test_targets_not_in_scheme` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)