### PR TITLE
fix(server): stabilize flaky BundlesLiveTest assertions

### DIFF
--- a/server/test/tuist_web/live/bundles_live_test.exs
+++ b/server/test/tuist_web/live/bundles_live_test.exs
@@ -25,23 +25,27 @@ defmodule TuistWeb.BundlesLiveTest do
     organization: organization,
     project: project
   } do
-    # Given
+    # Given — two bundles of the same app, so both fall under the page's
+    # app-name filter (defaulted from the first app with :ios platform).
     BundlesFixtures.bundle_fixture(
       project: project,
-      name: "AppOne"
+      name: "App",
+      git_commit_sha: "aaaa111bbbb",
+      inserted_at: DateTime.add(DateTime.utc_now(), -1, :hour)
     )
 
     BundlesFixtures.bundle_fixture(
       project: project,
-      name: "AppTwo"
+      name: "App",
+      git_commit_sha: "cccc222dddd"
     )
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/bundles")
 
     # Then
-    assert has_element?(lv, "span", "AppOne")
-    assert has_element?(lv, "span", "AppTwo")
+    assert has_element?(lv, "#bundles-table span", "aaaa111")
+    assert has_element?(lv, "#bundles-table span", "cccc222")
   end
 
   test "defaults download size to 0 MB when last bundle has only install size", %{
@@ -282,11 +286,12 @@ defmodule TuistWeb.BundlesLiveTest do
     organization: organization,
     project: project
   } do
+    # Use a single app name so all bundles match the page's app-name filter.
     for i <- 1..25 do
       BundlesFixtures.bundle_fixture(
         project: project,
-        name: "App-#{i}",
-        install_size: i * 1000
+        name: "App",
+        install_size: i * 1024
       )
     end
 
@@ -307,6 +312,7 @@ defmodule TuistWeb.BundlesLiveTest do
                ~p"/#{organization.account.name}/#{project.name}/bundles?bundles-sort-by=install-size&bundles-sort-order=asc&after=#{cursor}"
              )
 
-    assert has_element?(lv, "span", "App-1")
+    # install_size ascending starts at 1024 bytes = "1.0 KB".
+    assert has_element?(lv, "#bundles-table span", "1.0 KB")
   end
 end


### PR DESCRIPTION
## Summary

`BundlesLiveTest` has been flaky on `main` and PRs (e.g. [run 24878515745](https://github.com/tuist/tuist/actions/runs/24878515745), [run 24884032715](https://github.com/tuist/tuist/actions/runs/24884032715)). Two tests were affected:

- `lists latest bundles`
- `handles cursor mismatch when sort order changes`

**Root cause.** Since [#10376](https://github.com/tuist/tuist/pull/10376), the bundles page filters the table by app name (`bundle_size_selected_app`, defaulted via `Bundles.default_app/1` → first app with an `:ios` platform, or the most recently inserted). Both tests created fixtures with *different* app names, so only one app's bundle(s) ever reached the rendered table. The fixture sets `inserted_at` to `DateTime.utc_now()` truncated to the second (`utc_datetime`), so when two bundles land in the same second, `distinct_project_app_bundles/1` returns them in a non-deterministic order and `default_app/1` picks either one. Whichever app it picked won the assertion; the other failed.

The assertions ran against `<span>` text, but the non-matching app's name only appeared inside a `<.portal>` (a `<template>` element). Per [Phoenix.LiveView docs](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#portal/1), `has_element?` cannot see inside portal templates — so the second assertion was silently only ever passing when the visible bundle-table row happened to contain that name.

## Fix

- `lists latest bundles`: use one app name (`"App"`) for both fixtures with explicit `inserted_at` and unique `git_commit_sha` values, then assert on the short commit SHAs within `#bundles-table`.
- `handles cursor mismatch when sort order changes`: use one app name for all 25 fixtures and assert on the smallest install size (`"1.0 KB"`, from `i * 1024` with `i = 1`) within `#bundles-table`.

Keeps the change scoped to this test file; no stubs or production-code changes were needed (`BundlesLive`'s `assign_async` task is purely DB-backed — the S3 `nil bucket` signal referenced in the triage log is from a different LiveView).

## Test plan
- [x] `mix test test/tuist_web/live/bundles_live_test.exs` — 12 tests pass.
- [x] Repeated with seeds `0`, `42`, `12345` and five consecutive default-seed runs — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)