### PR TITLE
fix(server): unblock canary migration job by scoping ClickHouseRepo compile_env

### DIFF
--- a/server/lib/tuist/clickhouse_repo.ex
+++ b/server/lib/tuist/clickhouse_repo.ex
@@ -8,7 +8,5 @@ defmodule Tuist.ClickHouseRepo do
     adapter: Ecto.Adapters.ClickHouse,
     read_only: true,
     default_dynamic_repo:
-      :tuist
-      |> Application.compile_env(__MODULE__, [])
-      |> Keyword.get(:default_dynamic_repo, __MODULE__)
+      Application.compile_env(:tuist, [__MODULE__, :default_dynamic_repo], __MODULE__)
 end

--- a/server/lib/tuist/clickhouse_repo.ex
+++ b/server/lib/tuist/clickhouse_repo.ex
@@ -7,6 +7,5 @@ defmodule Tuist.ClickHouseRepo do
     otp_app: :tuist,
     adapter: Ecto.Adapters.ClickHouse,
     read_only: true,
-    default_dynamic_repo:
-      Application.compile_env(:tuist, [__MODULE__, :default_dynamic_repo], __MODULE__)
+    default_dynamic_repo: Application.compile_env(:tuist, [__MODULE__, :default_dynamic_repo], __MODULE__)
 end


### PR DESCRIPTION
## Summary

The canary cascade has been failing since the Syself migration merged because the pre-upgrade migration job crashes at boot with:

> ERROR! the application :tuist has a different value set for key `Tuist.ClickHouseRepo` during runtime compared to compile time.
> - Compile time value was not set
> - Runtime value was set to: `[url: ..., pool_size: 15, queue_target: 200, ...]`

Run: [tuist/tuist#24888505798](https://github.com/tuist/tuist/actions/runs/24888505798/job/72880581103).

### Root cause

[#10409](https://github.com/tuist/tuist/pull/10409) added `Application.compile_env(:tuist, __MODULE__, [])` to [server/lib/tuist/clickhouse_repo.ex](server/lib/tuist/clickhouse_repo.ex) so tests can route reads through `Tuist.IngestRepo`. But that call pins the **entire** `Tuist.ClickHouseRepo` config at compile time.

- Compile time (`MIX_ENV=can`): no `config :tuist, Tuist.ClickHouseRepo` is declared, so the recorded value is `[]`.
- Runtime (`runtime.exs` line 128): sets `url`, `pool_size`, `queue_target`, `settings`, `transport_opts`, ...

Releases run `:validate_compile_env` on boot, see the mismatch, and abort. The migration pod crashlooped until `BackoffLimitExceeded` and `--atomic` rolled the release back. Staging missed this bug because its last deploy (`71c71a273b10`, 2026-04-23) predated the `compile_env` commit (`9580a747e7`, 2026-04-24).

### Fix

Narrow the `compile_env` call to the `[Tuist.ClickHouseRepo, :default_dynamic_repo]` path, so only that sub-key is pinned. `runtime.exs` never touches `:default_dynamic_repo`, so compile-time and runtime lookups match in every env:

- **prod / stag / can**: path unset at both phases → default `__MODULE__` (matches).
- **test**: `test.exs` pins `Tuist.IngestRepo` at compile time; `runtime.exs` only adds `hostname/port/database`, so the path still resolves to `Tuist.IngestRepo` at runtime (matches).

### How to test locally

- `MIX_ENV=can mix compile` — succeeds (verified).
- `MIX_ENV=test mix compile` — succeeds (verified).
- ClickHouse-backed tests continue to use `Tuist.IngestRepo` via `test.exs`'s `default_dynamic_repo`.

Canary re-dispatch should unblock once this lands.