### PR TITLE
fix(app): app iOS auth logout handling

### DIFF
--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -62,61 +62,68 @@ import TuistServer
 
     @main
     struct TuistApp: App {
-        @StateObject private var authenticationService = AuthenticationService()
-        @State var activeTab = TabIdentifier.previews
-
         var body: some Scene {
             WindowGroup {
                 ServerCredentialsStore.$current.withValue(
                     ServerCredentialsStore(backend: .keychain)
                 ) {
                     CachedValueStore.$current.withValue(CachedValueStore(backend: .inSystemProcess)) {
-                        Group {
-                            if case let .loggedIn(account: account) = authenticationService.authenticationState {
-                                TabView(selection: $activeTab) {
-                                    PreviewsView()
-                                        .environmentObject(authenticationService)
-                                        .tabItem {
-                                            NooraIcon(.deviceMobile)
-                                            Text("Previews")
-                                        }
-                                        .tag(TabIdentifier.previews)
-
-                                    ProfileView(account: account)
-                                        .environmentObject(authenticationService)
-                                        .tabItem {
-                                            NooraIcon(.user)
-                                                .frame(width: 24, height: 24)
-                                            Text("Profile")
-                                        }
-                                        .tag(TabIdentifier.profile)
-                                }
-                                .onOpenURL { _ in
-                                    activeTab = .previews
-                                }
-                                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { _ in
-                                    activeTab = .previews
-                                }
-                                .accentColor(Noora.Colors.accent)
-                            } else {
-                                LogInView()
-                                #if DEBUG
-                                    .task {
-                                        await checkForAutomaticLogin()
-                                    }
-                                #endif
-                            }
-                        }
-                        .withErrorHandling()
-                        .task {
-                            TuistSDK(
-                                fullHandle: "tuist/tuist",
-                                apiKey: "tuist_019b26d5-fd7e-7b79-ae62-b5525b26ce38_OTSCoR3hGfPI20i1Hfnpl7HPSWI="
-                            )
-                            .monitorPreviewUpdates()
-                        }
+                        RootView()
                     }
                 }
+            }
+        }
+    }
+
+    private struct RootView: View {
+        @StateObject private var authenticationService = AuthenticationService()
+        @State private var activeTab = TabIdentifier.previews
+
+        var body: some View {
+            Group {
+                if case let .loggedIn(account: account) = authenticationService.authenticationState {
+                    TabView(selection: $activeTab) {
+                        PreviewsView()
+                            .environmentObject(authenticationService)
+                            .tabItem {
+                                NooraIcon(.deviceMobile)
+                                Text("Previews")
+                            }
+                            .tag(TabIdentifier.previews)
+
+                        ProfileView(account: account)
+                            .environmentObject(authenticationService)
+                            .tabItem {
+                                NooraIcon(.user)
+                                    .frame(width: 24, height: 24)
+                                Text("Profile")
+                            }
+                            .tag(TabIdentifier.profile)
+                    }
+                    .onOpenURL { _ in
+                        activeTab = .previews
+                    }
+                    .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { _ in
+                        activeTab = .previews
+                    }
+                    .accentColor(Noora.Colors.accent)
+                } else {
+                    LogInView()
+                        .environmentObject(authenticationService)
+                    #if DEBUG
+                        .task {
+                            await checkForAutomaticLogin()
+                        }
+                    #endif
+                }
+            }
+            .withErrorHandling()
+            .task {
+                TuistSDK(
+                    fullHandle: "tuist/tuist",
+                    apiKey: "tuist_019b26d5-fd7e-7b79-ae62-b5525b26ce38_OTSCoR3hGfPI20i1Hfnpl7HPSWI="
+                )
+                .monitorPreviewUpdates()
             }
         }
 

--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -80,43 +80,8 @@ import TuistServer
         @State private var activeTab = TabIdentifier.previews
 
         var body: some View {
-            Group {
-                if case let .loggedIn(account: account) = authenticationService.authenticationState {
-                    TabView(selection: $activeTab) {
-                        PreviewsView()
-                            .environmentObject(authenticationService)
-                            .tabItem {
-                                NooraIcon(.deviceMobile)
-                                Text("Previews")
-                            }
-                            .tag(TabIdentifier.previews)
-
-                        ProfileView(account: account)
-                            .environmentObject(authenticationService)
-                            .tabItem {
-                                NooraIcon(.user)
-                                    .frame(width: 24, height: 24)
-                                Text("Profile")
-                            }
-                            .tag(TabIdentifier.profile)
-                    }
-                    .onOpenURL { _ in
-                        activeTab = .previews
-                    }
-                    .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { _ in
-                        activeTab = .previews
-                    }
-                    .accentColor(Noora.Colors.accent)
-                } else {
-                    LogInView()
-                        .environmentObject(authenticationService)
-                    #if DEBUG
-                        .task {
-                            await checkForAutomaticLogin()
-                        }
-                    #endif
-                }
-            }
+            content
+                .environmentObject(authenticationService)
             .withErrorHandling()
             .task {
                 TuistSDK(
@@ -124,6 +89,43 @@ import TuistServer
                     apiKey: "tuist_019b26d5-fd7e-7b79-ae62-b5525b26ce38_OTSCoR3hGfPI20i1Hfnpl7HPSWI="
                 )
                 .monitorPreviewUpdates()
+            }
+        }
+
+        @ViewBuilder
+        private var content: some View {
+            switch authenticationService.authenticationState {
+            case let .loggedIn(account):
+                TabView(selection: $activeTab) {
+                    PreviewsView()
+                        .tabItem {
+                            NooraIcon(.deviceMobile)
+                            Text("Previews")
+                        }
+                        .tag(TabIdentifier.previews)
+
+                    ProfileView(account: account)
+                        .tabItem {
+                            NooraIcon(.user)
+                                .frame(width: 24, height: 24)
+                            Text("Profile")
+                        }
+                        .tag(TabIdentifier.profile)
+                }
+                .onOpenURL { _ in
+                    activeTab = .previews
+                }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { _ in
+                    activeTab = .previews
+                }
+                .accentColor(Noora.Colors.accent)
+            case .loggedOut:
+                LogInView()
+                #if DEBUG
+                    .task {
+                        await checkForAutomaticLogin()
+                    }
+                #endif
             }
         }
 

--- a/app/Sources/TuistErrorHandling/ErrorHandling.swift
+++ b/app/Sources/TuistErrorHandling/ErrorHandling.swift
@@ -19,7 +19,12 @@ public final class ErrorHandling: ObservableObject {
             if let underlyingServerClientError = clientError.underlyingError
                 as? ClientAuthenticationError
             {
-                errorDescription = "\(underlyingServerClientError.errorDescription ?? "Unknown error")"
+                Task {
+                    try await ServerCredentialsStore.current.delete(
+                        serverURL: ServerEnvironmentService().url()
+                    )
+                }
+                return
             } else {
                 errorDescription = clientError.underlyingError.localizedDescription
             }

--- a/app/Sources/TuistErrorHandling/ErrorHandling.swift
+++ b/app/Sources/TuistErrorHandling/ErrorHandling.swift
@@ -14,24 +14,20 @@ public final class ErrorHandling: ObservableObject {
 
     @MainActor
     public func handle(error: Error) {
-        let errorDescription: String
         if let clientError = error as? ClientError {
-            if let underlyingServerClientError = clientError.underlyingError
-                as? ClientAuthenticationError
-            {
+            if clientError.underlyingError is ClientAuthenticationError {
                 Task {
                     try await ServerCredentialsStore.current.delete(
                         serverURL: ServerEnvironmentService().url()
                     )
                 }
                 return
-            } else {
-                errorDescription = clientError.underlyingError.localizedDescription
             }
+            currentAlert = ErrorAlert(message: clientError.underlyingError.localizedDescription)
+            return
         } else {
-            errorDescription = error.localizedDescription
+            currentAlert = ErrorAlert(message: error.localizedDescription)
         }
-        currentAlert = ErrorAlert(message: errorDescription)
     }
 }
 

--- a/app/Sources/TuistOnboarding/LogInView.swift
+++ b/app/Sources/TuistOnboarding/LogInView.swift
@@ -6,7 +6,7 @@ import TuistNoora
 
 public struct LogInView: View {
     @EnvironmentObject var errorHandler: ErrorHandling
-    @StateObject private var authenticationService = AuthenticationService()
+    @EnvironmentObject private var authenticationService: AuthenticationService
     @Environment(\.colorScheme) private var colorScheme
     @State private var appleSignInDelegate: AppleSignInDelegate?
 
@@ -112,4 +112,6 @@ public struct LogInView: View {
 
 #Preview {
     LogInView()
+        .environmentObject(AuthenticationService())
+        .withErrorHandling()
 }

--- a/app/Tests/TuistMenuBarTests/Authentication/AuthenticationServiceTests.swift
+++ b/app/Tests/TuistMenuBarTests/Authentication/AuthenticationServiceTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Path
+import Testing
+import TuistAppStorage
+import TuistAuthentication
+import TuistServer
+
+@Suite struct AuthenticationServiceTests {
+    private let serverURL = URL(string: "https://tuist.dev")!
+
+    @Test func deleting_credentials_logs_the_user_out() async throws {
+        let store = makeCredentialsStore()
+        let appStorage = TestAppStorage(
+            authenticationState: .loggedIn(account: Account(email: "tuist@tuist.dev", handle: "tuist"))
+        )
+        let subject = await makeAuthenticationService(
+            store: store,
+            appStorage: appStorage
+        )
+
+        try await store.delete(serverURL: serverURL)
+        try await waitUntil {
+            subject.authenticationState == .loggedOut
+        }
+
+        #expect(subject.authenticationState == .loggedOut)
+        #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
+    }
+
+    @Test func storing_credentials_without_account_claims_logs_the_user_out() async throws {
+        let store = makeCredentialsStore()
+        let appStorage = TestAppStorage(
+            authenticationState: .loggedIn(account: Account(email: "tuist@tuist.dev", handle: "tuist"))
+        )
+        let subject = await makeAuthenticationService(
+            store: store,
+            appStorage: appStorage
+        )
+
+        try await store.store(
+            credentials: makeCredentials(
+                accessToken: try JWT.make(
+                    expiryDate: Date().addingTimeInterval(600),
+                    typ: "access"
+                ).token,
+                refreshToken: try JWT.make(
+                    expiryDate: Date().addingTimeInterval(3600),
+                    typ: "refresh"
+                ).token
+            ),
+            serverURL: serverURL
+        )
+
+        try await waitUntil {
+            subject.authenticationState == .loggedOut
+        }
+
+        #expect(subject.authenticationState == .loggedOut)
+        #expect(try appStorage.get(AuthenticationStateKey.self) == .loggedOut)
+    }
+
+    @Test func separate_store_instances_with_shared_storage_leave_the_original_service_stale() async throws {
+        let sharedConfigDirectory = makeTemporaryDirectory()
+        let rootStore = makeCredentialsStore(configDirectory: sharedConfigDirectory)
+        let loginStore = makeCredentialsStore(configDirectory: sharedConfigDirectory)
+        let rootAppStorage = TestAppStorage(authenticationState: .loggedOut)
+        let loginAppStorage = TestAppStorage(authenticationState: .loggedOut)
+        let rootService = await makeAuthenticationService(
+            store: rootStore,
+            appStorage: rootAppStorage
+        )
+        let loginService = await makeAuthenticationService(
+            store: loginStore,
+            appStorage: loginAppStorage
+        )
+        let account = Account(email: "tuist@tuist.dev", handle: "tuist")
+        let credentials = try makeCredentials(
+            email: account.email,
+            handle: account.handle
+        )
+
+        try await loginStore.store(
+            credentials: credentials,
+            serverURL: serverURL
+        )
+
+        try await waitUntil {
+            loginService.authenticationState == .loggedIn(account: account)
+        }
+
+        let storedCredentials = try #require(
+            try await rootStore.read(serverURL: serverURL)
+        )
+
+        for _ in 0 ..< 20 {
+            await Task.yield()
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(storedCredentials == credentials)
+        #expect(loginService.authenticationState == .loggedIn(account: account))
+        #expect(rootService.authenticationState == .loggedOut)
+    }
+
+    private func makeAuthenticationService(
+        store: ServerCredentialsStore,
+        appStorage: TestAppStorage
+    ) async -> AuthenticationService {
+        await ServerCredentialsStore.$current.withValue(store) {
+            AuthenticationService(appStorage: appStorage)
+        }
+    }
+
+    private func makeCredentialsStore(
+        configDirectory: AbsolutePath? = nil
+    ) -> ServerCredentialsStore {
+        ServerCredentialsStore(
+            backend: .fileSystem,
+            configDirectory: configDirectory ?? makeTemporaryDirectory()
+        )
+    }
+
+    private func makeTemporaryDirectory() -> AbsolutePath {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        return try! AbsolutePath(validating: path.path)
+    }
+
+    private func makeCredentials(
+        email: String = "tuist@tuist.dev",
+        handle: String = "tuist"
+    ) throws -> ServerCredentials {
+        try makeCredentials(
+            accessToken: JWT.make(
+                expiryDate: Date().addingTimeInterval(600),
+                typ: "access",
+                email: email,
+                preferredUsername: handle
+            ).token,
+            refreshToken: JWT.make(
+                expiryDate: Date().addingTimeInterval(3600),
+                typ: "refresh",
+                email: email,
+                preferredUsername: handle
+            ).token
+        )
+    }
+
+    private func makeCredentials(
+        accessToken: String,
+        refreshToken: String
+    ) throws -> ServerCredentials {
+        ServerCredentials(
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+    }
+
+    private func waitUntil(
+        _ predicate: () -> Bool
+    ) async throws {
+        for _ in 0 ..< 100 {
+            if predicate() {
+                return
+            }
+            await Task.yield()
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}
+
+private final class TestAppStorage: AppStoring, @unchecked Sendable {
+    private var authenticationState: AuthenticationState
+
+    init(authenticationState: AuthenticationState) {
+        self.authenticationState = authenticationState
+    }
+
+    func get<Key: AppStorageKey>(_ key: Key.Type) throws -> Key.Value {
+        if key.key == AuthenticationStateKey.key {
+            return authenticationState as! Key.Value
+        }
+        return key.defaultValue
+    }
+
+    func set<Key: AppStorageKey>(_ key: Key.Type, value: Key.Value) throws {
+        if key.key == AuthenticationStateKey.key,
+           let value = value as? AuthenticationState
+        {
+            authenticationState = value
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- scope the iOS root `AuthenticationService` inside the shared credentials context
- reuse that shared auth service from the login screen instead of creating a second instance
- clear stored credentials on `ClientAuthenticationError` so invalid sessions reset cleanly
- add auth regression tests for logout, malformed claims, and stale shared-store state

> [!IMPORTANT]
> This PR is based on an informed assumption about the remaining logout bug. `app@0.25.2` already shipped the iOS refresh-locking fix, so this change targets the next most likely cause: iOS auth-state/store scoping and invalid-credential cleanup paths that still match the reported logout behaviour. We have regression coverage for those paths, but we have not reproduced the full production issue end-to-end after the last release.

## Testing
- Generated the app workspace and verified the iOS app builds locally
- Ran the new `AuthenticationServiceTests` regression coverage in the app test target
