### PR TITLE
fix(server): drop mix _build cache mount to unblock deploys

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -113,12 +113,7 @@ COPY server/config/prod.exs server/config/can.exs server/config/stag.exs config/
 COPY processor/lib /processor/lib
 COPY xcode_processor/lib /xcode_processor/lib
 
-# Cache mount on _build persists compiled dep artifacts across builds, so
-# incremental compilation survives even when this layer is invalidated.
-# The mount masks the image layer, so /app/_build is empty in the committed
-# layer — every subsequent RUN that reads _build must use the same mount id.
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix deps.compile
+RUN mix deps.compile
 
 # ========================================
 # Stage 3: Main application builder
@@ -134,39 +129,25 @@ COPY examples/xcode /examples/xcode
 
 COPY server/lib lib
 
-# Install Chromium before the big mix RUN so it can generate OG images.
-# Kept in its own layer (no mix mount needed) so it caches independently
-# of source changes, and runs before mix compile so the compile RUN
-# doesn't interleave apt-get network I/O with Elixir compilation.
+RUN mix compile --warnings-as-errors
+
+# Install Chromium for OG image generation (headless, no GPU)
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends chromium fonts-noto-cjk fonts-noto-core && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# All mix steps that read/write _build share the same cache mount id so
-# incremental compilation persists both within this build (across RUNs)
-# and across builds (via BuildKit persistent cache).
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix compile --warnings-as-errors
-
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix docs.gen.og_images
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix marketing.gen.og_images
+# Generate OG images using headless Chromium
+RUN mix docs.gen.og_images
+RUN mix marketing.gen.og_images
 
 COPY server/config/runtime.exs config/
 COPY server/rel rel
 
 COPY --from=npm-deps /app/node_modules /app/node_modules
 COPY --from=npm-deps /noora/priv/static /noora/priv/static
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix assets.deploy
+RUN mix assets.deploy
 
-# mix release writes into the cache mount, so we copy the release output
-# out to /release (a real image path) in the same RUN. Downstream stages
-# COPY --from=builder /release instead of /app/_build/${MIX_ENV}/rel/tuist.
-RUN --mount=type=cache,id=mix-build,target=/app/_build \
-    mix release && \
-    cp -r /app/_build/${MIX_ENV}/rel/tuist /release
+RUN mix release
 
 # ========================================
 # Stage: NIF bridge builder (for selfhosted)
@@ -177,16 +158,16 @@ FROM builder AS nif-bridge-builder
 COPY processor/native/xcactivitylog_nif/nif_bridge.c /tmp/nif/nif_bridge.c
 COPY --from=swift-builder /nif/libXCActivityLogNIF.so /tmp/nif/libXCActivityLogNIF.so
 
-RUN mkdir -p /release/lib/processor-0.1.0/priv/native && \
+RUN mkdir -p /app/_build/prod/rel/tuist/lib/processor-0.1.0/priv/native && \
     ERL_INCLUDE=$(erl -eval 'io:format("~s/erts-~s/include", [code:root_dir(), erlang:system_info(version)])' -s init stop -noshell) && \
     cc -shared -fPIC \
-      -o /release/lib/processor-0.1.0/priv/native/xcactivitylog_nif.so \
+      -o /app/_build/prod/rel/tuist/lib/processor-0.1.0/priv/native/xcactivitylog_nif.so \
       /tmp/nif/nif_bridge.c \
       -I"$ERL_INCLUDE" \
       -L/tmp/nif \
       -lXCActivityLogNIF \
       -Wl,-rpath,'$ORIGIN' && \
-    cp /tmp/nif/libXCActivityLogNIF.so /release/lib/processor-0.1.0/priv/native/
+    cp /tmp/nif/libXCActivityLogNIF.so /app/_build/prod/rel/tuist/lib/processor-0.1.0/priv/native/
 
 # ========================================
 # Stage 5: Common runtime base
@@ -218,7 +199,7 @@ ARG EMBED_CLICKHOUSE=false
 ENV MIX_ENV=$MIX_ENV
 ENV TUIST_HOSTED=$TUIST_HOSTED
 
-COPY --from=builder --chown=nobody:root /release ./
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/tuist ./
 
 COPY server/priv/secrets/can.yml.enc /app/priv/secrets/can.yml.enc
 COPY server/priv/secrets/stag.yml.enc /app/priv/secrets/stag.yml.enc
@@ -263,7 +244,7 @@ COPY --from=swift-builder /nif/swift-libs/ /usr/local/lib/
 RUN ldconfig
 
 # Copy compiled NIF .so files into processor priv dir
-COPY --from=nif-bridge-builder /release/lib/processor-0.1.0/priv/native/ /app/lib/processor-0.1.0/priv/native/
+COPY --from=nif-bridge-builder /app/_build/prod/rel/tuist/lib/processor-0.1.0/priv/native/ /app/lib/processor-0.1.0/priv/native/
 
 USER nobody
 


### PR DESCRIPTION
## Summary
- Removes the persistent BuildKit `mix-build` cache mount from all `mix` RUN steps in the server Dockerfile
- Keeps the safe `mix-hex` and `mix-rebar3` download caches from #10439
- Restores the original release copy path (`/app/_build/\${MIX_ENV}/rel/tuist`) so no `/release` redirect is needed

## Why
Every `Server Production Deployment` since #10439 landed has been blocked. The two latest attempts on the #10442 fix commit each failed at the `mix compile --warnings-as-errors` step — first with a BEAM segfault (exit 139), then with:

\`\`\`
warning: redefining module Tuist.Cldr.Number.Symbol (current version loaded from _build/prod/lib/tuist/ebin/Elixir.Tuist.Cldr.Number.Symbol.beam)
...
Compilation failed due to warnings while using the --warnings-as-errors option
\`\`\`

Root cause: the `_build` cache mount persists `.beam` files across builds. When a new build starts, Elixir's auto-loader picks them up. Then `lib/tuist/cldr.ex`'s `use Cldr` macro dynamically defines the same module names, triggering "redefining module" warnings. With `--warnings-as-errors`, compilation fails.

Dynamic code-gen libraries like Cldr are fundamentally incompatible with a persistent `_build` cache — you can't avoid redefinition when the macro's sole job is to generate those modules.

The hex/rebar3 download caches are fine (they just store dep tarballs), so those stay.

## Test plan
- [ ] Server production deployment workflow succeeds for this commit
- [ ] Canary deploys successfully (verifies #10442's DB fix too)