### PR TITLE
feat(kura): add warm rollout and rollback primitives

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -3,6 +3,7 @@
 This node covers the `kura/` workspace, a Rust service for low-latency cache meshes that replicate artifacts and metadata across peer nodes.
 
 ## Key Boundaries
+- High-level architecture overview: `docs/architecture.md` — start here when onboarding or reasoning about how subsystems interact
 - Entry points: `src/main.rs`, `src/app.rs`
 - Public HTTP and gRPC surfaces: `src/http.rs`
 - Storage, metadata, and replication state: `src/store.rs`, `src/state.rs`
@@ -20,5 +21,6 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 
 ## Maintenance Notes
 - Keep `README.md` aligned with any protocol, configuration, or deployment changes
+- Keep `docs/architecture.md` in sync when changing how subsystems fit together (storage planes, replication model, traffic lifecycle, rollouts, observability surface)
 - When changing cache protocol behavior, update the relevant shellspec coverage under `spec/e2e/`
 - Keep Helm and local observability assets in `ops/` in sync with runtime configuration changes

--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -10,6 +10,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 - Observability and analytics: `src/metrics.rs`, `src/telemetry.rs`, `src/analytics.rs`
 - Peer TLS support: `src/peer_tls.rs`
 - Operational assets: `docker-compose.yml`, `ops/`, `test/e2e/`, `spec/e2e/`
+  - See `ops/AGENTS.md` for Helm, rollout helpers, and observability config boundaries
 
 ## Development
 - Install tools from `kura/mise.toml` with `mise install`

--- a/kura/Cargo.lock
+++ b/kura/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "hex",
  "hmac",
  "http-body-util",
+ "hyper-util",
  "jsonwebtoken",
  "libc",
  "mlua",

--- a/kura/Cargo.toml
+++ b/kura/Cargo.toml
@@ -14,6 +14,7 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 hmac = "0.12.1"
 http-body-util = "0.1.3"
+hyper-util = "0.1.20"
 libc = "0.2.177"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 mlua = { version = "0.11.4", features = ["async", "lua54", "send", "serialize", "vendored"] }

--- a/kura/README.md
+++ b/kura/README.md
@@ -45,8 +45,11 @@ docker compose up --build -d
 Useful endpoints:
 
 - `http://localhost:4101/up`
+- `http://localhost:4101/ready`
 - `http://localhost:4102/up`
+- `http://localhost:4102/ready`
 - `http://localhost:4103/up`
+- `http://localhost:4103/ready`
 - `grpc://localhost:5101` for Bazel/Buck2 REAPI against `kura-us`
 - `grpc://localhost:5102` for Bazel/Buck2 REAPI against `kura-eu`
 - `grpc://localhost:5103` for Bazel/Buck2 REAPI against `kura-ap`
@@ -299,11 +302,13 @@ It also exposes analytics-specific runtime metrics for:
 The repository includes a Helm chart at `ops/helm/kura` that deploys Kura as a `StatefulSet` with:
 
 - 💾 one PVC per pod for metadata-state and segment storage
+- 🔒 single-writer fencing through a process-held data-dir lock plus `ReadWriteOncePod` by default
 - 🧭 a headless service for stable pod DNS and peer discovery
 - 🌐 a regular service exposing both HTTP and gRPC
 - 🚪 optional ingress for the HTTP API
 - 🧩 optional inline extension script mounting through a `ConfigMap`
 - 🔐 optional peer mTLS for `/_internal/*` traffic via a mounted Kubernetes `Secret`
+- 🚦 `/ready` for public readiness and `/up` for liveness, with a `preStop` drain hook that removes pods from traffic before `SIGTERM`
 
 Lint and render the chart:
 
@@ -323,6 +328,8 @@ helm upgrade --install kura ./ops/helm/kura \
   --set config.region=fr-par \
   --set config.telemetry.otlpTracesEndpoint=http://otel-collector.monitoring.svc.cluster.local:4318/v1/traces
 ```
+
+The chart defaults persistence to `ReadWriteOncePod` so one Kura process owns each PVC. If your CSI driver does not support it, override `persistence.accessModes[0]=ReadWriteOnce`; Kura will still fence the volume with its app-level writer lock.
 
 For a local kind smoke test, the repo includes:
 

--- a/kura/README.md
+++ b/kura/README.md
@@ -308,7 +308,7 @@ The repository includes a Helm chart at `ops/helm/kura` that deploys Kura as a `
 - 🚪 optional ingress for the HTTP API
 - 🧩 optional inline extension script mounting through a `ConfigMap`
 - 🔐 optional peer mTLS for `/_internal/*` traffic via a mounted Kubernetes `Secret`
-- 🚦 `/ready` for public readiness and `/up` for liveness, with a `preStop` drain hook that removes pods from traffic before `SIGTERM`
+- 🚦 `/ready` for public readiness and `/up` for liveness, with a `preStop` `SIGUSR1` drain hook that removes pods from traffic before `SIGTERM`
 
 Lint and render the chart:
 

--- a/kura/README.md
+++ b/kura/README.md
@@ -46,10 +46,13 @@ Useful endpoints:
 
 - `http://localhost:4101/up`
 - `http://localhost:4101/ready`
+- `http://localhost:4101/status/rollout`
 - `http://localhost:4102/up`
 - `http://localhost:4102/ready`
+- `http://localhost:4102/status/rollout`
 - `http://localhost:4103/up`
 - `http://localhost:4103/ready`
+- `http://localhost:4103/status/rollout`
 - `grpc://localhost:5101` for Bazel/Buck2 REAPI against `kura-us`
 - `grpc://localhost:5102` for Bazel/Buck2 REAPI against `kura-eu`
 - `grpc://localhost:5103` for Bazel/Buck2 REAPI against `kura-ap`
@@ -191,6 +194,7 @@ When `Optional` is `Yes`, the `Default` column shows what Kura uses today. `auto
 | `KURA_DISCOVERY_DNS_NAME` | DNS name to probe for automatic peer discovery. | Yes | disabled |
 | `KURA_FILE_DESCRIPTOR_POOL_SIZE` | App-managed file-descriptor budget for request and background I/O. | Yes | auto |
 | `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` | How long a request waits before FD backpressure fails the checkout. | Yes | `5000` |
+| `KURA_DRAIN_COMPLETION_TIMEOUT_MS` | Maximum grace window Kura gives in-flight HTTP and gRPC work to finish during shutdown before forcing exit progression. | Yes | `240000` |
 | `KURA_SEGMENT_HANDLE_CACHE_SIZE` | Maximum number of pinned segment read handles; must stay below the FD pool size. | Yes | auto |
 | `KURA_MEMORY_SOFT_LIMIT_BYTES` | Soft watermark where Kura starts shedding optional memory use. | Yes | auto |
 | `KURA_MEMORY_HARD_LIMIT_BYTES` | Hard watermark where Kura pauses replication work and trims hot caches aggressively. | Yes | auto |
@@ -219,7 +223,7 @@ Auto-derived defaults currently follow these rules:
 - `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES` follows the same `memory_limit_bytes / 32` rule as the metadata-store read cache.
 - `KURA_METADATA_STORE_WRITE_BUFFER_BYTES` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / 4`, rounded down to MiB boundaries and clamped to `[4 MiB, 32 MiB]`.
 - `KURA_METADATA_STORE_MAX_WRITE_BUFFERS` is `KURA_METADATA_STORE_WRITE_BUFFER_POOL_BYTES / KURA_METADATA_STORE_WRITE_BUFFER_BYTES`, clamped to `[2, 8]`.
-- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, and `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`.
+- `KURA_MAX_KEYVALUE_BYTES` defaults to `1048576`, `KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS` defaults to `5000`, and `KURA_DRAIN_COMPLETION_TIMEOUT_MS` defaults to `240000`.
 
 A minimal direct-binary deployment still looks like:
 
@@ -309,6 +313,7 @@ The repository includes a Helm chart at `ops/helm/kura` that deploys Kura as a `
 - 🧩 optional inline extension script mounting through a `ConfigMap`
 - 🔐 optional peer mTLS for `/_internal/*` traffic via a mounted Kubernetes `Secret`
 - 🚦 `/ready` for public readiness and `/up` for liveness, with a `preStop` `SIGUSR1` drain hook that removes pods from traffic before `SIGTERM`
+- ⏱️ a pod grace period derived from Kura's own drain timeout plus small lifecycle buffers so Kubernetes does not cut shutdown short
 
 Lint and render the chart:
 
@@ -331,11 +336,31 @@ helm upgrade --install kura ./ops/helm/kura \
 
 The chart defaults persistence to `ReadWriteOncePod` so one Kura process owns each PVC. If your CSI driver does not support it, override `persistence.accessModes[0]=ReadWriteOnce`; Kura will still fence the volume with its app-level writer lock.
 
+The chart computes `terminationGracePeriodSeconds` from `config.shutdown.drainCompletionTimeoutMs`, `podLifecycle.preStopDelaySeconds`, and `podLifecycle.terminationGraceExtraSeconds`. That keeps the platform budget aligned with the application's shared shutdown deadline instead of relying on a separate hard-coded Kubernetes timeout.
+
 For a local kind smoke test, the repo includes:
 
 ```bash
 ./test/e2e/kura_helm_kind.sh
 ```
+
+For a gated in-place StatefulSet rollout, the repo also includes:
+
+```bash
+./ops/helm/kura/rollout.sh kura kura --set image.tag=<new-tag>
+```
+
+That script is the Kubernetes adapter. The rollout gate itself lives in `ops/rollout/gate.sh` and only assumes it can fetch Kura's rollout status endpoint once per node per poll. The Helm adapter stages the new revision behind a StatefulSet partition, rolls the highest ordinal first, and only advances after every node reports the same membership generation, all nodes are back in `serving`, the updated pod stays ready, ring membership is restored cluster-wide, outbox depth stays near baseline, no node is under critical memory pressure, and the cluster is not introducing new file-descriptor timeout activity.
+
+If the Kura container listens on a non-default HTTP port, set `KURA_HTTP_PORT=<port>` when invoking the rollout helper so the adapter samples the correct loopback endpoint inside each pod.
+
+For adjacent-version mixed rollout and rollback validation on the same persistent Docker volumes, use:
+
+```bash
+PREVIOUS_REF=origin/main ./test/e2e/kura_compatibility_rollout.sh
+```
+
+That harness proves `PREVIOUS_REF -> HEAD -> PREVIOUS_REF` across a mixed-version window, but it validates protocol and on-disk compatibility only. It does not try to model Kubernetes PVC reattachment behavior.
 
 To enable peer mTLS in Kubernetes, set:
 

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -1,0 +1,177 @@
+# Kura Architecture
+
+This document explains how Kura works, starting from a very high level and going deeper as you read on. Skim the first sections for an overview; read further for the runtime, replication, and rollout details.
+
+## What Kura Is
+
+Kura is a Rust service that builds **low-latency cache meshes**. A mesh is a small set of Kura nodes that each serve cache traffic from local disk and replicate writes to one another in the background. Clients (Bazel, Buck2, Xcode, Gradle, Tuist Module Cache, Nx, Metro) talk to whichever node is closest. Reads come back fast because they are local; writes propagate to peers asynchronously.
+
+The project name comes from the Japanese word `蔵` ("storehouse"). The role of a node fits the name: keep artifacts and metadata stored durably and close at hand.
+
+## The Problem It Solves
+
+Build caches are read-heavy and latency-sensitive. A central cache hundreds of milliseconds away wastes more time than it saves. Kura puts a writable cache node next to each cluster of clients and keeps the nodes loosely consistent in the background. There is no leader, no global lock, and no synchronous fan-out on the hot path.
+
+## High-Level Picture
+
+```
+        clients (Bazel/Buck2/Xcode/Gradle/...)
+                       │
+                       ▼
+   ┌──────────────────────────────────────────┐
+   │             Kura node (region X)         │
+   │                                          │
+   │   public HTTP   gRPC (REAPI)             │
+   │       │            │                     │
+   │       ▼            ▼                     │
+   │   ┌──────────────────────────┐           │
+   │   │ request handlers         │           │
+   │   └────────┬─────────┬───────┘           │
+   │            │         │                   │
+   │   ┌────────▼─┐   ┌───▼──────────┐        │
+   │   │ RocksDB  │   │ segment files│        │
+   │   │ metadata │   │ (blob bodies)│        │
+   │   │ + outbox │   │              │        │
+   │   └────┬─────┘   └──────────────┘        │
+   │        │                                 │
+   │        ▼                                 │
+   │  outbox worker ──► internal HTTP ──► peers
+   │                                          │
+   │   membership/discovery worker ◄── peers' │
+   │                                  /_internal/status
+   └──────────────────────────────────────────┘
+```
+
+Each node owns one persistent volume, runs one writer process, and exchanges traffic with peers over a separate **internal plane** that can be optionally protected with mTLS.
+
+## Subsystems And Where They Live
+
+| Concern | Code |
+| --- | --- |
+| Process entry, server wiring | `src/main.rs`, `src/app.rs` |
+| Public HTTP + gRPC handlers, readiness/rollout endpoints | `src/http.rs`, `src/reapi/` |
+| Storage (metadata, outbox, segments) | `src/store.rs` |
+| Replication (membership, bootstrap, outbox processing) | `src/replication/` |
+| Cluster membership and readiness state | `src/state.rs` |
+| Traffic state, drain, single-writer fencing | `src/runtime.rs` |
+| Configuration + auto-derived defaults | `src/config.rs`, `src/constants.rs` |
+| Metrics, traces, logs, error reporting | `src/metrics.rs`, `src/telemetry.rs`, `src/analytics.rs` |
+| Optional Lua extension hook | `src/extension.rs` |
+| Helm chart, rollout scripts, observability config | `ops/` |
+| End-to-end and shell-based tests | `test/e2e/`, `spec/e2e/` |
+
+## Storage Planes
+
+Kura splits durable state into two planes so that the hot path is simple and the cold path can compact freely:
+
+1. **RocksDB** holds metadata: artifact manifests, keyvalue payloads, multipart upload state, namespace tombstones, segment lifecycle records, and the **replication outbox**. Local writes and their outbox entries are committed together, so replication intent is durable as soon as the write is acknowledged.
+2. **Segment files** hold large immutable artifact bodies on disk. The hot path opens segment file descriptors directly, bypassing RocksDB for blob payloads.
+
+The metadata store uses tunable RocksDB budgets (`KURA_METADATA_STORE_*`) that auto-derive from the host's memory and FD limits.
+
+## Replication Model
+
+Replication is **leaderless and eventually consistent**:
+
+- Every node is a writer for its own clients.
+- A successful local write enqueues an `OutboxMessage` in RocksDB inside the same atomic batch as the metadata commit.
+- A background **outbox worker** drains the queue and PUTs each message to the corresponding peer over the internal plane. On success, the message is deleted; on failure it stays queued and the worker retries.
+- Conflicts are resolved by `version_ms` (last-writer-wins per key); stale applies are rejected with `ArtifactApplyOutcome::IgnoredStale`.
+
+Newly joined nodes catch up by **bootstrapping from a peer**: paginated manifest and tombstone fetches followed by lazy artifact body fetches. Bootstrap re-uses the same apply paths as live replication, so the same conflict rules apply.
+
+See `src/replication/mod.rs` for the membership/outbox/bootstrap loops, and `src/replication/operation.rs` + `outbox_message.rs` for the message types.
+
+## Discovery And Membership
+
+A node finds peers in two ways:
+
+1. **Static seeds** from `KURA_PEERS`.
+2. **DNS-based discovery** via `KURA_DISCOVERY_DNS_NAME`, which resolves to the addresses of the other pods (typical when running as a Kubernetes `StatefulSet` behind a headless service).
+
+A `spawn_membership_task` loop polls each candidate's `GET /_internal/status` every two seconds. Only peers that respond with the same `tenant_id` and a different `node_url` are admitted as members. The local node never lists itself.
+
+Each tick produces a `MembershipUpdate` and feeds it into `ReadinessState` (`src/state.rs`). The state tracks:
+
+- the set of `known_peers` (peers that responded successfully),
+- which peers we have **bootstrapped** from,
+- which bootstraps are currently **inflight**,
+- a monotonically increasing **generation** that bumps whenever the membership topology changes,
+- and a short **settle window** after each generation change.
+
+`initial_discovery_completed` only flips once we have actually observed a successful peer status check (or there are no discovery targets at all). This avoids promoting a node to "ready" when the seed peers were transiently unreachable.
+
+## Traffic Lifecycle
+
+A node moves through three explicit traffic states (`src/runtime.rs`):
+
+```
+        ┌──────────┐  membership generation     ┌──────────┐
+        │          │   advances or restart      │          │
+        │ joining  │ ◄──────────────────────────│ serving  │
+        │          │                            │          │
+        └────┬─────┘                            └─────┬────┘
+             │ all known peers bootstrapped,          │
+             │ discovery observed, settle window      │
+             │ elapsed                                │
+             ▼                                        ▼
+        ┌──────────┐         drain request      ┌──────────┐
+        │ serving  │ ─────────────────────────► │ draining │
+        └──────────┘                            └──────────┘
+```
+
+- **`joining`** — public reads/writes are accepted but `/ready` returns `503` until bootstrap completes for every known peer. This keeps load balancers from routing traffic to a half-warm pod.
+- **`serving`** — `/ready` returns `200`. Public APIs handle traffic normally.
+- **`draining`** — public HTTP rejects new requests and closes HTTP/1.1 connections; gRPC stops accepting new RPCs and ages out long-lived connections. Inflight work continues until a shared **drain deadline** (`KURA_DRAIN_COMPLETION_TIMEOUT_MS`) elapses.
+
+`/up` is a liveness signal that does not depend on any of this — it stays healthy as long as the process is alive.
+
+## Single-Writer Fencing
+
+Each PVC is owned by exactly one Kura process. On startup, `DataDirLock` (`src/runtime.rs`) takes an OS file lock on `.kura.writer.lock` inside `KURA_DATA_DIR`. If another process holds the lock, startup fails fast. Public readiness depends on the lock being held, so a node that loses the lock cannot serve traffic.
+
+The Kubernetes layer reinforces this with `ReadWriteOncePod` PVC access by default; the app-level lock is the source of truth and works even when the CSI driver only supports `ReadWriteOnce`.
+
+## Rollouts
+
+Rollouts are deliberately conservative because each node is stateful and serves cache traffic that should not regress to misses during an upgrade.
+
+The pieces:
+
+- A pod's `preStop` hook sends `SIGUSR1` to start drain. The pod stays alive long enough to finish inflight work, then exits.
+- `terminationGracePeriodSeconds` is computed from the application's own drain timeout plus small lifecycle buffers, so Kubernetes never cuts shutdown short.
+- A generic **rollout gate** (`ops/rollout/gate.sh`) polls each node's `/status/rollout` and only advances when every node reports the same membership generation, all are back in `serving`, ring size matches, no bootstrap is inflight, the outbox is near baseline, no node is under critical memory pressure, and there is no new file-descriptor timeout activity.
+- A **Kubernetes adapter** (`ops/helm/kura/rollout.sh`) stages the new revision behind a `StatefulSet` partition, rolls the highest ordinal first, and delegates health gating to the generic gate. The adapter is a thin transport layer; it does not own rollout semantics.
+- An **adjacent-version compatibility harness** (`test/e2e/kura_compatibility_rollout.sh`) validates `PREVIOUS_REF → HEAD → PREVIOUS_REF` on the same persistent Docker volumes for the artifact CAS path.
+
+The rollout gate explicitly assumes only that it can fetch `/status/rollout` from each node. It does not depend on Kubernetes probes or Prometheus.
+
+## Observability
+
+Each node exposes:
+
+- Prometheus metrics on `/metrics` (replication latency, FD pressure, manifest cache, RocksDB internals, outbox depth, traffic state, rollout-relevant counters).
+- OpenTelemetry traces for replication and request handling.
+- Structured logs intended for Loki/Promtail.
+- Optional Sentry forwarding for panics and `tracing::error!` events.
+
+Helm and the local docker-compose stack ship a complete Grafana/Prometheus/Loki/Tempo setup. See `ops/AGENTS.md` for layout.
+
+## Configuration Surface
+
+All configuration is environment-driven (`src/config.rs`). The full table lives in [`README.md`](../README.md#-runtime-model-and-limits). Highlights:
+
+- Required identity and addressing: `KURA_TENANT_ID`, `KURA_REGION`, `KURA_NODE_URL`, `KURA_PORT`, `KURA_GRPC_PORT`, `KURA_INTERNAL_PORT`, `KURA_DATA_DIR`, `KURA_TMP_DIR`.
+- Peer plane: `KURA_PEERS`, `KURA_DISCOVERY_DNS_NAME`, optional `KURA_INTERNAL_TLS_*` for peer mTLS.
+- Resource budgets: file-descriptor pool, memory soft/hard limits, manifest cache, RocksDB write buffer pool, all with `auto` defaults derived from the host.
+- Drain timing: `KURA_DRAIN_COMPLETION_TIMEOUT_MS`.
+
+When budget vars are unset Kura inspects `RLIMIT_NOFILE`, the cgroup memory limit, and detected CPU count to pick safe defaults.
+
+## Where To Read Next
+
+- For protocol surfaces (REAPI, Xcode, Gradle, Module Cache, Nx, Metro), start in `src/http.rs` and `src/reapi/mod.rs`.
+- For the storage layer, `src/store.rs` is the single entry point.
+- For replication invariants and bootstrap retry behavior, see `src/replication/mod.rs` and `src/state.rs`.
+- For the Helm chart and rollout scripts, see `ops/helm/kura/` and `ops/rollout/gate.sh`.
+- For end-to-end behavior, the shellspec suite under `spec/e2e/` exercises the live stack.

--- a/kura/ops/AGENTS.md
+++ b/kura/ops/AGENTS.md
@@ -1,0 +1,13 @@
+# Operations
+
+This node covers operational assets under `kura/ops/`.
+
+## Key Boundaries
+- `helm/kura/` - Kubernetes packaging and rollout adapter for the Kura StatefulSet
+- `rollout/` - Transport-agnostic rollout gate helpers that operate on Kura HTTP endpoints and metrics
+- `prometheus/`, `loki/`, `promtail/`, `tempo/` - Local observability stack configuration
+
+## Maintenance Notes
+- Keep rollout policy generic at the `ops/rollout/` layer. Platform-specific orchestration belongs in leaf adapters such as `ops/helm/kura/`.
+- When runtime readiness, drain, or metrics semantics change, update both the generic rollout helpers and any platform adapters that consume them.
+- Keep Helm lifecycle defaults aligned with runtime shutdown configuration, but do not introduce Kubernetes-specific assumptions into the core Rust service.

--- a/kura/ops/helm/kura/rollout.sh
+++ b/kura/ops/helm/kura/rollout.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <release> <namespace> [helm upgrade args...]" >&2
+  exit 1
+fi
+
+RELEASE_NAME="$1"
+NAMESPACE="$2"
+shift 2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${CHART_DIR:-$SCRIPT_DIR}"
+STATEFULSET_NAME="${STATEFULSET_NAME:-$RELEASE_NAME}"
+CONTAINER_NAME="${CONTAINER_NAME:-kura}"
+KURA_HTTP_PORT="${KURA_HTTP_PORT:-4000}"
+HELM_TIMEOUT="${HELM_TIMEOUT:-10m}"
+ROLLOUT_TIMEOUT_SECONDS="${ROLLOUT_TIMEOUT_SECONDS:-600}"
+READY_STEADY_STATE_SECONDS="${READY_STEADY_STATE_SECONDS:-120}"
+CANARY_STEADY_STATE_SECONDS="${CANARY_STEADY_STATE_SECONDS:-600}"
+POLL_SECONDS="${POLL_SECONDS:-5}"
+ROLLOUT_NONCE="${ROLLOUT_NONCE:-$(date +%s)}"
+HELM_ARGS=("$@")
+
+source "${SCRIPT_DIR}/../../rollout/gate.sh"
+
+require_non_empty() {
+  local value="$1"
+  local message="$2"
+  if [[ -z "${value}" ]]; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+pod_name_for_ordinal() {
+  local ordinal="$1"
+  printf '%s-%s' "${STATEFULSET_NAME}" "${ordinal}"
+}
+
+node_rollout_status_get() {
+  local node="$1"
+  kubectl exec -n "${NAMESPACE}" "${node}" -c "${CONTAINER_NAME}" -- \
+    curl -fsS "http://127.0.0.1:${KURA_HTTP_PORT}/status/rollout"
+}
+
+helm_upgrade_partition() {
+  local partition="$1"
+  helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
+    --namespace "${NAMESPACE}" \
+    --reuse-values \
+    --wait \
+    --timeout "${HELM_TIMEOUT}" \
+    --set "updateStrategy.rollingUpdatePartition=${partition}" \
+    --set-string "podAnnotations.rolloutNonce=${ROLLOUT_NONCE}" \
+    "${HELM_ARGS[@]}"
+}
+
+wait_for_updated_revision() {
+  local pod_name="$1"
+  local target_revision="$2"
+  local deadline=$((SECONDS + ROLLOUT_TIMEOUT_SECONDS))
+
+  while (( SECONDS < deadline )); do
+    local revision
+    revision="$(kubectl get pod "${pod_name}" -n "${NAMESPACE}" -o jsonpath='{.metadata.labels.controller-revision-hash}' 2>/dev/null || true)"
+    if [[ "${revision}" == "${target_revision}" ]]; then
+      return 0
+    fi
+    sleep "${POLL_SECONDS}"
+  done
+
+  echo "Timed out waiting for ${pod_name} to reach revision ${target_revision}" >&2
+  return 1
+}
+
+main() {
+  local replicas target_revision ordinal pod_name baseline_cluster_outbox baseline_cluster_fd_timeouts current_cluster_fd_timeouts
+  local cluster_nodes=()
+
+  replicas="$(kubectl get statefulset "${STATEFULSET_NAME}" -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}')"
+  require_non_empty "${replicas}" "Failed to resolve replica count for ${STATEFULSET_NAME}"
+
+  for ((ordinal = 0; ordinal < replicas; ordinal += 1)); do
+    cluster_nodes+=("$(pod_name_for_ordinal "${ordinal}")")
+  done
+
+  helm_upgrade_partition "${replicas}"
+  target_revision="$(kubectl get statefulset "${STATEFULSET_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.updateRevision}')"
+  require_non_empty "${target_revision}" "Failed to resolve target controller revision for ${STATEFULSET_NAME}"
+
+  for ((ordinal = replicas - 1; ordinal >= 0; ordinal -= 1)); do
+    pod_name="$(pod_name_for_ordinal "${ordinal}")"
+    read -r baseline_cluster_outbox baseline_cluster_fd_timeouts < <(
+      rollout_collect_cluster_load_totals "${cluster_nodes[@]}"
+    )
+
+    helm_upgrade_partition "${ordinal}"
+    wait_for_updated_revision "${pod_name}" "${target_revision}"
+    rollout_wait_for_gate \
+      "${pod_name}" \
+      "${replicas}" \
+      "${baseline_cluster_outbox}" \
+      "${baseline_cluster_fd_timeouts}" \
+      "${READY_STEADY_STATE_SECONDS}" \
+      "${cluster_nodes[@]}"
+
+    if (( ordinal == replicas - 1 )); then
+      read -r _ current_cluster_fd_timeouts < <(
+        rollout_collect_cluster_load_totals "${cluster_nodes[@]}"
+      )
+      rollout_wait_for_gate \
+        "${pod_name}" \
+        "${replicas}" \
+        "${baseline_cluster_outbox}" \
+        "${current_cluster_fd_timeouts}" \
+        "${CANARY_STEADY_STATE_SECONDS}" \
+        "${cluster_nodes[@]}"
+    fi
+  done
+
+  echo "Warm rollout completed for ${STATEFULSET_NAME} in namespace ${NAMESPACE}"
+}
+
+main

--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -8,6 +8,12 @@ spec:
   serviceName: {{ include "kura.headlessServiceName" . }}
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+    {{- if ne .Values.updateStrategy.rollingUpdatePartition nil }}
+    rollingUpdate:
+      partition: {{ int .Values.updateStrategy.rollingUpdatePartition }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "kura.selectorLabels" . | nindent 6 }}
@@ -24,7 +30,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "kura.serviceAccountName" . }}
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: {{ add (add (div (add (int64 .Values.config.shutdown.drainCompletionTimeoutMs) 999) 1000) (int .Values.podLifecycle.preStopDelaySeconds)) (int .Values.podLifecycle.terminationGraceExtraSeconds) }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -90,6 +96,8 @@ spec:
               value: {{ printf "%d" (int .Values.config.fileDescriptors.poolSize) | quote }}
             - name: KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS
               value: {{ printf "%d" (int64 .Values.config.fileDescriptors.acquireTimeoutMs) | quote }}
+            - name: KURA_DRAIN_COMPLETION_TIMEOUT_MS
+              value: {{ printf "%d" (int64 .Values.config.shutdown.drainCompletionTimeoutMs) | quote }}
             - name: KURA_SEGMENT_HANDLE_CACHE_SIZE
               value: {{ printf "%d" (int .Values.config.fileDescriptors.segmentHandleCacheSize) | quote }}
             - name: KURA_MEMORY_SOFT_LIMIT_BYTES
@@ -168,7 +176,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - KURA_PID="$(tr ' ' '\n' </proc/1/task/1/children | head -n1)" && if [ -n "$KURA_PID" ]; then kill -USR1 "$KURA_PID"; fi && sleep 20
+                  - KURA_PID="$(tr ' ' '\n' </proc/1/task/1/children | head -n1)" && if [ -n "$KURA_PID" ]; then kill -USR1 "$KURA_PID"; fi && sleep {{ int .Values.podLifecycle.preStopDelaySeconds }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -168,7 +168,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - touch /tmp/kura/drain && sleep 20
+                  - KURA_PID="$(tr ' ' '\n' </proc/1/task/1/children | head -n1)" && if [ -n "$KURA_PID" ]; then kill -USR1 "$KURA_PID"; fi && sleep 20
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/kura/ops/helm/kura/templates/statefulset.yaml
+++ b/kura/ops/helm/kura/templates/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "kura.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 300
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -142,7 +143,7 @@ spec:
             {{- end }}
           readinessProbe:
             httpGet:
-              path: /up
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -154,6 +155,20 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 20
             timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - touch /tmp/kura/drain && sleep 20
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -70,6 +70,15 @@ tolerations: []
 affinity: {}
 topologySpreadConstraints: []
 
+updateStrategy:
+  rollingUpdatePartition: null
+
+podLifecycle:
+  # Allow endpoint propagation to remove the pod from public traffic before SIGTERM.
+  preStopDelaySeconds: 20
+  # Leave a small platform buffer after Kura's own drain deadline for process exit.
+  terminationGraceExtraSeconds: 15
+
 pdb:
   enabled: true
   minAvailable: 1
@@ -86,6 +95,8 @@ config:
     hardLimitBytes: 805306368
     manifestCacheMaxBytes: 67108864
     maxKeyvalueBytes: 1048576
+  shutdown:
+    drainCompletionTimeoutMs: 240000
   metadataStore:
     maxOpenFiles: 1024
     maxBackgroundJobs: 4

--- a/kura/ops/helm/kura/values.yaml
+++ b/kura/ops/helm/kura/values.yaml
@@ -52,8 +52,10 @@ ingress:
 
 persistence:
   enabled: true
+  # Prefer ReadWriteOncePod to enforce one Kura writer per PVC.
+  # Override to ReadWriteOnce only when the CSI driver does not support it.
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOncePod
   size: 20Gi
   storageClass: ""
   annotations: {}

--- a/kura/ops/rollout/gate.sh
+++ b/kura/ops/rollout/gate.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+# shellcheck shell=bash
+
+: "${ROLLOUT_TIMEOUT_SECONDS:=600}"
+: "${POLL_SECONDS:=5}"
+: "${ROLLOUT_STATUS_RETRY_ATTEMPTS:=3}"
+: "${ROLLOUT_STATUS_RETRY_DELAY_SECONDS:=1}"
+
+rollout_require_transport() {
+  if ! declare -F node_rollout_status_get >/dev/null 2>&1; then
+    echo "Define node_rollout_status_get <node> before sourcing rollout gate helpers" >&2
+    return 1
+  fi
+}
+
+rollout_compact_json() {
+  tr -d '[:space:]'
+}
+
+rollout_json_number() {
+  local body="$1"
+  local key="$2"
+  sed -n "s/.*\"${key}\":\\([0-9][0-9]*\\).*/\\1/p" <<<"${body}"
+}
+
+rollout_json_bool() {
+  local body="$1"
+  local key="$2"
+  sed -n "s/.*\"${key}\":\\(true\\|false\\).*/\\1/p" <<<"${body}"
+}
+
+rollout_json_string() {
+  local body="$1"
+  local key="$2"
+  sed -n "s/.*\"${key}\":\"\\([^\"]*\\)\".*/\\1/p" <<<"${body}"
+}
+
+rollout_collect_status_with_retry() {
+  local node="$1"
+  local attempts="${2:-$ROLLOUT_STATUS_RETRY_ATTEMPTS}"
+  local delay_seconds="${3:-$ROLLOUT_STATUS_RETRY_DELAY_SECONDS}"
+  local attempt body
+
+  rollout_require_transport || return 1
+
+  for attempt in $(seq 1 "${attempts}"); do
+    if body="$(node_rollout_status_get "${node}" 2>/dev/null)"; then
+      rollout_compact_json <<<"${body}"
+      return 0
+    fi
+    if (( attempt < attempts )); then
+      sleep "${delay_seconds}"
+    fi
+  done
+
+  return 1
+}
+
+rollout_collect_cluster_load_totals() {
+  local node body outbox fd_timeouts
+  local total_outbox=0
+  local total_fd_timeouts=0
+
+  for node in "$@"; do
+    body="$(rollout_collect_status_with_retry "${node}")" || return 1
+    outbox="$(rollout_json_number "${body}" "outbox_messages")"
+    fd_timeouts="$(rollout_json_number "${body}" "fd_timeout_count")"
+    outbox="${outbox:-0}"
+    fd_timeouts="${fd_timeouts:-0}"
+    total_outbox=$((total_outbox + outbox))
+    total_fd_timeouts=$((total_fd_timeouts + fd_timeouts))
+  done
+
+  printf '%s %s\n' "${total_outbox}" "${total_fd_timeouts}"
+}
+
+rollout_wait_for_gate() {
+  local target_node="$1"
+  local expected_ring_members="$2"
+  local baseline_cluster_outbox="$3"
+  local previous_cluster_fd_timeouts="$4"
+  local steady_seconds="$5"
+  shift 5
+  local cluster_nodes=("$@")
+  local threshold_outbox=$((baseline_cluster_outbox + ((baseline_cluster_outbox + 9) / 10)))
+  local steady_since=""
+  local deadline=$((SECONDS + ROLLOUT_TIMEOUT_SECONDS))
+
+  while (( SECONDS < deadline )); do
+    local ok=1
+    local target_seen=0
+    local target_generation=""
+    local observed_generation=""
+    local cluster_outbox=0 cluster_fd_timeouts=0 fd_timeout_delta=0
+    local node body ready state generation ring_members inflight outbox fd_timeouts pressure
+
+    for node in "${cluster_nodes[@]}"; do
+      if ! body="$(rollout_collect_status_with_retry "${node}")"; then
+        ok=0
+        break
+      fi
+
+      ready="$(rollout_json_bool "${body}" "ready")"
+      state="$(rollout_json_string "${body}" "state")"
+      generation="$(rollout_json_number "${body}" "generation")"
+      ring_members="$(rollout_json_number "${body}" "ring_members")"
+      inflight="$(rollout_json_number "${body}" "bootstrap_inflight_peers")"
+      outbox="$(rollout_json_number "${body}" "outbox_messages")"
+      fd_timeouts="$(rollout_json_number "${body}" "fd_timeout_count")"
+      pressure="$(rollout_json_number "${body}" "memory_pressure_state")"
+
+      ready="${ready:-false}"
+      state="${state:-unknown}"
+      generation="${generation:-0}"
+      ring_members="${ring_members:-0}"
+      inflight="${inflight:-0}"
+      outbox="${outbox:-0}"
+      fd_timeouts="${fd_timeouts:-0}"
+      pressure="${pressure:-0}"
+
+      cluster_outbox=$((cluster_outbox + outbox))
+      cluster_fd_timeouts=$((cluster_fd_timeouts + fd_timeouts))
+
+      if [[ "${node}" == "${target_node}" ]]; then
+        target_seen=1
+        target_generation="${generation}"
+      fi
+
+      if [[ -z "${observed_generation}" ]]; then
+        observed_generation="${generation}"
+      elif [[ "${generation}" != "${observed_generation}" ]]; then
+        ok=0
+      fi
+
+      if [[ "${ready}" != "true" ]]; then
+        ok=0
+      fi
+      if [[ "${state}" != "serving" ]]; then
+        ok=0
+      fi
+      if [[ "${ring_members}" != "${expected_ring_members}" ]]; then
+        ok=0
+      fi
+      if (( inflight != 0 )); then
+        ok=0
+      fi
+      if (( pressure == 2 )); then
+        ok=0
+      fi
+    done
+
+    if (( cluster_fd_timeouts >= previous_cluster_fd_timeouts )); then
+      fd_timeout_delta=$((cluster_fd_timeouts - previous_cluster_fd_timeouts))
+    else
+      fd_timeout_delta=0
+    fi
+    previous_cluster_fd_timeouts="${cluster_fd_timeouts}"
+
+    if [[ "${target_seen}" != "1" ]]; then
+      ok=0
+    fi
+    if [[ -n "${observed_generation}" && -n "${target_generation}" && "${target_generation}" != "${observed_generation}" ]]; then
+      ok=0
+    fi
+    if (( cluster_outbox > threshold_outbox )); then
+      ok=0
+    fi
+    if (( fd_timeout_delta > 0 )); then
+      ok=0
+    fi
+
+    if [[ "${ok}" == "1" ]]; then
+      if [[ -z "${steady_since}" ]]; then
+        steady_since="${SECONDS}"
+      elif (( SECONDS - steady_since >= steady_seconds )); then
+        return 0
+      fi
+    else
+      steady_since=""
+    fi
+
+    sleep "${POLL_SECONDS}"
+  done
+
+  echo "Timed out waiting for rollout gate on ${target_node}" >&2
+  return 1
+}

--- a/kura/spec/e2e/rollout_spec.sh
+++ b/kura/spec/e2e/rollout_spec.sh
@@ -44,7 +44,7 @@ Describe 'warm rollout lifecycle'
       --data-binary "warm-rollout-binary")"
     The variable artifact_status should eq 204
 
-    dc exec -T kura-us sh -lc 'touch /tmp/kura/drain' >/dev/null 2>&1 || return 1
+    dc exec -T kura-us sh -lc 'KURA_PID="$(tr " " "\n" </proc/1/task/1/children | head -n1)" && [ -n "$KURA_PID" ] && kill -USR1 "$KURA_PID"' >/dev/null 2>&1 || return 1
 
     capture_into ready_status wait_for_status "${KURA_US_URL}/ready" 503 || return 1
     The variable ready_status should eq 503

--- a/kura/spec/e2e/rollout_spec.sh
+++ b/kura/spec/e2e/rollout_spec.sh
@@ -1,0 +1,105 @@
+# shellcheck shell=bash
+
+Describe 'warm rollout lifecycle'
+  Include spec/e2e/support.sh
+
+  setup_suite() {
+    export COMPOSE_PROJECT_NAME="kura-rollout"
+    export KURA_US_PORT=4601
+    export TEMPO_PORT=3315
+    export OTLP_PORT=4430
+    export KURA_US_URL="http://localhost:${KURA_US_PORT}"
+
+    COMPOSE_FILES=(
+      -f "${PROJECT_ROOT}/docker-compose.yml"
+      -f "${PROJECT_ROOT}/test/e2e/docker-compose.discovery.yml"
+    )
+    setup_suite_tmpdir
+
+    dc down -v --remove-orphans >/dev/null 2>&1 || true
+    dc build kura-us >/dev/null 2>&1
+  }
+
+  reset_cluster() {
+    dc down -v --remove-orphans >/dev/null 2>&1 || true
+    dc up -d kura-us >/dev/null 2>&1
+    wait_for_http "${KURA_US_URL}/up" || return 1
+    wait_for_http "${KURA_US_URL}/ready" || return 1
+    capture_into ready_body wait_for_contains "${KURA_US_URL}/ready" '"state":"serving"' || return 1
+    [[ "${ready_body}" == *'"ready":true'* ]]
+  }
+
+  teardown_suite() {
+    compose_teardown
+  }
+
+  BeforeAll 'setup_suite'
+  Before 'reset_cluster'
+  AfterAll 'teardown_suite'
+
+  It 'drains public traffic before replacement and comes back ready on the same PVC'
+    artifact_status="$(status_only -X POST \
+      "${KURA_US_URL}/api/cache/cas/warm-rollout-artifact?tenant_id=acme&namespace_id=ios" \
+      -H "content-type: application/octet-stream" \
+      --data-binary "warm-rollout-binary")"
+    The variable artifact_status should eq 204
+
+    dc exec -T kura-us sh -lc 'touch /tmp/kura/drain' >/dev/null 2>&1 || return 1
+
+    capture_into ready_status wait_for_status "${KURA_US_URL}/ready" 503 || return 1
+    The variable ready_status should eq 503
+
+    capture_into ready_body curl -sS "${KURA_US_URL}/ready" || return 1
+    The variable ready_body should include '"state":"draining"'
+    The variable ready_body should include '"ready":false'
+    The variable ready_body should include '"draining":true'
+
+    liveness_status="$(status_only "${KURA_US_URL}/up")"
+    The variable liveness_status should eq 200
+
+    capture_into draining_headers \
+      sh -lc "curl -sS --http1.1 -D - -o /dev/null '${KURA_US_URL}/api/cache/cas/warm-rollout-artifact?tenant_id=acme&namespace_id=ios' | tr '[:upper:]' '[:lower:]'" || return 1
+    The variable draining_headers should include 'http/1.1 503 service unavailable'
+    The variable draining_headers should include 'connection: close'
+
+    capture_into internal_status \
+      dc exec -T kura-us curl -fsS http://localhost:7443/_internal/status || return 1
+    The variable internal_status should include '"node_url":"http://kura-us.kura.internal:7443"'
+
+    dc stop kura-us >/dev/null 2>&1 || return 1
+    dc rm -f kura-us >/dev/null 2>&1 || return 1
+    dc up -d kura-us >/dev/null 2>&1 || return 1
+
+    wait_for_http "${KURA_US_URL}/up" || return 1
+    wait_for_http "${KURA_US_URL}/ready" || return 1
+    capture_into ready_after wait_for_contains "${KURA_US_URL}/ready" '"state":"serving"' || return 1
+    The variable ready_after should include '"ready":true'
+
+    capture_into artifact_after \
+      wait_for_contains \
+      "${KURA_US_URL}/api/cache/cas/warm-rollout-artifact?tenant_id=acme&namespace_id=ios" \
+      'warm-rollout-binary' || return 1
+    The variable artifact_after should eq 'warm-rollout-binary'
+  End
+
+  It 'refuses a second writer against the same PVC'
+    capture_into second_writer_output \
+      dc exec -T kura-us sh -lc '
+        rm -rf /tmp/kura-locktest &&
+        mkdir -p /tmp/kura-locktest &&
+        KURA_PORT=4010 \
+        KURA_GRPC_PORT=50110 \
+        KURA_INTERNAL_PORT=7444 \
+        KURA_NODE_URL=http://lock-test.kura.internal:7444 \
+        KURA_PEERS=http://lock-test.kura.internal:7444 \
+        KURA_DATA_DIR=/var/cache/kura \
+        KURA_TMP_DIR=/tmp/kura-locktest \
+        /usr/local/bin/kura >/tmp/second-writer.log 2>&1
+        status=$?
+        cat /tmp/second-writer.log
+        printf "\nexit_status=%s\n" "$status"
+      ' || return 1
+    The variable second_writer_output should include 'failed to acquire writer lock'
+    The variable second_writer_output should include 'exit_status=1'
+  End
+End

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -54,6 +54,26 @@ wait_for_http() {
   return 1
 }
 
+wait_for_status() {
+  local url="$1"
+  local expected_status="$2"
+  local attempts="${3:-45}"
+  local sleep_seconds="${4:-2}"
+  local actual_status
+
+  for _ in $(seq 1 "$attempts"); do
+    actual_status="$(status_only "$url" 2>/dev/null || true)"
+    if [ "$actual_status" = "$expected_status" ]; then
+      printf '%s' "$actual_status"
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  printf 'Timed out waiting for %s to return %s (last status %s)\n' "$url" "$expected_status" "${actual_status:-unknown}" >&2
+  return 1
+}
+
 wait_for_contains() {
   local url="$1"
   local needle="$2"

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    future::Future,
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
     time::Duration,
 };
 
 use axum_server::Handle;
+use hyper_util::rt::TokioTimer;
 use tokio::sync::{Notify, RwLock};
 use tracing::info;
 
@@ -21,6 +21,7 @@ use crate::{
     peer_tls::{build_internal_rustls_config, build_peer_client},
     reapi,
     replication::{spawn_membership_task, spawn_outbox_task},
+    runtime::{DataDirLock, RuntimeState},
     state::AppState,
     store::Store,
     telemetry::init_tracing,
@@ -36,6 +37,9 @@ pub async fn run() -> Result<(), String> {
         .map_err(|error| format!("failed to create directories: {error}"))?;
 
     let metrics = Metrics::new(config.region.clone(), config.tenant_id.clone());
+    let data_dir_lock = DataDirLock::acquire(&config.data_dir).inspect_err(|_| {
+        metrics.record_writer_lock_acquire_failure();
+    })?;
     let extension = ExtensionEngine::from_env(metrics.clone())
         .await
         .map_err(|error| format!("failed to initialize extension engine: {error}"))?;
@@ -60,10 +64,12 @@ pub async fn run() -> Result<(), String> {
 
     let state = Arc::new(AppState {
         config,
+        _data_dir_lock: data_dir_lock,
         store,
         io,
         memory,
         metrics,
+        runtime: RuntimeState::new(),
         extension,
         analytics,
         client,
@@ -71,11 +77,14 @@ pub async fn run() -> Result<(), String> {
         members,
         peer_nodes: RwLock::new(BTreeMap::new()),
         bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
+        bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
     });
+    state.sync_runtime_metrics().await;
 
     spawn_membership_task(state.clone());
     spawn_outbox_task(state.clone());
     spawn_snapshot_task(state.clone());
+    spawn_runtime_watch_task(state.clone());
 
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, state.config.port));
     let grpc_address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, state.config.grpc_port));
@@ -88,9 +97,6 @@ pub async fn run() -> Result<(), String> {
         info!("Kura internal HTTP service listening on {internal_address}");
     }
 
-    let listener = tokio::net::TcpListener::bind(address)
-        .await
-        .map_err(|error| format!("failed to bind TCP listener: {error}"))?;
     let grpc_listener = tokio::net::TcpListener::bind(grpc_address)
         .await
         .map_err(|error| format!("failed to bind gRPC listener: {error}"))?;
@@ -158,9 +164,25 @@ pub async fn run() -> Result<(), String> {
     };
 
     let router = http::public_router(state.clone());
+    let public_handle = Handle::new();
+    let public_shutdown_handle = public_handle.clone();
+    let public_shutdown_state = state.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        public_shutdown_state.enter_draining();
+        public_shutdown_state.sync_runtime_metrics().await;
+        public_shutdown_handle.graceful_shutdown(None);
+    });
 
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_signal())
+    let mut public_server = axum_server::bind(address).handle(public_handle);
+    public_server
+        .http_builder()
+        .http1()
+        .keep_alive(true)
+        .timer(TokioTimer::new())
+        .header_read_timeout(Some(Duration::from_secs(30)));
+    public_server
+        .serve(router.into_make_service())
         .await
         .map_err(|error| format!("server error: {error}"))?;
     let _ = shutdown_tx.send(true);
@@ -255,6 +277,18 @@ fn spawn_snapshot_task(state: Arc<AppState>) {
             }
 
             tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    });
+}
+
+fn spawn_runtime_watch_task(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(error) = state.refresh_drain_marker().await {
+                tracing::warn!("failed to refresh drain marker: {error}");
+            }
+            state.sync_runtime_metrics().await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     });
 }

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
     time::Duration,
@@ -7,7 +6,7 @@ use std::{
 
 use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::Notify;
 use tokio::time::Instant;
 use tracing::info;
 
@@ -23,7 +22,7 @@ use crate::{
     reapi,
     replication::{spawn_membership_task, spawn_outbox_task},
     runtime::{DataDirLock, RuntimeState},
-    state::AppState,
+    state::{AppState, ReadinessState},
     store::Store,
     telemetry::init_tracing,
 };
@@ -59,7 +58,6 @@ pub async fn run() -> Result<(), String> {
         config.memory_hard_limit_bytes,
     );
     let store = Store::open(&config, io.clone(), memory.clone())?;
-    let members = RwLock::new(BTreeSet::new());
     let client = build_peer_client(&config).await?;
     let notify = Notify::new();
 
@@ -75,24 +73,15 @@ pub async fn run() -> Result<(), String> {
         analytics,
         client,
         notify,
-        members,
-        peer_nodes: RwLock::new(BTreeMap::new()),
-        bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
-        bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
-        readiness_settle_until: tokio::sync::Mutex::new(Instant::now()),
+        readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
     });
-    if state.clear_stale_drain_marker().await? {
-        info!(
-            "Cleared stale drain marker at {}",
-            state.drain_marker_path().display()
-        );
-    }
     state.sync_runtime_metrics().await;
 
     spawn_membership_task(state.clone());
     spawn_outbox_task(state.clone());
     spawn_snapshot_task(state.clone());
-    spawn_runtime_watch_task(state.clone());
+    spawn_runtime_metrics_task(state.clone());
+    spawn_drain_signal_task(state.clone());
 
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, state.config.port));
     let grpc_address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, state.config.grpc_port));
@@ -177,7 +166,7 @@ pub async fn run() -> Result<(), String> {
     let public_shutdown_state = state.clone();
     tokio::spawn(async move {
         shutdown_signal().await;
-        public_shutdown_state.enter_draining();
+        let _ = public_shutdown_state.enter_draining();
         public_shutdown_state.sync_runtime_metrics().await;
         public_shutdown_handle.graceful_shutdown(None);
     });
@@ -289,17 +278,35 @@ fn spawn_snapshot_task(state: Arc<AppState>) {
     });
 }
 
-fn spawn_runtime_watch_task(state: Arc<AppState>) {
+fn spawn_runtime_metrics_task(state: Arc<AppState>) {
     tokio::spawn(async move {
         loop {
-            if let Err(error) = state.refresh_drain_marker().await {
-                tracing::warn!("failed to refresh drain marker: {error}");
-            }
             state.sync_runtime_metrics().await;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
     });
 }
+
+#[cfg(unix)]
+fn spawn_drain_signal_task(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut signal =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+                .expect("failed to install SIGUSR1 handler");
+        loop {
+            if signal.recv().await.is_none() {
+                return;
+            }
+            if state.enter_draining() {
+                state.sync_runtime_metrics().await;
+                info!("received SIGUSR1, entering draining state");
+            }
+        }
+    });
+}
+
+#[cfg(not(unix))]
+fn spawn_drain_signal_task(_state: Arc<AppState>) {}
 
 struct ProcessMemorySnapshot {
     resident_bytes: u64,

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -8,6 +8,7 @@ use std::{
 use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
 use tokio::sync::{Notify, RwLock};
+use tokio::time::Instant;
 use tracing::info;
 
 use crate::{
@@ -78,7 +79,14 @@ pub async fn run() -> Result<(), String> {
         peer_nodes: RwLock::new(BTreeMap::new()),
         bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
         bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
+        readiness_settle_until: tokio::sync::Mutex::new(Instant::now()),
     });
+    if state.clear_stale_drain_marker().await? {
+        info!(
+            "Cleared stale drain marker at {}",
+            state.drain_marker_path().display()
+        );
+    }
     state.sync_runtime_metrics().await;
 
     spawn_membership_task(state.clone());

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -1,4 +1,5 @@
 use std::{
+    future::Future,
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
     time::Duration,
@@ -6,9 +7,9 @@ use std::{
 
 use axum_server::Handle;
 use hyper_util::rt::TokioTimer;
-use tokio::sync::Notify;
-use tokio::time::Instant;
-use tracing::info;
+use tokio::sync::{Notify, oneshot};
+use tokio::{task::JoinHandle, time::Instant};
+use tracing::{info, warn};
 
 use crate::{
     analytics::Analytics,
@@ -26,6 +27,23 @@ use crate::{
     store::Store,
     telemetry::init_tracing,
 };
+
+#[derive(Clone, Copy, Debug)]
+struct ShutdownBudget {
+    deadline: Instant,
+}
+
+impl ShutdownBudget {
+    fn new(duration: Duration) -> Self {
+        Self {
+            deadline: Instant::now() + duration,
+        }
+    }
+
+    fn remaining(self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+}
 
 pub async fn run() -> Result<(), String> {
     let config = Config::from_env().map_err(|error| format!("invalid configuration: {error}"))?;
@@ -76,6 +94,7 @@ pub async fn run() -> Result<(), String> {
         readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
     });
     state.sync_runtime_metrics().await;
+    let drain_completion_timeout = Duration::from_millis(state.config.drain_completion_timeout_ms);
 
     spawn_membership_task(state.clone());
     spawn_outbox_task(state.clone());
@@ -97,16 +116,21 @@ pub async fn run() -> Result<(), String> {
     let grpc_listener = tokio::net::TcpListener::bind(grpc_address)
         .await
         .map_err(|error| format!("failed to bind gRPC listener: {error}"))?;
-    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(None::<ShutdownBudget>);
+    let (shutdown_budget_tx, shutdown_budget_rx) = oneshot::channel::<ShutdownBudget>();
     let grpc_shutdown_rx = shutdown_rx.clone();
     let grpc_state = state.clone();
     let grpc_handle = tokio::spawn(async move {
         let grpc_shutdown = async move {
             let mut shutdown_rx = grpc_shutdown_rx;
-            if *shutdown_rx.borrow() {
+            if shutdown_rx.borrow().is_some() {
                 return;
             }
-            let _ = shutdown_rx.changed().await;
+            while shutdown_rx.changed().await.is_ok() {
+                if shutdown_rx.borrow().is_some() {
+                    return;
+                }
+            }
         };
 
         if let Err(error) = reapi::serve(grpc_listener, grpc_state, grpc_shutdown).await {
@@ -121,12 +145,16 @@ pub async fn run() -> Result<(), String> {
         let handle = Handle::new();
         let shutdown_handle = handle.clone();
         tokio::spawn(async move {
-            if *internal_shutdown_rx.borrow() {
-                shutdown_handle.graceful_shutdown(None);
+            if let Some(budget) = *internal_shutdown_rx.borrow() {
+                shutdown_handle.graceful_shutdown(Some(budget.remaining()));
                 return;
             }
-            let _ = internal_shutdown_rx.changed().await;
-            shutdown_handle.graceful_shutdown(None);
+            while internal_shutdown_rx.changed().await.is_ok() {
+                if let Some(budget) = *internal_shutdown_rx.borrow() {
+                    shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+                    return;
+                }
+            }
         });
         Some(tokio::spawn(async move {
             if let Err(error) = axum_server::bind_rustls(internal_address, tls_config)
@@ -138,21 +166,26 @@ pub async fn run() -> Result<(), String> {
             }
         }))
     } else {
-        let internal_listener = tokio::net::TcpListener::bind(internal_address)
-            .await
-            .map_err(|error| format!("failed to bind internal TCP listener: {error}"))?;
         let internal_router = http::internal_router(state.clone());
         let mut internal_shutdown_rx = shutdown_rx.clone();
-        Some(tokio::spawn(async move {
-            let internal_shutdown = async move {
-                if *internal_shutdown_rx.borrow() {
+        let handle = Handle::new();
+        let shutdown_handle = handle.clone();
+        tokio::spawn(async move {
+            if let Some(budget) = *internal_shutdown_rx.borrow() {
+                shutdown_handle.graceful_shutdown(Some(budget.remaining()));
+                return;
+            }
+            while internal_shutdown_rx.changed().await.is_ok() {
+                if let Some(budget) = *internal_shutdown_rx.borrow() {
+                    shutdown_handle.graceful_shutdown(Some(budget.remaining()));
                     return;
                 }
-                let _ = internal_shutdown_rx.changed().await;
-            };
-
-            if let Err(error) = axum::serve(internal_listener, internal_router)
-                .with_graceful_shutdown(internal_shutdown)
+            }
+        });
+        Some(tokio::spawn(async move {
+            if let Err(error) = axum_server::bind(internal_address)
+                .handle(handle)
+                .serve(internal_router.into_make_service())
                 .await
             {
                 tracing::error!("internal server failed: {error}");
@@ -166,9 +199,11 @@ pub async fn run() -> Result<(), String> {
     let public_shutdown_state = state.clone();
     tokio::spawn(async move {
         shutdown_signal().await;
+        let budget = ShutdownBudget::new(drain_completion_timeout);
+        let _ = shutdown_budget_tx.send(budget);
         let _ = public_shutdown_state.enter_draining();
         public_shutdown_state.sync_runtime_metrics().await;
-        public_shutdown_handle.graceful_shutdown(None);
+        public_shutdown_handle.graceful_shutdown(Some(budget.remaining()));
     });
 
     let mut public_server = axum_server::bind(address).handle(public_handle);
@@ -182,10 +217,23 @@ pub async fn run() -> Result<(), String> {
         .serve(router.into_make_service())
         .await
         .map_err(|error| format!("server error: {error}"))?;
-    let _ = shutdown_tx.send(true);
-    let _ = grpc_handle.await;
+    let shutdown_budget = shutdown_budget_rx.await.unwrap_or_else(|_| {
+        warn!("shutdown budget channel closed before graceful shutdown completed");
+        ShutdownBudget::new(drain_completion_timeout)
+    });
+    let _ = shutdown_tx.send(Some(shutdown_budget));
+    let drained = wait_for_inflight_drain(state.clone(), shutdown_budget).await;
+    if !drained {
+        warn!(
+            http_inflight = state.runtime.http_inflight(),
+            grpc_inflight = state.runtime.grpc_inflight(),
+            drain_timeout_ms = state.config.drain_completion_timeout_ms,
+            "timed out waiting for inflight requests to drain during shutdown"
+        );
+    }
+    wait_for_task_shutdown(grpc_handle, "gRPC", shutdown_budget).await;
     if let Some(internal_handle) = internal_handle {
-        let _ = internal_handle.await;
+        wait_for_task_shutdown(internal_handle, "internal", shutdown_budget).await;
     }
 
     telemetry.shutdown();
@@ -349,11 +397,55 @@ where
     }
 }
 
+async fn wait_for_inflight_drain(state: Arc<AppState>, budget: ShutdownBudget) -> bool {
+    loop {
+        let inflight_changed = state.runtime.inflight_changed();
+        if state.runtime.total_inflight() == 0 {
+            return true;
+        }
+
+        let remaining = budget.remaining();
+        if remaining.is_zero() {
+            return false;
+        }
+
+        if tokio::time::timeout(remaining, inflight_changed)
+            .await
+            .is_err()
+        {
+            return false;
+        }
+    }
+}
+
+async fn wait_for_task_shutdown<T>(
+    mut handle: JoinHandle<T>,
+    server: &str,
+    budget: ShutdownBudget,
+) {
+    let remaining = budget.remaining();
+    match tokio::time::timeout(remaining, &mut handle).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            warn!("{server} server task ended unexpectedly: {error}");
+        }
+        Err(_) => {
+            warn!(
+                timeout_ms = remaining.as_millis(),
+                "timed out waiting for {server} server to shut down; aborting task"
+            );
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tokio::{sync::oneshot, time::timeout};
 
     use super::*;
+    use crate::test_support::test_context;
 
     #[tokio::test]
     async fn wait_for_shutdown_signal_returns_when_ctrl_c_resolves() {
@@ -399,5 +491,38 @@ mod tests {
             .await
             .expect("shutdown waiter should return after terminate")
             .expect("shutdown waiter task should finish cleanly");
+    }
+
+    #[tokio::test]
+    async fn wait_for_inflight_drain_returns_when_requests_finish() {
+        let context = test_context(|_| {}).await;
+        let guard = context.state.start_http_request();
+        let waiter = tokio::spawn(wait_for_inflight_drain(
+            context.state.clone(),
+            ShutdownBudget::new(Duration::from_millis(250)),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        drop(guard);
+
+        assert!(
+            waiter
+                .await
+                .expect("wait task should finish after request completion")
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_inflight_drain_times_out_when_requests_do_not_finish() {
+        let context = test_context(|_| {}).await;
+        let _guard = context.state.start_grpc_request();
+
+        assert!(
+            !wait_for_inflight_drain(
+                context.state.clone(),
+                ShutdownBudget::new(Duration::from_millis(25)),
+            )
+            .await
+        );
     }
 }

--- a/kura/src/config.rs
+++ b/kura/src/config.rs
@@ -17,6 +17,7 @@ const KURA_INTERNAL_TLS_CERT_PATH: &str = "KURA_INTERNAL_TLS_CERT_PATH";
 const KURA_INTERNAL_TLS_KEY_PATH: &str = "KURA_INTERNAL_TLS_KEY_PATH";
 const KURA_FILE_DESCRIPTOR_POOL_SIZE: &str = "KURA_FILE_DESCRIPTOR_POOL_SIZE";
 const KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS: &str = "KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS";
+const KURA_DRAIN_COMPLETION_TIMEOUT_MS: &str = "KURA_DRAIN_COMPLETION_TIMEOUT_MS";
 const KURA_SEGMENT_HANDLE_CACHE_SIZE: &str = "KURA_SEGMENT_HANDLE_CACHE_SIZE";
 const KURA_MEMORY_SOFT_LIMIT_BYTES: &str = "KURA_MEMORY_SOFT_LIMIT_BYTES";
 const KURA_MEMORY_HARD_LIMIT_BYTES: &str = "KURA_MEMORY_HARD_LIMIT_BYTES";
@@ -45,6 +46,7 @@ const KURA_SENTRY_DSN: &str = "KURA_SENTRY_DSN";
 
 const BYTES_PER_MIB: u64 = 1024 * 1024;
 const DEFAULT_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS: u64 = 240_000;
 const DEFAULT_MAX_KEYVALUE_BYTES: usize = 1024 * 1024;
 const FALLBACK_HOST_FD_LIMIT: usize = 4096;
 const FALLBACK_HOST_MEMORY_LIMIT_BYTES: u64 = 1024 * BYTES_PER_MIB;
@@ -65,6 +67,7 @@ pub struct Config {
     pub peer_tls: Option<PeerTlsConfig>,
     pub file_descriptor_pool_size: usize,
     pub file_descriptor_acquire_timeout_ms: u64,
+    pub drain_completion_timeout_ms: u64,
     pub segment_handle_cache_size: usize,
     pub memory_soft_limit_bytes: u64,
     pub memory_hard_limit_bytes: u64,
@@ -113,6 +116,7 @@ pub(crate) struct HostResources {
 struct DerivedRuntimeDefaults {
     file_descriptor_pool_size: usize,
     file_descriptor_acquire_timeout_ms: u64,
+    drain_completion_timeout_ms: u64,
     segment_handle_cache_size: usize,
     memory_soft_limit_bytes: u64,
     memory_hard_limit_bytes: u64,
@@ -189,6 +193,7 @@ impl DerivedRuntimeDefaults {
         Self {
             file_descriptor_pool_size,
             file_descriptor_acquire_timeout_ms: DEFAULT_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS,
+            drain_completion_timeout_ms: DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS,
             segment_handle_cache_size,
             memory_soft_limit_bytes,
             memory_hard_limit_bytes,
@@ -326,6 +331,22 @@ impl Config {
         if file_descriptor_acquire_timeout_ms == 0 {
             invalid.push(format!(
                 "{KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS} must be greater than 0"
+            ));
+        }
+        let drain_completion_timeout_ms = optional_parsed_value(
+            &mut lookup,
+            KURA_DRAIN_COMPLETION_TIMEOUT_MS,
+            &mut invalid,
+            |value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| format!("{KURA_DRAIN_COMPLETION_TIMEOUT_MS} must be a valid u64"))
+            },
+        )
+        .unwrap_or(derived_defaults.drain_completion_timeout_ms);
+        if drain_completion_timeout_ms == 0 {
+            invalid.push(format!(
+                "{KURA_DRAIN_COMPLETION_TIMEOUT_MS} must be greater than 0"
             ));
         }
         let segment_handle_cache_size = optional_parsed_value(
@@ -751,6 +772,7 @@ impl Config {
             peer_tls,
             file_descriptor_pool_size,
             file_descriptor_acquire_timeout_ms,
+            drain_completion_timeout_ms,
             segment_handle_cache_size,
             memory_soft_limit_bytes,
             memory_hard_limit_bytes,
@@ -993,6 +1015,7 @@ mod tests {
         );
         assert_eq!(config.file_descriptor_pool_size, 256);
         assert_eq!(config.file_descriptor_acquire_timeout_ms, 5_000);
+        assert_eq!(config.drain_completion_timeout_ms, 240_000);
         assert_eq!(config.segment_handle_cache_size, 64);
         assert_eq!(config.memory_soft_limit_bytes, 716 * BYTES_PER_MIB);
         assert_eq!(config.memory_hard_limit_bytes, 870 * BYTES_PER_MIB);
@@ -1035,6 +1058,7 @@ mod tests {
             ),
             (KURA_FILE_DESCRIPTOR_POOL_SIZE, "64"),
             (KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS, "5000"),
+            (KURA_DRAIN_COMPLETION_TIMEOUT_MS, "120000"),
             (KURA_SEGMENT_HANDLE_CACHE_SIZE, "16"),
             (KURA_MEMORY_SOFT_LIMIT_BYTES, "268435456"),
             (KURA_MEMORY_HARD_LIMIT_BYTES, "536870912"),
@@ -1070,6 +1094,7 @@ mod tests {
         assert_eq!(config.peer_tls, None);
         assert_eq!(config.file_descriptor_pool_size, 64);
         assert_eq!(config.file_descriptor_acquire_timeout_ms, 5000);
+        assert_eq!(config.drain_completion_timeout_ms, 120000);
         assert_eq!(config.segment_handle_cache_size, 16);
         assert_eq!(config.memory_soft_limit_bytes, 268_435_456);
         assert_eq!(config.memory_hard_limit_bytes, 536_870_912);
@@ -1104,6 +1129,7 @@ mod tests {
             (KURA_PEERS, "http://kura-a.example.com:7443"),
             (KURA_FILE_DESCRIPTOR_POOL_SIZE, "invalid"),
             (KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS, "invalid"),
+            (KURA_DRAIN_COMPLETION_TIMEOUT_MS, "invalid"),
             (KURA_SEGMENT_HANDLE_CACHE_SIZE, "invalid"),
             (KURA_MEMORY_SOFT_LIMIT_BYTES, "invalid"),
             (KURA_MEMORY_HARD_LIMIT_BYTES, "invalid"),
@@ -1129,6 +1155,7 @@ mod tests {
         assert!(error.contains("valid u16"));
         assert!(error.contains(KURA_FILE_DESCRIPTOR_POOL_SIZE));
         assert!(error.contains(KURA_FILE_DESCRIPTOR_ACQUIRE_TIMEOUT_MS));
+        assert!(error.contains(KURA_DRAIN_COMPLETION_TIMEOUT_MS));
         assert!(error.contains(KURA_SEGMENT_HANDLE_CACHE_SIZE));
         assert!(error.contains(KURA_MEMORY_SOFT_LIMIT_BYTES));
         assert!(error.contains(KURA_MEMORY_HARD_LIMIT_BYTES));

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1760,7 +1760,7 @@ mod tests {
             .write()
             .await
             .insert(peer.clone(), "remote".into());
-        context.state.mark_initial_discovery_completed();
+        context.state.mark_initial_discovery_completed().await;
         assert!(context.state.note_bootstrap_started(&peer).await);
 
         let response = public_router(context.state.clone())
@@ -1795,6 +1795,25 @@ mod tests {
             )
             .await
             .expect("ready route should respond");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        assert_eq!(body["state"], "joining");
+        assert_eq!(body["ready"], false);
+        assert!(body["reasons"].to_string().contains("discovery settling"));
+
+        context.state.expire_readiness_settle_window().await;
+        context.state.maybe_mark_serving().await;
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value = serde_json::from_str(&response_text(response).await)
             .expect("ready response should be json");
@@ -1805,7 +1824,8 @@ mod tests {
     #[tokio::test]
     async fn ready_reports_draining_state() {
         let context = test_context(|_| {}).await;
-        context.state.mark_initial_discovery_completed();
+        context.state.mark_initial_discovery_completed().await;
+        context.state.expire_readiness_settle_window().await;
         context.state.maybe_mark_serving().await;
         context.state.enter_draining();
 
@@ -1829,7 +1849,8 @@ mod tests {
     #[tokio::test]
     async fn draining_public_requests_return_service_unavailable_and_close_http1_connections() {
         let context = test_context(|_| {}).await;
-        context.state.mark_initial_discovery_completed();
+        context.state.mark_initial_discovery_completed().await;
+        context.state.expire_readiness_settle_window().await;
         context.state.maybe_mark_serving().await;
         context.state.enter_draining();
 
@@ -1848,6 +1869,27 @@ mod tests {
         assert_eq!(
             response.headers().get(axum::http::header::CONNECTION),
             Some(&HeaderValue::from_static("close"))
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_stale_drain_marker_removes_existing_file() {
+        let context = test_context(|_| {}).await;
+        tokio::fs::write(context.state.drain_marker_path(), b"stale-marker")
+            .await
+            .expect("failed to create stale drain marker");
+
+        let removed = context
+            .state
+            .clear_stale_drain_marker()
+            .await
+            .expect("clearing stale marker should succeed");
+
+        assert!(removed);
+        assert!(
+            !tokio::fs::try_exists(context.state.drain_marker_path())
+                .await
+                .expect("marker existence check should succeed")
         );
     }
 

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -4,7 +4,7 @@ use axum::{
     Json, Router,
     body::{Body, to_bytes},
     extract::{MatchedPath, Path as AxumPath, Query, Request, State},
-    http::{HeaderValue, StatusCode},
+    http::{HeaderValue, StatusCode, Version},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{delete, get, head, post, put},
@@ -29,6 +29,10 @@ pub fn public_router(state: SharedState) -> Router {
         .layer(middleware::from_fn_with_state(
             state.clone(),
             apply_extensions,
+        ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            reject_draining_public_requests,
         ))
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -69,6 +73,7 @@ pub(crate) fn router(state: SharedState) -> Router {
 fn public_routes() -> Router<SharedState> {
     Router::new()
         .route("/up", get(up))
+        .route("/ready", get(ready))
         .route("/metrics", get(metrics_handler))
         .route("/v1/cache/{hash}", get(get_nx).put(put_nx))
         .route(
@@ -322,6 +327,7 @@ async fn track_http_metrics(
     req: Request,
     next: Next,
 ) -> Response {
+    let _request_guard = state.start_http_request();
     let start = std::time::Instant::now();
     let route = req
         .extensions()
@@ -353,6 +359,32 @@ async fn track_http_metrics(
         .metrics
         .record_http(route, method, response.status(), start.elapsed());
 
+    response
+}
+
+async fn reject_draining_public_requests(
+    State(state): State<SharedState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_owned())
+        .unwrap_or_else(|| req.uri().path().to_owned());
+    let version = req.version();
+
+    if !is_probe_route(&route) && state.runtime.is_draining() {
+        return draining_response(version);
+    }
+
+    let mut response = next.run(req).await;
+    if state.runtime.is_draining() && is_http1(version) {
+        response.headers_mut().insert(
+            axum::http::header::CONNECTION,
+            HeaderValue::from_static("close"),
+        );
+    }
     response
 }
 
@@ -420,7 +452,15 @@ async fn apply_extensions(State(state): State<SharedState>, req: Request, next: 
 }
 
 fn should_skip_extension_route(route: &str) -> bool {
-    route == "/up" || route == "/metrics" || route.starts_with("/_internal/")
+    is_probe_route(route) || route.starts_with("/_internal/")
+}
+
+fn is_probe_route(route: &str) -> bool {
+    route == "/up" || route == "/ready" || route == "/metrics"
+}
+
+fn is_http1(version: Version) -> bool {
+    matches!(version, Version::HTTP_10 | Version::HTTP_11)
 }
 
 async fn extension_context_from_http(
@@ -664,6 +704,41 @@ async fn up(State(state): State<SharedState>) -> impl IntoResponse {
         "members": all_members.into_iter().collect::<Vec<_>>(),
         "nodes": nodes,
     }))
+}
+
+async fn ready(State(state): State<SharedState>) -> impl IntoResponse {
+    if let Err(error) = state.refresh_drain_marker().await {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("Failed to evaluate readiness: {error}"),
+        );
+    }
+
+    let readiness = state.readiness_report().await;
+    let status = if readiness.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (
+        status,
+        Json(serde_json::json!({
+            "status": if readiness.ready { "ok" } else { "not_ready" },
+            "state": readiness.state.as_str(),
+            "ready": readiness.ready,
+            "draining": readiness.draining,
+            "writer_lock_owned": readiness.writer_lock_owned,
+            "initial_discovery_completed": readiness.initial_discovery_completed,
+            "known_peers": readiness.known_peers,
+            "bootstrapped_peers": readiness.bootstrapped_peers,
+            "bootstrap_inflight_peers": readiness.bootstrap_inflight_peers,
+            "http_inflight_requests": readiness.http_inflight,
+            "grpc_inflight_requests": readiness.grpc_inflight,
+            "reasons": readiness.reasons,
+        })),
+    )
+        .into_response()
 }
 
 async fn metrics_handler(State(state): State<SharedState>) -> impl IntoResponse {
@@ -1604,6 +1679,17 @@ async fn serve_file(
     }
 }
 
+fn draining_response(version: Version) -> Response {
+    let mut response = error_response(StatusCode::SERVICE_UNAVAILABLE, "server is draining");
+    if is_http1(version) {
+        response.headers_mut().insert(
+            axum::http::header::CONNECTION,
+            HeaderValue::from_static("close"),
+        );
+    }
+    response
+}
+
 fn error_response(status: StatusCode, message: impl Into<String>) -> Response {
     let body = Json(serde_json::json!({ "message": message.into() }));
     (status, body).into_response()
@@ -1661,6 +1747,107 @@ mod tests {
             body["connected_nodes"]
                 .to_string()
                 .contains("http://peer.kura.internal:4000")
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_stays_unavailable_until_bootstrap_gate_completes() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .peer_nodes
+            .write()
+            .await
+            .insert(peer.clone(), "remote".into());
+        context.state.mark_initial_discovery_completed();
+        assert!(context.state.note_bootstrap_started(&peer).await);
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        assert_eq!(body["state"], "joining");
+        assert_eq!(body["ready"], false);
+        assert!(
+            body["reasons"]
+                .to_string()
+                .contains("bootstrap in progress")
+        );
+
+        context.state.note_bootstrap_succeeded(&peer).await;
+        context.state.maybe_mark_serving().await;
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        assert_eq!(body["state"], "serving");
+        assert_eq!(body["ready"], true);
+    }
+
+    #[tokio::test]
+    async fn ready_reports_draining_state() {
+        let context = test_context(|_| {}).await;
+        context.state.mark_initial_discovery_completed();
+        context.state.maybe_mark_serving().await;
+        context.state.enter_draining();
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("ready route should respond");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("ready response should be json");
+        assert_eq!(body["state"], "draining");
+        assert_eq!(body["draining"], true);
+        assert!(body["reasons"].to_string().contains("draining"));
+    }
+
+    #[tokio::test]
+    async fn draining_public_requests_return_service_unavailable_and_close_http1_connections() {
+        let context = test_context(|_| {}).await;
+        context.state.mark_initial_discovery_completed();
+        context.state.maybe_mark_serving().await;
+        context.state.enter_draining();
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/v1/cache/some-hash")
+                    .version(Version::HTTP_11)
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("public route should respond");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get(axum::http::header::CONNECTION),
+            Some(&HeaderValue::from_static("close"))
         );
     }
 

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -685,35 +685,29 @@ fn status_from_u16(status: u16) -> StatusCode {
 }
 
 async fn up(State(state): State<SharedState>) -> impl IntoResponse {
-    let members = state.members.read().await.clone();
-    let peer_nodes = state.peer_nodes.read().await.clone();
-    let mut all_members = members;
-    all_members.insert(state.config.region.clone());
-    let mut nodes = peer_nodes.keys().cloned().collect::<Vec<_>>();
+    let cluster = state.cluster_status_report().await;
+    let mut all_members = cluster.members;
+    all_members.push(state.config.region.clone());
+    all_members.sort();
+    let mut nodes = cluster.connected_nodes.clone();
     nodes.push(state.config.node_url.clone());
     nodes.sort();
 
     Json(serde_json::json!({
         "status": "ok",
+        "generation": cluster.generation,
         "tenant_id": state.config.tenant_id.clone(),
         "region": state.config.region.clone(),
         "node": state.config.region.clone(),
         "node_url": state.config.node_url.clone(),
-        "connected_nodes": peer_nodes.keys().cloned().collect::<Vec<_>>(),
-        "ring_members": peer_nodes.len() + 1,
+        "connected_nodes": cluster.connected_nodes,
+        "ring_members": nodes.len(),
         "members": all_members.into_iter().collect::<Vec<_>>(),
         "nodes": nodes,
     }))
 }
 
 async fn ready(State(state): State<SharedState>) -> impl IntoResponse {
-    if let Err(error) = state.refresh_drain_marker().await {
-        return error_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Failed to evaluate readiness: {error}"),
-        );
-    }
-
     let readiness = state.readiness_report().await;
     let status = if readiness.ready {
         StatusCode::OK
@@ -725,6 +719,7 @@ async fn ready(State(state): State<SharedState>) -> impl IntoResponse {
         status,
         Json(serde_json::json!({
             "status": if readiness.ready { "ok" } else { "not_ready" },
+            "generation": readiness.generation,
             "state": readiness.state.as_str(),
             "ready": readiness.ready,
             "draining": readiness.draining,
@@ -1719,13 +1714,16 @@ mod tests {
             config.region = "us-east".into();
         })
         .await;
-        context.state.members.write().await.insert("eu-west".into());
         context
             .state
-            .peer_nodes
-            .write()
-            .await
-            .insert("http://peer.kura.internal:4000".into(), "eu-west".into());
+            .apply_membership_view(
+                std::collections::BTreeSet::from(["eu-west".to_string()]),
+                std::collections::BTreeMap::from([(
+                    "http://peer.kura.internal:4000".to_string(),
+                    "eu-west".to_string(),
+                )]),
+            )
+            .await;
 
         let response = router(context.state.clone())
             .oneshot(
@@ -1741,6 +1739,7 @@ mod tests {
         let body: Value = serde_json::from_str(&response_text(response).await)
             .expect("failed to decode up response");
         assert_eq!(body["ring_members"], 2);
+        assert_eq!(body["generation"], 1);
         assert_eq!(body["region"], "us-east");
         assert!(body["members"].to_string().contains("eu-west"));
         assert!(
@@ -1756,11 +1755,11 @@ mod tests {
         let peer = "http://peer.kura.internal:7443".to_string();
         context
             .state
-            .peer_nodes
-            .write()
-            .await
-            .insert(peer.clone(), "remote".into());
-        context.state.mark_initial_discovery_completed().await;
+            .apply_membership_view(
+                std::collections::BTreeSet::from(["remote".to_string()]),
+                std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+            )
+            .await;
         assert!(context.state.note_bootstrap_started(&peer).await);
 
         let response = public_router(context.state.clone())
@@ -1822,9 +1821,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn up_and_ready_share_the_same_membership_generation() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                std::collections::BTreeSet::from(["remote".to_string()]),
+                std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+            )
+            .await;
+        context.state.note_bootstrap_succeeded(&peer).await;
+        context.state.expire_readiness_settle_window().await;
+        context.state.maybe_mark_serving().await;
+
+        let up_response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/up")
+                    .body(Body::empty())
+                    .expect("failed to build up request"),
+            )
+            .await
+            .expect("up route should respond");
+        let up_body: Value =
+            serde_json::from_str(&response_text(up_response).await).expect("up response json");
+
+        let ready_response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .expect("failed to build ready request"),
+            )
+            .await
+            .expect("ready route should respond");
+        let ready_body: Value = serde_json::from_str(&response_text(ready_response).await)
+            .expect("ready response json");
+
+        assert_eq!(up_body["generation"], ready_body["generation"]);
+    }
+
+    #[tokio::test]
     async fn ready_reports_draining_state() {
         let context = test_context(|_| {}).await;
-        context.state.mark_initial_discovery_completed().await;
+        context
+            .state
+            .apply_membership_view(
+                std::collections::BTreeSet::new(),
+                std::collections::BTreeMap::new(),
+            )
+            .await;
         context.state.expire_readiness_settle_window().await;
         context.state.maybe_mark_serving().await;
         context.state.enter_draining();
@@ -1849,7 +1896,13 @@ mod tests {
     #[tokio::test]
     async fn draining_public_requests_return_service_unavailable_and_close_http1_connections() {
         let context = test_context(|_| {}).await;
-        context.state.mark_initial_discovery_completed().await;
+        context
+            .state
+            .apply_membership_view(
+                std::collections::BTreeSet::new(),
+                std::collections::BTreeMap::new(),
+            )
+            .await;
         context.state.expire_readiness_settle_window().await;
         context.state.maybe_mark_serving().await;
         context.state.enter_draining();
@@ -1869,27 +1922,6 @@ mod tests {
         assert_eq!(
             response.headers().get(axum::http::header::CONNECTION),
             Some(&HeaderValue::from_static("close"))
-        );
-    }
-
-    #[tokio::test]
-    async fn clear_stale_drain_marker_removes_existing_file() {
-        let context = test_context(|_| {}).await;
-        tokio::fs::write(context.state.drain_marker_path(), b"stale-marker")
-            .await
-            .expect("failed to create stale drain marker");
-
-        let removed = context
-            .state
-            .clear_stale_drain_marker()
-            .await
-            .expect("clearing stale marker should succeed");
-
-        assert!(removed);
-        assert!(
-            !tokio::fs::try_exists(context.state.drain_marker_path())
-                .await
-                .expect("marker existence check should succeed")
         );
     }
 

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -1743,6 +1743,7 @@ mod tests {
                     "http://peer.kura.internal:4000".to_string(),
                     "eu-west".to_string(),
                 )]),
+                true,
             )
             .await;
 
@@ -1779,6 +1780,7 @@ mod tests {
             .apply_membership_view(
                 std::collections::BTreeSet::from(["remote".to_string()]),
                 std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
             )
             .await;
         assert!(context.state.note_bootstrap_started(&peer).await);
@@ -1850,6 +1852,7 @@ mod tests {
             .apply_membership_view(
                 std::collections::BTreeSet::from(["remote".to_string()]),
                 std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
             )
             .await;
         context.state.note_bootstrap_succeeded(&peer).await;
@@ -1891,6 +1894,7 @@ mod tests {
             .apply_membership_view(
                 std::collections::BTreeSet::new(),
                 std::collections::BTreeMap::new(),
+                true,
             )
             .await;
         context.state.expire_readiness_settle_window().await;
@@ -1923,6 +1927,7 @@ mod tests {
             .apply_membership_view(
                 std::collections::BTreeSet::from(["remote".to_string()]),
                 std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
             )
             .await;
         context.state.note_bootstrap_succeeded(&peer).await;
@@ -1967,6 +1972,7 @@ mod tests {
             .apply_membership_view(
                 std::collections::BTreeSet::new(),
                 std::collections::BTreeMap::new(),
+                true,
             )
             .await;
         context.state.expire_readiness_settle_window().await;

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -74,6 +74,7 @@ fn public_routes() -> Router<SharedState> {
     Router::new()
         .route("/up", get(up))
         .route("/ready", get(ready))
+        .route("/status/rollout", get(rollout_status))
         .route("/metrics", get(metrics_handler))
         .route("/v1/cache/{hash}", get(get_nx).put(put_nx))
         .route(
@@ -456,7 +457,7 @@ fn should_skip_extension_route(route: &str) -> bool {
 }
 
 fn is_probe_route(route: &str) -> bool {
-    route == "/up" || route == "/ready" || route == "/metrics"
+    route == "/up" || route == "/ready" || route == "/status/rollout" || route == "/metrics"
 }
 
 fn is_http1(version: Version) -> bool {
@@ -734,6 +735,26 @@ async fn ready(State(state): State<SharedState>) -> impl IntoResponse {
         })),
     )
         .into_response()
+}
+
+async fn rollout_status(State(state): State<SharedState>) -> impl IntoResponse {
+    let status = state.rollout_status_report().await;
+    Json(serde_json::json!({
+        "generation": status.generation,
+        "ready": status.ready,
+        "state": status.state.as_str(),
+        "ring_members": status.ring_members,
+        "initial_discovery_completed": status.initial_discovery_completed,
+        "writer_lock_owned": status.writer_lock_owned,
+        "bootstrap_known_peers": status.bootstrap_known_peers,
+        "bootstrap_completed_peers": status.bootstrap_completed_peers,
+        "bootstrap_inflight_peers": status.bootstrap_inflight_peers,
+        "http_inflight_requests": status.http_inflight,
+        "grpc_inflight_requests": status.grpc_inflight,
+        "outbox_messages": status.outbox_messages,
+        "memory_pressure_state": status.memory_pressure_state,
+        "fd_timeout_count": status.fd_timeout_count,
+    }))
 }
 
 async fn metrics_handler(State(state): State<SharedState>) -> impl IntoResponse {
@@ -1891,6 +1912,51 @@ mod tests {
         assert_eq!(body["state"], "draining");
         assert_eq!(body["draining"], true);
         assert!(body["reasons"].to_string().contains("draining"));
+    }
+
+    #[tokio::test]
+    async fn rollout_status_reports_rollout_summary_and_stays_available_while_draining() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                std::collections::BTreeSet::from(["remote".to_string()]),
+                std::collections::BTreeMap::from([(peer.clone(), "remote".to_string())]),
+            )
+            .await;
+        context.state.note_bootstrap_succeeded(&peer).await;
+        context.state.expire_readiness_settle_window().await;
+        context.state.maybe_mark_serving().await;
+        context.state.metrics.update_outbox_messages(7);
+        context
+            .state
+            .metrics
+            .record_file_descriptor_wait("timeout", Duration::from_millis(5));
+        context.state.enter_draining();
+
+        let response = public_router(context.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/status/rollout")
+                    .body(Body::empty())
+                    .expect("failed to build request"),
+            )
+            .await
+            .expect("rollout status route should respond");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_str(&response_text(response).await)
+            .expect("rollout status response should be json");
+        assert_eq!(body["generation"], 1);
+        assert_eq!(body["state"], "draining");
+        assert_eq!(body["ready"], false);
+        assert_eq!(body["ring_members"], 2);
+        assert_eq!(body["bootstrap_known_peers"], 1);
+        assert_eq!(body["bootstrap_completed_peers"], 1);
+        assert_eq!(body["bootstrap_inflight_peers"], 0);
+        assert_eq!(body["outbox_messages"], 7);
+        assert_eq!(body["memory_pressure_state"], 0);
+        assert_eq!(body["fd_timeout_count"], 1);
     }
 
     #[tokio::test]

--- a/kura/src/lib.rs
+++ b/kura/src/lib.rs
@@ -13,6 +13,7 @@ mod multipart;
 mod peer_tls;
 mod reapi;
 mod replication;
+mod runtime;
 mod segment;
 mod state;
 mod store;

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -44,6 +44,8 @@ pub struct Metrics {
     file_descriptor_available: Gauge,
     file_descriptor_waiting: Gauge,
     file_descriptor_capacity: Gauge,
+    http_inflight_requests: Gauge,
+    grpc_inflight_requests: Gauge,
     segment_handles_cached: Gauge,
     segment_handle_cache_capacity: Gauge,
     segment_handle_cache_lookups: Family<SegmentHandleCacheLookupLabels, Counter>,
@@ -59,6 +61,9 @@ pub struct Metrics {
     outbox_messages: Gauge,
     multipart_uploads: Gauge,
     discovered_peer_nodes: Gauge,
+    bootstrap_known_peers: Gauge,
+    bootstrap_completed_peers: Gauge,
+    bootstrap_inflight_peers: Gauge,
     bootstrap_runs: Family<BootstrapResultLabels, Counter>,
     bootstrap_duration: Histogram,
     bootstrap_applied_items: Family<BootstrapItemLabels, Counter>,
@@ -86,6 +91,12 @@ pub struct Metrics {
     memory_pressure_transitions: Family<MemoryPressureTransitionLabels, Counter>,
     background_work_paused: Family<BackgroundWorkerLabels, Gauge>,
     memory_actions: Family<MemoryActionLabels, Counter>,
+    traffic_state: Gauge,
+    ready_state: Gauge,
+    drain_state: Gauge,
+    initial_discovery_completed: Gauge,
+    writer_lock_owned: Gauge,
+    writer_lock_acquire_failures: Counter,
 }
 
 impl Metrics {
@@ -131,6 +142,8 @@ impl Metrics {
         let file_descriptor_available = Gauge::default();
         let file_descriptor_waiting = Gauge::default();
         let file_descriptor_capacity = Gauge::default();
+        let http_inflight_requests = Gauge::default();
+        let grpc_inflight_requests = Gauge::default();
         let segment_handles_cached = Gauge::default();
         let segment_handle_cache_capacity = Gauge::default();
         let segment_handle_cache_lookups =
@@ -147,6 +160,9 @@ impl Metrics {
         let outbox_messages = Gauge::default();
         let multipart_uploads = Gauge::default();
         let discovered_peer_nodes = Gauge::default();
+        let bootstrap_known_peers = Gauge::default();
+        let bootstrap_completed_peers = Gauge::default();
+        let bootstrap_inflight_peers = Gauge::default();
         let bootstrap_runs = Family::<BootstrapResultLabels, Counter>::default();
         let bootstrap_duration = Histogram::new(exponential_buckets(0.001, 2.0, 16));
         let bootstrap_applied_items = Family::<BootstrapItemLabels, Counter>::default();
@@ -182,6 +198,12 @@ impl Metrics {
             Family::<MemoryPressureTransitionLabels, Counter>::default();
         let background_work_paused = Family::<BackgroundWorkerLabels, Gauge>::default();
         let memory_actions = Family::<MemoryActionLabels, Counter>::default();
+        let traffic_state = Gauge::default();
+        let ready_state = Gauge::default();
+        let drain_state = Gauge::default();
+        let initial_discovery_completed = Gauge::default();
+        let writer_lock_owned = Gauge::default();
+        let writer_lock_acquire_failures = Counter::default();
         let process_start_time_seconds = Gauge::<i64>::default();
         process_start_time_seconds.set(
             SystemTime::now()
@@ -311,6 +333,16 @@ impl Metrics {
             file_descriptor_capacity.clone(),
         );
         registry.register(
+            "kura_http_inflight_requests",
+            "HTTP requests currently in flight across public and internal listeners",
+            http_inflight_requests.clone(),
+        );
+        registry.register(
+            "kura_grpc_inflight_requests",
+            "gRPC requests currently in flight",
+            grpc_inflight_requests.clone(),
+        );
+        registry.register(
             "kura_segment_handles_cached",
             "Long-lived segment file handles cached for offset-based reads",
             segment_handles_cached.clone(),
@@ -384,6 +416,21 @@ impl Metrics {
             "kura_discovered_peer_nodes",
             "Peer nodes currently discovered through health checks and DNS",
             discovered_peer_nodes.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_known_peers",
+            "Peers currently considered part of the bootstrap readiness set",
+            bootstrap_known_peers.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_completed_peers",
+            "Peers that finished bootstrap for this node",
+            bootstrap_completed_peers.clone(),
+        );
+        registry.register(
+            "kura_bootstrap_inflight_peers",
+            "Peers currently being bootstrapped",
+            bootstrap_inflight_peers.clone(),
         );
         registry.register(
             "kura_bootstrap_runs_total",
@@ -521,6 +568,36 @@ impl Metrics {
             memory_actions.clone(),
         );
         registry.register(
+            "kura_traffic_state",
+            "Current traffic state for this node: 0=joining, 1=serving, 2=draining",
+            traffic_state.clone(),
+        );
+        registry.register(
+            "kura_ready_state",
+            "Current readiness state for this node: 1=ready, 0=not ready",
+            ready_state.clone(),
+        );
+        registry.register(
+            "kura_drain_state",
+            "Current drain state for this node: 1=draining, 0=not draining",
+            drain_state.clone(),
+        );
+        registry.register(
+            "kura_initial_discovery_completed",
+            "Whether the first membership discovery pass has completed",
+            initial_discovery_completed.clone(),
+        );
+        registry.register(
+            "kura_writer_lock_owned",
+            "Whether this process currently owns the single-writer data-dir lock",
+            writer_lock_owned.clone(),
+        );
+        registry.register(
+            "kura_writer_lock_acquire_failures_total",
+            "Number of writer-lock acquisition failures detected during startup or tests",
+            writer_lock_acquire_failures.clone(),
+        );
+        registry.register(
             "kura_process_start_time_seconds",
             "Unix timestamp when the current Kura process started",
             process_start_time_seconds.clone(),
@@ -552,6 +629,8 @@ impl Metrics {
             file_descriptor_available,
             file_descriptor_waiting,
             file_descriptor_capacity,
+            http_inflight_requests,
+            grpc_inflight_requests,
             segment_handles_cached,
             segment_handle_cache_capacity,
             segment_handle_cache_lookups,
@@ -567,6 +646,9 @@ impl Metrics {
             outbox_messages,
             multipart_uploads,
             discovered_peer_nodes,
+            bootstrap_known_peers,
+            bootstrap_completed_peers,
+            bootstrap_inflight_peers,
             bootstrap_runs,
             bootstrap_duration,
             bootstrap_applied_items,
@@ -594,6 +676,12 @@ impl Metrics {
             memory_pressure_transitions,
             background_work_paused,
             memory_actions,
+            traffic_state,
+            ready_state,
+            drain_state,
+            initial_discovery_completed,
+            writer_lock_owned,
+            writer_lock_acquire_failures,
         };
 
         metrics
@@ -786,6 +874,14 @@ impl Metrics {
         self.file_descriptor_waiting.set(waiting as i64);
     }
 
+    pub fn update_http_inflight(&self, count: usize) {
+        self.http_inflight_requests.set(count as i64);
+    }
+
+    pub fn update_grpc_inflight(&self, count: usize) {
+        self.grpc_inflight_requests.set(count as i64);
+    }
+
     pub fn update_segment_handles_cached(&self, cached: usize) {
         self.segment_handles_cached.set(cached as i64);
     }
@@ -872,6 +968,12 @@ impl Metrics {
 
     pub fn update_discovered_peer_nodes(&self, count: usize) {
         self.discovered_peer_nodes.set(count as i64);
+    }
+
+    pub fn update_bootstrap_peers(&self, known: usize, completed: usize, inflight: usize) {
+        self.bootstrap_known_peers.set(known as i64);
+        self.bootstrap_completed_peers.set(completed as i64);
+        self.bootstrap_inflight_peers.set(inflight as i64);
     }
 
     pub fn record_bootstrap_run(
@@ -1041,6 +1143,27 @@ impl Metrics {
                 action: action.to_owned(),
             })
             .inc();
+    }
+
+    pub fn update_runtime_state(
+        &self,
+        traffic_state: i64,
+        ready: bool,
+        draining: bool,
+        initial_discovery_completed: bool,
+        writer_lock_owned: bool,
+    ) {
+        self.traffic_state.set(traffic_state);
+        self.ready_state.set(if ready { 1 } else { 0 });
+        self.drain_state.set(if draining { 1 } else { 0 });
+        self.initial_discovery_completed
+            .set(if initial_discovery_completed { 1 } else { 0 });
+        self.writer_lock_owned
+            .set(if writer_lock_owned { 1 } else { 0 });
+    }
+
+    pub fn record_writer_lock_acquire_failure(&self) {
+        self.writer_lock_acquire_failures.inc();
     }
 
     pub fn render(&self) -> String {
@@ -1258,6 +1381,8 @@ mod tests {
         metrics.record_file_descriptor_wait("ok", Duration::from_millis(1));
         metrics.record_file_operation("open_read", "ok", Duration::from_millis(2), 42);
         metrics.update_file_descriptor_pool(64, 3, 61, 1);
+        metrics.update_http_inflight(2);
+        metrics.update_grpc_inflight(1);
         metrics.update_segment_handles_cached(2);
         metrics.update_segment_handle_cache_capacity(8);
         metrics.record_segment_handle_cache_lookup("hit");
@@ -1273,6 +1398,7 @@ mod tests {
         metrics.update_outbox_messages(4);
         metrics.update_multipart_uploads(2);
         metrics.update_discovered_peer_nodes(3);
+        metrics.update_bootstrap_peers(3, 2, 1);
         metrics.record_bootstrap_run("ok", Duration::from_millis(6), 2, 5);
         metrics.update_analytics_queue(1000, 2);
         metrics.record_analytics_event("xcode", "sent", 2);
@@ -1287,6 +1413,8 @@ mod tests {
         metrics.record_memory_pressure_transition("normal", "constrained");
         metrics.update_background_work_paused("outbox", true);
         metrics.record_memory_action("manifest_cache_trim");
+        metrics.update_runtime_state(1, true, false, true, true);
+        metrics.record_writer_lock_acquire_failure();
 
         let rendered = metrics.render();
 
@@ -1309,6 +1437,8 @@ mod tests {
         assert!(rendered.contains("kura_file_descriptor_wait_seconds"));
         assert!(rendered.contains("kura_file_operations_total"));
         assert!(rendered.contains("kura_file_descriptor_in_use"));
+        assert!(rendered.contains("kura_http_inflight_requests"));
+        assert!(rendered.contains("kura_grpc_inflight_requests"));
         assert!(rendered.contains("kura_segment_handles_cached"));
         assert!(rendered.contains("kura_segment_handle_cache_capacity"));
         assert!(rendered.contains("kura_segment_handle_cache_lookups_total"));
@@ -1323,6 +1453,9 @@ mod tests {
         assert!(rendered.contains("kura_outbox_messages"));
         assert!(rendered.contains("kura_multipart_uploads"));
         assert!(rendered.contains("kura_discovered_peer_nodes"));
+        assert!(rendered.contains("kura_bootstrap_known_peers"));
+        assert!(rendered.contains("kura_bootstrap_completed_peers"));
+        assert!(rendered.contains("kura_bootstrap_inflight_peers"));
         assert!(rendered.contains("kura_bootstrap_runs_total"));
         assert!(rendered.contains("kura_bootstrap_duration_seconds"));
         assert!(rendered.contains("kura_bootstrap_applied_items_total"));
@@ -1344,6 +1477,12 @@ mod tests {
         assert!(rendered.contains("kura_memory_pressure_transitions_total"));
         assert!(rendered.contains("kura_background_work_paused"));
         assert!(rendered.contains("kura_memory_actions_total"));
+        assert!(rendered.contains("kura_traffic_state"));
+        assert!(rendered.contains("kura_ready_state"));
+        assert!(rendered.contains("kura_drain_state"));
+        assert!(rendered.contains("kura_initial_discovery_completed"));
+        assert!(rendered.contains("kura_writer_lock_owned"));
+        assert!(rendered.contains("kura_writer_lock_acquire_failures_total"));
         assert!(rendered.contains("kura_process_start_time_seconds"));
         assert!(rendered.contains("region=\"eu-west\""));
         assert!(rendered.contains("tenant_id=\"acme\""));

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -20,6 +23,7 @@ use crate::{artifact::producer::ArtifactProducer, utils::replication_target_labe
 #[derive(Clone)]
 pub struct Metrics {
     registry: Arc<Mutex<Registry>>,
+    rollout_snapshot: Arc<RolloutSnapshot>,
     http_requests: Family<HttpRequestLabels, Counter>,
     http_request_duration: Family<HttpRouteLabels, Histogram>,
     http_exceptions: Family<HttpExceptionLabels, Counter>,
@@ -99,9 +103,22 @@ pub struct Metrics {
     writer_lock_acquire_failures: Counter,
 }
 
+#[derive(Default)]
+struct RolloutSnapshot {
+    outbox_messages: AtomicU64,
+    fd_timeout_count: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RolloutMetricsSnapshot {
+    pub outbox_messages: u64,
+    pub fd_timeout_count: u64,
+}
+
 impl Metrics {
     pub fn new(region: String, tenant_id: String) -> Self {
         let mut registry = Registry::default();
+        let rollout_snapshot = Arc::new(RolloutSnapshot::default());
 
         let http_requests = Family::<HttpRequestLabels, Counter>::default();
         let http_request_duration =
@@ -605,6 +622,7 @@ impl Metrics {
 
         let metrics = Self {
             registry: Arc::new(Mutex::new(registry)),
+            rollout_snapshot,
             http_requests,
             http_request_duration,
             http_exceptions,
@@ -835,6 +853,11 @@ impl Metrics {
                 result: result.to_owned(),
             })
             .observe(duration.as_secs_f64());
+        if result == "timeout" {
+            self.rollout_snapshot
+                .fd_timeout_count
+                .fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     pub fn record_file_operation(
@@ -960,6 +983,9 @@ impl Metrics {
 
     pub fn update_outbox_messages(&self, count: usize) {
         self.outbox_messages.set(count as i64);
+        self.rollout_snapshot
+            .outbox_messages
+            .store(count as u64, Ordering::Relaxed);
     }
 
     pub fn update_multipart_uploads(&self, count: usize) {
@@ -1164,6 +1190,19 @@ impl Metrics {
 
     pub fn record_writer_lock_acquire_failure(&self) {
         self.writer_lock_acquire_failures.inc();
+    }
+
+    pub fn rollout_metrics_snapshot(&self) -> RolloutMetricsSnapshot {
+        RolloutMetricsSnapshot {
+            outbox_messages: self
+                .rollout_snapshot
+                .outbox_messages
+                .load(Ordering::Relaxed),
+            fd_timeout_count: self
+                .rollout_snapshot
+                .fd_timeout_count
+                .load(Ordering::Relaxed),
+        }
     }
 
     pub fn render(&self) -> String {

--- a/kura/src/reapi/mod.rs
+++ b/kura/src/reapi/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, future::Future, pin::Pin};
+use std::{collections::BTreeMap, future::Future, pin::Pin, time::Duration};
 
 use bazel_remote_apis::{
     build::bazel::{
@@ -66,6 +66,8 @@ where
     let byte_stream = ByteStreamServer::new(service).max_decoding_message_size(64 << 20);
 
     Server::builder()
+        .max_connection_age(Duration::from_secs(300))
+        .max_connection_age_grace(Duration::from_secs(300))
         .add_service(capabilities)
         .add_service(action_cache)
         .add_service(cas)
@@ -81,6 +83,9 @@ impl ReapiService {
         request: &Request<T>,
         spec: GrpcExtensionSpec<'_>,
     ) -> Result<Option<Principal>, Status> {
+        if self.state.runtime.is_draining() {
+            return Err(Status::unavailable("server is draining"));
+        }
         let Some(extension) = self.state.extension.as_ref() else {
             return Ok(None);
         };
@@ -121,6 +126,7 @@ impl Capabilities for ReapiService {
         &self,
         request: Request<reapi::GetCapabilitiesRequest>,
     ) -> Result<Response<reapi::ServerCapabilities>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         let extension = GrpcExtensionSpec {
             route: "reapi.capabilities.get",
             operation: "capabilities.read",
@@ -174,6 +180,7 @@ impl ActionCache for ReapiService {
         &self,
         request: Request<reapi::GetActionResultRequest>,
     ) -> Result<Response<reapi::ActionResult>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let digest = request
@@ -251,6 +258,7 @@ impl ActionCache for ReapiService {
         &self,
         request: Request<reapi::UpdateActionResultRequest>,
     ) -> Result<Response<reapi::ActionResult>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let digest = request
@@ -308,6 +316,7 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::FindMissingBlobsRequest>,
     ) -> Result<Response<reapi::FindMissingBlobsResponse>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -347,6 +356,7 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::BatchUpdateBlobsRequest>,
     ) -> Result<Response<reapi::BatchUpdateBlobsResponse>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -400,6 +410,7 @@ impl ContentAddressableStorage for ReapiService {
         &self,
         request: Request<reapi::BatchReadBlobsRequest>,
     ) -> Result<Response<reapi::BatchReadBlobsResponse>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         require_sha256(request.get_ref().digest_function)?;
         let namespace_id = namespace_from_instance(&request.get_ref().instance_name);
         let extension = GrpcExtensionSpec {
@@ -474,6 +485,7 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<bytestream::ReadRequest>,
     ) -> Result<Response<Self::ReadStream>, Status> {
+        let request_guard = self.state.start_grpc_request();
         let resource = parse_read_resource_name(&request.get_ref().resource_name)?;
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.read",
@@ -542,13 +554,16 @@ impl ByteStream for ReapiService {
         self.state
             .metrics
             .record_artifact_read(ArtifactProducer::Reapi, "ok", bytes_to_read);
-        let stream = ReaderStream::new(reader).map(|result| match result {
-            Ok(bytes) => Ok(bytestream::ReadResponse {
-                data: bytes.to_vec(),
-            }),
-            Err(error) => Err(Status::internal(format!(
-                "failed to stream blob chunk: {error}"
-            ))),
+        let stream = ReaderStream::new(reader).map(move |result| {
+            let _keep_guard_alive = &request_guard;
+            match result {
+                Ok(bytes) => Ok(bytestream::ReadResponse {
+                    data: bytes.to_vec(),
+                }),
+                Err(error) => Err(Status::internal(format!(
+                    "failed to stream blob chunk: {error}"
+                ))),
+            }
         });
 
         let mut response = Response::new(Box::pin(stream) as Self::ReadStream);
@@ -561,6 +576,7 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<tonic::Streaming<bytestream::WriteRequest>>,
     ) -> Result<Response<bytestream::WriteResponse>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.write",
             operation: "artifact.write",
@@ -699,6 +715,7 @@ impl ByteStream for ReapiService {
         &self,
         request: Request<bytestream::QueryWriteStatusRequest>,
     ) -> Result<Response<bytestream::QueryWriteStatusResponse>, Status> {
+        let _request_guard = self.state.start_grpc_request();
         let resource = parse_write_resource_name(&request.get_ref().resource_name)?;
         let extension = GrpcExtensionSpec {
             route: "reapi.bytestream.query_write_status",
@@ -1149,5 +1166,22 @@ mod tests {
         assert!(rendered.contains("kura_artifact_reads_total"));
         assert!(rendered.contains("producer=\"reapi\""));
         assert!(rendered.contains("result=\"ok\""));
+    }
+
+    #[tokio::test]
+    async fn draining_rejects_new_grpc_requests() {
+        let context = test_context(|_| {}).await;
+        let service = ReapiService {
+            state: context.state.clone(),
+        };
+        context.state.enter_draining();
+
+        let error = service
+            .get_capabilities(Request::new(reapi::GetCapabilitiesRequest::default()))
+            .await
+            .expect_err("draining nodes should reject new gRPC requests");
+
+        assert_eq!(error.code(), tonic::Code::Unavailable);
+        assert!(error.message().contains("draining"));
     }
 }

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -60,7 +60,6 @@ pub async fn enqueue_replication_for_artifact(state: &SharedState, manifest: &Ar
 
 pub fn spawn_membership_task(state: SharedState) {
     tokio::spawn(async move {
-        let mut initial_discovery_completed = false;
         loop {
             let mut members = BTreeSet::new();
             let mut peer_nodes = BTreeMap::new();
@@ -93,35 +92,11 @@ pub fn spawn_membership_task(state: SharedState) {
                 }
             }
 
-            *state.members.write().await = members;
-            let (discovered_peers, lost_peers) = {
-                let mut known_peers = state.peer_nodes.write().await;
-                let lost_peers = known_peers
-                    .keys()
-                    .filter(|peer| !peer_nodes.contains_key(*peer))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                let discovered_peers = peer_nodes
-                    .keys()
-                    .filter(|peer| !known_peers.contains_key(*peer))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                *known_peers = peer_nodes;
-                (discovered_peers, lost_peers)
-            };
-            if !lost_peers.is_empty() {
-                state.forget_peers(&lost_peers).await;
-            }
-            if !initial_discovery_completed {
-                state.mark_initial_discovery_completed().await;
-                initial_discovery_completed = true;
-            } else if !discovered_peers.is_empty() || !lost_peers.is_empty() {
-                state.extend_readiness_settle_window().await;
-            }
+            let membership_update = state.apply_membership_view(members, peer_nodes).await;
             state
                 .metrics
-                .update_discovered_peer_nodes(state.peer_nodes.read().await.len());
-            for peer in discovered_peers {
+                .update_discovered_peer_nodes(membership_update.known_peer_count);
+            for peer in membership_update.discovered_peers {
                 maybe_spawn_bootstrap_task(state.clone(), peer).await;
             }
             state.maybe_mark_serving().await;
@@ -150,10 +125,7 @@ pub fn spawn_outbox_task(state: SharedState) {
 }
 
 pub async fn replication_targets(state: &SharedState) -> Vec<String> {
-    let mut targets = state.config.peers.iter().cloned().collect::<BTreeSet<_>>();
-    targets.extend(state.peer_nodes.read().await.keys().cloned());
-    targets.remove(&state.config.node_url);
-    targets.into_iter().collect()
+    state.replication_targets().await
 }
 
 async fn maybe_spawn_bootstrap_task(state: SharedState, peer: String) {

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -63,7 +63,9 @@ pub fn spawn_membership_task(state: SharedState) {
         loop {
             let mut members = BTreeSet::new();
             let mut peer_nodes = BTreeMap::new();
-            for peer in discovery_targets(&state.config).await {
+            let targets = discovery_targets(&state.config).await;
+            let mut peer_status_successes = 0_usize;
+            for peer in &targets {
                 match state
                     .client
                     .get(format!("{peer}/_internal/status"))
@@ -75,6 +77,7 @@ pub fn spawn_membership_task(state: SharedState) {
                         .await
                     {
                         Ok(payload) => {
+                            peer_status_successes += 1;
                             if payload.tenant_id != state.config.tenant_id
                                 || payload.node_url == state.config.node_url
                             {
@@ -92,11 +95,14 @@ pub fn spawn_membership_task(state: SharedState) {
                 }
             }
 
-            let membership_update = state.apply_membership_view(members, peer_nodes).await;
+            let discovery_observed = targets.is_empty() || peer_status_successes > 0;
+            let membership_update = state
+                .apply_membership_view(members, peer_nodes, discovery_observed)
+                .await;
             state
                 .metrics
                 .update_discovered_peer_nodes(membership_update.known_peer_count);
-            for peer in membership_update.discovered_peers {
+            for peer in state.peers_needing_bootstrap().await {
                 maybe_spawn_bootstrap_task(state.clone(), peer).await;
             }
             state.maybe_mark_serving().await;

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -60,6 +60,7 @@ pub async fn enqueue_replication_for_artifact(state: &SharedState, manifest: &Ar
 
 pub fn spawn_membership_task(state: SharedState) {
     tokio::spawn(async move {
+        let mut initial_discovery_completed = false;
         loop {
             let mut members = BTreeSet::new();
             let mut peer_nodes = BTreeMap::new();
@@ -109,10 +110,11 @@ pub fn spawn_membership_task(state: SharedState) {
                 (discovered_peers, lost_peers)
             };
             if !lost_peers.is_empty() {
-                let mut bootstrapped = state.bootstrapped_peers.lock().await;
-                for peer in lost_peers {
-                    bootstrapped.remove(&peer);
-                }
+                state.forget_peers(&lost_peers).await;
+            }
+            if !initial_discovery_completed {
+                state.mark_initial_discovery_completed();
+                initial_discovery_completed = true;
             }
             state
                 .metrics
@@ -120,6 +122,7 @@ pub fn spawn_membership_task(state: SharedState) {
             for peer in discovered_peers {
                 maybe_spawn_bootstrap_task(state.clone(), peer).await;
             }
+            state.maybe_mark_serving().await;
             sleep(Duration::from_secs(2)).await;
         }
     });
@@ -152,30 +155,30 @@ pub async fn replication_targets(state: &SharedState) -> Vec<String> {
 }
 
 async fn maybe_spawn_bootstrap_task(state: SharedState, peer: String) {
-    let mut bootstrapped = state.bootstrapped_peers.lock().await;
-    if !bootstrapped.insert(peer.clone()) {
+    if !state.note_bootstrap_started(&peer).await {
         return;
     }
-    drop(bootstrapped);
 
     tokio::spawn(async move {
         let started_at = std::time::Instant::now();
         let result = bootstrap_from_peer(&state, &peer).await;
         match result {
             Ok(stats) => {
+                state.note_bootstrap_succeeded(&peer).await;
                 state.metrics.record_bootstrap_run(
                     "ok",
                     started_at.elapsed(),
                     stats.tombstones_applied,
                     stats.artifacts_applied,
                 );
+                state.maybe_mark_serving().await;
             }
             Err(error) => {
                 warn!("bootstrap from {peer} failed: {error}");
                 state
                     .metrics
                     .record_bootstrap_run("error", started_at.elapsed(), 0, 0);
-                state.bootstrapped_peers.lock().await.remove(&peer);
+                state.note_bootstrap_failed(&peer).await;
             }
         }
     });

--- a/kura/src/replication/mod.rs
+++ b/kura/src/replication/mod.rs
@@ -113,8 +113,10 @@ pub fn spawn_membership_task(state: SharedState) {
                 state.forget_peers(&lost_peers).await;
             }
             if !initial_discovery_completed {
-                state.mark_initial_discovery_completed();
+                state.mark_initial_discovery_completed().await;
                 initial_discovery_completed = true;
+            } else if !discovered_peers.is_empty() || !lost_peers.is_empty() {
+                state.extend_readiness_settle_window().await;
             }
             state
                 .metrics

--- a/kura/src/runtime.rs
+++ b/kura/src/runtime.rs
@@ -1,0 +1,262 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::Write,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+#[cfg(test)]
+use std::path::PathBuf;
+
+use crate::metrics::Metrics;
+
+const DATA_DIR_LOCK_FILE: &str = ".kura.writer.lock";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TrafficState {
+    Joining,
+    Serving,
+    Draining,
+}
+
+impl TrafficState {
+    pub fn as_i64(self) -> i64 {
+        match self {
+            Self::Joining => 0,
+            Self::Serving => 1,
+            Self::Draining => 2,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Joining => "joining",
+            Self::Serving => "serving",
+            Self::Draining => "draining",
+        }
+    }
+}
+
+pub struct RuntimeState {
+    draining: AtomicBool,
+    serving: AtomicBool,
+    initial_discovery_completed: AtomicBool,
+    writer_lock_owned: AtomicBool,
+    http_inflight: AtomicUsize,
+    grpc_inflight: AtomicUsize,
+}
+
+impl RuntimeState {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            draining: AtomicBool::new(false),
+            serving: AtomicBool::new(false),
+            initial_discovery_completed: AtomicBool::new(false),
+            writer_lock_owned: AtomicBool::new(true),
+            http_inflight: AtomicUsize::new(0),
+            grpc_inflight: AtomicUsize::new(0),
+        })
+    }
+
+    pub fn request_drain(&self) -> bool {
+        !self.draining.swap(true, Ordering::SeqCst)
+    }
+
+    pub fn is_draining(&self) -> bool {
+        self.draining.load(Ordering::SeqCst)
+    }
+
+    pub fn mark_serving(&self) -> bool {
+        !self.serving.swap(true, Ordering::SeqCst)
+    }
+
+    pub fn is_serving(&self) -> bool {
+        self.serving.load(Ordering::SeqCst)
+    }
+
+    pub fn mark_initial_discovery_completed(&self) -> bool {
+        !self
+            .initial_discovery_completed
+            .swap(true, Ordering::SeqCst)
+    }
+
+    pub fn initial_discovery_completed(&self) -> bool {
+        self.initial_discovery_completed.load(Ordering::SeqCst)
+    }
+
+    pub fn writer_lock_owned(&self) -> bool {
+        self.writer_lock_owned.load(Ordering::SeqCst)
+    }
+
+    pub fn traffic_state(&self) -> TrafficState {
+        if self.is_draining() {
+            TrafficState::Draining
+        } else if self.is_serving() {
+            TrafficState::Serving
+        } else {
+            TrafficState::Joining
+        }
+    }
+
+    pub fn http_inflight(&self) -> usize {
+        self.http_inflight.load(Ordering::SeqCst)
+    }
+
+    pub fn grpc_inflight(&self) -> usize {
+        self.grpc_inflight.load(Ordering::SeqCst)
+    }
+
+    pub fn start_http_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
+        let count = self.http_inflight.fetch_add(1, Ordering::SeqCst) + 1;
+        metrics.update_http_inflight(count);
+        InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Http)
+    }
+
+    pub fn start_grpc_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
+        let count = self.grpc_inflight.fetch_add(1, Ordering::SeqCst) + 1;
+        metrics.update_grpc_inflight(count);
+        InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Grpc)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum InflightKind {
+    Http,
+    Grpc,
+}
+
+pub struct InflightGuard {
+    runtime: Arc<RuntimeState>,
+    metrics: Metrics,
+    kind: InflightKind,
+    active: bool,
+}
+
+impl InflightGuard {
+    fn new(runtime: Arc<RuntimeState>, metrics: Metrics, kind: InflightKind) -> Self {
+        Self {
+            runtime,
+            metrics,
+            kind,
+            active: true,
+        }
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        match self.kind {
+            InflightKind::Http => {
+                let previous = self.runtime.http_inflight.fetch_sub(1, Ordering::SeqCst);
+                self.metrics
+                    .update_http_inflight(previous.saturating_sub(1));
+            }
+            InflightKind::Grpc => {
+                let previous = self.runtime.grpc_inflight.fetch_sub(1, Ordering::SeqCst);
+                self.metrics
+                    .update_grpc_inflight(previous.saturating_sub(1));
+            }
+        }
+    }
+}
+
+pub struct DataDirLock {
+    _file: File,
+    #[cfg(test)]
+    path: PathBuf,
+}
+
+impl DataDirLock {
+    pub fn acquire(data_dir: &Path) -> Result<Self, String> {
+        let path = data_dir.join(DATA_DIR_LOCK_FILE);
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| {
+                format!(
+                    "failed to open writer lock file {}: {error}",
+                    path.display()
+                )
+            })?;
+
+        try_lock_exclusive(&file).map_err(|error| {
+            format!("failed to acquire writer lock {}: {error}", path.display())
+        })?;
+
+        file.set_len(0).map_err(|error| {
+            format!(
+                "failed to reset writer lock file {}: {error}",
+                path.display()
+            )
+        })?;
+        writeln!(file, "pid={}", std::process::id()).map_err(|error| {
+            format!(
+                "failed to write writer lock file {}: {error}",
+                path.display()
+            )
+        })?;
+        file.flush().map_err(|error| {
+            format!(
+                "failed to flush writer lock file {}: {error}",
+                path.display()
+            )
+        })?;
+
+        Ok(Self {
+            _file: file,
+            #[cfg(test)]
+            path,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(unix)]
+fn try_lock_exclusive(file: &File) -> Result<(), std::io::Error> {
+    use std::os::fd::AsRawFd;
+
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn try_lock_exclusive(_file: &File) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn data_dir_lock_rejects_second_owner() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let first = DataDirLock::acquire(temp_dir.path()).expect("first lock should succeed");
+        let second = DataDirLock::acquire(temp_dir.path());
+        assert!(second.is_err(), "second lock acquisition should fail");
+        assert_eq!(
+            first.path(),
+            temp_dir.path().join(DATA_DIR_LOCK_FILE).as_path()
+        );
+    }
+}

--- a/kura/src/runtime.rs
+++ b/kura/src/runtime.rs
@@ -11,6 +11,8 @@ use std::{
 #[cfg(test)]
 use std::path::PathBuf;
 
+use tokio::sync::{Notify, futures::Notified};
+
 use crate::metrics::Metrics;
 
 const DATA_DIR_LOCK_FILE: &str = ".kura.writer.lock";
@@ -46,6 +48,7 @@ pub struct RuntimeState {
     writer_lock_owned: AtomicBool,
     http_inflight: AtomicUsize,
     grpc_inflight: AtomicUsize,
+    inflight_changed: Notify,
 }
 
 impl RuntimeState {
@@ -56,6 +59,7 @@ impl RuntimeState {
             writer_lock_owned: AtomicBool::new(true),
             http_inflight: AtomicUsize::new(0),
             grpc_inflight: AtomicUsize::new(0),
+            inflight_changed: Notify::new(),
         })
     }
 
@@ -101,15 +105,25 @@ impl RuntimeState {
         self.grpc_inflight.load(Ordering::SeqCst)
     }
 
+    pub fn total_inflight(&self) -> usize {
+        self.http_inflight() + self.grpc_inflight()
+    }
+
+    pub fn inflight_changed(&self) -> Notified<'_> {
+        self.inflight_changed.notified()
+    }
+
     pub fn start_http_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
         let count = self.http_inflight.fetch_add(1, Ordering::SeqCst) + 1;
         metrics.update_http_inflight(count);
+        self.inflight_changed.notify_waiters();
         InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Http)
     }
 
     pub fn start_grpc_request(self: &Arc<Self>, metrics: &Metrics) -> InflightGuard {
         let count = self.grpc_inflight.fetch_add(1, Ordering::SeqCst) + 1;
         metrics.update_grpc_inflight(count);
+        self.inflight_changed.notify_waiters();
         InflightGuard::new(self.clone(), metrics.clone(), InflightKind::Grpc)
     }
 }
@@ -156,6 +170,7 @@ impl Drop for InflightGuard {
                     .update_grpc_inflight(previous.saturating_sub(1));
             }
         }
+        self.runtime.inflight_changed.notify_waiters();
     }
 }
 
@@ -236,7 +251,10 @@ fn try_lock_exclusive(_file: &File) -> Result<(), std::io::Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use tempfile::tempdir;
+    use tokio::time::timeout;
 
     use super::*;
 
@@ -250,5 +268,19 @@ mod tests {
             first.path(),
             temp_dir.path().join(DATA_DIR_LOCK_FILE).as_path()
         );
+    }
+
+    #[tokio::test]
+    async fn inflight_change_notification_resolves_on_request_completion() {
+        let runtime = RuntimeState::new();
+        let metrics = Metrics::new("region".into(), "tenant".into());
+        let guard = runtime.start_http_request(&metrics);
+
+        let notified = runtime.inflight_changed();
+        drop(guard);
+
+        timeout(Duration::from_secs(1), notified)
+            .await
+            .expect("request completion should wake inflight waiters");
     }
 }

--- a/kura/src/runtime.rs
+++ b/kura/src/runtime.rs
@@ -43,7 +43,6 @@ impl TrafficState {
 pub struct RuntimeState {
     draining: AtomicBool,
     serving: AtomicBool,
-    initial_discovery_completed: AtomicBool,
     writer_lock_owned: AtomicBool,
     http_inflight: AtomicUsize,
     grpc_inflight: AtomicUsize,
@@ -54,7 +53,6 @@ impl RuntimeState {
         Arc::new(Self {
             draining: AtomicBool::new(false),
             serving: AtomicBool::new(false),
-            initial_discovery_completed: AtomicBool::new(false),
             writer_lock_owned: AtomicBool::new(true),
             http_inflight: AtomicUsize::new(0),
             grpc_inflight: AtomicUsize::new(0),
@@ -73,18 +71,12 @@ impl RuntimeState {
         !self.serving.swap(true, Ordering::SeqCst)
     }
 
+    pub fn clear_serving(&self) -> bool {
+        self.serving.swap(false, Ordering::SeqCst)
+    }
+
     pub fn is_serving(&self) -> bool {
         self.serving.load(Ordering::SeqCst)
-    }
-
-    pub fn mark_initial_discovery_completed(&self) -> bool {
-        !self
-            .initial_discovery_completed
-            .swap(true, Ordering::SeqCst)
-    }
-
-    pub fn initial_discovery_completed(&self) -> bool {
-        self.initial_discovery_completed.load(Ordering::SeqCst)
     }
 
     pub fn writer_lock_owned(&self) -> bool {

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    io::ErrorKind,
     path::PathBuf,
     sync::Arc,
 };
@@ -8,6 +9,7 @@ use reqwest::Client;
 use tokio::{
     fs,
     sync::{Mutex, Notify, RwLock},
+    time::{Duration, Instant},
 };
 
 use crate::{
@@ -20,6 +22,8 @@ use crate::{
     runtime::{DataDirLock, InflightGuard, RuntimeState, TrafficState},
     store::Store,
 };
+
+const READINESS_SETTLE_WINDOW: Duration = Duration::from_secs(5);
 
 pub struct AppState {
     pub config: Config,
@@ -37,6 +41,7 @@ pub struct AppState {
     pub peer_nodes: RwLock<BTreeMap<String, String>>,
     pub bootstrapped_peers: Mutex<BTreeSet<String>>,
     pub bootstrap_inflight_peers: Mutex<BTreeSet<String>>,
+    pub readiness_settle_until: Mutex<Instant>,
 }
 
 pub type SharedState = Arc<AppState>;
@@ -73,8 +78,37 @@ impl AppState {
         self.runtime.request_drain();
     }
 
-    pub fn mark_initial_discovery_completed(&self) {
+    pub async fn mark_initial_discovery_completed(&self) {
         self.runtime.mark_initial_discovery_completed();
+        self.extend_readiness_settle_window().await;
+    }
+
+    pub async fn clear_stale_drain_marker(&self) -> Result<bool, String> {
+        let drain_marker_path = self.drain_marker_path();
+        match fs::remove_file(&drain_marker_path).await {
+            Ok(()) => Ok(true),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(format!(
+                "failed to clear stale drain marker {}: {error}",
+                drain_marker_path.display()
+            )),
+        }
+    }
+
+    pub async fn extend_readiness_settle_window(&self) {
+        if self.runtime.is_serving() {
+            return;
+        }
+        *self.readiness_settle_until.lock().await = Instant::now() + READINESS_SETTLE_WINDOW;
+    }
+
+    async fn readiness_settle_window_elapsed(&self) -> bool {
+        Instant::now() >= *self.readiness_settle_until.lock().await
+    }
+
+    #[cfg(test)]
+    pub async fn expire_readiness_settle_window(&self) {
+        *self.readiness_settle_until.lock().await = Instant::now();
     }
 
     pub async fn refresh_drain_marker(&self) -> Result<(), String> {
@@ -149,6 +183,7 @@ impl AppState {
         if self.runtime.is_draining()
             || self.runtime.is_serving()
             || !self.runtime.initial_discovery_completed()
+            || !self.readiness_settle_window_elapsed().await
         {
             return;
         }
@@ -171,6 +206,7 @@ impl AppState {
         let state = self.runtime.traffic_state();
         let writer_lock_owned = self.runtime.writer_lock_owned();
         let initial_discovery_completed = self.runtime.initial_discovery_completed();
+        let readiness_settled = self.readiness_settle_window_elapsed().await;
         let known_peers = self
             .peer_nodes
             .read()
@@ -201,6 +237,9 @@ impl AppState {
         }
         if !initial_discovery_completed {
             reasons.push("initial discovery incomplete".to_string());
+        }
+        if !self.runtime.is_serving() && initial_discovery_completed && !readiness_settled {
+            reasons.push("discovery settling".to_string());
         }
         if !self.runtime.is_serving() && !bootstrap_inflight_peers.is_empty() {
             reasons.push("bootstrap in progress".to_string());

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -56,6 +56,24 @@ pub struct ReadinessReport {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct RolloutStatusReport {
+    pub generation: u64,
+    pub ready: bool,
+    pub state: TrafficState,
+    pub ring_members: usize,
+    pub initial_discovery_completed: bool,
+    pub writer_lock_owned: bool,
+    pub bootstrap_known_peers: usize,
+    pub bootstrap_completed_peers: usize,
+    pub bootstrap_inflight_peers: usize,
+    pub http_inflight: usize,
+    pub grpc_inflight: usize,
+    pub outbox_messages: u64,
+    pub memory_pressure_state: i64,
+    pub fd_timeout_count: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct ClusterStatusReport {
     pub generation: u64,
     pub members: Vec<String>,
@@ -348,6 +366,33 @@ impl AppState {
             bootstrap_inflight_peers: snapshot.bootstrap_inflight_peers,
             http_inflight: self.runtime.http_inflight(),
             grpc_inflight: self.runtime.grpc_inflight(),
+        }
+    }
+
+    pub async fn rollout_status_report(&self) -> RolloutStatusReport {
+        self.maybe_mark_serving().await;
+
+        let snapshot = self.readiness_snapshot().await;
+        let draining = self.runtime.is_draining();
+        let writer_lock_owned = self.runtime.writer_lock_owned();
+        let ready = writer_lock_owned && !draining && self.runtime.is_serving();
+        let metrics = self.metrics.rollout_metrics_snapshot();
+
+        RolloutStatusReport {
+            generation: snapshot.generation,
+            ready,
+            state: self.runtime.traffic_state(),
+            ring_members: snapshot.known_peers.len() + 1,
+            initial_discovery_completed: snapshot.initial_discovery_completed,
+            writer_lock_owned,
+            bootstrap_known_peers: snapshot.known_peers.len(),
+            bootstrap_completed_peers: snapshot.bootstrapped_peers.len(),
+            bootstrap_inflight_peers: snapshot.bootstrap_inflight_peers.len(),
+            http_inflight: self.runtime.http_inflight(),
+            grpc_inflight: self.runtime.grpc_inflight(),
+            outbox_messages: metrics.outbox_messages,
+            memory_pressure_state: self.memory.pressure().as_i64(),
+            fd_timeout_count: metrics.fd_timeout_count,
         }
     }
 

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -532,12 +532,7 @@ mod tests {
         let now = Instant::now();
         let mut readiness = ReadinessState::new(now);
 
-        let unobserved = readiness.apply_membership(
-            BTreeSet::new(),
-            BTreeSet::new(),
-            false,
-            now,
-        );
+        let unobserved = readiness.apply_membership(BTreeSet::new(), BTreeSet::new(), false, now);
         assert!(!unobserved.initial_discovery_completed);
         assert!(!unobserved.generation_changed);
         assert_eq!(readiness.generation, 0);

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -1,22 +1,34 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
     sync::Arc,
 };
 
 use reqwest::Client;
-use tokio::sync::{Mutex, Notify, RwLock};
+use tokio::{
+    fs,
+    sync::{Mutex, Notify, RwLock},
+};
 
 use crate::{
-    analytics::Analytics, config::Config, extension::SharedExtension, io::IoController,
-    memory::MemoryController, metrics::Metrics, store::Store,
+    analytics::Analytics,
+    config::Config,
+    extension::SharedExtension,
+    io::IoController,
+    memory::MemoryController,
+    metrics::Metrics,
+    runtime::{DataDirLock, InflightGuard, RuntimeState, TrafficState},
+    store::Store,
 };
 
 pub struct AppState {
     pub config: Config,
+    pub _data_dir_lock: DataDirLock,
     pub store: Store,
     pub io: IoController,
     pub memory: MemoryController,
     pub metrics: Metrics,
+    pub runtime: Arc<RuntimeState>,
     pub extension: Option<SharedExtension>,
     pub analytics: Option<Analytics>,
     pub client: Client,
@@ -24,6 +36,216 @@ pub struct AppState {
     pub members: RwLock<BTreeSet<String>>,
     pub peer_nodes: RwLock<BTreeMap<String, String>>,
     pub bootstrapped_peers: Mutex<BTreeSet<String>>,
+    pub bootstrap_inflight_peers: Mutex<BTreeSet<String>>,
 }
 
 pub type SharedState = Arc<AppState>;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReadinessReport {
+    pub ready: bool,
+    pub state: TrafficState,
+    pub reasons: Vec<String>,
+    pub draining: bool,
+    pub writer_lock_owned: bool,
+    pub initial_discovery_completed: bool,
+    pub known_peers: Vec<String>,
+    pub bootstrapped_peers: Vec<String>,
+    pub bootstrap_inflight_peers: Vec<String>,
+    pub http_inflight: usize,
+    pub grpc_inflight: usize,
+}
+
+impl AppState {
+    pub fn drain_marker_path(&self) -> PathBuf {
+        self.config.tmp_dir.join("drain")
+    }
+
+    pub fn start_http_request(&self) -> InflightGuard {
+        self.runtime.start_http_request(&self.metrics)
+    }
+
+    pub fn start_grpc_request(&self) -> InflightGuard {
+        self.runtime.start_grpc_request(&self.metrics)
+    }
+
+    pub fn enter_draining(&self) {
+        self.runtime.request_drain();
+    }
+
+    pub fn mark_initial_discovery_completed(&self) {
+        self.runtime.mark_initial_discovery_completed();
+    }
+
+    pub async fn refresh_drain_marker(&self) -> Result<(), String> {
+        if self.runtime.is_draining() {
+            return Ok(());
+        }
+        match fs::try_exists(self.drain_marker_path())
+            .await
+            .map_err(|error| format!("failed to inspect drain marker: {error}"))?
+        {
+            true => {
+                self.enter_draining();
+                Ok(())
+            }
+            false => Ok(()),
+        }
+    }
+
+    pub async fn forget_peers(&self, peers: &[String]) {
+        if peers.is_empty() {
+            return;
+        }
+        let peer_set = peers.iter().cloned().collect::<BTreeSet<_>>();
+        {
+            let mut bootstrapped = self.bootstrapped_peers.lock().await;
+            bootstrapped.retain(|peer| !peer_set.contains(peer));
+        }
+        {
+            let mut inflight = self.bootstrap_inflight_peers.lock().await;
+            inflight.retain(|peer| !peer_set.contains(peer));
+        }
+    }
+
+    pub async fn note_bootstrap_started(&self, peer: &str) -> bool {
+        {
+            let bootstrapped = self.bootstrapped_peers.lock().await;
+            if bootstrapped.contains(peer) {
+                return false;
+            }
+        }
+        let mut inflight = self.bootstrap_inflight_peers.lock().await;
+        if inflight.contains(peer) {
+            return false;
+        }
+        inflight.insert(peer.to_string());
+        true
+    }
+
+    pub async fn note_bootstrap_succeeded(&self, peer: &str) {
+        self.bootstrap_inflight_peers.lock().await.remove(peer);
+        self.bootstrapped_peers
+            .lock()
+            .await
+            .insert(peer.to_string());
+    }
+
+    pub async fn note_bootstrap_failed(&self, peer: &str) {
+        self.bootstrap_inflight_peers.lock().await.remove(peer);
+    }
+
+    async fn bootstrap_gate_satisfied(&self, known_peers: &[String]) -> bool {
+        let inflight = self.bootstrap_inflight_peers.lock().await;
+        if known_peers.iter().any(|peer| inflight.contains(peer)) {
+            return false;
+        }
+        drop(inflight);
+        let bootstrapped = self.bootstrapped_peers.lock().await;
+        known_peers.iter().all(|peer| bootstrapped.contains(peer))
+    }
+
+    pub async fn maybe_mark_serving(&self) {
+        if self.runtime.is_draining()
+            || self.runtime.is_serving()
+            || !self.runtime.initial_discovery_completed()
+        {
+            return;
+        }
+        let known_peers = self
+            .peer_nodes
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        if self.bootstrap_gate_satisfied(&known_peers).await {
+            self.runtime.mark_serving();
+        }
+    }
+
+    pub async fn readiness_report(&self) -> ReadinessReport {
+        self.maybe_mark_serving().await;
+
+        let draining = self.runtime.is_draining();
+        let state = self.runtime.traffic_state();
+        let writer_lock_owned = self.runtime.writer_lock_owned();
+        let initial_discovery_completed = self.runtime.initial_discovery_completed();
+        let known_peers = self
+            .peer_nodes
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let bootstrapped_peers = self
+            .bootstrapped_peers
+            .lock()
+            .await
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let bootstrap_inflight_peers = self
+            .bootstrap_inflight_peers
+            .lock()
+            .await
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut reasons = Vec::new();
+        if !writer_lock_owned {
+            reasons.push("writer lock not held".to_string());
+        }
+        if draining {
+            reasons.push("draining".to_string());
+        }
+        if !initial_discovery_completed {
+            reasons.push("initial discovery incomplete".to_string());
+        }
+        if !self.runtime.is_serving() && !bootstrap_inflight_peers.is_empty() {
+            reasons.push("bootstrap in progress".to_string());
+        }
+        if !self.runtime.is_serving() {
+            let bootstrapped = bootstrapped_peers.iter().cloned().collect::<BTreeSet<_>>();
+            let missing = known_peers
+                .iter()
+                .filter(|peer| !bootstrapped.contains(*peer))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !missing.is_empty() {
+                reasons.push(format!("bootstrap incomplete for {}", missing.join(", ")));
+            }
+        }
+
+        let ready = writer_lock_owned && !draining && self.runtime.is_serving();
+        ReadinessReport {
+            ready,
+            state,
+            reasons,
+            draining,
+            writer_lock_owned,
+            initial_discovery_completed,
+            known_peers,
+            bootstrapped_peers,
+            bootstrap_inflight_peers,
+            http_inflight: self.runtime.http_inflight(),
+            grpc_inflight: self.runtime.grpc_inflight(),
+        }
+    }
+
+    pub async fn sync_runtime_metrics(&self) {
+        let report = self.readiness_report().await;
+        self.metrics.update_runtime_state(
+            report.state.as_i64(),
+            report.ready,
+            report.draining,
+            report.initial_discovery_completed,
+            report.writer_lock_owned,
+        );
+        self.metrics.update_bootstrap_peers(
+            report.known_peers.len(),
+            report.bootstrapped_peers.len(),
+            report.bootstrap_inflight_peers.len(),
+        );
+    }
+}

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -128,6 +128,7 @@ impl ReadinessState {
         &mut self,
         members: BTreeSet<String>,
         known_peers: BTreeSet<String>,
+        discovery_observed: bool,
         now: Instant,
     ) -> MembershipUpdate {
         let discovered_peers = known_peers
@@ -142,10 +143,14 @@ impl ReadinessState {
         let topology_changed = !discovered_peers.is_empty() || !lost_peers.is_empty();
         let generation_changed;
         if !self.initial_discovery_completed {
-            self.initial_discovery_completed = true;
-            self.generation += 1;
-            self.settle_until = now + READINESS_SETTLE_WINDOW;
-            generation_changed = true;
+            if discovery_observed {
+                self.initial_discovery_completed = true;
+                self.generation += 1;
+                self.settle_until = now + READINESS_SETTLE_WINDOW;
+                generation_changed = true;
+            } else {
+                generation_changed = false;
+            }
         } else if topology_changed {
             self.generation += 1;
             self.settle_until = now + READINESS_SETTLE_WINDOW;
@@ -192,6 +197,17 @@ impl ReadinessState {
         self.bootstrap_inflight_peers.remove(peer);
     }
 
+    fn peers_needing_bootstrap(&self) -> Vec<String> {
+        self.known_peers
+            .iter()
+            .filter(|peer| {
+                !self.bootstrapped_peers.contains(*peer)
+                    && !self.bootstrap_inflight_peers.contains(*peer)
+            })
+            .cloned()
+            .collect()
+    }
+
     fn snapshot(&self, now: Instant) -> ReadinessSnapshot {
         ReadinessSnapshot {
             generation: self.generation,
@@ -227,18 +243,27 @@ impl AppState {
         &self,
         members: BTreeSet<String>,
         peer_nodes: BTreeMap<String, String>,
+        discovery_observed: bool,
     ) -> MembershipUpdate {
         let known_peers = peer_nodes.keys().cloned().collect::<BTreeSet<_>>();
 
         {
             let mut readiness = self.readiness.lock().await;
-            let membership_update =
-                readiness.apply_membership(members, known_peers, Instant::now());
+            let membership_update = readiness.apply_membership(
+                members,
+                known_peers,
+                discovery_observed,
+                Instant::now(),
+            );
             if membership_update.generation_changed {
                 self.runtime.clear_serving();
             }
             membership_update
         }
+    }
+
+    pub async fn peers_needing_bootstrap(&self) -> Vec<String> {
+        self.readiness.lock().await.peers_needing_bootstrap()
     }
 
     pub async fn note_bootstrap_started(&self, peer: &str) -> bool {
@@ -432,6 +457,7 @@ mod tests {
                 "http://peer-a.kura.internal:7443".to_string(),
                 "http://peer-b.kura.internal:7443".to_string(),
             ]),
+            true,
             now,
         );
         assert_eq!(readiness.generation, 1);
@@ -460,6 +486,7 @@ mod tests {
                 "http://peer-a.kura.internal:7443".to_string(),
                 "http://peer-c.kura.internal:7443".to_string(),
             ]),
+            true,
             now + Duration::from_secs(1),
         );
         assert_eq!(readiness.generation, 2);
@@ -490,6 +517,7 @@ mod tests {
         readiness.apply_membership(
             BTreeSet::from(["remote".to_string()]),
             BTreeSet::from(["http://peer.kura.internal:7443".to_string()]),
+            true,
             now,
         );
 
@@ -497,6 +525,58 @@ mod tests {
         assert!(!readiness.note_bootstrap_started("http://peer.kura.internal:7443"));
         readiness.note_bootstrap_failed("http://peer.kura.internal:7443");
         assert!(readiness.note_bootstrap_started("http://peer.kura.internal:7443"));
+    }
+
+    #[test]
+    fn readiness_state_keeps_joining_until_discovery_succeeds() {
+        let now = Instant::now();
+        let mut readiness = ReadinessState::new(now);
+
+        let unobserved = readiness.apply_membership(
+            BTreeSet::new(),
+            BTreeSet::new(),
+            false,
+            now,
+        );
+        assert!(!unobserved.initial_discovery_completed);
+        assert!(!unobserved.generation_changed);
+        assert_eq!(readiness.generation, 0);
+
+        let observed = readiness.apply_membership(
+            BTreeSet::new(),
+            BTreeSet::new(),
+            true,
+            now + Duration::from_secs(1),
+        );
+        assert!(observed.initial_discovery_completed);
+        assert!(observed.generation_changed);
+        assert_eq!(readiness.generation, 1);
+    }
+
+    #[test]
+    fn peers_needing_bootstrap_excludes_completed_and_inflight_entries() {
+        let now = Instant::now();
+        let mut readiness = ReadinessState::new(now);
+        let peer_a = "http://peer-a.kura.internal:7443".to_string();
+        let peer_b = "http://peer-b.kura.internal:7443".to_string();
+        let peer_c = "http://peer-c.kura.internal:7443".to_string();
+        readiness.apply_membership(
+            BTreeSet::from(["a".to_string(), "b".to_string(), "c".to_string()]),
+            BTreeSet::from([peer_a.clone(), peer_b.clone(), peer_c.clone()]),
+            true,
+            now,
+        );
+
+        readiness.note_bootstrap_succeeded(&peer_a);
+        assert!(readiness.note_bootstrap_started(&peer_b));
+
+        let pending = readiness.peers_needing_bootstrap();
+        assert_eq!(pending, vec![peer_c.clone()]);
+
+        readiness.note_bootstrap_failed(&peer_b);
+        let mut after_failure = readiness.peers_needing_bootstrap();
+        after_failure.sort();
+        assert_eq!(after_failure, vec![peer_b, peer_c]);
     }
 
     #[tokio::test]
@@ -508,6 +588,7 @@ mod tests {
             .apply_membership_view(
                 BTreeSet::from(["remote".to_string()]),
                 BTreeMap::from([(peer.clone(), "remote".to_string())]),
+                true,
             )
             .await;
 
@@ -548,6 +629,7 @@ mod tests {
             .apply_membership_view(
                 BTreeSet::from(["remote-a".to_string()]),
                 BTreeMap::from([(peer_a.clone(), "remote-a".to_string())]),
+                true,
             )
             .await;
         context.state.note_bootstrap_succeeded(&peer_a).await;
@@ -566,6 +648,7 @@ mod tests {
                     (peer_a.clone(), "remote-a".to_string()),
                     (peer_b.clone(), "remote-b".to_string()),
                 ]),
+                true,
             )
             .await;
 

--- a/kura/src/state.rs
+++ b/kura/src/state.rs
@@ -1,14 +1,11 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    io::ErrorKind,
-    path::PathBuf,
     sync::Arc,
 };
 
 use reqwest::Client;
 use tokio::{
-    fs,
-    sync::{Mutex, Notify, RwLock},
+    sync::{Mutex, Notify},
     time::{Duration, Instant},
 };
 
@@ -37,17 +34,14 @@ pub struct AppState {
     pub analytics: Option<Analytics>,
     pub client: Client,
     pub notify: Notify,
-    pub members: RwLock<BTreeSet<String>>,
-    pub peer_nodes: RwLock<BTreeMap<String, String>>,
-    pub bootstrapped_peers: Mutex<BTreeSet<String>>,
-    pub bootstrap_inflight_peers: Mutex<BTreeSet<String>>,
-    pub readiness_settle_until: Mutex<Instant>,
+    pub readiness: Mutex<ReadinessState>,
 }
 
 pub type SharedState = Arc<AppState>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReadinessReport {
+    pub generation: u64,
     pub ready: bool,
     pub state: TrafficState,
     pub reasons: Vec<String>,
@@ -61,11 +55,139 @@ pub struct ReadinessReport {
     pub grpc_inflight: usize,
 }
 
-impl AppState {
-    pub fn drain_marker_path(&self) -> PathBuf {
-        self.config.tmp_dir.join("drain")
+#[derive(Debug, PartialEq, Eq)]
+pub struct ClusterStatusReport {
+    pub generation: u64,
+    pub members: Vec<String>,
+    pub connected_nodes: Vec<String>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct MembershipUpdate {
+    pub discovered_peers: Vec<String>,
+    pub lost_peers: Vec<String>,
+    pub known_peer_count: usize,
+    pub initial_discovery_completed: bool,
+    pub generation_changed: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadinessState {
+    generation: u64,
+    initial_discovery_completed: bool,
+    settle_until: Instant,
+    members: BTreeSet<String>,
+    known_peers: BTreeSet<String>,
+    bootstrapped_peers: BTreeSet<String>,
+    bootstrap_inflight_peers: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReadinessSnapshot {
+    generation: u64,
+    initial_discovery_completed: bool,
+    readiness_settled: bool,
+    members: Vec<String>,
+    known_peers: Vec<String>,
+    bootstrapped_peers: Vec<String>,
+    bootstrap_inflight_peers: Vec<String>,
+}
+
+impl ReadinessState {
+    pub(crate) fn new(now: Instant) -> Self {
+        Self {
+            generation: 0,
+            initial_discovery_completed: false,
+            settle_until: now,
+            members: BTreeSet::new(),
+            known_peers: BTreeSet::new(),
+            bootstrapped_peers: BTreeSet::new(),
+            bootstrap_inflight_peers: BTreeSet::new(),
+        }
     }
 
+    fn apply_membership(
+        &mut self,
+        members: BTreeSet<String>,
+        known_peers: BTreeSet<String>,
+        now: Instant,
+    ) -> MembershipUpdate {
+        let discovered_peers = known_peers
+            .difference(&self.known_peers)
+            .cloned()
+            .collect::<Vec<_>>();
+        let lost_peers = self
+            .known_peers
+            .difference(&known_peers)
+            .cloned()
+            .collect::<Vec<_>>();
+        let topology_changed = !discovered_peers.is_empty() || !lost_peers.is_empty();
+        let generation_changed;
+        if !self.initial_discovery_completed {
+            self.initial_discovery_completed = true;
+            self.generation += 1;
+            self.settle_until = now + READINESS_SETTLE_WINDOW;
+            generation_changed = true;
+        } else if topology_changed {
+            self.generation += 1;
+            self.settle_until = now + READINESS_SETTLE_WINDOW;
+            generation_changed = true;
+        } else {
+            generation_changed = false;
+        }
+
+        self.members = members;
+        self.known_peers = known_peers;
+        self.bootstrapped_peers
+            .retain(|peer| self.known_peers.contains(peer));
+        self.bootstrap_inflight_peers
+            .retain(|peer| self.known_peers.contains(peer));
+
+        MembershipUpdate {
+            discovered_peers,
+            lost_peers,
+            known_peer_count: self.known_peers.len(),
+            initial_discovery_completed: self.initial_discovery_completed,
+            generation_changed,
+        }
+    }
+
+    fn note_bootstrap_started(&mut self, peer: &str) -> bool {
+        if !self.known_peers.contains(peer)
+            || self.bootstrapped_peers.contains(peer)
+            || self.bootstrap_inflight_peers.contains(peer)
+        {
+            return false;
+        }
+        self.bootstrap_inflight_peers.insert(peer.to_string());
+        true
+    }
+
+    fn note_bootstrap_succeeded(&mut self, peer: &str) {
+        self.bootstrap_inflight_peers.remove(peer);
+        if self.known_peers.contains(peer) {
+            self.bootstrapped_peers.insert(peer.to_string());
+        }
+    }
+
+    fn note_bootstrap_failed(&mut self, peer: &str) {
+        self.bootstrap_inflight_peers.remove(peer);
+    }
+
+    fn snapshot(&self, now: Instant) -> ReadinessSnapshot {
+        ReadinessSnapshot {
+            generation: self.generation,
+            initial_discovery_completed: self.initial_discovery_completed,
+            readiness_settled: now >= self.settle_until,
+            members: self.members.iter().cloned().collect(),
+            known_peers: self.known_peers.iter().cloned().collect(),
+            bootstrapped_peers: self.bootstrapped_peers.iter().cloned().collect(),
+            bootstrap_inflight_peers: self.bootstrap_inflight_peers.iter().cloned().collect(),
+        }
+    }
+}
+
+impl AppState {
     pub fn start_http_request(&self) -> InflightGuard {
         self.runtime.start_http_request(&self.metrics)
     }
@@ -74,127 +196,97 @@ impl AppState {
         self.runtime.start_grpc_request(&self.metrics)
     }
 
-    pub fn enter_draining(&self) {
-        self.runtime.request_drain();
-    }
-
-    pub async fn mark_initial_discovery_completed(&self) {
-        self.runtime.mark_initial_discovery_completed();
-        self.extend_readiness_settle_window().await;
-    }
-
-    pub async fn clear_stale_drain_marker(&self) -> Result<bool, String> {
-        let drain_marker_path = self.drain_marker_path();
-        match fs::remove_file(&drain_marker_path).await {
-            Ok(()) => Ok(true),
-            Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
-            Err(error) => Err(format!(
-                "failed to clear stale drain marker {}: {error}",
-                drain_marker_path.display()
-            )),
-        }
-    }
-
-    pub async fn extend_readiness_settle_window(&self) {
-        if self.runtime.is_serving() {
-            return;
-        }
-        *self.readiness_settle_until.lock().await = Instant::now() + READINESS_SETTLE_WINDOW;
-    }
-
-    async fn readiness_settle_window_elapsed(&self) -> bool {
-        Instant::now() >= *self.readiness_settle_until.lock().await
+    pub fn enter_draining(&self) -> bool {
+        self.runtime.request_drain()
     }
 
     #[cfg(test)]
     pub async fn expire_readiness_settle_window(&self) {
-        *self.readiness_settle_until.lock().await = Instant::now();
+        self.readiness.lock().await.settle_until = Instant::now();
     }
 
-    pub async fn refresh_drain_marker(&self) -> Result<(), String> {
-        if self.runtime.is_draining() {
-            return Ok(());
-        }
-        match fs::try_exists(self.drain_marker_path())
-            .await
-            .map_err(|error| format!("failed to inspect drain marker: {error}"))?
+    pub async fn apply_membership_view(
+        &self,
+        members: BTreeSet<String>,
+        peer_nodes: BTreeMap<String, String>,
+    ) -> MembershipUpdate {
+        let known_peers = peer_nodes.keys().cloned().collect::<BTreeSet<_>>();
+
         {
-            true => {
-                self.enter_draining();
-                Ok(())
+            let mut readiness = self.readiness.lock().await;
+            let membership_update =
+                readiness.apply_membership(members, known_peers, Instant::now());
+            if membership_update.generation_changed {
+                self.runtime.clear_serving();
             }
-            false => Ok(()),
-        }
-    }
-
-    pub async fn forget_peers(&self, peers: &[String]) {
-        if peers.is_empty() {
-            return;
-        }
-        let peer_set = peers.iter().cloned().collect::<BTreeSet<_>>();
-        {
-            let mut bootstrapped = self.bootstrapped_peers.lock().await;
-            bootstrapped.retain(|peer| !peer_set.contains(peer));
-        }
-        {
-            let mut inflight = self.bootstrap_inflight_peers.lock().await;
-            inflight.retain(|peer| !peer_set.contains(peer));
+            membership_update
         }
     }
 
     pub async fn note_bootstrap_started(&self, peer: &str) -> bool {
-        {
-            let bootstrapped = self.bootstrapped_peers.lock().await;
-            if bootstrapped.contains(peer) {
-                return false;
-            }
-        }
-        let mut inflight = self.bootstrap_inflight_peers.lock().await;
-        if inflight.contains(peer) {
-            return false;
-        }
-        inflight.insert(peer.to_string());
-        true
+        self.readiness.lock().await.note_bootstrap_started(peer)
     }
 
     pub async fn note_bootstrap_succeeded(&self, peer: &str) {
-        self.bootstrap_inflight_peers.lock().await.remove(peer);
-        self.bootstrapped_peers
-            .lock()
-            .await
-            .insert(peer.to_string());
+        self.readiness.lock().await.note_bootstrap_succeeded(peer);
     }
 
     pub async fn note_bootstrap_failed(&self, peer: &str) {
-        self.bootstrap_inflight_peers.lock().await.remove(peer);
+        self.readiness.lock().await.note_bootstrap_failed(peer);
     }
 
-    async fn bootstrap_gate_satisfied(&self, known_peers: &[String]) -> bool {
-        let inflight = self.bootstrap_inflight_peers.lock().await;
-        if known_peers.iter().any(|peer| inflight.contains(peer)) {
-            return false;
+    async fn readiness_snapshot(&self) -> ReadinessSnapshot {
+        self.readiness.lock().await.snapshot(Instant::now())
+    }
+
+    pub async fn cluster_status_report(&self) -> ClusterStatusReport {
+        let snapshot = self.readiness_snapshot().await;
+        ClusterStatusReport {
+            generation: snapshot.generation,
+            members: snapshot.members,
+            connected_nodes: snapshot.known_peers,
         }
-        drop(inflight);
-        let bootstrapped = self.bootstrapped_peers.lock().await;
-        known_peers.iter().all(|peer| bootstrapped.contains(peer))
+    }
+
+    pub async fn replication_targets(&self) -> Vec<String> {
+        let snapshot = self.readiness_snapshot().await;
+        let mut targets = self.config.peers.iter().cloned().collect::<BTreeSet<_>>();
+        targets.extend(snapshot.known_peers);
+        targets.remove(&self.config.node_url);
+        targets.into_iter().collect()
     }
 
     pub async fn maybe_mark_serving(&self) {
-        if self.runtime.is_draining()
-            || self.runtime.is_serving()
-            || !self.runtime.initial_discovery_completed()
-            || !self.readiness_settle_window_elapsed().await
+        if self.runtime.is_draining() || self.runtime.is_serving() {
+            return;
+        }
+        let snapshot = self.readiness_snapshot().await;
+        if !snapshot.initial_discovery_completed || !snapshot.readiness_settled {
+            return;
+        }
+
+        let bootstrapped = snapshot
+            .bootstrapped_peers
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let bootstrap_inflight = snapshot
+            .bootstrap_inflight_peers
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if snapshot
+            .known_peers
+            .iter()
+            .any(|peer| bootstrap_inflight.contains(peer))
         {
             return;
         }
-        let known_peers = self
-            .peer_nodes
-            .read()
-            .await
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        if self.bootstrap_gate_satisfied(&known_peers).await {
+        if snapshot
+            .known_peers
+            .iter()
+            .all(|peer| bootstrapped.contains(peer))
+        {
             self.runtime.mark_serving();
         }
     }
@@ -202,32 +294,10 @@ impl AppState {
     pub async fn readiness_report(&self) -> ReadinessReport {
         self.maybe_mark_serving().await;
 
+        let snapshot = self.readiness_snapshot().await;
         let draining = self.runtime.is_draining();
         let state = self.runtime.traffic_state();
         let writer_lock_owned = self.runtime.writer_lock_owned();
-        let initial_discovery_completed = self.runtime.initial_discovery_completed();
-        let readiness_settled = self.readiness_settle_window_elapsed().await;
-        let known_peers = self
-            .peer_nodes
-            .read()
-            .await
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        let bootstrapped_peers = self
-            .bootstrapped_peers
-            .lock()
-            .await
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        let bootstrap_inflight_peers = self
-            .bootstrap_inflight_peers
-            .lock()
-            .await
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
         let mut reasons = Vec::new();
         if !writer_lock_owned {
             reasons.push("writer lock not held".to_string());
@@ -235,18 +305,26 @@ impl AppState {
         if draining {
             reasons.push("draining".to_string());
         }
-        if !initial_discovery_completed {
+        if !snapshot.initial_discovery_completed {
             reasons.push("initial discovery incomplete".to_string());
         }
-        if !self.runtime.is_serving() && initial_discovery_completed && !readiness_settled {
+        if !self.runtime.is_serving()
+            && snapshot.initial_discovery_completed
+            && !snapshot.readiness_settled
+        {
             reasons.push("discovery settling".to_string());
         }
-        if !self.runtime.is_serving() && !bootstrap_inflight_peers.is_empty() {
+        if !self.runtime.is_serving() && !snapshot.bootstrap_inflight_peers.is_empty() {
             reasons.push("bootstrap in progress".to_string());
         }
         if !self.runtime.is_serving() {
-            let bootstrapped = bootstrapped_peers.iter().cloned().collect::<BTreeSet<_>>();
-            let missing = known_peers
+            let bootstrapped = snapshot
+                .bootstrapped_peers
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let missing = snapshot
+                .known_peers
                 .iter()
                 .filter(|peer| !bootstrapped.contains(*peer))
                 .cloned()
@@ -258,15 +336,16 @@ impl AppState {
 
         let ready = writer_lock_owned && !draining && self.runtime.is_serving();
         ReadinessReport {
+            generation: snapshot.generation,
             ready,
             state,
             reasons,
             draining,
             writer_lock_owned,
-            initial_discovery_completed,
-            known_peers,
-            bootstrapped_peers,
-            bootstrap_inflight_peers,
+            initial_discovery_completed: snapshot.initial_discovery_completed,
+            known_peers: snapshot.known_peers,
+            bootstrapped_peers: snapshot.bootstrapped_peers,
+            bootstrap_inflight_peers: snapshot.bootstrap_inflight_peers,
             http_inflight: self.runtime.http_inflight(),
             grpc_inflight: self.runtime.grpc_inflight(),
         }
@@ -285,6 +364,174 @@ impl AppState {
             report.known_peers.len(),
             report.bootstrapped_peers.len(),
             report.bootstrap_inflight_peers.len(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::Barrier;
+
+    use crate::test_support::test_context;
+
+    use super::*;
+
+    #[test]
+    fn readiness_state_advances_generation_and_reconciles_peer_sets() {
+        let now = Instant::now();
+        let mut readiness = ReadinessState::new(now);
+
+        let initial = readiness.apply_membership(
+            BTreeSet::from(["remote-a".to_string(), "remote-b".to_string()]),
+            BTreeSet::from([
+                "http://peer-a.kura.internal:7443".to_string(),
+                "http://peer-b.kura.internal:7443".to_string(),
+            ]),
+            now,
+        );
+        assert_eq!(readiness.generation, 1);
+        assert!(initial.initial_discovery_completed);
+        assert!(initial.lost_peers.is_empty());
+        assert_eq!(initial.known_peer_count, 2);
+        assert_eq!(
+            initial.discovered_peers,
+            vec![
+                "http://peer-a.kura.internal:7443".to_string(),
+                "http://peer-b.kura.internal:7443".to_string()
+            ]
+        );
+
+        assert!(readiness.note_bootstrap_started("http://peer-a.kura.internal:7443"));
+        readiness.note_bootstrap_succeeded("http://peer-a.kura.internal:7443");
+        assert!(
+            readiness
+                .bootstrapped_peers
+                .contains("http://peer-a.kura.internal:7443")
+        );
+
+        let topology_change = readiness.apply_membership(
+            BTreeSet::from(["remote-a".to_string(), "remote-c".to_string()]),
+            BTreeSet::from([
+                "http://peer-a.kura.internal:7443".to_string(),
+                "http://peer-c.kura.internal:7443".to_string(),
+            ]),
+            now + Duration::from_secs(1),
+        );
+        assert_eq!(readiness.generation, 2);
+        assert_eq!(
+            topology_change.discovered_peers,
+            vec!["http://peer-c.kura.internal:7443".to_string()]
+        );
+        assert_eq!(
+            topology_change.lost_peers,
+            vec!["http://peer-b.kura.internal:7443".to_string()]
+        );
+        assert!(
+            readiness
+                .bootstrapped_peers
+                .contains("http://peer-a.kura.internal:7443")
+        );
+        assert!(
+            !readiness
+                .bootstrapped_peers
+                .contains("http://peer-b.kura.internal:7443")
+        );
+    }
+
+    #[test]
+    fn readiness_state_deduplicates_bootstrap_start_per_peer() {
+        let now = Instant::now();
+        let mut readiness = ReadinessState::new(now);
+        readiness.apply_membership(
+            BTreeSet::from(["remote".to_string()]),
+            BTreeSet::from(["http://peer.kura.internal:7443".to_string()]),
+            now,
+        );
+
+        assert!(readiness.note_bootstrap_started("http://peer.kura.internal:7443"));
+        assert!(!readiness.note_bootstrap_started("http://peer.kura.internal:7443"));
+        readiness.note_bootstrap_failed("http://peer.kura.internal:7443");
+        assert!(readiness.note_bootstrap_started("http://peer.kura.internal:7443"));
+    }
+
+    #[tokio::test]
+    async fn app_state_serializes_concurrent_bootstrap_start_requests() {
+        let context = test_context(|_| {}).await;
+        let peer = "http://peer.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote".to_string()]),
+                BTreeMap::from([(peer.clone(), "remote".to_string())]),
+            )
+            .await;
+
+        let barrier = Arc::new(Barrier::new(3));
+        let state_one = context.state.clone();
+        let barrier_one = barrier.clone();
+        let peer_one = peer.clone();
+        let first = tokio::spawn(async move {
+            barrier_one.wait().await;
+            state_one.note_bootstrap_started(&peer_one).await
+        });
+        let state_two = context.state.clone();
+        let barrier_two = barrier.clone();
+        let second = tokio::spawn(async move {
+            barrier_two.wait().await;
+            state_two.note_bootstrap_started(&peer).await
+        });
+
+        barrier.wait().await;
+        let first_started = first.await.expect("first bootstrap task should finish");
+        let second_started = second.await.expect("second bootstrap task should finish");
+        assert_eq!(
+            [first_started, second_started]
+                .into_iter()
+                .filter(|started| *started)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn app_state_returns_to_joining_when_membership_generation_advances() {
+        let context = test_context(|_| {}).await;
+        let peer_a = "http://peer-a.kura.internal:7443".to_string();
+        let peer_b = "http://peer-b.kura.internal:7443".to_string();
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote-a".to_string()]),
+                BTreeMap::from([(peer_a.clone(), "remote-a".to_string())]),
+            )
+            .await;
+        context.state.note_bootstrap_succeeded(&peer_a).await;
+        context.state.expire_readiness_settle_window().await;
+        context.state.maybe_mark_serving().await;
+
+        let serving = context.state.readiness_report().await;
+        assert!(serving.ready);
+        assert_eq!(serving.state, TrafficState::Serving);
+
+        context
+            .state
+            .apply_membership_view(
+                BTreeSet::from(["remote-a".to_string(), "remote-b".to_string()]),
+                BTreeMap::from([
+                    (peer_a.clone(), "remote-a".to_string()),
+                    (peer_b.clone(), "remote-b".to_string()),
+                ]),
+            )
+            .await;
+
+        let joining = context.state.readiness_report().await;
+        assert!(!joining.ready);
+        assert_eq!(joining.state, TrafficState::Joining);
+        assert!(
+            joining
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("discovery settling"))
         );
     }
 }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -2181,6 +2181,7 @@ mod tests {
             peer_tls: None,
             file_descriptor_pool_size: 32,
             file_descriptor_acquire_timeout_ms: 5_000,
+            drain_completion_timeout_ms: 240_000,
             segment_handle_cache_size: 8,
             memory_soft_limit_bytes: 128 * 1024 * 1024,
             memory_hard_limit_bytes: 256 * 1024 * 1024,

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -9,6 +9,7 @@ use http_body_util::BodyExt;
 use reqwest::Client;
 use tempfile::TempDir;
 use tokio::sync::{Notify, RwLock};
+use tokio::time::Instant;
 
 use crate::{
     analytics::Analytics,
@@ -119,6 +120,7 @@ where
         peer_nodes: RwLock::new(BTreeMap::new()),
         bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
         bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
+        readiness_settle_until: tokio::sync::Mutex::new(Instant::now()),
     });
     state.sync_runtime_metrics().await;
 

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -11,8 +11,15 @@ use tempfile::TempDir;
 use tokio::sync::{Notify, RwLock};
 
 use crate::{
-    analytics::Analytics, config::Config, extension::SharedExtension, io::IoController,
-    memory::MemoryController, metrics::Metrics, state::AppState, store::Store,
+    analytics::Analytics,
+    config::Config,
+    extension::SharedExtension,
+    io::IoController,
+    memory::MemoryController,
+    metrics::Metrics,
+    runtime::{DataDirLock, RuntimeState},
+    state::AppState,
+    store::Store,
 };
 
 pub(crate) struct TestContext {
@@ -85,6 +92,8 @@ where
         config.memory_soft_limit_bytes,
         config.memory_hard_limit_bytes,
     );
+    let data_dir_lock =
+        DataDirLock::acquire(&config.data_dir).expect("failed to acquire test writer lock");
     let store =
         Store::open(&config, io.clone(), memory.clone()).expect("failed to open test store");
     let analytics =
@@ -96,10 +105,12 @@ where
         .expect("failed to build test client");
     let state = Arc::new(AppState {
         config,
+        _data_dir_lock: data_dir_lock,
         store,
         io,
         memory,
         metrics,
+        runtime: RuntimeState::new(),
         extension,
         analytics,
         client,
@@ -107,7 +118,9 @@ where
         members: RwLock::new(BTreeSet::new()),
         peer_nodes: RwLock::new(BTreeMap::new()),
         bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
+        bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
     });
+    state.sync_runtime_metrics().await;
 
     TestContext {
         _temp_dir: temp_dir,

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -53,6 +53,7 @@ where
         peer_tls: None,
         file_descriptor_pool_size: 32,
         file_descriptor_acquire_timeout_ms: 5_000,
+        drain_completion_timeout_ms: 240_000,
         segment_handle_cache_size: 8,
         memory_soft_limit_bytes: 128 * 1024 * 1024,
         memory_hard_limit_bytes: 256 * 1024 * 1024,

--- a/kura/src/test_support.rs
+++ b/kura/src/test_support.rs
@@ -1,14 +1,10 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use axum::response::Response;
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tempfile::TempDir;
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::Notify;
 use tokio::time::Instant;
 
 use crate::{
@@ -19,7 +15,7 @@ use crate::{
     memory::MemoryController,
     metrics::Metrics,
     runtime::{DataDirLock, RuntimeState},
-    state::AppState,
+    state::{AppState, ReadinessState},
     store::Store,
 };
 
@@ -116,11 +112,7 @@ where
         analytics,
         client,
         notify: Notify::new(),
-        members: RwLock::new(BTreeSet::new()),
-        peer_nodes: RwLock::new(BTreeMap::new()),
-        bootstrapped_peers: tokio::sync::Mutex::new(BTreeSet::new()),
-        bootstrap_inflight_peers: tokio::sync::Mutex::new(BTreeSet::new()),
-        readiness_settle_until: tokio::sync::Mutex::new(Instant::now()),
+        readiness: tokio::sync::Mutex::new(ReadinessState::new(Instant::now())),
     });
     state.sync_runtime_metrics().await;
 

--- a/kura/test/e2e/kura_compatibility_rollout.sh
+++ b/kura/test/e2e/kura_compatibility_rollout.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREVIOUS_REF="${PREVIOUS_REF:-}"
+CURRENT_REF="${CURRENT_REF:-HEAD}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-kura-compat}"
+KURA_US_PORT="${KURA_US_PORT:-4701}"
+KURA_EU_PORT="${KURA_EU_PORT:-4702}"
+PREVIOUS_IMAGE="${PREVIOUS_IMAGE:-kura-compat-previous:latest}"
+CURRENT_IMAGE="${CURRENT_IMAGE:-kura-compat-current:latest}"
+
+if [[ -z "${PREVIOUS_REF}" ]]; then
+  echo "Set PREVIOUS_REF to the adjacent version ref to validate, for example PREVIOUS_REF=origin/main" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kura-compat.XXXXXX")"
+PREVIOUS_WORKTREE="${TMP_DIR}/previous"
+PREVIOUS_OVERRIDE="${TMP_DIR}/compose.previous.yml"
+MIXED_OVERRIDE="${TMP_DIR}/compose.mixed.yml"
+
+cleanup() {
+  docker compose -p "${COMPOSE_PROJECT_NAME}" \
+    -f "${PROJECT_ROOT}/docker-compose.yml" \
+    -f "${PREVIOUS_OVERRIDE}" \
+    down -v --remove-orphans >/dev/null 2>&1 || true
+  if git -C "${PROJECT_ROOT}" worktree list --porcelain 2>/dev/null | grep -q "^worktree ${PREVIOUS_WORKTREE}\$"; then
+    git -C "${PROJECT_ROOT}" worktree remove --force "${PREVIOUS_WORKTREE}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+dc() {
+  docker compose -p "${COMPOSE_PROJECT_NAME}" \
+    -f "${PROJECT_ROOT}/docker-compose.yml" \
+    -f "$1" \
+    "${@:2}"
+}
+
+build_image_from_ref() {
+  local ref="$1"
+  local image="$2"
+  local context_dir="$3"
+
+  if [[ "${ref}" == "${CURRENT_REF}" ]]; then
+    docker build -t "${image}" "${PROJECT_ROOT}"
+    return
+  fi
+
+  git -C "${PROJECT_ROOT}" worktree add --detach "${context_dir}" "${ref}" >/dev/null
+  docker build -t "${image}" "${context_dir}"
+}
+
+write_override() {
+  local path="$1"
+  local kura_us_image="$2"
+  local kura_eu_image="$3"
+
+  cat >"${path}" <<EOF
+services:
+  kura-us:
+    build: null
+    image: ${kura_us_image}
+    pull_policy: never
+  kura-eu:
+    build: null
+    image: ${kura_eu_image}
+    pull_policy: never
+EOF
+}
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-90}"
+
+  for _ in $(seq 1 "${attempts}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${url}" >&2
+  return 1
+}
+
+wait_for_body() {
+  local url="$1"
+  local expected="$2"
+  local attempts="${3:-90}"
+
+  for _ in $(seq 1 "${attempts}"); do
+    local body
+    body="$(curl -fsS "${url}" 2>/dev/null || true)"
+    if [[ "${body}" == "${expected}" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${expected} from ${url}" >&2
+  return 1
+}
+
+put_artifact() {
+  local url="$1"
+  local artifact_id="$2"
+  local payload="$3"
+  curl -fsS -X POST \
+    "${url}/api/cache/cas/${artifact_id}?tenant_id=acme&namespace_id=ios" \
+    -H "content-type: application/octet-stream" \
+    --data-binary "${payload}" >/dev/null
+}
+
+artifact_url() {
+  local base_url="$1"
+  local artifact_id="$2"
+  printf '%s/api/cache/cas/%s?tenant_id=acme&namespace_id=ios' "${base_url}" "${artifact_id}"
+}
+
+wait_for_ready_pair() {
+  wait_for_http "http://127.0.0.1:${KURA_US_PORT}/ready"
+  wait_for_http "http://127.0.0.1:${KURA_EU_PORT}/ready"
+}
+
+main() {
+  local us_url="http://127.0.0.1:${KURA_US_PORT}"
+  local eu_url="http://127.0.0.1:${KURA_EU_PORT}"
+
+  build_image_from_ref "${PREVIOUS_REF}" "${PREVIOUS_IMAGE}" "${PREVIOUS_WORKTREE}"
+  build_image_from_ref "${CURRENT_REF}" "${CURRENT_IMAGE}" "${PROJECT_ROOT}"
+
+  write_override "${PREVIOUS_OVERRIDE}" "${PREVIOUS_IMAGE}" "${PREVIOUS_IMAGE}"
+  write_override "${MIXED_OVERRIDE}" "${CURRENT_IMAGE}" "${PREVIOUS_IMAGE}"
+
+  dc "${PREVIOUS_OVERRIDE}" down -v --remove-orphans >/dev/null 2>&1 || true
+  dc "${PREVIOUS_OVERRIDE}" up -d kura-us kura-eu >/dev/null
+  wait_for_ready_pair
+
+  put_artifact "${us_url}" "artifact-v1" "payload-from-previous"
+  wait_for_body "$(artifact_url "${eu_url}" "artifact-v1")" "payload-from-previous"
+
+  dc "${MIXED_OVERRIDE}" up -d kura-us kura-eu >/dev/null
+  wait_for_ready_pair
+
+  put_artifact "${us_url}" "artifact-v2" "payload-from-current"
+  wait_for_body "$(artifact_url "${eu_url}" "artifact-v2")" "payload-from-current"
+
+  dc "${PREVIOUS_OVERRIDE}" up -d kura-us kura-eu >/dev/null
+  wait_for_ready_pair
+
+  wait_for_body "$(artifact_url "${us_url}" "artifact-v1")" "payload-from-previous"
+  wait_for_body "$(artifact_url "${us_url}" "artifact-v2")" "payload-from-current"
+  wait_for_body "$(artifact_url "${eu_url}" "artifact-v1")" "payload-from-previous"
+  wait_for_body "$(artifact_url "${eu_url}" "artifact-v2")" "payload-from-current"
+
+  echo "Compatibility rollout passed for ${PREVIOUS_REF} -> ${CURRENT_REF} -> ${PREVIOUS_REF}"
+}
+
+main

--- a/kura/test/e2e/kura_helm_kind.sh
+++ b/kura/test/e2e/kura_helm_kind.sh
@@ -49,7 +49,7 @@ PF1_PID=$!
 
 for port in "${HTTP_PORT_0}" "${HTTP_PORT_1}"; do
   for _ in $(seq 1 60); do
-    if curl -fsS "http://127.0.0.1:${port}/up" >/dev/null 2>&1; then
+    if curl -fsS "http://127.0.0.1:${port}/ready" >/dev/null 2>&1; then
       break
     fi
     sleep 2


### PR DESCRIPTION
## Why
Kura needs warm in-place rollouts for PVC-owning `StatefulSet` pods.

- Public reads are local-only today, so routing traffic to a half-warm pod creates avoidable misses.
- We cannot assume every client retries cleanly during shutdown.
- We must preserve `one Kura process = one PVC = one writer`.

## What This PR Implements
This PR adds the runtime and operational primitives needed for warm rollouts and safe single-ordinal rollback.

- explicit traffic lifecycle: `joining -> serving -> draining`
- single-writer fencing in the data directory
- public readiness that stays false until discovery and bootstrap settle
- drain-first shutdown with a shared deadline for public HTTP, gRPC, and internal HTTP
- a rollout status surface that exposes the data needed to gate promotions
- a generic rollout gate that is not coupled to Kubernetes
- a Helm adapter for partitioned `StatefulSet` rollouts
- an adjacent-version compatibility and rollback harness on the same persistent volume

## Runtime
- Kept `/up` as liveness and made `/ready` the public readiness signal.
- Added `/status/rollout` as a machine-oriented rollout status endpoint with generation, state, ring size, bootstrap progress, inflight work, outbox depth, memory pressure, and FD timeout counters.
- Added `RuntimeState` and `DataDirLock` to track traffic state, inflight work, and enforce single-writer startup.
- Readiness now depends on writer-lock ownership, initial discovery, bootstrap completion for the current peer set, and a short settle window.
- Membership generation changes move a node back out of `serving` until it reconverges.
- Public HTTP rejects new requests while draining and closes HTTP/1.1 connections.
- gRPC rejects new RPCs while draining and uses bounded connection age to help long-lived clients move off the node.
- Shutdown now uses one shared drain deadline and waits for inflight HTTP and gRPC work to complete before forcing task shutdown.

## Rollout Gating
- Added a generic rollout gate in `ops/rollout/gate.sh`.
- The gate depends only on Kura's rollout status endpoint, not on Kubernetes probes or Prometheus text parsing.
- Promotion now requires every node to report the same membership generation, every node back in `serving`, expected ring size cluster-wide, zero bootstrap inflight peers, outbox depth near baseline, no critical memory pressure, and no new FD timeout activity.
- Added a Kubernetes adapter in `ops/helm/kura/rollout.sh` that stages revisions with `StatefulSet` partitions and delegates health gating to the generic rollout gate.
- The Kubernetes adapter now only handles revision rollout and transport to pods; it does not own rollout semantics.

## Helm
- Switched readiness probing to `/ready` and kept liveness on `/up`.
- Added a startup probe and drain-on-`preStop` behavior.
- Derived `terminationGracePeriodSeconds` from the app's own drain timeout plus small lifecycle buffers.
- Defaulted PVC access mode to `ReadWriteOncePod`, with `ReadWriteOnce` documented as the fallback when the CSI driver requires it.

## Compatibility And Rollback Validation
- Added `test/e2e/kura_compatibility_rollout.sh`.
- The harness validates `PREVIOUS_REF -> HEAD -> PREVIOUS_REF` on the same persistent Docker volumes.
- Today that validation is focused on the artifact CAS path, so it proves the adjacent-version rollback contract there without claiming a full protocol matrix.

## What This PR Does Not Do
- It does not add a rollout controller or operator.
- It does not add peer read-through for public cache misses.
- It does not change the compatibility contract to allow breaking wire or storage changes.
- It does not try to model every production environment; the shell helpers are operational building blocks, not a full deployment system.

## Testing
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `helm lint ops/helm/kura`
- `helm template kura ops/helm/kura --namespace kura`
- `helm template kura ops/helm/kura --namespace kura --set updateStrategy.rollingUpdatePartition=2`
- `bash -n ops/rollout/gate.sh`
- `bash -n ops/helm/kura/rollout.sh`
- `bash -n test/e2e/kura_compatibility_rollout.sh`
