### PR TITLE
feat(cli): add --inspect-mode off to skip result bundle upload

### DIFF
--- a/app/Sources/TuistApp/TuistApp.swift
+++ b/app/Sources/TuistApp/TuistApp.swift
@@ -82,14 +82,14 @@ import TuistServer
         var body: some View {
             content
                 .environmentObject(authenticationService)
-            .withErrorHandling()
-            .task {
-                TuistSDK(
-                    fullHandle: "tuist/tuist",
-                    apiKey: "tuist_019b26d5-fd7e-7b79-ae62-b5525b26ce38_OTSCoR3hGfPI20i1Hfnpl7HPSWI="
-                )
-                .monitorPreviewUpdates()
-            }
+                .withErrorHandling()
+                .task {
+                    TuistSDK(
+                        fullHandle: "tuist/tuist",
+                        apiKey: "tuist_019b26d5-fd7e-7b79-ae62-b5525b26ce38_OTSCoR3hGfPI20i1Hfnpl7HPSWI="
+                    )
+                    .monitorPreviewUpdates()
+                }
         }
 
         @ViewBuilder

--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -38,7 +38,7 @@
 
         @Option(
             name: .long,
-            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' is a no-op. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips test analysis entirely (nothing is parsed, archived, or uploaded). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var mode: TestProcessingMode?

--- a/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectTestCommand.swift
@@ -38,7 +38,7 @@
 
         @Option(
             name: .long,
-            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+            help: "Processing mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' is a no-op. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var mode: TestProcessingMode?

--- a/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
@@ -111,6 +111,10 @@
                     resolvedResultBundlePath: resolvedResultBundlePath,
                     config: config
                 )
+            case .off:
+                AlertController.current.warning(
+                    .alert("'tuist inspect test' requires a processing mode; 'off' skips upload and has nothing to inspect.")
+                )
             }
         }
 

--- a/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
@@ -113,7 +113,9 @@
                 )
             case .off:
                 AlertController.current.warning(
-                    .alert("'tuist inspect test' requires a processing mode; 'off' skips upload and has nothing to inspect.")
+                    .alert(
+                        "'tuist inspect test' cannot run with mode 'off' — 'off' skips test analysis entirely, leaving nothing for this command to do."
+                    )
                 )
             }
         }

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -43,7 +43,7 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips test analysis entirely (no xcresult parsing, archiving, or upload — the Tests dashboard is not populated). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestCommand.swift
@@ -43,7 +43,7 @@ public struct XcodeBuildTestCommand: AsyncParsableCommand, TrackableParsableComm
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -45,7 +45,7 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildTestWithoutBuildingCommand.swift
@@ -45,7 +45,7 @@ public struct XcodeBuildTestWithoutBuildingCommand: AsyncParsableCommand, Tracka
 
     @Option(
         name: .long,
-        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+        help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips test analysis entirely (no xcresult parsing, archiving, or upload — the Tests dashboard is not populated). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
         envKey: .inspectTestMode
     )
     var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistKit/Services/TestProcessingMode.swift
+++ b/cli/Sources/TuistKit/Services/TestProcessingMode.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum TestProcessingMode: String, Sendable, CaseIterable, ExpressibleByArgument {
     case local
     case remote
+    case off
 
     /// Returns the default processing mode for the given Tuist server URL.
     ///

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1630,6 +1630,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 AlertController.current.success(
                     .alert("Result bundle uploaded for processing. View at \(test.url)")
                 )
+            case .off:
+                return
             }
         } catch {
             AlertController.current.warning(.alert("Failed to upload test results: \(error.localizedDescription)"))

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -361,6 +361,8 @@ struct XcodeBuildTestCommandService {
                 AlertController.current.success(
                     .alert("Result bundle uploaded for processing. View at \(test.url)")
                 )
+            case .off:
+                return
             }
         } catch {
             AlertController.current.warning(.alert("Failed to upload test results: \(error.localizedDescription)"))

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -326,7 +326,7 @@
 
         @Option(
             name: .long,
-            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing. When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var inspectMode: TestProcessingMode?

--- a/cli/Sources/TuistTestCommand/TestRunCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestRunCommand.swift
@@ -326,7 +326,7 @@
 
         @Option(
             name: .long,
-            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips result bundle upload entirely (for runs that only need selective testing and command event metadata). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
+            help: "Inspect mode: 'local' parses the xcresult on this machine, 'remote' uploads it for server-side processing, 'off' skips test analysis entirely (no xcresult parsing, archiving, or upload — the Tests dashboard is not populated). When omitted, defaults to 'remote' for tuist-hosted instances and 'local' for self-hosted ones.",
             envKey: .inspectTestMode
         )
         var inspectMode: TestProcessingMode?

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -246,6 +246,61 @@ struct XcodeBuildTestCommandServiceTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func skipsResultBundleUploadWhenInspectModeIsOff() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        // Given
+        let resultBundlePath = temporaryDirectory.appending(component: "test.xcresult")
+        try await fileSystem.makeDirectory(at: resultBundlePath)
+        let arguments = ["test", "-scheme", "MyAppTests", "-resultBundlePath", resultBundlePath.pathString]
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+        let activityLogPath = derivedDataPath.appending(components: "Logs", "Build", "activity.xcactivitylog")
+        let activityLogFile: XCActivityLogFile = .test(path: activityLogPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://tuist.dev")!))
+
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: derivedDataPath))
+
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .value(derivedDataPath), filter: .any)
+            .willReturn(activityLogFile)
+
+        given(xcodeBuildController)
+            .run(arguments: .any)
+            .willReturn()
+
+        // When
+        try await subject.run(
+            passthroughXcodebuildArguments: arguments,
+            mode: .off
+        )
+
+        // Then
+        verify(uploadResultBundleService)
+            .uploadResultBundle(
+                resultBundlePath: .any,
+                config: .any,
+                quarantinedTests: .any,
+                buildRunId: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(0)
+        verify(uploadResultBundleService)
+            .uploadTestSummary(
+                testSummary: .any,
+                projectDerivedDataDirectory: .any,
+                config: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(0)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func passesShardArchivePathToShardService() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let shardArchivePath = temporaryDirectory.appending(component: "bundle.aar")


### PR DESCRIPTION
## Purpose

Follow-up to [#10416](https://github.com/tuist/tuist/pull/10416) for the test-insights overhead thread. Even after the AppleArchive + `--inspect-mode remote` fixes landed, every remote test run still pays ~2 min of post-test overhead (archiving xcresult ~40 s + multipart upload ~70 s) before `xcodebuild exit` returns. For teams that only want selective testing + command event metadata and don't need the test-runs dashboard, that overhead is pure waste.

This adds a third `--inspect-mode` value — `off` — that short-circuits the entire xcresult upload path. The xcresult is still written by xcodebuild (so local quarantine detection keeps working in the error branch), but nothing is parsed, archived, or sent to the server. Net result: zero post-test overhead on top of `xcodebuild` itself.

## Approach

- Add a `.off` case to [`TestProcessingMode`](cli/Sources/TuistKit/Services/TestProcessingMode.swift) (alongside existing `.local` and `.remote`). The URL-based default never resolves to `off` — it's strictly an explicit opt-in.
- Handle `.off` in the upload switches in [`TestService.uploadResultBundleIfNeeded`](cli/Sources/TuistKit/Services/TestService.swift) and [`XcodeBuildTestCommandService.uploadResultBundleIfNeeded`](cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift) — return immediately, don't touch the xcresult. Existing `if mode == .local` gates on summary-parsing already skip in `.off`, so no code duplication.
- `tuist inspect test` exists purely to upload/analyze, so with `.off` it emits a warning explaining the combination is a no-op ([InspectTestCommandService.swift](cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift)).
- Help text updated on all four entry points (`tuist test`, `tuist xcodebuild test`, `tuist xcodebuild test-without-building`, `tuist inspect test`).

### How to test locally

1. In a Tuist-backed project on macOS, run `tuist test --inspect-mode off`. Observe that no `result_bundle` archiving or upload log lines appear (`FileArchiver` / `AnalyticsArtifactUploadService` stay silent for the result bundle) and no "Result bundle uploaded for processing" success alert fires.
2. Confirm `tuist test --inspect-mode local` still parses + uploads the test summary and `tuist test --inspect-mode remote` still archives + uploads the xcresult — both unchanged.
3. Confirm selective testing hashes are still stored after a successful run in `off` mode (those are computed locally from the xcresult and are independent of `mode`).
4. `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistKitTests/XcodeBuildTestCommandServiceTests/skipsResultBundleUploadWhenInspectModeIsOff CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO` — covers the new behavior.