### PR TITLE
chore(server): bump XCLogParser to 0.2.47

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1f6d96b59d4ac0c449d7302ca00a15240d8bc98a9c2e8b6100f7ea87bf0ece99",
+  "originHash" : "ff91f77210b8991b3fa1311d8c0904413d69d86abdceada53823faec67d87d14",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -407,7 +407,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.2.46"
+        "version" : "0.2.47"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1728,7 +1728,7 @@ let package = Package(
         .package(id: "grpc.grpc-swift-nio-transport", from: "2.0.0"),
         .package(id: "facebook.zstd", from: "1.5.0"),
         .package(id: "chrisaljoudi.swift-log-oslog", .upToNextMajor(from: "0.2.2")),
-        .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.46")),
+        .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.47")),
         .package(path: "processor/native/xcactivitylog_nif"),
         .package(id: "swiftyJSON.SwiftyJSON", .upToNextMajor(from: "5.0.2")),
         .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.22")),

--- a/processor/native/xcactivitylog_nif/Package.resolved
+++ b/processor/native/xcactivitylog_nif/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7625bf075f2542c819989641fa1cbfca603f0003ba410d4d08a6b4aa8f7d7314",
+  "originHash" : "eaf0120aada03126bb2d5c22eea625b8ba0565517b1041850b9ed2c70ce15868",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -14,7 +14,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.7.0"
+        "version" : "1.7.1"
       }
     },
     {
@@ -38,7 +38,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.11.0"
+        "version" : "1.12.0"
       }
     },
     {
@@ -46,7 +46,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "2.97.1"
+        "version" : "2.99.0"
       }
     },
     {
@@ -86,7 +86,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.2.46"
+        "version" : "0.2.47"
       }
     },
     {

--- a/processor/native/xcactivitylog_nif/Package.swift
+++ b/processor/native/xcactivitylog_nif/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.46"),
+        .package(id: "MobileNativeFoundation.XCLogParser", from: "0.2.47"),
         .package(id: "tuist.Path", from: "0.3.8"),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
         .package(id: "stephencelis.SQLite_swift", from: "0.16.0"),

--- a/processor/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
+++ b/processor/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
@@ -48,6 +48,7 @@ struct XCActivityLogParserTests {
             #expect(!target.name.isEmpty)
             #expect(!target.project.isEmpty)
             #expect(target.build_duration >= 0)
+            #expect(target.compilation_duration >= 0)
             #expect(target.status == "success")
         }
     }


### PR DESCRIPTION
## Summary

Bumps \`MobileNativeFoundation.XCLogParser\` from \`0.2.46\` → \`0.2.47\`.

\`0.2.47\` ships [MobileNativeFoundation/XCLogParser#249](https://github.com/MobileNativeFoundation/XCLogParser/pull/249), which fixes a long-standing bug: \`addCompilationTimesToTarget\` was producing **negative** \`compilationDuration\` values for targets in incremental Xcode builds. Xcode reuses substep entries from prior build sessions for files that don't need recompilation; those substeps keep their original (older) timestamps and aren't flagged \`wasFetchedFromCache\`, so the latest substep's \`compilationEndTimestamp\` could pre-date the target's \`startTimestamp\`.

Downstream effect on the server: those negative \`Int\` values were sent to ClickHouse's \`UInt64 build_targets.compilation_duration\` column, where 2's-complement underflow turned them into huge positive numbers. The Build Insights UI then rendered them as e.g. \`5,124,095,576,030h 7m 41s\` (reported by Vinted: see \`a62b41e1-d59b-4b70-8c67-6b1eb3dc569a\`). After the bump, affected targets will report \`0ms\` (correct: no real compile work in this session) instead of the corrupted value.

Also adds an assertion in [\`XCActivityLogParserTests\`](processor/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift:51) that \`target.compilation_duration >= 0\` as a guard against future regressions.

## Test plan

- [x] \`swift package resolve --replace-scm-with-registry\` succeeds in both \`Package.swift\` files.
- [x] \`swift test --filter XCActivityLogParserTests\` passes (12/12) against \`0.2.47\`.

## Follow-up

Existing corrupted rows in ClickHouse (\`build_targets.compilation_duration\` near \`UInt64.max\`) are not touched by this PR. Backfill or display-side filtering can be done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)