### PR TITLE
feat(cli,server): add tuist test case update command

### DIFF
--- a/cli/Sources/TuistEnvKey/EnvKey.swift
+++ b/cli/Sources/TuistEnvKey/EnvKey.swift
@@ -220,6 +220,15 @@ public enum EnvKey: String, CaseIterable {
     case testCaseShowPath = "TUIST_TEST_CASE_SHOW_PATH"
     case testCaseShowJson = "TUIST_TEST_CASE_SHOW_JSON"
 
+    // TEST CASE UPDATE
+
+    case testCaseUpdateIdentifier = "TUIST_TEST_CASE_UPDATE_IDENTIFIER"
+    case testCaseUpdateState = "TUIST_TEST_CASE_UPDATE_STATE"
+    case testCaseUpdateFlaky = "TUIST_TEST_CASE_UPDATE_FLAKY"
+    case testCaseUpdateProject = "TUIST_TEST_CASE_UPDATE_PROJECT"
+    case testCaseUpdatePath = "TUIST_TEST_CASE_UPDATE_PATH"
+    case testCaseUpdateJson = "TUIST_TEST_CASE_UPDATE_JSON"
+
     // TEST CASE EVENTS
 
     case testCaseEventsIdentifier = "TUIST_TEST_CASE_EVENTS_IDENTIFIER"

--- a/cli/Sources/TuistEnvKey/ParseableArgument+Extension.swift
+++ b/cli/Sources/TuistEnvKey/ParseableArgument+Extension.swift
@@ -136,6 +136,23 @@ extension Flag where Value == Bool {
     }
 }
 
+extension Flag where Value == Bool? {
+    public init(
+        name: NameSpecification = .long,
+        inversion: FlagInversion,
+        exclusivity: FlagExclusivity = .chooseLast,
+        help: ArgumentHelp? = nil,
+        envKey: EnvKey
+    ) {
+        self.init(
+            name: name,
+            inversion: inversion,
+            exclusivity: exclusivity,
+            help: help?.withEnvKey(envKey)
+        )
+    }
+}
+
 extension Argument {
     public init<T>(
         wrappedValue value: [T] = [],

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -9383,8 +9383,8 @@ public struct Client: APIProtocol {
     ///
     /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
-    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
-    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    /// - Remark: HTTP `PATCH /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)`.
     public func updateTestCase(_ input: Operations.updateTestCase.Input) async throws -> Operations.updateTestCase.Output {
         try await client.send(
             input: input,
@@ -9400,7 +9400,7 @@ public struct Client: APIProtocol {
                 )
                 var request: HTTPTypes.HTTPRequest = .init(
                     soar_path: path,
-                    method: .put
+                    method: .patch
                 )
                 suppressMutabilityWarning(&request)
                 converter.setAcceptHeader(

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -9379,6 +9379,127 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Update a test case.
+    ///
+    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    public func updateTestCase(_ input: Operations.updateTestCase.Input) async throws -> Operations.updateTestCase.Output {
+        try await client.send(
+            input: input,
+            forOperation: Operations.updateTestCase.id,
+            serializer: { input in
+                let path = try converter.renderedPath(
+                    template: "/api/projects/{}/{}/tests/test-cases/{}",
+                    parameters: [
+                        input.path.account_handle,
+                        input.path.project_handle,
+                        input.path.test_case_id
+                    ]
+                )
+                var request: HTTPTypes.HTTPRequest = .init(
+                    soar_path: path,
+                    method: .put
+                )
+                suppressMutabilityWarning(&request)
+                converter.setAcceptHeader(
+                    in: &request.headerFields,
+                    contentTypes: input.headers.accept
+                )
+                let body: OpenAPIRuntime.HTTPBody?
+                switch input.body {
+                case .none:
+                    body = nil
+                case let .json(value):
+                    body = try converter.setOptionalRequestBodyAsJSON(
+                        value,
+                        headerFields: &request.headerFields,
+                        contentType: "application/json; charset=utf-8"
+                    )
+                }
+                return (request, body)
+            },
+            deserializer: { response, responseBody in
+                switch response.status.code {
+                case 200:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.updateTestCase.Output.Ok.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Operations.updateTestCase.Output.Ok.Body.jsonPayload.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .ok(.init(body: body))
+                case 403:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.updateTestCase.Output.Forbidden.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .forbidden(.init(body: body))
+                case 404:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.updateTestCase.Output.NotFound.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .notFound(.init(body: body))
+                default:
+                    return .undocumented(
+                        statusCode: response.status.code,
+                        .init(
+                            headerFields: response.headerFields,
+                            body: responseBody
+                        )
+                    )
+                }
+            }
+        )
+    }
     /// Get cache endpoints.
     ///
     /// Returns cache endpoints for the requested account.

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -9381,7 +9381,7 @@ public struct Client: APIProtocol {
     }
     /// Update a test case.
     ///
-    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
@@ -9444,6 +9444,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.updateTestCase.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
                 case 403:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.updateTestCase.Output.Forbidden.Body

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -443,8 +443,8 @@ public protocol APIProtocol: Sendable {
     ///
     /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
-    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
-    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    /// - Remark: HTTP `PATCH /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)`.
     func updateTestCase(_ input: Operations.updateTestCase.Input) async throws -> Operations.updateTestCase.Output
     /// Get cache endpoints.
     ///
@@ -1758,8 +1758,8 @@ extension APIProtocol {
     ///
     /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
-    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
-    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    /// - Remark: HTTP `PATCH /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)`.
     public func updateTestCase(
         path: Operations.updateTestCase.Input.Path,
         headers: Operations.updateTestCase.Input.Headers = .init(),
@@ -36617,8 +36617,8 @@ public enum Operations {
     ///
     /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
-    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
-    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    /// - Remark: HTTP `PATCH /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)`.
     public enum updateTestCase {
         public static let id: Swift.String = "updateTestCase"
         public struct Input: Sendable, Hashable {
@@ -36871,7 +36871,7 @@ public enum Operations {
             }
             /// The updated test case
             ///
-            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/200`.
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)/responses/200`.
             ///
             /// HTTP response code: `200 ok`.
             case ok(Operations.updateTestCase.Output.Ok)
@@ -36922,7 +36922,7 @@ public enum Operations {
             }
             /// Invalid update params (empty body or malformed field values)
             ///
-            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/400`.
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)/responses/400`.
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.updateTestCase.Output.BadRequest)
@@ -36973,7 +36973,7 @@ public enum Operations {
             }
             /// You don't have permission to update this resource
             ///
-            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/403`.
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)/responses/403`.
             ///
             /// HTTP response code: `403 forbidden`.
             case forbidden(Operations.updateTestCase.Output.Forbidden)
@@ -37024,7 +37024,7 @@ public enum Operations {
             }
             /// Test case not found
             ///
-            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/404`.
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/patch(updateTestCase)/responses/404`.
             ///
             /// HTTP response code: `404 notFound`.
             case notFound(Operations.updateTestCase.Output.NotFound)

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -441,7 +441,7 @@ public protocol APIProtocol: Sendable {
     func getTestCase(_ input: Operations.getTestCase.Input) async throws -> Operations.getTestCase.Output
     /// Update a test case.
     ///
-    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
@@ -1756,7 +1756,7 @@ extension APIProtocol {
     }
     /// Update a test case.
     ///
-    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
@@ -36615,7 +36615,7 @@ public enum Operations {
     }
     /// Update a test case.
     ///
-    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    /// Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
     ///
     /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
@@ -36887,6 +36887,57 @@ public enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/400/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/400/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateTestCase.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.updateTestCase.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// Invalid update params (empty body or malformed field values)
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.updateTestCase.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.updateTestCase.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
                             response: self
                         )
                     }

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -439,6 +439,13 @@ public protocol APIProtocol: Sendable {
     /// - Remark: HTTP `GET /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
     /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/get(getTestCase)`.
     func getTestCase(_ input: Operations.getTestCase.Input) async throws -> Operations.getTestCase.Output
+    /// Update a test case.
+    ///
+    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    func updateTestCase(_ input: Operations.updateTestCase.Input) async throws -> Operations.updateTestCase.Output
     /// Get cache endpoints.
     ///
     /// Returns cache endpoints for the requested account.
@@ -1745,6 +1752,23 @@ extension APIProtocol {
         try await getTestCase(Operations.getTestCase.Input(
             path: path,
             headers: headers
+        ))
+    }
+    /// Update a test case.
+    ///
+    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    public func updateTestCase(
+        path: Operations.updateTestCase.Input.Path,
+        headers: Operations.updateTestCase.Input.Headers = .init(),
+        body: Operations.updateTestCase.Input.Body? = nil
+    ) async throws -> Operations.updateTestCase.Output {
+        try await updateTestCase(Operations.updateTestCase.Input(
+            path: path,
+            headers: headers,
+            body: body
         ))
     }
     /// Get cache endpoints.
@@ -36546,6 +36570,418 @@ public enum Operations {
             /// - Throws: An error if `self` is not `.notFound`.
             /// - SeeAlso: `.notFound`.
             public var notFound: Operations.getTestCase.Output.NotFound {
+                get throws {
+                    switch self {
+                    case let .notFound(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "notFound",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        @frozen public enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            public init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            public var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            public static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Update a test case.
+    ///
+    /// Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+    ///
+    /// - Remark: HTTP `PUT /api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)`.
+    public enum updateTestCase {
+        public static let id: Swift.String = "updateTestCase"
+        public struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/path`.
+            public struct Path: Sendable, Hashable {
+                /// The handle of the account.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/path/account_handle`.
+                public var account_handle: Swift.String
+                /// The handle of the project.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/path/project_handle`.
+                public var project_handle: Swift.String
+                /// The ID of the test case.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/path/test_case_id`.
+                public var test_case_id: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_handle: The handle of the account.
+                ///   - project_handle: The handle of the project.
+                ///   - test_case_id: The ID of the test case.
+                public init(
+                    account_handle: Swift.String,
+                    project_handle: Swift.String,
+                    test_case_id: Swift.String
+                ) {
+                    self.account_handle = account_handle
+                    self.project_handle = project_handle
+                    self.test_case_id = test_case_id
+                }
+            }
+            public var path: Operations.updateTestCase.Input.Path
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/header`.
+            public struct Headers: Sendable, Hashable {
+                public var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.updateTestCase.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                public init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.updateTestCase.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            public var headers: Operations.updateTestCase.Input.Headers
+            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/requestBody`.
+            @frozen public enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/requestBody/json`.
+                public struct jsonPayload: Codable, Hashable, Sendable {
+                    /// Whether to mark the test case as flaky.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/requestBody/json/is_flaky`.
+                    public var is_flaky: Swift.Bool?
+                    /// The new state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/requestBody/json/state`.
+                    public var state: Swift.String?
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - is_flaky: Whether to mark the test case as flaky.
+                    ///   - state: The new state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                    public init(
+                        is_flaky: Swift.Bool? = nil,
+                        state: Swift.String? = nil
+                    ) {
+                        self.is_flaky = is_flaky
+                        self.state = state
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case is_flaky
+                        case state
+                    }
+                }
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/requestBody/content/application\/json`.
+                case json(Operations.updateTestCase.Input.Body.jsonPayload)
+            }
+            public var body: Operations.updateTestCase.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            public init(
+                path: Operations.updateTestCase.Input.Path,
+                headers: Operations.updateTestCase.Input.Headers = .init(),
+                body: Operations.updateTestCase.Input.Body? = nil
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Hashable {
+            public struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json`.
+                    public struct jsonPayload: Codable, Hashable, Sendable {
+                        /// The test case ID.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/id`.
+                        public var id: Swift.String
+                        /// Whether the test case is marked as flaky.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/is_flaky`.
+                        public var is_flaky: Swift.Bool
+                        /// Whether the test case is quarantined (either `muted` or `skipped`). Deprecated: use `state` instead.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/is_quarantined`.
+                        @available(*, deprecated)
+                        public var is_quarantined: Swift.Bool
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/module`.
+                        public struct modulePayload: Codable, Hashable, Sendable {
+                            /// ID of the module.
+                            ///
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/module/id`.
+                            public var id: Swift.String
+                            /// Name of the module.
+                            ///
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/module/name`.
+                            public var name: Swift.String
+                            /// Creates a new `modulePayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - id: ID of the module.
+                            ///   - name: Name of the module.
+                            public init(
+                                id: Swift.String,
+                                name: Swift.String
+                            ) {
+                                self.id = id
+                                self.name = name
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case id
+                                case name
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/module`.
+                        public var module: Operations.updateTestCase.Output.Ok.Body.jsonPayload.modulePayload
+                        /// Name of the test case.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/name`.
+                        public var name: Swift.String
+                        /// The state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/state`.
+                        public var state: Swift.String
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/suite`.
+                        public struct suitePayload: Codable, Hashable, Sendable {
+                            /// ID of the suite.
+                            ///
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/suite/id`.
+                            public var id: Swift.String
+                            /// Name of the suite.
+                            ///
+                            /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/suite/name`.
+                            public var name: Swift.String
+                            /// Creates a new `suitePayload`.
+                            ///
+                            /// - Parameters:
+                            ///   - id: ID of the suite.
+                            ///   - name: Name of the suite.
+                            public init(
+                                id: Swift.String,
+                                name: Swift.String
+                            ) {
+                                self.id = id
+                                self.name = name
+                            }
+                            public enum CodingKeys: String, CodingKey {
+                                case id
+                                case name
+                            }
+                        }
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/suite`.
+                        public var suite: Operations.updateTestCase.Output.Ok.Body.jsonPayload.suitePayload?
+                        /// URL to view the test case in the dashboard.
+                        ///
+                        /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/json/url`.
+                        public var url: Swift.String
+                        /// Creates a new `jsonPayload`.
+                        ///
+                        /// - Parameters:
+                        ///   - id: The test case ID.
+                        ///   - is_flaky: Whether the test case is marked as flaky.
+                        ///   - is_quarantined: Whether the test case is quarantined (either `muted` or `skipped`). Deprecated: use `state` instead.
+                        ///   - module:
+                        ///   - name: Name of the test case.
+                        ///   - state: The state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                        ///   - suite:
+                        ///   - url: URL to view the test case in the dashboard.
+                        public init(
+                            id: Swift.String,
+                            is_flaky: Swift.Bool,
+                            is_quarantined: Swift.Bool,
+                            module: Operations.updateTestCase.Output.Ok.Body.jsonPayload.modulePayload,
+                            name: Swift.String,
+                            state: Swift.String,
+                            suite: Operations.updateTestCase.Output.Ok.Body.jsonPayload.suitePayload? = nil,
+                            url: Swift.String
+                        ) {
+                            self.id = id
+                            self.is_flaky = is_flaky
+                            self.is_quarantined = is_quarantined
+                            self.module = module
+                            self.name = name
+                            self.state = state
+                            self.suite = suite
+                            self.url = url
+                        }
+                        public enum CodingKeys: String, CodingKey {
+                            case id
+                            case is_flaky
+                            case is_quarantined
+                            case module
+                            case name
+                            case state
+                            case suite
+                            case url
+                        }
+                    }
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/200/content/application\/json`.
+                    case json(Operations.updateTestCase.Output.Ok.Body.jsonPayload)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Operations.updateTestCase.Output.Ok.Body.jsonPayload {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateTestCase.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.updateTestCase.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// The updated test case
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.updateTestCase.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            public var ok: Operations.updateTestCase.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/403/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/403/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateTestCase.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.updateTestCase.Output.Forbidden.Body) {
+                    self.body = body
+                }
+            }
+            /// You don't have permission to update this resource
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.updateTestCase.Output.Forbidden)
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.updateTestCase.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct NotFound: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/404/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/PUT/responses/404/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateTestCase.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.updateTestCase.Output.NotFound.Body) {
+                    self.body = body
+                }
+            }
+            /// Test case not found
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_handle}/{project_handle}/tests/test-cases/{test_case_id}/put(updateTestCase)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.updateTestCase.Output.NotFound)
+            /// The associated value of the enum case if `self` is `.notFound`.
+            ///
+            /// - Throws: An error if `self` is not `.notFound`.
+            /// - SeeAlso: `.notFound`.
+            public var notFound: Operations.updateTestCase.Output.NotFound {
                 get throws {
                     switch self {
                     case let .notFound(response):

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -14015,6 +14015,164 @@ paths:
       summary: Get a test case by ID.
       tags:
         - Test Cases
+    put:
+      callbacks: {}
+      description: Updates mutable fields on a test case. Supports changing `state` (currently `enabled`, `muted`, or `skipped`) and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+      operationId: updateTestCase
+      parameters:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the project.
+          in: path
+          name: project_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: The ID of the test case.
+          in: path
+          name: test_case_id
+          required: true
+          schema:
+            format: uuid
+            type: string
+            x-struct:
+            x-validate:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                is_flaky:
+                  description: Whether to mark the test case as flaky.
+                  type: boolean
+                  x-struct:
+                  x-validate:
+                state:
+                  description: The new state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                  type: string
+                  x-struct:
+                  x-validate:
+              type: object
+              x-struct:
+              x-validate:
+        description: Test case update params
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    description: The test case ID.
+                    format: uuid
+                    type: string
+                    x-struct:
+                    x-validate:
+                  is_flaky:
+                    description: Whether the test case is marked as flaky.
+                    type: boolean
+                    x-struct:
+                    x-validate:
+                  is_quarantined:
+                    deprecated: true
+                    description: 'Whether the test case is quarantined. Deprecated: use `state` instead.'
+                    type: boolean
+                    x-struct:
+                    x-validate:
+                  module:
+                    properties:
+                      id:
+                        description: ID of the module.
+                        type: string
+                        x-struct:
+                        x-validate:
+                      name:
+                        description: Name of the module.
+                        type: string
+                        x-struct:
+                        x-validate:
+                    required:
+                      - id
+                      - name
+                    type: object
+                    x-struct:
+                    x-validate:
+                  name:
+                    description: Name of the test case.
+                    type: string
+                    x-struct:
+                    x-validate:
+                  state:
+                    description: The state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec.
+                    type: string
+                    x-struct:
+                    x-validate:
+                  suite:
+                    nullable: true
+                    properties:
+                      id:
+                        description: ID of the suite.
+                        type: string
+                        x-struct:
+                        x-validate:
+                      name:
+                        description: Name of the suite.
+                        type: string
+                        x-struct:
+                        x-validate:
+                    required:
+                      - id
+                      - name
+                    type: object
+                    x-struct:
+                    x-validate:
+                  url:
+                    description: URL to view the test case in the dashboard.
+                    type: string
+                    x-struct:
+                    x-validate:
+                required:
+                  - id
+                  - name
+                  - module
+                  - is_flaky
+                  - is_quarantined
+                  - state
+                  - url
+                type: object
+                x-struct:
+                x-validate:
+          description: The updated test case
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Invalid update params (empty body or malformed field values)
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: You don't have permission to update this resource
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Test case not found
+      summary: Update a test case.
+      tags:
+        - Test Cases
   /api/cache/endpoints:
     get:
       callbacks: {}

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -14015,7 +14015,7 @@ paths:
       summary: Get a test case by ID.
       tags:
         - Test Cases
-    put:
+    patch:
       callbacks: {}
       description: Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
       operationId: updateTestCase

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -14017,7 +14017,7 @@ paths:
         - Test Cases
     put:
       callbacks: {}
-      description: Updates mutable fields on a test case. Supports changing `state` (currently `enabled`, `muted`, or `skipped`) and toggling `is_flaky`. At least one of the fields must be provided. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
+      description: Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec) and toggling `is_flaky`. Corresponding events (`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded automatically when values transition.
       operationId: updateTestCase
       parameters:
         - description: The handle of the account.
@@ -14084,7 +14084,7 @@ paths:
                     x-validate:
                   is_quarantined:
                     deprecated: true
-                    description: 'Whether the test case is quarantined. Deprecated: use `state` instead.'
+                    description: 'Whether the test case is quarantined (either `muted` or `skipped`). Deprecated: use `state` instead.'
                     type: boolean
                     x-struct:
                     x-validate:

--- a/cli/Sources/TuistServer/Services/UpdateTestCaseService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateTestCaseService.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Mockable
+import OpenAPIRuntime
+import TuistHTTP
+
+public typealias ServerUpdatedTestCase = Operations.updateTestCase.Output.Ok.Body.jsonPayload
+
+@Mockable
+public protocol UpdateTestCaseServicing: Sendable {
+    func updateTestCase(
+        fullHandle: String,
+        testCaseId: String,
+        state: ServerTestCaseState?,
+        isFlaky: Bool?,
+        serverURL: URL
+    ) async throws -> ServerUpdatedTestCase
+}
+
+public enum ServerTestCaseState: String, Sendable, CaseIterable {
+    case enabled
+    case muted
+    case skipped
+}
+
+enum UpdateTestCaseServiceError: LocalizedError {
+    case unknownError(Int)
+    case notFound(String)
+    case forbidden(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The test case could not be updated due to an unknown Tuist response of \(statusCode)."
+        case let .notFound(message):
+            return message
+        case let .forbidden(message):
+            return message
+        }
+    }
+}
+
+public struct UpdateTestCaseService: UpdateTestCaseServicing {
+    private let fullHandleService: FullHandleServicing
+
+    public init(fullHandleService: FullHandleServicing = FullHandleService()) {
+        self.fullHandleService = fullHandleService
+    }
+
+    public func updateTestCase(
+        fullHandle: String,
+        testCaseId: String,
+        state: ServerTestCaseState?,
+        isFlaky: Bool?,
+        serverURL: URL
+    ) async throws -> ServerUpdatedTestCase {
+        let client = Client.authenticated(serverURL: serverURL)
+        let handles = try fullHandleService.parse(fullHandle)
+
+        let response = try await client.updateTestCase(
+            .init(
+                path: .init(
+                    account_handle: handles.accountHandle,
+                    project_handle: handles.projectHandle,
+                    test_case_id: testCaseId
+                ),
+                body: .json(.init(is_flaky: isFlaky, state: state?.rawValue))
+            )
+        )
+
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(json):
+                return json
+            }
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw UpdateTestCaseServiceError.notFound(error.message)
+            }
+        case let .forbidden(forbidden):
+            switch forbidden.body {
+            case let .json(error):
+                throw UpdateTestCaseServiceError.forbidden(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw UpdateTestCaseServiceError.unknownError(statusCode)
+        }
+    }
+}
+
+#if DEBUG
+    extension ServerUpdatedTestCase {
+        public static func test(
+            id: String = "test-case-id",
+            isFlaky: Bool = false,
+            isQuarantined: Bool = false,
+            module: Operations.updateTestCase.Output.Ok.Body.jsonPayload.modulePayload = .test(),
+            name: String = "testExample",
+            state: String = "enabled",
+            suite: Operations.updateTestCase.Output.Ok.Body.jsonPayload.suitePayload? = nil,
+            url: String = "https://tuist.dev/test-case"
+        ) -> Self {
+            .init(
+                id: id,
+                is_flaky: isFlaky,
+                is_quarantined: isQuarantined,
+                module: module,
+                name: name,
+                state: state,
+                suite: suite,
+                url: url
+            )
+        }
+    }
+
+    extension Operations.updateTestCase.Output.Ok.Body.jsonPayload.modulePayload {
+        public static func test(
+            id: String = "module-id",
+            name: String = "TestModule"
+        ) -> Self {
+            .init(id: id, name: name)
+        }
+    }
+
+    extension Operations.updateTestCase.Output.Ok.Body.jsonPayload.suitePayload {
+        public static func test(
+            id: String = "suite-id",
+            name: String = "TestSuite"
+        ) -> Self {
+            .init(id: id, name: name)
+        }
+    }
+#endif

--- a/cli/Sources/TuistServer/Services/UpdateTestCaseService.swift
+++ b/cli/Sources/TuistServer/Services/UpdateTestCaseService.swift
@@ -24,6 +24,7 @@ public enum ServerTestCaseState: String, Sendable, CaseIterable {
 
 enum UpdateTestCaseServiceError: LocalizedError {
     case unknownError(Int)
+    case badRequest(String)
     case notFound(String)
     case forbidden(String)
 
@@ -31,6 +32,8 @@ enum UpdateTestCaseServiceError: LocalizedError {
         switch self {
         case let .unknownError(statusCode):
             return "The test case could not be updated due to an unknown Tuist response of \(statusCode)."
+        case let .badRequest(message):
+            return message
         case let .notFound(message):
             return message
         case let .forbidden(message):
@@ -72,6 +75,11 @@ public struct UpdateTestCaseService: UpdateTestCaseServicing {
             switch okResponse.body {
             case let .json(json):
                 return json
+            }
+        case let .badRequest(badRequest):
+            switch badRequest.body {
+            case let .json(error):
+                throw UpdateTestCaseServiceError.badRequest(error.message)
             }
         case let .notFound(notFound):
             switch notFound.body {

--- a/cli/Sources/TuistTestCommand/TestCaseCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestCaseCommand.swift
@@ -10,6 +10,7 @@ public struct TestCaseCommand: ParsableCommand {
             subcommands: [
                 TestCaseListCommand.self,
                 TestCaseShowCommand.self,
+                TestCaseUpdateCommand.self,
                 TestCaseEventsCommand.self,
                 TestCaseRunCommand.self,
             ]

--- a/cli/Sources/TuistTestCommand/TestCaseUpdateCommand.swift
+++ b/cli/Sources/TuistTestCommand/TestCaseUpdateCommand.swift
@@ -1,0 +1,72 @@
+import ArgumentParser
+import Foundation
+import Path
+import TuistEnvKey
+import TuistNooraExtension
+import TuistServer
+
+public struct TestCaseUpdateCommand: AsyncParsableCommand, NooraReadyCommand {
+    public init() {}
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "update",
+            abstract: "Updates a test case."
+        )
+    }
+
+    @Argument(
+        help: "The test case identifier. Either a UUID or the format Module/Suite/TestCase (or Module/TestCase).",
+        envKey: .testCaseUpdateIdentifier
+    )
+    var testCaseIdentifier: String
+
+    @Option(
+        help: "The new state for the test case.",
+        envKey: .testCaseUpdateState
+    )
+    var state: ServerTestCaseState?
+
+    @Flag(
+        inversion: .prefixedNo,
+        exclusivity: .exclusive,
+        help: "Mark the test case as flaky (--flaky) or not flaky (--no-flaky).",
+        envKey: .testCaseUpdateFlaky
+    )
+    var flaky: Bool?
+
+    @Option(
+        name: [.customLong("project"), .customShort("P")],
+        help: "The full handle of the project. Must be in the format of account-handle/project-handle.",
+        envKey: .testCaseUpdateProject
+    )
+    var project: String?
+
+    @Option(
+        name: .shortAndLong,
+        help: "The path to the directory or a subdirectory of the project.",
+        completion: .directory,
+        envKey: .testCaseUpdatePath
+    )
+    var path: String?
+
+    @Flag(
+        help: "The output in JSON format.",
+        envKey: .testCaseUpdateJson
+    )
+    var json: Bool = false
+
+    public var jsonThroughNoora: Bool = true
+
+    public func run() async throws {
+        try await TestCaseUpdateCommandService().run(
+            project: project,
+            testCaseIdentifier: testCaseIdentifier,
+            state: state,
+            isFlaky: flaky,
+            path: path,
+            json: json
+        )
+    }
+}
+
+extension ServerTestCaseState: @retroactive ExpressibleByArgument {}

--- a/cli/Sources/TuistTestCommand/TestCaseUpdateCommandService.swift
+++ b/cli/Sources/TuistTestCommand/TestCaseUpdateCommandService.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Noora
+import Path
+import TuistConfigLoader
+import TuistEnvironment
+import TuistNooraExtension
+import TuistServer
+
+protocol TestCaseUpdateCommandServicing {
+    func run(
+        project: String?,
+        testCaseIdentifier: String,
+        state: ServerTestCaseState?,
+        isFlaky: Bool?,
+        path: String?,
+        json: Bool
+    ) async throws
+}
+
+enum TestCaseUpdateCommandServiceError: Equatable, LocalizedError {
+    case missingFullHandle
+    case missingUpdateFields
+
+    var errorDescription: String? {
+        switch self {
+        case .missingFullHandle:
+            return "We couldn't update the test case because the project is missing. You can pass either its value or a path to a Tuist project."
+        case .missingUpdateFields:
+            return "At least one of --state or --flaky/--no-flaky must be provided."
+        }
+    }
+}
+
+struct TestCaseUpdateCommandService: TestCaseUpdateCommandServicing {
+    private let getTestCaseService: GetTestCaseServicing
+    private let updateTestCaseService: UpdateTestCaseServicing
+    private let serverEnvironmentService: ServerEnvironmentServicing
+    private let configLoader: ConfigLoading
+
+    init(
+        getTestCaseService: GetTestCaseServicing = GetTestCaseService(),
+        updateTestCaseService: UpdateTestCaseServicing = UpdateTestCaseService(),
+        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        configLoader: ConfigLoading = ConfigLoader()
+    ) {
+        self.getTestCaseService = getTestCaseService
+        self.updateTestCaseService = updateTestCaseService
+        self.serverEnvironmentService = serverEnvironmentService
+        self.configLoader = configLoader
+    }
+
+    func run(
+        project: String?,
+        testCaseIdentifier: String,
+        state: ServerTestCaseState?,
+        isFlaky: Bool?,
+        path: String?,
+        json: Bool
+    ) async throws {
+        guard state != nil || isFlaky != nil else {
+            throw TestCaseUpdateCommandServiceError.missingUpdateFields
+        }
+
+        let directoryPath: AbsolutePath = try await Environment.current.pathRelativeToWorkingDirectory(path)
+
+        let config = try await configLoader.loadConfig(path: directoryPath)
+        guard let resolvedFullHandle = project ?? config.fullHandle else {
+            throw TestCaseUpdateCommandServiceError.missingFullHandle
+        }
+
+        let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
+
+        let testCaseId: String
+        switch try TestCaseIdentifier(testCaseIdentifier) {
+        case let .name(moduleName, suiteName, testName):
+            let testCase = try await getTestCaseService.getTestCaseByName(
+                fullHandle: resolvedFullHandle,
+                moduleName: moduleName,
+                name: testName,
+                suiteName: suiteName,
+                serverURL: serverURL
+            )
+            testCaseId = testCase.id
+        case let .id(id):
+            testCaseId = id
+        }
+
+        let updated = try await updateTestCaseService.updateTestCase(
+            fullHandle: resolvedFullHandle,
+            testCaseId: testCaseId,
+            state: state,
+            isFlaky: isFlaky,
+            serverURL: serverURL
+        )
+
+        if json {
+            try Noora.current.json(updated)
+            return
+        }
+
+        let info = formatUpdatedInfo(updated)
+        Noora.current.passthrough("\(info)")
+    }
+
+    private func formatUpdatedInfo(_ testCase: ServerUpdatedTestCase) -> String {
+        var info = [
+            "Test Case".bold(),
+            "Name: \(testCase.name)",
+            "Module: \(testCase.module.name)",
+        ]
+
+        if let suite = testCase.suite {
+            info.append("Suite: \(suite.name)")
+        }
+
+        info.append("State: \(testCase.state.rawValue)")
+        info.append("Flaky: \(testCase.is_flaky ? "Yes" : "No")")
+        info.append("URL: \(testCase.url)")
+
+        return info.joined(separator: "\n") + "\n"
+    }
+}

--- a/cli/Sources/TuistTestCommand/TestCaseUpdateCommandService.swift
+++ b/cli/Sources/TuistTestCommand/TestCaseUpdateCommandService.swift
@@ -113,7 +113,7 @@ struct TestCaseUpdateCommandService: TestCaseUpdateCommandServicing {
             info.append("Suite: \(suite.name)")
         }
 
-        info.append("State: \(testCase.state.rawValue)")
+        info.append("State: \(testCase.state)")
         info.append("Flaky: \(testCase.is_flaky ? "Yes" : "No")")
         info.append("URL: \(testCase.url)")
 

--- a/cli/Tests/TuistTestCommandTests/Services/TestCaseUpdateCommandServiceTests.swift
+++ b/cli/Tests/TuistTestCommandTests/Services/TestCaseUpdateCommandServiceTests.swift
@@ -1,0 +1,362 @@
+import Foundation
+import Mockable
+import Testing
+import TuistConfig
+import TuistConfigLoader
+import TuistEnvironment
+import TuistEnvironmentTesting
+import TuistNooraTesting
+import TuistServer
+
+@testable import TuistTestCommand
+
+struct TestCaseUpdateCommandServiceTests {
+    private let getTestCaseService = MockGetTestCaseServicing()
+    private let updateTestCaseService = MockUpdateTestCaseServicing()
+    private let serverEnvironmentService = MockServerEnvironmentServicing()
+    private let configLoader = MockConfigLoading()
+    private let subject: TestCaseUpdateCommandService
+
+    init() {
+        subject = TestCaseUpdateCommandService(
+            getTestCaseService: getTestCaseService,
+            updateTestCaseService: updateTestCaseService,
+            serverEnvironmentService: serverEnvironmentService,
+            configLoader: configLoader
+        )
+    }
+
+    @Test(.withMockedEnvironment()) func run_when_full_handle_is_not_passed_and_absent_in_config() async throws {
+        // Given
+        let tuist = Tuist.test(fullHandle: nil)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+
+        // When/Then
+        await #expect(throws: TestCaseUpdateCommandServiceError.missingFullHandle, performing: {
+            try await subject.run(
+                project: nil,
+                testCaseIdentifier: "test-case-id",
+                state: .enabled,
+                isFlaky: nil,
+                path: nil,
+                json: false
+            )
+        })
+    }
+
+    @Test(.withMockedEnvironment()) func run_when_neither_state_nor_flaky_provided() async throws {
+        // When/Then
+        await #expect(throws: TestCaseUpdateCommandServiceError.missingUpdateFields, performing: {
+            try await subject.run(
+                project: nil,
+                testCaseIdentifier: "test-case-id",
+                state: nil,
+                isFlaky: nil,
+                path: nil,
+                json: false
+            )
+        })
+    }
+
+    @Test(
+        .withMockedEnvironment(arguments: ["--json"]),
+        .withMockedNoora
+    ) func run_with_json_output_and_uuid() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let updated = ServerUpdatedTestCase.test(
+            module: .test(name: "AuthTests"),
+            name: "testLogin()",
+            state: .enabled
+        )
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(fullHandle),
+            testCaseId: .value("test-case-id"),
+            state: .value(.enabled),
+            isFlaky: .value(nil),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: nil,
+            testCaseIdentifier: "test-case-id",
+            state: .enabled,
+            isFlaky: nil,
+            path: nil,
+            json: true
+        )
+
+        // Then
+        let payload = try #require(decodeJSON(ui()))
+        #expect(payload["name"] as? String == "testLogin()")
+        #expect((payload["module"] as? [String: Any])?["name"] as? String == "AuthTests")
+        #expect(payload["state"] as? String == "enabled")
+    }
+
+    @Test(
+        .withMockedEnvironment(arguments: ["--json"]),
+        .withMockedNoora
+    ) func run_with_json_output_and_name_identifier() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let resolvedTestCase = ServerTestCase.test(
+            id: "resolved-id",
+            module: .test(name: "AuthTests"),
+            name: "testLogin()",
+            suite: .test(name: "LoginSuite")
+        )
+        given(getTestCaseService).getTestCaseByName(
+            fullHandle: .value(fullHandle),
+            moduleName: .value("AuthTests"),
+            name: .value("testLogin()"),
+            suiteName: .value("LoginSuite"),
+            serverURL: .value(serverURL)
+        ).willReturn(resolvedTestCase)
+        let updated = ServerUpdatedTestCase.test(
+            id: "resolved-id",
+            module: .test(name: "AuthTests"),
+            name: "testLogin()",
+            state: .muted
+        )
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(fullHandle),
+            testCaseId: .value("resolved-id"),
+            state: .value(.muted),
+            isFlaky: .value(nil),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: nil,
+            testCaseIdentifier: "AuthTests/LoginSuite/testLogin()",
+            state: .muted,
+            isFlaky: nil,
+            path: nil,
+            json: true
+        )
+
+        // Then
+        let payload = try #require(decodeJSON(ui()))
+        #expect(payload["name"] as? String == "testLogin()")
+        #expect(payload["state"] as? String == "muted")
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedNoora
+    ) func run_with_text_output() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let updated = ServerUpdatedTestCase.test(
+            isFlaky: true,
+            module: .test(name: "AppTests"),
+            name: "testFlaky()",
+            state: .muted,
+            suite: .test(name: "FlakyTests"),
+            url: "https://tuist.dev/some-test"
+        )
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(fullHandle),
+            testCaseId: .value("tc-123"),
+            state: .value(.muted),
+            isFlaky: .value(nil),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: nil,
+            testCaseIdentifier: "tc-123",
+            state: .muted,
+            isFlaky: nil,
+            path: nil,
+            json: false
+        )
+
+        // Then
+        #expect(ui().contains("testFlaky()"))
+        #expect(ui().contains("AppTests"))
+        #expect(ui().contains("FlakyTests"))
+        #expect(ui().contains("Flaky: Yes"))
+        #expect(ui().contains("State: muted"))
+        #expect(ui().contains("https://tuist.dev/some-test"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedNoora) func run_with_explicit_project_handle() async throws {
+        // Given
+        let configFullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let explicitFullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: configFullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let updated = ServerUpdatedTestCase.test()
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(explicitFullHandle),
+            testCaseId: .value("tc-123"),
+            state: .value(.enabled),
+            isFlaky: .value(nil),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: explicitFullHandle,
+            testCaseIdentifier: "tc-123",
+            state: .enabled,
+            isFlaky: nil,
+            path: nil,
+            json: false
+        )
+
+        // Then
+        verify(updateTestCaseService).updateTestCase(
+            fullHandle: .value(explicitFullHandle),
+            testCaseId: .any,
+            state: .any,
+            isFlaky: .any,
+            serverURL: .any
+        ).called(1)
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedNoora
+    ) func run_with_flaky_only_update() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let updated = ServerUpdatedTestCase.test(
+            isFlaky: true,
+            module: .test(name: "AuthTests"),
+            name: "testLogin()",
+            state: .enabled
+        )
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(fullHandle),
+            testCaseId: .value("tc-123"),
+            state: .value(nil),
+            isFlaky: .value(true),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: nil,
+            testCaseIdentifier: "tc-123",
+            state: nil,
+            isFlaky: true,
+            path: nil,
+            json: false
+        )
+
+        // Then
+        #expect(ui().contains("Flaky: Yes"))
+        verify(updateTestCaseService).updateTestCase(
+            fullHandle: .any,
+            testCaseId: .any,
+            state: .value(nil),
+            isFlaky: .value(true),
+            serverURL: .any
+        ).called(1)
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedNoora
+    ) func run_with_state_and_flaky_combined() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+        let updated = ServerUpdatedTestCase.test(
+            isFlaky: false,
+            module: .test(name: "AuthTests"),
+            name: "testLogin()",
+            state: .enabled
+        )
+        given(updateTestCaseService).updateTestCase(
+            fullHandle: .value(fullHandle),
+            testCaseId: .value("tc-123"),
+            state: .value(.enabled),
+            isFlaky: .value(false),
+            serverURL: .value(serverURL)
+        ).willReturn(updated)
+
+        // When
+        try await subject.run(
+            project: nil,
+            testCaseIdentifier: "tc-123",
+            state: .enabled,
+            isFlaky: false,
+            path: nil,
+            json: false
+        )
+
+        // Then
+        #expect(ui().contains("State: enabled"))
+        #expect(ui().contains("Flaky: No"))
+        verify(updateTestCaseService).updateTestCase(
+            fullHandle: .any,
+            testCaseId: .any,
+            state: .value(.enabled),
+            isFlaky: .value(false),
+            serverURL: .any
+        ).called(1)
+    }
+
+    @Test(.withMockedEnvironment()) func run_with_invalid_identifier() async throws {
+        // Given
+        let fullHandle = "\(UUID().uuidString)/\(UUID().uuidString)"
+        let tuist = Tuist.test(fullHandle: fullHandle)
+        let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(nil)
+        given(configLoader).loadConfig(path: .value(directoryPath)).willReturn(tuist)
+        let serverURL = URL(string: "https://\(UUID().uuidString).tuist.dev")!
+        given(serverEnvironmentService).url(configServerURL: .value(tuist.url)).willReturn(serverURL)
+
+        // When/Then
+        await #expect(throws: TestCaseIdentifierError.invalidIdentifier("a/b/c/d"), performing: {
+            try await subject.run(
+                project: nil,
+                testCaseIdentifier: "a/b/c/d",
+                state: .enabled,
+                isFlaky: nil,
+                path: nil,
+                json: false
+            )
+        })
+    }
+
+    private func decodeJSON(_ string: String) -> [String: Any]? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}

--- a/cli/Tests/TuistTestCommandTests/Services/TestCaseUpdateCommandServiceTests.swift
+++ b/cli/Tests/TuistTestCommandTests/Services/TestCaseUpdateCommandServiceTests.swift
@@ -75,7 +75,7 @@ struct TestCaseUpdateCommandServiceTests {
         let updated = ServerUpdatedTestCase.test(
             module: .test(name: "AuthTests"),
             name: "testLogin()",
-            state: .enabled
+            state: "enabled"
         )
         given(updateTestCaseService).updateTestCase(
             fullHandle: .value(fullHandle),
@@ -130,7 +130,7 @@ struct TestCaseUpdateCommandServiceTests {
             id: "resolved-id",
             module: .test(name: "AuthTests"),
             name: "testLogin()",
-            state: .muted
+            state: "muted"
         )
         given(updateTestCaseService).updateTestCase(
             fullHandle: .value(fullHandle),
@@ -171,7 +171,7 @@ struct TestCaseUpdateCommandServiceTests {
             isFlaky: true,
             module: .test(name: "AppTests"),
             name: "testFlaky()",
-            state: .muted,
+            state: "muted",
             suite: .test(name: "FlakyTests"),
             url: "https://tuist.dev/some-test"
         )
@@ -255,7 +255,7 @@ struct TestCaseUpdateCommandServiceTests {
             isFlaky: true,
             module: .test(name: "AuthTests"),
             name: "testLogin()",
-            state: .enabled
+            state: "enabled"
         )
         given(updateTestCaseService).updateTestCase(
             fullHandle: .value(fullHandle),
@@ -301,7 +301,7 @@ struct TestCaseUpdateCommandServiceTests {
             isFlaky: false,
             module: .test(name: "AuthTests"),
             name: "testLogin()",
-            state: .enabled
+            state: "enabled"
         )
         given(updateTestCaseService).updateTestCase(
             fullHandle: .value(fullHandle),

--- a/server/lib/tuist/authorization.ex
+++ b/server/lib/tuist/authorization.ex
@@ -486,6 +486,17 @@ defmodule Tuist.Authorization do
       allow([:authenticated_as_account, scopes_permit: "project:tests:read"])
       allow([:authenticated_as_account, scopes_permit: "project:tests:write"])
     end
+
+    action :update do
+      desc("Allows users of a project to update a tests data.")
+      allow([:authenticated_as_user, user_role: :user])
+
+      desc("Allows the admin of a project to update tests data.")
+      allow([:authenticated_as_user, user_role: :admin])
+
+      desc("Allows an account token with project:tests:write scope to update tests data.")
+      allow([:authenticated_as_account, scopes_permit: "project:tests:write"])
+    end
   end
 
   object :build do

--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -1,6 +1,6 @@
 defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
   @moduledoc """
-  Update mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: https://tuist.dev/{account_handle}/{project_handle}.
+  Update mutable fields on a test case. Supports changing `state` between `enabled`, `muted`, and `skipped`, and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: https://tuist.dev/{account_handle}/{project_handle}.
   """
 
   use Tuist.MCP.Tool,
@@ -28,7 +28,7 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
         },
         "state" => %{
           "type" => "string",
-          "enum" => ["enabled", "muted"],
+          "enum" => ["enabled", "muted", "skipped"],
           "description" => "The new state of the test case."
         },
         "is_flaky" => %{
@@ -51,7 +51,7 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
   @impl EMCP.Tool
   def description,
     do:
-      "Update mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+      "Update mutable fields on a test case. Supports changing `state` between `enabled`, `muted`, and `skipped`, and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
 
   @impl EMCP.Tool
   def call(conn, args) do
@@ -119,10 +119,12 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
     end
   end
 
-  defp maybe_put_state(attrs, %{"state" => state}) when state in ["enabled", "muted"],
+  defp maybe_put_state(attrs, %{"state" => state}) when state in ["enabled", "muted", "skipped"],
     do: {:ok, Map.put(attrs, :state, state)}
 
-  defp maybe_put_state(_attrs, %{"state" => _invalid}), do: {:error, "`state` must be either `enabled` or `muted`."}
+  defp maybe_put_state(_attrs, %{"state" => _invalid}),
+    do: {:error, "`state` must be one of `enabled`, `muted`, or `skipped`."}
+
   defp maybe_put_state(attrs, _args), do: {:ok, attrs}
 
   defp maybe_put_is_flaky(attrs, %{"is_flaky" => is_flaky}) when is_boolean(is_flaky),

--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -1,0 +1,172 @@
+defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
+  @moduledoc """
+  Update mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: https://tuist.dev/{account_handle}/{project_handle}.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "update_test_case",
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "test_case_id" => %{
+          "type" => "string",
+          "description" => "The ID of the test case. Required when not using identifier lookup."
+        },
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account handle (organization or user). Required for identifier lookup."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle. Required for identifier lookup."
+        },
+        "identifier" => %{
+          "type" => "string",
+          "description" =>
+            "Test case identifier in Module/Suite/TestCase or Module/TestCase format. " <>
+              "Required when not using test_case_id. Must be combined with account_handle and project_handle."
+        },
+        "state" => %{
+          "type" => "string",
+          "enum" => ["enabled", "muted"],
+          "description" => "The new state of the test case."
+        },
+        "is_flaky" => %{
+          "type" => "boolean",
+          "description" => "Whether to mark the test case as flaky."
+        }
+      }
+    }
+
+  alias Tuist.Accounts.AuthenticatedAccount
+  alias Tuist.Accounts.User
+  alias Tuist.MCP.Authorization
+  alias Tuist.MCP.Tool, as: MCPTool
+  alias Tuist.Projects.Project
+  alias Tuist.Tests
+
+  @authorization_action :update
+  @authorization_category :test
+
+  @impl EMCP.Tool
+  def description,
+    do:
+      "Update mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling `is_flaky`. The account_handle and project_handle can be extracted from a Tuist dashboard URL: #{Tuist.Environment.app_url()}/{account_handle}/{project_handle}."
+
+  @impl EMCP.Tool
+  def call(conn, args) do
+    case extract_update_attrs(args) do
+      {:ok, attrs} -> resolve_and_update(conn, args, attrs)
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  defp resolve_and_update(conn, %{"test_case_id" => test_case_id} = _args, attrs) when is_binary(test_case_id) do
+    case MCPTool.load_and_authorize(
+           Tests.get_test_case_by_id(test_case_id),
+           conn.assigns,
+           @authorization_action,
+           @authorization_category,
+           "Test case not found: #{test_case_id}"
+         ) do
+      {:ok, _test_case, _project} -> apply_update(conn, test_case_id, attrs)
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  defp resolve_and_update(conn, %{"identifier" => identifier} = args, attrs) when is_binary(identifier) do
+    with {:ok, {module_name, suite_name, name}} <- parse_identifier(identifier),
+         {:ok, project} <-
+           MCPTool.resolve_and_authorize_project(
+             args,
+             conn.assigns,
+             @authorization_action,
+             @authorization_category
+           ),
+         {:ok, test_case} <- find_test_case_by_name(project.id, module_name, suite_name, name) do
+      apply_update(conn, test_case.id, attrs)
+    else
+      {:error, message} -> EMCP.Tool.error(message)
+    end
+  end
+
+  defp resolve_and_update(_conn, _args, _attrs) do
+    EMCP.Tool.error("Provide either test_case_id, or identifier with account_handle and project_handle.")
+  end
+
+  defp apply_update(conn, test_case_id, attrs) do
+    actor_id = conn.assigns |> Authorization.authenticated_subject() |> subject_account_id()
+
+    case Tests.update_test_case(test_case_id, attrs, actor_id: actor_id) do
+      {:ok, updated} -> MCPTool.json_response(reply_payload(updated))
+      {:error, :not_found} -> EMCP.Tool.error("Test case not found: #{test_case_id}")
+    end
+  end
+
+  defp subject_account_id(%User{account: %{id: id}}), do: id
+  defp subject_account_id(%Project{account: %{id: id}}), do: id
+  defp subject_account_id(%AuthenticatedAccount{account: %{id: id}}), do: id
+  defp subject_account_id(_), do: nil
+
+  defp extract_update_attrs(args) do
+    with {:ok, attrs} <- maybe_put_state(%{}, args),
+         {:ok, attrs} <- maybe_put_is_flaky(attrs, args) do
+      if map_size(attrs) == 0 do
+        {:error, "Provide at least one of `state` or `is_flaky`."}
+      else
+        {:ok, attrs}
+      end
+    end
+  end
+
+  defp maybe_put_state(attrs, %{"state" => state}) when state in ["enabled", "muted"],
+    do: {:ok, Map.put(attrs, :state, state)}
+
+  defp maybe_put_state(_attrs, %{"state" => _invalid}), do: {:error, "`state` must be either `enabled` or `muted`."}
+  defp maybe_put_state(attrs, _args), do: {:ok, attrs}
+
+  defp maybe_put_is_flaky(attrs, %{"is_flaky" => is_flaky}) when is_boolean(is_flaky),
+    do: {:ok, Map.put(attrs, :is_flaky, is_flaky)}
+
+  defp maybe_put_is_flaky(_attrs, %{"is_flaky" => _invalid}), do: {:error, "`is_flaky` must be a boolean."}
+  defp maybe_put_is_flaky(attrs, _args), do: {:ok, attrs}
+
+  defp parse_identifier(identifier) do
+    case String.split(identifier, "/") do
+      [module_name, suite_name, name] -> {:ok, {module_name, suite_name, name}}
+      [module_name, name] -> {:ok, {module_name, nil, name}}
+      _ -> {:error, "Invalid identifier format. Use Module/Suite/TestCase or Module/TestCase."}
+    end
+  end
+
+  defp find_test_case_by_name(project_id, module_name, suite_name, name) do
+    filters =
+      [
+        %{field: :module_name, op: :==, value: module_name},
+        %{field: :name, op: :==, value: name}
+      ] ++ if(suite_name, do: [%{field: :suite_name, op: :==, value: suite_name}], else: [])
+
+    {test_cases, _meta} =
+      Tests.list_test_cases(project_id, %{
+        filters: filters,
+        page: 1,
+        page_size: 1
+      })
+
+    case test_cases do
+      [test_case | _] -> {:ok, test_case}
+      [] -> {:error, "Test case not found: #{module_name}/#{suite_name || name}"}
+    end
+  end
+
+  defp reply_payload(test_case) do
+    %{
+      id: test_case.id,
+      name: test_case.name,
+      module_name: test_case.module_name,
+      suite_name: test_case.suite_name,
+      is_flaky: test_case.is_flaky,
+      state: test_case.state || "enabled"
+    }
+  end
+end

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -22,6 +22,7 @@ defmodule Tuist.MCP.Server do
       Tuist.MCP.Components.Tools.ListTestCases,
       Tuist.MCP.Components.Tools.ListTestCaseEvents,
       Tuist.MCP.Components.Tools.GetTestCase,
+      Tuist.MCP.Components.Tools.UpdateTestCase,
       Tuist.MCP.Components.Tools.GetTestRun,
       Tuist.MCP.Components.Tools.GetTestCaseRun,
       Tuist.MCP.Components.Tools.ListTestCaseRunAttachments,

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -8,6 +8,7 @@ defmodule TuistWeb.API.TestCasesController do
   alias TuistWeb.API.Schemas.Error
   alias TuistWeb.API.Schemas.PaginationMetadata
   alias TuistWeb.API.Schemas.TestCase
+  alias TuistWeb.Authentication
 
   plug(TuistWeb.Plugs.CastAndValidate,
     json_render_error_v2: true,
@@ -282,6 +283,130 @@ defmodule TuistWeb.API.TestCasesController do
             total_runs: analytics.total_count,
             failed_runs: analytics.failed_count,
             url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{test_case.id}"
+          })
+        else
+          conn
+          |> put_status(:not_found)
+          |> json(%{message: "Test case not found."})
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{message: "Test case not found."})
+    end
+  end
+
+  operation(:update,
+    summary: "Update a test case.",
+    description:
+      "Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling " <>
+        "`is_flaky`. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded " <>
+        "automatically when values transition.",
+    operation_id: "updateTestCase",
+    parameters: [
+      account_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the account."
+      ],
+      project_handle: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The handle of the project."
+      ],
+      test_case_id: [
+        in: :path,
+        schema: %Schema{type: :string, format: :uuid},
+        required: true,
+        description: "The ID of the test case."
+      ]
+    ],
+    request_body:
+      {"Test case update params", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{
+           state: %Schema{
+             type: :string,
+             enum: ["enabled", "muted"],
+             description: "The new state of the test case."
+           },
+           is_flaky: %Schema{
+             type: :boolean,
+             description: "Whether to mark the test case as flaky."
+           }
+         }
+       }},
+    responses: %{
+      ok:
+        {"The updated test case", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             id: %Schema{type: :string, format: :uuid, description: "The test case ID."},
+             name: %Schema{type: :string, description: "Name of the test case."},
+             module: %Schema{
+               type: :object,
+               required: [:id, :name],
+               properties: %{
+                 id: %Schema{type: :string, description: "ID of the module."},
+                 name: %Schema{type: :string, description: "Name of the module."}
+               }
+             },
+             suite: %Schema{
+               type: :object,
+               nullable: true,
+               required: [:id, :name],
+               properties: %{
+                 id: %Schema{type: :string, description: "ID of the suite."},
+                 name: %Schema{type: :string, description: "Name of the suite."}
+               }
+             },
+             is_flaky: %Schema{type: :boolean, description: "Whether the test case is marked as flaky."},
+             is_quarantined: %Schema{
+               type: :boolean,
+               deprecated: true,
+               description: "Whether the test case is quarantined. Deprecated: use `state` instead."
+             },
+             state: %Schema{type: :string, enum: ["enabled", "muted"], description: "The state of the test case."},
+             url: %Schema{type: :string, description: "URL to view the test case in the dashboard."}
+           },
+           required: [:id, :name, :module, :is_flaky, :is_quarantined, :state, :url]
+         }},
+      not_found: {"Test case not found", "application/json", Error},
+      forbidden: {"You don't have permission to update this resource", "application/json", Error}
+    }
+  )
+
+  def update(
+        %{assigns: %{selected_project: selected_project}, params: %{test_case_id: test_case_id}, body_params: body_params} =
+          conn,
+        _params
+      ) do
+    attrs = Map.take(body_params, [:state, :is_flaky])
+
+    case Tests.get_test_case_by_id(test_case_id) do
+      {:ok, test_case} ->
+        if test_case.project_id == selected_project.id do
+          actor_id = Authentication.authenticated_subject_account(conn).id
+
+          {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
+
+          json(conn, %{
+            id: updated_test_case.id,
+            name: updated_test_case.name,
+            module: %{
+              id: updated_test_case.module_name,
+              name: updated_test_case.module_name
+            },
+            suite: build_suite(updated_test_case.suite_name),
+            is_flaky: updated_test_case.is_flaky,
+            is_quarantined: (updated_test_case.state || "enabled") == "muted",
+            state: updated_test_case.state || "enabled",
+            url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
           })
         else
           conn

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -18,6 +18,8 @@ defmodule TuistWeb.API.TestCasesController do
   plug(TuistWeb.Plugs.LoaderPlug)
   plug(TuistWeb.API.Authorization.AuthorizationPlug, :test)
 
+  @valid_states ["enabled", "muted", "skipped"]
+
   tags ["Test Cases"]
 
   operation(:index,
@@ -396,42 +398,53 @@ defmodule TuistWeb.API.TestCasesController do
       ) do
     attrs = Map.take(body_params, [:state, :is_flaky])
 
-    if map_size(attrs) == 0 do
-      conn
-      |> put_status(:bad_request)
-      |> json(%{message: "Provide at least one of `state` or `is_flaky`."})
-    else
-      case Tests.get_test_case_by_id(test_case_id) do
-        {:ok, test_case} ->
-          if test_case.project_id == selected_project.id do
-            actor_id = Authentication.authenticated_subject_account(conn).id
+    cond do
+      map_size(attrs) == 0 ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{message: "Provide at least one of `state` or `is_flaky`."})
 
-            {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
+      Map.has_key?(attrs, :state) and attrs.state not in @valid_states ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{message: "`state` must be one of `enabled`, `muted`, or `skipped`."})
 
-            json(conn, %{
-              id: updated_test_case.id,
-              name: updated_test_case.name,
-              module: %{
-                id: updated_test_case.module_name,
-                name: updated_test_case.module_name
-              },
-              suite: build_suite(updated_test_case.suite_name),
-              is_flaky: updated_test_case.is_flaky,
-              is_quarantined: quarantined?(updated_test_case.state),
-              state: updated_test_case.state || "enabled",
-              url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
-            })
-          else
-            conn
-            |> put_status(:not_found)
-            |> json(%{message: "Test case not found."})
-          end
+      true ->
+        update_test_case(conn, selected_project, test_case_id, attrs)
+    end
+  end
 
-        {:error, :not_found} ->
+  defp update_test_case(conn, selected_project, test_case_id, attrs) do
+    case Tests.get_test_case_by_id(test_case_id) do
+      {:ok, test_case} ->
+        if test_case.project_id == selected_project.id do
+          actor_id = Authentication.authenticated_subject_account(conn).id
+
+          {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
+
+          json(conn, %{
+            id: updated_test_case.id,
+            name: updated_test_case.name,
+            module: %{
+              id: updated_test_case.module_name,
+              name: updated_test_case.module_name
+            },
+            suite: build_suite(updated_test_case.suite_name),
+            is_flaky: updated_test_case.is_flaky,
+            is_quarantined: quarantined?(updated_test_case.state),
+            state: updated_test_case.state || "enabled",
+            url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
+          })
+        else
           conn
           |> put_status(:not_found)
           |> json(%{message: "Test case not found."})
-      end
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{message: "Test case not found."})
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -300,8 +300,10 @@ defmodule TuistWeb.API.TestCasesController do
   operation(:update,
     summary: "Update a test case.",
     description:
-      "Updates mutable fields on a test case. Supports changing `state` between `enabled` and `muted` and toggling " <>
-        "`is_flaky`. Corresponding events (`muted`/`unmuted`, `marked_flaky`/`unmarked_flaky`) are recorded " <>
+      "Updates mutable fields on a test case. Supports changing `state` (currently one of `enabled`, `muted`, " <>
+        "or `skipped`; the field is left as an open string so adding new states in the future doesn't break " <>
+        "clients pinned to the older spec) and toggling `is_flaky`. Corresponding events " <>
+        "(`muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky`) are recorded " <>
         "automatically when values transition.",
     operation_id: "updateTestCase",
     parameters: [
@@ -331,8 +333,8 @@ defmodule TuistWeb.API.TestCasesController do
          properties: %{
            state: %Schema{
              type: :string,
-             enum: ["enabled", "muted"],
-             description: "The new state of the test case."
+             description:
+               "The new state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec."
            },
            is_flaky: %Schema{
              type: :boolean,
@@ -369,13 +371,19 @@ defmodule TuistWeb.API.TestCasesController do
              is_quarantined: %Schema{
                type: :boolean,
                deprecated: true,
-               description: "Whether the test case is quarantined. Deprecated: use `state` instead."
+               description:
+                 "Whether the test case is quarantined (either `muted` or `skipped`). Deprecated: use `state` instead."
              },
-             state: %Schema{type: :string, enum: ["enabled", "muted"], description: "The state of the test case."},
+             state: %Schema{
+               type: :string,
+               description:
+                 "The state of the test case. Currently one of `enabled`, `muted`, or `skipped`; the field is left as an open string so adding new states in the future doesn't break clients pinned to the older spec."
+             },
              url: %Schema{type: :string, description: "URL to view the test case in the dashboard."}
            },
            required: [:id, :name, :module, :is_flaky, :is_quarantined, :state, :url]
          }},
+      bad_request: {"Invalid update params (empty body or malformed field values)", "application/json", Error},
       not_found: {"Test case not found", "application/json", Error},
       forbidden: {"You don't have permission to update this resource", "application/json", Error}
     }
@@ -388,36 +396,42 @@ defmodule TuistWeb.API.TestCasesController do
       ) do
     attrs = Map.take(body_params, [:state, :is_flaky])
 
-    case Tests.get_test_case_by_id(test_case_id) do
-      {:ok, test_case} ->
-        if test_case.project_id == selected_project.id do
-          actor_id = Authentication.authenticated_subject_account(conn).id
+    if map_size(attrs) == 0 do
+      conn
+      |> put_status(:bad_request)
+      |> json(%{message: "Provide at least one of `state` or `is_flaky`."})
+    else
+      case Tests.get_test_case_by_id(test_case_id) do
+        {:ok, test_case} ->
+          if test_case.project_id == selected_project.id do
+            actor_id = Authentication.authenticated_subject_account(conn).id
 
-          {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
+            {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
 
-          json(conn, %{
-            id: updated_test_case.id,
-            name: updated_test_case.name,
-            module: %{
-              id: updated_test_case.module_name,
-              name: updated_test_case.module_name
-            },
-            suite: build_suite(updated_test_case.suite_name),
-            is_flaky: updated_test_case.is_flaky,
-            is_quarantined: (updated_test_case.state || "enabled") == "muted",
-            state: updated_test_case.state || "enabled",
-            url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
-          })
-        else
+            json(conn, %{
+              id: updated_test_case.id,
+              name: updated_test_case.name,
+              module: %{
+                id: updated_test_case.module_name,
+                name: updated_test_case.module_name
+              },
+              suite: build_suite(updated_test_case.suite_name),
+              is_flaky: updated_test_case.is_flaky,
+              is_quarantined: quarantined?(updated_test_case.state),
+              state: updated_test_case.state || "enabled",
+              url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
+            })
+          else
+            conn
+            |> put_status(:not_found)
+            |> json(%{message: "Test case not found."})
+          end
+
+        {:error, :not_found} ->
           conn
           |> put_status(:not_found)
           |> json(%{message: "Test case not found."})
-        end
-
-      {:error, :not_found} ->
-        conn
-        |> put_status(:not_found)
-        |> json(%{message: "Test case not found."})
+      end
     end
   end
 

--- a/server/lib/tuist_web/controllers/api/test_cases_controller.ex
+++ b/server/lib/tuist_web/controllers/api/test_cases_controller.ex
@@ -420,21 +420,28 @@ defmodule TuistWeb.API.TestCasesController do
         if test_case.project_id == selected_project.id do
           actor_id = Authentication.authenticated_subject_account(conn).id
 
-          {:ok, updated_test_case} = Tests.update_test_case(test_case_id, attrs, actor_id: actor_id)
+          case Tests.update_test_case(test_case_id, attrs, actor_id: actor_id) do
+            {:ok, updated_test_case} ->
+              json(conn, %{
+                id: updated_test_case.id,
+                name: updated_test_case.name,
+                module: %{
+                  id: updated_test_case.module_name,
+                  name: updated_test_case.module_name
+                },
+                suite: build_suite(updated_test_case.suite_name),
+                is_flaky: updated_test_case.is_flaky,
+                is_quarantined: quarantined?(updated_test_case.state),
+                state: updated_test_case.state || "enabled",
+                url:
+                  ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
+              })
 
-          json(conn, %{
-            id: updated_test_case.id,
-            name: updated_test_case.name,
-            module: %{
-              id: updated_test_case.module_name,
-              name: updated_test_case.module_name
-            },
-            suite: build_suite(updated_test_case.suite_name),
-            is_flaky: updated_test_case.is_flaky,
-            is_quarantined: quarantined?(updated_test_case.state),
-            state: updated_test_case.state || "enabled",
-            url: ~p"/#{selected_project.account.name}/#{selected_project.name}/tests/test-cases/#{updated_test_case.id}"
-          })
+            {:error, :not_found} ->
+              conn
+              |> put_status(:not_found)
+              |> json(%{message: "Test case not found."})
+          end
         else
           conn
           |> put_status(:not_found)

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -497,7 +497,7 @@ defmodule TuistWeb.Router do
             end
 
             get "/:test_case_id", TestCasesController, :show
-            put "/:test_case_id", TestCasesController, :update
+            patch "/:test_case_id", TestCasesController, :update
             get "/:test_case_id/events", TestCasesController, :events
             get "/:test_case_id/runs", TestCaseRunsController, :index_by_test_case
           end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -497,6 +497,7 @@ defmodule TuistWeb.Router do
             end
 
             get "/:test_case_id", TestCasesController, :show
+            put "/:test_case_id", TestCasesController, :update
             get "/:test_case_id/events", TestCasesController, :events
             get "/:test_case_id/runs", TestCaseRunsController, :index_by_test_case
           end

--- a/server/test/tuist/mcp/components/tools/test_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/test_tools_test.exs
@@ -440,7 +440,7 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
                  "state" => "invalid"
                })
 
-      assert text =~ "`state` must be either `enabled` or `muted`."
+      assert text =~ "`state` must be one of `enabled`, `muted`, or `skipped`."
     end
 
     test "returns error without test_case_id or identifier" do

--- a/server/test/tuist/mcp/components/tools/test_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/test_tools_test.exs
@@ -13,6 +13,7 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
   alias Tuist.MCP.Components.Tools.ListTestRuns
   alias Tuist.MCP.Components.Tools.ListTestSuiteRuns
   alias Tuist.MCP.Components.Tools.ListXcodeTestTargets
+  alias Tuist.MCP.Components.Tools.UpdateTestCase
   alias Tuist.Projects
   alias Tuist.Tests
   alias Tuist.Tests.Analytics
@@ -396,6 +397,57 @@ defmodule Tuist.MCP.Components.Tools.TestToolsTest do
 
       assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
                GetTestCase.call(conn, %{})
+
+      assert text =~
+               "Provide either test_case_id, or identifier with account_handle and project_handle."
+    end
+  end
+
+  describe "update_test_case" do
+    test "requires :test_update authorization" do
+      project = %{id: "project-id", name: "project-name"}
+      project_id = project.id
+      stub(Tests, :get_test_case_by_id, fn "test-case-id" -> {:ok, %{project_id: project.id}} end)
+      stub(Projects, :get_project_by_id, fn ^project_id -> project end)
+
+      expect(Tuist.Authorization, :authorize, fn :test_update, :subject, ^project ->
+        {:error, :forbidden}
+      end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
+               UpdateTestCase.call(conn, %{"test_case_id" => "test-case-id", "state" => "muted"})
+
+      assert text =~ "You do not have access to this resource."
+    end
+
+    test "returns error without state or is_flaky" do
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
+               UpdateTestCase.call(conn, %{"test_case_id" => "test-case-id"})
+
+      assert text =~ "Provide at least one of `state` or `is_flaky`."
+    end
+
+    test "returns error for invalid state value" do
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
+               UpdateTestCase.call(conn, %{
+                 "test_case_id" => "test-case-id",
+                 "state" => "invalid"
+               })
+
+      assert text =~ "`state` must be either `enabled` or `muted`."
+    end
+
+    test "returns error without test_case_id or identifier" do
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} =
+               UpdateTestCase.call(conn, %{"state" => "muted"})
 
       assert text =~
                "Provide either test_case_id, or identifier with account_handle and project_handle."

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -606,7 +606,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
     end
   end
 
-  describe "PUT /api/projects/:account_handle/:project_handle/tests/test-cases/:test_case_id" do
+  describe "PATCH /api/projects/:account_handle/:project_handle/tests/test-cases/:test_case_id" do
     setup %{conn: conn} do
       user = AccountsFixtures.user_fixture(preload: [:account])
       project = ProjectsFixtures.project_fixture(account_id: user.account.id)
@@ -643,7 +643,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{state: "enabled"}
         )
@@ -681,7 +681,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{state: "muted"}
         )
@@ -700,8 +700,37 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
+          %{state: "enabled"}
+        )
+
+      # Then
+      assert json_response(conn, :not_found)
+    end
+
+    test "returns 404 when test case is deleted between lookup and update", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      # Given
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          state: "muted",
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+      stub(Tests, :update_test_case, fn _id, _attrs, _opts -> {:error, :not_found} end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{state: "enabled"}
         )
 
@@ -729,7 +758,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{state: "enabled"}
         )
@@ -747,7 +776,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{project.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
           %{state: "enabled"}
         )
@@ -761,7 +790,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
           %{state: "not-a-real-state"}
         )
@@ -775,7 +804,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
           %{}
         )
@@ -807,7 +836,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{is_flaky: true}
         )
@@ -841,7 +870,7 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> put(
+        |> patch(
           "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
           %{state: "enabled", is_flaky: false}
         )

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -770,6 +770,20 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       assert response(conn, 400)
     end
 
+    test "returns 400 when body omits both state and is_flaky", %{conn: conn, user: user, project: project} do
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
+          %{}
+        )
+
+      # Then
+      assert json_response(conn, :bad_request)["message"] =~ "Provide at least one"
+    end
+
     test "marks a test case as flaky", %{conn: conn, user: user, project: project} do
       # Given
       test_case =

--- a/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_cases_controller_test.exs
@@ -605,4 +605,237 @@ defmodule TuistWeb.API.TestCasesControllerTest do
       assert json_response(conn, :forbidden)
     end
   end
+
+  describe "PUT /api/projects/:account_handle/:project_handle/tests/test-cases/:test_case_id" do
+    setup %{conn: conn} do
+      user = AccountsFixtures.user_fixture(preload: [:account])
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      %{conn: conn, user: user, project: project}
+    end
+
+    test "updates state from muted to enabled", %{conn: conn, user: user, project: project} do
+      # Given
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "testExample",
+          module_name: "MyTests",
+          suite_name: "MySuite",
+          state: "muted",
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      updated = %{test_case | state: "enabled"}
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+
+      expect(Tests, :update_test_case, fn id, attrs, opts ->
+        assert id == test_case.id
+        assert attrs == %{state: "enabled"}
+        assert Keyword.fetch!(opts, :actor_id) == user.account.id
+        {:ok, updated}
+      end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
+          %{state: "enabled"}
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+      assert response["id"] == test_case.id
+      assert response["state"] == "enabled"
+      assert response["is_quarantined"] == false
+      assert response["module"]["name"] == "MyTests"
+      assert response["suite"]["name"] == "MySuite"
+      assert response["url"] =~ test_case.id
+    end
+
+    test "updates state from enabled to muted", %{conn: conn, user: user, project: project} do
+      # Given
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "testExample",
+          state: "enabled",
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      updated = %{test_case | state: "muted"}
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+
+      expect(Tests, :update_test_case, fn _id, attrs, _opts ->
+        assert attrs == %{state: "muted"}
+        {:ok, updated}
+      end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
+          %{state: "muted"}
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+      assert response["state"] == "muted"
+      assert response["is_quarantined"] == true
+    end
+
+    test "returns 404 when test case does not exist", %{conn: conn, user: user, project: project} do
+      # Given
+      stub(Tests, :get_test_case_by_id, fn _id -> {:error, :not_found} end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
+          %{state: "enabled"}
+        )
+
+      # Then
+      assert json_response(conn, :not_found)
+    end
+
+    test "returns 404 when test case belongs to a different project", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      # Given
+      other_project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: other_project.id,
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
+          %{state: "enabled"}
+        )
+
+      # Then
+      assert json_response(conn, :not_found)
+    end
+
+    test "returns 403 when user is not authorized", %{conn: conn, project: project} do
+      # Given
+      other_user = AccountsFixtures.user_fixture(preload: [:account])
+      conn = Authentication.put_current_user(conn, other_user)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{project.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
+          %{state: "enabled"}
+        )
+
+      # Then
+      assert json_response(conn, :forbidden)
+    end
+
+    test "returns 400 when state value is invalid", %{conn: conn, user: user, project: project} do
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{UUIDv7.generate()}",
+          %{state: "not-a-real-state"}
+        )
+
+      # Then
+      assert response(conn, 400)
+    end
+
+    test "marks a test case as flaky", %{conn: conn, user: user, project: project} do
+      # Given
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "testExample",
+          is_flaky: false,
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      updated = %{test_case | is_flaky: true}
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+
+      expect(Tests, :update_test_case, fn _id, attrs, _opts ->
+        assert attrs == %{is_flaky: true}
+        {:ok, updated}
+      end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
+          %{is_flaky: true}
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+      assert response["is_flaky"] == true
+    end
+
+    test "updates state and is_flaky together", %{conn: conn, user: user, project: project} do
+      # Given
+      test_case =
+        RunsFixtures.test_case_fixture(
+          project_id: project.id,
+          name: "testExample",
+          state: "muted",
+          is_flaky: true,
+          last_ran_at: NaiveDateTime.utc_now()
+        )
+
+      updated = %{test_case | state: "enabled", is_flaky: false}
+
+      stub(Tests, :get_test_case_by_id, fn _id -> {:ok, test_case} end)
+
+      expect(Tests, :update_test_case, fn _id, attrs, _opts ->
+        assert attrs == %{state: "enabled", is_flaky: false}
+        {:ok, updated}
+      end)
+
+      # When
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/#{test_case.id}",
+          %{state: "enabled", is_flaky: false}
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+      assert response["state"] == "enabled"
+      assert response["is_flaky"] == false
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a `tuist test case update` CLI command backed by a new `PATCH /projects/:account/:project/test-cases/:id` server endpoint. The command accepts either a test case UUID or a `Module/Suite/TestName` identifier and can change the test case's `state` (via `--state`) and/or its flaky flag (via `--flaky`/`--no-flaky`). At least one of the two must be provided.

Primary motivation: give operators a one-shot, scriptable way to mutate a test case; in particular to unquarantine tests that were flagged as flaky by auto-quarantine but turned out to be false positives, and to toggle the flaky flag from CI without going through the dashboard.

```bash
tuist test case update AppTests/LoginTests/testHappyPath --state enabled
tuist test case update 123e4567-e89b-12d3-a456-426614174000 --state muted
tuist test case update AppTests/testFoo --no-flaky --json
tuist test case update AppTests/testFoo --state enabled --flaky
```

## Changes

- **server**: new `PATCH /api/projects/:account_handle/:project_handle/tests/test-cases/:test_case_id` endpoint on `TestCasesController`. Accepts optional `state` and `is_flaky`; returns 400 on empty body or invalid state, 404 when the test case is missing or belongs to another project (including the TOCTOU case where it disappears between lookup and update), 403 when the caller lacks project write access. Response mirrors the existing test case payload shape (`id`, `name`, `module`, `suite`, `is_flaky`, `is_quarantined`, `state`, `url`) and records the corresponding `muted`/`unmuted`, `skipped`/`unskipped`, `marked_flaky`/`unmarked_flaky` events on transitions. Scoped to project `:user` role to mirror the dashboard's existing mute/flaky permissions.
- **cli**: new `TestCaseUpdateCommand` and `TestCaseUpdateCommandService`, plus `UpdateTestCaseService` in `TuistServer`. Input supports both test case UUID and `Module[/Suite]/TestName`; reuses the existing `TestCaseIdentifier` parsing pattern from `test case show`. Flags: `--state`, `--flaky/--no-flaky`, `--project`, `--path`, `--json`.
- **OpenAPI**: hand-edited client + types + spec to register the new `updateTestCase` operation and its `Ok`/`BadRequest`/`Forbidden`/`NotFound` responses. `state` is modeled as an open string so new server-side states (e.g. `skipped` from #10429) don't break clients pinned to an older spec.
- **tests**: server controller tests cover enabled -> muted, muted -> enabled, marking flaky, state + is_flaky together, 400 on empty body, 400 on invalid state, 404 on missing test case, 404 on cross-project access, 404 on the TOCTOU path, and 403 on unauthorized. CLI service tests cover missing full handle, missing update fields, UUID + JSON, UUID + text, name lookup, explicit `--project` flag, both `--flaky` and `--no-flaky`, and invalid identifier.

## Test plan

- [x] `xcodebuild test ... TuistTestCommandTests/TestCaseUpdateCommandServiceTests` passes
- [x] `xcodebuild test ... TuistTestCommandTests TuistKitTests/TestQuarantineServiceTests` passes (affected modules)
- [x] `mix format --check-formatted` clean on touched server files
- [x] CI: SwiftPM Build, Unit Tests, Linux Build, Linux Unit Tests, Server Test all green
- [ ] Smoke test against staging: update a test case by UUID and by name; toggle `state` and `is_flaky` independently and together

🤖 Generated with [Claude Code](https://claude.com/claude-code)
