### PR TITLE
ci(server): capture diagnostics when helm deploy fails

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -195,6 +195,52 @@ jobs:
             -f "$HELM_CHART_PATH/${{ needs.plan.outputs.values_overlay }}" \
             --set server.image.tag="${{ needs.plan.outputs.image_tag }}" \
             --atomic --timeout 15m --wait
+      - name: Diagnostics on failure
+        # `--atomic` rolls back the release on timeout, so `helm history` and
+        # most cluster state reflect the rolled-back revision rather than the
+        # failure. Migration-job pods linger long enough for logs to be useful;
+        # everything else is best-effort.
+        if: failure()
+        env:
+          NS: ${{ needs.plan.outputs.namespace }}
+        run: |
+          set +e
+          echo "::group::helm history"
+          helm history "$HELM_RELEASE_NAME" -n "$NS" --max 10 || true
+          echo "::endgroup::"
+          echo "::group::helm get manifest (last attempted revision)"
+          helm get manifest "$HELM_RELEASE_NAME" -n "$NS" 2>&1 | head -200 || true
+          echo "::endgroup::"
+          echo "::group::pods"
+          kubectl -n "$NS" get pods -o wide || true
+          echo "::endgroup::"
+          echo "::group::events (last 100, sorted)"
+          kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+          echo "::endgroup::"
+          echo "::group::migration job"
+          kubectl -n "$NS" get jobs -l app.kubernetes.io/component=server-migration -o wide || true
+          for job in $(kubectl -n "$NS" get jobs -l app.kubernetes.io/component=server-migration -o name 2>/dev/null); do
+            echo "--- describe $job ---"
+            kubectl -n "$NS" describe "$job" || true
+            echo "--- logs $job ---"
+            kubectl -n "$NS" logs "$job" --all-containers --tail=500 || true
+          done
+          echo "::endgroup::"
+          echo "::group::server deployment + pods"
+          kubectl -n "$NS" describe deploy/tuist-tuist-server || true
+          for pod in $(kubectl -n "$NS" get pods -l app.kubernetes.io/component=server -o name 2>/dev/null); do
+            echo "--- describe $pod ---"
+            kubectl -n "$NS" describe "$pod" || true
+            echo "--- logs $pod (current) ---"
+            kubectl -n "$NS" logs "$pod" --all-containers --tail=500 || true
+            echo "--- logs $pod (previous) ---"
+            kubectl -n "$NS" logs "$pod" --all-containers --previous --tail=500 || true
+          done
+          echo "::endgroup::"
+          echo "::group::external secrets"
+          kubectl -n "$NS" get externalsecret,secretstore 2>&1 || true
+          kubectl -n "$NS" describe externalsecret 2>&1 || true
+          echo "::endgroup::"
       - name: Post-deploy smoke test
         run: |
           kubectl -n "${{ needs.plan.outputs.namespace }}" rollout status deploy/tuist-tuist-server --timeout=10m


### PR DESCRIPTION
## Summary

Every `Server Production Deployment` since the Render→Syself/Hetzner migration ([#10368](https://github.com/tuist/tuist/pull/10368)) has failed at `helm upgrade --atomic --timeout 15m --wait` with nothing more than:

```
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to atomic being set: context deadline exceeded
```

`--atomic` rolls the release back on timeout, so `kubectl get` after the fact shows the rolled-back state, not the failure. Recent fixes ([#10437](https://github.com/tuist/tuist/pull/10437), [#10442](https://github.com/tuist/tuist/pull/10442), [#10444](https://github.com/tuist/tuist/pull/10444)) have each been guesses at which link in the hook chain (`ExternalSecret` → `app-secrets` → migration `Job` → `Deployment` + `Service`) broke this time. Canary is currently down (`https://canary.tuist.dev/ready` returns Cloudflare 521); the [latest deploy](https://github.com/tuist/tuist/actions/runs/24901119853/job/72926476630) timed out with no signal about which resource was waiting.

This PR adds a `failure()`-gated `Diagnostics on failure` step to the deploy job that dumps:

- `helm history` and `helm get manifest` for the rolled-back release
- pod listing + events (sorted by `lastTimestamp`)
- migration `Job` describe and logs — these survive `--atomic` rollback because the hook uses `before-hook-creation` deletion, not `hook-succeeded`
- server `Deployment` describe, current and previous pod logs
- `ExternalSecret` / `SecretStore` status, to catch ESO failing to sync `MASTER_KEY` from 1Password (the first hook in the chain — invisible from outside the cluster)

Each section is wrapped in `::group::` so the failure log stays scannable. Every command runs with `|| true` so a missing resource in one section doesn't suppress the rest.

## Test plan

- [ ] Trigger a deploy on a known-failing canary state and confirm the diagnostics step runs and surfaces the actual blocker (migration logs / ESO status / pod events)
- [ ] Confirm the step is skipped on a successful deploy (it's `if: failure()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)