### PR TITLE
fix(server): fix API catalog endpoint

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -121,6 +121,10 @@ config :logger, :console,
     :selected_project_handle
   ]
 
+config :mime, :types, %{
+  "application/linkset+json" => ["linkset"]
+}
+
 # Money
 config :money,
   default_currency: :USD

--- a/server/lib/tuist_web/agent_discovery.ex
+++ b/server/lib/tuist_web/agent_discovery.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.AgentDiscovery do
   @api_catalog_profile_uri "https://www.rfc-editor.org/info/rfc9727"
   @service_desc_path "/api/spec"
   @service_doc_path "/api/docs"
+  @status_path "/ready"
 
   def homepage_link_header_value do
     Enum.join(
@@ -44,6 +45,11 @@ defmodule TuistWeb.AgentDiscovery do
             %{
               "href" => origin <> @service_doc_path,
               "type" => "text/html"
+            }
+          ],
+          "status" => [
+            %{
+              "href" => origin <> @status_path
             }
           ]
         }

--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -18,7 +18,7 @@ defmodule TuistWeb.WellKnownController do
     conn
     |> put_resp_header("content-type", AgentDiscovery.api_catalog_content_type())
     |> put_resp_header("link", AgentDiscovery.api_catalog_link_header_value())
-    |> send_resp(:ok, Jason.encode!(catalog))
+    |> send_resp(:ok, JSON.encode!(catalog))
   end
 
   @doc """

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -156,6 +156,10 @@ defmodule TuistWeb.Router do
     plug TuistWeb.WarningsHeaderPlug
   end
 
+  pipeline :api_catalog do
+    plug :accepts, ["linkset"]
+  end
+
   pipeline :mcp do
     plug TuistWeb.AuthenticationPlug, :load_authenticated_subject
     plug TuistWeb.AuthenticationPlug, {:require_authentication, response_type: :mcp}
@@ -374,7 +378,7 @@ defmodule TuistWeb.Router do
   end
 
   scope "/.well-known", TuistWeb do
-    pipe_through [:open_api]
+    pipe_through [:open_api, :api_catalog]
 
     get "/api-catalog", WellKnownController, :api_catalog
   end

--- a/server/test/tuist_web/agent_discovery_test.exs
+++ b/server/test/tuist_web/agent_discovery_test.exs
@@ -34,6 +34,11 @@ defmodule TuistWeb.AgentDiscoveryTest do
                      "href" => "https://tuist.dev/api/docs",
                      "type" => "text/html"
                    }
+                 ],
+                 "status" => [
+                   %{
+                     "href" => "https://tuist.dev/ready"
+                   }
                  ]
                }
              ]

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -22,7 +22,7 @@ defmodule TuistWeb.WellKnownControllerTest do
                ~s(</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727")
              ]
 
-      assert Jason.decode!(conn.resp_body) == %{
+      assert JSON.decode!(conn.resp_body) == %{
                "linkset" => [
                  %{
                    "anchor" => "http://www.example.com/api",
@@ -57,7 +57,7 @@ defmodule TuistWeb.WellKnownControllerTest do
                ~s(application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727")
              ]
 
-      assert Jason.decode!(conn.resp_body) == %{
+      assert JSON.decode!(conn.resp_body) == %{
                "linkset" => [
                  %{
                    "anchor" => "http://www.example.com/api",

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -37,6 +37,46 @@ defmodule TuistWeb.WellKnownControllerTest do
                        "href" => "http://www.example.com/api/docs",
                        "type" => "text/html"
                      }
+                   ],
+                   "status" => [
+                     %{
+                       "href" => "http://www.example.com/ready"
+                     }
+                   ]
+                 }
+               ]
+             }
+    end
+
+    test "returns the API catalog without requiring an explicit linkset accept header", %{conn: conn} do
+      conn = get(conn, "/.well-known/api-catalog")
+
+      assert response(conn, 200)
+
+      assert get_resp_header(conn, "content-type") == [
+               ~s(application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727")
+             ]
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "linkset" => [
+                 %{
+                   "anchor" => "http://www.example.com/api",
+                   "service-desc" => [
+                     %{
+                       "href" => "http://www.example.com/api/spec",
+                       "type" => "application/json"
+                     }
+                   ],
+                   "service-doc" => [
+                     %{
+                       "href" => "http://www.example.com/api/docs",
+                       "type" => "text/html"
+                     }
+                   ],
+                   "status" => [
+                     %{
+                       "href" => "http://www.example.com/ready"
+                     }
                    ]
                  }
                ]


### PR DESCRIPTION
## Summary
- Add `application/linkset+json` MIME support so Phoenix can serve the API catalog without negotiating to `406`.
- Route `/.well-known/api-catalog` through a dedicated accept pipeline and return an RFC 9727 linkset body.
- Include the API `status` relation alongside `service-desc` and `service-doc`.
- Update discovery and controller tests to cover the new catalog shape and default request path.

## Testing
- Updated unit tests for `TuistWeb.AgentDiscovery`.
- Updated controller tests for `/.well-known/api-catalog` response shape and headers.
- Not run (local test execution was blocked by the worktree database setup).

## Agent Readiness Failure
<img width="817" height="437" alt="image" src="https://github.com/user-attachments/assets/0e4d6dc1-d3c7-4e4c-a700-e8ed120f8018" />
