### PR TITLE
fix(cli,server): fix test reporting and shard acceptance setup

### DIFF
--- a/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
+++ b/cli/Sources/TuistAcceptanceTesting/TuistAcceptanceTestFixtureTestingTrait.swift
@@ -44,6 +44,8 @@ public struct TuistAcceptanceTestFixtureTestingTrait: TestTrait, SuiteTrait, Tes
                         component: fixtureDirectory.basename
                     )
                     try await fileSystem.copy(fixtureDirectory, to: fixtureTemporaryDirectory)
+                    Environment.mocked?.currentWorkingDirectoryStub = fixtureTemporaryDirectory
+                    Environment.mocked?.variables.removeValue(forKey: EnvKey.testShardIndex.rawValue)
                     try await TuistTest.$fixtureDirectory.withValue(fixtureTemporaryDirectory) {
                         try await TuistTest.$fixtureAccountHandle.withValue(organizationHandle) {
                             try await TuistTest.$fixtureFullHandle.withValue(fullHandle) {

--- a/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
+++ b/cli/Sources/TuistEnvironmentTesting/MockEnvironment.swift
@@ -35,6 +35,7 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
     public var isGitHubActions: Bool = false
     public var variables: [String: String] = [:]
     public var arguments: [String] = []
+    public var currentWorkingDirectoryStub: AbsolutePath?
     public var workspacePath: AbsolutePath?
     public var schemeName: String?
     public var currentExecutablePathStub: AbsolutePath?
@@ -55,7 +56,7 @@ public final class MockEnvironment: Environmenting, @unchecked Sendable {
     }
 
     public func currentWorkingDirectory() async throws -> AbsolutePath {
-        baseDirectory.appending(component: "current")
+        currentWorkingDirectoryStub ?? baseDirectory.appending(component: "current")
     }
 
     public var cacheDirectory: AbsolutePath

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -481,19 +481,21 @@ defmodule Tuist.Tests do
   end
 
   defp compute_final_shard_status(existing_test, current_shard_status) do
-    has_failed_shard =
-      ClickHouseRepo.one(
+    shard_statuses =
+      ClickHouseRepo.all(
         from(sr in ShardRun,
           where: sr.test_run_id == ^existing_test.id,
-          where: sr.status == "failure",
-          select: count(),
-          limit: 1
+          select: sr.status
         )
-      ) || 0
+      ) || []
+
+    shard_statuses = [current_shard_status | shard_statuses]
 
     cond do
-      current_shard_status == "failure" -> "failure"
-      has_failed_shard > 0 -> "failure"
+      Enum.any?(shard_statuses, &(&1 == "failure")) -> "failure"
+      Enum.any?(shard_statuses, &(&1 == "failed_processing")) -> "failed_processing"
+      Enum.any?(shard_statuses, &(&1 in ["processing", "in_progress"])) -> "processing"
+      Enum.all?(shard_statuses, &(&1 == "skipped")) -> "skipped"
       true -> "success"
     end
   end

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -116,7 +116,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
     attrs =
       Map.merge(base_attrs(args), %{
         scheme: parsed_data["test_plan_name"] || Map.get(args, "scheme"),
-        status: parsed_data["status"] || "success",
+        status: parsed_data["status"] || "failed_processing",
         duration: parsed_data["duration"] || 0,
         test_modules: parsed_data["test_modules"] || [],
         run_destinations: normalize_run_destinations(parsed_data["run_destinations"] || [])

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -363,6 +363,24 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
                ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id)))
     end
 
+    test "marks parsed xcresult payloads without a status as failed_processing", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+      body = Map.delete(parsed_data(), "status")
+
+      expect(Req, :post, fn _url, _opts -> {:ok, %{status: 200, body: body}} end)
+
+      expect(Tuist.Tests, :create_test, fn attrs ->
+        assert attrs.status == "failed_processing"
+        {:ok, %{id: test_run_id}}
+      end)
+
+      assert :ok ==
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id)))
+    end
+
     test "signs webhook request with HMAC-SHA256", %{account: account, project: project} do
       test_run_id = Ecto.UUID.generate()
 

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1755,6 +1755,125 @@ defmodule Tuist.TestsTest do
       assert test.shard_plan_id == plan.id
     end
 
+    test "skipped shards stay skipped after the final shard reports" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "skipped",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0,
+          test_modules: [
+            %{
+              name: "ModuleA",
+              status: "success",
+              duration: 500,
+              test_cases: [
+                %{name: "testA", status: "skipped", duration: 500}
+              ]
+            }
+          ]
+        })
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "skipped",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1,
+          test_modules: [
+            %{
+              name: "ModuleB",
+              status: "success",
+              duration: 800,
+              test_cases: [
+                %{name: "testB", status: "skipped", duration: 800}
+              ]
+            }
+          ]
+        })
+
+      assert updated_test.status == "skipped"
+    end
+
+    test "failed_processing in a shard propagates to the final status" do
+      project = ProjectsFixtures.project_fixture()
+      account = AccountsFixtures.user_fixture(preload: [:account]).account
+      plan = ShardsFixtures.shard_plan_fixture(project_id: project.id, shard_count: 2)
+
+      {:ok, _first_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 500,
+          status: "success",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 0,
+          test_modules: [
+            %{
+              name: "ModuleA",
+              status: "success",
+              duration: 500,
+              test_cases: [
+                %{name: "testA", status: "success", duration: 500}
+              ]
+            }
+          ]
+        })
+
+      {:ok, updated_test} =
+        Tests.create_test(%{
+          id: UUIDv7.generate(),
+          project_id: project.id,
+          account_id: account.id,
+          duration: 800,
+          status: "failed_processing",
+          model_identifier: "Mac15,6",
+          macos_version: "14.0",
+          xcode_version: "15.0",
+          git_branch: "main",
+          git_commit_sha: "abc123",
+          ran_at: NaiveDateTime.utc_now(),
+          is_ci: true,
+          shard_plan_id: plan.id,
+          shard_index: 1,
+          test_modules: []
+        })
+
+      assert updated_test.status == "failed_processing"
+    end
+
     test "failure in first shard propagates to final status" do
       project = ProjectsFixtures.project_fixture()
       account = AccountsFixtures.user_fixture(preload: [:account]).account


### PR DESCRIPTION
## Summary
- Treat missing xcresult parse status as `failed_processing` instead of `success`
- Aggregate shard statuses with `failed_processing`, `processing`, and `skipped` preserved
- Add acceptance harness isolation so nested runs do not inherit the outer shard index and resolve cwd from the fixture directory
- Add coverage for missing xcresult status and shard-status rollup edge cases

## Testing
- `swift test --replace-scm-with-registry` compile check passed for the touched CLI modules
- Added targeted Elixir unit coverage for xcresult processing and shard status aggregation
- Full targeted Elixir test execution was blocked by shared Mix build-lock contention and a separate cold-compile issue in `yamerl`