### PR TITLE
feat(server): publish OAuth protected resource metadata

### DIFF
--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -72,31 +72,27 @@ defmodule TuistWeb.WellKnownController do
   end
 
   @doc """
-  Returns OAuth Protected Resource metadata for the MCP endpoint.
+  Returns OAuth Protected Resource metadata.
   """
-  def oauth_protected_resource(conn, %{"resource_path" => ["mcp"]}) do
+  def oauth_protected_resource(conn, params) do
     app_url = RequestOrigin.from_conn(conn)
 
-    metadata = %{
-      resource: "#{app_url}#{@mcp_path}",
-      authorization_servers: [app_url],
-      bearer_methods_supported: ["header"],
-      scopes_supported: ["mcp"]
-    }
+    case Map.get(params, "resource_path", []) do
+      [] ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> json(oauth_protected_resource_metadata(app_url))
 
-    conn
-    |> put_resp_content_type("application/json")
-    |> json(metadata)
-  end
+      ["mcp"] ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> json(oauth_protected_resource_metadata(app_url, @mcp_path))
 
-  def oauth_protected_resource(conn, %{"resource_path" => []}) do
-    oauth_protected_resource(conn, %{"resource_path" => ["mcp"]})
-  end
-
-  def oauth_protected_resource(conn, _params) do
-    conn
-    |> put_status(:not_found)
-    |> json(%{error: "not_found"})
+      _ ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "not_found"})
+    end
   end
 
   @doc """
@@ -173,5 +169,14 @@ defmodule TuistWeb.WellKnownController do
       end
 
     "#{team_id}.#{bundle_id}"
+  end
+
+  defp oauth_protected_resource_metadata(resource_identifier, resource_path \\ "") do
+    %{
+      resource: "#{resource_identifier}#{resource_path}",
+      authorization_servers: [resource_identifier],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["mcp"]
+    }
   end
 end

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -104,6 +104,20 @@ defmodule TuistWeb.WellKnownControllerTest do
     end
   end
 
+  describe "GET /.well-known/oauth-protected-resource" do
+    test "returns host-level protected resource metadata", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource")
+
+      response = json_response(conn, 200)
+
+      assert response["resource"] == "http://www.example.com"
+      assert response["authorization_servers"] == ["http://www.example.com"]
+      assert response["bearer_methods_supported"] == ["header"]
+      assert response["scopes_supported"] == ["mcp"]
+      refute Map.has_key?(response, "resource_documentation")
+    end
+  end
+
   describe "GET /.well-known/oauth-protected-resource/mcp" do
     test "returns MCP protected resource metadata", %{conn: conn} do
       conn = get(conn, "/.well-known/oauth-protected-resource/mcp")
@@ -128,6 +142,12 @@ defmodule TuistWeb.WellKnownControllerTest do
 
       assert response["resource"] == "http://custom.tuist.dev:8443/mcp"
       assert response["authorization_servers"] == ["http://custom.tuist.dev:8443"]
+    end
+
+    test "returns not found for unsupported protected resources", %{conn: conn} do
+      conn = get(conn, "/.well-known/oauth-protected-resource/api")
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
     end
   end
 


### PR DESCRIPTION
## Summary
- Publish `/.well-known/oauth-protected-resource` so agents can discover the host-level protected resource metadata.
- Keep the MCP-specific `/.well-known/oauth-protected-resource/mcp` response intact.
- Add controller coverage for the base metadata endpoint and unsupported resource paths.

## Testing
- Added unit coverage for the new well-known metadata behavior.
- Local `mix test` verification was attempted after bootstrapping deps and the test database, but the worktree hit repeated background Mix/build collisions before a clean isolated run completed.

## Agent readiness failure
<img width="786" height="432" alt="image" src="https://github.com/user-attachments/assets/5e0ec65c-bce4-4856-bfc0-6e5d9239387c" />
