### PR TITLE
fix(server): shrink canary memory request so rolling surge fits

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -37,10 +37,14 @@ server:
       load-balancer.hetzner.cloud/name: tuist-canary
 
   # Canary is always a single pod, so no anti-affinity here.
+  # Requests are sized so a rolling deploy's surge pod (maxSurge: 1) fits
+  # alongside the existing pod on the canary nodepool's two workers — at
+  # 1 GiB each they don't both fit. Limits stay generous so the live pod
+  # has headroom under load.
   resources:
     requests:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "250m"
+      memory: "512Mi"
     limits:
       cpu: "2000m"
       memory: "2Gi"


### PR DESCRIPTION
## Summary

Diagnostics from [#10451](https://github.com/tuist/tuist/pull/10451) caught the actual blocker on the [latest failed canary deploy](https://github.com/tuist/tuist/actions/runs/24926779937/job/72998220629):

```
4m43s   Warning   FailedScheduling   pod/tuist-tuist-server-5f7d844d4-qxxrm
0/5 nodes are available: 2 Insufficient memory, 3 node(s) had untolerated taint(s).
```

Migration job 17 succeeded in 25 s — the migration-related fixes from [#10437](https://github.com/tuist/tuist/pull/10437) / [#10442](https://github.com/tuist/tuist/pull/10442) / [#10444](https://github.com/tuist/tuist/pull/10444) are working. What's still hanging the deploy is the **server pod**: with `maxSurge: 1, maxUnavailable: 0` the rolling deploy needs a second pod scheduled *before* the existing one is terminated, and neither of the canary nodepool's two workers has another 1 GiB free alongside the 41-hour-old revision-8 pod (the other 3 nodes are tainted control-plane). Helm `--wait` blocks for 15 m, `--atomic` rolls back, repeat — that's revisions 13/15/17 in `helm history`.

## Why a request shrink (not a strategy change)

Acceptance tests run against canary, so `Recreate` (which would briefly take the env down) is undesirable. Lowering the *request* keeps the rolling strategy and just stops asking the scheduler to reserve more memory than the pod actually needs:

- Staging runs the same image with `requests.memory: 768Mi` and is healthy.
- A Phoenix release on a single canary node sees a small working set; 1 GiB requested vs ~150–250 MiB used is wasted reservation.
- Limits stay at `2Gi` / `2000m`, so the live pod still has headroom under load — only the scheduler's view changes.

512 MiB requested means two pods need 1 GiB total during the surge window. That comfortably fits on the existing two workers.

## Test plan

- [ ] Merge and watch the Server Production Deployment workflow on the resulting commit
- [ ] `helm history -n tuist-canary tuist` shows a `deployed` (not `superseded` rollback) revision
- [ ] `kubectl -n tuist-canary get pods -l app.kubernetes.io/component=server` shows a single Running pod with the new SHA, the 41h pod gone
- [ ] `https://canary.tuist.dev/ready` returns 200 (currently 521)
- [ ] Acceptance tests pass and the cascade promotes to production

## Follow-ups

If 512 MiB turns out to be too tight in practice (OOMKilled events on the live pod), step it back up to `768Mi` to match staging — still well below the original 1 GiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)