### PR TITLE
fix(server): align canary overlay with staging/production (ingress-nginx + Origin cert)

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -20,21 +20,14 @@ server:
   podDisruptionBudget:
     enabled: false
 
-  # LoadBalancer service with Hetzner Cloud Controller Manager annotations.
-  # Cloudflare terminates TLS at the edge and proxies to the Hetzner LB
-  # over HTTP — no cert-manager / ingress-nginx / external-dns required
-  # inside the cluster. End-to-end TLS (Ingress + cert-manager + external-
-  # dns) is a planned follow-up.
+  # ingress-nginx fronts the server on port 443 with a Cloudflare Origin
+  # CA cert (synced into the tuist-tls-cloudflare-origin Secret out-of-
+  # band; 15-year validity). Cloudflare is set to Full (strict) SSL.
   ingress:
-    enabled: false
-  service:
-    type: LoadBalancer
-    port: 80
-    targetPort: 8080
-    annotations:
-      load-balancer.hetzner.cloud/location: fsn1
-      load-balancer.hetzner.cloud/type: lb11
-      load-balancer.hetzner.cloud/name: tuist-canary
+    enabled: true
+    className: nginx
+    host: canary.tuist.dev
+    tlsSecretName: tuist-tls-cloudflare-origin
 
   # Canary is always a single pod, so no anti-affinity here.
   # Requests are sized so a rolling deploy's surge pod (maxSurge: 1) fits


### PR DESCRIPTION
### Why

`canary.tuist.dev` returns HTTP 521 from Cloudflare even after a successful Helm deploy — the app pod is healthy and the Hetzner LB at `91.98.11.250:80` serves a direct 200, but Cloudflare can't reach the origin and surfaces 521.

Root cause: the `tuist.dev` zone runs at **Full (strict)** SSL/TLS (production + staging require it). Cloudflare therefore tries the origin on port 443. Staging and production already migrated to `ingress-nginx` + the `tuist-tls-cloudflare-origin` Secret, so they terminate HTTPS on 443. Canary's overlay was still on the **pre-migration** shape — `Service type: LoadBalancer`, port 80 only, no Ingress — so the origin had no 443 listener and Cloudflare's connection got refused.

A WIP merge ([9db1f0c0b0](https://github.com/tuist/tuist/commit/9db1f0c0b0) "On main: canary-ingress-nginx-pending") attempted this switchover but did not survive into HEAD; this PR redoes it cleanly.

### What

Bring `infra/helm/tuist/values-managed-canary.yaml` to the same shape as `values-managed-staging.yaml` and `values-managed-production.yaml`:

- Drop the `service.type: LoadBalancer` block (Hetzner CCM annotations + port 80) — Service falls back to ClusterIP.
- Enable Ingress with `className: nginx`, `host: canary.tuist.dev`, `tlsSecretName: tuist-tls-cloudflare-origin`.
- Update the surrounding comment to match staging/production.

The `ingress-nginx` controller and the `tuist-tls-cloudflare-origin` Secret are already provisioned in the canary cluster (verified live), so this is a values-only change.

### Deploy steps (manual)

1. Merge + redeploy canary via the usual `server-deployment.yml` workflow.
   - The `helm upgrade` will swap the Service to ClusterIP and create the Ingress; Hetzner CCM tears down the old `tuist-canary` LB and releases `91.98.11.250`.
2. Update the proxied A record for `canary` in Cloudflare from `91.98.11.250` → `167.235.217.66` (the canary cluster's ingress-nginx LB IP).

Between steps 1 and 2 canary will continue to 521 (the old LB IP is gone but DNS still points at it) — no regression vs. the current state. After step 2, `https://canary.tuist.dev/` should return 200 the same way `staging.tuist.dev` does.

### How to test locally

This is an environment overlay change — verification happens against the live canary cluster, not locally.

After deploy + DNS update:

```sh
curl -I https://canary.tuist.dev/   # expect HTTP/2 200
```

Pre-flight, before flipping DNS, confirm the new origin terminates TLS correctly:

```sh
curl -kI --resolve canary.tuist.dev:443:167.235.217.66 https://canary.tuist.dev/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)