### PR TITLE
fix(server): grant CI deployer SA admin in observability namespace

### DIFF
--- a/infra/k8s/syself/ci-service-account.yaml
+++ b/infra/k8s/syself/ci-service-account.yaml
@@ -3,9 +3,11 @@
 # and stored as the KUBECONFIG GitHub Environment secret.
 #
 # The RBAC is deliberately narrow: full control inside the namespace the
-# chart deploys into, plus the minimum cluster-scoped verbs Helm needs for
-# CRD-adjacent resources (ClusterRoles it creates for its own components,
-# if any). Review + tighten if you notice it pulling more than it needs.
+# chart deploys into, the same inside the shared `observability` namespace
+# (where the k8s-monitoring chart installs), plus the minimum cluster-scoped
+# verbs Helm needs for CRD-adjacent resources (ClusterRoles it creates for
+# its own components, if any). Review + tighten if you notice it pulling
+# more than it needs.
 #
 # Applied per-environment by substituting __NAMESPACE__ with the target
 # namespace (tuist-staging / tuist-canary / tuist) and piping into kubectl.
@@ -46,6 +48,30 @@ kind: RoleBinding
 metadata:
   name: github-actions-deployer
   namespace: __NAMESPACE__
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: github-actions-deployer
+    namespace: __NAMESPACE__
+---
+# observability namespace is shared (one per cluster, hosts the
+# k8s-monitoring Helm release). The deploy workflow's
+# `observability-install` job runs as this same SA, so it needs admin
+# access there too — without it Helm's first call (listing release
+# Secrets) 403s.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-actions-deployer
+  namespace: observability
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
### Context

[#10440](https://github.com/tuist/tuist/pull/10440) added the `infra/helm/k8s-monitoring/` chart, which installs into the shared `observability` namespace via a new `observability-install` job in `server-deployment.yml`. Every CI deploy since then has failed at that job:

```
Error: query: failed to query with labels: secrets is forbidden:
User "system:serviceaccount:tuist-canary:github-actions-deployer"
cannot list resource "secrets" in API group "" in the namespace "observability"
```

The `github-actions-deployer` ServiceAccount only had a `RoleBinding` to `admin` inside the per-environment namespace (`tuist-staging` / `tuist-canary` / `tuist`). Helm's first action — listing release Secrets — 403s in `observability`.

### Change

`infra/k8s/syself/ci-service-account.yaml` now also creates:

- a `Namespace` declaration for `observability` (idempotent on clusters where it already exists from the legacy alloy install)
- a second `RoleBinding` in `observability` that grants the same SA the `admin` ClusterRole

The leading comment is updated to mention the cross-namespace scope.

### How to test locally

`helm template` doesn't exercise this since it's a raw manifest. Validate via:

```bash
sed 's/__NAMESPACE__/tuist-canary/g' infra/k8s/syself/ci-service-account.yaml \
  | kubectl --kubeconfig ~/.kube/tuist-canary.yaml apply --dry-run=server -f -
```

### Required follow-up to unblock CI

This manifest is applied imperatively (no GitOps controller reconciles it), so the merge alone does not unblock CI. After merging, run against each workload cluster's kubeconfig:

```bash
# canary (the immediate blocker)
sed 's/__NAMESPACE__/tuist-canary/g' infra/k8s/syself/ci-service-account.yaml \
  | kubectl --kubeconfig ~/.kube/tuist-canary.yaml apply -f -

# staging
sed 's/__NAMESPACE__/tuist-staging/g' infra/k8s/syself/ci-service-account.yaml \
  | kubectl --kubeconfig ~/.kube/tuist-staging.yaml apply -f -

# production
sed 's/__NAMESPACE__/tuist/g' infra/k8s/syself/ci-service-account.yaml \
  | kubectl --kubeconfig ~/.kube/tuist-production.yaml apply -f -
```

Then re-run the failing deploy: <https://github.com/tuist/tuist/actions/runs/24941287267>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)