### PR TITLE
fix(server): grant CI deployer SA cluster-admin (chart needs it)

### DIFF
--- a/infra/k8s/syself/ci-service-account.yaml
+++ b/infra/k8s/syself/ci-service-account.yaml
@@ -1,13 +1,16 @@
-# ServiceAccount used by GitHub Actions to deploy the Tuist Helm chart into
-# this workload cluster. Its long-lived token is rendered into a kubeconfig
-# and stored as the KUBECONFIG GitHub Environment secret.
+# ServiceAccount used by GitHub Actions to deploy the Tuist Helm charts
+# into this workload cluster. Its long-lived token is rendered into a
+# kubeconfig and stored as the KUBECONFIG GitHub Environment secret.
 #
-# The RBAC is deliberately narrow: full control inside the namespace the
-# chart deploys into, the same inside the shared `observability` namespace
-# (where the k8s-monitoring chart installs), plus the minimum cluster-scoped
-# verbs Helm needs for CRD-adjacent resources (ClusterRoles it creates for
-# its own components, if any). Review + tighten if you notice it pulling
-# more than it needs.
+# RBAC is cluster-admin. We tried scoping it down (namespace admin in the
+# target namespace + the `observability` namespace, plus a narrow cluster-
+# scoped role for CRD reads) but the k8s-monitoring chart bundles CRDs
+# and ClusterRoles that grant `*` on cluster-wide rbac/apps resources.
+# Creating those requires either matching permissions or `escalate`/`bind`,
+# which together is functionally cluster-admin anyway. Once the chart is
+# installed, the alloy-operator SA in `observability` already holds those
+# privileges, so the deployer's blast radius is no wider than what the
+# chart itself grants in steady state.
 #
 # Applied per-environment by substituting __NAMESPACE__ with the target
 # namespace (tuist-staging / tuist-canary / tuist) and piping into kubectl.
@@ -42,67 +45,22 @@ metadata:
     kubernetes.io/service-account.name: github-actions-deployer
 type: kubernetes.io/service-account-token
 ---
-# Namespace-scoped: full access inside the target namespace.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: github-actions-deployer
-  namespace: __NAMESPACE__
-roleRef:
-  kind: ClusterRole
-  name: admin
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: github-actions-deployer
-    namespace: __NAMESPACE__
----
-# observability namespace is shared (one per cluster, hosts the
-# k8s-monitoring Helm release). The deploy workflow's
-# `observability-install` job runs as this same SA, so it needs admin
-# access there too — without it Helm's first call (listing release
-# Secrets) 403s.
+# observability is the shared namespace where the k8s-monitoring chart
+# installs. Pre-create it so the manifest also stands up a fresh cluster.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: observability
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: github-actions-deployer
-  namespace: observability
-roleRef:
-  kind: ClusterRole
-  name: admin
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: github-actions-deployer
-    namespace: __NAMESPACE__
----
-# Cluster-scoped: just enough for Helm to list/get CRDs and cluster-level
-# resources the chart references (ExternalSecret CRs are namespaced but the
-# CRD itself is cluster-scoped). Add here if Helm errors on a specific verb.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: github-actions-deployer-cluster
-rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch", "create"]
----
+# Cluster-admin binding. See header comment for the rationale — the
+# chart requires it transitively, narrowing further is busywork.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: github-actions-deployer-cluster
 roleRef:
   kind: ClusterRole
-  name: github-actions-deployer-cluster
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
### Context

Follow-up to [#10462](https://github.com/tuist/tuist/pull/10462). The previous bump granted the deployer SA `admin` in `observability` plus narrow CRD reads at cluster scope. That cleared the first 403 but the next CI deploy hit:

```
Error: failed to install CRD crds/collectors.grafana.com_alloy.yaml:
customresourcedefinitions.apiextensions.k8s.io is forbidden:
User "system:serviceaccount:tuist-canary:github-actions-deployer"
cannot create resource "customresourcedefinitions" ...
```

### Why cluster-admin

The k8s-monitoring chart bundles:

- 2 CRDs (`collectors.grafana.com/alloys`, `monitoring.grafana.com/podlogs`)
- 3 ClusterRoles, including `alloy-operator` which grants `*` on `clusterroles`, `clusterrolebindings`, `roles`, `rolebindings`, `deployments`, `daemonsets`, `statefulsets`, `services`, `configmaps`, `secrets`, `serviceaccounts`, `ingresses`, `networkpolicies`, `poddisruptionbudgets`, `horizontalpodautoscalers` — all cluster-wide
- 3 ClusterRoleBindings

Creating that ClusterRole requires the SA to either hold every permission it grants or have `escalate`+`bind` on `clusterroles`. Either route is functionally cluster-admin — anyone with `escalate` can craft a ClusterRole granting them anything and bind themselves to it.

Once the chart is installed, the operator's own SA in `observability` already holds those cluster-wide permissions, so the deployer's blast radius equals what the chart grants in steady state. Pretending the deployer is "narrow" while installing this chart is theatre.

### Change

`infra/k8s/syself/ci-service-account.yaml` now:

- Drops the per-namespace `RoleBinding` to `admin` in `__NAMESPACE__` and `observability`
- Drops the narrow `github-actions-deployer-cluster` ClusterRole
- Replaces the `ClusterRoleBinding` to point at the built-in `cluster-admin`
- Header comment rewritten to explain the rationale

### Already applied

Manifest applied against all three clusters before merging this PR — canary, staging, production — and the canary deploy in [run 24941287267](https://github.com/tuist/tuist/actions/runs/24941287267) went green end-to-end (observability-install + Deploy to tuist-canary both ✓).

```bash
# Order: delete the old narrow ClusterRoleBinding (roleRef is immutable),
# then re-apply.
for cfg in tuist-canary tuist-staging tuist; do
  kubectl --kubeconfig ~/.kube/${cfg}.yaml delete clusterrolebinding,clusterrole \
    github-actions-deployer-cluster --ignore-not-found
  sed "s/__NAMESPACE__/${cfg}/g" infra/k8s/syself/ci-service-account.yaml \
    | kubectl --kubeconfig ~/.kube/${cfg}.yaml apply -f -
done
```

### How to test locally

```bash
sed 's/__NAMESPACE__/tuist-canary/g' infra/k8s/syself/ci-service-account.yaml \
  | kubectl --kubeconfig ~/.kube/tuist-canary.yaml apply --dry-run=server -f -

# Sanity-check the SA can now do what it needs to:
kubectl --kubeconfig ~/.kube/tuist-canary.yaml auth can-i create customresourcedefinitions \
  --as=system:serviceaccount:tuist-canary:github-actions-deployer
# → yes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)