### PR TITLE
feat(cli): add CopyFileElement.buildProduct for embedding target products in Copy Files phases

### DIFF
--- a/cli/Sources/ProjectDescription/CopyFileElement.swift
+++ b/cli/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,4 +1,5 @@
-/// A file element from a glob pattern, a folder reference, or a build product which is conditionally applied to specific platforms
+/// A file element from a glob pattern, a folder reference, or a build product which is conditionally applied to specific
+/// platforms
 /// with an optional "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringInterpolation {
     /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies.

--- a/cli/Sources/ProjectDescription/CopyFileElement.swift
+++ b/cli/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,5 +1,5 @@
-/// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms with an optional
-/// "Code Sign On Copy" flag.
+/// A file element from a glob pattern, a folder reference, or a build product which is conditionally applied to specific platforms
+/// with an optional "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringInterpolation {
     /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies.
     /// "Code Sign on Copy" can be optionally enabled for the glob.
@@ -9,9 +9,14 @@ public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringIn
     /// to. "Code Sign on Copy" can be optionally enabled for the folder reference.
     case folderReference(path: Path, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
+    /// A reference to a dependent target's build product (e.g. a helper `.app` for Login Items embedding).
+    /// The product is resolved from `BUILT_PRODUCTS_DIR` during the build, not from the filesystem at generation time.
+    case buildProduct(name: String, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
+
     private enum TypeName: String, Codable, Sendable {
         case glob
         case folderReference
+        case buildProduct
     }
 
     private var typeName: TypeName {
@@ -20,6 +25,8 @@ public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringIn
             return .glob
         case .folderReference:
             return .folderReference
+        case .buildProduct:
+            return .buildProduct
         }
     }
 

--- a/cli/Sources/ProjectDescription/CopyFileElement.swift
+++ b/cli/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,6 +1,5 @@
-/// A file element from a glob pattern, a folder reference, or a build product which is conditionally applied to specific
-/// platforms
-/// with an optional "Code Sign On Copy" flag.
+/// A file element from a glob pattern, a folder reference, or a build product which is conditionally
+/// applied to specific platforms with an optional "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringInterpolation {
     /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies.
     /// "Code Sign on Copy" can be optionally enabled for the glob.
@@ -14,7 +13,7 @@ public enum CopyFileElement: Codable, Equatable, Sendable, ExpressibleByStringIn
     /// The product is resolved from `BUILT_PRODUCTS_DIR` during the build, not from the filesystem at generation time.
     case buildProduct(name: String, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
-    private enum TypeName: String, Codable, Sendable {
+    private enum TypeName: String, Codable {
         case glob
         case folderReference
         case buildProduct

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -443,28 +443,42 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             pbxTarget.buildPhases.append(copyFilesPhase)
 
             var buildFilesCache = Set<AbsolutePath>()
-            let files = action.files.sorted(using: KeyPathComparator(\.path))
+            var buildProductCache = Set<String>()
 
             var pbxBuildFiles = [PBXBuildFile]()
-            for file in files {
-                let filePath = file.path
-                guard let fileReference = fileElements.file(path: filePath) else {
-                    throw BuildPhaseGenerationError.missingFileReference(filePath)
-                }
-
-                var settings: [String: BuildFileSetting]?
-
-                // File ATTRIBUTES
-                // example: `settings = {ATTRIBUTES = (Codesign, )}`
-                if file.codeSignOnCopy {
-                    settings = ["ATTRIBUTES": ["CodeSignOnCopy"]]
-                }
-
-                if buildFilesCache.contains(filePath) == false {
-                    let pbxBuildFile = PBXBuildFile(file: fileReference, settings: settings)
-                    pbxBuildFile.applyPlatformFilters(file.condition?.platformFilters)
-                    pbxBuildFiles.append(pbxBuildFile)
-                    buildFilesCache.insert(filePath)
+            for file in action.files {
+                switch file {
+                case .file, .folderReference:
+                    let filePath = file.path
+                    guard let fileReference = fileElements.file(path: filePath) else {
+                        throw BuildPhaseGenerationError.missingFileReference(filePath)
+                    }
+                    if buildFilesCache.contains(filePath) == false {
+                        var settings: [String: BuildFileSetting]?
+                        if file.codeSignOnCopy {
+                            settings = ["ATTRIBUTES": ["CodeSignOnCopy"]]
+                        }
+                        let pbxBuildFile = PBXBuildFile(file: fileReference, settings: settings)
+                        pbxBuildFile.applyPlatformFilters(file.condition?.platformFilters)
+                        pbxBuildFiles.append(pbxBuildFile)
+                        buildFilesCache.insert(filePath)
+                    }
+                case let .buildProduct(name, _, _):
+                    guard let productReference = fileElements.product(target: name) else {
+                        throw BuildPhaseGenerationError.missingFileReference(
+                            try AbsolutePath(validating: "/BUILT_PRODUCTS_DIR/\(name)")
+                        )
+                    }
+                    if !buildProductCache.contains(name) {
+                        var settings: [String: BuildFileSetting]?
+                        if file.codeSignOnCopy {
+                            settings = ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]]
+                        }
+                        let pbxBuildFile = PBXBuildFile(file: productReference, settings: settings)
+                        pbxBuildFile.applyPlatformFilters(file.condition?.platformFilters)
+                        pbxBuildFiles.append(pbxBuildFile)
+                        buildProductCache.insert(name)
+                    }
                 }
             }
             pbxBuildFiles.forEach { pbxproj.add(object: $0) }

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -8,17 +8,20 @@ import XcodeProj
 
 enum BuildPhaseGenerationError: FatalError, Equatable {
     case missingFileReference(AbsolutePath)
+    case missingProductReference(targetName: String)
 
     var description: String {
         switch self {
         case let .missingFileReference(path):
             return "Trying to add a file at path \(path.pathString) to a build phase that hasn't been added to the project."
+        case let .missingProductReference(targetName):
+            return "Trying to embed the product of target '\(targetName)' in a Copy Files phase, but no product reference was found. Make sure '\(targetName)' is declared as a dependency of this target."
         }
     }
 
     var type: ErrorType {
         switch self {
-        case .missingFileReference:
+        case .missingFileReference, .missingProductReference:
             return .bug
         }
     }
@@ -445,11 +448,12 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             var buildFilesCache = Set<AbsolutePath>()
             var buildProductCache = Set<String>()
 
+            let files = action.files.sorted(by: { copyFileElementSortKey($0) < copyFileElementSortKey($1) })
+
             var pbxBuildFiles = [PBXBuildFile]()
-            for file in action.files {
+            for file in files {
                 switch file {
-                case .file, .folderReference:
-                    let filePath = file.path
+                case let .file(filePath, _, _), let .folderReference(filePath, _, _):
                     guard let fileReference = fileElements.file(path: filePath) else {
                         throw BuildPhaseGenerationError.missingFileReference(filePath)
                     }
@@ -465,13 +469,14 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
                     }
                 case let .buildProduct(name, _, _):
                     guard let productReference = fileElements.product(target: name) else {
-                        throw BuildPhaseGenerationError.missingFileReference(
-                            try AbsolutePath(validating: "/BUILT_PRODUCTS_DIR/\(name)")
-                        )
+                        throw BuildPhaseGenerationError.missingProductReference(targetName: name)
                     }
                     if !buildProductCache.contains(name) {
                         var settings: [String: BuildFileSetting]?
                         if file.codeSignOnCopy {
+                            // `RemoveHeadersOnCopy` mirrors the attributes Xcode emits for the standard
+                            // "Embed App Extensions" / "Embed Frameworks" build phases, stripping public
+                            // headers from the embedded product so they don't ship in the bundle.
                             settings = ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]]
                         }
                         let pbxBuildFile = PBXBuildFile(file: productReference, settings: settings)
@@ -483,6 +488,17 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             }
             pbxBuildFiles.forEach { pbxproj.add(object: $0) }
             copyFilesPhase.files = pbxBuildFiles
+        }
+    }
+
+    private func copyFileElementSortKey(_ element: CopyFileElement) -> String {
+        switch element {
+        case let .file(path, _, _):
+            return "0:\(path.pathString)"
+        case let .folderReference(path, _, _):
+            return "1:\(path.pathString)"
+        case let .buildProduct(name, _, _):
+            return "2:\(name)"
         }
     }
 
@@ -616,8 +632,7 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         let currentVersionReference = fileElements.file(path: currentVersionPath)!
         modelReference.currentVersion = currentVersionReference
 
-        let pbxBuildFile = PBXBuildFile(file: modelReference)
-        return pbxBuildFile
+        return PBXBuildFile(file: modelReference)
     }
 
     private func generateResourceBundle(
@@ -629,7 +644,7 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         let bundles = graphTraverser
             .resourceBundleDependencies(path: path, name: target.name)
             .sorted()
-        let buildFiles = bundles.compactMap { dependency -> PBXBuildFile? in
+        return bundles.compactMap { dependency -> PBXBuildFile? in
             switch dependency {
             case let .bundle(path: path, condition: condition):
                 let buildFile = PBXBuildFile(file: fileElements.file(path: path))
@@ -643,8 +658,6 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
                 return nil
             }
         }
-
-        return buildFiles
     }
 
     func generateAppExtensionsBuildPhase(

--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -26,10 +26,11 @@ public enum GroupFileElement: Hashable {
         }
     }
 
-    init(_ copyFileElement: CopyFileElement, group: ProjectGroup) {
+    init?(_ copyFileElement: CopyFileElement, group: ProjectGroup) {
         switch copyFileElement {
         case let .file(path, _, _): self = .file(path: path, group: group)
         case let .folderReference(path, _, _): self = .folder(path: path, group: group)
+        case .buildProduct: return nil
         }
     }
 
@@ -232,7 +233,7 @@ class ProjectFileElements {
 
         for copyFile in target.copyFiles {
             elements.formUnion(
-                copyFile.files.map {
+                copyFile.files.compactMap {
                     GroupFileElement(
                         $0,
                         group: target.filesGroup

--- a/cli/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/cli/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -29,23 +29,43 @@ public struct CopyFilesContentHasher: CopyFilesContentHashing {
                 MerkleNode(hash: try contentHasher.hash(action.name), identifier: "name"),
                 MerkleNode(hash: try contentHasher.hash(action.destination.rawValue), identifier: "destination"),
             ]
-            let actionFiles = try await action.files.sorted(by: { $0.path < $1.path }).concurrentMap { file in
-                var fileChildren: [MerkleNode] = [
-                    MerkleNode(hash: try await contentHasher.hash(path: file.path), identifier: "content"),
-                    MerkleNode(hash: try contentHasher.hash(file.isReference), identifier: "isReference"),
-                    MerkleNode(hash: try contentHasher.hash(file.codeSignOnCopy), identifier: "codeSignOnCopy"),
-                ]
-                if let condition = file.condition {
-                    fileChildren.append(try platformConditionContentHasher.hash(
-                        identifier: "condition",
-                        platformCondition: condition
-                    ))
+            let actionFiles = try await action.files.concurrentMap { file -> MerkleNode in
+                switch file {
+                case .file, .folderReference:
+                    var fileChildren: [MerkleNode] = [
+                        MerkleNode(hash: try await contentHasher.hash(path: file.path), identifier: "content"),
+                        MerkleNode(hash: try contentHasher.hash(file.isReference), identifier: "isReference"),
+                        MerkleNode(hash: try contentHasher.hash(file.codeSignOnCopy), identifier: "codeSignOnCopy"),
+                    ]
+                    if let condition = file.condition {
+                        fileChildren.append(try platformConditionContentHasher.hash(
+                            identifier: "condition",
+                            platformCondition: condition
+                        ))
+                    }
+                    return MerkleNode(
+                        hash: try contentHasher.hash(fileChildren),
+                        identifier: file.path.pathString,
+                        children: fileChildren
+                    )
+                case let .buildProduct(name, condition, codeSignOnCopy):
+                    var fileChildren: [MerkleNode] = [
+                        MerkleNode(hash: try contentHasher.hash("buildProduct"), identifier: "type"),
+                        MerkleNode(hash: try contentHasher.hash(name), identifier: "productName"),
+                        MerkleNode(hash: try contentHasher.hash(codeSignOnCopy), identifier: "codeSignOnCopy"),
+                    ]
+                    if let condition {
+                        fileChildren.append(try platformConditionContentHasher.hash(
+                            identifier: "condition",
+                            platformCondition: condition
+                        ))
+                    }
+                    return MerkleNode(
+                        hash: try contentHasher.hash(fileChildren),
+                        identifier: "buildProduct:\(name)",
+                        children: fileChildren
+                    )
                 }
-                return MerkleNode(
-                    hash: try contentHasher.hash(fileChildren),
-                    identifier: file.path.pathString,
-                    children: fileChildren
-                )
             }.sorted(by: { $0.hash < $1.hash })
             actionChildren.append(MerkleNode(
                 hash: try contentHasher.hash(actionFiles),

--- a/cli/Sources/TuistHasher/CopyFilesContentHasher.swift
+++ b/cli/Sources/TuistHasher/CopyFilesContentHasher.swift
@@ -31,13 +31,14 @@ public struct CopyFilesContentHasher: CopyFilesContentHashing {
             ]
             let actionFiles = try await action.files.concurrentMap { file -> MerkleNode in
                 switch file {
-                case .file, .folderReference:
+                case let .file(path, condition, codeSignOnCopy),
+                     let .folderReference(path, condition, codeSignOnCopy):
                     var fileChildren: [MerkleNode] = [
-                        MerkleNode(hash: try await contentHasher.hash(path: file.path), identifier: "content"),
+                        MerkleNode(hash: try await contentHasher.hash(path: path), identifier: "content"),
                         MerkleNode(hash: try contentHasher.hash(file.isReference), identifier: "isReference"),
-                        MerkleNode(hash: try contentHasher.hash(file.codeSignOnCopy), identifier: "codeSignOnCopy"),
+                        MerkleNode(hash: try contentHasher.hash(codeSignOnCopy), identifier: "codeSignOnCopy"),
                     ]
-                    if let condition = file.condition {
+                    if let condition {
                         fileChildren.append(try platformConditionContentHasher.hash(
                             identifier: "condition",
                             platformCondition: condition
@@ -45,7 +46,7 @@ public struct CopyFilesContentHasher: CopyFilesContentHashing {
                     }
                     return MerkleNode(
                         hash: try contentHasher.hash(fileChildren),
-                        identifier: file.path.pathString,
+                        identifier: path.pathString,
                         children: fileChildren
                     )
                 case let .buildProduct(name, condition, codeSignOnCopy):

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -82,6 +82,12 @@ extension XcodeGraph.CopyFileElement {
                 condition: condition?.asGraphCondition,
                 codeSignOnCopy: codeSign
             ) }
+        case let .buildProduct(name: name, condition: condition, codeSignOnCopy: codeSign):
+            return [.buildProduct(
+                name: name,
+                condition: condition?.asGraphCondition,
+                codeSignOnCopy: codeSign
+            )]
         }
     }
 }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFilesAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/CopyFilesAction+ManifestMapper.swift
@@ -97,18 +97,20 @@ extension [XcodeGraph.CopyFileElement] {
     ///
     /// - Returns: List of clean `AbsolutePath`s
     public func cleanPackages() -> [Self.Element] {
-        compactMap {
-            var filePath = $0.path
+        compactMap { element in
+            guard var filePath = element.path else {
+                return element
+            }
             while !filePath.isRoot {
                 if filePath.parentDirectory.isPackage {
                     return nil
                 } else if filePath.isPackage {
-                    return $0
+                    return element
                 } else {
                     filePath = filePath.parentDirectory
                 }
             }
-            return $0
+            return element
         }
     }
 }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
@@ -4,6 +4,7 @@ import Path
 public enum CopyFileElement: Equatable, Hashable, Codable, Sendable {
     case file(path: AbsolutePath, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
     case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
+    case buildProduct(name: String, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
     public var path: AbsolutePath {
         switch self {
@@ -11,12 +12,14 @@ public enum CopyFileElement: Equatable, Hashable, Codable, Sendable {
             return path
         case let .folderReference(path, _, _):
             return path
+        case .buildProduct:
+            return try! AbsolutePath(validating: "/")
         }
     }
 
     public var isReference: Bool {
         switch self {
-        case .file:
+        case .file, .buildProduct:
             return false
         case .folderReference:
             return true
@@ -25,14 +28,18 @@ public enum CopyFileElement: Equatable, Hashable, Codable, Sendable {
 
     public var condition: PlatformCondition? {
         switch self {
-        case let .file(_, condition, _), let .folderReference(_, condition, _):
+        case let .file(_, condition, _),
+             let .folderReference(_, condition, _),
+             let .buildProduct(_, condition, _):
             return condition
         }
     }
 
     public var codeSignOnCopy: Bool {
         switch self {
-        case let .file(_, _, codeSignOnCopy), let .folderReference(_, _, codeSignOnCopy):
+        case let .file(_, _, codeSignOnCopy),
+             let .folderReference(_, _, codeSignOnCopy),
+             let .buildProduct(_, _, codeSignOnCopy):
             return codeSignOnCopy
         }
     }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
@@ -6,14 +6,14 @@ public enum CopyFileElement: Equatable, Hashable, Codable, Sendable {
     case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
     case buildProduct(name: String, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
-    public var path: AbsolutePath {
+    public var path: AbsolutePath? {
         switch self {
         case let .file(path, _, _):
             return path
         case let .folderReference(path, _, _):
             return path
         case .buildProduct:
-            return .root
+            return nil
         }
     }
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/CopyFileElement.swift
@@ -13,7 +13,7 @@ public enum CopyFileElement: Equatable, Hashable, Codable, Sendable {
         case let .folderReference(path, _, _):
             return path
         case .buildProduct:
-            return try! AbsolutePath(validating: "/")
+            return .root
         }
     }
 

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXCopyFilesBuildPhaseMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Phases/PBXCopyFilesBuildPhaseMapper.swift
@@ -52,19 +52,23 @@ struct PBXCopyFilesBuildPhaseMapper: PBXCopyFilesBuildPhaseMapping {
     ) throws -> CopyFilesAction? {
         let files = try (phase.files ?? [])
             .compactMap { buildFile -> CopyFileElement? in
-                guard let fileRef = buildFile.file,
-                      let pathString = try fileRef.fullPath(sourceRoot: xcodeProj.srcPathString)
-                else {
+                guard let fileRef = buildFile.file else { return nil }
+
+                let attributes = buildFile.attributes
+                let codeSignOnCopy = attributes?.contains(BuildFileAttribute.codeSignOnCopy.rawValue) ?? false
+
+                if fileRef.sourceTree == .buildProductsDir, let name = fileRef.path ?? fileRef.name {
+                    return .buildProduct(name: name, condition: nil, codeSignOnCopy: codeSignOnCopy)
+                }
+
+                guard let pathString = try fileRef.fullPath(sourceRoot: xcodeProj.srcPathString) else {
                     return nil
                 }
 
                 let absolutePath = try AbsolutePath(validating: pathString)
-                let attributes = buildFile.attributes
-                let codeSignOnCopy = attributes?.contains(BuildFileAttribute.codeSignOnCopy.rawValue) ?? false
-
                 return .file(path: absolutePath, condition: nil, codeSignOnCopy: codeSignOnCopy)
             }
-            .sorted { $0.path < $1.path }
+            .sorted { copyFileElementSortKey($0) < copyFileElementSortKey($1) }
         let groupsFiles = try fileSystemSynchronizedGroupsFiles(
             phase,
             fileSystemSynchronizedGroups: fileSystemSynchronizedGroups,
@@ -104,6 +108,17 @@ struct PBXCopyFilesBuildPhaseMapper: PBXCopyFilesBuildPhaseMapping {
             }
         }
         return files
+    }
+
+    private func copyFileElementSortKey(_ element: CopyFileElement) -> String {
+        switch element {
+        case let .file(path, _, _):
+            return "0:\(path.pathString)"
+        case let .folderReference(path, _, _):
+            return "1:\(path.pathString)"
+        case let .buildProduct(name, _, _):
+            return "2:\(name)"
+        }
     }
 
     /// Maps a `PBXCopyFilesBuildPhase.SubFolder` to a `CopyFilesAction.Destination`.

--- a/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXCopyFilesBuildPhaseMapperTests.swift
+++ b/cli/Sources/XcodeGraph/Tests/XcodeGraphMapperTests/MapperTests/Phases/PBXCopyFilesBuildPhaseMapperTests.swift
@@ -3,7 +3,6 @@ import XcodeGraph
 import XcodeProj
 @testable import XcodeGraphMapper
 
-@Suite
 struct PBXCopyFilesBuildPhaseMapperTests {
     @Test("Maps copy files actions, verifying code-sign-on-copy attributes")
     func mapCopyFiles() async throws {
@@ -60,7 +59,7 @@ struct PBXCopyFilesBuildPhaseMapperTests {
 
         let fileAction = try #require(action.files.first)
         #expect(fileAction.codeSignOnCopy == true)
-        #expect(fileAction.path.basename == "MyLibrary.dylib")
+        #expect(fileAction.path?.basename == "MyLibrary.dylib")
     }
 
     @Test("Maps copy files actions with a synchronized group")

--- a/cli/Sources/XcodeGraph/Tests/XcodeGraphTests/Models/CopyFileElementTests.swift
+++ b/cli/Sources/XcodeGraph/Tests/XcodeGraphTests/Models/CopyFileElementTests.swift
@@ -22,4 +22,31 @@ final class CopyFileElementTests: XCTestCase {
         // Then
         XCTAssertCodable(subject)
     }
+
+    func test_codable_buildProduct() throws {
+        // Given
+        let subject = CopyFileElement.buildProduct(
+            name: "HelperApp",
+            condition: .when([.macos]),
+            codeSignOnCopy: true
+        )
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+
+    func test_buildProduct_isNotReference() {
+        let subject = CopyFileElement.buildProduct(name: "HelperApp")
+        XCTAssertFalse(subject.isReference)
+    }
+
+    func test_buildProduct_condition() {
+        let subject = CopyFileElement.buildProduct(name: "HelperApp", condition: .when([.macos]))
+        XCTAssertEqual(subject.condition, .when([.macos]))
+    }
+
+    func test_buildProduct_codeSignOnCopy() {
+        let subject = CopyFileElement.buildProduct(name: "HelperApp", codeSignOnCopy: true)
+        XCTAssertTrue(subject.codeSignOnCopy)
+    }
 }

--- a/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/cli/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -947,6 +947,22 @@ struct GenerateAcceptanceTestmacOSAppWithCopyFiles {
         XCTAssertTrue(
             buildPhases.contains(where: { $0.name() == "Copy Templates" })
         )
+
+        let embedLoginItemsPhase = try #require(
+            buildPhases
+                .compactMap { $0 as? PBXCopyFilesBuildPhase }
+                .first(where: { $0.name == "Embed Login Items" })
+        )
+        #expect(embedLoginItemsPhase.dstSubfolderSpec == .wrapper)
+        #expect(embedLoginItemsPhase.dstPath == "Contents/Library/LoginItems")
+
+        let buildFile = try #require(embedLoginItemsPhase.files?.first)
+        let fileRef = try #require(buildFile.file as? PBXFileReference)
+        #expect(fileRef.path == "LoginItemHelper.app")
+        #expect(fileRef.sourceTree == .buildProductsDir)
+        let attributes = buildFile.settings?["ATTRIBUTES"] as? [String]
+        #expect(attributes?.contains("CodeSignOnCopy") == true)
+        #expect(attributes?.contains("RemoveHeadersOnCopy") == true)
     }
 }
 

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1176,7 +1176,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func test_generateCopyFilesBuildPhases_withBuildProduct() throws {
+    ) func generateCopyFilesBuildPhases_withBuildProduct() throws {
         // Given
         let files: [CopyFileElement] = [
             .buildProduct(name: "LoginItemHelper", codeSignOnCopy: true),
@@ -1226,7 +1226,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func test_generateCopyFilesBuildPhases_withMixedFilesAndBuildProducts() throws {
+    ) func generateCopyFilesBuildPhases_withMixedFilesAndBuildProducts() throws {
         // Given
         let pbxproj = PBXProj()
         let nativeTarget = PBXNativeTarget(name: "App")

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1176,6 +1176,109 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
+    ) func test_generateCopyFilesBuildPhases_withBuildProduct() throws {
+        // Given
+        let files: [CopyFileElement] = [
+            .buildProduct(name: "LoginItemHelper", codeSignOnCopy: true),
+            .buildProduct(name: "AnotherHelper"),
+        ]
+
+        let pbxproj = PBXProj()
+        let nativeTarget = PBXNativeTarget(name: "App")
+        let fileElements = createProductFileElements(for: [
+            Target.test(name: "LoginItemHelper", product: .app),
+            Target.test(name: "AnotherHelper", product: .app),
+        ])
+
+        let target = Target.test(copyFiles: [
+            CopyFilesAction(
+                name: "Embed Login Items",
+                destination: .wrapper,
+                subpath: "Contents/Library/LoginItems",
+                files: files
+            ),
+        ])
+
+        // When
+        try subject.generateCopyFilesBuildPhases(
+            target: target,
+            pbxTarget: nativeTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try #require(nativeTarget.buildPhases.first as? PBXCopyFilesBuildPhase)
+        #expect(buildPhase.name == "Embed Login Items")
+        #expect(buildPhase.dstSubfolderSpec == .wrapper)
+        #expect(buildPhase.dstPath == "Contents/Library/LoginItems")
+        #expect(buildPhase.files?.compactMap { $0.file?.nameOrPath } == [
+            "LoginItemHelper",
+            "AnotherHelper",
+        ])
+        #expect(buildPhase.files?.map(\.settings) == [
+            ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
+            nil,
+        ])
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func test_generateCopyFilesBuildPhases_withMixedFilesAndBuildProducts() throws {
+        // Given
+        let pbxproj = PBXProj()
+        let nativeTarget = PBXNativeTarget(name: "App")
+
+        let fileElements = ProjectFileElements()
+        fileElements.elements = [
+            try AbsolutePath(validating: "/path/config.plist"):
+                PBXFileReference(sourceTree: .group, name: "config.plist"),
+        ]
+        fileElements.products = [
+            "LoginItemHelper": PBXFileReference(name: "LoginItemHelper"),
+        ]
+
+        let files: [CopyFileElement] = [
+            .file(path: try AbsolutePath(validating: "/path/config.plist")),
+            .buildProduct(name: "LoginItemHelper", codeSignOnCopy: true),
+        ]
+
+        let target = Target.test(copyFiles: [
+            CopyFilesAction(
+                name: "Embed Items",
+                destination: .wrapper,
+                subpath: "Contents/Library/LoginItems",
+                files: files
+            ),
+        ])
+
+        // When
+        try subject.generateCopyFilesBuildPhases(
+            target: target,
+            pbxTarget: nativeTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = try #require(nativeTarget.buildPhases.first as? PBXCopyFilesBuildPhase)
+        #expect(buildPhase.files?.count == 2)
+        #expect(buildPhase.files?.compactMap { $0.file?.nameOrPath } == [
+            "config.plist",
+            "LoginItemHelper",
+        ])
+        #expect(buildPhase.files?.map(\.settings) == [
+            nil,
+            ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
+        ])
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
     ) func test_generateAppExtensionsBuildPhase() throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -17,8 +17,8 @@ struct BuildPhaseGenerationErrorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func description_when_missingFileReference() {
-        let path = try! AbsolutePath(validating: "/test")
+    ) func description_when_missingFileReference() throws {
+        let path = try AbsolutePath(validating: "/test")
         let expected = "Trying to add a file at path \(path.pathString) to a build phase that hasn't been added to the project."
         #expect(BuildPhaseGenerationError.missingFileReference(path).description == expected)
     }
@@ -27,13 +27,12 @@ struct BuildPhaseGenerationErrorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func type_when_missingFileReference() {
-        let path = try! AbsolutePath(validating: "/test")
+    ) func type_when_missingFileReference() throws {
+        let path = try AbsolutePath(validating: "/test")
         #expect(BuildPhaseGenerationError.missingFileReference(path).type == .bug)
     }
 }
 
-@Suite
 struct BuildPhaseGeneratorTests {
     var subject: BuildPhaseGenerator!
 
@@ -364,7 +363,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedXcodeController,
         .inTemporaryDirectory
     ) func generateSourcesBuildPhase_throws_when_theFileReferenceIsMissing() async throws {
-        let path = try! AbsolutePath(validating: "/test/file.swift")
+        let path = try AbsolutePath(validating: "/test/file.swift")
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
         pbxproj.add(object: pbxTarget)
@@ -466,7 +465,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedXcodeController,
         .inTemporaryDirectory
     ) func generateSourcesBuildPhase_throws_whenLocalizedFileAndFileReferenceIsMissing() async throws {
-        let path = try! AbsolutePath(validating: "/test/Base.lproj/file.intentdefinition")
+        let path = try AbsolutePath(validating: "/test/Base.lproj/file.intentdefinition")
         let pbxTarget = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
         pbxproj.add(object: pbxTarget)
@@ -1118,7 +1117,7 @@ struct BuildPhaseGeneratorTests {
 
         let pbxproj = PBXProj()
         let nativeTarget = PBXNativeTarget(name: "Test")
-        let fileElements = createFileElements(for: (fonts + templates).map(\.path))
+        let fileElements = createFileElements(for: (fonts + templates).compactMap(\.path))
 
         let target = Target.test(copyFiles: [
             CopyFilesAction(name: "Copy Fonts", destination: .resources, subpath: "Fonts", files: fonts),
@@ -1213,13 +1212,45 @@ struct BuildPhaseGeneratorTests {
         #expect(buildPhase.dstSubfolderSpec == .wrapper)
         #expect(buildPhase.dstPath == "Contents/Library/LoginItems")
         #expect(buildPhase.files?.compactMap { $0.file?.nameOrPath } == [
-            "LoginItemHelper",
             "AnotherHelper",
+            "LoginItemHelper",
         ])
         #expect(buildPhase.files?.map(\.settings) == [
-            ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
             nil,
+            ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
         ])
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateCopyFilesBuildPhases_withBuildProduct_throwsWhenProductIsMissing() throws {
+        // Given
+        let pbxproj = PBXProj()
+        let nativeTarget = PBXNativeTarget(name: "App")
+        let fileElements = ProjectFileElements()
+
+        let target = Target.test(copyFiles: [
+            CopyFilesAction(
+                name: "Embed Login Items",
+                destination: .wrapper,
+                subpath: "Contents/Library/LoginItems",
+                files: [.buildProduct(name: "MissingHelper")]
+            ),
+        ])
+
+        // When / Then
+        #expect {
+            try subject.generateCopyFilesBuildPhases(
+                target: target,
+                pbxTarget: nativeTarget,
+                fileElements: fileElements,
+                pbxproj: pbxproj
+            )
+        } throws: { error in
+            error as? BuildPhaseGenerationError == .missingProductReference(targetName: "MissingHelper")
+        }
     }
 
     @Test(
@@ -1231,17 +1262,14 @@ struct BuildPhaseGeneratorTests {
         let pbxproj = PBXProj()
         let nativeTarget = PBXNativeTarget(name: "App")
 
-        let fileElements = ProjectFileElements()
-        fileElements.elements = [
-            try AbsolutePath(validating: "/path/config.plist"):
-                PBXFileReference(sourceTree: .group, name: "config.plist"),
-        ]
-        fileElements.products = [
-            "LoginItemHelper": PBXFileReference(name: "LoginItemHelper"),
-        ]
+        let configPath = try AbsolutePath(validating: "/path/config.plist")
+        let fileElements = createFileElements(for: [configPath])
+        fileElements.products = createProductFileElements(
+            for: [Target.test(name: "LoginItemHelper", product: .app)]
+        ).products
 
         let files: [CopyFileElement] = [
-            .file(path: try AbsolutePath(validating: "/path/config.plist")),
+            .file(path: configPath),
             .buildProduct(name: "LoginItemHelper", codeSignOnCopy: true),
         ]
 
@@ -1304,7 +1332,7 @@ struct BuildPhaseGeneratorTests {
             ]),
         ]
         let dependencyConditions: [GraphEdge: PlatformCondition] = [
-            .init(from: appGraphDependency, to: stickerPackGraphDependency): .when([.ios])!,
+            .init(from: appGraphDependency, to: stickerPackGraphDependency): try #require(.when([.ios])),
         ]
 
         let graph = Graph.test(
@@ -1443,7 +1471,7 @@ struct BuildPhaseGeneratorTests {
             appGraphDependency: Set([watchAppGraphDependency]),
         ]
         let dependencyConditions: [GraphEdge: PlatformCondition] = [
-            .init(from: appGraphDependency, to: watchAppGraphDependency): .when([.ios])!,
+            .init(from: appGraphDependency, to: watchAppGraphDependency): try #require(.when([.ios])),
         ]
         let graph = Graph.test(
             path: project.path,
@@ -1495,7 +1523,7 @@ struct BuildPhaseGeneratorTests {
         ]
 
         let dependencyConditions: [GraphEdge: PlatformCondition] = [
-            .init(from: appGraphDependency, to: watchAppGraphDependency): .when([.ios])!,
+            .init(from: appGraphDependency, to: watchAppGraphDependency): try #require(.when([.ios])),
         ]
 
         let graph = Graph.test(
@@ -2000,7 +2028,7 @@ struct BuildPhaseGeneratorTests {
         ]
 
         let dependencyConditions: [GraphEdge: PlatformCondition] = [
-            .init(from: appGraphDependency, to: appClipGraphDependency): .when([.ios])!,
+            .init(from: appGraphDependency, to: appClipGraphDependency): try #require(.when([.ios])),
         ]
 
         let graph = Graph.test(

--- a/cli/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/CopyFilesContentHasherTests.swift
@@ -148,4 +148,29 @@ final class CopyFilesContentHasherTests: TuistUnitTestCase {
             ]
         ))
     }
+
+    func test_hash_buildProduct_isDeterministicAcrossRuns() async throws {
+        // Given
+        let copyFilesAction = CopyFilesAction(
+            name: "Embed Login Items",
+            destination: .wrapper,
+            subpath: "Contents/Library/LoginItems",
+            files: [
+                CopyFileElement.buildProduct(
+                    name: "LoginItemHelper",
+                    condition: .when(Set([.macos])),
+                    codeSignOnCopy: true
+                ),
+            ]
+        )
+        var results: Set<String> = Set()
+
+        // When
+        for _ in 0 ... 100 {
+            results.insert(try await subject.hash(identifier: "copyFilesActions", copyFiles: [copyFilesAction]).hash)
+        }
+
+        // Then
+        XCTAssertEqual(results.count, 1)
+    }
 }

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/CopyFileElement+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/CopyFileElement+ManifestMapperTests.swift
@@ -117,4 +117,31 @@ final class CopyFileElementManifestMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEmpty(got)
     }
+
+    func test_from_buildProduct_maps_correctly() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let rootDirectory = temporaryPath
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: temporaryPath,
+            rootDirectory: rootDirectory
+        )
+        let manifest = ProjectDescription.CopyFileElement.buildProduct(
+            name: "HelperApp",
+            condition: .when([.macos]),
+            codeSignOnCopy: true
+        )
+
+        // When
+        let got = try await XcodeGraph.CopyFileElement.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths,
+            fileSystem: fileSystem
+        )
+
+        // Then
+        XCTAssertEqual(got, [
+            .buildProduct(name: "HelperApp", condition: .when([.macos]), codeSignOnCopy: true),
+        ])
+    }
 }

--- a/examples/xcode/generated_macos_app_with_copy_files/LoginItemHelper/Info.plist
+++ b/examples/xcode/generated_macos_app_with_copy_files/LoginItemHelper/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/xcode/generated_macos_app_with_copy_files/LoginItemHelper/Sources/main.swift
+++ b/examples/xcode/generated_macos_app_with_copy_files/LoginItemHelper/Sources/main.swift
@@ -1,0 +1,9 @@
+import AppKit
+
+class HelperAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_: Notification) {}
+}
+
+let delegate = HelperAppDelegate()
+NSApplication.shared.delegate = delegate
+_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)

--- a/examples/xcode/generated_macos_app_with_copy_files/Project.swift
+++ b/examples/xcode/generated_macos_app_with_copy_files/Project.swift
@@ -1,25 +1,40 @@
 import ProjectDescription
 
-func target(name: String) -> Target {
-    .target(
-        name: name,
-        destinations: [.mac],
-        product: .app,
-        bundleId: "dev.tuist.\(name)",
-        infoPlist: .file(path: .relativeToManifest("Info.plist")),
-        sources: .paths([.relativeToManifest("Sources/**")]),
-        copyFiles: [
-            .sharedSupport(
-                name: "Copy Templates",
-                subpath: "Templates",
-                files: [.glob(pattern: "Templates/**", condition: .when([.macos]))]
-            ),
-        ],
-        settings: .settings(base: ["CODE_SIGN_IDENTITY": "", "CODE_SIGNING_REQUIRED": "NO"])
-    )
-}
-
 let project = Project(
     name: "App",
-    targets: [target(name: "App")]
+    targets: [
+        .target(
+            name: "App",
+            destinations: [.mac],
+            product: .app,
+            bundleId: "dev.tuist.App",
+            infoPlist: .file(path: .relativeToManifest("Info.plist")),
+            sources: .paths([.relativeToManifest("Sources/**")]),
+            copyFiles: [
+                .sharedSupport(
+                    name: "Copy Templates",
+                    subpath: "Templates",
+                    files: [.glob(pattern: "Templates/**", condition: .when([.macos]))]
+                ),
+                .wrapper(
+                    name: "Embed Login Items",
+                    subpath: "Contents/Library/LoginItems",
+                    files: [.buildProduct(name: "LoginItemHelper", codeSignOnCopy: true)]
+                ),
+            ],
+            dependencies: [
+                .target(name: "LoginItemHelper"),
+            ],
+            settings: .settings(base: ["CODE_SIGN_IDENTITY": "", "CODE_SIGNING_REQUIRED": "NO"])
+        ),
+        .target(
+            name: "LoginItemHelper",
+            destinations: [.mac],
+            product: .app,
+            bundleId: "dev.tuist.App.LoginItemHelper",
+            infoPlist: .file(path: .relativeToManifest("LoginItemHelper/Info.plist")),
+            sources: .paths([.relativeToManifest("LoginItemHelper/Sources/**")]),
+            settings: .settings(base: ["CODE_SIGN_IDENTITY": "", "CODE_SIGNING_REQUIRED": "NO"])
+        ),
+    ]
 )


### PR DESCRIPTION
Adds a new `.buildProduct(name:condition:codeSignOnCopy:)` case to `CopyFileElement` so that a dependent target's build product can be referenced in a Copy Files build phase. The product is resolved from `BUILT_PRODUCTS_DIR` at build time rather than from the filesystem at generation time.

This enables the standard macOS Login Item embedding pattern where a helper `.app` is copied into `Contents/Library/LoginItems` via a Copy Files phase referencing the helper target's product.

Resolves <https://github.com/tuist/tuist/issues/YYY>

### How to test locally

Unit tests and/or fixtures