### PR TITLE
ci(app): run macOS app release on macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -782,7 +782,7 @@ jobs:
     name: Release App
     needs: check-releases
     if: needs.check-releases.outputs.app-should-release == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The `release-app` job in `release.yml` ran on `macos-15` (macOS 15.7.4) but uses Xcode 26.2 (`.xcode-version`), causing `AssetCatalogAgent` to crash with dyld errors against `MediaToolbox.framework` (`_kFigVideoQueueNotification_DecodeError`/`_Failed`) during `CompileAssetCatalogVariant`.
- All other macOS app workflows (`app.yml`) already use `macos-26`; bringing the release job in line fixes the bundle step.

Failing job: https://github.com/tuist/tuist/actions/runs/24952635726/job/73065420717

## Test plan
- [ ] Re-run the release workflow after merge and confirm the `Release App` job's `Bundle macOS app` step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)