### PR TITLE
ci(server): surface deploy failure root cause inline + as annotation

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -235,13 +235,52 @@ jobs:
         # baked into the image and pulls MASTER_KEY from 1Password via an
         # in-cluster ExternalSecret. Passing secrets through --set would
         # leak them into `helm get manifest`.
+        env:
+          NS: ${{ needs.plan.outputs.namespace }}
         run: |
+          set +e
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
-            --namespace "${{ needs.plan.outputs.namespace }}" --create-namespace \
+            --namespace "$NS" --create-namespace \
             -f "$HELM_CHART_PATH/values-managed-common.yaml" \
             -f "$HELM_CHART_PATH/${{ needs.plan.outputs.values_overlay }}" \
             --set server.image.tag="${{ needs.plan.outputs.image_tag }}" \
-            --atomic --timeout 60m --wait
+            --atomic --timeout 60m --wait 2>&1 | tee /tmp/helm.out
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -eq 0 ] && exit 0
+
+          # Helm's own message ("BackoffLimitExceeded", "context deadline
+          # exceeded", "release tuist failed") names the symptom but not the
+          # cause. Pull the most-likely root-cause logs into THIS step so the
+          # failed-step view shows them without scrolling to "Diagnostics on
+          # failure", and surface a one-line summary via ::error:: so it
+          # lands at the top of the GitHub Actions run UI.
+          summary=""
+          if grep -q "pre-upgrade hooks failed" /tmp/helm.out; then
+            echo "::group::root cause — most-recent migration job logs"
+            job=$(kubectl -n "$NS" get jobs -l app.kubernetes.io/component=server-migration \
+              --sort-by=.metadata.creationTimestamp -o name 2>/dev/null | tail -1)
+            if [ -n "$job" ]; then
+              echo "Job: $job"
+              kubectl -n "$NS" logs "$job" --all-containers --tail=300 2>&1 | tee /tmp/migrate.out
+              # First Elixir crash header or Postgres error code line.
+              err=$(grep -E '^\*\* \(.+\) |ERROR [0-9]+ \(' /tmp/migrate.out | head -1 | tr -d '\r')
+              [ -n "$err" ] && summary="Migration failed: $err"
+              [ -z "$summary" ] && summary="Migration job ${job#*/} failed (BackoffLimitExceeded). See logs above."
+            else
+              summary="Pre-upgrade migration hook failed but no migration job found in $NS."
+            fi
+            echo "::endgroup::"
+          elif grep -qE "context deadline exceeded|timed out waiting" /tmp/helm.out; then
+            summary="helm upgrade timed out (--timeout 60m). Release rolled back; see Diagnostics on failure → pods/events for stuck workload."
+          elif grep -qE "ImagePullBackOff|ErrImagePull" /tmp/helm.out; then
+            summary="Pod image pull failed. Check Diagnostics on failure → pods for details."
+          else
+            first_err=$(grep -iE 'error|failed' /tmp/helm.out | head -1 | tr -d '\r')
+            summary="helm upgrade failed: ${first_err:-see helm output above}"
+          fi
+
+          echo "::error::$summary"
+          exit "$rc"
       - name: Diagnostics on failure
         # `--atomic` rolls back the release on timeout, so `helm history` and
         # most cluster state reflect the rolled-back revision rather than the


### PR DESCRIPTION
### What you see today

When the deploy fails, the failed-step view starts with helm's own message:

```
Run helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" ...
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to atomic being set: pre-upgrade hooks failed: 1 error occurred:
	* job tuist-tuist-server-migrate-3 failed: BackoffLimitExceeded

Error: Process completed with exit code 1.
```

That names the symptom (`BackoffLimitExceeded`) but not the cause. The actual `Postgrex.Error` stack lived in the separate "Diagnostics on failure" step, several `::group::` blocks deep — easy to miss when scanning a failed run. (Concrete example from last week: [run 24941287267](https://github.com/tuist/tuist/actions/runs/24941287267/job/73066254598).)

### What this PR changes

When `helm upgrade` exits non-zero, the step now:

1. **Pulls the most-recent migration job's pod logs into the same step** when helm reports `pre-upgrade hooks failed`, so the failed-step view shows the actual error without scrolling
2. **Emits a one-line `::error::` annotation** that GitHub Actions promotes to the top of the run UI. The same `WidenBundleSizeColumnsToBigint` failure would surface as:

   > **Error: Migration failed: ** (Postgrex.Error) ERROR 57014 (query_canceled) canceling statement due to statement timeout

3. Pattern-matches helm's output to give specific summaries for the common cases:
   - Pre-upgrade migration failure → migration logs + extracted error line
   - Helm timeout (`context deadline exceeded`) → "timed out, see Diagnostics → pods/events"
   - Image pull failure → "see Diagnostics → pods"
   - Other → first error/failure line from helm's output

### What stays the same

The "Diagnostics on failure" step still runs and captures broader cluster state (helm history, manifest, events, pod descriptions, ESO). The new inline output isn't a replacement — it's a fast path to the most-common root cause.

### How to test

Hard to test cleanly without intentionally breaking a deploy. The bash logic is straightforward grep + kubectl invocations; failure case is a no-op except on actual failure. If a future deploy fails we'll see whether the annotation lands as expected and tune from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)