### PR TITLE
chore(cli): bump FileSystem to 0.17.0 and drop SwiftNIO

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ff91f77210b8991b3fa1311d8c0904413d69d86abdceada53823faec67d87d14",
+  "originHash" : "65d5aa8c03b8905da78593b53c570eac77940ebdbb5f5811e2825c3e208d28c3",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -30,7 +30,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.5.1"
+        "version" : "1.7.0"
       }
     },
     {
@@ -54,7 +54,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.18.0"
+        "version" : "1.19.0"
       }
     },
     {
@@ -78,7 +78,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.6.0"
+        "version" : "1.7.0"
       }
     },
     {
@@ -110,7 +110,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.32.1"
+        "version" : "1.34.0"
       }
     },
     {
@@ -118,7 +118,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.39.1"
+        "version" : "1.43.0"
       }
     },
     {
@@ -126,7 +126,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "2.36.0"
+        "version" : "2.37.0"
       }
     },
     {
@@ -134,7 +134,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.26.0"
+        "version" : "1.27.0"
       }
     },
     {
@@ -198,7 +198,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.18.0"
+        "version" : "0.18.1"
       }
     },
     {
@@ -383,7 +383,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.22.0"
+        "version" : "1.23.0"
       }
     },
     {
@@ -455,7 +455,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.4.1"
+        "version" : "1.5.0"
       }
     },
     {
@@ -599,7 +599,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.16.2"
+        "version" : "0.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1713,10 +1713,9 @@ let package = Package(
         ),
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
-        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.16.2")),
+        .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.0")),
         .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
-        .package(id: "apple.swift-nio", from: "2.70.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),
         .package(

--- a/cli/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/cli/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -2,7 +2,6 @@ import CryptoKit
 import FileSystem
 import Foundation
 import Path
-import TuistEnvironment
 
 /// `ContentHasher`
 /// is the single source of truth for hashing content.
@@ -56,11 +55,10 @@ public struct ContentHasher: ContentHashing {
 
     public func hash(path filePath: AbsolutePath) async throws -> String {
         if try await fileSystem.exists(filePath, isDirectory: true) {
-            let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 100
             return try await fileSystem.glob(directory: filePath, include: ["*"])
                 .collect()
                 .filter { filesFilter($0) }
-                .concurrentMap(maxConcurrentTasks: maxConcurrentTasks) { filePath -> String? in
+                .concurrentMap { filePath -> String? in
                     guard try await fileSystem.exists(filePath) else { return nil }
                     let filePath = try await fileSystem.resolveSymbolicLink(filePath)
                     return try await hash(path: filePath)

--- a/cli/Sources/TuistEnvironment/Environment.swift
+++ b/cli/Sources/TuistEnvironment/Environment.swift
@@ -125,14 +125,6 @@ extension Environmenting {
         isVariableTruthy("TUIST_LEGACY_MODULE_CACHE")
     }
 
-    public var isSwiftFileSystemBackendEnabled: Bool {
-        let value = variables["TUIST_FILESYSTEM_BACKEND"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        guard let value else { return true }
-        return ["swift-file-system", "swift_file_system", "swiftfilesystem"].contains(value)
-    }
-
     public func pathRelativeToWorkingDirectory(_ path: String?) async throws -> AbsolutePath {
         let currentWorkingDirectory = try await currentWorkingDirectory()
         if let path {

--- a/cli/Sources/TuistHasher/GraphContentHasher.swift
+++ b/cli/Sources/TuistHasher/GraphContentHasher.swift
@@ -80,38 +80,14 @@ public struct GraphContentHasher: GraphContentHashing {
             )
         }
 
-        let hashes: [TargetContentHash]
-        if Environment.current.isSwiftFileSystemBackendEnabled {
-            hashes = try await concurrentContentHashes(
-                hashableTargets: hashableTargets,
-                graphTraverser: graphTraverser,
-                hashedTargets: hashedTargets,
-                hashedPaths: hashedPaths,
-                destination: destination,
-                additionalStrings: additionalStrings
-            )
-        } else {
-            hashes = try await hashableTargets
-                .serialMap { (target: GraphTarget) async throws -> TargetContentHash in
-                    let hash = try await targetContentHasher.contentHash(
-                        for: target,
-                        hashedTargets: hashedTargets.value,
-                        hashedPaths: hashedPaths.value,
-                        destination: destination,
-                        additionalStrings: additionalStrings
-                    )
-                    hashedPaths.mutate { $0 = hash.hashedPaths }
-                    hashedTargets.mutate {
-                        $0[
-                            GraphHashedTarget(
-                                projectPath: target.path,
-                                targetName: target.target.name
-                            )
-                        ] = hash.hash
-                    }
-                    return hash
-                }
-        }
+        let hashes = try await concurrentContentHashes(
+            hashableTargets: hashableTargets,
+            graphTraverser: graphTraverser,
+            hashedTargets: hashedTargets,
+            hashedPaths: hashedPaths,
+            destination: destination,
+            additionalStrings: additionalStrings
+        )
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }
 

--- a/cli/Sources/TuistHasher/HeadersContentHasher.swift
+++ b/cli/Sources/TuistHasher/HeadersContentHasher.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Mockable
 import TuistCore
-import TuistEnvironment
 import TuistSupport
 import XcodeGraph
 
@@ -25,12 +24,7 @@ public struct HeadersContentHasher: HeadersContentHashing {
 
     public func hash(headers: Headers) async throws -> String {
         let allHeaders = headers.public + headers.private + headers.project
-        let headersContent: [String]
-        if Environment.current.isSwiftFileSystemBackendEnabled {
-            headersContent = try await allHeaders.concurrentMap { try await contentHasher.hash(path: $0) }
-        } else {
-            headersContent = try await allHeaders.serialMap { try await contentHasher.hash(path: $0) }
-        }
+        let headersContent = try await allHeaders.concurrentMap { try await contentHasher.hash(path: $0) }
         return try contentHasher.hash(headersContent)
     }
 }

--- a/cli/Sources/TuistInspectCommand/Services/TargetImportsScanner.swift
+++ b/cli/Sources/TuistInspectCommand/Services/TargetImportsScanner.swift
@@ -2,7 +2,6 @@
     import FileSystem
     import Mockable
     import Path
-    import TuistEnvironment
     import XcodeGraph
 
     @Mockable
@@ -30,9 +29,8 @@
                 filesToScan.append(contentsOf: headers.public)
                 filesToScan.append(contentsOf: headers.project)
             }
-            let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 100
             var imports = Set(
-                try await filesToScan.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) { file in
+                try await filesToScan.concurrentMap { file in
                     try await matchPattern(at: file)
                 }
                 .flatMap { $0 }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildableFolder+ManifestMapper.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistAlert
-import TuistEnvironment
 import TuistLogging
 import TuistSupport
 import XcodeGraph
@@ -53,9 +52,8 @@ extension XcodeGraph.BuildableFolder {
         let allPaths = try await fileSystem
             .glob(directory: path, include: ["**/*"]).collect()
             .filter { !exclusions.contains($0) }
-        let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 100
         let resolvedFiles = try await allPaths
-            .concurrentCompactMap(maxConcurrentTasks: maxConcurrentTasks) { filePath -> BuildableFolderFile? in
+            .concurrentCompactMap { filePath -> BuildableFolderFile? in
                 if filePath.isInOpaqueDirectory { return nil }
                 if filePath.isOpaqueDirectory {
                     return BuildableFolderFile(

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -2,7 +2,6 @@ import FileSystem
 import Foundation
 import ProjectDescription
 import TuistCore
-import TuistEnvironment
 import XcodeGraph
 
 extension XcodeGraph.Project {
@@ -38,8 +37,7 @@ extension XcodeGraph.Project {
         case .external: .remote
         }
 
-        let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 20
-        let targets = try await manifest.targets.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let targets = try await manifest.targets.concurrentMap {
             try await XcodeGraph.Target.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -3,7 +3,6 @@ import Foundation
 import Path
 import ProjectDescription
 import TuistCore
-import TuistEnvironment
 import TuistLogging
 import TuistSupport
 import XcodeGraph
@@ -74,8 +73,7 @@ extension XcodeGraph.Target {
             fileSystem: fileSystem
         )
 
-        let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 100
-        let copyFiles = try await (manifest.copyFiles ?? []).concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let copyFiles = try await (manifest.copyFiles ?? []).concurrentMap {
             try await XcodeGraph.CopyFilesAction.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,
@@ -95,20 +93,20 @@ extension XcodeGraph.Target {
             headers = nil
         }
 
-        let coreDataModels = try await manifest.coreDataModels.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let coreDataModels = try await manifest.coreDataModels.concurrentMap {
             try await XcodeGraph.CoreDataModel.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,
                 fileSystem: fileSystem
             )
-        } + resourcesCoreDatas.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        } + resourcesCoreDatas.concurrentMap {
             try await XcodeGraph.CoreDataModel.from(
                 path: $0,
                 fileSystem: fileSystem
             )
         }
 
-        let scripts = try await manifest.scripts.concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let scripts = try await manifest.scripts.concurrentMap {
             try await XcodeGraph.TargetScript.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,
@@ -122,7 +120,7 @@ extension XcodeGraph.Target {
         let playgrounds = sourcesPlaygrounds + resourcesPlaygrounds
 
         let additionalFiles = try await manifest.additionalFiles
-            .concurrentMap(maxConcurrentTasks: maxConcurrentTasks) {
+            .concurrentMap {
                 try await XcodeGraph.FileElement.from(
                     manifest: $0,
                     generatorPaths: generatorPaths,
@@ -140,7 +138,7 @@ extension XcodeGraph.Target {
         }
 
         let metadata = XcodeGraph.TargetMetadata(tags: Set(manifest.metadata.tags))
-        let buildableFolders = try await manifest.buildableFolders.concurrentCompactMap(maxConcurrentTasks: maxConcurrentTasks) {
+        let buildableFolders = try await manifest.buildableFolders.concurrentCompactMap {
             try await XcodeGraph.BuildableFolder.from(
                 manifest: $0,
                 generatorPaths: generatorPaths,
@@ -241,9 +239,8 @@ extension XcodeGraph.Target {
         var playgrounds: Set<AbsolutePath> = []
         var coreDataModels: Set<AbsolutePath> = []
 
-        let maxConcurrentTasks = Environment.current.isSwiftFileSystemBackendEnabled ? Int.max : 100
         let result = try await (manifest.resources?.resources ?? [])
-            .concurrentMap(maxConcurrentTasks: maxConcurrentTasks) { manifest async throws -> [XcodeGraph.ResourceFileElement] in
+            .concurrentMap { manifest async throws -> [XcodeGraph.ResourceFileElement] in
                 do {
                     return try await XcodeGraph.ResourceFileElement.from(
                         manifest: manifest,

--- a/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/GraphContentHasherTests.swift
@@ -4,8 +4,6 @@ import Mockable
 import Path
 import Testing
 import TuistCore
-import TuistEnvironment
-import TuistEnvironmentTesting
 import TuistRootDirectoryLocator
 import TuistTesting
 import XcodeGraph
@@ -110,70 +108,5 @@ struct GraphContentHasherTests {
 
         // Then
         #expect(hashedTargets == expectedCachableTargets)
-    }
-
-    @Test(.withMockedEnvironment())
-    func contentHashes_withSwiftFileSystemBackend_producesSameResultsAsSerial() async throws {
-        // Given
-        let path: AbsolutePath = "/project"
-        let frameworkATarget: Target = .test(
-            name: "FrameworkA",
-            product: .framework,
-            infoPlist: nil,
-            entitlements: nil
-        )
-        let frameworkBTarget: Target = .test(
-            name: "FrameworkB",
-            product: .framework,
-            infoPlist: nil,
-            entitlements: nil,
-            dependencies: [.target(name: "FrameworkA")]
-        )
-        let frameworkCTarget: Target = .test(
-            name: "FrameworkC",
-            product: .framework,
-            infoPlist: nil,
-            entitlements: nil,
-            dependencies: [.target(name: "FrameworkB")]
-        )
-        let project: Project = .test(
-            path: path,
-            targets: [frameworkATarget, frameworkBTarget, frameworkCTarget]
-        )
-        let graph = Graph.test(
-            path: path,
-            projects: [project.path: project],
-            dependencies: [
-                .target(name: frameworkBTarget.name, path: project.path): [
-                    .target(name: frameworkATarget.name, path: project.path),
-                ],
-                .target(name: frameworkCTarget.name, path: project.path): [
-                    .target(name: frameworkBTarget.name, path: project.path),
-                ],
-            ]
-        )
-
-        // When: serial (default)
-        let serialHashes = try await subject.contentHashes(
-            for: graph,
-            include: { _ in true },
-            destination: nil,
-            additionalStrings: []
-        )
-
-        // When: concurrent (swift-file-system backend)
-        Environment.mocked?.variables["TUIST_FILESYSTEM_BACKEND"] = "swift-file-system"
-        let concurrentHashes = try await subject.contentHashes(
-            for: graph,
-            include: { _ in true },
-            destination: nil,
-            additionalStrings: []
-        )
-
-        // Then: same set of targets, same hashes per target
-        #expect(Set(serialHashes.keys) == Set(concurrentHashes.keys))
-        for (target, hash) in serialHashes {
-            #expect(concurrentHashes[target]?.hash == hash.hash)
-        }
     }
 }

--- a/cli/Tests/TuistHasherTests/HeadersContentHasherTests.swift
+++ b/cli/Tests/TuistHasherTests/HeadersContentHasherTests.swift
@@ -2,8 +2,6 @@ import Foundation
 import Mockable
 import Path
 import TuistCore
-import TuistEnvironment
-import TuistEnvironmentTesting
 import TuistSupport
 import TuistTesting
 import XcodeGraph
@@ -70,47 +68,5 @@ final class HeadersContentHasherTests: TuistUnitTestCase {
         verify(contentHasher)
             .hash(path: .any)
             .called(6)
-    }
-
-    func test_hash_withSwiftFileSystemBackend_preservesInputOrder() async throws {
-        try await withMockedEnvironment {
-            // Given
-            Environment.mocked?.variables["TUIST_FILESYSTEM_BACKEND"] = "swift-file-system"
-            given(contentHasher)
-                .hash(path: .value(filePath1))
-                .willReturn("1")
-            given(contentHasher)
-                .hash(path: .value(filePath2))
-                .willReturn("2")
-            given(contentHasher)
-                .hash(path: .value(filePath3))
-                .willReturn("3")
-            given(contentHasher)
-                .hash(path: .value(filePath4))
-                .willReturn("4")
-            given(contentHasher)
-                .hash(path: .value(filePath5))
-                .willReturn("5")
-            given(contentHasher)
-                .hash(path: .value(filePath6))
-                .willReturn("6")
-            given(contentHasher)
-                .hash(Parameter<[String]>.any)
-                .willProduce { $0.joined(separator: ";") }
-
-            // When
-            let headers = Headers(
-                public: [filePath1, filePath2],
-                private: [filePath3, filePath4],
-                project: [filePath5, filePath6]
-            )
-
-            // Then
-            let hash = try await subject.hash(headers: headers)
-            XCTAssertEqual(hash, "1;2;3;4;5;6")
-            verify(contentHasher)
-                .hash(path: .any)
-                .called(6)
-        }
     }
 }

--- a/cli/Tests/TuistSupportTests/Utils/EnvironmentTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/EnvironmentTests.swift
@@ -6,18 +6,6 @@ import Testing
 @testable import TuistTesting
 
 struct EnvironmentTests {
-    @Test() func isSwiftFileSystemBackendEnabled_isEnabledByDefault() {
-        let subject = Environment(variables: [:])
-
-        #expect(subject.isSwiftFileSystemBackendEnabled)
-    }
-
-    @Test() func isSwiftFileSystemBackendEnabled_isDisabledWhenUsingAnyOtherValue() {
-        let subject = Environment(variables: ["TUIST_FILESYSTEM_BACKEND": "legacy"])
-
-        #expect(!subject.isSwiftFileSystemBackendEnabled)
-    }
-
     // MARK: - Cache Directory Tests
 
     @Test() func cacheDirectory_withTuistXDGCacheHome() throws {


### PR DESCRIPTION
## Summary
- Bump `tuist.FileSystem` from `0.16.2` to `0.17.0`.
- Remove the `TUIST_FILESYSTEM_BACKEND` env var and the `isSwiftFileSystemBackendEnabled` flag — FileSystem 0.17 drops the file system backend concept, so the conditional concurrency branches are no longer needed (call sites now always run concurrently with `Int.max`).
- Drop `apple.swift-nio` as a direct dependency of the CLI; it had no remaining direct usage. `grpc-swift-nio-transport` (used by gRPC) stays.

## Test plan
- [x] `xcodebuild build -scheme tuist` succeeds
- [x] `tuist test TuistUnitTests --test-targets TuistHasherTests/HeadersContentHasherTests --test-targets TuistHasherTests/GraphContentHasherTests` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)