### PR TITLE
fix(cli): upload build run when -derivedDataPath is passed via passthrough

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1474,9 +1474,14 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
+        let passthroughDerivedDataPath = try? await xcodeBuildAgumentParser
+            .parse(passthroughXcodeBuildArguments)
+            .derivedDataPath
         let projectDerivedDataDirectory: AbsolutePath?
         if let derivedDataPath {
             projectDerivedDataDirectory = derivedDataPath
+        } else if let passthroughDerivedDataPath {
+            projectDerivedDataDirectory = passthroughDerivedDataPath
         } else {
             projectDerivedDataDirectory = try? await derivedDataLocator.locate(
                 for: graphTraverser.workspace.xcWorkspacePath

--- a/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/XcodeBuildTestCommandService.swift
@@ -34,6 +34,7 @@ struct XcodeBuildTestCommandService {
     private let testQuarantineService: TestQuarantineServicing
     private let shardService: ShardServicing
     private let serverEnvironmentService: ServerEnvironmentServicing
+    private let uploadBuildRunService: UploadBuildRunServicing?
 
     init(
         fileSystem: FileSysteming = FileSystem(),
@@ -49,7 +50,8 @@ struct XcodeBuildTestCommandService {
         rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
         testQuarantineService: TestQuarantineServicing = TestQuarantineService(),
         shardService: ShardServicing = ShardService(),
-        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService()
+        serverEnvironmentService: ServerEnvironmentServicing = ServerEnvironmentService(),
+        uploadBuildRunService: UploadBuildRunServicing? = UploadBuildRunService()
     ) {
         self.fileSystem = fileSystem
         self.xcodeBuildController = xcodeBuildController
@@ -65,6 +67,7 @@ struct XcodeBuildTestCommandService {
         self.testQuarantineService = testQuarantineService
         self.shardService = shardService
         self.serverEnvironmentService = serverEnvironmentService
+        self.uploadBuildRunService = uploadBuildRunService
     }
 
     func run(
@@ -138,7 +141,12 @@ struct XcodeBuildTestCommandService {
             try await xcodeBuildController.run(arguments: passthroughXcodebuildArguments)
         } catch {
             if let derivedDataPath {
-                await updateBuildRunId(projectDerivedDataDirectory: derivedDataPath)
+                await processBuildRun(
+                    projectDerivedDataDirectory: derivedDataPath,
+                    projectPath: path,
+                    config: config,
+                    passthroughXcodebuildArguments: passthroughXcodebuildArguments
+                )
             }
 
             var testSummary: TestSummary?
@@ -191,7 +199,12 @@ struct XcodeBuildTestCommandService {
         }
 
         if let derivedDataPath {
-            await updateBuildRunId(projectDerivedDataDirectory: derivedDataPath)
+            await processBuildRun(
+                projectDerivedDataDirectory: derivedDataPath,
+                projectPath: path,
+                config: config,
+                passthroughXcodebuildArguments: passthroughXcodebuildArguments
+            )
         }
 
         var testSummary: TestSummary?
@@ -228,13 +241,31 @@ struct XcodeBuildTestCommandService {
         }
     }
 
-    private func updateBuildRunId(projectDerivedDataDirectory: AbsolutePath) async {
+    private func processBuildRun(
+        projectDerivedDataDirectory: AbsolutePath,
+        projectPath: AbsolutePath,
+        config: Tuist,
+        passthroughXcodebuildArguments: [String]
+    ) async {
         guard let mostRecentActivityLogPath = try? await xcActivityLogController.mostRecentActivityLogFile(
             projectDerivedDataDirectory: projectDerivedDataDirectory
         )
         else { return }
 
         await RunMetadataStorage.current.update(buildRunId: mostRecentActivityLogPath.path.basenameWithoutExt)
+
+        guard let uploadBuildRunService, config.fullHandle != nil else { return }
+        do {
+            try await uploadBuildRunService.uploadBuildRun(
+                activityLogPath: mostRecentActivityLogPath.path,
+                projectPath: projectPath,
+                config: config,
+                scheme: passedValue(for: "-scheme", arguments: passthroughXcodebuildArguments),
+                configuration: passedValue(for: "-configuration", arguments: passthroughXcodebuildArguments)
+            )
+        } catch {
+            AlertController.current.warning(.alert("Failed to upload build: \(error.localizedDescription)"))
+        }
     }
 
     private func projectPath(xcodeBuildArguments: XcodeBuildArguments) async throws -> AbsolutePath? {

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -762,6 +762,111 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(0)
     }
 
+    func test_run_uploads_build_run_using_passthrough_derived_data_path() async throws {
+        // Given
+        givenGenerator()
+        let path = try temporaryPath()
+        let projectPath = path.appending(component: "Project")
+        let passthroughDerivedDataPath = path.appending(component: "passthrough-derived-data")
+        let activityLogPath = passthroughDerivedDataPath.appending(
+            components: "Logs", "Build", "activity.xcactivitylog"
+        )
+        let scheme = Scheme.test(
+            name: "AppTests",
+            testAction: .test(
+                targets: [
+                    .test(target: TargetReference(projectPath: projectPath, name: "AppTests")),
+                ]
+            )
+        )
+
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([scheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any, testPlan: .any, testTargets: .any, skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willReturn(.test(target: .test(name: "AppTests")))
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (
+                    path,
+                    .test(
+                        workspace: .test(schemes: [scheme]),
+                        projects: [
+                            projectPath: .test(
+                                path: projectPath,
+                                targets: [.test(name: "AppTests")],
+                                schemes: [scheme]
+                            ),
+                        ]
+                    ),
+                    MapperEnvironment()
+                )
+            }
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                .test(
+                    project: .testGeneratedProject(),
+                    fullHandle: "tuist/tuist",
+                    url: URL(string: "https://example.com")!
+                )
+            )
+
+        xcodeBuildArgumentParser.reset()
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: passthroughDerivedDataPath))
+
+        var mostRecentActivityLogProjectDirectory: AbsolutePath?
+        xcActivityLogController.reset()
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .any, filter: .any)
+            .willProduce { directory, _ in
+                mostRecentActivityLogProjectDirectory = directory
+                return .test(path: activityLogPath)
+            }
+
+        given(uploadBuildRunService)
+            .uploadBuildRun(
+                activityLogPath: .any,
+                projectPath: .any,
+                config: .any,
+                scheme: .any,
+                configuration: .any
+            )
+            .willReturn(URL(string: "https://tuist.dev/test")!)
+
+        // When
+        try await testRun(
+            path: path,
+            passthroughXcodeBuildArguments: ["-derivedDataPath", passthroughDerivedDataPath.pathString]
+        )
+
+        // Then — derivedDataLocator must NOT have been used; the passthrough path is honored.
+        XCTAssertEqual(mostRecentActivityLogProjectDirectory, passthroughDerivedDataPath)
+        verify(derivedDataLocator)
+            .locate(for: .any)
+            .called(0)
+
+        verify(uploadBuildRunService)
+            .uploadBuildRun(
+                activityLogPath: .value(activityLogPath),
+                projectPath: .any,
+                config: .any,
+                scheme: .any,
+                configuration: .any
+            )
+            .called(1)
+    }
+
     func test_run_tests_individual_scheme() async throws {
         // Given
         givenGenerator()

--- a/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/XcodeBuildTestCommandServiceTests.swift
@@ -39,6 +39,7 @@ struct XcodeBuildTestCommandServiceTests {
     private let testQuarantineService = MockTestQuarantineServicing()
     private let shardService = MockShardServicing()
     private let serverEnvironmentService = MockServerEnvironmentServicing()
+    private let uploadBuildRunService = MockUploadBuildRunServicing()
     private let subject: XcodeBuildTestCommandService
 
     init() {
@@ -57,6 +58,9 @@ struct XcodeBuildTestCommandServiceTests {
         given(rootDirectoryLocator)
             .locate(from: .any)
             .willReturn(nil)
+        given(uploadBuildRunService)
+            .uploadBuildRun(activityLogPath: .any, projectPath: .any, config: .any, scheme: .any, configuration: .any)
+            .willReturn(URL(string: "https://tuist.dev/test")!)
 
         subject = XcodeBuildTestCommandService(
             fileSystem: fileSystem,
@@ -72,7 +76,8 @@ struct XcodeBuildTestCommandServiceTests {
             rootDirectoryLocator: rootDirectoryLocator,
             testQuarantineService: testQuarantineService,
             shardService: shardService,
-            serverEnvironmentService: serverEnvironmentService
+            serverEnvironmentService: serverEnvironmentService,
+            uploadBuildRunService: uploadBuildRunService
         )
     }
 
@@ -297,6 +302,96 @@ struct XcodeBuildTestCommandServiceTests {
                 shardPlanId: .any,
                 shardIndex: .any
             )
+            .called(0)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func uploadsBuildRunWhenFullHandleConfigured() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        // Given
+        let arguments = ["test", "-scheme", "MyAppTests"]
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+        let activityLogPath = derivedDataPath.appending(components: "Logs", "Build", "activity.xcactivitylog")
+        let activityLogFile: XCActivityLogFile = .test(path: activityLogPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", url: URL(string: "https://example.com")!))
+
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(temporaryDirectory.appending(component: "cache"))
+
+        given(uniqueIDGenerator)
+            .uniqueID()
+            .willReturn("unique-id-123")
+
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: derivedDataPath))
+
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .value(derivedDataPath), filter: .any)
+            .willReturn(activityLogFile)
+
+        given(xcodeBuildController)
+            .run(arguments: .any)
+            .willReturn()
+
+        // When
+        try await subject.run(passthroughXcodebuildArguments: arguments)
+
+        // Then
+        verify(uploadBuildRunService)
+            .uploadBuildRun(
+                activityLogPath: .value(activityLogPath),
+                projectPath: .any,
+                config: .any,
+                scheme: .value("MyAppTests"),
+                configuration: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func doesNotUploadBuildRunWhenNoFullHandle() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        // Given
+        let arguments = ["test", "-scheme", "MyAppTests"]
+        let derivedDataPath = temporaryDirectory.appending(component: "DerivedData")
+        let activityLogPath = derivedDataPath.appending(components: "Logs", "Build", "activity.xcactivitylog")
+        let activityLogFile: XCActivityLogFile = .test(path: activityLogPath)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: nil))
+
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.runs))
+            .willReturn(temporaryDirectory.appending(component: "cache"))
+
+        given(uniqueIDGenerator)
+            .uniqueID()
+            .willReturn("unique-id-123")
+
+        given(xcodeBuildArgumentParser)
+            .parse(.any)
+            .willReturn(.test(derivedDataPath: derivedDataPath))
+
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .value(derivedDataPath), filter: .any)
+            .willReturn(activityLogFile)
+
+        given(xcodeBuildController)
+            .run(arguments: .any)
+            .willReturn()
+
+        // When
+        try await subject.run(passthroughXcodebuildArguments: arguments)
+
+        // Then
+        verify(uploadBuildRunService)
+            .uploadBuildRun(activityLogPath: .any, projectPath: .any, config: .any, scheme: .any, configuration: .any)
             .called(0)
     }
 


### PR DESCRIPTION
## Summary
- `tuist test` now honors `-derivedDataPath` when passed as a passthrough arg (after `--`) when locating the xcactivitylog for build run upload. Previously, users following the deprecation warning got no build insights from their test runs because the upload looked in the wrong DerivedData directory.
- `tuist xcodebuild test` now uploads the build run via `UploadBuildRunService`, matching the behavior already wired into `tuist xcodebuild build`.

## Why
A `tuist test` run on 4.181.1 with `-derivedDataPath /custom/path` after `--` showed no associated build run on the dashboard, even though the test run was uploaded. Trace: [TestService.swift:1477-1484](https://github.com/tuist/tuist/blob/main/cli/Sources/TuistKit/Services/TestService.swift#L1477-L1484) fell through to `DerivedDataLocator.locate(...)` (default \`~/Library/Developer/Xcode/DerivedData/<hash>\`), so \`xcActivityLogController.mostRecentActivityLogFile(...)\` searched the wrong directory and the upload was silently skipped.

## Test plan
- [x] New `TestServiceTests.test_run_uploads_build_run_using_passthrough_derived_data_path` verifies the passthrough path is used as the activity-log lookup directory and `derivedDataLocator.locate` is not called.
- [x] New `XcodeBuildTestCommandServiceTests.uploadsBuildRunWhenFullHandleConfigured` verifies `tuist xcodebuild test` uploads the build run when a full handle is configured.
- [x] New `XcodeBuildTestCommandServiceTests.doesNotUploadBuildRunWhenNoFullHandle` verifies it does not upload when no handle is configured.
- [x] Full `TestServiceTests` suite passes locally (62 tests).
- [x] Full `XcodeBuildTestCommandServiceTests` suite passes locally.
- [x] `mise run cli:lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)