### PR TITLE
chore(server): enrich Slack deploy success message with commit details

### DIFF
--- a/.github/workflows/notify-deploy-success.yml
+++ b/.github/workflows/notify-deploy-success.yml
@@ -29,9 +29,11 @@ jobs:
         env:
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
           SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           SHORT_SHA="${SHA:0:7}"
-          TEXT=$(printf ':white_check_mark: New deploy for tuist%s: %s\n\nhttps://tuist.dev' "$SHORT_SHA" "$COMMIT_MESSAGE")
+          COMMIT_URL="${REPO_URL}/commit/${SHA}"
+          TEXT=$(printf ':white_check_mark: New deploy for <%s|tuist%s>: %s\n\nhttps://tuist.dev' "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MESSAGE")
           jq -n --arg text "$TEXT" '{text: $text}' > "$RUNNER_TEMP/slack-payload.json"
       - uses: slackapi/slack-github-action@v2
         with:

--- a/.github/workflows/notify-deploy-success.yml
+++ b/.github/workflows/notify-deploy-success.yml
@@ -25,11 +25,16 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+      - name: Build Slack payload
+        env:
+          COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          SHORT_SHA="${SHA:0:7}"
+          TEXT=$(printf ':white_check_mark: New deploy for tuist%s: %s\n\nhttps://tuist.dev' "$SHORT_SHA" "$COMMIT_MESSAGE")
+          jq -n --arg text "$TEXT" '{text: $text}' > "$RUNNER_TEMP/slack-payload.json"
       - uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": ":white_check_mark: `${{ github.event.workflow_run.name }}` succeeded on main: ${{ github.event.workflow_run.html_url }}"
-            }
+          payload-file-path: ${{ runner.temp }}/slack-payload.json


### PR DESCRIPTION
> Brings the production deploy notification closer to Render's old format.

### What changed

`.github/workflows/notify-deploy-success.yml` now posts a richer Slack message on a successful production deploy:

```
:white_check_mark: New deploy for tuist3c96ae7: feat(cli): resolve inspect bundle app names like share (#9916)

Co-authored-by: ...
Co-authored-by: ...

https://tuist.dev
```

Instead of the previous one-liner that only linked to the workflow run.

The payload is built with `jq -n --arg` and passed via `payload-file-path`, so commit messages with quotes, backticks, or newlines stay safely encoded.

### How to test locally

This workflow only runs on `workflow_run` from `Server Production Deployment` on `main`, so it can't be triggered from a branch. Verification will happen on the next production deploy after merge.