### PR TITLE
fix(cli): sanitize target name in generated Obj-C bundle accessor identifiers

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -321,6 +321,7 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
     static func objcHeaderFileContent(
         targetName: String
     ) -> String {
+        let identifier = targetName.toValidSwiftIdentifier()
         return """
         #import <Foundation/Foundation.h>
 
@@ -328,9 +329,9 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         extern "C" {
         #endif
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
+        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) NS_SWIFT_NONISOLATED;
 
-        #define SWIFTPM_MODULE_BUNDLE \(targetName)_SWIFTPM_MODULE_BUNDLE()
+        #define SWIFTPM_MODULE_BUNDLE \(identifier)_SWIFTPM_MODULE_BUNDLE()
 
         #if __cplusplus
         }
@@ -342,20 +343,21 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
         targetName: String,
         bundleName: String
     ) -> String {
+        let identifier = targetName.toValidSwiftIdentifier()
         return """
         #import <Foundation/Foundation.h>
         #import "TuistBundle+\(targetName).h"
 
-        @interface \(targetName)BundleFinder : NSObject
+        @interface \(identifier)BundleFinder : NSObject
         @end
 
-        @implementation \(targetName)BundleFinder
+        @implementation \(identifier)BundleFinder
         @end
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
+        NSBundle* \(identifier)_SWIFTPM_MODULE_BUNDLE(void) {
             NSString *bundleName = @"\(bundleName)";
 
-            NSURL *bundleURL = [[NSBundle bundleForClass:\(targetName)BundleFinder.self] resourceURL];
+            NSURL *bundleURL = [[NSBundle bundleForClass:\(identifier)BundleFinder.self] resourceURL];
             NSMutableArray *candidates = [NSMutableArray arrayWithObjects:
                                           [[NSBundle mainBundle] resourceURL],
                                           bundleURL,

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1157,6 +1157,37 @@ struct ResourcesProjectMapperTests {
         #expect(targetKindSetting == .string("regular"))
     }
 
+    @Test
+    func objcImplementationFileContentSanitizesTargetNameWithHyphens() {
+        // Given
+        let targetName = "YoutubePlayer-in-WKWebView"
+
+        // When
+        let got = ResourcesProjectMapper.objcImplementationFileContent(
+            targetName: targetName,
+            bundleName: "MyProject_YoutubePlayer-in-WKWebView"
+        )
+
+        // Then
+        #expect(!got.contains("YoutubePlayer-in-WKWebViewBundleFinder"))
+        #expect(got.contains("YoutubePlayerInWKWebViewBundleFinder"))
+        #expect(got.contains("YoutubePlayerInWKWebView_SWIFTPM_MODULE_BUNDLE"))
+        #expect(!got.contains("YoutubePlayer-in-WKWebView_SWIFTPM_MODULE_BUNDLE"))
+    }
+
+    @Test
+    func objcHeaderFileContentSanitizesTargetNameWithHyphens() {
+        // Given
+        let targetName = "YoutubePlayer-in-WKWebView"
+
+        // When
+        let got = ResourcesProjectMapper.objcHeaderFileContent(targetName: targetName)
+
+        // Then
+        #expect(got.contains("YoutubePlayerInWKWebView_SWIFTPM_MODULE_BUNDLE"))
+        #expect(!got.contains("YoutubePlayer-in-WKWebView_SWIFTPM_MODULE_BUNDLE"))
+    }
+
     // MARK: - Helpers
 
     private func verifySideEffects(


### PR DESCRIPTION
## Summary
- Fixes #8705: SPM dependencies whose target name contains hyphens (e.g. `YoutubePlayer-in-WKWebView`) failed to compile because the generated `TuistBundle+*.{h,m}` files emitted invalid C/Obj-C identifiers like `YoutubePlayer-in-WKWebViewBundleFinder` and `YoutubePlayer-in-WKWebView_SWIFTPM_MODULE_BUNDLE`.
- Applies `toValidSwiftIdentifier()` to the target name in identifier positions inside `objcHeaderFileContent` and `objcImplementationFileContent`, mirroring the Swift-side fix from #6151. The `#import "TuistBundle+<name>.h"` reference still uses the raw target name to match the on-disk filename.

## Test plan
- [x] New unit tests in `ResourcesProjectMapperTests` cover both the header and implementation generation with a hyphenated target name (`YoutubePlayer-in-WKWebView`).
- [x] Existing `ResourcesProjectMapperTests` suite passes (31 tests).
- [ ] Manual verification with the reproduction project from #8705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)