### PR TITLE
fix(server): refresh PR comment after xcresult processing finishes

### DIFF
--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -27,6 +27,13 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
       {:ok, parsed_data} ->
         replace_test_run(parsed_data, args)
 
+        case Map.get(args, "vcs_comment_params", %{}) do
+          params when params != %{} -> Tuist.VCS.enqueue_vcs_pull_request_comment(params)
+          _ -> :ok
+        end
+
+        :ok
+
       {:error, reason} ->
         if attempt >= max_attempts do
           Logger.error(

--- a/server/lib/tuist/vcs/workers/comment_worker.ex
+++ b/server/lib/tuist/vcs/workers/comment_worker.ex
@@ -9,9 +9,17 @@ defmodule Tuist.VCS.Workers.CommentWorker do
 
   import Ecto.Query
 
+  alias Tuist.Environment
   alias Tuist.Projects
   alias Tuist.Repo
   alias Tuist.VCS
+
+  @preview_url_path "/:account_name/:project_name/previews/:preview_id"
+  @preview_qr_code_url_path "/:account_name/:project_name/previews/:preview_id/qr-code.png"
+  @command_run_url_path "/:account_name/:project_name/runs/:command_event_id"
+  @test_run_url_path "/:account_name/:project_name/tests/test-runs/:test_run_id"
+  @bundle_url_path "/:account_name/:project_name/bundles/:bundle_id"
+  @build_url_path "/:account_name/:project_name/builds/build-runs/:build_id"
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -20,13 +28,7 @@ defmodule Tuist.VCS.Workers.CommentWorker do
           "git_commit_sha" => git_commit_sha,
           "git_ref" => git_ref,
           "git_remote_url_origin" => git_remote_url_origin,
-          "project_id" => project_id,
-          "preview_url_template" => preview_url_template,
-          "preview_qr_code_url_template" => preview_qr_code_url_template,
-          "command_run_url_template" => command_run_url_template,
-          "test_run_url_template" => test_run_url_template,
-          "bundle_url_template" => bundle_url_template,
-          "build_url_template" => build_url_template
+          "project_id" => project_id
         }
       }) do
     # Cancel any other running jobs targeting the same PR to implement debouncing.
@@ -36,18 +38,19 @@ defmodule Tuist.VCS.Workers.CommentWorker do
     cancel_competing_jobs(job_id, project_id, git_ref)
 
     project = Projects.get_project_by_id(project_id)
+    base_url = Environment.app_url()
 
     VCS.post_vcs_pull_request_comment(%{
       git_commit_sha: git_commit_sha,
       git_ref: git_ref,
       git_remote_url_origin: git_remote_url_origin,
       project: project,
-      preview_url: &build_url(preview_url_template, &1),
-      preview_qr_code_url: &build_url(preview_qr_code_url_template, &1),
-      command_run_url: &build_url(command_run_url_template, &1),
-      test_run_url: &build_url(test_run_url_template, &1),
-      bundle_url: &build_url(bundle_url_template, &1),
-      build_url: &build_url(build_url_template, &1)
+      preview_url: &build_url(base_url <> @preview_url_path, &1),
+      preview_qr_code_url: &build_url(base_url <> @preview_qr_code_url_path, &1),
+      command_run_url: &build_url(base_url <> @command_run_url_path, &1),
+      test_run_url: &build_url(base_url <> @test_run_url_path, &1),
+      bundle_url: &build_url(base_url <> @bundle_url_path, &1),
+      build_url: &build_url(base_url <> @build_url_path, &1)
     })
 
     :ok

--- a/server/lib/tuist/vcs/workers/comment_worker.ex
+++ b/server/lib/tuist/vcs/workers/comment_worker.ex
@@ -7,19 +7,15 @@ defmodule Tuist.VCS.Workers.CommentWorker do
   """
   use Oban.Worker
 
+  use Phoenix.VerifiedRoutes,
+    endpoint: TuistWeb.Endpoint,
+    router: TuistWeb.Router
+
   import Ecto.Query
 
-  alias Tuist.Environment
   alias Tuist.Projects
   alias Tuist.Repo
   alias Tuist.VCS
-
-  @preview_url_path "/:account_name/:project_name/previews/:preview_id"
-  @preview_qr_code_url_path "/:account_name/:project_name/previews/:preview_id/qr-code.png"
-  @command_run_url_path "/:account_name/:project_name/runs/:command_event_id"
-  @test_run_url_path "/:account_name/:project_name/tests/test-runs/:test_run_id"
-  @bundle_url_path "/:account_name/:project_name/bundles/:bundle_id"
-  @build_url_path "/:account_name/:project_name/builds/build-runs/:build_id"
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -38,22 +34,45 @@ defmodule Tuist.VCS.Workers.CommentWorker do
     cancel_competing_jobs(job_id, project_id, git_ref)
 
     project = Projects.get_project_by_id(project_id)
-    base_url = Environment.app_url()
 
     VCS.post_vcs_pull_request_comment(%{
       git_commit_sha: git_commit_sha,
       git_ref: git_ref,
       git_remote_url_origin: git_remote_url_origin,
       project: project,
-      preview_url: &build_url(base_url <> @preview_url_path, &1),
-      preview_qr_code_url: &build_url(base_url <> @preview_qr_code_url_path, &1),
-      command_run_url: &build_url(base_url <> @command_run_url_path, &1),
-      test_run_url: &build_url(base_url <> @test_run_url_path, &1),
-      bundle_url: &build_url(base_url <> @bundle_url_path, &1),
-      build_url: &build_url(base_url <> @build_url_path, &1)
+      preview_url: &preview_url/1,
+      preview_qr_code_url: &preview_qr_code_url/1,
+      command_run_url: &command_run_url/1,
+      test_run_url: &test_run_url/1,
+      bundle_url: &bundle_url/1,
+      build_url: &build_url/1
     })
 
     :ok
+  end
+
+  defp preview_url(%{project: %{account: account} = project, preview: preview}) do
+    url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}")
+  end
+
+  defp preview_qr_code_url(%{project: %{account: account} = project, preview: preview}) do
+    url(~p"/#{account.name}/#{project.name}/previews/#{preview.id}/qr-code.png")
+  end
+
+  defp command_run_url(%{project: %{account: account} = project, command_event: command_event}) do
+    url(~p"/#{account.name}/#{project.name}/runs/#{command_event.id}")
+  end
+
+  defp test_run_url(%{project: %{account: account} = project, test_run: test_run}) do
+    url(~p"/#{account.name}/#{project.name}/tests/test-runs/#{test_run.id}")
+  end
+
+  defp bundle_url(%{project: %{account: account} = project, bundle: bundle}) do
+    url(~p"/#{account.name}/#{project.name}/bundles/#{bundle.id}")
+  end
+
+  defp build_url(%{project: %{account: account} = project, build: build}) do
+    url(~p"/#{account.name}/#{project.name}/builds/build-runs/#{build.id}")
   end
 
   defp cancel_competing_jobs(current_job_id, project_id, git_ref) do
@@ -72,23 +91,5 @@ defmodule Tuist.VCS.Workers.CommentWorker do
     Enum.each(competing_jobs, fn job ->
       Oban.cancel_job(job.id)
     end)
-  end
-
-  defp build_url(template, data) do
-    template
-    |> String.replace(":account_name", data.project.account.name)
-    |> String.replace(":project_name", data.project.name)
-    |> replace_if_present(data, :preview, ":preview_id")
-    |> replace_if_present(data, :command_event, ":command_event_id")
-    |> replace_if_present(data, :test_run, ":test_run_id")
-    |> replace_if_present(data, :bundle, ":bundle_id")
-    |> replace_if_present(data, :build, ":build_id")
-  end
-
-  defp replace_if_present(template, data, key, placeholder) do
-    case Map.get(data, key) do
-      nil -> String.replace(template, placeholder, "")
-      value -> String.replace(template, placeholder, to_string(Map.get(value, :id)))
-    end
   end
 end

--- a/server/lib/tuist_web/controllers/api/analytics_controller.ex
+++ b/server/lib/tuist_web/controllers/api/analytics_controller.ex
@@ -461,13 +461,7 @@ defmodule TuistWeb.API.AnalyticsController do
         git_commit_sha: git_commit_sha,
         git_ref: git_ref,
         git_remote_url_origin: git_remote_url_origin,
-        project_id: selected_project.id,
-        preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-        preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-        command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-        test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-        bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-        build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+        project_id: selected_project.id
       })
     end
 

--- a/server/lib/tuist_web/controllers/api/builds_controller.ex
+++ b/server/lib/tuist_web/controllers/api/builds_controller.ex
@@ -859,13 +859,7 @@ defmodule TuistWeb.API.BuildsController do
         git_commit_sha: build.git_commit_sha,
         git_ref: build.git_ref,
         git_remote_url_origin: Map.get(body_params, :git_remote_url_origin),
-        project_id: selected_project.id,
-        preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-        preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-        command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-        test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-        bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-        build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+        project_id: selected_project.id
       })
     end
 
@@ -953,13 +947,7 @@ defmodule TuistWeb.API.BuildsController do
               git_commit_sha: Map.get(params, :git_commit_sha),
               git_ref: Map.get(params, :git_ref),
               git_remote_url_origin: Map.get(params, :git_remote_url_origin),
-              project_id: params.project.id,
-              preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-              preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-              command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-              test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-              bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-              build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+              project_id: params.project.id
             }
           }
           |> Tuist.Builds.Workers.ProcessBuildWorker.new()

--- a/server/lib/tuist_web/controllers/api/gradle_controller.ex
+++ b/server/lib/tuist_web/controllers/api/gradle_controller.ex
@@ -178,13 +178,7 @@ defmodule TuistWeb.API.GradleController do
       git_commit_sha: body[:git_commit_sha],
       git_ref: body[:git_ref],
       git_remote_url_origin: body[:git_remote_url_origin],
-      project_id: project.id,
-      preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-      preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-      command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-      test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-      bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-      build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+      project_id: project.id
     })
 
     conn

--- a/server/lib/tuist_web/controllers/api/runs_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runs_controller.ex
@@ -788,13 +788,7 @@ defmodule TuistWeb.API.RunsController do
               git_commit_sha: build.git_commit_sha,
               git_ref: build.git_ref,
               git_remote_url_origin: Map.get(body_params, :git_remote_url_origin),
-              project_id: selected_project.id,
-              preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-              preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-              command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-              test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-              bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-              build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+              project_id: selected_project.id
             })
 
             conn

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -521,6 +521,19 @@ defmodule TuistWeb.API.TestsController do
 
     case get_or_create_test(run_params) do
       {:ok, test_run} ->
+        vcs_comment_params = %{
+          git_commit_sha: Map.get(body_params, :git_commit_sha),
+          git_ref: Map.get(body_params, :git_ref),
+          git_remote_url_origin: Map.get(body_params, :git_remote_url_origin),
+          project_id: selected_project.id,
+          preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
+          preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
+          command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
+          test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
+          bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
+          build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+        }
+
         if test_run.status == "processing" do
           storage_key =
             "#{selected_project.account.name}/#{selected_project.name}/runs/#{test_run.id}/result_bundle.zip"
@@ -546,24 +559,14 @@ defmodule TuistWeb.API.TestsController do
             ci_provider: test_run.ci_provider,
             build_run_id: test_run.build_run_id,
             shard_plan_id: test_run.shard_plan_id,
-            shard_index: Map.get(body_params, :shard_index)
+            shard_index: Map.get(body_params, :shard_index),
+            vcs_comment_params: vcs_comment_params
           }
           |> Tuist.Tests.Workers.ProcessXcresultWorker.new()
           |> Oban.insert()
           |> then(fn {:ok, _job} -> :ok end)
         else
-          Tuist.VCS.enqueue_vcs_pull_request_comment(%{
-            git_commit_sha: Map.get(body_params, :git_commit_sha),
-            git_ref: Map.get(body_params, :git_ref),
-            git_remote_url_origin: Map.get(body_params, :git_remote_url_origin),
-            project_id: selected_project.id,
-            preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-            preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-            command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-            test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-            bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-            build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
-          })
+          Tuist.VCS.enqueue_vcs_pull_request_comment(vcs_comment_params)
         end
 
         conn

--- a/server/lib/tuist_web/controllers/api/tests_controller.ex
+++ b/server/lib/tuist_web/controllers/api/tests_controller.ex
@@ -525,13 +525,7 @@ defmodule TuistWeb.API.TestsController do
           git_commit_sha: Map.get(body_params, :git_commit_sha),
           git_ref: Map.get(body_params, :git_ref),
           git_remote_url_origin: Map.get(body_params, :git_remote_url_origin),
-          project_id: selected_project.id,
-          preview_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id",
-          preview_qr_code_url_template: "#{url(~p"/")}:account_name/:project_name/previews/:preview_id/qr-code.png",
-          command_run_url_template: "#{url(~p"/")}:account_name/:project_name/runs/:command_event_id",
-          test_run_url_template: "#{url(~p"/")}:account_name/:project_name/tests/test-runs/:test_run_id",
-          bundle_url_template: "#{url(~p"/")}:account_name/:project_name/bundles/:bundle_id",
-          build_url_template: "#{url(~p"/")}:account_name/:project_name/builds/build-runs/:build_id"
+          project_id: selected_project.id
         }
 
         if test_run.status == "processing" do

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -392,8 +392,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/1/merge",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "build_url_template" => "http://localhost/builds/:build_id"
+        "project_id" => project.id
       }
 
       expect(Tuist.VCS, :enqueue_vcs_pull_request_comment, fn params ->

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -553,4 +553,92 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       assert {:error, _} = ProcessXcresultWorker.perform(oban_job(args, 3, 3))
     end
   end
+
+  describe "perform/1 VCS comment refresh" do
+    setup do
+      stub(Tuist.Environment, :xcode_processor_url, fn -> "http://localhost:4003" end)
+      stub(Tuist.Environment, :xcode_processor_webhook_secret, fn -> "test-secret" end)
+      :ok
+    end
+
+    test "enqueues VCS comment after successful processing when vcs_comment_params present", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      expect(Req, :post, fn _url, _opts ->
+        {:ok, %{status: 200, body: parsed_data()}}
+      end)
+
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+
+      vcs_params = %{
+        "git_commit_sha" => "abc123",
+        "git_ref" => "refs/pull/1/merge",
+        "git_remote_url_origin" => "https://github.com/tuist/tuist",
+        "project_id" => project.id,
+        "test_run_url_template" => "http://localhost/tests/test-runs/:test_run_id"
+      }
+
+      expect(Tuist.VCS, :enqueue_vcs_pull_request_comment, fn params ->
+        assert params["git_commit_sha"] == "abc123"
+        assert params["git_ref"] == "refs/pull/1/merge"
+        assert params["git_remote_url_origin"] == "https://github.com/tuist/tuist"
+        assert params["project_id"] == project.id
+        {:ok, %{}}
+      end)
+
+      args =
+        test_run_id
+        |> job_args(account.id, project.id)
+        |> Map.put("vcs_comment_params", vcs_params)
+
+      assert :ok == ProcessXcresultWorker.perform(oban_job(args))
+    end
+
+    test "does not enqueue VCS comment when vcs_comment_params not present", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      expect(Req, :post, fn _url, _opts ->
+        {:ok, %{status: 200, body: parsed_data()}}
+      end)
+
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+      reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
+
+      assert :ok ==
+               ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id)))
+    end
+
+    test "does not enqueue VCS comment on failed processing", %{
+      account: account,
+      project: project
+    } do
+      test_run_id = Ecto.UUID.generate()
+
+      expect(Req, :post, fn _url, _opts ->
+        {:ok, %{status: 500, body: %{"error" => "internal error"}}}
+      end)
+
+      expect(Tuist.Tests, :create_test, fn _attrs -> {:ok, %{id: test_run_id}} end)
+      reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
+
+      vcs_params = %{
+        "git_commit_sha" => "abc123",
+        "git_ref" => "refs/pull/1/merge",
+        "project_id" => project.id
+      }
+
+      args =
+        test_run_id
+        |> job_args(account.id, project.id)
+        |> Map.put("vcs_comment_params", vcs_params)
+
+      assert {:error, _} = ProcessXcresultWorker.perform(oban_job(args, 3, 3))
+    end
+  end
 end

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -577,8 +577,7 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/1/merge",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "test_run_url_template" => "http://localhost/tests/test-runs/:test_run_id"
+        "project_id" => project.id
       }
 
       expect(Tuist.VCS, :enqueue_vcs_pull_request_comment, fn params ->

--- a/server/test/tuist/vcs/workers/comment_worker_test.exs
+++ b/server/test/tuist/vcs/workers/comment_worker_test.exs
@@ -2,12 +2,14 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
+  alias Tuist.Environment
   alias Tuist.VCS
   alias Tuist.VCS.Workers.CommentWorker
   alias TuistTestSupport.Fixtures.AppBuildsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   setup do
+    stub(Environment, :app_url, fn -> "" end)
     project = ProjectsFixtures.project_fixture()
     %{project: project}
   end
@@ -35,13 +37,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/123/head",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "preview_url_template" => "/:account_name/:project_name/previews/:preview_id",
-        "preview_qr_code_url_template" => "/:account_name/:project_name/previews/:preview_id/qr-code.png",
-        "command_run_url_template" => "/:account_name/:project_name/runs/:command_event_id",
-        "test_run_url_template" => "/:account_name/:project_name/tests/test-runs/:test_run_id",
-        "bundle_url_template" => "/:account_name/:project_name/bundles/:bundle_id",
-        "build_url_template" => "/:account_name/:project_name/builds/build-runs/:build_id"
+        "project_id" => project.id
       }
 
       # When
@@ -51,10 +47,11 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
       assert result == :ok
     end
 
-    test "URL template functions work correctly", %{project: project} do
+    test "URL template functions prefix the configured app_url and substitute placeholders", %{project: project} do
       # Given
+      stub(Environment, :app_url, fn -> "https://tuist.example" end)
+
       expect(VCS, :post_vcs_pull_request_comment, fn args ->
-        # Test the URL functions with mock data
         mock_data = %{
           project: %{account: %{name: "test-account"}, name: "test-project"},
           preview: %{id: 456},
@@ -64,23 +61,23 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
           build: %{id: 202}
         }
 
-        preview_url = args.preview_url.(mock_data)
-        assert preview_url == "/test-account/test-project/previews/456"
+        assert args.preview_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/previews/456"
 
-        qr_code_url = args.preview_qr_code_url.(mock_data)
-        assert qr_code_url == "/test-account/test-project/previews/456/qr-code.png"
+        assert args.preview_qr_code_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/previews/456/qr-code.png"
 
-        command_url = args.command_run_url.(mock_data)
-        assert command_url == "/test-account/test-project/runs/789"
+        assert args.command_run_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/runs/789"
 
-        test_run_url = args.test_run_url.(mock_data)
-        assert test_run_url == "/test-account/test-project/tests/test-runs/303"
+        assert args.test_run_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/tests/test-runs/303"
 
-        bundle_url = args.bundle_url.(mock_data)
-        assert bundle_url == "/test-account/test-project/bundles/101"
+        assert args.bundle_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/bundles/101"
 
-        build_url = args.build_url.(mock_data)
-        assert build_url == "/test-account/test-project/builds/build-runs/202"
+        assert args.build_url.(mock_data) ==
+                 "https://tuist.example/test-account/test-project/builds/build-runs/202"
 
         :ok
       end)
@@ -89,13 +86,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/123/head",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "preview_url_template" => "/:account_name/:project_name/previews/:preview_id",
-        "preview_qr_code_url_template" => "/:account_name/:project_name/previews/:preview_id/qr-code.png",
-        "command_run_url_template" => "/:account_name/:project_name/runs/:command_event_id",
-        "test_run_url_template" => "/:account_name/:project_name/tests/test-runs/:test_run_id",
-        "bundle_url_template" => "/:account_name/:project_name/bundles/:bundle_id",
-        "build_url_template" => "/:account_name/:project_name/builds/build-runs/:build_id"
+        "project_id" => project.id
       }
 
       # When
@@ -128,13 +119,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/123/head",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "preview_url_template" => "/:account_name/:project_name/previews/:preview_id",
-        "preview_qr_code_url_template" => "/:account_name/:project_name/previews/:preview_id/qr-code.png",
-        "command_run_url_template" => "/:account_name/:project_name/runs/:command_event_id",
-        "test_run_url_template" => "/:account_name/:project_name/tests/test-runs/:test_run_id",
-        "bundle_url_template" => "/:account_name/:project_name/bundles/:bundle_id",
-        "build_url_template" => "/:account_name/:project_name/builds/build-runs/:build_id"
+        "project_id" => project.id
       }
 
       # When / Then - This should work without raising an error
@@ -152,13 +137,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/123/head",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "preview_url_template" => "/:account_name/:project_name/previews/:preview_id",
-        "preview_qr_code_url_template" => "/:account_name/:project_name/previews/:preview_id/qr-code.png",
-        "command_run_url_template" => "/:account_name/:project_name/runs/:command_event_id",
-        "test_run_url_template" => "/:account_name/:project_name/tests/test-runs/:test_run_id",
-        "bundle_url_template" => "/:account_name/:project_name/bundles/:bundle_id",
-        "build_url_template" => "/:account_name/:project_name/builds/build-runs/:build_id"
+        "project_id" => project.id
       }
 
       # Insert a competing job and set it to "executing" state
@@ -183,13 +162,7 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
         "git_commit_sha" => "abc123",
         "git_ref" => "refs/pull/123/head",
         "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id,
-        "preview_url_template" => "/:account_name/:project_name/previews/:preview_id",
-        "preview_qr_code_url_template" => "/:account_name/:project_name/previews/:preview_id/qr-code.png",
-        "command_run_url_template" => "/:account_name/:project_name/runs/:command_event_id",
-        "test_run_url_template" => "/:account_name/:project_name/tests/test-runs/:test_run_id",
-        "bundle_url_template" => "/:account_name/:project_name/bundles/:bundle_id",
-        "build_url_template" => "/:account_name/:project_name/builds/build-runs/:build_id"
+        "project_id" => project.id
       }
 
       # When

--- a/server/test/tuist/vcs/workers/comment_worker_test.exs
+++ b/server/test/tuist/vcs/workers/comment_worker_test.exs
@@ -2,14 +2,16 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
-  alias Tuist.Environment
+  use Phoenix.VerifiedRoutes,
+    endpoint: TuistWeb.Endpoint,
+    router: TuistWeb.Router
+
   alias Tuist.VCS
   alias Tuist.VCS.Workers.CommentWorker
   alias TuistTestSupport.Fixtures.AppBuildsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
 
   setup do
-    stub(Environment, :app_url, fn -> "" end)
     project = ProjectsFixtures.project_fixture()
     %{project: project}
   end
@@ -47,37 +49,32 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
       assert result == :ok
     end
 
-    test "URL template functions prefix the configured app_url and substitute placeholders", %{project: project} do
-      # Given
-      stub(Environment, :app_url, fn -> "https://tuist.example" end)
+    test "URL functions resolve to verified routes for each domain object", %{project: project} do
+      # Given - real domain object IDs
+      preview = AppBuildsFixtures.preview_fixture(project: project)
+      command_event_id = "command-event-1"
+      test_run_id = "test-run-1"
+      bundle_id = "bundle-1"
+      build_id = "build-1"
 
       expect(VCS, :post_vcs_pull_request_comment, fn args ->
-        mock_data = %{
-          project: %{account: %{name: "test-account"}, name: "test-project"},
-          preview: %{id: 456},
-          command_event: %{id: 789},
-          test_run: %{id: 303},
-          bundle: %{id: 101},
-          build: %{id: 202}
-        }
+        assert args.preview_url.(%{project: project, preview: preview}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/previews/#{preview.id}")
 
-        assert args.preview_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/previews/456"
+        assert args.preview_qr_code_url.(%{project: project, preview: preview}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/previews/#{preview.id}/qr-code.png")
 
-        assert args.preview_qr_code_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/previews/456/qr-code.png"
+        assert args.command_run_url.(%{project: project, command_event: %{id: command_event_id}}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/runs/#{command_event_id}")
 
-        assert args.command_run_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/runs/789"
+        assert args.test_run_url.(%{project: project, test_run: %{id: test_run_id}}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/tests/test-runs/#{test_run_id}")
 
-        assert args.test_run_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/tests/test-runs/303"
+        assert args.bundle_url.(%{project: project, bundle: %{id: bundle_id}}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/bundles/#{bundle_id}")
 
-        assert args.bundle_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/bundles/101"
-
-        assert args.build_url.(mock_data) ==
-                 "https://tuist.example/test-account/test-project/builds/build-runs/202"
+        assert args.build_url.(%{project: project, build: %{id: build_id}}) ==
+                 url(~p"/#{project.account.name}/#{project.name}/builds/build-runs/#{build_id}")
 
         :ok
       end)
@@ -93,37 +90,6 @@ defmodule Tuist.VCS.Workers.CommentWorkerTest do
       result = CommentWorker.perform(%Oban.Job{id: 1, args: job_args})
 
       # Then
-      assert result == :ok
-    end
-
-    test "handles missing keys gracefully when URL functions are called with partial data", %{
-      project: project
-    } do
-      # Given - Create a preview to test URL generation with missing keys
-      preview = AppBuildsFixtures.preview_fixture(project: project)
-
-      # Mock VCS.post_vcs_pull_request_comment to test URL functions with different data types
-      expect(VCS, :post_vcs_pull_request_comment, fn args ->
-        # Test preview URL with only project and preview data (no command_event, bundle, build)
-        preview_url = args.preview_url.(%{project: project, preview: preview})
-        assert preview_url =~ "/#{project.account.name}/#{project.name}/previews/#{preview.id}"
-
-        # Test command_run_url template with missing command_event - should remove placeholder
-        command_url = args.command_run_url.(%{project: project, preview: preview})
-        assert command_url == "/#{project.account.name}/#{project.name}/runs/"
-
-        :ok
-      end)
-
-      job_args = %{
-        "git_commit_sha" => "abc123",
-        "git_ref" => "refs/pull/123/head",
-        "git_remote_url_origin" => "https://github.com/tuist/tuist",
-        "project_id" => project.id
-      }
-
-      # When / Then - This should work without raising an error
-      result = CommentWorker.perform(%Oban.Job{id: 1, args: job_args})
       assert result == :ok
     end
 

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -2807,12 +2807,7 @@ defmodule Tuist.VCSTest do
         git_commit_sha: "abc123",
         git_ref: "refs/pull/123/head",
         git_remote_url_origin: "https://github.com/tuist/tuist",
-        project_id: project.id,
-        preview_url_template: "/{{account_name}}/{{project_name}}/previews/{{preview_id}}",
-        preview_qr_code_url_template: "/{{account_name}}/{{project_name}}/previews/{{preview_id}}/qr-code.png",
-        command_run_url_template: "/{{account_name}}/{{project_name}}/runs/{{command_event_id}}",
-        bundle_url_template: "/{{account_name}}/{{project_name}}/bundles/{{bundle_id}}",
-        build_url_template: "/{{account_name}}/{{project_name}}/builds/build-runs/{{build_id}}"
+        project_id: project.id
       }
 
       # When / Then
@@ -2844,13 +2839,7 @@ defmodule Tuist.VCSTest do
         git_commit_sha: "abc123",
         git_ref: "refs/pull/123/head",
         git_remote_url_origin: "https://github.com/tuist/tuist",
-        project_id: project.id,
-        preview_url_template: "url",
-        preview_qr_code_url_template: "url",
-        command_run_url_template: "url",
-        test_run_url_template: "url",
-        bundle_url_template: "url",
-        build_url_template: "url"
+        project_id: project.id
       }
 
       # When

--- a/server/test/tuist_web/controllers/api/tests_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/tests_controller_test.exs
@@ -599,6 +599,74 @@ defmodule TuistWeb.API.TestsControllerTest do
       assert args.git_remote_url_origin == "https://github.com/tuist/tuist.git"
       assert args.project_id == project.id
     end
+
+    test "embeds vcs_comment_params in ProcessXcresultWorker args when status is processing", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      expect(Tests, :get_test, fn _id, _opts -> {:error, :not_found} end)
+
+      expect(Tests, :create_test, fn attrs ->
+        {:ok,
+         %Test{
+           id: attrs.id,
+           duration: attrs.duration,
+           project_id: project.id,
+           account_id: attrs.account_id,
+           is_ci: true,
+           git_branch: attrs.git_branch,
+           git_commit_sha: attrs.git_commit_sha,
+           git_ref: attrs.git_ref,
+           macos_version: attrs.macos_version,
+           xcode_version: attrs.xcode_version,
+           model_identifier: attrs.model_identifier,
+           scheme: attrs.scheme,
+           ci_run_id: attrs.ci_run_id,
+           ci_project_handle: attrs.ci_project_handle,
+           ci_host: attrs.ci_host,
+           ci_provider: attrs.ci_provider,
+           build_run_id: attrs.build_run_id,
+           shard_plan_id: attrs.shard_plan_id,
+           build_system: "xcode",
+           status: "processing",
+           test_case_runs: []
+         }}
+      end)
+
+      reject(&Tuist.VCS.enqueue_vcs_pull_request_comment/1)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        "/api/projects/#{user.account.name}/#{project.name}/tests",
+        %{
+          duration: 0,
+          macos_version: "15.0",
+          xcode_version: "16.0",
+          is_ci: true,
+          status: "processing",
+          scheme: "TuistAcceptanceTests",
+          git_commit_sha: "abc123",
+          git_ref: "refs/pull/42/merge",
+          git_remote_url_origin: "https://github.com/tuist/tuist.git",
+          shard_index: 1,
+          test_modules: []
+        }
+      )
+
+      assert_enqueued(
+        worker: Tuist.Tests.Workers.ProcessXcresultWorker,
+        args: %{
+          "vcs_comment_params" => %{
+            "git_commit_sha" => "abc123",
+            "git_ref" => "refs/pull/42/merge",
+            "git_remote_url_origin" => "https://github.com/tuist/tuist.git",
+            "project_id" => project.id
+          }
+        }
+      )
+    end
   end
 
   describe "GET /api/projects/:account_handle/:project_handle/tests/:test_run_id" do


### PR DESCRIPTION
> Describe here the purpose of your PR.

When the CLI uploads a test run with `status: "processing"` (the default for `tuist.dev`, used for sharded acceptance-test xcresults), the server stores the run in a pending state and enqueues `ProcessXcresultWorker` to parse the bundle asynchronously. That branch never enqueued a VCS PR-comment refresh, and the worker itself didn't trigger one after writing the test record to ClickHouse — so sharded test runs would only land in the Tuist Run Report comment if some unrelated upload happened to refresh the comment *after* xcresult parsing had already completed (a race that almost never wins on short workflows).

Concrete symptom: on PR #10478, both `Acceptance Tests (0)` and `Acceptance Tests (1)` succeeded but the [Tuist Run Report comment](https://github.com/tuist/tuist/pull/10478#issuecomment-4327189926) only shows `TuistUnitTests`. The comment was last updated 2s after the final shard finished — far less than the time needed for upload + ClickHouse flush + xcresult processing.

This PR mirrors the `ProcessBuildWorker` flow:

- **`tests_controller.create`**: hoist `vcs_comment_params` and embed it in the `ProcessXcresultWorker` job args (and reuse it for the non-`processing` branch to keep the call site DRY).
- **`ProcessXcresultWorker`**: after `replace_test_run/2` succeeds, call `Tuist.VCS.enqueue_vcs_pull_request_comment/1` when `vcs_comment_params` is present in args.

While here, two follow-on cleanups land in separate commits:

- **Slim caller args**: the 5 `enqueue_vcs_pull_request_comment` callers (analytics/builds/gradle/runs/tests controllers) all passed identical `*_url_template` strings — six per call. Move template construction into `CommentWorker` itself; callers now pass only the dynamic context (`git_commit_sha`, `git_ref`, `git_remote_url_origin`, `project_id`).
- **Compile-time route validation**: `CommentWorker` now uses Phoenix's `~p` sigil (`use Phoenix.VerifiedRoutes, endpoint: TuistWeb.Endpoint, router: TuistWeb.Router`) so each URL path is verified against the router at compile time. Verified by temporarily mistyping a path — build failed with `no route path for TuistWeb.Router matches ~p"..."`.

### Note on `TuistWeb` reference from `Tuist.VCS.Workers.CommentWorker`

The worker now references `TuistWeb.Endpoint`/`TuistWeb.Router`, which technically crosses the `Tuist` → `TuistWeb` boundary. This is allowed (`TuistWeb` declares `exports: [Endpoint, Router]` precisely so other boundaries can reach them, and `Tuist.Slack` already does the same for `Phoenix.Token.sign`). The worker exists to render PR-comment links into the web UI, so it sits at the seam by nature; the alternative (string templates) doesn't actually decouple anything, it just turns "compile-verified route" into "stale string in a module attribute." Mild antipattern accepted in exchange for compile-time safety.

Built TDD-style with new failing tests added before the implementation:

- `process_xcresult_worker_test.exs` — asserts comment is enqueued on success, skipped when params absent, skipped on failed processing.
- `tests_controller_test.exs` — asserts `vcs_comment_params` is embedded in the `ProcessXcresultWorker` job args when status is `processing`.

### How to test locally

1. Run the new tests:
   \`\`\`sh
   cd server
   mix test test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist_web/controllers/api/tests_controller_test.exs test/tuist/vcs/workers/comment_worker_test.exs
   \`\`\`
2. (Optional) Trigger an end-to-end run by pushing a CLI commit that runs sharded `TuistAcceptanceTests` against tuist.dev and confirm the PR comment lists the acceptance-test scheme after the xcresults finish processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)