### PR TITLE
fix(server,processor,xcode_processor): trim webhook secrets, log mismatch fingerprint

### DIFF
--- a/processor/lib/processor_web/plugs/webhook_auth_plug.ex
+++ b/processor/lib/processor_web/plugs/webhook_auth_plug.ex
@@ -3,10 +3,16 @@ defmodule ProcessorWeb.Plugs.WebhookAuthPlug do
 
   import Plug.Conn
 
+  require Logger
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    secret = Application.get_env(:processor, :webhook_secret)
+    secret =
+      case Application.get_env(:processor, :webhook_secret) do
+        nil -> nil
+        value when is_binary(value) -> String.trim(value)
+      end
 
     if is_nil(secret) or secret == "" do
       conn
@@ -37,11 +43,20 @@ defmodule ProcessorWeb.Plugs.WebhookAuthPlug do
       if Plug.Crypto.secure_compare(signature, expected) do
         conn
       else
+        Logger.warning(fn ->
+          "Webhook signature mismatch: body_size=#{byte_size(raw_body)} " <>
+            "secret_fingerprint=#{secret_fingerprint(secret)}"
+        end)
+
         conn
         |> json_error(403, "Invalid signature")
         |> halt()
       end
     end
+  end
+
+  defp secret_fingerprint(secret) do
+    :crypto.hash(:sha256, secret) |> Base.encode16(case: :lower) |> binary_part(0, 8)
   end
 
   defp json_error(conn, status, message) do

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -107,7 +107,20 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
           {:ok, parsed_data}
 
         {:ok, %{status: status, body: body}} ->
-          Logger.error("Processor returned #{status} for build #{build_id}: #{inspect(body)}")
+          extra =
+            if status == 403 do
+              fingerprint =
+                :sha256
+                |> :crypto.hash(webhook_secret)
+                |> Base.encode16(case: :lower)
+                |> binary_part(0, 8)
+
+              " body_size=#{byte_size(json_body)} secret_fingerprint=#{fingerprint}"
+            else
+              ""
+            end
+
+          Logger.error("Processor returned #{status} for build #{build_id}: #{inspect(body)}#{extra}")
           {:error, "processor_error_#{status}: #{inspect(body)}"}
 
         {:error, reason} ->

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -572,7 +572,7 @@ defmodule Tuist.Environment do
   end
 
   def processor_webhook_secret(secrets \\ secrets()) do
-    get([:processor, :webhook_secret], secrets)
+    [:processor, :webhook_secret] |> get(secrets) |> trim_secret()
   end
 
   def xcode_processor_url(secrets \\ secrets()) do
@@ -580,8 +580,16 @@ defmodule Tuist.Environment do
   end
 
   def xcode_processor_webhook_secret(secrets \\ secrets()) do
-    get([:xcode_processor, :webhook_secret], secrets)
+    [:xcode_processor, :webhook_secret] |> get(secrets) |> trim_secret()
   end
+
+  # Webhook secrets shared with the (xcode_)processor services arrive via
+  # encrypted YAML or env vars; copy/paste from a password manager often
+  # carries a stray newline. HMAC compares byte-for-byte, so a single
+  # rogue \n flips every request to 403. Same trim is applied on the
+  # processor side so both ends agree.
+  defp trim_secret(nil), do: nil
+  defp trim_secret(value) when is_binary(value), do: String.trim(value)
 
   def clickhouse_flush_interval_ms(secrets \\ secrets()) do
     case get([:clickhouse, :flush_interval_ms], secrets) do

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -100,7 +100,20 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
           {:ok, parsed_data}
 
         {:ok, %{status: status, body: body}} ->
-          Logger.error("Xcode processor returned #{status} for test run #{test_run_id}: #{inspect(body)}")
+          extra =
+            if status == 403 do
+              fingerprint =
+                :sha256
+                |> :crypto.hash(webhook_secret)
+                |> Base.encode16(case: :lower)
+                |> binary_part(0, 8)
+
+              " body_size=#{byte_size(json_body)} secret_fingerprint=#{fingerprint}"
+            else
+              ""
+            end
+
+          Logger.error("Xcode processor returned #{status} for test run #{test_run_id}: #{inspect(body)}#{extra}")
 
           {:error, "xcode_processor_error_#{status}: #{inspect(body)}"}
 

--- a/xcode_processor/lib/xcode_processor/environment.ex
+++ b/xcode_processor/lib/xcode_processor/environment.ex
@@ -2,7 +2,10 @@ defmodule XcodeProcessor.Environment do
   @moduledoc false
 
   def webhook_secret do
-    Application.get_env(:xcode_processor, :webhook_secret)
+    case Application.get_env(:xcode_processor, :webhook_secret) do
+      nil -> nil
+      value when is_binary(value) -> String.trim(value)
+    end
   end
 
   def s3_bucket do

--- a/xcode_processor/lib/xcode_processor_web/plugs/webhook_auth_plug.ex
+++ b/xcode_processor/lib/xcode_processor_web/plugs/webhook_auth_plug.ex
@@ -3,6 +3,8 @@ defmodule XcodeProcessorWeb.Plugs.WebhookAuthPlug do
 
   import Plug.Conn
 
+  require Logger
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
@@ -37,11 +39,22 @@ defmodule XcodeProcessorWeb.Plugs.WebhookAuthPlug do
       if Plug.Crypto.secure_compare(signature, expected) do
         conn
       else
+        # Body lengths and a hash of the secret help diagnose drift between
+        # the server and xcode_processor secret stores without leaking either.
+        Logger.warning(fn ->
+          "Webhook signature mismatch: body_size=#{byte_size(raw_body)} " <>
+            "secret_fingerprint=#{secret_fingerprint(secret)}"
+        end)
+
         conn
         |> json_error(403, "Invalid signature")
         |> halt()
       end
     end
+  end
+
+  defp secret_fingerprint(secret) do
+    :crypto.hash(:sha256, secret) |> Base.encode16(case: :lower) |> binary_part(0, 8)
   end
 
   defp json_error(conn, status, message) do


### PR DESCRIPTION
Resolves the canary-only [Sentry issue TUIST-AZ](https://tuist.sentry.io/issues/111483041/) — `Tuist.Tests.Workers.ProcessXcresultWorker failed with {:error, "xcode_processor_error_403: %{\"error\" => \"Invalid signature\"}"}` (375 occurrences over ~15 days, environment `can` only).

## What's failing

The canary `tuist` server posts xcresult-processing webhooks to the canary `xcode_processor`. Auth is HMAC-SHA256 over the JSON body with a shared secret stored separately on each side:

- Server: `xcode_processor.webhook_secret` in `server/priv/secrets/can.yml.enc`
- xcode_processor: `webhook_secret` in `xcode_processor/platform/secrets/canary.yaml`, surfaced as `WEBHOOK_SECRET` env var

HMAC compares byte-for-byte, so a single stray whitespace character (most often a newline pasted from 1Password — same failure mode `infra/helm/tuist/templates/external-secrets.yaml` already explicitly guards `MASTER_KEY` against) flips every request to 403. The webhook secret had no such trim.

## Changes

**Defensive trim on both ends:**
- `server/lib/tuist/environment.ex` — `processor_webhook_secret/1` and `xcode_processor_webhook_secret/1` now pipe through a `trim_secret/1` helper.
- `xcode_processor/lib/xcode_processor/environment.ex` — trim the value loaded from `WEBHOOK_SECRET`.
- `processor/lib/processor_web/plugs/webhook_auth_plug.ex` — same trim, applied at the plug since this side reads `Application.get_env` directly.

**Diagnostic logging on signature mismatch (sender + receiver):**
- `xcode_processor` and `processor` webhook plugs log `Webhook signature mismatch: body_size=… secret_fingerprint=…` on 403, where `secret_fingerprint` is the first 8 hex chars of SHA-256 of the secret (no leakage).
- `process_xcresult_worker` and `process_build_worker` emit the same `body_size` + `secret_fingerprint` when the response is 403.

If the trim doesn't resolve the canary 403s, the new logs surface two different `secret_fingerprint=` values across services, which is the unambiguous signal that the two secret stores need to be re-aligned.

## How to test locally

1. `cd server && MIX_ENV=test mix test test/tuist/tests/workers/process_xcresult_worker_test.exs test/tuist/builds/workers/process_build_worker_test.exs test/tuist/environment_test.exs`
2. `cd xcode_processor && MIX_ENV=test mix test`
3. `cd processor && MIX_ENV=test mix test`

All four suites pass: 20 + 31 + 19 + 11 tests, 0 failures. The diagnostic log is visible in the xcode_processor and processor outputs (`Webhook signature mismatch: body_size=16 secret_fingerprint=d4d0f3c5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)