### PR TITLE
feat(server): add ephemeral preview environments on dedicated kubernetes cluster

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,295 @@
+name: Preview Deploy
+
+# Deploy an ephemeral preview environment for a PR or a specific commit.
+#
+# Usage:
+#   - Run from the GitHub UI (Actions → Preview Deploy → Run workflow).
+#   - Provide EITHER pr_number OR commit_sha. ttl_hours sets when the sweep
+#     workflow auto-deletes the namespace.
+#
+# Convention:
+#   pr_number=1234   → release pr-1234,    namespace preview-pr-1234,
+#                      host pr-1234.preview.tuist.dev
+#   commit_sha=abc…  → release sha-abc1234, namespace preview-sha-abc1234,
+#                      host sha-abc1234.preview.tuist.dev (7-char short SHA)
+#
+# Required GitHub Environment secrets (environment: server-k8s-preview):
+#   KUBECONFIG       - base64 kubeconfig for the preview WORKLOAD cluster's
+#                      CI ServiceAccount (cluster-admin in preview-system).
+#   KUBECONFIG_MGMT  - base64 kubeconfig for the SYSELF MANAGEMENT cluster's
+#                      `preview-scaler` SA (narrow Role: get/patch on
+#                      Cluster/tuist-preview, read on MachineDeployments).
+#
+# Both are minted at cluster bootstrap; see infra/k8s/syself-onboarding.md §10.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to deploy (omit if using commit_sha)
+        required: false
+      commit_sha:
+        description: Commit SHA to deploy (omit if using pr_number)
+        required: false
+      ttl_hours:
+        description: Auto-delete after N hours (max 168 = 7 days)
+        required: true
+        default: "24"
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tuist/tuist
+  HELM_CHART_PATH: infra/helm/tuist
+  PREVIEW_BASE_DOMAIN: preview.tuist.dev
+
+jobs:
+  resolve:
+    name: Resolve inputs
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.r.outputs.release }}
+      namespace: ${{ steps.r.outputs.namespace }}
+      host: ${{ steps.r.outputs.host }}
+      ref: ${{ steps.r.outputs.ref }}
+      short_sha: ${{ steps.r.outputs.short_sha }}
+      expires_at: ${{ steps.r.outputs.expires_at }}
+    steps:
+      - id: r
+        env:
+          PR: ${{ inputs.pr_number }}
+          SHA: ${{ inputs.commit_sha }}
+          TTL_HOURS: ${{ inputs.ttl_hours }}
+        run: |
+          set -euo pipefail
+          if [ -n "$PR" ] && [ -n "$SHA" ]; then
+            echo "::error::Provide pr_number OR commit_sha, not both."
+            exit 1
+          fi
+          if [ -z "$PR" ] && [ -z "$SHA" ]; then
+            echo "::error::Provide either pr_number or commit_sha."
+            exit 1
+          fi
+
+          # Clamp TTL to [1, 168].
+          if ! [[ "$TTL_HOURS" =~ ^[0-9]+$ ]] || [ "$TTL_HOURS" -lt 1 ] || [ "$TTL_HOURS" -gt 168 ]; then
+            echo "::error::ttl_hours must be an integer between 1 and 168."
+            exit 1
+          fi
+          EXPIRES_AT=$(( $(date +%s) + TTL_HOURS * 3600 ))
+
+          if [ -n "$PR" ]; then
+            REF=$(gh pr view "$PR" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+            RELEASE="pr-${PR}"
+          else
+            REF="$SHA"
+            RELEASE="sha-${SHA:0:7}"
+          fi
+
+          SHORT_SHA="${REF:0:12}"
+          NAMESPACE="preview-${RELEASE}"
+          HOST="${RELEASE}.${PREVIEW_BASE_DOMAIN}"
+
+          echo "release=$RELEASE"     >> "$GITHUB_OUTPUT"
+          echo "namespace=$NAMESPACE" >> "$GITHUB_OUTPUT"
+          echo "host=$HOST"           >> "$GITHUB_OUTPUT"
+          echo "ref=$REF"             >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "expires_at=$EXPIRES_AT" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Preview deploy"
+            echo "- Release: \`$RELEASE\`"
+            echo "- Namespace: \`$NAMESPACE\`"
+            echo "- Host: https://$HOST"
+            echo "- Image tag: \`sha-$SHORT_SHA\`"
+            echo "- Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  build:
+    name: Build + push
+    needs: resolve
+    runs-on: namespace-profile-default-with-volume
+    timeout-minutes: 40
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          submodules: false
+      - id: tag
+        run: echo "image_tag=sha-${{ needs.resolve.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
+      - uses: namespacelabs/nscloud-setup-buildx-action@v0
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./server/Dockerfile
+          target: runner
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+          build-args: |
+            TUIST_HOSTED=1
+            MIX_ENV=prod
+            APT_CACHE_BUST=${{ needs.resolve.outputs.ref }}
+          # Share the same cache scope as the managed-env builds — same image,
+          # same Dockerfile, layers are interchangeable.
+          cache-from: type=gha,scope=server-cluster
+          cache-to: type=gha,mode=max,scope=server-cluster
+
+  deploy:
+    name: Deploy ${{ needs.resolve.outputs.release }}
+    needs: [resolve, build]
+    runs-on: namespace-profile-default
+    environment:
+      name: server-k8s-preview
+      url: https://${{ needs.resolve.outputs.host }}
+    # Serialize per-release so two runs against the same PR don't race.
+    concurrency:
+      group: preview-deploy-${{ needs.resolve.outputs.release }}
+      cancel-in-progress: false
+    timeout-minutes: 30
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      KUBECONFIG_MGMT: ${{ github.workspace }}/.kube/mgmt
+      RELEASE: ${{ needs.resolve.outputs.release }}
+      NAMESPACE: ${{ needs.resolve.outputs.namespace }}
+      HOST: ${{ needs.resolve.outputs.host }}
+      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+      EXPIRES_AT: ${{ needs.resolve.outputs.expires_at }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load kubeconfigs
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+          echo "${{ secrets.KUBECONFIG_MGMT }}" | base64 -d > "$KUBECONFIG_MGMT"
+          chmod 600 "$KUBECONFIG_MGMT"
+
+      - name: Scale preview worker pool up
+        # Patches the management Cluster CR to ensure md-0 has at least 1
+        # replica. Idempotent: a no-op when a worker is already up.
+        run: |
+          set -euo pipefail
+          ORG_NS=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
+          CURRENT=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" get cluster tuist-preview \
+            -o jsonpath='{.spec.topology.workers.machineDeployments[?(@.name=="md-0")].replicas}')
+          echo "md-0 replicas currently: $CURRENT"
+          if [ "${CURRENT:-0}" -lt 1 ]; then
+            echo "==> Scaling md-0 to 1..."
+            KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" patch cluster tuist-preview \
+              --type=json \
+              -p='[{"op":"replace","path":"/spec/topology/workers/machineDeployments/0/replicas","value":1}]'
+          fi
+
+      - name: Wait for worker node Ready
+        # Cold-boot a Hetzner cpx31 + kubelet/CNI takes ~3–5 min. Tolerate
+        # the upper bound; the helm install that follows already has its
+        # own --wait so we don't need a tight bound here.
+        run: |
+          echo "Waiting for at least one worker node to be Ready..."
+          for i in $(seq 1 60); do
+            COUNT=$(kubectl get nodes -l '!node-role.kubernetes.io/control-plane' \
+              -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+              | grep -c "^True$" || true)
+            if [ "$COUNT" -ge 1 ]; then
+              echo "Worker(s) Ready: $COUNT"
+              kubectl get nodes
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::No worker became Ready within 10 minutes."
+          kubectl get nodes -o wide
+          exit 1
+
+      - name: Re-apply role=preview label/taint on workers
+        # CAPI/Syself doesn't surface node labels via topology variables, so
+        # workers come up un-labeled. Re-applying every deploy makes the
+        # workflow idempotent and survives MachineDeployment scale events
+        # that bring up fresh nodes.
+        run: |
+          kubectl label nodes -l '!node-role.kubernetes.io/control-plane' role=preview --overwrite
+          kubectl taint nodes -l '!node-role.kubernetes.io/control-plane' role=preview:NoSchedule --overwrite
+
+      - name: helm upgrade --install
+        run: |
+          helm upgrade --install "$RELEASE" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" --create-namespace \
+            -f "$HELM_CHART_PATH/values-preview.yaml" \
+            --set server.image.tag="$IMAGE_TAG" \
+            --set server.ingress.enabled=true \
+            --set server.ingress.host="$HOST" \
+            --set "server.appUrl=https://$HOST" \
+            --atomic --timeout 15m --wait
+
+      - name: Annotate namespace with TTL
+        # The sweep workflow reads this label to decide what to delete.
+        # Set after helm install so a failed deploy doesn't leave a "valid"
+        # expiry on a broken namespace the sweeper might still wait on.
+        run: |
+          kubectl label namespace "$NAMESPACE" \
+            "tuist.dev/expires-at=$EXPIRES_AT" \
+            "tuist.dev/preview=true" \
+            --overwrite
+
+      - name: Smoke test
+        run: |
+          kubectl -n "$NAMESPACE" rollout status deploy/${RELEASE}-tuist-server --timeout=10m
+          kubectl -n "$NAMESPACE" run smoke-$RANDOM --rm -i --restart=Never \
+            --image=curlimages/curl --command -- \
+            curl -fsS "http://${RELEASE}-tuist-server/ready"
+
+      - name: Comment on PR
+        if: ${{ inputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          🟢 Preview deployed: **https://$HOST**
+
+          - Release: \`$RELEASE\`
+          - Image: \`$IMAGE_TAG\`
+          - Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')
+
+          Re-run this workflow against the same PR to update; the sweep workflow tears it down at expiry.
+          EOF
+          )"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "::group::pods"
+          kubectl -n "$NAMESPACE" get pods -o wide || true
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp | tail -50 || true
+          echo "::endgroup::"
+          echo "::group::external secret"
+          kubectl -n "$NAMESPACE" describe externalsecret 2>&1 || true
+          echo "::endgroup::"
+          for pod in $(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=server -o name 2>/dev/null); do
+            echo "::group::$pod logs"
+            kubectl -n "$NAMESPACE" logs "$pod" --all-containers --tail=200 || true
+            echo "::endgroup::"
+          done

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -76,6 +76,15 @@ jobs:
             exit 1
           fi
 
+          if [ -n "$PR" ] && ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be a positive integer."
+            exit 1
+          fi
+          if [ -n "$SHA" ] && ! [[ "$SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::commit_sha must be 7–40 lowercase hex chars."
+            exit 1
+          fi
+
           # Clamp TTL to [1, 168].
           if ! [[ "$TTL_HOURS" =~ ^[0-9]+$ ]] || [ "$TTL_HOURS" -lt 1 ] || [ "$TTL_HOURS" -gt 168 ]; then
             echo "::error::ttl_hours must be an integer between 1 and 168."
@@ -149,33 +158,29 @@ jobs:
           cache-from: type=gha,scope=server-cluster
           cache-to: type=gha,mode=max,scope=server-cluster
 
-  deploy:
-    name: Deploy ${{ needs.resolve.outputs.release }}
+  scale-up:
+    # Scaling the management cluster's `tuist-preview` Cluster CR is the only
+    # write the deploy workflow shares with the sweep workflow. Splitting it
+    # into its own job lets us put a workflow-spanning concurrency group
+    # (`preview-cluster-scale`) on just this step — two PRs deploying at the
+    # same time still helm-install in parallel, but only one of them (and
+    # never the sweep) is mid-patch on the Cluster CR.
+    name: Scale preview worker pool up
     needs: [resolve, build]
     runs-on: namespace-profile-default
     environment:
       name: server-k8s-preview
-      url: https://${{ needs.resolve.outputs.host }}
-    # Serialize per-release so two runs against the same PR don't race.
     concurrency:
-      group: preview-deploy-${{ needs.resolve.outputs.release }}
+      group: preview-cluster-scale
       cancel-in-progress: false
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       KUBECONFIG_MGMT: ${{ github.workspace }}/.kube/mgmt
-      RELEASE: ${{ needs.resolve.outputs.release }}
-      NAMESPACE: ${{ needs.resolve.outputs.namespace }}
-      HOST: ${{ needs.resolve.outputs.host }}
-      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
-      EXPIRES_AT: ${{ needs.resolve.outputs.expires_at }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve.outputs.ref }}
       - uses: jdx/mise-action@v3.2.0
         with:
-          install_args: "helm kubectl"
+          install_args: "kubectl"
           cache: "false"
       - name: Load kubeconfigs
         run: |
@@ -184,10 +189,7 @@ jobs:
           chmod 600 "$KUBECONFIG"
           echo "${{ secrets.KUBECONFIG_MGMT }}" | base64 -d > "$KUBECONFIG_MGMT"
           chmod 600 "$KUBECONFIG_MGMT"
-
-      - name: Scale preview worker pool up
-        # Patches the management Cluster CR to ensure md-0 has at least 1
-        # replica. Idempotent: a no-op when a worker is already up.
+      - name: Patch Cluster CR to ensure md-0 has ≥1 replica
         run: |
           set -euo pipefail
           ORG_NS=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
@@ -200,11 +202,10 @@ jobs:
               --type=json \
               -p='[{"op":"replace","path":"/spec/topology/workers/machineDeployments/0/replicas","value":1}]'
           fi
-
       - name: Wait for worker node Ready
-        # Cold-boot a Hetzner cpx31 + kubelet/CNI takes ~3–5 min. Tolerate
-        # the upper bound; the helm install that follows already has its
-        # own --wait so we don't need a tight bound here.
+        # Cold-boot a Hetzner cpx31 + kubelet/CNI takes ~3–5 min. Done in
+        # this job (not the deploy job) so the Cluster CR concurrency lock
+        # is held until the new node is actually usable.
         run: |
           echo "Waiting for at least one worker node to be Ready..."
           for i in $(seq 1 60); do
@@ -221,6 +222,40 @@ jobs:
           echo "::error::No worker became Ready within 10 minutes."
           kubectl get nodes -o wide
           exit 1
+
+  deploy:
+    name: Deploy ${{ needs.resolve.outputs.release }}
+    needs: [resolve, build, scale-up]
+    runs-on: namespace-profile-default
+    environment:
+      name: server-k8s-preview
+      url: https://${{ needs.resolve.outputs.host }}
+    # Per-release lane so two runs against the same PR don't race on the
+    # Helm release. Different PRs deploy in parallel.
+    concurrency:
+      group: preview-deploy-${{ needs.resolve.outputs.release }}
+      cancel-in-progress: false
+    timeout-minutes: 25
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      RELEASE: ${{ needs.resolve.outputs.release }}
+      NAMESPACE: ${{ needs.resolve.outputs.namespace }}
+      HOST: ${{ needs.resolve.outputs.host }}
+      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+      EXPIRES_AT: ${{ needs.resolve.outputs.expires_at }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load kubeconfig
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
 
       - name: Re-apply role=preview label/taint on workers
         # CAPI/Syself doesn't surface node labels via topology variables, so
@@ -253,27 +288,60 @@ jobs:
             --overwrite
 
       - name: Smoke test
+        # `helm install --wait` + the rollout status check below cover server
+        # readiness internally (the pod's own /ready probe must pass for the
+        # rollout to complete). An in-cluster `kubectl run` curl was tempting
+        # but would inherit no tolerations and so couldn't schedule onto the
+        # tainted preview worker. The external curl below also exercises
+        # ingress + wildcard cert + DNS — the user-facing path.
         run: |
           kubectl -n "$NAMESPACE" rollout status deploy/${RELEASE}-tuist-server --timeout=10m
-          kubectl -n "$NAMESPACE" run smoke-$RANDOM --rm -i --restart=Never \
-            --image=curlimages/curl --command -- \
-            curl -fsS "http://${RELEASE}-tuist-server/ready"
+          # Hit /ready through the public host. Retries cover DNS / cert
+          # propagation lag on a brand-new preview cluster.
+          for i in $(seq 1 20); do
+            if curl -fsSL --max-time 5 "https://${HOST}/ready" >/dev/null; then
+              echo "OK — https://${HOST}/ready returned 200"
+              exit 0
+            fi
+            echo "Attempt $i: https://${HOST}/ready not yet reachable; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::https://${HOST}/ready never returned 200 after ~3 min."
+          exit 1
 
       - name: Comment on PR
+        # Edits the existing bot comment if one exists (matched by a hidden
+        # HTML marker keyed on release name) so re-deploys don't spam the
+        # PR with new comments. Falls back to creating a fresh one.
         if: ${{ inputs.pr_number != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          MARKER="<!-- preview-deploy:${RELEASE} -->"
+          BODY=$(cat <<EOF
+          $MARKER
           🟢 Preview deployed: **https://$HOST**
 
           - Release: \`$RELEASE\`
           - Image: \`$IMAGE_TAG\`
+          - Last updated: $(date -u '+%Y-%m-%d %H:%M UTC')
           - Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')
 
-          Re-run this workflow against the same PR to update; the sweep workflow tears it down at expiry.
+          Re-run the workflow against the same PR to update; the sweep workflow tears it down at expiry.
           EOF
-          )"
+          )
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Editing comment $EXISTING"
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING" \
+              -f body="$BODY" >/dev/null
+          else
+            echo "Creating new PR comment"
+            gh pr comment "${{ inputs.pr_number }}" \
+              --repo "${{ github.repository }}" --body "$BODY"
+          fi
 
       - name: Diagnostics on failure
         if: failure()

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,17 +1,29 @@
 name: Preview Deploy
 
-# Deploy an ephemeral preview environment for a PR or a specific commit.
+# Deploy / refresh / tear down an ephemeral preview environment for a PR or a
+# specific commit.
 #
-# Usage:
-#   - Run from the GitHub UI (Actions → Preview Deploy → Run workflow).
-#   - Provide EITHER pr_number OR commit_sha. ttl_hours sets when the sweep
-#     workflow auto-deletes the namespace.
+# Triggers:
+#
+#   pull_request: [labeled, synchronize, unlabeled, closed]
+#     Auto-deploys when the `preview` label is added to a PR; re-deploys on
+#     every push thereafter; tears down when the label is removed or the PR
+#     is closed. Internal PRs only — fork PRs are filtered out at the
+#     `resolve` job because they can't access the deploy secrets.
+#
+#   workflow_dispatch:
+#     Manual run for one-off commits or for re-deploying a closed PR. Provide
+#     EITHER pr_number OR commit_sha plus ttl_hours.
 #
 # Convention:
 #   pr_number=1234   → release pr-1234,    namespace preview-pr-1234,
 #                      host pr-1234.preview.tuist.dev
 #   commit_sha=abc…  → release sha-abc1234, namespace preview-sha-abc1234,
 #                      host sha-abc1234.preview.tuist.dev (7-char short SHA)
+#
+# Each PR-driven preview also gets a per-PR GitHub Deployment so the PR
+# timeline shows a "Preview – PR #1234" card (active during the deploy, set
+# inactive on teardown).
 #
 # Required GitHub Environment secrets (environment: server-k8s-preview):
 #   KUBECONFIG       - base64 kubeconfig for the preview WORKLOAD cluster's
@@ -20,7 +32,7 @@ name: Preview Deploy
 #                      `preview-scaler` SA (narrow Role: get/patch on
 #                      Cluster/tuist-preview, read on MachineDeployments).
 #
-# Both are minted at cluster bootstrap; see infra/k8s/syself-onboarding.md §10.
+# Both are minted at cluster bootstrap; see infra/k8s/syself-onboarding.md §9.
 
 on:
   workflow_dispatch:
@@ -35,12 +47,15 @@ on:
         description: Auto-delete after N hours (max 168 = 7 days)
         required: true
         default: "24"
+  pull_request:
+    types: [labeled, synchronize, unlabeled, closed]
 
 permissions:
   contents: read
   packages: write
   pull-requests: write
   id-token: write
+  deployments: write
 
 env:
   REGISTRY: ghcr.io
@@ -52,79 +67,158 @@ jobs:
   resolve:
     name: Resolve inputs
     runs-on: ubuntu-latest
+    # Skip pull_request events that aren't a preview-label action and aren't
+    # a synchronize/close on an already-labeled PR. Also skip fork PRs:
+    # secrets don't propagate to fork-based runs and a deploy attempt would
+    # fail at the kubeconfig load anyway.
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && (
+          (github.event.action == 'labeled'   && github.event.label.name == 'preview') ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview')) ||
+          (github.event.action == 'closed'      && contains(github.event.pull_request.labels.*.name, 'preview'))
+        )
+      )
     outputs:
+      action: ${{ steps.r.outputs.action }}
       release: ${{ steps.r.outputs.release }}
       namespace: ${{ steps.r.outputs.namespace }}
       host: ${{ steps.r.outputs.host }}
       ref: ${{ steps.r.outputs.ref }}
       short_sha: ${{ steps.r.outputs.short_sha }}
       expires_at: ${{ steps.r.outputs.expires_at }}
+      pr_number: ${{ steps.r.outputs.pr_number }}
     steps:
       - id: r
         env:
           PR: ${{ inputs.pr_number }}
           SHA: ${{ inputs.commit_sha }}
           TTL_HOURS: ${{ inputs.ttl_hours }}
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if [ -n "$PR" ] && [ -n "$SHA" ]; then
-            echo "::error::Provide pr_number OR commit_sha, not both."
-            exit 1
-          fi
-          if [ -z "$PR" ] && [ -z "$SHA" ]; then
-            echo "::error::Provide either pr_number or commit_sha."
-            exit 1
-          fi
 
-          if [ -n "$PR" ] && ! [[ "$PR" =~ ^[0-9]+$ ]]; then
-            echo "::error::pr_number must be a positive integer."
-            exit 1
-          fi
-          if [ -n "$SHA" ] && ! [[ "$SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
-            echo "::error::commit_sha must be 7–40 lowercase hex chars."
-            exit 1
-          fi
-
-          # Clamp TTL to [1, 168].
-          if ! [[ "$TTL_HOURS" =~ ^[0-9]+$ ]] || [ "$TTL_HOURS" -lt 1 ] || [ "$TTL_HOURS" -gt 168 ]; then
-            echo "::error::ttl_hours must be an integer between 1 and 168."
-            exit 1
-          fi
-          EXPIRES_AT=$(( $(date +%s) + TTL_HOURS * 3600 ))
-
-          if [ -n "$PR" ]; then
-            REF=$(gh pr view "$PR" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
-            RELEASE="pr-${PR}"
+          # Branch on event type. workflow_dispatch keeps the existing pr/sha
+          # input shape; pull_request derives everything from the PR context
+          # and picks deploy vs. teardown from the action.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            ACTION_OUT=deploy
+            if [ -n "$PR" ] && [ -n "$SHA" ]; then
+              echo "::error::Provide pr_number OR commit_sha, not both."; exit 1
+            fi
+            if [ -z "$PR" ] && [ -z "$SHA" ]; then
+              echo "::error::Provide either pr_number or commit_sha."; exit 1
+            fi
+            if [ -n "$PR" ] && ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be a positive integer."; exit 1
+            fi
+            if [ -n "$SHA" ] && ! [[ "$SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+              echo "::error::commit_sha must be 7–40 lowercase hex chars."; exit 1
+            fi
+            if ! [[ "$TTL_HOURS" =~ ^[0-9]+$ ]] || [ "$TTL_HOURS" -lt 1 ] || [ "$TTL_HOURS" -gt 168 ]; then
+              echo "::error::ttl_hours must be an integer between 1 and 168."; exit 1
+            fi
+            if [ -n "$PR" ]; then
+              REF=$(gh pr view "$PR" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+              RELEASE="pr-${PR}"
+              PR_OUT="$PR"
+            else
+              REF="$SHA"
+              RELEASE="sha-${SHA:0:7}"
+              PR_OUT=""
+            fi
           else
-            REF="$SHA"
-            RELEASE="sha-${SHA:0:7}"
+            # pull_request — auto-deploy on label/sync, auto-teardown on
+            # unlabel/close. TTL defaults to a long horizon (the sweep is a
+            # backstop; teardown is normally label/close-driven now).
+            case "$ACTION" in
+              labeled|synchronize) ACTION_OUT=deploy ;;
+              unlabeled|closed)    ACTION_OUT=teardown ;;
+              *) echo "::error::unhandled action $ACTION"; exit 1 ;;
+            esac
+            TTL_HOURS=168
+            REF="$EVENT_HEAD_SHA"
+            RELEASE="pr-${EVENT_PR}"
+            PR_OUT="$EVENT_PR"
           fi
 
+          EXPIRES_AT=$(( $(date +%s) + TTL_HOURS * 3600 ))
           SHORT_SHA="${REF:0:12}"
           NAMESPACE="preview-${RELEASE}"
           HOST="${RELEASE}.${PREVIEW_BASE_DOMAIN}"
 
-          echo "release=$RELEASE"     >> "$GITHUB_OUTPUT"
-          echo "namespace=$NAMESPACE" >> "$GITHUB_OUTPUT"
-          echo "host=$HOST"           >> "$GITHUB_OUTPUT"
-          echo "ref=$REF"             >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "expires_at=$EXPIRES_AT" >> "$GITHUB_OUTPUT"
+          {
+            echo "action=$ACTION_OUT"
+            echo "release=$RELEASE"
+            echo "namespace=$NAMESPACE"
+            echo "host=$HOST"
+            echo "ref=$REF"
+            echo "short_sha=$SHORT_SHA"
+            echo "expires_at=$EXPIRES_AT"
+            echo "pr_number=$PR_OUT"
+          } >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Preview deploy"
+            echo "## Preview $ACTION_OUT"
             echo "- Release: \`$RELEASE\`"
             echo "- Namespace: \`$NAMESPACE\`"
             echo "- Host: https://$HOST"
-            echo "- Image tag: \`sha-$SHORT_SHA\`"
-            echo "- Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')"
+            if [ "$ACTION_OUT" = "deploy" ]; then
+              echo "- Image tag: \`sha-$SHORT_SHA\`"
+              echo "- Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           GH_TOKEN: ${{ github.token }}
 
+  start-deployment:
+    # Per-PR GitHub Deployment so the PR timeline shows a "Preview – PR #N"
+    # card. One Deployment row per PR (we transition existing deployments
+    # rather than creating duplicates on each push).
+    name: Start GitHub Deployment
+    needs: resolve
+    if: needs.resolve.outputs.action == 'deploy' && needs.resolve.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    outputs:
+      deployment_id: ${{ steps.create.outputs.deployment_id }}
+    steps:
+      - id: create
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ needs.resolve.outputs.ref }}
+          RELEASE: ${{ needs.resolve.outputs.release }}
+          PR: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          # transient_environment + auto_inactive let GitHub mark the prior
+          # deployment row inactive automatically when this one goes active.
+          DEPLOYMENT_ID=$(gh api "repos/${{ github.repository }}/deployments" \
+            --method POST \
+            -f ref="$REF" \
+            -f environment="preview-$RELEASE" \
+            -F transient_environment=true \
+            -F production_environment=false \
+            -F auto_merge=false \
+            -F required_contexts:='[]' \
+            -f description="Preview for PR #$PR" \
+            --jq .id)
+          echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+          gh api "repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
+            --method POST \
+            -f state=in_progress \
+            -f description="Building + deploying" \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >/dev/null
+
   build:
     name: Build + push
     needs: resolve
+    if: needs.resolve.outputs.action == 'deploy'
     runs-on: namespace-profile-default-with-volume
     timeout-minutes: 40
     outputs:
@@ -167,6 +261,7 @@ jobs:
     # never the sweep) is mid-patch on the Cluster CR.
     name: Scale preview worker pool up
     needs: [resolve, build]
+    if: needs.resolve.outputs.action == 'deploy'
     runs-on: namespace-profile-default
     environment:
       name: server-k8s-preview
@@ -225,7 +320,13 @@ jobs:
 
   deploy:
     name: Deploy ${{ needs.resolve.outputs.release }}
-    needs: [resolve, build, scale-up]
+    needs: [resolve, build, scale-up, start-deployment]
+    if: |
+      always()
+      && needs.resolve.outputs.action == 'deploy'
+      && needs.build.result == 'success'
+      && needs.scale-up.result == 'success'
+      && (needs.start-deployment.result == 'success' || needs.start-deployment.result == 'skipped')
     runs-on: namespace-profile-default
     environment:
       name: server-k8s-preview
@@ -309,13 +410,33 @@ jobs:
           echo "::error::https://${HOST}/ready never returned 200 after ~3 min."
           exit 1
 
+      - name: Mark GitHub Deployment success
+        # Source-of-truth for the PR-timeline "Preview" card. Setting
+        # auto_inactive=true here flips any prior active deployment for the
+        # same environment into inactive so the timeline only ever shows the
+        # latest live preview.
+        if: needs.start-deployment.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/deployments/${{ needs.start-deployment.outputs.deployment_id }}/statuses" \
+            --method POST \
+            -f state=success \
+            -f environment_url="https://$HOST" \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -F auto_inactive=true \
+            -f description="Preview live at https://$HOST" >/dev/null
+
       - name: Comment on PR
         # Edits the existing bot comment if one exists (matched by a hidden
         # HTML marker keyed on release name) so re-deploys don't spam the
-        # PR with new comments. Falls back to creating a fresh one.
-        if: ${{ inputs.pr_number != '' }}
+        # PR with new comments. Falls back to creating a fresh one. The
+        # GitHub Deployment timeline card carries most of the signal now;
+        # the comment is here for the URL + expiry copy.
+        if: needs.resolve.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
         run: |
           MARKER="<!-- preview-deploy:${RELEASE} -->"
           BODY=$(cat <<EOF
@@ -327,10 +448,10 @@ jobs:
           - Last updated: $(date -u '+%Y-%m-%d %H:%M UTC')
           - Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')
 
-          Re-run the workflow against the same PR to update; the sweep workflow tears it down at expiry.
+          Push to this PR to update the preview; remove the \`preview\` label or close the PR to tear it down.
           EOF
           )
-          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
             --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
             | head -1)
           if [ -n "$EXISTING" ]; then
@@ -339,9 +460,20 @@ jobs:
               -f body="$BODY" >/dev/null
           else
             echo "Creating new PR comment"
-            gh pr comment "${{ inputs.pr_number }}" \
+            gh pr comment "$PR_NUMBER" \
               --repo "${{ github.repository }}" --body "$BODY"
           fi
+
+      - name: Mark GitHub Deployment failure
+        if: failure() && needs.start-deployment.outputs.deployment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/deployments/${{ needs.start-deployment.outputs.deployment_id }}/statuses" \
+            --method POST \
+            -f state=failure \
+            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f description="Preview deploy failed" >/dev/null
 
       - name: Diagnostics on failure
         if: failure()
@@ -361,3 +493,77 @@ jobs:
             kubectl -n "$NAMESPACE" logs "$pod" --all-containers --tail=200 || true
             echo "::endgroup::"
           done
+
+  teardown:
+    # Triggered when the `preview` label is removed from a PR or the PR is
+    # closed. Mirrors what preview-sweep.yml does on TTL expiry: helm
+    # uninstall + namespace delete + flip the GitHub Deployment to inactive.
+    name: Teardown ${{ needs.resolve.outputs.release }}
+    needs: resolve
+    if: needs.resolve.outputs.action == 'teardown'
+    runs-on: ubuntu-latest
+    environment:
+      name: server-k8s-preview
+    concurrency:
+      group: preview-deploy-${{ needs.resolve.outputs.release }}
+      cancel-in-progress: false
+    timeout-minutes: 15
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      RELEASE: ${{ needs.resolve.outputs.release }}
+      NAMESPACE: ${{ needs.resolve.outputs.namespace }}
+    steps:
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load kubeconfig
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: helm uninstall + delete namespace
+        run: |
+          set -euo pipefail
+          if helm status "$RELEASE" --namespace "$NAMESPACE" >/dev/null 2>&1; then
+            helm uninstall "$RELEASE" --namespace "$NAMESPACE" --wait --timeout 5m || true
+          else
+            echo "No helm release '$RELEASE' in $NAMESPACE — skipping uninstall."
+          fi
+          if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            kubectl delete namespace "$NAMESPACE" --wait=true --timeout 5m || true
+          fi
+      - name: Mark GitHub Deployment inactive
+        # Find the most recent active deployment for this PR's environment
+        # and set it inactive. Cheap idempotent best-effort: if there's no
+        # active deployment (e.g. unlabel before first deploy completed),
+        # the loop simply finds nothing.
+        if: needs.resolve.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ENV="preview-${RELEASE}"
+          IDS=$(gh api "repos/${{ github.repository }}/deployments?environment=$ENV&per_page=20" \
+            --jq '.[].id')
+          for ID in $IDS; do
+            gh api "repos/${{ github.repository }}/deployments/$ID/statuses" \
+              --method POST \
+              -f state=inactive \
+              -f description="Preview torn down" >/dev/null || true
+          done
+      - name: Update PR comment
+        if: needs.resolve.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          MARKER="<!-- preview-deploy:${RELEASE} -->"
+          BODY="$MARKER"$'\n'"⚪ Preview torn down ($(date -u '+%Y-%m-%d %H:%M UTC')). Re-add the \`preview\` label to bring it back."
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --paginate --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING" \
+              -f body="$BODY" >/dev/null
+          fi

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: server-k8s-preview
+    # Shares the cluster-scale lane with preview-deploy.yml's scale-up job
+    # so the sweep can never patch the management Cluster CR while a deploy
+    # is mid-scale. Uses the same group name across both workflows.
+    concurrency:
+      group: preview-cluster-scale
+      cancel-in-progress: false
     timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -1,0 +1,104 @@
+name: Preview Sweep
+
+# Hourly cleanup pass over the preview cluster. Two responsibilities:
+#
+#   1. Delete preview namespaces whose `tuist.dev/expires-at` label is in
+#      the past (uninstalls the release + drops the namespace).
+#   2. Scale the preview MachineDeployment back to 0 when no preview
+#      namespaces remain. Combined with the always-on single control plane,
+#      this gets idle cost down to ~€5/mo.
+#
+# Also exposed as workflow_dispatch for force-runs (e.g. after manually
+# uninstalling something out-of-band).
+#
+# Requires the same two GitHub Environment secrets (server-k8s-preview) as
+# preview-deploy.yml: KUBECONFIG (workload) + KUBECONFIG_MGMT (management).
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    name: Sweep + scale to zero
+    runs-on: ubuntu-latest
+    environment:
+      name: server-k8s-preview
+    timeout-minutes: 15
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+      KUBECONFIG_MGMT: ${{ github.workspace }}/.kube/mgmt
+    steps:
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - name: Load kubeconfigs
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+          echo "${{ secrets.KUBECONFIG_MGMT }}" | base64 -d > "$KUBECONFIG_MGMT"
+          chmod 600 "$KUBECONFIG_MGMT"
+
+      - name: Delete expired preview namespaces
+        # We helm-uninstall first so chart hooks (PVC retention etc.) get a
+        # chance to run, then drop the namespace. `kubectl delete namespace`
+        # is itself a backstop — if helm uninstall fails, the namespace
+        # delete cascades through anyway.
+        run: |
+          set -euo pipefail
+          NOW=$(date +%s)
+          MAPPING=$(kubectl get namespaces -l tuist.dev/preview=true \
+            -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.labels.tuist\.dev/expires-at}{"\n"}{end}')
+          if [ -z "$MAPPING" ]; then
+            echo "No preview namespaces found."
+            exit 0
+          fi
+          echo "Found preview namespaces:"
+          echo "$MAPPING"
+
+          while IFS='=' read -r NS EXP; do
+            [ -z "$NS" ] && continue
+            if [ -z "$EXP" ] || ! [[ "$EXP" =~ ^[0-9]+$ ]]; then
+              echo "::warning::namespace $NS has missing/invalid expires-at label; skipping"
+              continue
+            fi
+            if [ "$EXP" -le "$NOW" ]; then
+              echo "==> Expired: $NS (expired $((NOW - EXP))s ago) — uninstalling"
+              # Strip the `preview-` prefix to get the helm release name.
+              RELEASE="${NS#preview-}"
+              helm uninstall "$RELEASE" --namespace "$NS" --wait --timeout 5m || true
+              kubectl delete namespace "$NS" --wait=true --timeout 5m || true
+            else
+              echo "    Live: $NS (expires in $((EXP - NOW))s)"
+            fi
+          done <<< "$MAPPING"
+
+      - name: Scale worker pool to zero if idle
+        # If no `tuist.dev/preview=true` namespaces remain, the worker pool
+        # has nothing to host. Scale md-0 back to 0 to drop cost to control
+        # plane only.
+        run: |
+          set -euo pipefail
+          REMAINING=$(kubectl get namespaces -l tuist.dev/preview=true -o name | wc -l | tr -d '[:space:]')
+          echo "Remaining preview namespaces: $REMAINING"
+          if [ "$REMAINING" -gt 0 ]; then
+            echo "Previews still live — leaving worker pool alone."
+            exit 0
+          fi
+
+          ORG_NS=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
+          CURRENT=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" get cluster tuist-preview \
+            -o jsonpath='{.spec.topology.workers.machineDeployments[?(@.name=="md-0")].replicas}')
+          echo "md-0 replicas currently: $CURRENT"
+          if [ "${CURRENT:-0}" -gt 0 ]; then
+            echo "==> Scaling md-0 to 0..."
+            KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" patch cluster tuist-preview \
+              --type=json \
+              -p='[{"op":"replace","path":"/spec/topology/workers/machineDeployments/0/replicas","value":0}]'
+          fi

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -198,6 +198,33 @@ http://{{ include "tuist.componentName" (dict "root" . "component" "otel-collect
 {{- end -}}
 {{- end -}}
 
+{{/*
+License env vars. Resolves to (in order):
+  1. ESO-managed Secret (server.externalSecrets.license.item set) — preview /
+     managed envs that sync the license from 1Password. Mirrors the MASTER_KEY
+     flow in templates/external-secrets.yaml.
+  2. Chart-managed app-secrets Secret — when server.license.key is inlined.
+*/}}
+{{- define "tuist.licenseEnv" -}}
+{{- $appSecret := include "tuist.componentName" (dict "root" . "component" "app-secrets") -}}
+{{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
+{{- $useEso := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
+{{- if or $useEso .Values.server.license.key }}
+- name: TUIST_LICENSE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ ternary $esoSecret $appSecret $useEso | quote }}
+      key: server-license-key
+{{- end }}
+{{- if .Values.server.license.certificateBase64 }}
+- name: TUIST_LICENSE_CERTIFICATE_BASE64
+  valueFrom:
+    secretKeyRef:
+      name: {{ $appSecret | quote }}
+      key: server-license-certificate-base64
+{{- end }}
+{{- end -}}
+
 {{- define "tuist.serverHeadlessServiceName" -}}
 {{- include "tuist.componentName" (dict "root" . "component" "server-headless") -}}
 {{- end -}}

--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -209,6 +209,9 @@ License env vars. Resolves to (in order):
 {{- $appSecret := include "tuist.componentName" (dict "root" . "component" "app-secrets") -}}
 {{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
 {{- $useEso := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
+{{- if and $useEso .Values.server.license.key -}}
+{{- fail "server.externalSecrets.license.item and server.license.key are mutually exclusive — pick one license source." -}}
+{{- end -}}
 {{- if or $useEso .Values.server.license.key }}
 - name: TUIST_LICENSE_KEY
   valueFrom:

--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -1,7 +1,11 @@
-{{- if and .Values.server.enabled .Values.server.managedSecrets }}
-# When managedSecrets is on, ESO syncs secrets from the configured SecretStore
-# (1Password by default) into a dedicated Secret that this ExternalSecret
-# owns. The Deployment/Migration Job reference this Secret for MASTER_KEY.
+{{- $syncMaster := and .Values.server.enabled .Values.server.managedSecrets -}}
+{{- $syncLicense := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
+{{- if or $syncMaster $syncLicense }}
+# ESO syncs secrets from the configured SecretStore (1Password by default)
+# into a dedicated Secret that this ExternalSecret owns. The Deployment /
+# Migration Job reference this Secret for MASTER_KEY (managed shape) and the
+# Tuist license (any shape that opts into license sync — e.g. preview envs
+# without the encrypted priv/secrets blob).
 #
 # A separate Secret (not a Merge into app-secrets) is used on purpose: helm
 # upgrade rewrites chart-managed resources, which would wipe ESO-managed keys
@@ -38,12 +42,24 @@ spec:
     template:
       engineVersion: v2
       data:
+        {{- if $syncMaster }}
         server-master-key: "{{ `{{ .server_master_key | trim }}` }}"
+        {{- end }}
+        {{- if $syncLicense }}
+        server-license-key: "{{ `{{ .server_license_key | trim }}` }}"
+        {{- end }}
   data:
+    {{- if $syncMaster }}
     - secretKey: server_master_key
       remoteRef:
         # 1Password SDK provider expects a single "<item>/<field>" string in
         # remoteRef.key (NOT separate key + property). The vault is set at the
         # SecretStore level.
         key: "{{ .Values.server.externalSecrets.masterKey.item | default "MASTER_KEY" }}/{{ .Values.server.externalSecrets.masterKey.field | default "password" }}"
+    {{- end }}
+    {{- if $syncLicense }}
+    - secretKey: server_license_key
+      remoteRef:
+        key: "{{ .Values.server.externalSecrets.license.item }}/{{ .Values.server.externalSecrets.license.field | default "password" }}"
+    {{- end }}
 {{- end }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -85,20 +85,7 @@ spec:
               value: {{ .Values.server.skipEmailConfirmation | ternary "1" "0" | quote }}
             - name: TUIST_SELF_HOSTING_DEVELOPMENT_MODE
               value: {{ .Values.server.license.selfHostingDevelopmentMode | ternary "1" "0" | quote }}
-            {{- if .Values.server.license.key }}
-            - name: TUIST_LICENSE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-license-key
-            {{- end }}
-            {{- if .Values.server.license.certificateBase64 }}
-            - name: TUIST_LICENSE_CERTIFICATE_BASE64
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-license-certificate-base64
-            {{- end }}
+            {{- include "tuist.licenseEnv" . | nindent 12 }}
             {{- if or .Values.server.masterKey .Values.server.managedSecrets }}
             - name: MASTER_KEY
               valueFrom:

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -92,20 +92,7 @@ spec:
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
             - name: TUIST_SELF_HOSTING_DEVELOPMENT_MODE
               value: {{ .Values.server.license.selfHostingDevelopmentMode | ternary "1" "0" | quote }}
-            {{- if .Values.server.license.key }}
-            - name: TUIST_LICENSE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-license-key
-            {{- end }}
-            {{- if .Values.server.license.certificateBase64 }}
-            - name: TUIST_LICENSE_CERTIFICATE_BASE64
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-license-certificate-base64
-            {{- end }}
+            {{- include "tuist.licenseEnv" . | nindent 12 }}
             {{- if or .Values.server.masterKey .Values.server.managedSecrets }}
             - name: MASTER_KEY
               valueFrom:

--- a/infra/helm/tuist/values-preview.yaml
+++ b/infra/helm/tuist/values-preview.yaml
@@ -1,0 +1,121 @@
+# Overlay for ephemeral preview environments.
+#
+# Pins every pod (server, cache, embedded postgres / clickhouse / minio /
+# redis, migration job) onto nodes labeled `role=preview` and tolerates the
+# matching `role=preview:NoSchedule` taint so the dedicated preview node pool
+# is reserved for these short-lived releases. The chart's tuist.podScheduling
+# helper already threads these into every workload — no template changes
+# required.
+#
+# Apply with:
+#   helm install pr-1234 infra/helm/tuist -f infra/helm/tuist/values-preview.yaml
+global:
+  nodeSelector:
+    role: preview
+  tolerations:
+    - key: role
+      operator: Equal
+      value: preview
+      effect: NoSchedule
+  commonLabels:
+    tuist.dev/environment: preview
+
+server:
+  replicaCount: 1
+  autoscaling:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  cluster:
+    enabled: false
+  # License is synced from 1Password via ESO into the chart's
+  # server-external-secrets Secret. The 1P item must exist in the vault that
+  # the ClusterSecretStore (default name: onepassword) is bound to. ESO and
+  # the SecretStore must be installed in the cluster before `helm install`.
+  externalSecrets:
+    license:
+      item: TUIST_LICENSE_KEY
+      field: password
+  # Static ingress configuration for the preview cluster. The dynamic per-deploy
+  # bits (enabled, host, and the matching appUrl) are passed by CI:
+  #
+  #   --set server.ingress.enabled=true
+  #   --set server.ingress.host=pr-1234.preview.tuist.dev
+  #   --set server.appUrl=https://pr-1234.preview.tuist.dev
+  #
+  # Convention for the host label:
+  #   pr-<number>      for PR builds (stable across pushes; redeploys upgrade)
+  #   sha-<7chars>     for one-off commits / branches without a PR
+  #
+  # TLS comes from a wildcard cert for *.preview.tuist.dev pre-issued at
+  # cluster bootstrap (cert-manager DNS-01 against Cloudflare). Two ways to
+  # plug it in — pick one when bootstrapping the preview cluster:
+  #
+  #   1. ingress-nginx default-ssl-certificate: start the controller with
+  #      --default-ssl-certificate=ingress-nginx/preview-tuist-dev-wildcard-tls
+  #      and leave tlsSecretName empty here. Every Ingress without its own
+  #      tls: block falls back to the wildcard. No per-namespace plumbing.
+  #   2. cert-manager + reflector: mirror the wildcard Secret into each
+  #      preview-* namespace and set tlsSecretName below to its name.
+  #
+  # No external-dns annotations are needed: a single A record
+  #   *.preview.tuist.dev -> <preview ingress IP>
+  # already resolves every per-PR subdomain.
+  ingress:
+    enabled: false
+    className: nginx
+    host: ""
+    tlsSecretName: ""
+    annotations: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+cache:
+  enabled: true
+  replicaCount: 1
+  storage:
+    pvc:
+      size: 5Gi
+  data:
+    pvc:
+      size: 2Gi
+
+postgresql:
+  mode: embedded
+  embedded:
+    persistence:
+      size: 2Gi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+clickhouse:
+  mode: embedded
+  embedded:
+    persistence:
+      size: 5Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+
+redis:
+  enabled: false
+
+objectStorage:
+  mode: embedded
+  embedded:
+    persistence:
+      size: 5Gi
+
+observability:
+  enabled: false

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -59,6 +59,12 @@ server:
       # Field within the item. 1P "Password" category items expose their
       # value under `password`; custom items can use any label.
       field: password
+    # Sync the Tuist license key from the external store. Independent of
+    # managedSecrets — preview environments use this without the encrypted
+    # priv/secrets blob. Leave `item` empty to skip license sync.
+    license:
+      item: ""
+      field: password
   license:
     key: ""
     certificateBase64: ""

--- a/infra/k8s/kind-preview.yaml
+++ b/infra/k8s/kind-preview.yaml
@@ -1,0 +1,21 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: tuist-preview
+# Three-node layout that mirrors how preview environments will run on the
+# managed Syself cluster: a control plane, a "general" worker for shared
+# workloads, and a dedicated worker labeled `role=preview` and tainted so
+# only ephemeral preview releases land on it. Used by `mise run helm:preview-up`.
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      role: general
+  - role: worker
+    labels:
+      role: preview
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            register-with-taints: "role=preview:NoSchedule"

--- a/infra/k8s/syself-onboarding.md
+++ b/infra/k8s/syself-onboarding.md
@@ -279,7 +279,233 @@ helm upgrade --install k8s-monitoring infra/helm/k8s-monitoring \
 
 After the chart is live, check **Observability → Kubernetes** in Grafana Cloud for the cluster named `tuist-staging` / `tuist-canary` / `tuist-production`. Full verification steps live in [`infra/helm/k8s-monitoring/README.md`](../helm/k8s-monitoring/README.md).
 
-## 9. Teardown
+## 9. Preview environments (ephemeral PR / commit deploys)
+
+Preview environments live on a dedicated workload cluster (`tuist-preview`) that runs everything embedded — Postgres, ClickHouse, MinIO — alongside the server. Each preview is its own Helm release in its own namespace, with auto-deletion driven by a TTL label and an hourly sweep workflow. The worker pool scales to 0 when no previews are live.
+
+This section is the one-time bootstrap. Once it's done, deploys are purely a GitHub Actions affair — `Actions → Preview Deploy → Run workflow`.
+
+### 9.1 Prerequisites
+
+- The `tuist-k8s-preview` 1Password vault, with item `TUIST_LICENSE_KEY` (Login or Password category, value in the `password` field).
+- A 1Password Service Account scoped to that vault. Stash its token in `Founders` as `1Password SA — tuist-k8s-preview`.
+- A Cloudflare API token scoped to `Zone.DNS:Edit` on `tuist.dev` (you already have one for the other clusters — reuse).
+
+### 9.2 Provision the cluster
+
+```bash
+export KUBECONFIG=~/.kube/tuist-syself-mgmt.yaml
+ORG_NS="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')"
+
+kubectl apply -f infra/k8s/syself/workload-cluster-preview.yaml
+kubectl -n "$ORG_NS" get cluster tuist-preview -w
+# Ready=True once control plane is up. Note: workers default to replicas: 0,
+# so initially you'll see 1 control-plane and 0 workers — that's expected.
+```
+
+Fetch the workload kubeconfig the same way as staging:
+
+```bash
+kubectl -n "$ORG_NS" get secret tuist-preview-kubeconfig -o jsonpath='{.data.value}' \
+  | base64 -d > ~/.kube/tuist-preview.yaml
+chmod 600 ~/.kube/tuist-preview.yaml
+```
+
+### 9.3 ESO + 1Password store
+
+```bash
+export KUBECONFIG=~/.kube/tuist-preview.yaml
+
+helm upgrade --install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace \
+  --set installCRDs=true
+
+kubectl create namespace onepassword --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n onepassword create secret generic onepassword-sa-token \
+  --from-literal=token="$(op read 'op://Founders/1Password SA — tuist-k8s-preview/password')" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+cat <<'YAML' | kubectl apply -f -
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+spec:
+  provider:
+    onepasswordSDK:
+      vault: tuist-k8s-preview
+      auth:
+        serviceAccountSecretRef:
+          name: onepassword-sa-token
+          namespace: onepassword
+          key: token
+YAML
+
+kubectl get clustersecretstore onepassword
+# Expect READY=True.
+```
+
+### 9.4 Wildcard DNS + cert
+
+In Cloudflare's `tuist.dev` zone, create a single A record:
+
+```
+*.preview.tuist.dev   A   <preview cluster ingress IP>
+```
+
+The ingress IP is the LB Hetzner provisions when ingress-nginx is installed (next step). Bring up ingress-nginx first, grab the LB IP from `kubectl get svc -n ingress-nginx ingress-nginx-controller`, then create the record.
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  -n ingress-nginx --create-namespace \
+  -f infra/k8s/syself/ingress-nginx-values.yaml \
+  --set controller.extraArgs.default-ssl-certificate=ingress-nginx/preview-tuist-dev-wildcard-tls
+kubectl -n ingress-nginx get svc ingress-nginx-controller -w
+# Wait for EXTERNAL-IP, then create the *.preview.tuist.dev A record.
+```
+
+Issue the wildcard cert via cert-manager DNS-01 (re-uses the same Cloudflare token pattern as the other clusters):
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm upgrade --install cert-manager jetstack/cert-manager \
+  -n cert-manager --create-namespace \
+  --set installCRDs=true
+
+# Cloudflare token Secret (same item the other clusters reuse).
+kubectl -n cert-manager create secret generic cloudflare-api-token \
+  --from-literal=api-token="$(op read 'op://Founders/cloudflare-tuist-dev-dns/credential')"
+
+cat <<'YAML' | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-cloudflare
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ops@tuist.dev
+    privateKeySecretRef:
+      name: letsencrypt-cloudflare-account
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              namespace: cert-manager
+              key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: preview-tuist-dev-wildcard
+  namespace: ingress-nginx
+spec:
+  secretName: preview-tuist-dev-wildcard-tls
+  issuerRef:
+    name: letsencrypt-cloudflare
+    kind: ClusterIssuer
+  commonName: "*.preview.tuist.dev"
+  dnsNames:
+    - "*.preview.tuist.dev"
+    - "preview.tuist.dev"
+YAML
+
+# Wait for issuance (DNS-01 is ~1–3 min).
+kubectl -n ingress-nginx get certificate preview-tuist-dev-wildcard -w
+```
+
+The `--default-ssl-certificate=ingress-nginx/preview-tuist-dev-wildcard-tls` flag we passed to ingress-nginx makes this single Secret cover every preview Ingress automatically — no per-namespace TLS plumbing.
+
+### 9.5 CI ServiceAccount (workload cluster)
+
+```bash
+export KUBECONFIG=~/.kube/tuist-preview.yaml
+sed 's/__NAMESPACE__/preview-system/g' infra/k8s/syself/ci-service-account.yaml \
+  | kubectl apply -f -
+
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CA=$(kubectl -n preview-system get secret github-actions-deployer-token -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl -n preview-system get secret github-actions-deployer-token -o jsonpath='{.data.token}' | base64 -d)
+
+cat > /tmp/preview-kubeconfig.yaml <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: tuist-preview
+    cluster:
+      server: $SERVER
+      certificate-authority-data: $CA
+contexts:
+  - name: ci
+    context: { cluster: tuist-preview, user: github-actions-deployer }
+users:
+  - name: github-actions-deployer
+    user: { token: $TOKEN }
+current-context: ci
+EOF
+
+base64 < /tmp/preview-kubeconfig.yaml | gh secret set KUBECONFIG \
+  --env server-k8s-preview --repo tuist/tuist
+shred -u /tmp/preview-kubeconfig.yaml
+```
+
+### 9.6 Scaler ServiceAccount (management cluster)
+
+The deploy + sweep workflows scale the worker MachineDeployment up and down. The Cluster CR for that lives in the **management** cluster, so we mint a separate, narrowly-scoped SA there.
+
+```bash
+export KUBECONFIG=~/.kube/tuist-syself-mgmt.yaml
+ORG_NS="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')"
+
+sed "s/__ORG_NS__/$ORG_NS/g" infra/k8s/syself/preview-mgmt-rbac.yaml | kubectl apply -f -
+
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CA=$(kubectl -n "$ORG_NS" get secret preview-scaler-token -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl -n "$ORG_NS" get secret preview-scaler-token -o jsonpath='{.data.token}' | base64 -d)
+
+cat > /tmp/preview-mgmt-kubeconfig.yaml <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: syself-mgmt
+    cluster:
+      server: $SERVER
+      certificate-authority-data: $CA
+contexts:
+  - name: ci
+    context: { cluster: syself-mgmt, namespace: $ORG_NS, user: preview-scaler }
+users:
+  - name: preview-scaler
+    user: { token: $TOKEN }
+current-context: ci
+EOF
+
+base64 < /tmp/preview-mgmt-kubeconfig.yaml | gh secret set KUBECONFIG_MGMT \
+  --env server-k8s-preview --repo tuist/tuist
+shred -u /tmp/preview-mgmt-kubeconfig.yaml
+```
+
+### 9.7 First preview
+
+```bash
+gh workflow run preview-deploy.yml \
+  -f pr_number=1234 \
+  -f ttl_hours=24
+```
+
+Or for a one-off commit:
+
+```bash
+gh workflow run preview-deploy.yml \
+  -f commit_sha=abc1234567890... \
+  -f ttl_hours=4
+```
+
+The workflow scales the worker pool up if needed (~3–5 min cold start), labels/taints the new node, runs `helm upgrade --install`, and posts the URL back to the PR. The hourly `preview-sweep.yml` workflow handles deletion + scale-down.
+
+## 10. Teardown
 
 Workload cluster:
 

--- a/infra/k8s/syself/preview-mgmt-rbac.yaml
+++ b/infra/k8s/syself/preview-mgmt-rbac.yaml
@@ -1,0 +1,61 @@
+# Narrowly-scoped ServiceAccount for the preview-deploy and preview-sweep
+# GitHub workflows. Lives in the SYSELF MANAGEMENT cluster (not the workload
+# cluster) because the Cluster / MachineDeployment CRs the workflows patch
+# to scale the worker pool live there.
+#
+# Permissions are intentionally minimal:
+#   - get / patch the `tuist-preview` Cluster (to bump
+#     spec.topology.workers.machineDeployments[0].replicas).
+#   - get / list MachineDeployments in org-tuist (to read current replica count).
+#   - get Machines (to wait for new nodes to become Ready before deploying).
+#
+# Apply against the management cluster:
+#   sed 's/__ORG_NS__/org-tuist/g' infra/k8s/syself/preview-mgmt-rbac.yaml \
+#     | kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml apply -f -
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: preview-scaler
+  namespace: __ORG_NS__
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: preview-scaler-token
+  namespace: __ORG_NS__
+  annotations:
+    kubernetes.io/service-account.name: preview-scaler
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: preview-scaler
+  namespace: __ORG_NS__
+rules:
+  # Read the Cluster (verify name + current replica count) and patch its
+  # topology to scale the MachineDeployment.
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [clusters]
+    resourceNames: [tuist-preview]
+    verbs: [get, patch]
+  # Read MachineDeployments + Machines to wait for the scale-up to land.
+  # No resourceNames filter — the names include hashes that change.
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [machinedeployments, machines]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: preview-scaler
+  namespace: __ORG_NS__
+roleRef:
+  kind: Role
+  name: preview-scaler
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: preview-scaler
+    namespace: __ORG_NS__

--- a/infra/k8s/syself/workload-cluster-preview.yaml
+++ b/infra/k8s/syself/workload-cluster-preview.yaml
@@ -1,0 +1,61 @@
+# Preview workload Cluster for ephemeral PR / commit environments.
+#
+# Shape: 1 × cpx22 control plane + 0 × cpx31 workers (scale-to-zero) in fsn1.
+# Single control-plane is acceptable — the cluster is not user-facing and
+# short downtime during upgrades is fine.
+#
+# Idle cost: ~€5/mo (control plane only). Workers spin up on demand:
+#   - preview-deploy.yml scales md-0 to 1 before the first helm install
+#     and waits for the new node to go Ready (~3–5 min from cold).
+#   - preview-sweep.yml runs hourly, deletes expired namespaces, and scales
+#     md-0 back to 0 when no preview releases remain.
+#
+# Both workflows talk to the SYSELF MANAGEMENT CLUSTER to scale (the Cluster
+# CR lives there, not in the workload cluster). The narrow RBAC for that
+# lives in preview-mgmt-rbac.yaml.
+#
+# Worker labeling/tainting:
+# CAPI/Syself doesn't surface node labels via topology variables, so workers
+# come up un-labeled. The `role=preview` label and `role=preview:NoSchedule`
+# taint are applied by the deploy workflow on every run (idempotent), so
+# fresh nodes from scale-up events get the right scheduling immediately.
+
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: tuist-preview
+  namespace: org-tuist
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+  topology:
+    class: hetzner-apalla-1-34-v6
+    version: v1.34.6
+    controlPlane:
+      replicas: 1
+    workers:
+      machineDeployments:
+        - class: workeramd64hcloud
+          name: md-0
+          # Scale-to-zero default. CI scales up before deploy and back down
+          # in the hourly sweep when no previews remain.
+          replicas: 0
+          failureDomain: fsn1
+    variables:
+      - name: region
+        value: fsn1
+      - name: controlPlaneMachineTypeHcloud
+        value: cpx22
+      - name: controlPlaneMachineArchHcloud
+        value: amd64
+      - name: workerMachineTypeHcloud
+        value: cpx31
+      - name: SSHKeyNameHcloud
+        value:
+          - name: tuist-syself

--- a/infra/mise/tasks/helm/preview-down.sh
+++ b/infra/mise/tasks/helm/preview-down.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Tear down the multi-node preview kind cluster"
+#USAGE flag "--cluster <name>" help="Kind cluster name" default="tuist-preview"
+
+set -euo pipefail
+
+echo "==> Deleting kind cluster '${usage_cluster}'..."
+kind delete cluster --name "${usage_cluster}"
+echo "==> Done."

--- a/infra/mise/tasks/helm/preview-up.sh
+++ b/infra/mise/tasks/helm/preview-up.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#MISE description="Spin up a multi-node kind cluster and deploy a preview release pinned to role=preview node"
+#USAGE flag "--cluster <name>" help="Kind cluster name" default="tuist-preview"
+#USAGE flag "--release <name>" help="Helm release name" default="pr-demo"
+#USAGE flag "--remote" help="Use pre-built images from ghcr.io instead of building locally"
+#USAGE flag "--version <version>" help="Image version tag when using --remote" default="latest"
+#
+# Two license-source modes, picked by which env var is exported:
+#
+#   $OP_SERVICE_ACCOUNT_TOKEN  → "prod-shape" path. Installs External Secrets
+#                                Operator + a 1Password ClusterSecretStore in
+#                                the kind cluster. The chart's ExternalSecret
+#                                pulls the license from item TUIST_LICENSE_KEY
+#                                in 1Password. Mirrors how the Syself clusters
+#                                are configured (see infra/k8s/syself-onboarding.md).
+#
+#   $TUIST_LICENSE_KEY         → local fallback. Skips ESO and inlines the key
+#                                so kind clusters without 1P access still work.
+#                                Only for local development — never commit
+#                                values that include the plaintext.
+#
+# CI should always go through the OP_SERVICE_ACCOUNT_TOKEN path: source the
+# token from the platform's secret store (GitHub Actions, Vault) and export it
+# before invoking this task.
+
+set -euo pipefail
+
+CLUSTER_NAME="${usage_cluster}"
+RELEASE_NAME="${usage_release}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PLATFORM="linux/$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+    LICENSE_MODE="eso"
+elif [ -n "${TUIST_LICENSE_KEY:-}" ]; then
+    LICENSE_MODE="inline"
+else
+    echo "ERROR: set either OP_SERVICE_ACCOUNT_TOKEN (preferred, ESO path)" >&2
+    echo "       or TUIST_LICENSE_KEY (local fallback) before running." >&2
+    exit 1
+fi
+echo "==> License source: $LICENSE_MODE"
+
+if [ "${usage_remote:-}" = "true" ]; then
+    SERVER_REPO="ghcr.io/tuist/tuist"
+    CACHE_REPO="ghcr.io/tuist/cache"
+    IMAGE_TAG="${usage_version}"
+    echo "==> Pulling remote images for ${PLATFORM}..."
+    docker pull --platform "$PLATFORM" "${SERVER_REPO}:${IMAGE_TAG}"
+    docker pull --platform "$PLATFORM" "${CACHE_REPO}:${IMAGE_TAG}"
+else
+    SERVER_REPO="tuist-server"
+    CACHE_REPO="tuist-cache"
+    IMAGE_TAG="latest"
+    echo "==> Building images locally..."
+    mise run helm:build
+fi
+
+echo "==> Creating multi-node kind cluster '$CLUSTER_NAME' (control-plane + general worker + preview worker)..."
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+    kind create cluster --name "$CLUSTER_NAME" --config "$REPO_ROOT/infra/k8s/kind-preview.yaml"
+else
+    echo "    Cluster '$CLUSTER_NAME' already exists, reusing."
+fi
+
+echo "==> Verifying node labels and taints..."
+kubectl get nodes -L role
+kubectl get nodes -o json | jq -r '.items[] | select(.spec.taints) | "\(.metadata.name): \(.spec.taints[] | "\(.key)=\(.value):\(.effect)")"'
+
+echo "==> Loading images into kind..."
+kind load docker-image "${SERVER_REPO}:${IMAGE_TAG}" "${CACHE_REPO}:${IMAGE_TAG}" --name "$CLUSTER_NAME"
+
+HELM_LICENSE_ARGS=()
+
+if [ "$LICENSE_MODE" = "eso" ]; then
+    echo "==> Installing External Secrets Operator..."
+    helm repo add external-secrets https://charts.external-secrets.io >/dev/null 2>&1 || true
+    helm repo update external-secrets >/dev/null
+    helm upgrade --install external-secrets external-secrets/external-secrets \
+        -n external-secrets --create-namespace \
+        --set installCRDs=true \
+        --wait --timeout 3m
+
+    echo "==> Configuring 1Password ClusterSecretStore..."
+    # Mirrors infra/k8s/syself-onboarding.md: SA token Secret lives in the
+    # `onepassword` namespace, store uses the onepasswordSDK provider (matches
+    # the "<item>/<field>" remoteRef syntax in templates/external-secrets.yaml).
+    kubectl create namespace onepassword --dry-run=client -o yaml | kubectl apply -f -
+    kubectl -n onepassword delete secret onepassword-sa-token --ignore-not-found
+    kubectl -n onepassword create secret generic onepassword-sa-token \
+        --from-literal=token="$OP_SERVICE_ACCOUNT_TOKEN"
+
+    cat <<'EOF' | kubectl apply -f -
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+spec:
+  provider:
+    onepasswordSDK:
+      vault: tuist-k8s-preview
+      auth:
+        serviceAccountSecretRef:
+          name: onepassword-sa-token
+          namespace: onepassword
+          key: token
+EOF
+
+    echo "==> Waiting for ClusterSecretStore to go Ready..."
+    kubectl wait --for=condition=Ready clustersecretstore/onepassword --timeout=60s
+
+    # The chart's preview overlay already sets
+    # server.externalSecrets.license.item=TUIST_LICENSE_KEY — nothing else to
+    # pass here. helm waits for the migration job, which transitively waits
+    # for the ExternalSecret target Secret to materialize.
+else
+    echo "==> Local fallback: license will be inlined (no ESO)."
+    HELM_LICENSE_ARGS=(
+        --set "server.externalSecrets.license.item="
+        --set "server.license.key=${TUIST_LICENSE_KEY}"
+    )
+fi
+
+echo "==> Cleaning up previous release if any..."
+if helm status "$RELEASE_NAME" >/dev/null 2>&1; then
+    helm uninstall "$RELEASE_NAME" --wait 2>/dev/null || true
+    kubectl delete pvc -l app.kubernetes.io/instance="$RELEASE_NAME" --wait=true 2>/dev/null || true
+fi
+
+echo "==> Installing preview release..."
+helm install "$RELEASE_NAME" "$REPO_ROOT/infra/helm/tuist" \
+    -f "$REPO_ROOT/infra/helm/tuist/values-preview.yaml" \
+    --set "server.image.repository=${SERVER_REPO}" \
+    --set "server.image.tag=${IMAGE_TAG}" \
+    --set "cache.image.repository=${CACHE_REPO}" \
+    --set "cache.image.tag=${IMAGE_TAG}" \
+    --set "server.appUrl=http://${RELEASE_NAME}.preview.local" \
+    --set "server.cacheEndpointUrl=http://${RELEASE_NAME}-cache.preview.local" \
+    "${HELM_LICENSE_ARGS[@]}" \
+    --wait --timeout 5m
+
+echo ""
+echo "==> Pod placement (every pod should land on the role=preview worker):"
+kubectl get pods -l app.kubernetes.io/instance="$RELEASE_NAME" -o wide
+
+echo ""
+echo "==> Verifying pinning..."
+UNEXPECTED=$(kubectl get pods -l app.kubernetes.io/instance="$RELEASE_NAME" \
+    -o json | jq -r '.items[] | select(.spec.nodeName != null) |
+    "\(.metadata.name) \(.spec.nodeName)"' \
+    | grep -v "preview-worker" || true)
+if [ -n "$UNEXPECTED" ]; then
+    echo "    FAIL — pods scheduled outside the preview worker:"
+    echo "$UNEXPECTED"
+    exit 1
+fi
+echo "    OK — all preview pods landed on the role=preview worker."
+
+echo ""
+echo "Tear down with: mise run helm:preview-down"


### PR DESCRIPTION
## Summary

Per-PR / per-commit ephemeral preview deploys on a dedicated `tuist-preview` Syself/Hetzner cluster. The worker pool scales to zero at idle so resting cost is ~€5/mo (single small control plane); workers spin up on demand and the hourly sweep workflow scales them back down once nothing is live.

Each preview is one Helm release in its own namespace, running the full embedded stack (server + cache + postgres + clickhouse + minio) on a single labeled+tainted worker. URLs follow:

```
pr-1234.preview.tuist.dev      # PR builds (stable across pushes; redeploy upgrades)
sha-abc1234.preview.tuist.dev  # one-off commits / branches without a PR
```

TLS comes from a wildcard cert pre-issued at cluster bootstrap (cert-manager DNS-01 against Cloudflare); per-PR ingresses pick it up via ingress-nginx's `--default-ssl-certificate` flag — no per-namespace plumbing.

## How previews are triggered

**Label-driven (default):** add the `preview` label to a PR. Subsequent pushes auto-redeploy; removing the label or closing the PR tears down. The PR timeline gets a "Preview – PR #1234" GitHub Deployment card (active during the deploy, set inactive on teardown) and a single auto-edited bot comment with the URL.

**Manual (one-offs):** `gh workflow run preview-deploy.yml -f pr_number=1234 -f ttl_hours=24` or `-f commit_sha=abc1234 -f ttl_hours=4`. Useful for re-deploying a closed PR or for branches without a PR.

Fork PRs are filtered out at the resolve job — secrets don't propagate to fork-based runs anyway.

## What's new

**Chart**
- `server.externalSecrets.license.{item,field}` — license syncs from 1Password through the same ESO ClusterSecretStore pattern already used for `MASTER_KEY`, gated independently of `managedSecrets` so previews don't need the encrypted `priv/secrets` blob. Backwards-compatible with the existing inline-license path; mutually exclusive with `server.license.key` (helper `fail`s if both are set).
- New `tuist.licenseEnv` helper centralises the license env wiring across deployment + migration job.
- `values-preview.yaml` overlay: pin to `role=preview` node, embed all dependencies, scaled-down resource requests, ingress configured for the wildcard-cert path.

**Cluster**
- `infra/k8s/syself/workload-cluster-preview.yaml` — CAPI Cluster CR (1 × cpx22 control plane + 0 × cpx31 workers default).
- `infra/k8s/syself/preview-mgmt-rbac.yaml` — narrow `preview-scaler` SA on the management cluster (only `get/patch` on the preview Cluster, read-only on MachineDeployments) for the workflows to scale the worker pool.

**CI**
- `.github/workflows/preview-deploy.yml` — `pull_request` (label-driven) + `workflow_dispatch`. Split into `resolve` (gates on event filter, decides deploy vs. teardown), `start-deployment`, `build`, `scale-up` (concurrency: `preview-cluster-scale`, shared with sweep), per-release `deploy`, and `teardown`. Different PRs deploy in parallel while the management Cluster CR patches stay one-at-a-time.
- `.github/workflows/preview-sweep.yml` — hourly cron + manual dispatch. Backstop deletion for any namespace past its `tuist.dev/expires-at` label, scales the worker pool back to 0 when no previews remain.

**Local validation**
- `infra/k8s/kind-preview.yaml` + `infra/mise/tasks/helm/preview-{up,down}.sh` — multi-node kind config (control plane + general worker + labeled+tainted preview worker) and end-to-end task. Supports both ESO mode (`OP_SERVICE_ACCOUNT_TOKEN`) and inline fallback (`TUIST_LICENSE_KEY`) for offline validation.

**Docs**
- `infra/k8s/syself-onboarding.md` §9 — preview cluster bootstrap end-to-end (cluster apply → ESO → wildcard DNS+cert → both CI ServiceAccounts → first deploy).

## Test plan

Verified live on a multi-node kind cluster:

- [x] All 8 workloads schedule to the `role=preview` worker; default workloads stay on the general worker
- [x] ESO + 1Password license sync works against the real `tuist-k8s-preview` vault (license bytes round-trip with `| trim` correctly handling trailing newline)
- [x] `helm install --atomic --wait` succeeds in ~70s
- [x] Postgres + ClickHouse migrations both run forward in the migration job
- [x] Server pod boots and serves `GET /ready` → `HTTP 200`, `GET /` → `HTTP 302` (Phoenix redirect to configured `appUrl`)
- [x] Both modes of license sourcing (ESO + inline) render correctly via `helm template`; mutually-exclusive guard `fail`s when both are set
- [x] Preview overlay leaves Ingress unrendered without CI overrides; renders correctly with both default-ssl-certificate and reflector paths

Not exercised here (require real Syself + Cloudflare):

- [ ] CAPI scale-up timing on Hetzner cold-boot
- [ ] cert-manager DNS-01 against Cloudflare for the wildcard cert
- [ ] GitHub Actions secret + environment resolution
- [ ] `pull_request` label-trigger event flow + GitHub Deployment status transitions

## Follow-ups (separate PRs)

- **Durable node labels at bootstrap.** Custom Syself ClusterClass variant that sets `role=preview` label + taint at kubelet registration, so the workflow's relabel-before-deploy step becomes belt-and-braces rather than load-bearing. Genuinely upstream-dependent — needs Syself to expose label/taint config via ClusterClass variables.

## Sharp edges

- Worker labels/taints aren't durable across MachineDeployment scale events; the deploy workflow re-applies them before `helm install` as a safeguard. See follow-up above for the long-term fix.
- One-replica worker = single point of failure. Acceptable for previews; flagged in the onboarding doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)