### PR TITLE
feat(server): serve MCP Server Card at /.well-known/mcp/server-card.json

### DIFF
--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -27,6 +27,37 @@ defmodule TuistWeb.WellKnownController do
   end
 
   @doc """
+  Returns the MCP Server Card for agent discovery (SEP-1649).
+  """
+  def mcp_server_card(conn, _params) do
+    server = Tuist.MCP.Server.server()
+
+    capabilities =
+      [
+        {map_size(server.tools) > 0, "tools"},
+        {map_size(server.resources) > 0, "resources"},
+        {map_size(server.prompts) > 0, "prompts"}
+      ]
+      |> Enum.filter(fn {present, _} -> present end)
+      |> Enum.map(fn {_, name} -> name end)
+
+    card = %{
+      serverInfo: %{
+        name: server.name,
+        version: server.version
+      },
+      transport: %{
+        endpoint: @mcp_path
+      },
+      capabilities: capabilities
+    }
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> json(card)
+  end
+
+  @doc """
   Returns the OpenID configuration for JWT verification.
   """
   def openid_configuration(conn, _params) do

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -403,6 +403,7 @@ defmodule TuistWeb.Router do
     get "/oauth-protected-resource", WellKnownController, :oauth_protected_resource
     get "/oauth-protected-resource/*resource_path", WellKnownController, :oauth_protected_resource
     get "/jwks.json", WellKnownController, :jwks
+    get "/mcp/server-card.json", WellKnownController, :mcp_server_card
     get "/apple-app-site-association", WellKnownController, :apple_app_site_association
     get "/assetlinks.json", WellKnownController, :assetlinks
   end

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -103,6 +103,22 @@ defmodule TuistWeb.WellKnownControllerTest do
     end
   end
 
+  describe "GET /.well-known/mcp/server-card.json" do
+    test "returns the MCP server card", %{conn: conn} do
+      conn = get(conn, "/.well-known/mcp/server-card.json")
+
+      response = json_response(conn, 200)
+      server = Tuist.MCP.Server.server()
+
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert response["serverInfo"]["name"] == server.name
+      assert response["serverInfo"]["version"] == server.version
+      assert response["transport"]["endpoint"] == "/mcp"
+      assert "tools" in response["capabilities"]
+      assert "prompts" in response["capabilities"]
+    end
+  end
+
   describe "GET /.well-known/openid_configuration" do
     test "returns the OpenID configuration", %{conn: conn} do
       issuer = "https://test.example.com"


### PR DESCRIPTION
## Summary
- Adds an MCP Server Card endpoint at `/.well-known/mcp/server-card.json` per [SEP-1649](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), so agents can discover the Tuist MCP server.
- The card is derived from `Tuist.MCP.Server.server()`: `serverInfo` (name, version), `transport.endpoint` (`/mcp`), and `capabilities` filtered to those actually registered (currently `tools` and `prompts`).

## Test plan
- [x] `mix test test/tuist_web/controllers/well_known_controller_test.exs`
- [ ] Verify with `POST https://isitagentready.com/api/scan` once deployed — `checks.discovery.mcpServerCard.status` should be `"pass"`.