### PR TITLE
fix(cli): restore [Path] overload of TestAction.testPlans as deprecated

### DIFF
--- a/cli/Sources/ProjectDescription/TestAction.swift
+++ b/cli/Sources/ProjectDescription/TestAction.swift
@@ -131,4 +131,27 @@ public struct TestAction: Equatable, Codable, Sendable {
             skippedTests: nil
         )
     }
+
+    /// Returns a test action from a list of test plan paths.
+    @_disfavoredOverload
+    @available(
+        *,
+        deprecated,
+        message: "Pass [TestPlan] instead — wrap each path with `.path(...)` or use a string literal."
+    )
+    public static func testPlans(
+        _ testPlans: [Path],
+        configuration: ConfigurationName = .debug,
+        attachDebugger: Bool = true,
+        preActions: [ExecutionAction] = [],
+        postActions: [ExecutionAction] = []
+    ) -> Self {
+        Self.testPlans(
+            testPlans.map(TestPlan.path),
+            configuration: configuration,
+            attachDebugger: attachDebugger,
+            preActions: preActions,
+            postActions: postActions
+        )
+    }
 }

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/TestAction+ManifestMapperTests.swift
@@ -288,6 +288,33 @@ struct TestActionManifestMapperTests {
         #expect(testAction.testPlans?[1].path == preConfiguredPath)
     }
 
+    @Test(.inTemporaryDirectory) func action_with_deprecated_path_array_overload() async throws {
+        // Given: callers on the pre-TestPlan API still pass `[Path]` directly, e.g.
+        //   func testPlans(for variant: Variant) -> [Path]
+        //   testAction: .testPlans(testPlans(for: variant))
+        // The deprecated overload must keep compiling and behave as if each path were `.path(...)`.
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let testPlanPath = temporaryDirectory.appending(component: "TestPlan.xctestplan")
+        try await fileSystem.writeText(testPlanContent, at: testPlanPath)
+
+        let paths: [ProjectDescription.Path] = [.path(testPlanPath.pathString)]
+
+        let manifest = ProjectDescription.TestAction.testPlans(paths)
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryDirectory, rootDirectory: temporaryDirectory)
+
+        // When
+        let testAction = try await XcodeGraph.TestAction.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths
+        )
+
+        // Then
+        #expect(testAction.testPlans?.count == 1)
+        #expect(testAction.testPlans?.first?.path == testPlanPath)
+        #expect(testAction.testPlans?.first?.kind == .referenced)
+        #expect(testAction.testPlans?.first?.isDefault == true)
+    }
+
     @Test(.inTemporaryDirectory, .withScopedAlertController())
     func action_with_literal_test_plan_missing_file_warns() async throws {
         // Given


### PR DESCRIPTION
Resolves the regression reported by Jon Bailey in Slack — after upgrading, manifests using the pre-existing `[Path]` form of `TestAction.testPlans` failed to compile.

### What changed

PR #10426 changed `TestAction.testPlans(_:)` from accepting `[Path]` to `[TestPlan]` without a deprecation path. Real-world setups like:

```swift
func testPlans(for variant: Variant) -> [Path]
testAction: .testPlans(testPlans(for: variant))
```

stopped compiling against `ProjectDescription` because `[Path]` no longer matches the new signature. ProjectDescription is a public surface and changes to it should go through deprecation, not silent breakage.

This PR adds a `@_disfavoredOverload`-tagged deprecated `[Path]` overload that maps each path through `TestPlan.path(...)` and forwards to the new API:

```swift
@_disfavoredOverload
@available(*, deprecated, message: "Pass [TestPlan] instead — wrap each path with `.path(...)` or use a string literal.")
public static func testPlans(_ testPlans: [Path], ...) -> Self {
    Self.testPlans(testPlans.map(TestPlan.path), ...)
}
```

`@_disfavoredOverload` is required: without it, `.testPlans([])`, `.testPlans([.path("...")])`, and `.testPlans(["..."])` would either be ambiguous or pick the deprecated overload (since `Path` itself has a `static func path(_:String)` factory). With it, only call sites whose argument is unambiguously `[Path]` fall through to the deprecated overload, and everything else keeps resolving cleanly to the new `[TestPlan]` API.

### How to test locally

Unit test added in `TestActionManifestMapperTests`:

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace \
  -only-testing:TuistLoaderTests/TestActionManifestMapperTests \
  -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

End-to-end check (the failure mode Jon hit) — drop a `Project.swift` like:

```swift
import ProjectDescription

func testPlans(for variant: String) -> [Path] {
    ["TestPlans/Smoke.xctestplan", "TestPlans/Full.xctestplan"]
}

let project = Project(
    name: "App",
    targets: [/* … */],
    schemes: [
        .scheme(
            name: "App",
            buildAction: .buildAction(targets: ["App"]),
            testAction: .testPlans(testPlans(for: "debug")),
            runAction: .runAction(configuration: .debug, executable: "App")
        ),
    ]
)
```

then run `tuist generate --no-open`. The manifest compiles (with a deprecation warning pointing to the new API) and the generated `App.xcscheme` contains both `<TestPlanReference>` entries with the first plan marked default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)