### PR TITLE
fix(server): raise ingress-nginx body size to unblock createBundle

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -28,6 +28,15 @@ server:
     port: 80
     targetPort: 8080
 
+  # ingress-nginx defaults `proxy-body-size` to 1m, which rejects large
+  # `createBundle` requests (the JSON manifest carries one entry per
+  # artifact and grows past 1 MB on big iOS apps). Match the Phoenix
+  # Plug.Parsers limit at lib/tuist_web/endpoint.ex so the two stay in
+  # lockstep — bump both when bumping either.
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
   # All runtime secrets (DATABASE_URL, CLICKHOUSE_URL, S3 creds, Sentry, Stripe,
   # OAuth, Mailgun, etc.) live in priv/secrets/<env>.yml.enc baked into the
   # image. The app decrypts them at boot when MASTER_KEY is present in the


### PR DESCRIPTION
## Summary

`tuist inspect bundle` started failing for large iOS apps at ~14:31 UTC today with two symptoms — `unknownError(502)` on `createBundle`, and `unknown server response of 413` on the bundle upload itself.

Root cause: today's release [server@1.173.0](https://github.com/tuist/tuist/commit/aedd70ce0c) was the first successful production deploy since [#10400](https://github.com/tuist/tuist/pull/10400) (Apr 23) — every prior deploy failed on the bigint widening migration, finally cleared by [#10477](https://github.com/tuist/tuist/pull/10477). That successful deploy carried the Render → Syself Kubernetes cutover ([#10368](https://github.com/tuist/tuist/pull/10368)), so production traffic now flows through `ingress-nginx` for the first time.

`ingress-nginx` defaults `proxy-body-size` to `1m`. The `createBundle` JSON ([bundles_controller.ex#L179](https://github.com/tuist/tuist/blob/main/server/lib/tuist_web/controllers/api/bundles_controller.ex#L179)) carries one `BundleArtifact` entry per file in the IPA — for large apps this easily exceeds 1 MB. nginx rejects with 413; Cloudflare or the Swift OpenAPI client surface that as either a raw 413 or a 502 with an undecodable body (no 413 declared in the OpenAPI responses, so Swift's generated `Client.swift` can't deserialize the nginx error page).

The Phoenix-level `Plug.Parsers` limit at [endpoint.ex#L105](https://github.com/tuist/tuist/blob/main/server/lib/tuist_web/endpoint.ex#L105) is `50_000_000`. This PR sets the ingress annotation to match, so the two stay in lockstep — Phoenix is still authoritative; nginx no longer rejects ahead of it.

The annotation lives in `values-managed-common.yaml` so it applies to canary, staging, and production via deep-merge with each overlay's `server.ingress` block. Verified via `helm template` against all three overlays.

## Notes

- This does **not** revisit the bigint widening — that needs a separate, out-of-band approach as called out in [#10477](https://github.com/tuist/tuist/pull/10477).
- The Phoenix `length: 50_000_000` was originally sized for `/api/runs` (per the comment at [endpoint.ex#L98](https://github.com/tuist/tuist/blob/main/server/lib/tuist_web/endpoint.ex#L98)). If 50 MB turns out to be too tight for the largest realistic `createBundle` payloads, both numbers should bump together.

## Follow-up

This is a stop-gap. The longer-term fix is to stop sending the artifact manifest as a single JSON blob from the CLI: have the CLI upload the raw bundle (`.ipa` / `.xcarchive`) to object storage and let the server unpack and analyze it. That removes the request-size ceiling entirely, moves heavy parsing off user machines, and lets us iterate on bundle analysis without shipping a new CLI.

## Test plan

- [x] `helm template` renders the annotation on the production, staging, and canary `server-ingress.yaml`
- [ ] Deploy to canary and re-run `tuist inspect bundle` against `canary.tuist.dev`
- [ ] Promote to staging, then production once canary is clean