### PR TITLE
fix(server): remove unused quarantined_count_at to unblock prod build

### DIFF
--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -315,19 +315,6 @@ defmodule Tuist.Tests.Analytics do
     DateTime.add(datetime, 3599, :second)
   end
 
-  defp quarantined_count_at(project_id, datetime) do
-    inner =
-      from(tc in TestCase,
-        where: tc.project_id == ^project_id,
-        where: tc.inserted_at <= ^datetime,
-        group_by: tc.id,
-        having: fragment("argMax(?, ?) = 'muted'", tc.state, tc.inserted_at),
-        select: tc.id
-      )
-
-    ClickHouseRepo.one(from(tc in subquery(inner), select: count())) || 0
-  end
-
   @scatter_data_limit 10_000
 
   def test_run_duration_scatter_data(project_id, opts \\ []) do


### PR DESCRIPTION
## Summary
- Production Deployment ([run 25011204551](https://github.com/tuist/tuist/actions/runs/25011204551)) failed in the `Build server image` job because `mix compile --warnings-as-errors` flagged `Tuist.Tests.Analytics.quarantined_count_at/2` as unused.
- The function's only call site was removed in [#10373](https://github.com/tuist/tuist/pull/10373) (`feat(server): move filters to page level for tests related pages`), which replaced `quarantined_count_at(project_id, end_datetime)` with `List.last(values) || 0` but left the `defp` behind.
- `grep` confirms no other callers, so this PR deletes the dead function.

## Test plan
- [ ] CI: `Build server image` step passes (`mix compile --warnings-as-errors` succeeds)
- [ ] Production Deployment workflow proceeds past the build stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)