### PR TITLE
feat(server): alert on ingress-nginx 4xx/5xx for tuist-server

### DIFF
--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -11,6 +11,7 @@ Wraps [`grafana/k8s-monitoring`](https://github.com/grafana/k8s-monitoring-helm)
 | node-exporter | Deployed as DaemonSet (node CPU / mem / disk / net) |
 | kubelet + cAdvisor | Scraped (container resource usage) |
 | Kubernetes Events | Streamed to Loki as structured logs |
+| Alert rules | YAML under [`alerts/`](./alerts) synced to Grafana Cloud Mimir on every `helm upgrade` (see [Alerting](#alerting)) |
 
 With these in place the Grafana Cloud **Observability → Kubernetes** app populates automatically (Cluster / Namespace / Workload / Pod / Node views) without importing dashboards by hand.
 
@@ -96,6 +97,23 @@ curl -s http://localhost:12345/metrics | grep 'prometheus_remote_storage_samples
 ```
 
 In Grafana Cloud: **Observability → Kubernetes → Cluster navigation** and pick the cluster by name (`tuist-staging` / `tuist-canary` / `tuist-production`).
+
+## Alerting
+
+Grafana Cloud Mimir evaluates alert rules server-side, so there is no in-cluster Prometheus or Alertmanager to configure. Rule groups live as YAML files under [`alerts/`](./alerts) in this chart and are pushed to Mimir on every `helm upgrade` by a Job that runs `mimirtool rules sync` against the same Grafana Cloud stack metrics flow into. The Job authenticates with the existing `prometheus-username` / `prometheus-password` keys from the ESO-managed Grafana Cloud Secret — no extra credentials.
+
+Each YAML file under `alerts/` is a self-contained Mimir rule namespace (`namespace:` at the top, `groups:` below). `mimirtool rules sync` is declarative: rules in the file get created or updated, rules in Mimir not present in the file get deleted, so the file is the source of truth for that namespace. Rolling back a whole rule namespace is `mimirtool rules delete-namespace <name>` against the same endpoint.
+
+The sync runs from every environment install. Mimir's ruler API doesn't shard by tenant on push (single Grafana Cloud stack across staging / canary / production), so the redundant runs converge on the same target state and self-heal if Mimir's view ever drifts. If you want to disable the sync for a specific environment, set `alertRules.enabled: false` in that overlay.
+
+To add a new rule:
+
+1. Drop a `<name>.yaml` file under `alerts/` with the rule namespace and groups.
+2. `helm template ...` to confirm it renders into the ConfigMap (see [Local validation](#local-validation)).
+3. `mimirtool rules check alerts/<name>.yaml` to lint the PromQL.
+4. Open a PR — the next deploy syncs it.
+
+`alerts/ingress-nginx.yaml` covers the `tuist-tuist-server` Ingress and is intentionally scoped — see the file header for the rationale and aggregation choices.
 
 ## Label conventions (for dashboards / queries)
 

--- a/infra/helm/k8s-monitoring/alerts/ingress-nginx.yaml
+++ b/infra/helm/k8s-monitoring/alerts/ingress-nginx.yaml
@@ -1,0 +1,90 @@
+# Prometheus rule group for the tuist-server Ingress, evaluated by
+# Grafana Cloud Mimir. Synced from this file by the `alert-rules-sync`
+# Job in this chart on every install/upgrade.
+#
+# Why this exists: ingress-nginx returns 4xx/5xx itself (413, 429, 499,
+# 502, 504) before the request ever reaches Phoenix, so Sentry — which
+# only sees what the app receives — cannot catch these. Without a
+# proxy-layer alert the next regression in this category gets reported
+# to us by a customer in Slack, the way `tuist inspect bundle` was
+# (PR #10492 raised proxy-body-size from 1m to 50m).
+#
+# Aggregation is `by (env, cluster)` so each environment fires its own
+# alert independently — same rule definition, three evaluation contexts.
+# Filtering only on `ingress` (not `namespace`) sidesteps the
+# `namespace` vs `exported_namespace` ambiguity that depends on the
+# scrape's `honor_labels` setting; the Ingress name is unique across
+# the stack.
+#
+# `mimirtool rules sync` picks up the namespace from this top-level
+# field, so the entire rule set under `tuist-server-ingress` can be
+# rolled back atomically with `mimirtool rules delete-namespace
+# tuist-server-ingress`.
+namespace: tuist-server-ingress
+groups:
+  - name: tuist-server-ingress-availability
+    interval: 30s
+    rules:
+      - alert: TuistServerIngress5xx
+        expr: |
+          sum by (env, cluster, ingress) (
+            rate(nginx_ingress_controller_requests{ingress="tuist-tuist-server", status=~"5.."}[5m])
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: tuist-server
+          component: ingress-nginx
+        annotations:
+          summary: "tuist-server ingress is returning 5xx ({{ $labels.env }})"
+          description: |-
+            ingress-nginx is returning 5xx for the tuist-server Ingress
+            in env={{ $labels.env }} cluster={{ $labels.cluster }} at
+            {{ printf "%.2f" $value }} req/s sustained over 5m.
+
+            5xx at the ingress layer means nginx itself returned the
+            error before Phoenix saw the request — Sentry will not have
+            caught it. Common causes: 502 (upstream pod
+            unreachable/crashing), 503 (upstream not ready), 504
+            (upstream timeout).
+
+            Triage:
+              - kubectl -n {{ if eq $labels.env "production" }}tuist{{ else }}tuist-{{ $labels.env }}{{ end }} get pods,events --sort-by=.lastTimestamp
+              - Grafana Cloud → Logs → ingress-nginx controller pod logs
+                in the `platform` namespace
+              - Grafana Cloud → Logs → tuist-server pod logs for the
+                same time window
+          runbook_url: "https://github.com/tuist/tuist/pull/10492"
+
+      - alert: TuistServerIngressBlocking4xx
+        expr: |
+          sum by (env, cluster, ingress, status) (
+            rate(nginx_ingress_controller_requests{ingress="tuist-tuist-server", status=~"413|429|499"}[5m])
+          ) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          service: tuist-server
+          component: ingress-nginx
+        annotations:
+          summary: "tuist-server ingress blocking requests at the proxy ({{ $labels.status }} in {{ $labels.env }})"
+          description: |-
+            ingress-nginx is returning HTTP {{ $labels.status }} for the
+            tuist-server Ingress in env={{ $labels.env }} cluster={{ $labels.cluster }}
+            at {{ printf "%.2f" $value }} req/s sustained over 10m.
+
+            These status codes indicate the proxy layer is rejecting or
+            terminating requests before Phoenix can see them, so Sentry
+            cannot catch them:
+              - 413 Payload Too Large — body exceeded proxy-body-size
+                (the regression PR #10492 fixed: 1 MB default rejected
+                bundle metadata for large iOS apps after the Render →
+                Syself cutover in 1.173.0)
+              - 429 Too Many Requests — rate limit hit at the proxy
+              - 499 Client Closed Request — nginx-specific code that
+                usually means upstream slowness caused the client to
+                give up
+
+            General 401/404 are intentionally excluded — they're noisy
+            and rarely indicate a regression in this category.
+          runbook_url: "https://github.com/tuist/tuist/pull/10492"

--- a/infra/helm/k8s-monitoring/templates/alert-rules-configmap.yaml
+++ b/infra/helm/k8s-monitoring/templates/alert-rules-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.alertRules.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-alert-rules
+  namespace: {{ .Release.Namespace }}
+  # Re-render and re-sync on every upgrade by hashing the bundled rule
+  # files into the ConfigMap name? — no: keeping a stable name means
+  # `mimirtool rules sync` sees the diff and reconciles. The hook Job
+  # itself runs on every upgrade, so the ConfigMap content changing is
+  # what drives the sync.
+  annotations:
+    # Tie the ConfigMap to the same hook lifecycle as the Job that reads
+    # it. Without this, the Job's pre-create hook-delete would tear down
+    # the Job before the ConfigMap is mounted.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  {{- range $path, $_ := .Files.Glob "alerts/*.yaml" }}
+  {{ base $path }}: |-
+    {{- $.Files.Get $path | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/k8s-monitoring/templates/alert-rules-sync-job.yaml
+++ b/infra/helm/k8s-monitoring/templates/alert-rules-sync-job.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.alertRules.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-alert-rules-sync
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Run after the ConfigMap and the Grafana Cloud Secret are in place
+    # but before the chart is considered "ready" — failures here should
+    # surface as a failed `helm upgrade` rather than silently leaving
+    # alerts stale.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  # Three retries handle transient Grafana Cloud blips (502s from the
+  # ruler API are not unheard of); beyond that we want the helm release
+  # to fail loudly so the deploy workflow surfaces it.
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      name: {{ .Release.Name }}-alert-rules-sync
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: mimirtool
+          image: "{{ .Values.alertRules.image.repository }}:{{ .Values.alertRules.image.tag }}"
+          imagePullPolicy: {{ .Values.alertRules.image.pullPolicy }}
+          # `mimirtool rules sync` reads the namespace from the top-level
+          # `namespace:` field in each YAML file under /alerts and
+          # reconciles Mimir's ruler state to match — creating, updating
+          # or deleting rule groups as needed. The endpoint is the same
+          # base URL the metrics push to.
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              for f in /alerts/*.yaml; do
+                echo "Syncing $f"
+                mimirtool rules sync \
+                  --address="$MIMIR_ADDRESS" \
+                  --id="$MIMIR_TENANT_ID" \
+                  --key="$MIMIR_API_KEY" \
+                  "$f"
+              done
+          env:
+            - name: MIMIR_ADDRESS
+              value: {{ .Values.grafanaCloud.prometheus.url | quote }}
+            - name: MIMIR_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.grafanaCloud.secretName }}
+                  key: prometheus-username
+            - name: MIMIR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.grafanaCloud.secretName }}
+                  key: prometheus-password
+          volumeMounts:
+            - name: alert-rules
+              mountPath: /alerts
+              readOnly: true
+          resources:
+            {{- toYaml .Values.alertRules.resources | nindent 12 }}
+      volumes:
+        - name: alert-rules
+          configMap:
+            name: {{ .Release.Name }}-alert-rules
+{{- end }}

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -23,6 +23,10 @@ grafanaCloud:
   secretName: k8s-monitoring-grafana-cloud
   prometheus:
     username: "1774467"
+    # Base URL of the Grafana Cloud Mimir stack — used by the alert-rules
+    # sync Job below as `mimirtool --address`. The remote_write URL under
+    # `destinations.grafana-cloud-metrics.url` is this base + /api/prom/push.
+    url: https://prometheus-prod-24-prod-eu-west-2.grafana.net
     token:
       item: PROMETHEUS_TOKEN
       field: password
@@ -36,6 +40,36 @@ grafanaCloud:
     token:
       item: TEMPO_TOKEN
       field: password
+
+# Alert rules synced to Grafana Cloud Mimir's ruler API.
+#
+# Mimir evaluates rules server-side, so there's no in-cluster Prometheus
+# / Alertmanager. We ship rule groups as static YAML files under
+# `alerts/` in this chart, render them into a ConfigMap, and run a
+# `grafana/mimirtool rules sync` Job as a Helm post-install/post-upgrade
+# hook against the same Grafana Cloud stack the metrics flow into. The
+# Job uses the existing `prometheus-username` / `prometheus-password`
+# keys from the grafanaCloud Secret — no extra credentials needed.
+#
+# Sync runs on every `helm upgrade`, from every environment. Mimir rule
+# group sync is idempotent, so the redundant runs from staging / canary
+# / production all converge on the same target state and self-heal if
+# the cluster's view ever drifts.
+alertRules:
+  enabled: true
+  # Image used by the post-install/post-upgrade hook Job.
+  image:
+    repository: grafana/mimirtool
+    tag: 2.16.0
+    pullPolicy: IfNotPresent
+  # Resource floor for the short-lived sync Job. mimirtool spends most
+  # of its time blocked on the Mimir ruler API, so this is generous.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
 
 # Upstream grafana/k8s-monitoring chart values. Everything under this key
 # is passed verbatim to the subchart — see


### PR DESCRIPTION
## Summary

- Wires Prometheus alert rules for the `tuist-tuist-server` Ingress, evaluated by Grafana Cloud Mimir, so the next proxy-layer regression in the shape of [#10492](https://github.com/tuist/tuist/pull/10492) (1 MB body-size limit silently rejecting bundle metadata for `tuist inspect bundle`) is caught before a customer reports it in Slack. Sentry is blind to these because nginx returns the error before the request ever reaches Phoenix.
- Ships two alerts on `nginx_ingress_controller_requests`, scoped to the tuist-server Ingress and aggregated `by (env, cluster)` so each environment fires independently:
  - `TuistServerIngress5xx` — `severity: critical`, `> 0.05 req/s` for 5m
  - `TuistServerIngressBlocking4xx` — `severity: warning` on 413/429/499 only (excludes noisy 401/404), `> 0.1 req/s` for 10m
- Adds an `alerts/` directory + post-install/post-upgrade `mimirtool rules sync` Job to the k8s-monitoring chart. Auth reuses the existing ESO Grafana Cloud Secret (`prometheus-username` / `prometheus-password`) — no extra credentials. Sync runs from every environment install and is idempotent.

## Why a Helm-managed sync Job

There is no in-cluster Prometheus or Alertmanager — metrics flow to Grafana Cloud Mimir, which evaluates rules server-side. So `PrometheusRule` CRs (the operator-native pattern) wouldn't be picked up by anything: there's no Prometheus Operator running, and the [grafana/k8s-monitoring chart's `prometheusOperatorObjects`](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-prometheus-operator-objects) feature only handles `ServiceMonitor` / `PodMonitor` / `Probe`, not `PrometheusRule`. The sync-job pattern keeps rule definitions declarative and version-controlled in this repo, scoped to the same Helm lifecycle as the rest of the observability stack.

## Test plan

- [x] `helm lint` clean across all three overlays (staging / canary / production)
- [x] `helm template` renders both the ConfigMap and the post-install Job for each overlay; rendered command, env vars, and volume mounts inspected
- [x] `promtool check rules` passes on the rule file (after stripping the Mimir `namespace:` key)
- [x] Embedded YAML in the ConfigMap re-parses cleanly as a Mimir rule namespace with two alerts
- [ ] Deploy to canary, confirm the `*-alert-rules-sync` Job lands `Completed`, and verify the rule group appears under namespace `tuist-server-ingress` in Grafana Cloud → Alerts & IRM → Mimir-managed rules
- [ ] Manually fire the 4xx alert by sending a >50 MB body through the canary ingress — expect a 413 from nginx, then the alert in Grafana Cloud after the `for: 10m` window
- [ ] After ~24h on canary, confirm no false-positives at the chosen thresholds (`> 0.05` for 5xx, `> 0.1` for 413/429/499); tune in a follow-up if baseline says otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)