### PR TITLE
fix(server): unflake tests pages and shorten Test job runtime

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -187,11 +187,6 @@ jobs:
           install_args: "erlang elixir github:ClickHouse/ClickHouse"
           cache: "false"
           working_directory: server
-      # Cache key is bumped (mix-test-v2) to force a one-time refresh.
-      # `actions/cache@v4` only saves on cache miss, so a previously-saved
-      # cache that lacked `_build/test` would keep being restored forever
-      # and recompile every run. The MIX_ENV-scoped key prevents a dev-env
-      # cache from contaminating the test job.
       - name: Restore Mix Cache
         uses: actions/cache@v4
         with:
@@ -203,8 +198,6 @@ jobs:
             mix-test-v2-
       - name: Install dependencies
         run: mix deps.get
-      # Compile in its own step so its time is visible in the job timeline
-      # and so `mix ecto.create` / `mix test` don't trigger a fresh compile.
       - name: Compile
         run: mix compile --warnings-as-errors
       - name: Start ClickHouse

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -187,17 +187,26 @@ jobs:
           install_args: "erlang elixir github:ClickHouse/ClickHouse"
           cache: "false"
           working_directory: server
+      # Cache key is bumped (mix-test-v2) to force a one-time refresh.
+      # `actions/cache@v4` only saves on cache miss, so a previously-saved
+      # cache that lacked `_build/test` would keep being restored forever
+      # and recompile every run. The MIX_ENV-scoped key prevents a dev-env
+      # cache from contaminating the test job.
       - name: Restore Mix Cache
         uses: actions/cache@v4
         with:
           path: |
             server/deps
             server/_build
-          key: mix-${{ hashFiles('server/mix.lock') }}
+          key: mix-test-v2-${{ hashFiles('server/mix.lock') }}
           restore-keys: |
-            mix-
+            mix-test-v2-
       - name: Install dependencies
         run: mix deps.get
+      # Compile in its own step so its time is visible in the job timeline
+      # and so `mix ecto.create` / `mix test` don't trigger a fresh compile.
+      - name: Compile
+        run: mix compile --warnings-as-errors
       - name: Start ClickHouse
         run: mise run --no-deps clickhouse:start
       - name: Setup database

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1577,52 +1577,44 @@ defmodule Tuist.Tests do
   end
 
   defp build_flaky_test_cases_query(project_id, search_term, opts) do
-    currently_flaky_subquery = currently_flaky_test_case_ids_subquery(project_id, opts)
-    stats_subquery = build_flaky_stats_subquery(project_id, opts)
-
     base_query =
-      if stats_filter?(opts) do
-        from(test_case in TestCase,
-          hints: ["FINAL"],
-          inner_join: flaky in subquery(currently_flaky_subquery),
-          on: test_case.id == flaky.test_case_id,
-          inner_join: stats in subquery(stats_subquery),
-          on: test_case.id == stats.test_case_id,
-          where: test_case.project_id == ^project_id,
-          select: %{
-            id: test_case.id,
-            name: test_case.name,
-            module_name: test_case.module_name,
-            suite_name: test_case.suite_name,
-            flaky_runs_count: stats.flaky_runs_count,
-            last_flaky_at: stats.last_flaky_at,
-            last_flaky_run_id: stats.last_flaky_run_id
-          }
-        )
-      else
-        from(test_case in TestCase,
-          hints: ["FINAL"],
-          inner_join: flaky in subquery(currently_flaky_subquery),
-          on: test_case.id == flaky.test_case_id,
-          left_join: stats in subquery(stats_subquery),
-          on: test_case.id == stats.test_case_id,
-          where: test_case.project_id == ^project_id,
-          select: %{
-            id: test_case.id,
-            name: test_case.name,
-            module_name: test_case.module_name,
-            suite_name: test_case.suite_name,
-            flaky_runs_count: coalesce(stats.flaky_runs_count, 0),
-            last_flaky_at: stats.last_flaky_at,
-            last_flaky_run_id: stats.last_flaky_run_id
-          }
-        )
-      end
+      from(test_case in TestCase,
+        hints: ["FINAL"],
+        inner_join: flaky in subquery(currently_flaky_test_case_ids_subquery(project_id, opts)),
+        on: test_case.id == flaky.test_case_id,
+        inner_join: stats in subquery(flaky_stats_subquery(project_id, opts)),
+        on: test_case.id == stats.test_case_id,
+        where: test_case.project_id == ^project_id,
+        select: %{
+          id: test_case.id,
+          name: test_case.name,
+          module_name: test_case.module_name,
+          suite_name: test_case.suite_name,
+          flaky_runs_count: stats.flaky_runs_count,
+          last_flaky_at: stats.last_flaky_at,
+          last_flaky_run_id: stats.last_flaky_run_id
+        }
+      )
 
     apply_name_search(base_query, search_term)
   end
 
-  defp build_flaky_stats_subquery(project_id, opts) do
+  defp build_flaky_test_cases_count_query(project_id, search_term, opts) do
+    base_query =
+      from(test_case in TestCase,
+        hints: ["FINAL"],
+        inner_join: flaky in subquery(currently_flaky_test_case_ids_subquery(project_id, opts)),
+        on: test_case.id == flaky.test_case_id,
+        inner_join: stats in subquery(flaky_stats_subquery(project_id, opts)),
+        on: test_case.id == stats.test_case_id,
+        where: test_case.project_id == ^project_id,
+        select: count(test_case.id)
+      )
+
+    apply_name_search(base_query, search_term)
+  end
+
+  defp flaky_stats_subquery(project_id, opts) do
     from(flaky_run in FlakyTestCaseRun,
       where: flaky_run.project_id == ^project_id,
       group_by: flaky_run.test_case_id,
@@ -1635,48 +1627,6 @@ defmodule Tuist.Tests do
     )
     |> apply_flaky_time_filter(opts)
     |> apply_flaky_environment_filter(opts)
-  end
-
-  defp build_flaky_test_cases_count_query(project_id, search_term, opts) do
-    currently_flaky_subquery = currently_flaky_test_case_ids_subquery(project_id, opts)
-
-    base_query =
-      if stats_filter?(opts) do
-        stats_id_subquery =
-          from(flaky_run in FlakyTestCaseRun,
-            where: flaky_run.project_id == ^project_id,
-            group_by: flaky_run.test_case_id,
-            select: %{test_case_id: flaky_run.test_case_id}
-          )
-          |> apply_flaky_time_filter(opts)
-          |> apply_flaky_environment_filter(opts)
-
-        from(test_case in TestCase,
-          hints: ["FINAL"],
-          inner_join: flaky in subquery(currently_flaky_subquery),
-          on: test_case.id == flaky.test_case_id,
-          inner_join: stats in subquery(stats_id_subquery),
-          on: test_case.id == stats.test_case_id,
-          where: test_case.project_id == ^project_id,
-          select: count(test_case.id)
-        )
-      else
-        from(test_case in TestCase,
-          hints: ["FINAL"],
-          inner_join: flaky in subquery(currently_flaky_subquery),
-          on: test_case.id == flaky.test_case_id,
-          where: test_case.project_id == ^project_id,
-          select: count(test_case.id)
-        )
-      end
-
-    apply_name_search(base_query, search_term)
-  end
-
-  defp stats_filter?(opts) do
-    not is_nil(Keyword.get(opts, :start_datetime)) or
-      not is_nil(Keyword.get(opts, :end_datetime)) or
-      not is_nil(Keyword.get(opts, :is_ci))
   end
 
   defp currently_flaky_test_case_ids_subquery(project_id, opts) do

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -1578,56 +1578,105 @@ defmodule Tuist.Tests do
 
   defp build_flaky_test_cases_query(project_id, search_term, opts) do
     currently_flaky_subquery = currently_flaky_test_case_ids_subquery(project_id, opts)
-
-    stats_subquery =
-      from(flaky_run in FlakyTestCaseRun,
-        where: flaky_run.project_id == ^project_id,
-        group_by: flaky_run.test_case_id,
-        select: %{
-          test_case_id: flaky_run.test_case_id,
-          flaky_runs_count: count(flaky_run.test_case_id),
-          last_flaky_at: max(flaky_run.inserted_at),
-          last_flaky_run_id: fragment("argMax(test_run_id, inserted_at)")
-        }
-      )
-      |> apply_flaky_time_filter(opts)
-      |> apply_flaky_environment_filter(opts)
+    stats_subquery = build_flaky_stats_subquery(project_id, opts)
 
     base_query =
-      from(test_case in TestCase,
-        hints: ["FINAL"],
-        inner_join: flaky in subquery(currently_flaky_subquery),
-        on: test_case.id == flaky.test_case_id,
-        left_join: stats in subquery(stats_subquery),
-        on: test_case.id == stats.test_case_id,
-        where: test_case.project_id == ^project_id,
-        select: %{
-          id: test_case.id,
-          name: test_case.name,
-          module_name: test_case.module_name,
-          suite_name: test_case.suite_name,
-          flaky_runs_count: coalesce(stats.flaky_runs_count, 0),
-          last_flaky_at: stats.last_flaky_at,
-          last_flaky_run_id: stats.last_flaky_run_id
-        }
-      )
+      if stats_filter?(opts) do
+        from(test_case in TestCase,
+          hints: ["FINAL"],
+          inner_join: flaky in subquery(currently_flaky_subquery),
+          on: test_case.id == flaky.test_case_id,
+          inner_join: stats in subquery(stats_subquery),
+          on: test_case.id == stats.test_case_id,
+          where: test_case.project_id == ^project_id,
+          select: %{
+            id: test_case.id,
+            name: test_case.name,
+            module_name: test_case.module_name,
+            suite_name: test_case.suite_name,
+            flaky_runs_count: stats.flaky_runs_count,
+            last_flaky_at: stats.last_flaky_at,
+            last_flaky_run_id: stats.last_flaky_run_id
+          }
+        )
+      else
+        from(test_case in TestCase,
+          hints: ["FINAL"],
+          inner_join: flaky in subquery(currently_flaky_subquery),
+          on: test_case.id == flaky.test_case_id,
+          left_join: stats in subquery(stats_subquery),
+          on: test_case.id == stats.test_case_id,
+          where: test_case.project_id == ^project_id,
+          select: %{
+            id: test_case.id,
+            name: test_case.name,
+            module_name: test_case.module_name,
+            suite_name: test_case.suite_name,
+            flaky_runs_count: coalesce(stats.flaky_runs_count, 0),
+            last_flaky_at: stats.last_flaky_at,
+            last_flaky_run_id: stats.last_flaky_run_id
+          }
+        )
+      end
 
     apply_name_search(base_query, search_term)
+  end
+
+  defp build_flaky_stats_subquery(project_id, opts) do
+    from(flaky_run in FlakyTestCaseRun,
+      where: flaky_run.project_id == ^project_id,
+      group_by: flaky_run.test_case_id,
+      select: %{
+        test_case_id: flaky_run.test_case_id,
+        flaky_runs_count: count(flaky_run.test_case_id),
+        last_flaky_at: max(flaky_run.inserted_at),
+        last_flaky_run_id: fragment("argMax(test_run_id, inserted_at)")
+      }
+    )
+    |> apply_flaky_time_filter(opts)
+    |> apply_flaky_environment_filter(opts)
   end
 
   defp build_flaky_test_cases_count_query(project_id, search_term, opts) do
     currently_flaky_subquery = currently_flaky_test_case_ids_subquery(project_id, opts)
 
     base_query =
-      from(test_case in TestCase,
-        hints: ["FINAL"],
-        inner_join: flaky in subquery(currently_flaky_subquery),
-        on: test_case.id == flaky.test_case_id,
-        where: test_case.project_id == ^project_id,
-        select: count(test_case.id)
-      )
+      if stats_filter?(opts) do
+        stats_id_subquery =
+          from(flaky_run in FlakyTestCaseRun,
+            where: flaky_run.project_id == ^project_id,
+            group_by: flaky_run.test_case_id,
+            select: %{test_case_id: flaky_run.test_case_id}
+          )
+          |> apply_flaky_time_filter(opts)
+          |> apply_flaky_environment_filter(opts)
+
+        from(test_case in TestCase,
+          hints: ["FINAL"],
+          inner_join: flaky in subquery(currently_flaky_subquery),
+          on: test_case.id == flaky.test_case_id,
+          inner_join: stats in subquery(stats_id_subquery),
+          on: test_case.id == stats.test_case_id,
+          where: test_case.project_id == ^project_id,
+          select: count(test_case.id)
+        )
+      else
+        from(test_case in TestCase,
+          hints: ["FINAL"],
+          inner_join: flaky in subquery(currently_flaky_subquery),
+          on: test_case.id == flaky.test_case_id,
+          where: test_case.project_id == ^project_id,
+          select: count(test_case.id)
+        )
+      end
 
     apply_name_search(base_query, search_term)
+  end
+
+  defp stats_filter?(opts) do
+    not is_nil(Keyword.get(opts, :start_datetime)) or
+      not is_nil(Keyword.get(opts, :end_datetime)) or
+      not is_nil(Keyword.get(opts, :is_ci))
   end
 
   defp currently_flaky_test_case_ids_subquery(project_id, opts) do

--- a/server/test/tuist_web/live/flaky_tests_live_test.exs
+++ b/server/test/tuist_web/live/flaky_tests_live_test.exs
@@ -160,9 +160,21 @@ defmodule TuistWeb.FlakyTestsLiveTest do
 
     IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
 
+    # The flaky-tests page derives "currently flaky" from `marked_flaky` events
+    # (see Tuist.Tests.currently_flaky_test_case_ids_subquery/2). Anchor the
+    # event timestamp to the run's ran_at so it falls inside the page's
+    # second-truncated date window.
+    ran_at = Keyword.get(opts, :ran_at, NaiveDateTime.add(NaiveDateTime.utc_now(), -60))
+
+    RunsFixtures.test_case_event_fixture(
+      test_case_id: test_case.id,
+      event_type: "marked_flaky",
+      inserted_at: ran_at
+    )
+
     RunsFixtures.test_case_run_fixture(
       Keyword.merge(
-        [project_id: project.id, test_case_id: test_case.id, is_flaky: true],
+        [project_id: project.id, test_case_id: test_case.id, is_flaky: true, ran_at: ran_at],
         opts
       )
     )

--- a/server/test/tuist_web/live/flaky_tests_live_test.exs
+++ b/server/test/tuist_web/live/flaky_tests_live_test.exs
@@ -17,7 +17,8 @@ defmodule TuistWeb.FlakyTestsLiveTest do
       project: project
     } do
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests")
 
       # Then
       assert has_element?(lv, "[data-part='flaky-tests']")
@@ -35,7 +36,8 @@ defmodule TuistWeb.FlakyTestsLiveTest do
       RunsFixtures.optimize_test_case_runs()
 
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests")
 
       # Then
       assert has_element?(lv, "[data-part='flaky-tests-table']")
@@ -55,7 +57,10 @@ defmodule TuistWeb.FlakyTestsLiveTest do
 
       # When
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?search=First")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?search=First"
+        )
 
       # Then
       assert has_element?(lv, "#flaky-tests-table", "testFirstFlaky")
@@ -69,7 +74,10 @@ defmodule TuistWeb.FlakyTestsLiveTest do
     } do
       # When
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?sort_by=name&sort_order=asc")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?sort_by=name&sort_order=asc"
+        )
 
       # Then
       assert has_element?(lv, "[data-part='flaky-tests']")
@@ -82,7 +90,10 @@ defmodule TuistWeb.FlakyTestsLiveTest do
     } do
       # When
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?sort_by=invalid_field")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?sort_by=invalid_field"
+        )
 
       # Then
       assert has_element?(lv, "[data-part='flaky-tests']")
@@ -101,7 +112,10 @@ defmodule TuistWeb.FlakyTestsLiveTest do
 
       # When - filter by CI environment
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?analytics-environment=ci")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/flaky-tests?analytics-environment=ci"
+        )
 
       # Then
       assert has_element?(lv, "#flaky-tests-table", "testCIFlaky")
@@ -160,10 +174,6 @@ defmodule TuistWeb.FlakyTestsLiveTest do
 
     IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
 
-    # The flaky-tests page derives "currently flaky" from `marked_flaky` events
-    # (see Tuist.Tests.currently_flaky_test_case_ids_subquery/2). Anchor the
-    # event timestamp to the run's ran_at so it falls inside the page's
-    # second-truncated date window.
     ran_at = Keyword.get(opts, :ran_at, NaiveDateTime.add(NaiveDateTime.utc_now(), -60))
 
     RunsFixtures.test_case_event_fixture(

--- a/server/test/tuist_web/live/test_cases_live_test.exs
+++ b/server/test/tuist_web/live/test_cases_live_test.exs
@@ -7,6 +7,7 @@ defmodule TuistWeb.TestCasesLiveTest do
   import Phoenix.LiveViewTest
 
   alias Tuist.Tests.Analytics
+  alias TuistTestSupport.Fixtures.RunsFixtures
 
   describe "test cases page" do
     setup do
@@ -56,11 +57,25 @@ defmodule TuistWeb.TestCasesLiveTest do
       organization: organization,
       project: project
     } do
-      # Given - create test run with test modules/cases using the proper flow
-      {:ok, _test_run} = create_test_run_with_cases(project, organization.account)
-
-      # Wait for ClickHouse to process
-      Process.sleep(100)
+      # Given - create test run with test modules/cases via the fixture
+      # so all ClickHouse buffers are flushed synchronously. Backdate ran_at
+      # so it falls inside the page's second-truncated date window.
+      {:ok, _test_run} =
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: organization.account.id,
+          ran_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -60),
+          test_modules: [
+            %{
+              name: "MyTests",
+              status: "success",
+              duration: 100,
+              test_cases: [
+                %{name: "testExample", test_suite_name: "TestSuite", status: "success", duration: 100}
+              ]
+            }
+          ]
+        )
 
       # When
       {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
@@ -145,33 +160,4 @@ defmodule TuistWeb.TestCasesLiveTest do
     end
   end
 
-  defp create_test_run_with_cases(project, account) do
-    Tuist.Tests.create_test(%{
-      id: UUIDv7.generate(),
-      project_id: project.id,
-      account_id: account.id,
-      git_ref: "refs/heads/main",
-      git_commit_sha: "abc123",
-      status: "success",
-      scheme: "TestScheme",
-      duration: 1000,
-      macos_version: "14.0",
-      xcode_version: "15.0",
-      is_ci: true,
-      ran_at: NaiveDateTime.utc_now(),
-      test_modules: [
-        %{
-          name: "MyTests",
-          status: "success",
-          duration: 100,
-          test_suites: [
-            %{name: "TestSuite", status: "success", duration: 100}
-          ],
-          test_cases: [
-            %{name: "testExample", test_suite_name: "TestSuite", status: "success", duration: 100}
-          ]
-        }
-      ]
-    })
-  end
 end

--- a/server/test/tuist_web/live/test_cases_live_test.exs
+++ b/server/test/tuist_web/live/test_cases_live_test.exs
@@ -45,7 +45,10 @@ defmodule TuistWeb.TestCasesLiveTest do
       project: project
     } do
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
+
+      render_async(lv)
 
       # Then
       assert has_element?(lv, "[data-part='test-cases']")
@@ -57,9 +60,6 @@ defmodule TuistWeb.TestCasesLiveTest do
       organization: organization,
       project: project
     } do
-      # Given - create test run with test modules/cases via the fixture
-      # so all ClickHouse buffers are flushed synchronously. Backdate ran_at
-      # so it falls inside the page's second-truncated date window.
       {:ok, _test_run} =
         RunsFixtures.test_fixture(
           project_id: project.id,
@@ -71,14 +71,21 @@ defmodule TuistWeb.TestCasesLiveTest do
               status: "success",
               duration: 100,
               test_cases: [
-                %{name: "testExample", test_suite_name: "TestSuite", status: "success", duration: 100}
+                %{
+                  name: "testExample",
+                  test_suite_name: "TestSuite",
+                  status: "success",
+                  duration: 100
+                }
               ]
             }
           ]
         )
 
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
+
       render_async(lv)
 
       # Then
@@ -91,7 +98,8 @@ defmodule TuistWeb.TestCasesLiveTest do
       project: project
     } do
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases")
 
       # Then
       assert has_element?(lv, "[data-part='analytics']")
@@ -126,7 +134,10 @@ defmodule TuistWeb.TestCasesLiveTest do
     } do
       # When - navigate directly with date range param
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases?analytics_date_range=last_30_days")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/test-cases?analytics_date_range=last_30_days"
+        )
 
       # Then - verify the page loads with the date range param
       assert has_element?(lv, "[data-part='analytics']")
@@ -139,7 +150,10 @@ defmodule TuistWeb.TestCasesLiveTest do
     } do
       # When - navigate with an invalid sort_by parameter (ran_at instead of last_ran_at)
       {:ok, lv, _html} =
-        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-cases?sort_by=ran_at")
+        live(
+          conn,
+          ~p"/#{organization.account.name}/#{project.name}/tests/test-cases?sort_by=ran_at"
+        )
 
       # Then - page should load successfully with default sort
       assert has_element?(lv, "[data-part='test-cases']")
@@ -159,5 +173,4 @@ defmodule TuistWeb.TestCasesLiveTest do
       assert has_element?(lv, "#widget-test-cases-count")
     end
   end
-
 end

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -29,12 +29,27 @@ defmodule TuistWeb.TestRunsLiveTest do
       organization: organization,
       project: project
     } do
-      # Given
+      # Given - backdate ran_at so the runs land safely inside the page's
+      # second-truncated date window (the page's end_datetime is floored to
+      # the second by DatePicker, so a freshly-stamped ran_at can fall just
+      # past it under fast scheduling).
+      ran_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -60)
+
       {:ok, _test_run1} =
-        RunsFixtures.test_fixture(project_id: project.id, account_id: organization.account.id, scheme: "App")
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: organization.account.id,
+          scheme: "App",
+          ran_at: ran_at
+        )
 
       {:ok, _test_run2} =
-        RunsFixtures.test_fixture(project_id: project.id, account_id: organization.account.id, scheme: "AppTwo")
+        RunsFixtures.test_fixture(
+          project_id: project.id,
+          account_id: organization.account.id,
+          scheme: "AppTwo",
+          ran_at: ran_at
+        )
 
       # When
       {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-runs")

--- a/server/test/tuist_web/live/test_runs_live_test.exs
+++ b/server/test/tuist_web/live/test_runs_live_test.exs
@@ -29,10 +29,6 @@ defmodule TuistWeb.TestRunsLiveTest do
       organization: organization,
       project: project
     } do
-      # Given - backdate ran_at so the runs land safely inside the page's
-      # second-truncated date window (the page's end_datetime is floored to
-      # the second by DatePicker, so a freshly-stamped ran_at can fall just
-      # past it under fast scheduling).
       ran_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -60)
 
       {:ok, _test_run1} =
@@ -52,7 +48,8 @@ defmodule TuistWeb.TestRunsLiveTest do
         )
 
       # When
-      {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-runs")
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-runs")
 
       # Then
       assert has_element?(lv, "[data-part='test-runs-table']")


### PR DESCRIPTION
## Summary

The Test job in CI failed with 9 failures in [run 25011136332](https://github.com/tuist/tuist/actions/runs/25011136332/job/73246885978) and the job took 9 minutes. This PR fixes both.

### Test failures (all caused by [#10373](https://github.com/tuist/tuist/pull/10373))

- **3 in `Tuist.TestsTest`** — \`list_flaky_test_cases/2\` time-range, CI-environment, and combined filter tests. After #10373 the stats subquery moved to a `left_join`, so the time/env filters silently became no-ops on the result set (they only affected the stats column). Restored the filtering by `inner_join`'ing stats whenever any of `start_datetime`, `end_datetime`, or `is_ci` is set; the no-opts callers (e.g. `tests_live.ex` "most flaky" widget) keep the `left_join`.
- **4 in `TuistWeb.FlakyTestsLiveTest`** — the new `currently_flaky_test_case_ids_subquery` derives "currently flaky" from `marked_flaky` `TestCaseEvent`s, but the test fixture only inserted into `TestCase`. Updated `create_flaky_test_case` to also insert a `marked_flaky` event anchored to the run's `ran_at`.
- **1 in `TuistWeb.TestCasesLiveTest`** — the new `active_period` join requires a `TestCaseRun` in `[start, end]`, but the test called `Tuist.Tests.create_test` directly without flushing the ClickHouse buffers, and used a fresh `NaiveDateTime.utc_now()` that could race past the page's second-truncated `end_datetime`. Switched to `RunsFixtures.test_fixture` (which flushes buffers) and backdated `ran_at` by 60s.
- **1 in `TuistWeb.TestRunsLiveTest`** — same `end_datetime` truncation race against the fixture's `ran_at`. Backdated `ran_at` by 60s.

### CI runtime (9:01 → expected ~3:00)

The "Setup database" step took **5:07** of the 9 minutes — it was running a full `mix deps.compile` + `mix compile` from scratch on every run despite a cache hit. The restored cache was only 70 MB (just `deps/`, no `_build/test`). `actions/cache@v4` only saves on cache miss, so a previously-saved incomplete cache propagates forever.

- Bumped the cache key to `mix-test-v2-` to force a one-time fresh save that includes `_build/test`.
- Scoped the key to MIX_ENV so a dev-env cache can't poison the test job.
- Added an explicit `Compile` step before `Setup database` so its time is visible in the job timeline (and `mix ecto.create` / `mix test` stop triggering compile work).

After the next run populates the cache, subsequent runs should drop from ~9 min to ~3 min (deps.get + incremental compile + db reset + 165s test execution).

## Test plan

- [x] `mix test test/tuist/tests_test.exs` — 190 tests, 0 failures
- [x] `mix test test/tuist_web/live/flaky_tests_live_test.exs` — 8 tests, 0 failures
- [x] `mix test test/tuist_web/live/test_cases_live_test.exs` — passing
- [x] `mix test test/tuist_web/live/test_runs_live_test.exs` — passing
- [ ] CI Test job runtime drops on the second run after merge (cache populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)