### PR TITLE
fix(server): unblock preview deploy workflow + bump worker SKU

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -101,6 +101,7 @@ jobs:
           ACTION: ${{ github.event.action }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -174,8 +175,6 @@ jobs:
               echo "- Expires: $(date -u -d "@$EXPIRES_AT" '+%Y-%m-%d %H:%M UTC')"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   start-deployment:
     # Per-PR GitHub Deployment so the PR timeline shows a "Preview – PR #N"

--- a/infra/k8s/syself/workload-cluster-preview.yaml
+++ b/infra/k8s/syself/workload-cluster-preview.yaml
@@ -1,6 +1,6 @@
 # Preview workload Cluster for ephemeral PR / commit environments.
 #
-# Shape: 1 × cpx22 control plane + 0 × cpx31 workers (scale-to-zero) in fsn1.
+# Shape: 1 × cpx22 control plane + 0 × cpx32 workers (scale-to-zero) in fsn1.
 # Single control-plane is acceptable — the cluster is not user-facing and
 # short downtime during upgrades is fine.
 #
@@ -55,7 +55,13 @@ spec:
       - name: controlPlaneMachineArchHcloud
         value: amd64
       - name: workerMachineTypeHcloud
-        value: cpx31
+        # cpx32 (4 vCPU / 8 GB AMD, new-gen series). The old-gen cpx*1
+        # series (cpx21, cpx31, cpx41) is currently out of stock in fsn1 —
+        # same issue affecting staging/canary md-0 scale-ups. The cpx*2
+        # series is the in-stock new-gen replacement and is what the
+        # control plane (cpx22) is already on, so Syself's ClusterClass
+        # accepts the SKU.
+        value: cpx32
       - name: SSHKeyNameHcloud
         value:
           - name: tuist-syself


### PR DESCRIPTION
## Summary

Two fixes uncovered by running the preview cluster bootstrap end-to-end (per [§9 of the syself onboarding doc](https://github.com/tuist/tuist/blob/main/infra/k8s/syself-onboarding.md)).

**1. `preview-deploy.yml`: duplicate `env:` block.** GitHub Actions parser rejects two `env:` blocks on a single step ("'env' is already defined" at L177). YAML technically allows it; Actions schema doesn't. Introduced when the resolve step was rewritten for the label-driven trigger — the new top env block was added without removing the old one that only carried `GH_TOKEN`. Folded `GH_TOKEN` into the unified block.

**2. `workload-cluster-preview.yaml`: bump worker SKU to `cpx32`.** Hetzner currently has the old-gen `cpx*1` series (`cpx21`, `cpx31`, `cpx41`) out of stock in `fsn1` — same issue is silently affecting staging/canary `md-0` scale-ups (only their existing workers from earlier provisioning are still running; new ones can't provision). The new-gen `cpx*2` series is fully in stock and is what the control plane (`cpx22`) is already on, so Syself's ClusterClass accepts the SKU.

## Test plan

- [x] `ruby -ryaml` parses the workflow file
- [ ] Re-trigger by removing + re-adding the `preview` label on a PR; confirm the workflow now starts (no "Invalid workflow file" annotation)

## Side note

Staging and canary are both affected by the `cpx31` stock-out for any new worker provisioning. Worth following up to bump those to the `cpx*2` series too, otherwise the next worker scale-up event (node failure / replacement) won't recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)