### PR TITLE
fix(server): unblock preview deploys when GitHub Deployment creation fails

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -193,26 +193,43 @@ jobs:
           REF: ${{ needs.resolve.outputs.ref }}
           RELEASE: ${{ needs.resolve.outputs.release }}
           PR: ${{ needs.resolve.outputs.pr_number }}
+        # The Deployment object is purely a PR-timeline UI nicety — its
+        # creation must never block the actual deploy. We swallow API
+        # failures here and emit an empty deployment_id; the deploy job
+        # checks for that and skips its status-update steps when empty.
         run: |
-          set -euo pipefail
-          # transient_environment + auto_inactive let GitHub mark the prior
-          # deployment row inactive automatically when this one goes active.
-          DEPLOYMENT_ID=$(gh api "repos/${{ github.repository }}/deployments" \
-            --method POST \
-            -f ref="$REF" \
-            -f environment="preview-$RELEASE" \
-            -F transient_environment=true \
-            -F production_environment=false \
-            -F auto_merge=false \
-            -F required_contexts:='[]' \
-            -f description="Preview for PR #$PR" \
-            --jq .id)
+          set -uo pipefail
+
+          # gh api doesn't have httpie's `:=` JSON-value operator, so
+          # building the body with jq is the reliable way to send a real
+          # empty array for required_contexts (which bypasses GitHub's
+          # default "all status checks must pass" gate on Deployments).
+          BODY=$(jq -nc \
+            --arg ref "$REF" \
+            --arg env "preview-$RELEASE" \
+            --arg desc "Preview for PR #$PR" \
+            '{ref: $ref,
+              environment: $env,
+              transient_environment: true,
+              production_environment: false,
+              auto_merge: false,
+              required_contexts: [],
+              description: $desc}')
+
+          if DEPLOYMENT_ID=$(echo "$BODY" | gh api "repos/${{ github.repository }}/deployments" \
+              --method POST --input - --jq .id 2>&1); then
+            echo "Created GitHub Deployment $DEPLOYMENT_ID"
+            gh api "repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
+              --method POST \
+              -f state=in_progress \
+              -f description="Building + deploying" \
+              -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >/dev/null \
+              || echo "::warning::Could not set Deployment status to in_progress"
+          else
+            echo "::warning::Could not create GitHub Deployment: $DEPLOYMENT_ID"
+            DEPLOYMENT_ID=""
+          fi
           echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
-          gh api "repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses" \
-            --method POST \
-            -f state=in_progress \
-            -f description="Building + deploying" \
-            -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >/dev/null
 
   build:
     name: Build + push
@@ -320,12 +337,15 @@ jobs:
   deploy:
     name: Deploy ${{ needs.resolve.outputs.release }}
     needs: [resolve, build, scale-up, start-deployment]
+    # The GitHub Deployment object is a PR-timeline UI nicety, never a
+    # gate. We only require the actual prerequisites (build + scale-up) to
+    # succeed; start-deployment can fail (e.g. status-check API conflict)
+    # without blocking the real deploy.
     if: |
       always()
       && needs.resolve.outputs.action == 'deploy'
       && needs.build.result == 'success'
       && needs.scale-up.result == 'success'
-      && (needs.start-deployment.result == 'success' || needs.start-deployment.result == 'skipped')
     runs-on: namespace-profile-default
     environment:
       name: server-k8s-preview


### PR DESCRIPTION
## Summary

Surfaced when triggering the preview workflow against [#10424](https://github.com/tuist/tuist/pull/10424) post-rebase. Two bugs in [.github/workflows/preview-deploy.yml](.github/workflows/preview-deploy.yml):

**1. Wrong `gh api` JSON syntax.** The previous \`-F required_contexts:='[]'\` was meant to send `required_contexts: []` and bypass GitHub's default "all status checks must pass" gate on Deployments. But `gh api` doesn't have httpie's `:=` operator — it sent the literal string `'[]'`, GitHub kept the gate, and every deploy failed with `409 Conflict: Commit status checks failed`.

Fix: build the request body with `jq` so `required_contexts: []` is sent as a real empty array.

**2. Decorative step gating the real deploy.** The `Start GitHub Deployment` step exit-coded on any API failure, and the `deploy` job's `if:` required it to be `success` or `skipped`. So a transient Deployment-API hiccup (or the bug above) bricked the actual `helm install`.

Fix: wrap the API calls so the step always exits 0; emit an empty `deployment_id` when creation fails; drop `start-deployment` from `deploy`'s gating condition. The Deployment object is purely a PR-timeline UI nicety — never a gate.

## Test plan

- [x] `ruby -ryaml` parses the workflow file
- [x] Verified by hand that the new `jq` body produces valid JSON with `required_contexts: []`
- [ ] Re-trigger by removing + re-adding the `preview` label on a PR; confirm `Start GitHub Deployment` either succeeds or warns (without failing) and the rest of the pipeline runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)