### PR TITLE
perf(cli): lower URLSession resource timeout from 300s to 90s

### DIFF
--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -24,7 +24,7 @@ private func environmentProxyURL() -> URL? {
 public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
     configuration.timeoutIntervalForRequest = 120
-    configuration.timeoutIntervalForResource = 300
+    configuration.timeoutIntervalForResource = 90
     configuration.httpMaximumConnectionsPerHost = 20
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         configuration.allowsCellularAccess = true


### PR DESCRIPTION
## Summary

- Lowers `URLSessionConfiguration.timeoutIntervalForResource` on the shared Tuist URL session from **300s → 90s**.
- Targets the cold module-cache fetch slowdown where stalled Tigris streams hold a connection open for 5 minutes before the per-artifact retry path in `ModuleCacheRemoteStorage.fetchBinaryItems` can recover.

## Investigation

A runner trace on a large project showed:

- 603 cache module requests across ~12.8 minutes wall clock.
- Only 87 MB of total payload (median 2.3 KB, max 1 MB) — bytes-on-wire is not the bottleneck.
- HTTP/2 multiplexing actually pushes peak in-flight to 84 simultaneous requests, so the 20-connection / 100-task concurrency limit is not the bottleneck either.
- ~half of the successful 200 responses returned with `body=0` after a median of 77 seconds (max 281s) of `receive` time, with backend `server-timing` reporting ~110ms — i.e. the server returns 200 + `Content-Length` headers immediately, then body delivery from Tigris stalls.
- A wave of 17 simultaneous `Transport threw an error / The request timed out` errors lands at exactly 300.7s after the first cache request — `timeoutIntervalForResource` firing.
- 118 status-0 entries in the HAR map 1:1 to 118 retry events in the CLI logs.

So the user-observed "~6 minute fetch" is dominated by URLSession holding stalled streams open until the 5-minute resource ceiling, not by client concurrency or unzip work.

## Why 90s

- Largest observed single artifact body: 1 MB, completed in ~25s.
- Multipart upload chunks are 10 MB ([MultipartUploadArtifactService.swift:82](https://github.com/tuist/tuist/blob/main/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift#L82)). 90s requires ≥114 KB/s sustained — comfortable for any modern connection, and the `RetryProvider` wrapping that upload absorbs occasional timeouts.
- 90s is short enough that a stalled cache stream surfaces to the per-artifact retry path within the cold-fetch budget rather than burning a full 5 minutes per stall.

## Caveat / follow-ups

- This affects the shared `URLSession.tuistShared`, which is also used for multipart uploads, preview icon uploads, file uploads, and the OpenAPI transport. If we hear from users on very slow links that uploads now time out, the right next step is to split the shared session (one for short downloads, one for long uploads) rather than to revert this. I left that follow-up out of this PR to keep the mitigation surgical.
- The deeper root cause looks server/Tigris-side: the runner was being routed to `cache-us-east-3.tuist.dev` despite EU endpoints being available, and Tigris was serving FRA-stored objects via the JNB edge with consistent cache misses. Worth a separate infra-side investigation (endpoint selection in `TuistCAS` and Tigris regional warming).

## Test plan

- [ ] Land and observe cold-fetch wall time on the affected runner — expect to drop from 6+ minutes toward the time it would take if every stall converted into a fast retry.
- [ ] Watch retry counts in CLI logs to confirm retries are absorbing the previously-silent stalls.
- [ ] Watch for any new upload-side timeouts on slow links; if they appear, follow up by splitting the shared `URLSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)