### PR TITLE
fix(cli): re-embed test target frameworks not embedded in host

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -494,10 +494,20 @@ public class GraphTraverser: GraphTraversing {
             }
         )
 
-        // Unit tests never embed frameworks — they either run inside a host app
-        // (which embeds the frameworks) or standalone (where DYLD paths are used instead).
+        // For hosted unit tests, subtract frameworks already embedded in the host app
+        // to avoid duplicate embedding (and the runtime issues that follow). Frameworks
+        // the test depends on but the host doesn't must still be embedded in the .xctest
+        // bundle — otherwise dyld finds them in BUILT_PRODUCTS_DIR unsigned and a hardened
+        // host process rejects them with a Team ID / signature mismatch at launch.
+        // For standalone unit tests there is no host to load into, so embed nothing.
         if target.target.product == .unitTests {
-            references = Set()
+            if let hostApp = unitTestHost(path: path, name: name) {
+                references.subtract(
+                    embeddableFrameworks(path: hostApp.path, name: hostApp.target.name)
+                )
+            } else {
+                references = Set()
+            }
         }
 
         return references

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1724,7 +1724,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
     func test_embeddableFrameworks_whenHostedTestTarget_withDirectFrameworkNotInHost() throws {
         // Given: Unit test depends on a host app AND a framework that the host does NOT depend on.
-        // The framework should NOT be embedded in the .xctest bundle.
+        // The framework MUST be embedded in the .xctest bundle — otherwise dyld finds the
+        // unsigned framework in BUILT_PRODUCTS_DIR and a hardened host rejects it at launch.
         let featureFramework = Target.test(name: "FeatureA", product: .framework)
         let app = Target.test(name: "SharedTestHost", product: .app)
         let tests = Target.test(name: "FeatureATests", product: .unitTests)
@@ -1749,7 +1750,12 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let got = subject.embeddableFrameworks(path: featureProject.path, name: tests.name).sorted()
 
         // Then
-        XCTAssertTrue(got.isEmpty)
+        XCTAssertEqual(got, [
+            GraphDependencyReference.product(
+                target: featureFramework.name,
+                productName: featureFramework.productNameWithExtension
+            ),
+        ])
     }
 
     func test_embeddableFrameworks_whenUITest_andAppPrecompiledDependencies() throws {


### PR DESCRIPTION
## Summary

Restores the **subtract-from-host** approach in `GraphTraverser.embeddableFrameworks` for hosted unit tests, undoing the embed-phase regression introduced in #10139.

#10139 simplified the logic to `references = Set()` for all unit tests, on the premise that "hosted tests run inside the host app process and should not embed frameworks; if a test needs a framework, add it to the host app's deps." That premise is wrong:

- Native Xcode does embed test-only frameworks in the `.xctest` bundle when the host app doesn't depend on them — that was Tuist's behaviour through 4.91.1.
- The suggested workaround (add the framework to the host) ships test-only mocks into the production app binary.
- With a hardened-runtime host, dyld finds the unsigned framework in `BUILT_PRODUCTS_DIR` and rejects it at launch with a Team ID / signature mismatch.

## Behaviour matrix (hosted unit test)

| Test depends on framework | Host depends on it too? | Before #10139 | After #10139 (current) | This PR |
|---|---|---|---|---|
| Yes | Yes | Don't embed in test | Don't embed | Don't embed |
| Yes | No | **Embed in test** | Don't embed → dyld fails | **Embed in test** |
| No host (standalone test) | — | Don't embed | Don't embed | Don't embed |

## What's preserved from #10139

The cross-project `TEST_HOST` / `BUNDLE_LOADER` fix in `DefaultSettingsProvider` (`directLocalTargetDependencies` → `directTargetDependencies`) is independent and stays.

## Repro

Reported by a user on a macOS unit-test target whose host app has no framework deps but the test depends on `APIMocks` / `ToolsMocks`. Generated with 4.91.1: 4 frameworks in Embed Frameworks, tests run. Generated with the current main: empty Embed Frameworks phase, dyld signature mismatch at launch.

## Test plan

- [x] Updated `test_embeddableFrameworks_whenHostedTestTarget_withDirectFrameworkNotInHost` — was asserting the bug; now asserts the framework IS embedded.
- [x] Full `GraphTraverserTests` suite passes locally (`xcodebuild test ... -only-testing TuistCoreTests/GraphTraverserTests`).
- [ ] Re-test with the user's reproduction project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)