### PR TITLE
fix(server): drop scale-to-zero for preview cluster, pin replicas to 2

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,14 +25,16 @@ name: Preview Deploy
 # timeline shows a "Preview – PR #1234" card (active during the deploy, set
 # inactive on teardown).
 #
-# Required GitHub Environment secrets (environment: server-k8s-preview):
-#   KUBECONFIG       - base64 kubeconfig for the preview WORKLOAD cluster's
-#                      CI ServiceAccount (cluster-admin in preview-system).
-#   KUBECONFIG_MGMT  - base64 kubeconfig for the SYSELF MANAGEMENT cluster's
-#                      `preview-scaler` SA (narrow Role: get/patch on
-#                      Cluster/tuist-preview, read on MachineDeployments).
+# Required GitHub Environment secret (environment: server-k8s-preview):
+#   KUBECONFIG  - base64 kubeconfig for the preview WORKLOAD cluster's CI
+#                 ServiceAccount (cluster-admin in preview-system). Minted
+#                 at cluster bootstrap; see infra/k8s/syself-onboarding.md §9.
 #
-# Both are minted at cluster bootstrap; see infra/k8s/syself-onboarding.md §9.
+# No management-cluster kubeconfig: the preview cluster keeps a fixed worker
+# pool (see workload-cluster-preview.yaml's "Why pinned `replicas: 1`"
+# comment) because Syself's OIDC users can't create the ServiceAccount we'd
+# need to scale from CI. ~€13/mo of always-on cost in exchange for sidestepping
+# that dependency entirely.
 
 on:
   workflow_dispatch:
@@ -268,84 +270,20 @@ jobs:
           cache-from: type=gha,scope=server-cluster
           cache-to: type=gha,mode=max,scope=server-cluster
 
-  scale-up:
-    # Scaling the management cluster's `tuist-preview` Cluster CR is the only
-    # write the deploy workflow shares with the sweep workflow. Splitting it
-    # into its own job lets us put a workflow-spanning concurrency group
-    # (`preview-cluster-scale`) on just this step — two PRs deploying at the
-    # same time still helm-install in parallel, but only one of them (and
-    # never the sweep) is mid-patch on the Cluster CR.
-    name: Scale preview worker pool up
-    needs: [resolve, build]
-    if: needs.resolve.outputs.action == 'deploy'
-    runs-on: namespace-profile-default
-    environment:
-      name: server-k8s-preview
-    concurrency:
-      group: preview-cluster-scale
-      cancel-in-progress: false
-    timeout-minutes: 15
-    env:
-      KUBECONFIG: ${{ github.workspace }}/.kube/config
-      KUBECONFIG_MGMT: ${{ github.workspace }}/.kube/mgmt
-    steps:
-      - uses: jdx/mise-action@v3.2.0
-        with:
-          install_args: "kubectl"
-          cache: "false"
-      - name: Load kubeconfigs
-        run: |
-          mkdir -p "$(dirname "$KUBECONFIG")"
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
-          chmod 600 "$KUBECONFIG"
-          echo "${{ secrets.KUBECONFIG_MGMT }}" | base64 -d > "$KUBECONFIG_MGMT"
-          chmod 600 "$KUBECONFIG_MGMT"
-      - name: Patch Cluster CR to ensure md-0 has ≥1 replica
-        run: |
-          set -euo pipefail
-          ORG_NS=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
-          CURRENT=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" get cluster tuist-preview \
-            -o jsonpath='{.spec.topology.workers.machineDeployments[?(@.name=="md-0")].replicas}')
-          echo "md-0 replicas currently: $CURRENT"
-          if [ "${CURRENT:-0}" -lt 1 ]; then
-            echo "==> Scaling md-0 to 1..."
-            KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" patch cluster tuist-preview \
-              --type=json \
-              -p='[{"op":"replace","path":"/spec/topology/workers/machineDeployments/0/replicas","value":1}]'
-          fi
-      - name: Wait for worker node Ready
-        # Cold-boot a Hetzner cpx31 + kubelet/CNI takes ~3–5 min. Done in
-        # this job (not the deploy job) so the Cluster CR concurrency lock
-        # is held until the new node is actually usable.
-        run: |
-          echo "Waiting for at least one worker node to be Ready..."
-          for i in $(seq 1 60); do
-            COUNT=$(kubectl get nodes -l '!node-role.kubernetes.io/control-plane' \
-              -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-              | grep -c "^True$" || true)
-            if [ "$COUNT" -ge 1 ]; then
-              echo "Worker(s) Ready: $COUNT"
-              kubectl get nodes
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "::error::No worker became Ready within 10 minutes."
-          kubectl get nodes -o wide
-          exit 1
-
   deploy:
     name: Deploy ${{ needs.resolve.outputs.release }}
-    needs: [resolve, build, scale-up, start-deployment]
+    needs: [resolve, build, start-deployment]
     # The GitHub Deployment object is a PR-timeline UI nicety, never a
-    # gate. We only require the actual prerequisites (build + scale-up) to
-    # succeed; start-deployment can fail (e.g. status-check API conflict)
-    # without blocking the real deploy.
+    # gate. We only require the actual prerequisite (build) to succeed;
+    # start-deployment can fail (e.g. status-check API conflict) without
+    # blocking the real deploy. There's no scale-up job — the preview
+    # cluster keeps a fixed worker pool because we can't get the
+    # management-cluster permissions Syself would require for elastic
+    # scaling (see infra/k8s/syself/workload-cluster-preview.yaml).
     if: |
       always()
       && needs.resolve.outputs.action == 'deploy'
       && needs.build.result == 'success'
-      && needs.scale-up.result == 'success'
     runs-on: namespace-profile-default
     environment:
       name: server-k8s-preview

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -1,18 +1,17 @@
 name: Preview Sweep
 
-# Hourly cleanup pass over the preview cluster. Two responsibilities:
+# Hourly cleanup pass over the preview cluster. Deletes preview namespaces
+# whose `tuist.dev/expires-at` label is in the past — uninstalls the
+# release and drops the namespace. Also exposed as workflow_dispatch for
+# force-runs (e.g. after manually uninstalling something out-of-band).
 #
-#   1. Delete preview namespaces whose `tuist.dev/expires-at` label is in
-#      the past (uninstalls the release + drops the namespace).
-#   2. Scale the preview MachineDeployment back to 0 when no preview
-#      namespaces remain. Combined with the always-on single control plane,
-#      this gets idle cost down to ~€5/mo.
+# No worker-pool scaling here: the preview cluster keeps a fixed worker
+# pool (see infra/k8s/syself/workload-cluster-preview.yaml). Scaling from
+# CI would require management-cluster permissions Syself's OIDC users
+# don't have.
 #
-# Also exposed as workflow_dispatch for force-runs (e.g. after manually
-# uninstalling something out-of-band).
-#
-# Requires the same two GitHub Environment secrets (server-k8s-preview) as
-# preview-deploy.yml: KUBECONFIG (workload) + KUBECONFIG_MGMT (management).
+# Required GitHub Environment secret (environment: server-k8s-preview):
+#   KUBECONFIG  - same secret used by preview-deploy.yml.
 
 on:
   schedule:
@@ -24,32 +23,23 @@ permissions:
 
 jobs:
   sweep:
-    name: Sweep + scale to zero
+    name: Sweep expired previews
     runs-on: ubuntu-latest
     environment:
       name: server-k8s-preview
-    # Shares the cluster-scale lane with preview-deploy.yml's scale-up job
-    # so the sweep can never patch the management Cluster CR while a deploy
-    # is mid-scale. Uses the same group name across both workflows.
-    concurrency:
-      group: preview-cluster-scale
-      cancel-in-progress: false
     timeout-minutes: 15
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
-      KUBECONFIG_MGMT: ${{ github.workspace }}/.kube/mgmt
     steps:
       - uses: jdx/mise-action@v3.2.0
         with:
           install_args: "helm kubectl"
           cache: "false"
-      - name: Load kubeconfigs
+      - name: Load kubeconfig
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
           echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
-          echo "${{ secrets.KUBECONFIG_MGMT }}" | base64 -d > "$KUBECONFIG_MGMT"
-          chmod 600 "$KUBECONFIG_MGMT"
 
       - name: Delete expired preview namespaces
         # We helm-uninstall first so chart hooks (PVC retention etc.) get a
@@ -84,27 +74,3 @@ jobs:
               echo "    Live: $NS (expires in $((EXP - NOW))s)"
             fi
           done <<< "$MAPPING"
-
-      - name: Scale worker pool to zero if idle
-        # If no `tuist.dev/preview=true` namespaces remain, the worker pool
-        # has nothing to host. Scale md-0 back to 0 to drop cost to control
-        # plane only.
-        run: |
-          set -euo pipefail
-          REMAINING=$(kubectl get namespaces -l tuist.dev/preview=true -o name | wc -l | tr -d '[:space:]')
-          echo "Remaining preview namespaces: $REMAINING"
-          if [ "$REMAINING" -gt 0 ]; then
-            echo "Previews still live — leaving worker pool alone."
-            exit 0
-          fi
-
-          ORG_NS=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
-          CURRENT=$(KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" get cluster tuist-preview \
-            -o jsonpath='{.spec.topology.workers.machineDeployments[?(@.name=="md-0")].replicas}')
-          echo "md-0 replicas currently: $CURRENT"
-          if [ "${CURRENT:-0}" -gt 0 ]; then
-            echo "==> Scaling md-0 to 0..."
-            KUBECONFIG="$KUBECONFIG_MGMT" kubectl -n "$ORG_NS" patch cluster tuist-preview \
-              --type=json \
-              -p='[{"op":"replace","path":"/spec/topology/workers/machineDeployments/0/replicas","value":0}]'
-          fi

--- a/infra/k8s/syself-onboarding.md
+++ b/infra/k8s/syself-onboarding.md
@@ -451,41 +451,11 @@ base64 < /tmp/preview-kubeconfig.yaml | gh secret set KUBECONFIG \
 shred -u /tmp/preview-kubeconfig.yaml
 ```
 
-### 9.6 Scaler ServiceAccount (management cluster)
+### 9.6 Scaler ServiceAccount (management cluster) — skipped
 
-The deploy + sweep workflows scale the worker MachineDeployment up and down. The Cluster CR for that lives in the **management** cluster, so we mint a separate, narrowly-scoped SA there.
+The original design had CI scale the preview MachineDeployment to/from 0 via a narrow SA on the management cluster. That requires `create serviceaccounts,roles,rolebindings` in your `org-tuist` namespace, which Syself's OIDC users don't have by default. Until Syself grants those (open a support ticket if you want to revisit), the preview cluster keeps a fixed `replicas: 1` worker pool. See the "Why pinned `replicas: 1`" comment at the top of [`infra/k8s/syself/workload-cluster-preview.yaml`](syself/workload-cluster-preview.yaml).
 
-```bash
-export KUBECONFIG=~/.kube/tuist-syself-mgmt.yaml
-ORG_NS="$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')"
-
-sed "s/__ORG_NS__/$ORG_NS/g" infra/k8s/syself/preview-mgmt-rbac.yaml | kubectl apply -f -
-
-SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
-CA=$(kubectl -n "$ORG_NS" get secret preview-scaler-token -o jsonpath='{.data.ca\.crt}')
-TOKEN=$(kubectl -n "$ORG_NS" get secret preview-scaler-token -o jsonpath='{.data.token}' | base64 -d)
-
-cat > /tmp/preview-mgmt-kubeconfig.yaml <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-  - name: syself-mgmt
-    cluster:
-      server: $SERVER
-      certificate-authority-data: $CA
-contexts:
-  - name: ci
-    context: { cluster: syself-mgmt, namespace: $ORG_NS, user: preview-scaler }
-users:
-  - name: preview-scaler
-    user: { token: $TOKEN }
-current-context: ci
-EOF
-
-base64 < /tmp/preview-mgmt-kubeconfig.yaml | gh secret set KUBECONFIG_MGMT \
-  --env server-k8s-preview --repo tuist/tuist
-shred -u /tmp/preview-mgmt-kubeconfig.yaml
-```
+The unused [`preview-mgmt-rbac.yaml`](syself/preview-mgmt-rbac.yaml) manifest stays checked in — once the perms are granted, applying it + setting `KUBECONFIG_MGMT` is enough to re-enable elastic scaling.
 
 ### 9.7 First preview
 

--- a/infra/k8s/syself/workload-cluster-preview.yaml
+++ b/infra/k8s/syself/workload-cluster-preview.yaml
@@ -1,24 +1,27 @@
 # Preview workload Cluster for ephemeral PR / commit environments.
 #
-# Shape: 1 × cpx22 control plane + 0 × cpx32 workers (scale-to-zero) in fsn1.
-# Single control-plane is acceptable — the cluster is not user-facing and
-# short downtime during upgrades is fine.
+# Shape: 1 × cpx22 control plane + 1 × cpx42 worker in fsn1. ~€18/mo.
+# Both single-instance — the cluster is not user-facing, short downtime
+# during upgrades is fine, and the worker is sized large enough (8 vCPU /
+# 16 GB) to fit ~8–12 concurrent previews at typical resource profiles
+# (server + postgres + clickhouse + minio + cache ≈ 1 GB request each).
 #
-# Idle cost: ~€5/mo (control plane only). Workers spin up on demand:
-#   - preview-deploy.yml scales md-0 to 1 before the first helm install
-#     and waits for the new node to go Ready (~3–5 min from cold).
-#   - preview-sweep.yml runs hourly, deletes expired namespaces, and scales
-#     md-0 back to 0 when no preview releases remain.
-#
-# Both workflows talk to the SYSELF MANAGEMENT CLUSTER to scale (the Cluster
-# CR lives there, not in the workload cluster). The narrow RBAC for that
-# lives in preview-mgmt-rbac.yaml.
+# Why pinned `replicas: 1` and not scale-to-zero:
+# Scaling the worker pool from CI requires write access to the SYSELF
+# MANAGEMENT cluster (the `Cluster` CR for tuist-preview lives there, not
+# in this workload cluster). Syself's OIDC users cannot create the
+# ServiceAccount we'd need for that, so the original scale-to-zero design
+# was blocked on Syself support. Pinning to a fixed replica trades ~€13/mo
+# of idle cost for sidestepping that dependency entirely. Side benefit:
+# avoids the konnectivity-agent-on-empty-worker-pool footgun (the agent
+# only runs on workers, so workers=0 breaks every webhook on the cluster).
 #
 # Worker labeling/tainting:
-# CAPI/Syself doesn't surface node labels via topology variables, so workers
-# come up un-labeled. The `role=preview` label and `role=preview:NoSchedule`
-# taint are applied by the deploy workflow on every run (idempotent), so
-# fresh nodes from scale-up events get the right scheduling immediately.
+# CAPI/Syself doesn't surface node labels via topology variables, so
+# workers come up un-labeled. The `role=preview` label and
+# `role=preview:NoSchedule` taint are applied by the deploy workflow on
+# every run (idempotent), so any fresh nodes from MachineDeployment
+# replacement events get the right scheduling immediately.
 
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -43,9 +46,7 @@ spec:
       machineDeployments:
         - class: workeramd64hcloud
           name: md-0
-          # Scale-to-zero default. CI scales up before deploy and back down
-          # in the hourly sweep when no previews remain.
-          replicas: 0
+          replicas: 1
           failureDomain: fsn1
     variables:
       - name: region
@@ -55,13 +56,14 @@ spec:
       - name: controlPlaneMachineArchHcloud
         value: amd64
       - name: workerMachineTypeHcloud
-        # cpx32 (4 vCPU / 8 GB AMD, new-gen series). The old-gen cpx*1
+        # cpx42 (8 vCPU / 16 GB AMD, new-gen series). The old-gen cpx*1
         # series (cpx21, cpx31, cpx41) is currently out of stock in fsn1 —
-        # same issue affecting staging/canary md-0 scale-ups. The cpx*2
-        # series is the in-stock new-gen replacement and is what the
-        # control plane (cpx22) is already on, so Syself's ClusterClass
-        # accepts the SKU.
-        value: cpx32
+        # the cpx*2 series is the in-stock replacement and what the control
+        # plane (cpx22) is already on, so Syself's ClusterClass accepts it.
+        # One cpx42 fits ~8–12 concurrent previews at typical resource
+        # requests (server + postgres + clickhouse + minio + cache ≈ 1 GB
+        # request per preview).
+        value: cpx42
       - name: SSHKeyNameHcloud
         value:
           - name: tuist-syself


### PR DESCRIPTION
## Why

Scaling the preview worker pool from CI requires write access to the Syself **management cluster** (the `Cluster` CR for `tuist-preview` lives there, not in the workload cluster). Syself's OIDC users don't have permission to create the `ServiceAccount` / `Role` / `RoleBinding` that the original elastic design needed — the `scale-up` job has been failing with `current-context must exist in order to minify` since the very first run on [#10424](https://github.com/tuist/tuist/pull/10424) because `KUBECONFIG_MGMT` was unbuildable.

Open a Syself support ticket asking for `create serviceaccounts,roles,rolebindings` in `org-tuist` if/when we want to revisit. Until then, this PR pins the worker pool and removes the elastic-scaling code paths.

## Changes

- **`infra/k8s/syself/workload-cluster-preview.yaml`** — `replicas: 0 → 1`, `cpx32 → cpx42`. One cpx42 (8 vCPU / 16 GB) fits ~8–12 concurrent previews at typical resource profiles.
- **`.github/workflows/preview-deploy.yml`** — delete the `scale-up` job; drop `KUBECONFIG_MGMT` from secrets and env. Deploy gates on `build` succeeding.
- **`.github/workflows/preview-sweep.yml`** — drop the scale-back-to-0 step. Keeps TTL-based namespace deletion.
- **`infra/k8s/syself-onboarding.md` §9.6** — replaced with a note explaining the permission gap.
- The unused `preview-mgmt-rbac.yaml` stays checked in — once Syself grants the perms, re-enabling elastic scaling is a single apply + secret-set away.

## Cost shape (after this PR)

- Idle: ~€18/mo (1 × cpx22 control plane + 1 × cpx42 worker)
- vs. theoretical scale-to-zero idle: ~€5/mo

The €13/mo delta also pays for **fixing** the konnectivity-agent-on-empty-worker-pool footgun we hit during bootstrap — the agent only runs on workers, so `workers=0` broke every webhook on the cluster (ESO, ingress-nginx admission, cert-manager). That bug never had a clean fix; the always-on worker pool side-steps it.

Single-worker means a hardware failure takes previews down until CAPI replaces it (~5 min). Acceptable for non-user-facing preview environments.

## Test plan

- [x] All three workflow YAML files parse
- [ ] Apply the updated cluster CR via `kubectl apply -f workload-cluster-preview.yaml` and confirm md-0 rolls to a cpx42
- [ ] Trigger a preview deploy (label a PR or `workflow_dispatch` against a SHA) and confirm it runs end-to-end without `KUBECONFIG_MGMT`

## Apply

After this lands, the preview cluster's CR needs to be re-applied to pick up the SKU bump:

```bash
KUBECONFIG=~/.kube/tuist-syself-mgmt.yaml \
  kubectl apply -f infra/k8s/syself/workload-cluster-preview.yaml
```

CAPI will roll md-0 to a cpx42 (drains current worker, provisions replacement) over the next ~5–10 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)