### PR TITLE
fix(cli): update xcactivitylog_nif package path after processor consolidation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1728,7 +1728,7 @@ let package = Package(
         .package(id: "facebook.zstd", from: "1.5.0"),
         .package(id: "chrisaljoudi.swift-log-oslog", .upToNextMajor(from: "0.2.2")),
         .package(id: "MobileNativeFoundation.XCLogParser", .upToNextMajor(from: "0.2.47")),
-        .package(path: "processor/native/xcactivitylog_nif"),
+        .package(path: "server/native/xcactivitylog_nif"),
         .package(id: "swiftyJSON.SwiftyJSON", .upToNextMajor(from: "5.0.2")),
         .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.22")),
         .package(id: "swiftGen.StencilSwiftKit", exact: "2.10.1"),


### PR DESCRIPTION
## Summary

- Update the local package path in `Package.swift` from `processor/native/xcactivitylog_nif` to `server/native/xcactivitylog_nif`.
- The directory was relocated in [tuist#10428](https://github.com/tuist/tuist/pull/10428) (processor consolidation into server) but the Swift package reference was missed, breaking CI on `main`.

Failing run: https://github.com/tuist/tuist/actions/runs/25053043890

```
error: 'xcactivitylog_nif': the package at '/__w/tuist/tuist/processor/native/xcactivitylog_nif' cannot be accessed
```

Affected jobs: Linux Build, Cache, Build Acceptance Tests, Lint.

## Test plan

- [x] `swift package --replace-scm-with-registry resolve` succeeds locally
- [ ] CI Linux Build passes
- [ ] CI Cache passes
- [ ] CI Build Acceptance Tests passes
- [ ] CI Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)