### PR TITLE
fix(cli): bump tuist.Command to 0.14.1 to surface xcodebuild stderr

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "65d5aa8c03b8905da78593b53c570eac77940ebdbb5f5811e2825c3e208d28c3",
+  "originHash" : "785f8d767ea189efec3da158fb40e400266befde56842e18ea6e231d66afa629",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -591,7 +591,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.0"
+        "version" : "0.14.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1718,7 +1718,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.0")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.0")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.1")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),


### PR DESCRIPTION
### Summary

When `tuist test --shard-granularity suite` failed at the test enumeration step, users got the opaque error:

```
Test enumeration failed: <path>: The operation couldn't be completed. (Command.CommandError error 0.)
```

The root cause was upstream in `tuist/Command`: `CommandError` only conformed to `CustomStringConvertible`, not `LocalizedError`, so any caller reading `error.localizedDescription` got the default NSError fallback — discarding the exit code, command, and **stderr** that the runner had already collected.

[tuist/Command#231](https://github.com/tuist/Command/pull/231) (released as `0.14.1`) fixes this at the source:
- `CommandError` now conforms to `LocalizedError`.
- `.terminated`'s description includes the trimmed stderr when present.

This PR is just the version bump to pull that fix in. With it, `XCTestEnumerator`'s existing catch path surfaces the actual `xcodebuild` stderr, e.g.:

```
Test enumeration failed: <path>: The command 'xcodebuild test-without-building -enumerate-tests' terminated with the code 70:
xcodebuild: error: No such scheme.
```

Every other consumer of `tuist/Command` in the CLI gets the same improvement for free.

### How to test locally

```sh
tuist install
tuist generate tuist Tuist-Workspace --no-open
xcodebuild test \
  -workspace Tuist.xcworkspace \
  -scheme Tuist-Workspace \
  -only-testing TuistAutomationTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)