### PR TITLE
fix(cli): include Package.swift in CI cache key

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -79,7 +79,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -114,7 +114,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -197,7 +197,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -239,7 +239,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -290,7 +290,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -337,7 +337,7 @@ jobs:
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -379,7 +379,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: linux-cli-${{ hashFiles('Package.resolved') }}
+          key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - name: Resolve dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: swift package resolve --replace-scm-with-registry
@@ -407,7 +407,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: linux-cli-${{ hashFiles('Package.resolved') }}
+          key: linux-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
       - name: Resolve dependencies
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: swift package resolve --replace-scm-with-registry


### PR DESCRIPTION
## Summary

- The CLI workflow's `.build` cache key was `${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved') }}` — it only depended on `Package.resolved`. Local SwiftPM packages aren't recorded in `Package.resolved`, so when the path of `xcactivitylog_nif` moved from `processor/native/` to `server/native/` (#10428) and `Package.swift` was fixed in #10507, the cache key didn't change.
- Result: macOS jobs on `main` keep restoring stale workspace state from the previous successful run, the `tuist install` step is skipped on cache hit, and `tuist cache` / `tuist test` fail with `Package.swift not found at path .../processor/native/xcactivitylog_nif`.
- Add `Package.swift` to `hashFiles(...)` in every cache key in `.github/workflows/cli.yml` so any change to local-package paths or dependency declarations busts the cache.

## Test plan

- [ ] CI on this PR completes successfully — both macOS jobs (Lint, Cache, Unit Tests, Acceptance Tests) and Linux jobs.
- [ ] Confirm the cache key visible in the workflow logs differs from the stale key, forcing a fresh `tuist install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)