### PR TITLE
fix(server): pin canary processor to single replica

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -60,6 +60,24 @@ processor:
   # role provisioned via infra/supabase/tuist-processor-role.sql.
   database:
     host: db.thapckmapmffdgaiarvu.supabase.co
+  # Single replica on canary — the 2-worker nodepool can't fit a second
+  # processor pod alongside the server pod + system DaemonSets (the second
+  # replica gets stuck in FailedScheduling with "Insufficient memory" and
+  # helm rolls the upgrade back after the atomic timeout). PDB stays off
+  # too; rolling deploys terminate the one pod, jobs queue up briefly in
+  # oban_jobs, and resume once the new pod boots — same trade-off as
+  # staging.
+  replicaCount: 1
+  podDisruptionBudget:
+    enabled: false
+  # maxSurge: 0 / maxUnavailable: 1 because the surge pod won't fit on the
+  # cramped canary cluster — terminate the old pod first, accept brief
+  # gaps in queue consumption during deploy.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   extraEnv:
     # Must match the server's TUIST_DEPLOY_ENV above so the processor pod
     # decrypts the same priv/secrets/<env>.yml.enc file the web tier does.

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -60,19 +60,9 @@ processor:
   # role provisioned via infra/supabase/tuist-processor-role.sql.
   database:
     host: db.thapckmapmffdgaiarvu.supabase.co
-  # Single replica on canary — the 2-worker nodepool can't fit a second
-  # processor pod alongside the server pod + system DaemonSets (the second
-  # replica gets stuck in FailedScheduling with "Insufficient memory" and
-  # helm rolls the upgrade back after the atomic timeout). PDB stays off
-  # too; rolling deploys terminate the one pod, jobs queue up briefly in
-  # oban_jobs, and resume once the new pod boots — same trade-off as
-  # staging.
   replicaCount: 1
   podDisruptionBudget:
     enabled: false
-  # maxSurge: 0 / maxUnavailable: 1 because the surge pod won't fit on the
-  # cramped canary cluster — terminate the old pod first, accept brief
-  # gaps in queue consumption during deploy.
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary

The Tuist Server canary deploy [run 25052691430](https://github.com/tuist/tuist/actions/runs/25052691430/job/73385720137) failed with `UPGRADE FAILED: ... context deadline exceeded` after waiting an hour, then rolled back due to `--atomic`.

Root cause from the diagnostics dump:

```
4m38s  Warning  FailedScheduling  pod/tuist-tuist-processor-5f7fbff84-sdtwc
       0/5 nodes are available: 2 Insufficient memory,
       3 node(s) had untolerated taint(s).
```

[#10428](https://github.com/tuist/tuist/pull/10428) introduced the in-cluster processor with `replicaCount: 2` (in [values-managed-common.yaml](infra/helm/tuist/values-managed-common.yaml)). The canary nodepool only has 2 workers and can fit one processor pod alongside the server pod + system DaemonSets — the second pod is unschedulable. Helm waits the full atomic timeout (60m) and rolls back.

Staging hit the same shape and worked around it. This PR mirrors that overlay onto canary:

- `processor.replicaCount: 1`
- `processor.podDisruptionBudget.enabled: false`
- `processor.strategy: maxSurge=0 / maxUnavailable=1` (the surge pod won't fit; terminate first instead)

Production keeps `replicaCount: 2` — it runs on larger ccx23 workers that have the headroom.

## Test plan

- [ ] Canary deploy succeeds on next push to `main`
- [ ] `tuist-tuist-processor` rolls out with 1 ready replica in the `tuist-canary` namespace
- [ ] Oban `:process_build` queue drains as builds come through canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)