### PR TITLE
feat(cli): re-add config-driven network proxy opt-out

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -383,6 +383,7 @@ tuistHTTPDependencies.append(contentsOf: ["TuistSupport", "TuistHAR"])
 tuistCASDependencies.append(contentsOf: ["TuistCache", "TuistCASAnalytics"])
 tuistConfigLoaderDependencies.append(contentsOf: [
     "TuistLoader", "TuistCore", "TuistAlert", "TuistSupport",
+    "TuistHTTP",
     "ProjectDescription",
 ])
 tuistConfigLoaderTestDependencies.append(contentsOf: [

--- a/Package.swift
+++ b/Package.swift
@@ -301,6 +301,7 @@ var tuistConfigLoaderTestDependencies: [Target.Dependency] = [
     "TuistConfigLoader",
     "TuistConfig",
     "TuistConstants",
+    "TuistHTTP",
     "TuistRootDirectoryLocator",
     pathDependency,
     fileSystemDependency,
@@ -909,6 +910,8 @@ var targets: [Target] = [
         name: "TuistHTTPTests",
         dependencies: [
             "TuistHTTP",
+            "TuistEnvironment",
+            "TuistEnvironmentTesting",
             mockableDependency,
         ],
         path: "cli/Tests/TuistHTTPTests"

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1538,6 +1538,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.config.targetName),
                     .target(name: Module.rootDirectoryLocator.targetName),
                     .target(name: Module.constants.targetName),
+                    .target(name: Module.http.targetName),
                     .target(name: Module.loader.targetName),
                     .target(name: Module.testing.targetName),
                     .target(name: Module.support.targetName),
@@ -1955,6 +1956,8 @@ public enum Module: String, CaseIterable {
                 [
                     .target(name: Module.testing.targetName),
                     .target(name: Module.support.targetName),
+                    .target(name: Module.environment.targetName),
+                    .target(name: Module.environmentTesting.targetName),
                     .external(name: "OpenAPIRuntime"),
                     .external(name: "HTTPTypes"),
                 ]

--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -28,6 +28,19 @@
 public typealias Config = Tuist
 
 public struct Tuist: Codable, Equatable, Sendable {
+    /// Options for configuring network behavior.
+    public struct Network: Codable, Equatable, Sendable {
+        /// When `true` (default), Tuist automatically uses the proxy defined by
+        /// `HTTPS_PROXY`/`HTTP_PROXY` when present in the environment.
+        public let proxy: Bool
+
+        /// Creates network options.
+        /// - Parameter proxy: Whether Tuist should use the proxy defined in the environment. Defaults to `true`.
+        public static func network(proxy: Bool = true) -> Self {
+            Network(proxy: proxy)
+        }
+    }
+
     /// Options for configuring the Xcode Cache behavior.
     public struct Cache: Codable, Equatable, Sendable {
         /// When `true` (default), the local proxy uploads artifacts to the remote cache.
@@ -50,6 +63,9 @@ public struct Tuist: Codable, Equatable, Sendable {
 
     /// The options to use when running `tuist inspect`.
     public let inspectOptions: InspectOptions
+
+    /// The network configuration.
+    public let network: Network
 
     /// The Xcode Cache configuration.
     public let cache: Cache
@@ -75,6 +91,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         cloud: Cloud? = nil,
         fullHandle: String? = nil,
         url: String = "https://tuist.dev",
+        network: Network = .network(),
         swiftVersion _: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: GenerationOptions = .options(),
@@ -96,6 +113,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         )
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.network = network
         cache = .cache()
         self.url = url
         dumpIfNeeded(self)
@@ -106,11 +124,13 @@ public struct Tuist: Codable, Equatable, Sendable {
         inspectOptions: InspectOptions = .options(),
         cache: Cache = .cache(),
         url: String = "https://tuist.dev",
+        network: Network = .network(),
         project: TuistProject
     ) {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.network = network
         self.cache = cache
         self.url = url
         dumpIfNeeded(self)

--- a/cli/Sources/TuistConfig/Tuist.swift
+++ b/cli/Sources/TuistConfig/Tuist.swift
@@ -13,6 +13,14 @@ public enum TuistConfigError: LocalizedError, Equatable {
 }
 
 public struct Tuist: Equatable, Hashable, Sendable {
+    public struct Network: Equatable, Hashable, Sendable {
+        public let proxy: Bool
+
+        public init(proxy: Bool = true) {
+            self.proxy = proxy
+        }
+    }
+
     public struct Cache: Equatable, Hashable, Sendable {
         public let upload: Bool
 
@@ -24,6 +32,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public let project: TuistProject
     public let fullHandle: String?
     public let inspectOptions: InspectOptions
+    public let network: Network
     public let cache: Cache
     public let url: URL
 
@@ -33,7 +42,8 @@ public struct Tuist: Equatable, Hashable, Sendable {
             fullHandle: nil,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
             cache: Cache(),
-            url: Constants.URLs.production
+            url: Constants.URLs.production,
+            network: Network()
         )
     }
 
@@ -42,11 +52,13 @@ public struct Tuist: Equatable, Hashable, Sendable {
         fullHandle: String?,
         inspectOptions: InspectOptions,
         cache: Cache = Cache(),
-        url: URL
+        url: URL,
+        network: Network = Network()
     ) {
         self.project = project
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
+        self.network = network
         self.cache = cache
         self.url = url
     }
@@ -54,6 +66,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(project)
         hasher.combine(fullHandle)
+        hasher.combine(network)
         hasher.combine(url)
     }
 
@@ -70,14 +83,16 @@ public struct Tuist: Equatable, Hashable, Sendable {
             fullHandle: String? = nil,
             inspectOptions: InspectOptions = .init(redundantDependencies: .init(ignoreTagsMatching: [])),
             cache: Cache = Cache(),
-            url: URL = Constants.URLs.production
+            url: URL = Constants.URLs.production,
+            network: Network = Network()
         ) -> Self {
             return Tuist(
                 project: project,
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         }
     #endif

--- a/cli/Sources/TuistConfigLoader/ConfigLoader.swift
+++ b/cli/Sources/TuistConfigLoader/ConfigLoader.swift
@@ -5,6 +5,7 @@ import Path
 import TuistConfig
 import TuistConstants
 import TuistEnvironment
+import TuistHTTP
 
 @Mockable
 public protocol ConfigLoading: Sendable {
@@ -43,14 +44,19 @@ public struct ConfigLoader: ConfigLoading {
     public func loadConfig(path: AbsolutePath) async throws -> TuistConfig.Tuist {
         #if os(macOS)
             if let _ = try await swiftConfigLoader.locateConfig(at: path) {
-                return try await swiftConfigLoader.loadConfig(path: path)
+                let config = try await swiftConfigLoader.loadConfig(path: path)
+                applyRuntimeSettings(from: config)
+                return config
             }
         #endif
 
         if let tomlConfig = try await tomlConfigLoader.loadConfig(at: path) {
-            return configFromToml(tomlConfig)
+            let config = configFromToml(tomlConfig)
+            applyRuntimeSettings(from: config)
+            return config
         }
 
+        applyRuntimeSettings(from: .default)
         return .default
     }
 
@@ -59,7 +65,12 @@ public struct ConfigLoader: ConfigLoading {
             project: .defaultGeneratedProject(),
             fullHandle: tomlConfig.project,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            url: tomlConfig.url ?? Constants.URLs.production
+            url: tomlConfig.url ?? Constants.URLs.production,
+            network: .init(proxy: tomlConfig.network?.proxy ?? true)
         )
+    }
+
+    private func applyRuntimeSettings(from config: TuistConfig.Tuist) {
+        HTTPSettings.current = .init(useEnvironmentProxy: config.network.proxy)
     }
 }

--- a/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
+++ b/cli/Sources/TuistConfigLoader/TuistTomlConfig.swift
@@ -2,25 +2,37 @@ import Foundation
 import TuistConfig
 
 struct TuistTomlConfig: Equatable, Sendable, Decodable {
-    let project: String
+    struct Network: Equatable, Sendable, Decodable {
+        let proxy: Bool?
+
+        init(proxy: Bool? = nil) {
+            self.proxy = proxy
+        }
+    }
+
+    let project: String?
     let url: URL?
+    let network: Network?
 
     init(
-        project: String,
-        url: URL? = nil
+        project: String? = nil,
+        url: URL? = nil,
+        network: Network? = nil
     ) {
         self.project = project
         self.url = url
+        self.network = network
     }
 
     private enum CodingKeys: String, CodingKey {
         case project
         case url
+        case network
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        project = try container.decode(String.self, forKey: .project)
+        project = try container.decodeIfPresent(String.self, forKey: .project)
         if let urlString = try container.decodeIfPresent(String.self, forKey: .url) {
             guard let parsed = URL(string: urlString) else {
                 throw DecodingError.dataCorruptedError(
@@ -33,5 +45,6 @@ struct TuistTomlConfig: Equatable, Sendable, Decodable {
         } else {
             url = nil
         }
+        network = try container.decodeIfPresent(Network.self, forKey: .network)
     }
 }

--- a/cli/Sources/TuistHTTP/AGENTS.md
+++ b/cli/Sources/TuistHTTP/AGENTS.md
@@ -17,3 +17,4 @@ This module provides HTTP client helpers used by server and cache integrations.
 ## Invariants
 - File transfers treat non-2xx responses as fatal errors.
 - Default URL session uses explicit request/resource timeouts.
+- Default proxy mode comes from runtime HTTP settings, and the shared session is resolved lazily, reused process-wide, and invalidated when those runtime settings change.

--- a/cli/Sources/TuistHTTP/FileClient.swift
+++ b/cli/Sources/TuistHTTP/FileClient.swift
@@ -57,14 +57,14 @@ import Path
     public struct FileClient: FileClienting {
         // MARK: - Attributes
 
-        let session: URLSession
+        private let session: URLSession?
         private let fileSystem: FileSysteming
         private let successStatusCodeRange = 200 ..< 300
 
         // MARK: - Init
 
         public init(
-            session: URLSession = .tuistShared,
+            session: URLSession? = nil,
             fileSystem: FileSysteming = FileSystem()
         ) {
             self.session = session
@@ -75,6 +75,7 @@ import Path
 
         public func download(url: URL) async throws -> AbsolutePath {
             let request = URLRequest(url: url)
+            let session = resolvedSession()
             do {
                 let (localUrl, response) = try await session.download(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -107,6 +108,7 @@ import Path
             let fileSize = UInt64(metadata.size)
             let fileData = try Data(contentsOf: file.url)
             let request = uploadRequest(url: url, fileSize: fileSize, data: fileData)
+            let session = resolvedSession()
             do {
                 let (_, response) = try await session.data(for: request)
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -142,6 +144,10 @@ import Path
             request.setValue("zip", forHTTPHeaderField: "Content-Encoding")
             request.httpBody = data
             return request
+        }
+
+        private func resolvedSession() -> URLSession {
+            session ?? .tuistShared
         }
 
         // MARK: - HAR Recording

--- a/cli/Sources/TuistHTTP/HTTPSettings.swift
+++ b/cli/Sources/TuistHTTP/HTTPSettings.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct HTTPSettings: Sendable {
+    public var useEnvironmentProxy: Bool
+
+    private static let lock = NSLock()
+    private static var storedCurrent = HTTPSettings()
+
+    public init(useEnvironmentProxy: Bool = true) {
+        self.useEnvironmentProxy = useEnvironmentProxy
+    }
+
+    public static var current: HTTPSettings {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedCurrent
+        }
+        set {
+            lock.lock()
+            storedCurrent = newValue
+            lock.unlock()
+            invalidateSharedTuistURLSession()
+        }
+    }
+}

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -15,9 +15,9 @@ import OpenAPIRuntime
 /// uses `data(for:delegate:)` which triggers the URLSessionTaskDelegate methods including
 /// `didFinishCollecting` for capturing detailed timing metrics.
 public struct TuistURLSessionTransport: ClientTransport {
-    private let session: URLSession
+    private let session: URLSession?
 
-    public init(session: URLSession = .tuistShared) {
+    public init(session: URLSession? = nil) {
         self.session = session
     }
 
@@ -28,6 +28,7 @@ public struct TuistURLSessionTransport: ClientTransport {
         operationID _: String
     ) async throws -> (HTTPResponse, HTTPBody?) {
         let urlRequest = try await buildURLRequest(from: request, body: body, baseURL: baseURL)
+        let session = resolvedSession()
 
         #if canImport(TuistHAR)
             let metricsDelegate = TaskMetricsDelegate()
@@ -54,6 +55,10 @@ public struct TuistURLSessionTransport: ClientTransport {
         let responseBody: HTTPBody? = data.isEmpty ? nil : HTTPBody(data)
 
         return (httpResponseObj, responseBody)
+    }
+
+    private func resolvedSession() -> URLSession {
+        session ?? .tuistShared
     }
 
     private func buildURLRequest(from request: HTTPRequest, body: HTTPBody?, baseURL: URL) async throws -> URLRequest {

--- a/cli/Sources/TuistHTTP/URLSession+Tuist.swift
+++ b/cli/Sources/TuistHTTP/URLSession+Tuist.swift
@@ -8,8 +8,6 @@ import TuistEnvironment
     import TuistHAR
 #endif
 
-private let _tuistURLSession: URLSession = makeTuistURLSession()
-
 private func environmentProxyURL() -> URL? {
     let environment = Environment.current.variables
     let candidates = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]
@@ -21,7 +19,15 @@ private func environmentProxyURL() -> URL? {
     return nil
 }
 
-public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
+private func resolvedUseEnvironmentProxy(_ useEnvironmentProxy: Bool?) -> Bool {
+    useEnvironmentProxy ?? HTTPSettings.current.useEnvironmentProxy
+}
+
+public func tuistURLSessionConfiguration(useEnvironmentProxy: Bool? = nil) -> URLSessionConfiguration {
+    tuistURLSessionConfigurationResolved(useEnvironmentProxy: resolvedUseEnvironmentProxy(useEnvironmentProxy))
+}
+
+private func tuistURLSessionConfigurationResolved(useEnvironmentProxy: Bool) -> URLSessionConfiguration {
     let configuration: URLSessionConfiguration = .ephemeral
     configuration.timeoutIntervalForRequest = 120
     configuration.timeoutIntervalForResource = 90
@@ -32,28 +38,75 @@ public func tuistURLSessionConfiguration() -> URLSessionConfiguration {
         configuration.allowsExpensiveNetworkAccess = true
     #endif
     #if os(macOS)
-        if let proxyURL = environmentProxyURL(), let dictionary = proxyDictionary(for: proxyURL) {
+        if useEnvironmentProxy,
+           let proxyURL = environmentProxyURL(),
+           let dictionary = proxyDictionary(for: proxyURL)
+        {
             configuration.connectionProxyDictionary = dictionary
         }
     #endif
     return configuration
 }
 
-private func makeTuistURLSession() -> URLSession {
+private func makeTuistURLSession(useEnvironmentProxy: Bool) -> URLSession {
     #if canImport(TuistHAR)
         return URLSession(
-            configuration: tuistURLSessionConfiguration(),
+            configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy),
             delegate: URLSessionMetricsDelegate.shared,
             delegateQueue: nil
         )
     #else
-        return URLSession(configuration: tuistURLSessionConfiguration())
+        return URLSession(configuration: tuistURLSessionConfigurationResolved(useEnvironmentProxy: useEnvironmentProxy))
     #endif
+}
+
+private final class SharedTuistURLSession: @unchecked Sendable {
+    private let lock = NSLock()
+    private var useEnvironmentProxy: Bool?
+    private var session: URLSession?
+
+    func resolve(useEnvironmentProxy: Bool) -> URLSession {
+        let sessionToInvalidate: URLSession?
+        lock.lock()
+
+        if let session, self.useEnvironmentProxy == useEnvironmentProxy {
+            lock.unlock()
+            return session
+        }
+
+        sessionToInvalidate = session
+        let session = makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
+        self.useEnvironmentProxy = useEnvironmentProxy
+        self.session = session
+        lock.unlock()
+        sessionToInvalidate?.invalidateAndCancel()
+        return session
+    }
+
+    func invalidate() {
+        let sessionToInvalidate: URLSession?
+        lock.lock()
+        useEnvironmentProxy = nil
+        sessionToInvalidate = session
+        session = nil
+        lock.unlock()
+        sessionToInvalidate?.invalidateAndCancel()
+    }
+}
+
+private let sharedTuistURLSession = SharedTuistURLSession()
+
+func invalidateSharedTuistURLSession() {
+    sharedTuistURLSession.invalidate()
 }
 
 extension URLSession {
     public static var tuistShared: URLSession {
-        _tuistURLSession
+        sharedTuistURLSession.resolve(useEnvironmentProxy: HTTPSettings.current.useEnvironmentProxy)
+    }
+
+    public static func tuistShared(useEnvironmentProxy: Bool) -> URLSession {
+        makeTuistURLSession(useEnvironmentProxy: useEnvironmentProxy)
     }
 }
 

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -38,6 +38,7 @@ extension TuistConfig.Tuist {
     ) async throws -> TuistConfig.Tuist {
         let fullHandle = manifest.fullHandle
         let inspectOptions = InspectOptions.from(manifest: manifest.inspectOptions)
+        let network = TuistConfig.Tuist.Network(proxy: manifest.network.proxy)
         let cache = TuistConfig.Tuist.Cache(upload: manifest.cache.upload)
         let urlString = manifest.url
 
@@ -81,7 +82,8 @@ extension TuistConfig.Tuist {
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         case .xcode:
             return TuistConfig.Tuist(
@@ -89,7 +91,8 @@ extension TuistConfig.Tuist {
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
                 cache: cache,
-                url: url
+                url: url,
+                network: network
             )
         }
     }

--- a/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
+++ b/cli/Sources/TuistLoader/Utils/ProjectDescription+TestData.swift
@@ -9,12 +9,14 @@ import TuistSupport
         public static func test(
             fullHandle: String? = nil,
             url: String = Constants.URLs.production.absoluteString,
+            network: Config.Network = .network(),
             generationOptions: Config.GenerationOptions = .options(),
             plugins: [PluginLocation] = []
         ) -> Config {
             Config(
                 fullHandle: fullHandle,
                 url: url,
+                network: network,
                 plugins: plugins,
                 generationOptions: generationOptions
             )

--- a/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
+++ b/cli/Sources/TuistServer/Services/CreateTestCaseRunAttachmentService.swift
@@ -46,12 +46,12 @@ enum CreateTestCaseRunAttachmentServiceError: LocalizedError {
 public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentServicing {
     private let fileSystem: FileSystem
     private let fullHandleService: FullHandleServicing
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init(
         fileSystem: FileSystem = FileSystem(),
         fullHandleService: FullHandleServicing = FullHandleService(),
-        urlSession: URLSession = .tuistShared
+        urlSession: URLSession? = nil
     ) {
         self.fileSystem = fileSystem
         self.fullHandleService = fullHandleService
@@ -99,6 +99,7 @@ public struct CreateTestCaseRunAttachmentService: CreateTestCaseRunAttachmentSer
                 request.setValue(Self.contentType(for: fileName), forHTTPHeaderField: "Content-Type")
                 request.httpBody = try await fileSystem.readFile(at: filePath)
 
+                let urlSession = urlSession ?? .tuistShared
                 let (_, uploadResponse) = try await urlSession.data(for: request)
                 guard let httpResponse = uploadResponse as? HTTPURLResponse,
                       (200 ..< 300).contains(httpResponse.statusCode)

--- a/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
+++ b/cli/Sources/TuistServer/Services/MultipartUploadArtifactService.swift
@@ -5,6 +5,7 @@ import FileSystem
 import Foundation
 import Mockable
 import Path
+import TuistHTTP
 import TuistThreadSafe
 
 public struct MultipartUploadArtifactPart {
@@ -60,12 +61,12 @@ public protocol MultipartUploadArtifactServicing {
 }
 
 public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
     private let fileSystem: FileSysteming
     private let retryProvider: RetryProviding
 
     public init(
-        urlSession: URLSession = .tuistShared,
+        urlSession: URLSession? = nil,
         fileSystem: FileSysteming = FileSystem(),
         retryProvider: RetryProviding = RetryProvider()
     ) {
@@ -131,6 +132,7 @@ public struct MultipartUploadArtifactService: MultipartUploadArtifactServicing {
     }
 
     private func upload(for request: URLRequest) async throws -> String {
+        let urlSession = urlSession ?? .tuistShared
         let (data, response) = try await urlSession.data(for: request)
         guard let urlResponse = response as? HTTPURLResponse else {
             throw MultipartUploadArtifactServiceError.noURLResponse(request.url)

--- a/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
+++ b/cli/Sources/TuistServer/Services/UploadPreviewIconService.swift
@@ -40,20 +40,20 @@ enum UploadPreviewIconServiceError: LocalizedError {
 public struct UploadPreviewIconService: UploadPreviewIconServicing {
     private let fullHandleService: FullHandleServicing
     private let fileSystem: FileSysteming
-    private let urlSession: URLSession
+    private let urlSession: URLSession?
 
     public init() {
         self.init(
             fullHandleService: FullHandleService(),
             fileSystem: FileSystem(),
-            urlSession: .tuistShared
+            urlSession: nil
         )
     }
 
     init(
         fullHandleService: FullHandleServicing,
         fileSystem: FileSysteming,
-        urlSession: URLSession
+        urlSession: URLSession? = nil
     ) {
         self.fullHandleService = fullHandleService
         self.fileSystem = fileSystem
@@ -86,6 +86,7 @@ public struct UploadPreviewIconService: UploadPreviewIconServicing {
                 let data = try await fileSystem.readFile(at: icon)
                 let fileSize = try await fileSystem.fileSizeInBytes(at: icon)
                 guard let url = URL(string: json.url) else { fatalError() }
+                let urlSession = urlSession ?? .tuistShared
                 let (_, response) = try await urlSession.data(
                     for: uploadRequest(
                         url: url,

--- a/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/ConfigLoaderTests.swift
@@ -6,18 +6,26 @@ import Path
 import Testing
 import TuistConfig
 import TuistConstants
+import TuistHTTP
 
 @testable import TuistConfigLoader
 
+@Suite(.serialized)
 struct ConfigLoaderTests {
     @Test(.inTemporaryDirectory)
     func loadConfig_returns_toml_config_when_toml_exists() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
 
         given(tomlConfigLoader)
             .loadConfig(at: .any)
-            .willReturn(TuistTomlConfig(project: "tuist/tuist", url: URL(string: "https://custom.tuist.dev")!))
+            .willReturn(TuistTomlConfig(
+                project: "tuist/tuist",
+                url: URL(string: "https://custom.tuist.dev")!,
+                network: .init(proxy: false)
+            ))
 
         let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
 
@@ -25,12 +33,16 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "tuist/tuist")
         #expect(config.url == URL(string: "https://custom.tuist.dev")!)
+        #expect(config.network.proxy == false)
+        #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
     @Test(.inTemporaryDirectory)
     func loadConfig_uses_production_url_when_toml_has_no_url() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
 
         given(tomlConfigLoader)
             .loadConfig(at: .any)
@@ -42,6 +54,29 @@ struct ConfigLoaderTests {
 
         #expect(config.fullHandle == "org/project")
         #expect(config.url == Constants.URLs.production)
+        #expect(config.network.proxy == true)
+        #expect(HTTPSettings.current.useEnvironmentProxy == true)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func loadConfig_returns_toml_network_config_without_project() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlConfigLoader = MockTuistTomlConfigLoading()
+        let previousSettings = HTTPSettings.current
+        defer { HTTPSettings.current = previousSettings }
+
+        given(tomlConfigLoader)
+            .loadConfig(at: .any)
+            .willReturn(TuistTomlConfig(network: .init(proxy: false)))
+
+        let subject = makeConfigLoader(tomlConfigLoader: tomlConfigLoader)
+
+        let config = try await subject.loadConfig(path: temporaryDirectory)
+
+        #expect(config.fullHandle == nil)
+        #expect(config.url == Constants.URLs.production)
+        #expect(config.network.proxy == false)
+        #expect(HTTPSettings.current.useEnvironmentProxy == false)
     }
 
     private func makeConfigLoader(tomlConfigLoader: TuistTomlConfigLoading) -> ConfigLoader {

--- a/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/SwiftConfigLoaderTests.swift
@@ -180,7 +180,8 @@
             stubConfig(
                 .test(
                     fullHandle: "tuist/tuist",
-                    url: "https://test.tuist.io"
+                    url: "https://test.tuist.io",
+                    network: .network(proxy: false)
                 ),
                 at: configPath.parentDirectory
             )
@@ -202,7 +203,8 @@
                 )),
                 fullHandle: "tuist/tuist",
                 inspectOptions: .test(),
-                url: expectedURL
+                url: expectedURL,
+                network: .init(proxy: false)
             ))
         }
 

--- a/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
+++ b/cli/Tests/TuistConfigLoaderTests/TuistTomlConfigLoaderTests.swift
@@ -20,6 +20,9 @@ struct TuistTomlConfigLoaderTests {
             """
             project = "tuist/tuist"
             url = "https://custom.tuist.dev"
+
+            [network]
+            proxy = false
             """,
             at: tomlPath
         )
@@ -35,6 +38,7 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "tuist/tuist")
         #expect(config?.url == URL(string: "https://custom.tuist.dev")!)
+        #expect(config?.network?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)
@@ -59,6 +63,33 @@ struct TuistTomlConfigLoaderTests {
 
         #expect(config?.project == "org/project")
         #expect(config?.url == nil)
+        #expect(config?.network == nil)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func loadConfig_returns_config_with_network_only() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let tomlPath = temporaryDirectory.appending(component: Constants.tuistTomlFileName)
+        try await fileSystem.writeText(
+            """
+            [network]
+            proxy = false
+            """,
+            at: tomlPath
+        )
+
+        let rootDirectoryLocator = MockRootDirectoryLocating()
+        given(rootDirectoryLocator).locate(from: .any).willReturn(temporaryDirectory)
+
+        let subject = TuistTomlConfigLoader(
+            fileSystem: fileSystem,
+            rootDirectoryLocator: rootDirectoryLocator
+        )
+        let config = try await subject.loadConfig(at: temporaryDirectory)
+
+        #expect(config?.project == nil)
+        #expect(config?.url == nil)
+        #expect(config?.network?.proxy == false)
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -1,0 +1,105 @@
+#if os(macOS)
+    import Foundation
+    import Testing
+    import TuistEnvironment
+    import TuistEnvironmentTesting
+
+    @testable import TuistHTTP
+
+    @Suite(.serialized)
+    struct URLSessionTuistTests {
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_uses_environment_proxy_when_enabled() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let configuration = tuistURLSessionConfiguration(useEnvironmentProxy: true)
+            let proxyHost = configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+            let proxyPort = configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPPort as String] as? Int
+
+            #expect(proxyHost == "proxy.tuist.dev")
+            #expect(proxyPort == 8080)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_skips_environment_proxy_when_disabled() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let configuration = tuistURLSessionConfiguration(useEnvironmentProxy: false)
+
+            #expect(configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistURLSessionConfiguration_uses_current_http_settings_by_default() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            defer { HTTPSettings.current = previousSettings }
+
+            let configuration = tuistURLSessionConfiguration()
+
+            #expect(configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistShared_resolves_proxy_mode_from_runtime_settings() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            defer { HTTPSettings.current = previousSettings }
+
+            let defaultSession = URLSession.tuistShared
+            let explicitProxiedSession = URLSession.tuistShared(useEnvironmentProxy: true)
+
+            #expect(defaultSession.configuration.connectionProxyDictionary == nil)
+            #expect(
+                explicitProxiedSession.configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+                    == "proxy.tuist.dev"
+            )
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistShared_reuses_the_process_shared_session() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            defer { HTTPSettings.current = previousSettings }
+
+            let firstSession = URLSession.tuistShared
+            let secondSession = URLSession.tuistShared
+
+            #expect(firstSession === secondSession)
+            #expect(firstSession.configuration.connectionProxyDictionary == nil)
+        }
+
+        @Test(.withMockedEnvironment())
+        func tuistShared_recreates_the_shared_session_when_runtime_settings_change() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            defer { HTTPSettings.current = previousSettings }
+
+            HTTPSettings.current = .init(useEnvironmentProxy: false)
+            let firstSession = URLSession.tuistShared
+
+            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            let secondSession = URLSession.tuistShared
+
+            #expect(firstSession !== secondSession)
+            #expect(firstSession.configuration.connectionProxyDictionary == nil)
+            #expect(
+                secondSession.configuration.connectionProxyDictionary?[kCFNetworkProxiesHTTPProxy as String] as? String
+                    == "proxy.tuist.dev"
+            )
+        }
+    }
+#endif

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -195,6 +195,9 @@ final class DumpServiceTests: TuistTestCase {
                   ]
                 }
               },
+              "network": {
+                "proxy": true
+              },
               "project": {
                 "tuist": {
                   "cacheOptions": {

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -91,3 +91,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+}

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TomlParser.kt
@@ -6,7 +6,12 @@ import java.io.File
 
 data class TomlConfig(
     val project: String?,
-    val url: String?
+    val url: String?,
+    val network: TomlNetworkConfig?
+)
+
+data class TomlNetworkConfig(
+    val proxy: Boolean?
 )
 
 object TomlParser {
@@ -23,11 +28,26 @@ object TomlParser {
             }
             TomlConfig(
                 project = result.getString("project"),
-                url = result.getString("url")
+                url = result.getString("url"),
+                network = result.getBoolean("network.proxy")?.let { TomlNetworkConfig(proxy = it) }
             )
         } catch (e: Exception) {
             logger.warn("Tuist: Failed to parse {}: {}", file, e.message)
             null
         }
+    }
+}
+
+object EnvironmentProxyResolver {
+    fun resolve(extensionProxy: Boolean?, projectDir: File?): Boolean {
+        extensionProxy?.let { return it }
+
+        if (projectDir != null) {
+            ServerUrlResolver.findTomlFile(projectDir)?.let { tomlFile ->
+                TomlParser.parse(tomlFile)?.network?.proxy?.let { return it }
+            }
+        }
+
+        return true
     }
 }

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
@@ -23,6 +23,8 @@ open class TuistBuildCache : AbstractBuildCache() {
     @Deprecated("No longer used. The plugin resolves auth natively.")
     var executablePath: String? = null
     var url: String? = null
+    lateinit var projectDir: String
+    var useEnvironmentProxy: Boolean = true
     var allowInsecureProtocol: Boolean = false
 }
 
@@ -39,8 +41,8 @@ class TuistBuildCacheServiceFactory : BuildCacheServiceFactory<TuistBuildCache> 
             .type("Tuist")
             .config("project", configuration.project ?: "(from tuist.toml)")
 
-        val projectDir = java.io.File(System.getProperty("user.dir"))
-        val httpClients = TuistHttpClients()
+        val projectDir = java.io.File(configuration.projectDir)
+        val httpClients = TuistHttpClients(useEnvironmentProxy = configuration.useEnvironmentProxy)
         val configurationProvider = DefaultConfigurationProvider(
             project = configuration.project,
             serverUrl = configuration.url ?: "https://tuist.dev",

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildInsights.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.GradleInternal
@@ -111,8 +112,10 @@ abstract class TuistBuildInsightsService :
     interface Params : BuildServiceParameters {
         val url: Property<String>
         val project: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
         val gradleVersion: Property<String>
         val rootProjectName: Property<String>
+        val projectDir: DirectoryProperty
     }
 
     private val logger = Logging.getLogger(TuistBuildInsightsService::class.java)
@@ -145,10 +148,7 @@ abstract class TuistBuildInsightsService :
 
     override fun started(buildOperation: BuildOperationDescriptor, startEvent: OperationStartEvent) {
         val opId = buildOperation.id ?: return
-        val parentId = buildOperation.parentId
-        if (parentId != null) {
-            operationParents[opId] = parentId
-        }
+        buildOperation.parentId?.let { operationParents[opId] = it }
 
         val details = buildOperation.details
         if (details is ExecuteTaskBuildOperationType.Details) {
@@ -221,12 +221,11 @@ abstract class TuistBuildInsightsService :
      * the cache load op up to the task op and returns `:app:compileKotlin`.
      */
     private fun findTaskPathForOperation(opId: OperationIdentifier): String? {
-        var currentId: OperationIdentifier? = opId
-        while (currentId != null) {
+        var currentId = opId
+        while (true) {
             operationTaskPaths[currentId]?.let { return it }
-            currentId = operationParents[currentId]
+            currentId = operationParents[currentId] ?: return null
         }
-        return null
     }
 
     override fun onFinish(event: FinishEvent) {
@@ -312,8 +311,8 @@ abstract class TuistBuildInsightsService :
 
     private fun sendReport(machineMetrics: List<MachineMetricSample>) {
         val projectValue = parameters.project.orNull
-        val httpClients = TuistHttpClients()
-        val projectDir = java.io.File(System.getProperty("user.dir"))
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
+        val projectDir = parameters.projectDir.asFile.get()
 
         val configProvider = DefaultConfigurationProvider(
             project = projectValue,
@@ -347,7 +346,7 @@ abstract class TuistBuildInsightsService :
         val response = httpClient.execute { config ->
             val resolvedUrl = ServerUrlResolver.resolve(
                 extensionUrl = parameters.url.get(),
-                projectDir = java.io.File(System.getProperty("user.dir"))
+                projectDir = projectDir
             )
             val url = URI(resolvedUrl).resolve("/api/projects/${config.accountHandle}/${config.projectHandle}/gradle/builds")
             val connection = httpClient.openConnection(url, config)
@@ -458,8 +457,10 @@ internal abstract class TuistBuildInsightsPlugin @Inject constructor(
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
+            parameters.useEnvironmentProxy.set(config.network.proxy)
             parameters.gradleVersion.set(project.gradle.gradleVersion)
             parameters.rootProjectName.set(project.rootProject.name)
+            parameters.projectDir.set(project.rootProject.layout.projectDirectory)
         }
 
         eventsListenerRegistry.onTaskCompletion(serviceProvider)

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistHttpClients.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistHttpClients.kt
@@ -17,14 +17,19 @@ import java.util.concurrent.TimeUnit
  * pool is shared.
  *
  * When the `HTTPS_PROXY` or `HTTP_PROXY` environment variable is set, the
- * clients automatically route requests through it; otherwise they use direct
- * connections. No explicit configuration is exposed to users.
+ * clients automatically route requests through it by default; otherwise they use
+ * direct connections. Callers can opt out by setting [useEnvironmentProxy] to
+ * `false`.
  */
 open class TuistHttpClients(
+    private val useEnvironmentProxy: Boolean = true,
+    private val proxyURLProvider: () -> String? = { environmentProxyURL() },
     private val environmentVariables: Map<String, String> = System.getenv()
 ) {
 
-    val javaProxy: java.net.Proxy? by lazy { environmentProxy() }
+    val javaProxy: java.net.Proxy? by lazy {
+        if (useEnvironmentProxy) environmentProxy() else null
+    }
 
     open val okHttp: OkHttpClient by lazy {
         OkHttpClient.Builder()
@@ -93,23 +98,28 @@ open class TuistHttpClients(
 
         private val PROXY_ENV_VARS = listOf("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
 
-        private fun environmentProxy(): java.net.Proxy? {
+        private fun environmentProxyURL(): String? {
             for (name in PROXY_ENV_VARS) {
                 val value = System.getenv(name)
-                if (!value.isNullOrBlank()) {
-                    val uri = runCatching { URI(value) }.getOrNull() ?: continue
-                    val host = uri.host ?: continue
-                    val port = if (uri.port != -1) uri.port else defaultProxyPort(uri.scheme)
-                    return java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress(host, port))
-                }
+                if (!value.isNullOrBlank()) return value
             }
             return null
         }
+    }
 
-        private fun defaultProxyPort(scheme: String?): Int = when (scheme?.lowercase()) {
-            "https" -> 443
-            "http" -> 80
-            else -> 8080
-        }
+    private fun environmentProxy(): java.net.Proxy? {
+        val value = proxyURLProvider()
+        if (value.isNullOrBlank()) return null
+
+        val uri = runCatching { URI(value) }.getOrNull() ?: return null
+        val host = uri.host ?: return null
+        val port = if (uri.port != -1) uri.port else defaultProxyPort(uri.scheme)
+        return java.net.Proxy(java.net.Proxy.Type.HTTP, InetSocketAddress(host, port))
+    }
+
+    private fun defaultProxyPort(scheme: String?): Int = when (scheme?.lowercase()) {
+        "https" -> 443
+        "http" -> 80
+        else -> 8080
     }
 }

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistPlugin.kt
@@ -24,6 +24,10 @@ import org.gradle.api.logging.Logging
  *
  *     uploadInBackground = true // default: true locally, false on CI
  *
+ *     network {
+ *         proxy = false
+ *     }
+ *
  *     buildCache {
  *         enabled = true
  *         push = true
@@ -38,9 +42,12 @@ import org.gradle.api.logging.Logging
 data class TuistGradleConfig(
     val url: String,
     val project: String?,
+    val network: Network,
     val uploadInBackground: Boolean? = null,
     val testQuarantineEnabled: Boolean? = null
 ) {
+    data class Network(val proxy: Boolean)
+
     companion object {
         internal const val EXTRA_PROPERTY_KEY = "tuist.config"
 
@@ -48,6 +55,12 @@ data class TuistGradleConfig(
             TuistGradleConfig(
                 url = extension.url,
                 project = extension.project.ifBlank { null },
+                network = Network(
+                    proxy = EnvironmentProxyResolver.resolve(
+                        extensionProxy = extension.network.proxy,
+                        projectDir = settings.settingsDir
+                    )
+                ),
                 uploadInBackground = extension.uploadInBackground,
                 testQuarantineEnabled = extension.testQuarantine.enabled
             )
@@ -124,6 +137,8 @@ class TuistPlugin : Plugin<Settings> {
             remote(TuistBuildCache::class.java) {
                 this.project = config.project
                 this.url = config.url
+                this.projectDir = settings.settingsDir.absolutePath
+                this.useEnvironmentProxy = config.network.proxy
                 isPush = buildCacheConfig.push
                 this.allowInsecureProtocol = buildCacheConfig.allowInsecureProtocol
             }
@@ -160,6 +175,18 @@ open class TuistExtension {
      * to ensure it completes before ephemeral agents exit.
      */
     var uploadInBackground: Boolean? = null
+
+    /**
+     * Network configuration.
+     */
+    val network: NetworkSettings = NetworkSettings()
+
+    /**
+     * Configure network settings.
+     */
+    fun network(action: Action<NetworkSettings>) {
+        action.execute(network)
+    }
 
     /**
      * Build cache configuration.
@@ -204,6 +231,18 @@ open class BuildCacheExtension {
      * Whether to allow insecure HTTP connections. Defaults to false.
      */
     var allowInsecureProtocol: Boolean = false
+}
+
+/**
+ * Configuration for Tuist's network behavior.
+ */
+open class NetworkSettings {
+    /**
+     * Whether the plugin should use the proxy defined by `HTTPS_PROXY`/`HTTP_PROXY`.
+     * When null (default), the plugin reads `[network].proxy` from `tuist.toml`
+     * and otherwise falls back to `true`.
+     */
+    var proxy: Boolean? = null
 }
 
 /**

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestInsights.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logging
@@ -288,7 +289,9 @@ abstract class TuistTestInsightsService :
     interface Params : BuildServiceParameters {
         val url: Property<String>
         val project: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
         val rootProjectName: Property<String>
+        val projectDir: DirectoryProperty
     }
 
     private val logger = Logging.getLogger(TuistTestInsightsService::class.java)
@@ -372,12 +375,13 @@ abstract class TuistTestInsightsService :
 
     private fun sendReport() {
         val projectValue = parameters.project.orNull
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
+        val projectDir = parameters.projectDir.asFile.get()
 
         val configProvider = DefaultConfigurationProvider(
             project = projectValue,
             serverUrl = parameters.url.get(),
-            projectDir = java.io.File(System.getProperty("user.dir")),
+            projectDir = projectDir,
             httpClients = httpClients
         )
 
@@ -464,7 +468,9 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
         ) {
             parameters.url.set(config.url)
             config.project?.let { parameters.project.set(it) }
+            parameters.useEnvironmentProxy.set(config.network.proxy)
             parameters.rootProjectName.set(project.rootProject.name)
+            parameters.projectDir.set(project.rootProject.layout.projectDirectory)
         }
 
         val quarantineEnabled = config.testQuarantineEnabled ?: ciDetector.isCi()
@@ -475,7 +481,8 @@ internal abstract class TuistTestInsightsPlugin @Inject constructor() : Plugin<P
             ) {
                 parameters.serverUrl.set(config.url)
                 config.project?.let { parameters.tuistProject.set(it) }
-                parameters.projectDir.set(System.getProperty("user.dir"))
+                parameters.useEnvironmentProxy.set(config.network.proxy)
+                parameters.projectDir.set(project.rootProject.layout.projectDirectory)
             }
         } else {
             null

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestQuarantine.kt
@@ -2,6 +2,7 @@ package dev.tuist.gradle
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
@@ -172,7 +173,8 @@ abstract class TuistTestQuarantineBuildService :
     interface Params : BuildServiceParameters {
         val serverUrl: Property<String>
         val tuistProject: Property<String>
-        val projectDir: Property<String>
+        val useEnvironmentProxy: Property<Boolean>
+        val projectDir: DirectoryProperty
     }
 
     @Volatile
@@ -190,11 +192,11 @@ abstract class TuistTestQuarantineBuildService :
 
     private fun createDelegate(): TuistTestQuarantineService {
         val serverUrl = parameters.serverUrl.get()
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = parameters.useEnvironmentProxy.get())
         val configProvider = DefaultConfigurationProvider(
             project = parameters.tuistProject.orNull,
             serverUrl = serverUrl,
-            projectDir = java.io.File(parameters.projectDir.get()),
+            projectDir = parameters.projectDir.asFile.get(),
             httpClients = httpClients
         )
         val httpClient = TuistHttpClient(

--- a/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/TuistTestSharding.kt
@@ -9,10 +9,16 @@ import okhttp3.OkHttpClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.Test
 import retrofit2.Retrofit
@@ -110,13 +116,6 @@ private fun createShardsApi(
         .create(ShardsApi::class.java)
 }
 
-fun discoverTestSuites(project: Project): List<String> {
-    val classDirs = project.allprojects.flatMap { subproject ->
-        subproject.tasks.withType(Test::class.java).flatMap { it.testClassesDirs.files }
-    }
-    return discoverTestSuitesFromDirs(classDirs)
-}
-
 fun discoverTestSuitesFromDirs(classDirs: List<java.io.File>): List<String> {
     val testSuites = mutableSetOf<String>()
     for (dir in classDirs) {
@@ -174,6 +173,15 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
     @get:Internal
     var tuistProject: String? = null
 
+    @get:Input
+    var useEnvironmentProxy: Boolean = true
+
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    @get:IgnoreEmptyDirectories
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val compiledTestClassDirectories: ConfigurableFileCollection
+
     @TaskAction
     fun execute() {
         val shardingService = createShardingService()
@@ -184,7 +192,7 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
                 "Could not derive shard reference. Set TUIST_SHARD_REFERENCE or run in a supported CI environment."
             )
 
-        val testSuites = discoverTestSuites(project)
+        val testSuites = discoverTestSuitesFromDirs(compiledTestClassDirectories.files.toList())
         if (testSuites.isEmpty()) {
             throw org.gradle.api.GradleException("No test classes found in compiled test output.")
         }
@@ -293,7 +301,7 @@ abstract class TuistPrepareTestShardsTask : DefaultTask() {
     }
 
     private fun createShardingService(): TuistTestShardingService {
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = useEnvironmentProxy)
         val configProvider = DefaultConfigurationProvider(
             project = tuistProject,
             serverUrl = serverUrl,
@@ -321,41 +329,42 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
         if (project !== project.rootProject) return
 
         val config = TuistGradleConfig.from(project) ?: return
+        val providers = project.providers
+        val testClassDirectories = project.objects.fileCollection()
 
-        project.tasks.register("tuistPrepareTestShards", TuistPrepareTestShardsTask::class.java).configure {
+        val prepareTestShards = project.tasks.register("tuistPrepareTestShards", TuistPrepareTestShardsTask::class.java)
+        prepareTestShards.configure {
             group = "tuist"
             description = "Build test classes, discover test suites, and create a shard plan on the Tuist server"
             serverUrl = config.url
             tuistProject = config.project
+            useEnvironmentProxy = config.network.proxy
+            compiledTestClassDirectories.from(testClassDirectories)
 
-            project.findProperty("tuistShardMax")?.toString()?.toIntOrNull()?.let { shardMax = it }
-            project.findProperty("tuistShardMin")?.toString()?.toIntOrNull()?.let { shardMin = it }
-            project.findProperty("tuistShardMaxDuration")?.toString()?.toIntOrNull()?.let { shardMaxDuration = it }
+            providers.gradleProperty("tuistShardMax").orNull?.toIntOrNull()?.let { shardMax = it }
+            providers.gradleProperty("tuistShardMin").orNull?.toIntOrNull()?.let { shardMin = it }
+            providers.gradleProperty("tuistShardMaxDuration").orNull?.toIntOrNull()?.let { shardMaxDuration = it }
+            providers.environmentVariable("TUIST_SHARD_REFERENCE").orNull?.let { shardReference = it }
+        }
 
-            System.getenv("TUIST_SHARD_REFERENCE")?.let { shardReference = it }
-
-            // Depend on whatever tasks produce the compiled test classes.
-            // This works for both standard JVM projects (testClasses) and Android
-            // projects (compileDebugUnitTestSources, etc.).
-            project.allprojects.forEach { subproject ->
-                subproject.tasks.withType(Test::class.java).forEach { testTask ->
-                    dependsOn(testTask.testClassesDirs.buildDependencies)
-                }
+        project.allprojects.forEach { subproject ->
+            subproject.tasks.withType(Test::class.java).configureEach {
+                testClassDirectories.from(testClassesDirs)
             }
         }
 
-        val shardIndexStr = System.getenv("TUIST_SHARD_INDEX") ?: return
+        val shardIndexStr = providers.environmentVariable("TUIST_SHARD_INDEX").orNull ?: return
         val shardIndex = shardIndexStr.toIntOrNull()
         if (shardIndex == null) {
             logger.warn("Tuist: TUIST_SHARD_INDEX is not a valid integer: $shardIndexStr")
             return
         }
 
-        val httpClients = TuistHttpClients()
+        val httpClients = TuistHttpClients(useEnvironmentProxy = config.network.proxy)
         val configProvider = DefaultConfigurationProvider(
             project = config.project,
             serverUrl = config.url,
-            projectDir = java.io.File(System.getProperty("user.dir")),
+            projectDir = project.rootProject.projectDir,
             httpClients = httpClients
         )
         val cacheConfig = configProvider.getConfiguration()
@@ -367,7 +376,7 @@ abstract class TuistTestShardingPlugin : Plugin<Project> {
             httpClients = httpClients
         )
 
-        val reference = System.getenv("TUIST_SHARD_REFERENCE") ?: shardingService.deriveReference()
+        val reference = providers.environmentVariable("TUIST_SHARD_REFERENCE").orNull ?: shardingService.deriveReference()
             ?: throw org.gradle.api.GradleException(
                 "Could not derive shard reference. Set TUIST_SHARD_REFERENCE or run in a supported CI environment."
             )

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistConfigReaderTest.kt
@@ -17,12 +17,16 @@ class TomlParserTest {
         toml.writeText("""
             project = "my-org/my-project"
             url = "https://custom.server.dev"
+
+            [network]
+            proxy = false
         """.trimIndent())
 
         val config = TomlParser.parse(toml)
 
         assertEquals("my-org/my-project", config?.project)
         assertEquals("https://custom.server.dev", config?.url)
+        assertEquals(false, config?.network?.proxy)
     }
 
     @Test
@@ -65,6 +69,19 @@ class TomlParserTest {
 
         val config = TomlParser.parse(toml)
         assertEquals("spaced/project", config?.project)
+    }
+
+    @Test
+    fun `parse handles network proxy only`() {
+        val toml = File(tempDir, "tuist.toml")
+        toml.writeText("""
+            [network]
+            proxy = false
+        """.trimIndent())
+
+        val config = TomlParser.parse(toml)
+
+        assertEquals(false, config?.network?.proxy)
     }
 
 }
@@ -141,5 +158,42 @@ class ServerUrlResolverFindTomlTest {
         nested.mkdirs()
 
         assertNull(ServerUrlResolver.findTomlFile(nested))
+    }
+}
+
+class EnvironmentProxyResolverTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `resolve returns extension value when set`() {
+        File(tempDir, "tuist.toml").writeText("""
+            [network]
+            proxy = false
+        """.trimIndent())
+
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = true, projectDir = tempDir)
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `resolve reads from tuist toml when extension value is not set`() {
+        File(tempDir, "tuist.toml").writeText("""
+            [network]
+            proxy = false
+        """.trimIndent())
+
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = null, projectDir = tempDir)
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `resolve defaults to true when nothing is configured`() {
+        val result = EnvironmentProxyResolver.resolve(extensionProxy = null, projectDir = tempDir)
+
+        assertEquals(true, result)
     }
 }

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
@@ -35,6 +35,26 @@ class TuistHttpClientsTest {
     }
 
     @Test
+    fun `does not create proxy when environment proxy usage is disabled`() {
+        val httpClients = TuistHttpClients(
+            useEnvironmentProxy = false,
+            proxyURLProvider = { "http://proxy.tuist.dev:8080" }
+        )
+
+        assertNull(httpClients.javaProxy)
+    }
+
+    @Test
+    fun `creates proxy from environment when enabled`() {
+        val httpClients = TuistHttpClients(
+            useEnvironmentProxy = true,
+            proxyURLProvider = { "http://proxy.tuist.dev:8080" }
+        )
+
+        assertNotNull(httpClients.javaProxy)
+    }
+
+    @Test
     fun `unauthenticatedRetrofit reaches the target server when no proxy env var is set`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"access_token":"at","refresh_token":"rt"}"""))
 

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistPluginTest.kt
@@ -293,6 +293,46 @@ class TuistPluginTest {
     }
 
     @Test
+    fun `plugin reads network proxy from tuist toml`() {
+        File(testProjectDir, "tuist.toml").writeText("""
+            project = "test-account/test-project"
+
+            [network]
+            proxy = false
+        """.trimIndent())
+
+        settingsFile.writeText("""
+            import dev.tuist.gradle.TuistGradleConfig
+
+            plugins {
+                id("dev.tuist")
+            }
+
+            rootProject.name = "test-project"
+        """.trimIndent())
+
+        buildFile.writeText("""
+            import dev.tuist.gradle.TuistGradleConfig
+
+            tasks.register("printProxyConfig") {
+                doLast {
+                    val config = project.extensions.extraProperties["tuist.config"] as TuistGradleConfig
+                    println("proxy=${'$'}{config.network.proxy}")
+                }
+            }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("printProxyConfig")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":printProxyConfig")?.outcome)
+        assertTrue(result.output.contains("proxy=false"))
+    }
+
+    @Test
     fun `build insights logs message when configured`() {
         settingsFile.writeText("""
             plugins {

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistTestShardingTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistTestShardingTest.kt
@@ -46,7 +46,7 @@ class TuistTestShardingTest {
         val project = org.gradle.testfixtures.ProjectBuilder.builder()
             .withProjectDir(projectDir)
             .build()
-        return project.tasks.create("testShards", TuistPrepareTestShardsTask::class.java)
+        return project.tasks.register("testShards", TuistPrepareTestShardsTask::class.java).get()
     }
 
     private fun shardPlan(shardCount: Int = 2) = ShardPlan(


### PR DESCRIPTION
## Summary
- Reapplies [#10334](https://github.com/tuist/tuist/pull/10334), which was reverted in `99de15ad36` shortly after merging.
- Restores `network.proxy` configuration in `Tuist.swift`, `tuist.toml`, and the Gradle plugin, mapped into shared runtime HTTP settings.
- Restores the focused Swift and Gradle test coverage that landed with the original PR.

## Why
The original PR was reverted after merge while the design tradeoff (global runtime settings vs. threading proxy config through service layers) was being discussed. Reapplying so the feature isn't lost while we decide whether any rework is needed; happy to rebase onto a slimmer approach if preferred.
