### PR TITLE
fix(server): sync S3 credentials from 1Password via ESO

### DIFF
--- a/infra/helm/tuist/templates/object-storage-external-secrets.yaml
+++ b/infra/helm/tuist/templates/object-storage-external-secrets.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.objectStorage.mode "external") .Values.objectStorage.external.managedSecrets }}
+# ESO syncs the S3 access key + secret access key from the configured store
+# (1Password by default). Keys are emitted as TUIST_S3_ACCESS_KEY_ID /
+# TUIST_S3_SECRET_ACCESS_KEY env vars on server and processor pods, picked up
+# by Tuist.Environment.s3_*. Storing the credentials separately from the
+# MASTER_KEY-decrypted priv/secrets/<env>.yml.enc means rotation is a single
+# 1Password edit instead of re-encrypting the secrets blob and rebuilding the
+# image — and the credentials never live in git, even encrypted.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.objectStorage.external.externalSecrets.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.objectStorage.external.externalSecrets.storeRef.name | default "onepassword" }}
+    kind: {{ .Values.objectStorage.external.externalSecrets.storeRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+    creationPolicy: Owner
+  data:
+    - secretKey: object-storage-access-key
+      remoteRef:
+        key: "{{ .Values.objectStorage.external.externalSecrets.accessKey.item | default "S3_CREDENTIALS" }}/{{ .Values.objectStorage.external.externalSecrets.accessKey.field | default "access_key_id" }}"
+    - secretKey: object-storage-secret-key
+      remoteRef:
+        key: "{{ .Values.objectStorage.external.externalSecrets.secretKey.item | default "S3_CREDENTIALS" }}/{{ .Values.objectStorage.external.externalSecrets.secretKey.field | default "secret_access_key" }}"
+{{- end }}

--- a/infra/helm/tuist/templates/object-storage-external-secrets.yaml
+++ b/infra/helm/tuist/templates/object-storage-external-secrets.yaml
@@ -13,11 +13,19 @@ spec:
   target:
     name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
     creationPolicy: Owner
+    # Strip trailing whitespace — the 1P web UI appends a newline when pasting,
+    # and an S3 access key with a trailing \n produces a 403 Invalid signature
+    # at request time (the exact failure mode this PR is fixing).
+    template:
+      engineVersion: v2
+      data:
+        object-storage-access-key: "{{ `{{ .object_storage_access_key | trim }}` }}"
+        object-storage-secret-key: "{{ `{{ .object_storage_secret_key | trim }}` }}"
   data:
-    - secretKey: object-storage-access-key
+    - secretKey: object_storage_access_key
       remoteRef:
         key: "{{ .Values.objectStorage.external.externalSecrets.accessKey.item | default "S3_CREDENTIALS" }}/{{ .Values.objectStorage.external.externalSecrets.accessKey.field | default "access_key_id" }}"
-    - secretKey: object-storage-secret-key
+    - secretKey: object_storage_secret_key
       remoteRef:
         key: "{{ .Values.objectStorage.external.externalSecrets.secretKey.item | default "S3_CREDENTIALS" }}/{{ .Values.objectStorage.external.externalSecrets.secretKey.field | default "secret_access_key" }}"
 {{- end }}

--- a/infra/helm/tuist/templates/object-storage-external-secrets.yaml
+++ b/infra/helm/tuist/templates/object-storage-external-secrets.yaml
@@ -1,11 +1,4 @@
 {{- if and (eq .Values.objectStorage.mode "external") .Values.objectStorage.external.managedSecrets }}
-# ESO syncs the S3 access key + secret access key from the configured store
-# (1Password by default). Keys are emitted as TUIST_S3_ACCESS_KEY_ID /
-# TUIST_S3_SECRET_ACCESS_KEY env vars on server and processor pods, picked up
-# by Tuist.Environment.s3_*. Storing the credentials separately from the
-# MASTER_KEY-decrypted priv/secrets/<env>.yml.enc means rotation is a single
-# 1Password edit instead of re-encrypting the secrets blob and rebuilding the
-# image — and the credentials never live in git, even encrypted.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.processor.enabled }}
-{{- $processorSecretName := ternary (include "tuist.componentName" (dict "root" . "component" "processor-external-secrets")) (include "tuist.componentName" (dict "root" . "component" "app-secrets")) .Values.processor.managedSecrets }}
+{{- $secretName := include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
+{{- $processorSecretName := ternary (include "tuist.componentName" (dict "root" . "component" "processor-external-secrets")) $secretName .Values.processor.managedSecrets }}
+{{- $objectStorageAccessKey := include "tuist.objectStorageAccessKey" . -}}
+{{- $objectStorageSecretKey := include "tuist.objectStorageSecretKey" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -110,6 +113,42 @@ spec:
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
             - name: TUIST_LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
+            # S3 config — same shape as the server pod. Tuist.Environment.s3_*
+            # reads these env vars before falling back to the :s3 block in
+            # priv/secrets/<env>.yml.enc, so the chart is the source of truth.
+            - name: TUIST_S3_BUCKET_NAME
+              value: {{ include "tuist.objectStorageBucketDefault" . | quote }}
+            - name: TUIST_S3_ENDPOINT
+              value: {{ include "tuist.objectStorageEndpoint" . | quote }}
+            - name: TUIST_S3_REGION
+              value: {{ include "tuist.objectStorageRegion" . | quote }}
+            - name: TUIST_S3_VIRTUAL_HOST
+              value: {{ .Values.server.s3.virtualHost | ternary "1" "0" | quote }}
+            - name: TUIST_S3_BUCKET_AS_HOST
+              value: {{ .Values.server.s3.bucketAsHost | ternary "1" "0" | quote }}
+            {{- if and (eq .Values.objectStorage.mode "external") .Values.objectStorage.external.managedSecrets }}
+            - name: TUIST_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+                  key: object-storage-access-key
+            - name: TUIST_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+                  key: object-storage-secret-key
+            {{- else if and $objectStorageAccessKey $objectStorageSecretKey }}
+            - name: TUIST_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: object-storage-access-key
+            - name: TUIST_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: object-storage-secret-key
+            {{- end }}
             {{- with .Values.processor.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -113,9 +113,6 @@ spec:
               value: {{ .Values.server.hosted | ternary "1" "0" | quote }}
             - name: TUIST_LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
-            # S3 config — same shape as the server pod. Tuist.Environment.s3_*
-            # reads these env vars before falling back to the :s3 block in
-            # priv/secrets/<env>.yml.enc, so the chart is the source of truth.
             - name: TUIST_S3_BUCKET_NAME
               value: {{ include "tuist.objectStorageBucketDefault" . | quote }}
             - name: TUIST_S3_ENDPOINT

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -117,31 +117,44 @@ spec:
             - name: RELEASE_NODE
               value: "$(TUIST_CLUSTER_APP_NAME)@$(POD_IP)"
             {{- end }}
-            {{- if not .Values.server.managedSecrets }}
+            # S3 config is emitted in both managed and self-hosted modes.
+            # Tuist.Environment.s3_* checks TUIST_S3_* env vars before falling
+            # back to the :s3 block in priv/secrets/<env>.yml.enc, so setting
+            # these here makes the chart the source of truth and lets us keep
+            # bucket/region/endpoint visible in values overlays instead of
+            # buried in the encrypted secrets blob.
             - name: TUIST_S3_BUCKET_NAME
-              value: {{ .Values.server.s3.bucketName | quote }}
+              value: {{ include "tuist.objectStorageBucketDefault" . | quote }}
             - name: TUIST_S3_ENDPOINT
               value: {{ include "tuist.objectStorageEndpoint" . | quote }}
             - name: TUIST_S3_REGION
-              value: {{ .Values.server.s3.region | quote }}
-            {{- if $objectStorageAccessKey }}
+              value: {{ include "tuist.objectStorageRegion" . | quote }}
+            - name: TUIST_S3_VIRTUAL_HOST
+              value: {{ .Values.server.s3.virtualHost | ternary "1" "0" | quote }}
+            - name: TUIST_S3_BUCKET_AS_HOST
+              value: {{ .Values.server.s3.bucketAsHost | ternary "1" "0" | quote }}
+            {{- if and (eq .Values.objectStorage.mode "external") .Values.objectStorage.external.managedSecrets }}
+            - name: TUIST_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+                  key: object-storage-access-key
+            - name: TUIST_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.componentName" (dict "root" . "component" "object-storage-external-secrets") }}
+                  key: object-storage-secret-key
+            {{- else if and $objectStorageAccessKey $objectStorageSecretKey }}
             - name: TUIST_S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: object-storage-access-key
-            {{- end }}
-            {{- if $objectStorageSecretKey }}
             - name: TUIST_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: object-storage-secret-key
-            {{- end }}
-            - name: TUIST_S3_VIRTUAL_HOST
-              value: {{ .Values.server.s3.virtualHost | ternary "1" "0" | quote }}
-            - name: TUIST_S3_BUCKET_AS_HOST
-              value: {{ .Values.server.s3.bucketAsHost | ternary "1" "0" | quote }}
             {{- end }}
             {{- if .Values.cache.enabled }}
             - name: TUIST_CACHE_ENDPOINTS

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -117,12 +117,6 @@ spec:
             - name: RELEASE_NODE
               value: "$(TUIST_CLUSTER_APP_NAME)@$(POD_IP)"
             {{- end }}
-            # S3 config is emitted in both managed and self-hosted modes.
-            # Tuist.Environment.s3_* checks TUIST_S3_* env vars before falling
-            # back to the :s3 block in priv/secrets/<env>.yml.enc, so setting
-            # these here makes the chart the source of truth and lets us keep
-            # bucket/region/endpoint visible in values overlays instead of
-            # buried in the encrypted secrets blob.
             - name: TUIST_S3_BUCKET_NAME
               value: {{ include "tuist.objectStorageBucketDefault" . | quote }}
             - name: TUIST_S3_ENDPOINT

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -53,6 +53,11 @@ server:
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
 
+objectStorage:
+  external:
+    buckets:
+      default: tuist-can-storage
+
 processor:
   # Supabase canary project (thapckmapmffdgaiarvu) — dedicated pooler on
   # port 6543 (transaction mode). Same hostname as the direct Postgres

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -20,12 +20,6 @@ server:
   podDisruptionBudget:
     enabled: false
 
-  # Terminate-first on canary: the 2-worker canary nodepool can't fit a
-  # surge pod alongside the existing server + processor + Valkey + system
-  # DaemonSets, so a maxSurge: 1 rollout strands the surge pod in
-  # FailedScheduling: Insufficient memory until helm --wait times out at
-  # 60m. Production keeps the surge strategy (larger nodes have headroom).
-  # Mirrors the processor's strategy on canary for the same reason.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -20,6 +20,18 @@ server:
   podDisruptionBudget:
     enabled: false
 
+  # Terminate-first on canary: the 2-worker canary nodepool can't fit a
+  # surge pod alongside the existing server + processor + Valkey + system
+  # DaemonSets, so a maxSurge: 1 rollout strands the surge pod in
+  # FailedScheduling: Insufficient memory until helm --wait times out at
+  # 60m. Production keeps the surge strategy (larger nodes have headroom).
+  # Mirrors the processor's strategy on canary for the same reason.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
   # ingress-nginx fronts the server on port 443 with a Cloudflare Origin
   # CA cert (synced into the tuist-tls-cloudflare-origin Secret out-of-
   # band; 15-year validity). Cloudflare is set to Full (strict) SSL.

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -172,17 +172,25 @@ clickhouse:
 
 objectStorage:
   mode: external
-  # Tigris S3-compatible storage.
+  # Tigris S3-compatible storage. Per-env access key + secret access key are
+  # synced from 1Password via ESO (item S3_CREDENTIALS in tuist-k8s-<env>);
+  # endpoint and region are vendor-level constants and live here. Per-env
+  # bucket name is set in values-managed-<env>.yaml.
   external:
-    endpoint: ""       # e.g. https://fly.storage.tigris.dev
-    accessKey: ""
-    secretKey: ""
+    endpoint: https://t3.storage.dev
     region: auto
-    buckets:
-      default: tuist
-      cache: tuist-cache
-      xcodeCache: tuist-xcode-cache
-      registry: tuist-registry
+    managedSecrets: true
+    externalSecrets:
+      refreshInterval: "1h"
+      storeRef:
+        kind: ClusterSecretStore
+        name: onepassword
+      accessKey:
+        item: S3_CREDENTIALS
+        field: access_key_id
+      secretKey:
+        item: S3_CREDENTIALS
+        field: secret_access_key
 
 observability:
   # We forward to Grafana Cloud via an in-cluster Alloy DaemonSet installed by

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -81,12 +81,8 @@ clickhouse:
 
 objectStorage:
   external:
-    endpoint: https://fly.storage.tigris.dev
     buckets:
       default: tuist
-      cache: tuist-cache
-      xcodeCache: tuist-xcode-cache
-      registry: tuist-registry
 
 processor:
   # Supabase production project (yltsvvtmlktxdgpcbylg) — dedicated pooler on

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -82,7 +82,7 @@ clickhouse:
 objectStorage:
   external:
     buckets:
-      default: tuist
+      default: tuist-prod-storage
 
 processor:
   # Supabase production project (yltsvvtmlktxdgpcbylg) — dedicated pooler on

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -71,6 +71,11 @@ server:
       cpu: "1000m"
       memory: "1536Mi"
 
+objectStorage:
+  external:
+    buckets:
+      default: tuist-stag-storage
+
 processor:
   # Supabase staging project (inzgspjesrhqhleomvkb) — dedicated pooler on
   # port 6543 (transaction mode). Same hostname as the direct Postgres

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -374,6 +374,25 @@ objectStorage:
       cache: tuist-cache
       xcodeCache: tuist-xcode-cache
       registry: tuist-registry
+    # When true, the chart provisions an ExternalSecret that syncs S3
+    # access keys from the configured store (1Password by default) and
+    # the deployments source TUIST_S3_ACCESS_KEY_ID / TUIST_S3_SECRET_ACCESS_KEY
+    # from that ESO-synced Secret. When false, accessKey/secretKey above
+    # are used directly via the bundled app-secrets Secret.
+    managedSecrets: false
+    externalSecrets:
+      refreshInterval: "1h"
+      storeRef:
+        kind: ClusterSecretStore
+        name: onepassword
+      accessKey:
+        # 1Password item title and field. With the 1P SDK provider the vault
+        # is set on the ClusterSecretStore, not here.
+        item: S3_CREDENTIALS
+        field: access_key_id
+      secretKey:
+        item: S3_CREDENTIALS
+        field: secret_access_key
   embedded:
     provider: minio
     image:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -374,11 +374,6 @@ objectStorage:
       cache: tuist-cache
       xcodeCache: tuist-xcode-cache
       registry: tuist-registry
-    # When true, the chart provisions an ExternalSecret that syncs S3
-    # access keys from the configured store (1Password by default) and
-    # the deployments source TUIST_S3_ACCESS_KEY_ID / TUIST_S3_SECRET_ACCESS_KEY
-    # from that ESO-synced Secret. When false, accessKey/secretKey above
-    # are used directly via the bundled app-secrets Secret.
     managedSecrets: false
     externalSecrets:
       refreshInterval: "1h"

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -340,7 +340,10 @@ defmodule Tuist.Environment do
 
   def s3_virtual_host(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      [:s3, :virtual_host] |> get(secrets) |> truthy?()
+      case System.get_env("TUIST_S3_VIRTUAL_HOST") do
+        nil -> [:s3, :virtual_host] |> get(secrets) |> truthy?()
+        value -> truthy?(value)
+      end
     else
       false
     end
@@ -348,7 +351,10 @@ defmodule Tuist.Environment do
 
   def s3_bucket_as_host(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      [:s3, :bucket_as_host] |> get(secrets) |> truthy?()
+      case System.get_env("TUIST_S3_BUCKET_AS_HOST") do
+        nil -> [:s3, :bucket_as_host] |> get(secrets) |> truthy?()
+        value -> truthy?(value)
+      end
     else
       false
     end

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -293,7 +293,9 @@ defmodule Tuist.Environment do
 
   def s3_access_key_id(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      System.get_env("AWS_ACCESS_KEY_ID") || get([:s3, :access_key_id], secrets)
+      System.get_env("TUIST_S3_ACCESS_KEY_ID") ||
+        System.get_env("AWS_ACCESS_KEY_ID") ||
+        get([:s3, :access_key_id], secrets)
     else
       "minio"
     end
@@ -301,19 +303,24 @@ defmodule Tuist.Environment do
 
   def s3_secret_access_key(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      System.get_env("AWS_SECRET_ACCESS_KEY") || get([:s3, :secret_access_key], secrets)
+      System.get_env("TUIST_S3_SECRET_ACCESS_KEY") ||
+        System.get_env("AWS_SECRET_ACCESS_KEY") ||
+        get([:s3, :secret_access_key], secrets)
     else
       "minio1234"
     end
   end
 
   def s3_region(secrets \\ secrets()) do
-    System.get_env("AWS_REGION") || get([:s3, :region], secrets) || "auto"
+    System.get_env("TUIST_S3_REGION") ||
+      System.get_env("AWS_REGION") ||
+      get([:s3, :region], secrets) ||
+      "auto"
   end
 
   def s3_bucket_name(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      get([:s3, :bucket_name], secrets)
+      System.get_env("TUIST_S3_BUCKET_NAME") || get([:s3, :bucket_name], secrets)
     else
       "tuist-development"
     end
@@ -321,7 +328,7 @@ defmodule Tuist.Environment do
 
   def s3_endpoint(secrets \\ secrets()) do
     if dev_use_remote_storage?() do
-      get([:s3, :endpoint], secrets)
+      System.get_env("TUIST_S3_ENDPOINT") || get([:s3, :endpoint], secrets)
     else
       System.get_env("TUIST_LOCAL_S3_ENDPOINT") ||
         case System.get_env("TUIST_MINIO_API_PORT") do


### PR DESCRIPTION
## What

Move the Tigris S3 credentials and non-secret config (bucket / region / endpoint) out of `priv/secrets/<env>.yml.enc` into 1Password (per-env vault) + helm values, synced via ExternalSecret. The chart becomes the source of truth for S3 config; rotation is now a single 1Password edit instead of re-encrypting the secrets blob and rebuilding the image.

## Why

Today's canary deploy ([run 25052893041](https://github.com/tuist/tuist/actions/runs/25052893041)) hung for the full 60m `helm --wait` window. Root cause from Grafana:

- Both `ProcessXcresultWorker` (server pods) and `ProcessBuildWorker` (processor pods) failing with `403 Invalid signature` against Tigris.
- The `:s3` block in `priv/secrets/can.yml.enc` is stale.

Server and processor read the *same* `:s3` map (the in-cluster processor migration in #10428 dropped per-processor S3 creds; both pods now share the server's secrets file), so a single bad credential block 403s every storage read across the canary fleet uniformly. Rotating the keys today requires editing the encrypted file, re-encrypting, and rebuilding the image — high friction for what should be a routine credential rotation.

This PR closes that loop: credentials live in 1Password, ExternalSecret syncs them in, env vars override the encrypted file's `:s3` block. Future rotations are an `op item edit` away.

## How

- **`Tuist.Environment.s3_*`** now reads `TUIST_S3_*` env vars before falling back to `AWS_*` env vars, then to `:s3` in the encrypted secrets file. Backward compatible — self-hosters who don't migrate keep working off the encrypted blob. Also closes a latent bug where the chart was already emitting `TUIST_S3_*` env vars in self-hosted mode but nothing read them. `s3_virtual_host` / `s3_bucket_as_host` got the same treatment so the chart's flags actually take effect.
- **New `templates/object-storage-external-secrets.yaml`** — ExternalSecret that pulls `access_key_id` and `secret_access_key` from a 1Password item (default name `S3_CREDENTIALS`). The Secret template pipes both values through `| trim` so a stray newline from a 1P web-UI paste doesn't reproduce the exact `403 Invalid signature` failure mode this PR is fixing (mirrors the existing trim on `MASTER_KEY`).
- **Server + processor deployments** — emit `TUIST_S3_BUCKET_NAME`, `TUIST_S3_ENDPOINT`, `TUIST_S3_REGION`, `TUIST_S3_VIRTUAL_HOST`, `TUIST_S3_BUCKET_AS_HOST` from the existing helm helpers. Access keys come from the new ESO Secret when `objectStorage.external.managedSecrets: true`, else from the bundled `app-secrets` Secret.
- **`values-managed-common.yaml`** — endpoint `https://t3.storage.dev` (note: replaces the old `https://fly.storage.tigris.dev` override that lived in production overlay), region `auto`, `managedSecrets: true`, ESO refs.
- **Per-env overlays** — bucket overrides only:
  - canary: `tuist-can-storage`
  - staging: `tuist-stag-storage`
  - production: `tuist-prod-storage`
- **Canary server strategy** — flipped to `maxSurge: 0, maxUnavailable: 1` (terminate-first). The previous `maxSurge: 1` strategy strands the surge pod in `FailedScheduling: Insufficient memory` on the 2-worker canary nodepool — same root cause as #10512 fixed for the processor, just biting the server now. Production keeps the surge strategy because it runs on larger nodes with the headroom.

## Verification

Triggered the deploy workflow against this branch on canary ([run 25072560864](https://github.com/tuist/tuist/actions/runs/25072560864)) — succeeded. ESO synced the `S3_CREDENTIALS` 1P item, the server pod terminated and re-scheduled cleanly, smoke test (`curl /ready`) passed. The credential rotation works end-to-end on the actively-broken environment.

## Pre-merge operator steps (already done for canary; do for staging + production)

1. Create a 1Password item in each per-env vault:
   - Vault: `tuist-k8s-{canary,staging,production}`
   - Title: `S3_CREDENTIALS`
   - Fields: `access_key_id` (text), `secret_access_key` (password)
   - Values: per-env Tigris keys scoped to the env's bucket via Tigris Bucket Roles → Editor.
2. Verify each item is reachable:

   ```bash
   for E in canary staging production; do
     op read "op://tuist-k8s-$E/S3_CREDENTIALS/access_key_id" >/dev/null \
       && echo "$E ✓" || echo "$E ✗"
   done
   ```

3. Confirm the per-env bucket names in the overlays match what's actually provisioned in Tigris: canary `tuist-can-storage`, staging `tuist-stag-storage`, production `tuist-prod-storage`.

## How to test locally

```bash
cd infra/helm/tuist
helm template tuist . \
  -f values-managed-common.yaml \
  -f values-managed-canary.yaml \
  --set server.image.tag=test
```

Render should show `TUIST_S3_*` env vars on both `tuist-tuist-server` and `tuist-tuist-processor` Deployments, with `TUIST_S3_ACCESS_KEY_ID` / `TUIST_S3_SECRET_ACCESS_KEY` sourced from `tuist-tuist-object-storage-external-secrets`. Repeat for staging / production overlays — only the bucket name should differ.

## Migration risk

`TUIST_S3_*` env vars now override the `:s3` block. If the 1P item / vault / field names are misaligned for staging or production, the deploy will 403 the same way today's does — rollback puts you back into the previous (broken-creds) state on canary, or the still-working state on staging/production. Worth eyeballing pod logs after rollout on each env before promoting.

## Follow-ups (separate PRs)

- Strip the `:s3` block from `priv/secrets/{can,stag,prod}.yml.enc` once all three envs are confirmed working.
- Rotate the old (pre-migration) Tigris keys out of existence so the encrypted-blob copies stop being valid credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
