### PR TITLE
fix(server): recover half-bootstrapped dev database installs

### DIFF
--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -48,6 +48,9 @@ if [ -z "${CI:-}" ]; then
   if ! postgres_database_exists; then
     bootstrap_postgres_database
   elif ! postgres_database_bootstrapped; then
+    # A previous install may have created the DB but exited before `ecto.load`
+    # finished. In that state later runs skip bootstrapping and migrations fail
+    # against missing base tables such as `users`, so rebuild the local DB.
     rebootstrap_postgres_database
   fi
 

--- a/server/mise/tasks/install.sh
+++ b/server/mise/tasks/install.sh
@@ -9,6 +9,12 @@ postgres_database_exists() {
   psql -Atqc "SELECT 1 FROM pg_database WHERE datname = '${TUIST_SERVER_POSTGRES_DB}'" postgres | grep -qx 1
 }
 
+postgres_database_bootstrapped() {
+  psql -d "${TUIST_SERVER_POSTGRES_DB}" -Atqc \
+    "SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users')" |
+    grep -qx t
+}
+
 clickhouse_database_exists() {
   curl -fsS "${CLICKHOUSE_HTTP_URL}" --data-binary "EXISTS DATABASE ${TUIST_SERVER_CLICKHOUSE_DB}" | grep -qx 1
 }
@@ -16,6 +22,11 @@ clickhouse_database_exists() {
 bootstrap_postgres_database() {
   mix ecto.create -r Tuist.Repo
   mix ecto.load -r Tuist.Repo
+}
+
+rebootstrap_postgres_database() {
+  mix ecto.drop -r Tuist.Repo
+  bootstrap_postgres_database
 }
 
 bootstrap_clickhouse_database() {
@@ -36,6 +47,8 @@ if [ -z "${CI:-}" ]; then
   # Fresh worktrees use isolated database names, so bootstrap missing repos independently.
   if ! postgres_database_exists; then
     bootstrap_postgres_database
+  elif ! postgres_database_bootstrapped; then
+    rebootstrap_postgres_database
   fi
 
   if ! clickhouse_database_exists; then


### PR DESCRIPTION
## Summary
This makes `server/mise/tasks/install.sh` heal a half-bootstrapped local Postgres database instead of assuming that an existing database has already loaded the baseline schema.

## Root cause
Fresh worktrees use isolated database names, but the install script only checked whether the database existed. If a previous install run created the database and stopped before `ecto.load` finished, later runs skipped the schema load and went straight to `db:migrate`, which then failed when migrations referenced tables like `users` that only exist in `priv/repo/structure.sql`.

## What changed
- add a bootstrap check that verifies the Postgres dev database already contains the baseline `users` table
- drop and recreate the local Postgres database when it exists but is missing the loaded schema
- continue to use the existing bootstrap path for fully missing databases

## Impact
Local `mise run install` becomes self-healing for interrupted or partially initialized dev databases, which removes a confusing migration failure mode when bootstrapping fresh worktrees.

## Validation
- `bash -n server/mise/tasks/install.sh`
- `mise run install`