### PR TITLE
feat(server): split flaky widgets into three granularities

### DIFF
--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -8,6 +8,7 @@ defmodule Tuist.Tests.Analytics do
   alias Tuist.ClickHouseRepo
   alias Tuist.CommandEvents.Event
   alias Tuist.Tests
+  alias Tuist.Tests.FlakyTestCaseRun
   alias Tuist.Tests.Test
   alias Tuist.Tests.TestCase
   alias Tuist.Tests.TestCaseEvent
@@ -164,6 +165,87 @@ defmodule Tuist.Tests.Analytics do
       dates: dates
     }
   end
+
+  @doc """
+  Returns analytics for the number of flaky test case runs over time for a project.
+  Counts every individual test case execution where `is_flaky = true`, not the
+  number of test cases flagged or the number of build runs that contained
+  flakiness. Backed by the `flaky_test_case_runs` materialized view.
+  """
+  def flaky_test_case_runs_analytics(project_id, opts \\ []) do
+    start_datetime = Keyword.get(opts, :start_datetime, DateTime.add(DateTime.utc_now(), -30, :day))
+    end_datetime = Keyword.get(opts, :end_datetime, DateTime.utc_now())
+
+    days_delta = Date.diff(DateTime.to_date(end_datetime), DateTime.to_date(start_datetime))
+    date_period = date_period(start_datetime: start_datetime, end_datetime: end_datetime)
+    time_bucket = time_bucket_for_date_period(date_period)
+    clickhouse_time_bucket = time_bucket_to_clickhouse_interval(time_bucket)
+
+    current_runs_data =
+      flaky_test_case_runs_count(
+        project_id,
+        start_datetime,
+        end_datetime,
+        date_period,
+        clickhouse_time_bucket,
+        opts
+      )
+
+    current_runs = process_runs_count_data(current_runs_data, start_datetime, end_datetime, date_period)
+
+    previous_runs_count =
+      flaky_test_case_runs_total_count(
+        project_id,
+        DateTime.add(start_datetime, -days_delta, :day),
+        start_datetime,
+        opts
+      )
+
+    current_runs_count = flaky_test_case_runs_total_count(project_id, start_datetime, end_datetime, opts)
+
+    %{
+      trend: trend(previous_value: previous_runs_count, current_value: current_runs_count),
+      count: current_runs_count,
+      values: Enum.map(current_runs, & &1.count),
+      dates: Enum.map(current_runs, & &1.date)
+    }
+  end
+
+  defp flaky_test_case_runs_count(project_id, start_datetime, end_datetime, _date_period, time_bucket, opts) do
+    date_format = get_clickhouse_date_format(time_bucket)
+    is_ci = Keyword.get(opts, :is_ci)
+
+    from(f in FlakyTestCaseRun,
+      where: f.project_id == ^project_id,
+      where: f.ran_at >= ^start_datetime,
+      where: f.ran_at <= ^end_datetime,
+      group_by: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format),
+      select: %{
+        date: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format),
+        count: count(f.test_case_id)
+      },
+      order_by: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format)
+    )
+    |> apply_flaky_test_case_run_is_ci_filter(is_ci)
+    |> ClickHouseRepo.all()
+  end
+
+  defp flaky_test_case_runs_total_count(project_id, start_datetime, end_datetime, opts) do
+    is_ci = Keyword.get(opts, :is_ci)
+
+    from(f in FlakyTestCaseRun,
+      where: f.project_id == ^project_id,
+      where: f.ran_at >= ^start_datetime,
+      where: f.ran_at <= ^end_datetime,
+      select: count(f.test_case_id)
+    )
+    |> apply_flaky_test_case_run_is_ci_filter(is_ci)
+    |> ClickHouseRepo.one() || 0
+  end
+
+  defp apply_flaky_test_case_run_is_ci_filter(query, nil), do: query
+  defp apply_flaky_test_case_run_is_ci_filter(query, true), do: where(query, [f], f.is_ci == true)
+  defp apply_flaky_test_case_run_is_ci_filter(query, false), do: where(query, [f], f.is_ci == false)
 
   @doc """
   Returns analytics for the number of flaky test cases over time for a project.

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -221,7 +221,7 @@ defmodule Tuist.Tests.Analytics do
       group_by: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format),
       select: %{
         date: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format),
-        count: count(f.test_case_id)
+        count: count()
       },
       order_by: fragment("formatDateTime(?, ?)", f.ran_at, ^date_format)
     )
@@ -236,7 +236,7 @@ defmodule Tuist.Tests.Analytics do
       where: f.project_id == ^project_id,
       where: f.ran_at >= ^start_datetime,
       where: f.ran_at <= ^end_datetime,
-      select: count(f.test_case_id)
+      select: count()
     )
     |> apply_flaky_test_case_run_is_ci_filter(is_ci)
     |> ClickHouseRepo.one() || 0

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -186,7 +186,6 @@ defmodule Tuist.Tests.Analytics do
         project_id,
         start_datetime,
         end_datetime,
-        date_period,
         clickhouse_time_bucket,
         opts
       )
@@ -211,7 +210,7 @@ defmodule Tuist.Tests.Analytics do
     }
   end
 
-  defp flaky_test_case_runs_count(project_id, start_datetime, end_datetime, _date_period, time_bucket, opts) do
+  defp flaky_test_case_runs_count(project_id, start_datetime, end_datetime, time_bucket, opts) do
     date_format = get_clickhouse_date_format(time_bucket)
     is_ci = Keyword.get(opts, :is_ci)
 

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -273,6 +273,8 @@ defmodule TuistWeb.FlakyTestsLive do
   defp normalize_selected_widget(widget) when widget in ["flaky_test_cases", "flaky_test_case_runs", "flaky_test_runs"],
     do: widget
 
+  defp normalize_selected_widget("flaky_tests"), do: "flaky_test_cases"
+  defp normalize_selected_widget("flaky_runs"), do: "flaky_test_runs"
   defp normalize_selected_widget(_), do: "flaky_test_cases"
 
   defp analytics_trend_label("last-24-hours"), do: dgettext("dashboard_tests", "since yesterday")

--- a/server/lib/tuist_web/live/flaky_tests_live.ex
+++ b/server/lib/tuist_web/live/flaky_tests_live.ex
@@ -238,7 +238,7 @@ defmodule TuistWeb.FlakyTestsLive do
 
   defp assign_analytics(%{assigns: %{selected_project: project}} = socket, params) do
     analytics_environment = params["analytics-environment"] || "any"
-    analytics_selected_widget = params["analytics-selected-widget"] || "flaky_tests"
+    analytics_selected_widget = normalize_selected_widget(params["analytics-selected-widget"])
 
     %{preset: preset, period: {start_datetime, end_datetime} = period} =
       DatePicker.date_picker_params(params, "analytics")
@@ -259,13 +259,21 @@ defmodule TuistWeb.FlakyTestsLive do
     |> assign(:analytics_period, period)
     |> assign(:analytics_trend_label, analytics_trend_label(preset))
     |> assign(:analytics_selected_widget, analytics_selected_widget)
-    |> assign_async(:flaky_runs_analytics, fn ->
-      {:ok, %{flaky_runs_analytics: Analytics.test_run_analytics(project.id, Keyword.put(opts, :is_flaky, true))}}
+    |> assign_async(:flaky_test_cases_analytics, fn ->
+      {:ok, %{flaky_test_cases_analytics: Analytics.flaky_tests_analytics(project.id, opts)}}
     end)
-    |> assign_async(:flaky_tests_analytics, fn ->
-      {:ok, %{flaky_tests_analytics: Analytics.flaky_tests_analytics(project.id, opts)}}
+    |> assign_async(:flaky_test_case_runs_analytics, fn ->
+      {:ok, %{flaky_test_case_runs_analytics: Analytics.flaky_test_case_runs_analytics(project.id, opts)}}
+    end)
+    |> assign_async(:flaky_test_runs_analytics, fn ->
+      {:ok, %{flaky_test_runs_analytics: Analytics.test_run_analytics(project.id, Keyword.put(opts, :is_flaky, true))}}
     end)
   end
+
+  defp normalize_selected_widget(widget) when widget in ["flaky_test_cases", "flaky_test_case_runs", "flaky_test_runs"],
+    do: widget
+
+  defp normalize_selected_widget(_), do: "flaky_test_cases"
 
   defp analytics_trend_label("last-24-hours"), do: dgettext("dashboard_tests", "since yesterday")
   defp analytics_trend_label("last-7-days"), do: dgettext("dashboard_tests", "since last week")

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -90,78 +90,113 @@
     <div data-part="analytics-content">
       <div data-part="widgets">
         <.widget
-          loading={!@flaky_tests_analytics.ok?}
-          title={dgettext("dashboard_tests", "Flaky Tests")}
+          loading={!@flaky_test_cases_analytics.ok?}
+          title={dgettext("dashboard_tests", "Flaky test cases")}
           description={
             dgettext(
               "dashboard_tests",
-              "Number of test cases currently flagged as flaky at each point in the period."
+              "Number of unique test cases currently flagged as flaky at the end of the period. Each test case is counted at most once, regardless of how often it flaked."
             )
           }
           value={
-            if @flaky_tests_analytics.ok?,
-              do: format_number(@flaky_tests_analytics.result.count)
+            if @flaky_test_cases_analytics.ok?,
+              do: format_number(@flaky_test_cases_analytics.result.count)
           }
-          id="widget-flaky-tests"
+          id="widget-flaky-test-cases"
           legend_color="flaky"
           trend_value={
-            if @flaky_tests_analytics.ok?,
-              do: @flaky_tests_analytics.result.trend,
+            if @flaky_test_cases_analytics.ok?,
+              do: @flaky_test_cases_analytics.result.trend,
               else: nil
           }
           trend_type={:inverse}
           trend_label={@analytics_trend_label}
           phx_click="select_widget"
-          phx_value_widget="flaky_tests"
-          selected={@analytics_selected_widget == "flaky_tests"}
+          phx_value_widget="flaky_test_cases"
+          selected={@analytics_selected_widget == "flaky_test_cases"}
           empty={
-            @flaky_tests_analytics.ok? &&
-              @flaky_tests_analytics.result.count == 0 &&
-              Enum.all?(@flaky_tests_analytics.result.values, &(&1 == 0))
+            @flaky_test_cases_analytics.ok? &&
+              @flaky_test_cases_analytics.result.count == 0 &&
+              Enum.all?(@flaky_test_cases_analytics.result.values, &(&1 == 0))
           }
         />
         <.widget
-          loading={!@flaky_runs_analytics.ok?}
-          title={dgettext("dashboard_tests", "Flaky Runs")}
+          loading={!@flaky_test_case_runs_analytics.ok?}
+          title={dgettext("dashboard_tests", "Flaky test case runs")}
           description={
             dgettext(
               "dashboard_tests",
-              "Number of individual test runs marked as flaky during the period."
+              "Total number of individual test case executions marked as flaky in the period. A single test case can be counted many times if it flaked across multiple runs."
             )
           }
           value={
-            if @flaky_runs_analytics.ok?,
-              do: format_number(@flaky_runs_analytics.result.count)
+            if @flaky_test_case_runs_analytics.ok?,
+              do: format_number(@flaky_test_case_runs_analytics.result.count)
           }
-          id="widget-flaky-runs"
+          id="widget-flaky-test-case-runs"
           legend_color="primary"
           trend_value={
-            if @flaky_runs_analytics.ok?,
-              do: @flaky_runs_analytics.result.trend,
+            if @flaky_test_case_runs_analytics.ok?,
+              do: @flaky_test_case_runs_analytics.result.trend,
               else: nil
           }
           trend_type={:inverse}
           trend_label={@analytics_trend_label}
           phx_click="select_widget"
-          phx_value_widget="flaky_runs"
-          selected={@analytics_selected_widget == "flaky_runs"}
-          empty={@flaky_runs_analytics.ok? && @flaky_runs_analytics.result.count == 0}
+          phx_value_widget="flaky_test_case_runs"
+          selected={@analytics_selected_widget == "flaky_test_case_runs"}
+          empty={
+            @flaky_test_case_runs_analytics.ok? &&
+              @flaky_test_case_runs_analytics.result.count == 0
+          }
+        />
+        <.widget
+          loading={!@flaky_test_runs_analytics.ok?}
+          title={dgettext("dashboard_tests", "Flaky test runs")}
+          description={
+            dgettext(
+              "dashboard_tests",
+              "Number of test runs (build-level test invocations) that contained at least one flaky test case. Each test run is counted once even if it contained many flaky executions."
+            )
+          }
+          value={
+            if @flaky_test_runs_analytics.ok?,
+              do: format_number(@flaky_test_runs_analytics.result.count)
+          }
+          id="widget-flaky-test-runs"
+          legend_color="tertiary"
+          trend_value={
+            if @flaky_test_runs_analytics.ok?,
+              do: @flaky_test_runs_analytics.result.trend,
+              else: nil
+          }
+          trend_type={:inverse}
+          trend_label={@analytics_trend_label}
+          phx_click="select_widget"
+          phx_value_widget="flaky_test_runs"
+          selected={@analytics_selected_widget == "flaky_test_runs"}
+          empty={@flaky_test_runs_analytics.ok? && @flaky_test_runs_analytics.result.count == 0}
         />
       </div>
       <.card_section :if={
-        (@analytics_selected_widget == "flaky_tests" and !@flaky_tests_analytics.ok?) or
-          (@analytics_selected_widget == "flaky_runs" and !@flaky_runs_analytics.ok?)
+        (@analytics_selected_widget == "flaky_test_cases" and !@flaky_test_cases_analytics.ok?) or
+          (@analytics_selected_widget == "flaky_test_case_runs" and
+             !@flaky_test_case_runs_analytics.ok?) or
+          (@analytics_selected_widget == "flaky_test_runs" and !@flaky_test_runs_analytics.ok?)
       }>
         <div data-part="analytics-chart">
           <.skeleton_chart />
         </div>
       </.card_section>
       <.card_section :if={
-        (@analytics_selected_widget == "flaky_tests" and @flaky_tests_analytics.ok? and
-           (@flaky_tests_analytics.result.count != 0 or
-              Enum.any?(@flaky_tests_analytics.result.values, &(&1 > 0)))) or
-          (@analytics_selected_widget == "flaky_runs" and @flaky_runs_analytics.ok? and
-             @flaky_runs_analytics.result.count != 0)
+        (@analytics_selected_widget == "flaky_test_cases" and @flaky_test_cases_analytics.ok? and
+           (@flaky_test_cases_analytics.result.count != 0 or
+              Enum.any?(@flaky_test_cases_analytics.result.values, &(&1 > 0)))) or
+          (@analytics_selected_widget == "flaky_test_case_runs" and
+             @flaky_test_case_runs_analytics.ok? and
+             @flaky_test_case_runs_analytics.result.count != 0) or
+          (@analytics_selected_widget == "flaky_test_runs" and @flaky_test_runs_analytics.ok? and
+             @flaky_test_runs_analytics.result.count != 0)
       }>
         <div data-part="analytics-chart">
           <.chart
@@ -184,16 +219,22 @@
                     formatter: "fn:toLocaleDate",
                     customValues:
                       case @analytics_selected_widget do
-                        "flaky_tests" ->
+                        "flaky_test_cases" ->
                           [
-                            List.first(@flaky_tests_analytics.result.dates),
-                            List.last(@flaky_tests_analytics.result.dates)
+                            List.first(@flaky_test_cases_analytics.result.dates),
+                            List.last(@flaky_test_cases_analytics.result.dates)
+                          ]
+
+                        "flaky_test_runs" ->
+                          [
+                            List.first(@flaky_test_runs_analytics.result.dates),
+                            List.last(@flaky_test_runs_analytics.result.dates)
                           ]
 
                         _ ->
                           [
-                            List.first(@flaky_runs_analytics.result.dates),
-                            List.last(@flaky_runs_analytics.result.dates)
+                            List.first(@flaky_test_case_runs_analytics.result.dates),
+                            List.last(@flaky_test_case_runs_analytics.result.dates)
                           ]
                       end,
                     padding: [10, 0, 0, 0]
@@ -225,25 +266,32 @@
               %{
                 color:
                   case @analytics_selected_widget do
-                    "flaky_tests" -> "var:noora-chart-flaky"
+                    "flaky_test_cases" -> "var:noora-chart-flaky"
+                    "flaky_test_runs" -> "var:noora-chart-tertiary"
                     _ -> "var:noora-chart-primary"
                   end,
                 data:
                   case @analytics_selected_widget do
-                    "flaky_tests" ->
-                      @flaky_tests_analytics.result.dates
-                      |> Enum.zip(@flaky_tests_analytics.result.values)
+                    "flaky_test_cases" ->
+                      @flaky_test_cases_analytics.result.dates
+                      |> Enum.zip(@flaky_test_cases_analytics.result.values)
+                      |> Enum.map(&Tuple.to_list/1)
+
+                    "flaky_test_runs" ->
+                      @flaky_test_runs_analytics.result.dates
+                      |> Enum.zip(@flaky_test_runs_analytics.result.values)
                       |> Enum.map(&Tuple.to_list/1)
 
                     _ ->
-                      @flaky_runs_analytics.result.dates
-                      |> Enum.zip(@flaky_runs_analytics.result.values)
+                      @flaky_test_case_runs_analytics.result.dates
+                      |> Enum.zip(@flaky_test_case_runs_analytics.result.values)
                       |> Enum.map(&Tuple.to_list/1)
                   end,
                 name:
                   case @analytics_selected_widget do
-                    "flaky_tests" -> dgettext("dashboard_tests", "Flaky tests")
-                    _ -> dgettext("dashboard_tests", "Flaky runs")
+                    "flaky_test_cases" -> dgettext("dashboard_tests", "Flaky test cases")
+                    "flaky_test_runs" -> dgettext("dashboard_tests", "Flaky test runs")
+                    _ -> dgettext("dashboard_tests", "Flaky test case runs")
                   end,
                 type: "line",
                 smooth: 0.1,
@@ -256,11 +304,14 @@
       </.card_section>
       <.empty_card_section
         :if={
-          (@analytics_selected_widget == "flaky_tests" and @flaky_tests_analytics.ok? and
-             @flaky_tests_analytics.result.count == 0 and
-             Enum.all?(@flaky_tests_analytics.result.values, &(&1 == 0))) or
-            (@analytics_selected_widget == "flaky_runs" and @flaky_runs_analytics.ok? and
-               @flaky_runs_analytics.result.count == 0)
+          (@analytics_selected_widget == "flaky_test_cases" and @flaky_test_cases_analytics.ok? and
+             @flaky_test_cases_analytics.result.count == 0 and
+             Enum.all?(@flaky_test_cases_analytics.result.values, &(&1 == 0))) or
+            (@analytics_selected_widget == "flaky_test_case_runs" and
+               @flaky_test_case_runs_analytics.ok? and
+               @flaky_test_case_runs_analytics.result.count == 0) or
+            (@analytics_selected_widget == "flaky_test_runs" and @flaky_test_runs_analytics.ok? and
+               @flaky_test_runs_analytics.result.count == 0)
         }
         title={dgettext("dashboard_tests", "No data yet")}
       >

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -91,7 +91,7 @@
       <div data-part="widgets">
         <.widget
           loading={!@flaky_test_cases_analytics.ok?}
-          title={dgettext("dashboard_tests", "Flaky test cases")}
+          title={dgettext("dashboard_tests", "Flagged flaky test cases")}
           description={
             dgettext(
               "dashboard_tests",
@@ -289,7 +289,7 @@
                   end,
                 name:
                   case @analytics_selected_widget do
-                    "flaky_test_cases" -> dgettext("dashboard_tests", "Flaky test cases")
+                    "flaky_test_cases" -> dgettext("dashboard_tests", "Flagged flaky test cases")
                     "flaky_test_runs" -> dgettext("dashboard_tests", "Flaky test runs")
                     _ -> dgettext("dashboard_tests", "Flaky test case runs")
                   end,

--- a/server/lib/tuist_web/live/flaky_tests_live.html.heex
+++ b/server/lib/tuist_web/live/flaky_tests_live.html.heex
@@ -225,16 +225,16 @@
                             List.last(@flaky_test_cases_analytics.result.dates)
                           ]
 
+                        "flaky_test_case_runs" ->
+                          [
+                            List.first(@flaky_test_case_runs_analytics.result.dates),
+                            List.last(@flaky_test_case_runs_analytics.result.dates)
+                          ]
+
                         "flaky_test_runs" ->
                           [
                             List.first(@flaky_test_runs_analytics.result.dates),
                             List.last(@flaky_test_runs_analytics.result.dates)
-                          ]
-
-                        _ ->
-                          [
-                            List.first(@flaky_test_case_runs_analytics.result.dates),
-                            List.last(@flaky_test_case_runs_analytics.result.dates)
                           ]
                       end,
                     padding: [10, 0, 0, 0]
@@ -267,8 +267,8 @@
                 color:
                   case @analytics_selected_widget do
                     "flaky_test_cases" -> "var:noora-chart-flaky"
+                    "flaky_test_case_runs" -> "var:noora-chart-primary"
                     "flaky_test_runs" -> "var:noora-chart-tertiary"
-                    _ -> "var:noora-chart-primary"
                   end,
                 data:
                   case @analytics_selected_widget do
@@ -277,21 +277,21 @@
                       |> Enum.zip(@flaky_test_cases_analytics.result.values)
                       |> Enum.map(&Tuple.to_list/1)
 
+                    "flaky_test_case_runs" ->
+                      @flaky_test_case_runs_analytics.result.dates
+                      |> Enum.zip(@flaky_test_case_runs_analytics.result.values)
+                      |> Enum.map(&Tuple.to_list/1)
+
                     "flaky_test_runs" ->
                       @flaky_test_runs_analytics.result.dates
                       |> Enum.zip(@flaky_test_runs_analytics.result.values)
-                      |> Enum.map(&Tuple.to_list/1)
-
-                    _ ->
-                      @flaky_test_case_runs_analytics.result.dates
-                      |> Enum.zip(@flaky_test_case_runs_analytics.result.values)
                       |> Enum.map(&Tuple.to_list/1)
                   end,
                 name:
                   case @analytics_selected_widget do
                     "flaky_test_cases" -> dgettext("dashboard_tests", "Flagged flaky test cases")
+                    "flaky_test_case_runs" -> dgettext("dashboard_tests", "Flaky test case runs")
                     "flaky_test_runs" -> dgettext("dashboard_tests", "Flaky test runs")
-                    _ -> dgettext("dashboard_tests", "Flaky test case runs")
                   end,
                 type: "line",
                 smooth: 0.1,

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -16,7 +16,7 @@ msgstr ""
 msgid "%{duration}s"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:738
+#: lib/tuist_web/live/tests_live.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "%{selective_test_effectiveness}%"
 msgstr ""
@@ -27,35 +27,33 @@ msgstr ""
 msgid "All tests passed!"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:2
-#: lib/tuist_web/live/test_cases_live.html.heex:2
-#: lib/tuist_web/live/test_runs_live.html.heex:2
-#: lib/tuist_web/live/tests_live.html.heex:2
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:55
+#: lib/tuist_web/live/test_cases_live.html.heex:81
+#: lib/tuist_web/live/test_runs_live.html.heex:81
+#: lib/tuist_web/live/tests_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Analytics"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:281
-#: lib/tuist_web/live/flaky_tests_live.html.heex:15
-#: lib/tuist_web/live/test_cases_live.ex:383
-#: lib/tuist_web/live/test_cases_live.html.heex:11
-#: lib/tuist_web/live/test_runs_live.ex:359
-#: lib/tuist_web/live/tests_live.ex:445
-#: lib/tuist_web/live/tests_live.ex:454
-#: lib/tuist_web/live/tests_live.html.heex:18
-#: lib/tuist_web/live/tests_live.html.heex:41
-#: lib/tuist_web/live/tests_live.html.heex:643
+#: lib/tuist_web/live/flaky_tests_live.ex:286
+#: lib/tuist_web/live/flaky_tests_live.html.heex:10
+#: lib/tuist_web/live/test_cases_live.ex:390
+#: lib/tuist_web/live/test_cases_live.html.heex:10
+#: lib/tuist_web/live/test_runs_live.ex:364
+#: lib/tuist_web/live/tests_live.ex:418
+#: lib/tuist_web/live/tests_live.ex:427
+#: lib/tuist_web/live/tests_live.html.heex:17
+#: lib/tuist_web/live/tests_live.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Any"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:80
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:46
-#: lib/tuist_web/live/shards_live.html.heex:44
-#: lib/tuist_web/live/test_cases_live.html.heex:74
-#: lib/tuist_web/live/test_runs_live.html.heex:74
-#: lib/tuist_web/live/tests_live.html.heex:106
-#: lib/tuist_web/live/tests_live.html.heex:708
+#: lib/tuist_web/live/flaky_tests_live.html.heex:75
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:45
+#: lib/tuist_web/live/shards_live.html.heex:43
+#: lib/tuist_web/live/test_cases_live.html.heex:73
+#: lib/tuist_web/live/test_runs_live.html.heex:73
+#: lib/tuist_web/live/tests_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
@@ -65,17 +63,17 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:466
+#: lib/tuist_web/live/test_case_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Automatically by Tuist"
 msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:348
 #: lib/tuist_web/live/shards_live.html.heex:466
-#: lib/tuist_web/live/test_cases_live.html.heex:401
+#: lib/tuist_web/live/test_cases_live.html.heex:407
 #: lib/tuist_web/live/test_runs_live.html.heex:358
 #: lib/tuist_web/live/tests_live.html.heex:356
-#: lib/tuist_web/live/tests_live.html.heex:835
+#: lib/tuist_web/live/tests_live.html.heex:751
 #, elixir-autogen, elixir-format
 msgid "Average"
 msgstr ""
@@ -95,14 +93,14 @@ msgstr ""
 msgid "Average duration of test runs during a given period."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:257
+#: lib/tuist_web/live/test_case_live.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Average duration of this test case across the last 50 runs."
 msgstr ""
 
-#: lib/tuist_web/live/test_cases_live.html.heex:480
-#: lib/tuist_web/live/test_cases_live.html.heex:504
-#: lib/tuist_web/live/test_cases_live.html.heex:592
+#: lib/tuist_web/live/test_cases_live.html.heex:486
+#: lib/tuist_web/live/test_cases_live.html.heex:510
+#: lib/tuist_web/live/test_cases_live.html.heex:605
 #, elixir-autogen, elixir-format
 msgid "Avg. duration"
 msgstr ""
@@ -120,14 +118,14 @@ msgstr ""
 msgid "Avg. test case duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:255
-#: lib/tuist_web/live/test_cases_live.ex:359
+#: lib/tuist_web/live/test_case_live.html.heex:250
+#: lib/tuist_web/live/test_cases_live.ex:365
 #: lib/tuist_web/live/test_cases_live.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Avg. test case run duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:341
+#: lib/tuist_web/live/test_runs_live.ex:346
 #: lib/tuist_web/live/test_runs_live.html.heex:135
 #: lib/tuist_web/live/tests_live.html.heex:174
 #: lib/tuist_web/live/xcode_overview_live.html.heex:176
@@ -136,12 +134,12 @@ msgid "Avg. test run duration"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_live.ex:93
-#: lib/tuist_web/live/test_case_live.html.heex:552
+#: lib/tuist_web/live/test_case_live.html.heex:547
 #: lib/tuist_web/live/test_case_run_live.html.heex:169
 #: lib/tuist_web/live/test_run_live.html.heex:281
 #: lib/tuist_web/live/test_runs_live.ex:52
 #: lib/tuist_web/live/test_runs_live.html.heex:482
-#: lib/tuist_web/live/tests_live.html.heex:1044
+#: lib/tuist_web/live/tests_live.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "Branch"
 msgstr ""
@@ -156,16 +154,15 @@ msgstr ""
 msgid "Build: %{scheme}"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:283
-#: lib/tuist_web/live/flaky_tests_live.html.heex:31
+#: lib/tuist_web/live/flaky_tests_live.ex:288
+#: lib/tuist_web/live/flaky_tests_live.html.heex:26
 #: lib/tuist_web/live/test_case_live.ex:116
-#: lib/tuist_web/live/test_cases_live.ex:385
-#: lib/tuist_web/live/test_cases_live.html.heex:27
-#: lib/tuist_web/live/test_runs_live.ex:361
-#: lib/tuist_web/live/tests_live.ex:447
-#: lib/tuist_web/live/tests_live.ex:448
-#: lib/tuist_web/live/tests_live.html.heex:49
-#: lib/tuist_web/live/tests_live.html.heex:651
+#: lib/tuist_web/live/test_cases_live.ex:392
+#: lib/tuist_web/live/test_cases_live.html.heex:26
+#: lib/tuist_web/live/test_runs_live.ex:366
+#: lib/tuist_web/live/tests_live.ex:420
+#: lib/tuist_web/live/tests_live.ex:421
+#: lib/tuist_web/live/tests_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "CI"
 msgstr ""
@@ -176,13 +173,12 @@ msgstr ""
 msgid "CI Run"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:71
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:37
-#: lib/tuist_web/live/shards_live.html.heex:37
-#: lib/tuist_web/live/test_cases_live.html.heex:67
-#: lib/tuist_web/live/test_runs_live.html.heex:67
-#: lib/tuist_web/live/tests_live.html.heex:97
-#: lib/tuist_web/live/tests_live.html.heex:699
+#: lib/tuist_web/live/flaky_tests_live.html.heex:66
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:36
+#: lib/tuist_web/live/shards_live.html.heex:36
+#: lib/tuist_web/live/test_cases_live.html.heex:66
+#: lib/tuist_web/live/test_runs_live.html.heex:66
+#: lib/tuist_web/live/tests_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -236,13 +232,12 @@ msgstr ""
 msgid "Crash Report"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:62
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:28
-#: lib/tuist_web/live/shards_live.html.heex:28
-#: lib/tuist_web/live/test_cases_live.html.heex:58
-#: lib/tuist_web/live/test_runs_live.html.heex:58
-#: lib/tuist_web/live/tests_live.html.heex:88
-#: lib/tuist_web/live/tests_live.html.heex:690
+#: lib/tuist_web/live/flaky_tests_live.html.heex:57
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:27
+#: lib/tuist_web/live/shards_live.html.heex:27
+#: lib/tuist_web/live/test_cases_live.html.heex:57
+#: lib/tuist_web/live/test_runs_live.html.heex:57
+#: lib/tuist_web/live/tests_live.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Custom"
 msgstr ""
@@ -255,9 +250,9 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:594
 #: lib/tuist_web/live/test_case_live.ex:85
-#: lib/tuist_web/live/test_case_live.html.heex:475
-#: lib/tuist_web/live/test_case_live.html.heex:491
-#: lib/tuist_web/live/test_case_live.html.heex:567
+#: lib/tuist_web/live/test_case_live.html.heex:470
+#: lib/tuist_web/live/test_case_live.html.heex:486
+#: lib/tuist_web/live/test_case_live.html.heex:562
 #: lib/tuist_web/live/test_case_run_live.html.heex:149
 #: lib/tuist_web/live/test_run_live.ex:922
 #: lib/tuist_web/live/test_run_live.ex:984
@@ -274,26 +269,25 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:1522
 #: lib/tuist_web/live/test_run_live.html.heex:1639
 #: lib/tuist_web/live/test_runs_live.html.heex:495
-#: lib/tuist_web/live/tests_live.html.heex:1057
+#: lib/tuist_web/live/tests_live.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Duration"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:11
-#: lib/tuist_web/live/test_cases_live.html.heex:7
-#: lib/tuist_web/live/test_runs_live.html.heex:7
-#: lib/tuist_web/live/tests_live.html.heex:37
-#: lib/tuist_web/live/tests_live.html.heex:639
+#: lib/tuist_web/live/flaky_tests_live.html.heex:6
+#: lib/tuist_web/live/test_cases_live.html.heex:6
+#: lib/tuist_web/live/test_runs_live.html.heex:6
+#: lib/tuist_web/live/tests_live.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Environment:"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:462
+#: lib/tuist_web/live/test_case_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Event"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:655
+#: lib/tuist_web/live/test_case_live.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Events will appear here when the test case status changes."
 msgstr ""
@@ -325,14 +319,14 @@ msgstr ""
 msgid "Expectation failed: %{message}"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:280
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:296
 #: lib/tuist_web/live/shards_live.ex:32
 #: lib/tuist_web/live/shards_live.html.heex:573
 #: lib/tuist_web/live/test_case_live.ex:76
-#: lib/tuist_web/live/test_case_live.html.heex:168
-#: lib/tuist_web/live/test_case_live.html.heex:376
-#: lib/tuist_web/live/test_case_live.html.heex:420
-#: lib/tuist_web/live/test_case_live.html.heex:543
+#: lib/tuist_web/live/test_case_live.html.heex:163
+#: lib/tuist_web/live/test_case_live.html.heex:371
+#: lib/tuist_web/live/test_case_live.html.heex:415
+#: lib/tuist_web/live/test_case_live.html.heex:538
 #: lib/tuist_web/live/test_case_run_live.html.heex:129
 #: lib/tuist_web/live/test_case_run_live.html.heex:307
 #: lib/tuist_web/live/test_case_run_live.html.heex:364
@@ -345,7 +339,7 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1007
 #: lib/tuist_web/live/test_case_run_live.html.heex:1044
 #: lib/tuist_web/live/test_cases_live.ex:45
-#: lib/tuist_web/live/test_cases_live.html.heex:619
+#: lib/tuist_web/live/test_cases_live.html.heex:632
 #: lib/tuist_web/live/test_run_live.ex:935
 #: lib/tuist_web/live/test_run_live.ex:997
 #: lib/tuist_web/live/test_run_live.ex:1054
@@ -364,13 +358,13 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:2200
 #: lib/tuist_web/live/test_runs_live.ex:43
 #: lib/tuist_web/live/test_runs_live.html.heex:468
-#: lib/tuist_web/live/tests_live.ex:511
-#: lib/tuist_web/live/tests_live.html.heex:1035
+#: lib/tuist_web/live/tests_live.ex:484
+#: lib/tuist_web/live/tests_live.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:324
+#: lib/tuist_web/live/test_runs_live.ex:329
 #: lib/tuist_web/live/test_runs_live.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Failed run count"
@@ -381,13 +375,13 @@ msgstr ""
 msgid "Failed run count represents a number of how many test runs failed during a given period. A test run is executed by either running 'tuist test' or 'tuist xcodebuild test'."
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:957
+#: lib/tuist_web/live/tests_live.html.heex:873
 #, elixir-autogen, elixir-format
 msgid "Failed runs"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:245
-#: lib/tuist_web/live/test_cases_live.ex:342
+#: lib/tuist_web/live/test_case_live.html.heex:240
+#: lib/tuist_web/live/test_cases_live.ex:347
 #: lib/tuist_web/live/test_cases_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Failed test case runs"
@@ -426,11 +420,11 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:321
+#: lib/tuist_web/live/flaky_tests_live.html.heex:369
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:206
 #: lib/tuist_web/live/shards_live.html.heex:531
-#: lib/tuist_web/live/test_case_live.html.heex:500
-#: lib/tuist_web/live/test_cases_live.html.heex:513
+#: lib/tuist_web/live/test_case_live.html.heex:495
+#: lib/tuist_web/live/test_cases_live.html.heex:519
 #: lib/tuist_web/live/test_run_live.html.heex:1088
 #: lib/tuist_web/live/test_run_live.html.heex:1305
 #: lib/tuist_web/live/test_run_live.html.heex:1531
@@ -439,21 +433,20 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:455
+#: lib/tuist_web/live/test_case_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "First run of this test"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:205
+#: lib/tuist_web/live/test_case_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:37
-#: lib/tuist_web/live/test_case_live.html.heex:526
+#: lib/tuist_web/live/test_case_live.html.heex:521
 #: lib/tuist_web/live/test_case_run_live.html.heex:40
 #: lib/tuist_web/live/test_cases_live.ex:74
-#: lib/tuist_web/live/test_cases_live.html.heex:562
+#: lib/tuist_web/live/test_cases_live.html.heex:568
 #: lib/tuist_web/live/test_run_live.ex:949
 #: lib/tuist_web/live/test_run_live.html.heex:55
 #: lib/tuist_web/live/test_run_live.html.heex:1125
@@ -463,9 +456,8 @@ msgstr ""
 msgid "Flaky"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:125
-#: lib/tuist_web/live/test_case_live.html.heex:134
-#: lib/tuist_web/live/test_case_live.html.heex:319
+#: lib/tuist_web/live/test_case_live.html.heex:129
+#: lib/tuist_web/live/test_case_live.html.heex:314
 #: lib/tuist_web/live/test_case_run_live.html.heex:667
 #: lib/tuist_web/live/test_run_live.html.heex:204
 #: lib/tuist_web/live/test_run_live.html.heex:837
@@ -477,25 +469,27 @@ msgid "Flaky Runs"
 msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.ex:23
-#: lib/tuist_web/live/flaky_tests_live.html.heex:3
-#: lib/tuist_web/live/flaky_tests_live.html.heex:94
+#: lib/tuist_web/live/flaky_tests_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:244
-#: lib/tuist_web/live/flaky_tests_live.html.heex:289
-#: lib/tuist_web/live/flaky_tests_live.html.heex:296
-#: lib/tuist_web/live/flaky_tests_live.html.heex:372
+#: lib/tuist_web/live/flaky_tests_live.html.heex:337
+#: lib/tuist_web/live/flaky_tests_live.html.heex:344
+#: lib/tuist_web/live/flaky_tests_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:94
+#: lib/tuist_web/live/flaky_tests_live.html.heex:287
 #: lib/tuist_web/live/test_run_live.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Flaky test cases"
 msgstr ""
 
+#: lib/tuist_web/live/flaky_tests_live.html.heex:152
+#: lib/tuist_web/live/flaky_tests_live.html.heex:288
 #: lib/tuist_web/live/tests_live.html.heex:133
 #: lib/tuist_web/live/tests_live.html.heex:542
 #, elixir-autogen, elixir-format
@@ -537,90 +531,86 @@ msgstr ""
 msgid "Issue recorded: %{message}"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:59
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:25
-#: lib/tuist_web/live/shards_live.html.heex:25
-#: lib/tuist_web/live/test_cases_live.html.heex:55
-#: lib/tuist_web/live/test_runs_live.html.heex:55
-#: lib/tuist_web/live/tests_live.html.heex:85
-#: lib/tuist_web/live/tests_live.html.heex:687
+#: lib/tuist_web/live/flaky_tests_live.html.heex:54
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:24
+#: lib/tuist_web/live/shards_live.html.heex:24
+#: lib/tuist_web/live/test_cases_live.html.heex:54
+#: lib/tuist_web/live/test_runs_live.html.heex:54
+#: lib/tuist_web/live/tests_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Last 12 months"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:44
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:10
-#: lib/tuist_web/live/shards_live.html.heex:10
-#: lib/tuist_web/live/test_cases_live.html.heex:40
-#: lib/tuist_web/live/test_runs_live.html.heex:40
-#: lib/tuist_web/live/tests_live.html.heex:70
-#: lib/tuist_web/live/tests_live.html.heex:672
+#: lib/tuist_web/live/flaky_tests_live.html.heex:39
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:9
+#: lib/tuist_web/live/shards_live.html.heex:9
+#: lib/tuist_web/live/test_cases_live.html.heex:39
+#: lib/tuist_web/live/test_runs_live.html.heex:39
+#: lib/tuist_web/live/tests_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "Last 24 hours"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:54
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:20
-#: lib/tuist_web/live/shards_live.html.heex:20
-#: lib/tuist_web/live/test_cases_live.html.heex:50
-#: lib/tuist_web/live/test_runs_live.html.heex:50
-#: lib/tuist_web/live/tests_live.html.heex:80
-#: lib/tuist_web/live/tests_live.html.heex:682
+#: lib/tuist_web/live/flaky_tests_live.html.heex:49
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:19
+#: lib/tuist_web/live/shards_live.html.heex:19
+#: lib/tuist_web/live/test_cases_live.html.heex:49
+#: lib/tuist_web/live/test_runs_live.html.heex:49
+#: lib/tuist_web/live/tests_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:49
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:15
-#: lib/tuist_web/live/shards_live.html.heex:15
-#: lib/tuist_web/live/test_cases_live.html.heex:45
-#: lib/tuist_web/live/test_runs_live.html.heex:45
-#: lib/tuist_web/live/tests_live.html.heex:75
-#: lib/tuist_web/live/tests_live.html.heex:677
+#: lib/tuist_web/live/flaky_tests_live.html.heex:44
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:14
+#: lib/tuist_web/live/shards_live.html.heex:14
+#: lib/tuist_web/live/test_cases_live.html.heex:44
+#: lib/tuist_web/live/test_runs_live.html.heex:44
+#: lib/tuist_web/live/tests_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Last 7 days"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:158
+#: lib/tuist_web/live/test_case_live.html.heex:153
 #: lib/tuist_web/live/test_cases_live.ex:40
 #, elixir-autogen, elixir-format
 msgid "Last Status"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:288
-#: lib/tuist_web/live/flaky_tests_live.html.heex:312
-#: lib/tuist_web/live/flaky_tests_live.html.heex:386
+#: lib/tuist_web/live/flaky_tests_live.html.heex:336
+#: lib/tuist_web/live/flaky_tests_live.html.heex:360
+#: lib/tuist_web/live/flaky_tests_live.html.heex:434
 #, elixir-autogen, elixir-format
 msgid "Last flaky run"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:191
-#: lib/tuist_web/live/test_cases_live.html.heex:481
-#: lib/tuist_web/live/test_cases_live.html.heex:488
-#: lib/tuist_web/live/test_cases_live.html.heex:629
+#: lib/tuist_web/live/test_case_live.html.heex:186
+#: lib/tuist_web/live/test_cases_live.html.heex:487
+#: lib/tuist_web/live/test_cases_live.html.heex:494
+#: lib/tuist_web/live/test_cases_live.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "Last ran at"
 msgstr ""
 
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:182
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:189
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:291
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:307
 #, elixir-autogen, elixir-format
 msgid "Last run"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:182
+#: lib/tuist_web/live/test_case_live.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Last run duration"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:272
-#: lib/tuist_web/live/test_cases_live.html.heex:611
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:288
+#: lib/tuist_web/live/test_cases_live.html.heex:624
 #, elixir-autogen, elixir-format
 msgid "Last status"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:665
+#: lib/tuist_web/live/test_case_live.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -631,16 +621,15 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:282
-#: lib/tuist_web/live/flaky_tests_live.html.heex:23
-#: lib/tuist_web/live/test_cases_live.ex:384
-#: lib/tuist_web/live/test_cases_live.html.heex:19
+#: lib/tuist_web/live/flaky_tests_live.ex:287
+#: lib/tuist_web/live/flaky_tests_live.html.heex:18
+#: lib/tuist_web/live/test_cases_live.ex:391
+#: lib/tuist_web/live/test_cases_live.html.heex:18
 #: lib/tuist_web/live/test_run_live.html.heex:1768
-#: lib/tuist_web/live/test_runs_live.ex:360
-#: lib/tuist_web/live/tests_live.ex:446
-#: lib/tuist_web/live/tests_live.ex:449
-#: lib/tuist_web/live/tests_live.html.heex:57
-#: lib/tuist_web/live/tests_live.html.heex:659
+#: lib/tuist_web/live/test_runs_live.ex:365
+#: lib/tuist_web/live/tests_live.ex:419
+#: lib/tuist_web/live/tests_live.ex:422
+#: lib/tuist_web/live/tests_live.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "Local"
 msgstr ""
@@ -655,29 +644,19 @@ msgstr ""
 msgid "Mac device"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:468
+#: lib/tuist_web/live/test_case_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Manually by @%{name}"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:110
+#: lib/tuist_web/live/test_case_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:456
-#, elixir-autogen, elixir-format
-msgid "Marked as flaky"
-msgstr ""
-
 #: lib/tuist_web/live/test_case_live.ex:458
 #, elixir-autogen, elixir-format
-msgid "Marked as quarantined"
-msgstr ""
-
-#: lib/tuist_web/live/test_case_live.ex:459
-#, elixir-autogen, elixir-format
-msgid "Marked as unquarantined"
+msgid "Marked as flaky"
 msgstr ""
 
 #: lib/tuist_web/live/test_run_live.html.heex:1774
@@ -702,7 +681,7 @@ msgstr ""
 msgid "Modules"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:1155
+#: lib/tuist_web/live/tests_live.html.heex:1071
 #, elixir-autogen, elixir-format
 msgid "Most occurring flaky tests"
 msgstr ""
@@ -716,22 +695,22 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:130
 #: lib/tuist_web/live/shards_live.html.heex:192
-#: lib/tuist_web/live/test_case_live.html.heex:228
-#: lib/tuist_web/live/test_case_live.html.heex:271
+#: lib/tuist_web/live/test_case_live.html.heex:223
+#: lib/tuist_web/live/test_case_live.html.heex:266
 #: lib/tuist_web/live/test_cases_live.html.heex:216
 #: lib/tuist_web/live/test_runs_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "No data"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:262
+#: lib/tuist_web/live/flaky_tests_live.html.heex:310
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:150
-#: lib/tuist_web/live/test_cases_live.html.heex:452
-#: lib/tuist_web/live/test_cases_live.html.heex:659
+#: lib/tuist_web/live/test_cases_live.html.heex:458
+#: lib/tuist_web/live/test_cases_live.html.heex:672
 #: lib/tuist_web/live/test_runs_live.html.heex:409
 #: lib/tuist_web/live/test_runs_live.html.heex:518
 #: lib/tuist_web/live/tests_live.html.heex:620
-#: lib/tuist_web/live/tests_live.html.heex:1072
+#: lib/tuist_web/live/tests_live.html.heex:988
 #, elixir-autogen, elixir-format
 msgid "No data yet"
 msgstr ""
@@ -742,12 +721,12 @@ msgstr ""
 msgid "No failures detected"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:426
+#: lib/tuist_web/live/flaky_tests_live.html.heex:472
 #, elixir-autogen, elixir-format
 msgid "No flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:653
+#: lib/tuist_web/live/test_case_live.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "No history available"
 msgstr ""
@@ -757,12 +736,12 @@ msgstr ""
 msgid "No modules found"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:331
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:334
 #, elixir-autogen, elixir-format
 msgid "No quarantined tests"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:603
+#: lib/tuist_web/live/test_case_live.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "No test case runs found"
 msgstr ""
@@ -772,7 +751,7 @@ msgstr ""
 msgid "No test cases found"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:1210
+#: lib/tuist_web/live/tests_live.html.heex:1126
 #, elixir-autogen, elixir-format
 msgid "No test cases yet"
 msgstr ""
@@ -797,7 +776,7 @@ msgstr ""
 msgid "Number of test cases that passed after retry."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:247
+#: lib/tuist_web/live/test_case_live.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "Number of times this test case has failed."
 msgstr ""
@@ -812,21 +791,21 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:124
+#: lib/tuist_web/live/test_case_live.html.heex:119
 #: lib/tuist_web/live/test_case_run_live.html.heex:96
 #: lib/tuist_web/live/test_run_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:275
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:291
 #: lib/tuist_web/live/shards_live.ex:31
 #: lib/tuist_web/live/shards_live.html.heex:568
 #: lib/tuist_web/live/test_case_live.ex:75
-#: lib/tuist_web/live/test_case_live.html.heex:161
-#: lib/tuist_web/live/test_case_live.html.heex:369
-#: lib/tuist_web/live/test_case_live.html.heex:413
-#: lib/tuist_web/live/test_case_live.html.heex:538
+#: lib/tuist_web/live/test_case_live.html.heex:156
+#: lib/tuist_web/live/test_case_live.html.heex:364
+#: lib/tuist_web/live/test_case_live.html.heex:408
+#: lib/tuist_web/live/test_case_live.html.heex:533
 #: lib/tuist_web/live/test_case_run_live.html.heex:122
 #: lib/tuist_web/live/test_case_run_live.html.heex:357
 #: lib/tuist_web/live/test_case_run_live.html.heex:396
@@ -838,7 +817,7 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1000
 #: lib/tuist_web/live/test_case_run_live.html.heex:1037
 #: lib/tuist_web/live/test_cases_live.ex:44
-#: lib/tuist_web/live/test_cases_live.html.heex:615
+#: lib/tuist_web/live/test_cases_live.html.heex:628
 #: lib/tuist_web/live/test_run_live.ex:934
 #: lib/tuist_web/live/test_run_live.ex:996
 #: lib/tuist_web/live/test_run_live.ex:1053
@@ -856,18 +835,18 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:2193
 #: lib/tuist_web/live/test_runs_live.ex:42
 #: lib/tuist_web/live/test_runs_live.html.heex:463
-#: lib/tuist_web/live/tests_live.ex:510
-#: lib/tuist_web/live/tests_live.html.heex:1030
+#: lib/tuist_web/live/tests_live.ex:483
+#: lib/tuist_web/live/tests_live.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:952
+#: lib/tuist_web/live/tests_live.html.heex:868
 #, elixir-autogen, elixir-format
 msgid "Passed runs"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:207
+#: lib/tuist_web/live/test_case_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Percentage of test runs that were flaky in the last 30 days."
 msgstr ""
@@ -877,13 +856,7 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:431
-#: lib/tuist_web/live/test_case_live.ex:460
-#: lib/tuist_web/live/test_case_live.html.heex:44
-#: lib/tuist_web/live/test_case_live.html.heex:89
 #: lib/tuist_web/live/test_case_run_live.html.heex:54
-#: lib/tuist_web/live/test_cases_live.ex:75
-#: lib/tuist_web/live/test_cases_live.html.heex:569
 #: lib/tuist_web/live/test_run_live.html.heex:536
 #: lib/tuist_web/live/test_run_live.html.heex:881
 #: lib/tuist_web/live/test_run_live.html.heex:1139
@@ -900,8 +873,8 @@ msgstr ""
 msgid "Quarantined Tests"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.ex:62
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:255
+#: lib/tuist_web/live/quarantined_tests_live.ex:75
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:271
 #, elixir-autogen, elixir-format
 msgid "Quarantined by"
 msgstr ""
@@ -912,30 +885,30 @@ msgid "Quarantined tests"
 msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:610
-#: lib/tuist_web/live/test_case_live.html.heex:476
-#: lib/tuist_web/live/test_case_live.html.heex:483
-#: lib/tuist_web/live/test_case_live.html.heex:588
+#: lib/tuist_web/live/test_case_live.html.heex:471
+#: lib/tuist_web/live/test_case_live.html.heex:478
+#: lib/tuist_web/live/test_case_live.html.heex:583
 #: lib/tuist_web/live/test_case_run_live.html.heex:158
 #: lib/tuist_web/live/test_run_live.html.heex:273
 #: lib/tuist_web/live/test_run_live.html.heex:409
 #: lib/tuist_web/live/test_runs_live.html.heex:503
-#: lib/tuist_web/live/tests_live.html.heex:1065
+#: lib/tuist_web/live/tests_live.html.heex:981
 #, elixir-autogen, elixir-format
 msgid "Ran at"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_live.ex:110
-#: lib/tuist_web/live/test_case_live.html.heex:562
+#: lib/tuist_web/live/test_case_live.html.heex:557
 #: lib/tuist_web/live/test_case_run_live.html.heex:143
 #: lib/tuist_web/live/test_run_live.html.heex:252
 #: lib/tuist_web/live/test_runs_live.ex:69
 #: lib/tuist_web/live/test_runs_live.html.heex:492
-#: lib/tuist_web/live/tests_live.html.heex:1054
+#: lib/tuist_web/live/tests_live.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Ran by"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:923
+#: lib/tuist_web/live/tests_live.html.heex:839
 #, elixir-autogen, elixir-format
 msgid "Recent Test Runs"
 msgstr ""
@@ -952,28 +925,28 @@ msgstr ""
 
 #: lib/tuist_web/helpers/test_labels.ex:30
 #: lib/tuist_web/live/shards_live.html.heex:551
-#: lib/tuist_web/live/tests_live.ex:494
+#: lib/tuist_web/live/tests_live.ex:467
 #: lib/tuist_web/live/tests_live.html.heex:267
 #, elixir-autogen, elixir-format
 msgid "Scheme"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:7
+#: lib/tuist_web/live/tests_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Scheme:"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:277
+#: lib/tuist_web/live/flaky_tests_live.html.heex:325
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:171
 #: lib/tuist_web/live/shards_live.html.heex:523
-#: lib/tuist_web/live/test_case_live.html.heex:465
-#: lib/tuist_web/live/test_cases_live.html.heex:469
+#: lib/tuist_web/live/test_case_live.html.heex:460
+#: lib/tuist_web/live/test_cases_live.html.heex:475
 #: lib/tuist_web/live/test_run_live.html.heex:1053
 #: lib/tuist_web/live/test_run_live.html.heex:1242
 #: lib/tuist_web/live/test_run_live.html.heex:1457
 #: lib/tuist_web/live/test_run_live.html.heex:1736
 #: lib/tuist_web/live/test_runs_live.html.heex:426
-#: lib/tuist_web/live/tests_live.html.heex:12
+#: lib/tuist_web/live/tests_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Search..."
 msgstr ""
@@ -984,7 +957,7 @@ msgstr ""
 msgid "Selective Testing"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:736
+#: lib/tuist_web/live/tests_live.html.heex:653
 #, elixir-autogen, elixir-format
 msgid "Selective test effectiveness"
 msgstr ""
@@ -1009,7 +982,7 @@ msgstr ""
 msgid "Selective test misses represents the number of test modules that were run as they were not successfully run before."
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:912
+#: lib/tuist_web/live/tests_live.html.heex:828
 #, elixir-autogen, elixir-format
 msgid "Selective testing: no data yet"
 msgstr ""
@@ -1021,14 +994,21 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:285
+#: lib/tuist_web/live/quarantined_tests_live.ex:64
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:265
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:301
 #: lib/tuist_web/live/shards_live.html.heex:583
 #: lib/tuist_web/live/test_case_live.ex:77
-#: lib/tuist_web/live/test_case_live.html.heex:175
-#: lib/tuist_web/live/test_case_live.html.heex:548
+#: lib/tuist_web/live/test_case_live.ex:432
+#: lib/tuist_web/live/test_case_live.ex:462
+#: lib/tuist_web/live/test_case_live.html.heex:84
+#: lib/tuist_web/live/test_case_live.html.heex:170
+#: lib/tuist_web/live/test_case_live.html.heex:543
 #: lib/tuist_web/live/test_case_run_live.html.heex:136
 #: lib/tuist_web/live/test_cases_live.ex:46
-#: lib/tuist_web/live/test_cases_live.html.heex:622
+#: lib/tuist_web/live/test_cases_live.ex:76
+#: lib/tuist_web/live/test_cases_live.html.heex:582
+#: lib/tuist_web/live/test_cases_live.html.heex:635
 #: lib/tuist_web/live/test_run_live.ex:936
 #: lib/tuist_web/live/test_run_live.ex:998
 #: lib/tuist_web/live/test_run_live.html.heex:245
@@ -1036,20 +1016,20 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:1398
 #: lib/tuist_web/live/test_runs_live.ex:44
 #: lib/tuist_web/live/test_runs_live.html.heex:473
-#: lib/tuist_web/live/tests_live.html.heex:1040
+#: lib/tuist_web/live/tests_live.html.heex:956
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:1099
+#: lib/tuist_web/live/tests_live.html.heex:1015
 #, elixir-autogen, elixir-format
 msgid "Slowest test cases"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:292
+#: lib/tuist_web/live/flaky_tests_live.html.heex:340
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:185
-#: lib/tuist_web/live/test_case_live.html.heex:479
-#: lib/tuist_web/live/test_cases_live.html.heex:484
+#: lib/tuist_web/live/test_case_live.html.heex:474
+#: lib/tuist_web/live/test_cases_live.html.heex:490
 #: lib/tuist_web/live/test_run_live.html.heex:1067
 #: lib/tuist_web/live/test_run_live.html.heex:1268
 #: lib/tuist_web/live/test_run_live.html.heex:1486
@@ -1060,7 +1040,7 @@ msgstr ""
 #: lib/tuist_web/live/shards_live.ex:27
 #: lib/tuist_web/live/shards_live.html.heex:565
 #: lib/tuist_web/live/test_case_live.ex:71
-#: lib/tuist_web/live/test_case_live.html.heex:535
+#: lib/tuist_web/live/test_case_live.html.heex:530
 #: lib/tuist_web/live/test_case_run_live.html.heex:119
 #: lib/tuist_web/live/test_case_run_live.html.heex:845
 #: lib/tuist_web/live/test_run_live.ex:930
@@ -1071,7 +1051,7 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:1385
 #: lib/tuist_web/live/test_run_live.html.heex:1625
 #: lib/tuist_web/live/test_runs_live.ex:38
-#: lib/tuist_web/live/tests_live.ex:495
+#: lib/tuist_web/live/tests_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
@@ -1083,7 +1063,7 @@ msgstr ""
 msgid "Subtype"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:219
+#: lib/tuist_web/live/test_case_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Success rate based on runs from the %{branch} branch. Falls back to all branches if no runs exist on %{branch}."
 msgstr ""
@@ -1093,26 +1073,26 @@ msgstr ""
 msgid "Suite"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:149
+#: lib/tuist_web/live/test_case_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Summary"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:287
-#: lib/tuist_web/live/flaky_tests_live.html.heex:304
-#: lib/tuist_web/live/flaky_tests_live.html.heex:344
+#: lib/tuist_web/live/flaky_tests_live.html.heex:335
+#: lib/tuist_web/live/flaky_tests_live.html.heex:352
+#: lib/tuist_web/live/flaky_tests_live.html.heex:392
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:181
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:197
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:229
-#: lib/tuist_web/live/test_cases_live.html.heex:479
-#: lib/tuist_web/live/test_cases_live.html.heex:496
-#: lib/tuist_web/live/test_cases_live.html.heex:546
+#: lib/tuist_web/live/test_cases_live.html.heex:485
+#: lib/tuist_web/live/test_cases_live.html.heex:502
+#: lib/tuist_web/live/test_cases_live.html.heex:552
 #: lib/tuist_web/live/test_run_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Test Case"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:454
+#: lib/tuist_web/live/test_case_live.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Test Case Runs"
 msgstr ""
@@ -1124,10 +1104,10 @@ msgstr ""
 
 #: lib/tuist_web/live/test_case_live.html.heex:3
 #: lib/tuist_web/live/test_cases_live.ex:24
-#: lib/tuist_web/live/test_cases_live.html.heex:461
+#: lib/tuist_web/live/test_cases_live.html.heex:467
 #: lib/tuist_web/live/test_run_live.html.heex:1024
 #: lib/tuist_web/live/test_run_live.html.heex:1042
-#: lib/tuist_web/live/tests_live.html.heex:1082
+#: lib/tuist_web/live/tests_live.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "Test Cases"
 msgstr ""
@@ -1147,8 +1127,8 @@ msgstr ""
 msgid "Test Details"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:140
-#: lib/tuist_web/live/test_case_live.html.heex:623
+#: lib/tuist_web/live/test_case_live.html.heex:135
+#: lib/tuist_web/live/test_case_live.html.heex:618
 #, elixir-autogen, elixir-format
 msgid "Test History"
 msgstr ""
@@ -1208,8 +1188,8 @@ msgstr ""
 msgid "Test case run not found."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:232
-#: lib/tuist_web/live/test_cases_live.ex:334
+#: lib/tuist_web/live/test_case_live.html.heex:227
+#: lib/tuist_web/live/test_cases_live.ex:338
 #: lib/tuist_web/live/test_cases_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Test case runs"
@@ -1220,7 +1200,7 @@ msgstr ""
 msgid "Test case runs represents the total number of individual test case executions during a given period."
 msgstr ""
 
-#: lib/tuist_web/live/test_cases_live.ex:326
+#: lib/tuist_web/live/test_cases_live.ex:329
 #: lib/tuist_web/live/test_cases_live.html.heex:220
 #: lib/tuist_web/live/test_run_live.ex:968
 #: lib/tuist_web/live/test_run_live.ex:1025
@@ -1235,17 +1215,17 @@ msgstr ""
 msgid "Test cases"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:281
+#: lib/tuist_web/live/test_case_live.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Test history"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:217
+#: lib/tuist_web/live/test_case_live.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:316
+#: lib/tuist_web/live/test_runs_live.ex:321
 #: lib/tuist_web/live/test_runs_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Test run count"
@@ -1313,7 +1293,7 @@ msgstr ""
 msgid "Total number of test cases executed."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:234
+#: lib/tuist_web/live/test_case_live.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Total number of times this test case has been executed."
 msgstr ""
@@ -1323,7 +1303,7 @@ msgstr ""
 msgid "Try changing your search term"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:604
+#: lib/tuist_web/live/test_case_live.html.heex:599
 #: lib/tuist_web/live/test_run_live.html.heex:1212
 #: lib/tuist_web/live/test_run_live.html.heex:1427
 #: lib/tuist_web/live/test_run_live.html.heex:1662
@@ -1331,8 +1311,8 @@ msgstr ""
 msgid "Try updating your search"
 msgstr ""
 
-#: lib/tuist_web/live/quarantined_tests_live.ex:67
-#: lib/tuist_web/live/quarantined_tests_live.html.heex:258
+#: lib/tuist_web/live/quarantined_tests_live.ex:80
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Tuist"
 msgstr ""
@@ -1344,8 +1324,8 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:555
 #: lib/tuist_web/live/shards_live.html.heex:562
-#: lib/tuist_web/live/test_case_live.html.heex:523
-#: lib/tuist_web/live/test_case_live.html.heex:557
+#: lib/tuist_web/live/test_case_live.html.heex:518
+#: lib/tuist_web/live/test_case_live.html.heex:552
 #: lib/tuist_web/live/test_case_run_live.html.heex:174
 #: lib/tuist_web/live/test_case_run_live.html.heex:183
 #: lib/tuist_web/live/test_case_run_live.html.heex:190
@@ -1358,9 +1338,9 @@ msgstr ""
 #: lib/tuist_web/live/test_run_live.html.heex:304
 #: lib/tuist_web/live/test_run_live.html.heex:1781
 #: lib/tuist_web/live/test_runs_live.html.heex:487
-#: lib/tuist_web/live/tests_live.ex:506
-#: lib/tuist_web/live/tests_live.html.heex:1024
-#: lib/tuist_web/live/tests_live.html.heex:1049
+#: lib/tuist_web/live/tests_live.ex:479
+#: lib/tuist_web/live/tests_live.html.heex:940
+#: lib/tuist_web/live/tests_live.html.heex:965
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -1370,23 +1350,23 @@ msgstr ""
 msgid "Unknown error"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:99
+#: lib/tuist_web/live/test_case_live.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:457
+#: lib/tuist_web/live/test_case_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.html.heex:304
+#: lib/tuist_web/live/test_case_live.html.heex:299
 #: lib/tuist_web/live/test_case_run_live.html.heex:237
 #: lib/tuist_web/live/test_run_live.html.heex:511
 #: lib/tuist_web/live/test_run_live.html.heex:854
-#: lib/tuist_web/live/tests_live.html.heex:930
-#: lib/tuist_web/live/tests_live.html.heex:1102
-#: lib/tuist_web/live/tests_live.html.heex:1159
+#: lib/tuist_web/live/tests_live.html.heex:846
+#: lib/tuist_web/live/tests_live.html.heex:1018
+#: lib/tuist_web/live/tests_live.html.heex:1075
 #, elixir-autogen, elixir-format
 msgid "View more"
 msgstr ""
@@ -1398,21 +1378,21 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:387
 #: lib/tuist_web/live/shards_live.html.heex:505
-#: lib/tuist_web/live/test_cases_live.html.heex:440
+#: lib/tuist_web/live/test_cases_live.html.heex:446
 #: lib/tuist_web/live/test_runs_live.html.heex:397
 #: lib/tuist_web/live/tests_live.html.heex:395
-#: lib/tuist_web/live/tests_live.html.heex:883
+#: lib/tuist_web/live/tests_live.html.heex:799
 #, elixir-autogen, elixir-format
 msgid "p50"
 msgstr ""
 
-#: lib/tuist_web/live/test_cases_live.ex:356
+#: lib/tuist_web/live/test_cases_live.ex:362
 #: lib/tuist_web/live/test_cases_live.html.heex:149
 #, elixir-autogen, elixir-format
 msgid "p50 test case run duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:338
+#: lib/tuist_web/live/test_runs_live.ex:343
 #: lib/tuist_web/live/test_runs_live.html.heex:138
 #: lib/tuist_web/live/tests_live.html.heex:173
 #, elixir-autogen, elixir-format
@@ -1421,21 +1401,21 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:374
 #: lib/tuist_web/live/shards_live.html.heex:492
-#: lib/tuist_web/live/test_cases_live.html.heex:427
+#: lib/tuist_web/live/test_cases_live.html.heex:433
 #: lib/tuist_web/live/test_runs_live.html.heex:384
 #: lib/tuist_web/live/tests_live.html.heex:382
-#: lib/tuist_web/live/tests_live.html.heex:867
+#: lib/tuist_web/live/tests_live.html.heex:783
 #, elixir-autogen, elixir-format
 msgid "p90"
 msgstr ""
 
-#: lib/tuist_web/live/test_cases_live.ex:353
+#: lib/tuist_web/live/test_cases_live.ex:359
 #: lib/tuist_web/live/test_cases_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "p90 test case run duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:335
+#: lib/tuist_web/live/test_runs_live.ex:340
 #: lib/tuist_web/live/test_runs_live.html.heex:137
 #: lib/tuist_web/live/tests_live.html.heex:172
 #, elixir-autogen, elixir-format
@@ -1444,68 +1424,68 @@ msgstr ""
 
 #: lib/tuist_web/live/shards_live.html.heex:361
 #: lib/tuist_web/live/shards_live.html.heex:479
-#: lib/tuist_web/live/test_cases_live.html.heex:414
+#: lib/tuist_web/live/test_cases_live.html.heex:420
 #: lib/tuist_web/live/test_runs_live.html.heex:371
 #: lib/tuist_web/live/tests_live.html.heex:369
-#: lib/tuist_web/live/tests_live.html.heex:851
+#: lib/tuist_web/live/tests_live.html.heex:767
 #, elixir-autogen, elixir-format
 msgid "p99"
 msgstr ""
 
-#: lib/tuist_web/live/test_cases_live.ex:350
+#: lib/tuist_web/live/test_cases_live.ex:356
 #: lib/tuist_web/live/test_cases_live.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "p99 test case run duration"
 msgstr ""
 
-#: lib/tuist_web/live/test_runs_live.ex:332
+#: lib/tuist_web/live/test_runs_live.ex:337
 #: lib/tuist_web/live/test_runs_live.html.heex:136
 #: lib/tuist_web/live/tests_live.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "p99 test run duration"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:279
-#: lib/tuist_web/live/shards_live.ex:333
-#: lib/tuist_web/live/test_cases_live.ex:381
-#: lib/tuist_web/live/test_runs_live.ex:357
-#: lib/tuist_web/live/tests_live.ex:443
+#: lib/tuist_web/live/flaky_tests_live.ex:284
+#: lib/tuist_web/live/shards_live.ex:338
+#: lib/tuist_web/live/test_cases_live.ex:388
+#: lib/tuist_web/live/test_runs_live.ex:362
+#: lib/tuist_web/live/tests_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "since last month"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:278
-#: lib/tuist_web/live/shards_live.ex:332
-#: lib/tuist_web/live/test_cases_live.ex:380
-#: lib/tuist_web/live/test_runs_live.ex:356
-#: lib/tuist_web/live/tests_live.ex:442
+#: lib/tuist_web/live/flaky_tests_live.ex:283
+#: lib/tuist_web/live/shards_live.ex:337
+#: lib/tuist_web/live/test_cases_live.ex:387
+#: lib/tuist_web/live/test_runs_live.ex:361
+#: lib/tuist_web/live/tests_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "since last period"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:276
-#: lib/tuist_web/live/shards_live.ex:330
-#: lib/tuist_web/live/test_cases_live.ex:378
-#: lib/tuist_web/live/test_runs_live.ex:354
-#: lib/tuist_web/live/tests_live.ex:440
+#: lib/tuist_web/live/flaky_tests_live.ex:281
+#: lib/tuist_web/live/shards_live.ex:335
+#: lib/tuist_web/live/test_cases_live.ex:385
+#: lib/tuist_web/live/test_runs_live.ex:359
+#: lib/tuist_web/live/tests_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "since last week"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:277
-#: lib/tuist_web/live/shards_live.ex:331
-#: lib/tuist_web/live/test_cases_live.ex:379
-#: lib/tuist_web/live/test_runs_live.ex:355
-#: lib/tuist_web/live/tests_live.ex:441
+#: lib/tuist_web/live/flaky_tests_live.ex:282
+#: lib/tuist_web/live/shards_live.ex:336
+#: lib/tuist_web/live/test_cases_live.ex:386
+#: lib/tuist_web/live/test_runs_live.ex:360
+#: lib/tuist_web/live/tests_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "since last year"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.ex:275
-#: lib/tuist_web/live/shards_live.ex:329
-#: lib/tuist_web/live/test_cases_live.ex:377
-#: lib/tuist_web/live/test_runs_live.ex:353
-#: lib/tuist_web/live/tests_live.ex:439
+#: lib/tuist_web/live/flaky_tests_live.ex:280
+#: lib/tuist_web/live/shards_live.ex:334
+#: lib/tuist_web/live/test_cases_live.ex:384
+#: lib/tuist_web/live/test_runs_live.ex:358
+#: lib/tuist_web/live/tests_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "since yesterday"
 msgstr ""
@@ -1518,13 +1498,13 @@ msgstr ""
 msgid "•"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:317
+#: lib/tuist_web/live/shards_live.ex:322
 #: lib/tuist_web/live/shards_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Avg. shard balance"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:294
+#: lib/tuist_web/live/shards_live.ex:299
 #: lib/tuist_web/live/shards_live.html.heex:75
 #, elixir-autogen, elixir-format
 msgid "Avg. shard count"
@@ -1589,13 +1569,13 @@ msgstr ""
 msgid "Shard %{index}"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:277
+#: lib/tuist_web/live/shards_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Sharded run count"
 msgstr ""
 
 #: lib/tuist_web/live/shards_live.ex:22
-#: lib/tuist_web/live/shards_live.html.heex:2
+#: lib/tuist_web/live/shards_live.html.heex:51
 #: lib/tuist_web/live/shards_live.html.heex:587
 #: lib/tuist_web/live/test_run_live.html.heex:424
 #, elixir-autogen, elixir-format
@@ -1612,37 +1592,37 @@ msgstr ""
 msgid "Total sharded runs"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:314
+#: lib/tuist_web/live/shards_live.ex:319
 #: lib/tuist_web/live/shards_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "p50 shard balance"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:291
+#: lib/tuist_web/live/shards_live.ex:296
 #: lib/tuist_web/live/shards_live.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "p50 shard count"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:311
+#: lib/tuist_web/live/shards_live.ex:316
 #: lib/tuist_web/live/shards_live.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "p90 shard balance"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:288
+#: lib/tuist_web/live/shards_live.ex:293
 #: lib/tuist_web/live/shards_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "p90 shard count"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:308
+#: lib/tuist_web/live/shards_live.ex:313
 #: lib/tuist_web/live/shards_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "p99 shard balance"
 msgstr ""
 
-#: lib/tuist_web/live/shards_live.ex:285
+#: lib/tuist_web/live/shards_live.ex:290
 #: lib/tuist_web/live/shards_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "p99 shard count"
@@ -1690,14 +1670,14 @@ msgid_plural "Devices"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/tests_live.ex:496
-#: lib/tuist_web/live/tests_live.ex:502
+#: lib/tuist_web/live/tests_live.ex:469
+#: lib/tuist_web/live/tests_live.ex:475
 #: lib/tuist_web/live/tests_live.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Environment"
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.ex:509
+#: lib/tuist_web/live/tests_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Passed (flaky)"
 msgstr ""
@@ -1707,14 +1687,15 @@ msgstr ""
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering by scheme or other properties to narrow down the dataset."
 msgstr ""
 
-#: lib/tuist_web/live/tests_live.html.heex:900
+#: lib/tuist_web/live/tests_live.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset."
 msgstr ""
 
-#: lib/tuist_web/live/test_case_live.ex:432
+#: lib/tuist_web/live/test_case_live.ex:433
 #: lib/tuist_web/live/test_case_live.ex:461
-#: lib/tuist_web/live/test_case_live.html.heex:80
+#: lib/tuist_web/live/test_case_live.ex:463
+#: lib/tuist_web/live/test_case_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
@@ -1724,17 +1705,40 @@ msgstr ""
 msgid "Number of distinct test cases with at least one run in the 14 days ending on each date."
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:243
+#: lib/tuist_web/live/quarantined_tests_live.ex:59
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:255
 #, elixir-autogen, elixir-format
-msgid "Flaky tests"
+msgid "Mode"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:127
+#: lib/tuist_web/live/quarantined_tests_live.ex:63
+#: lib/tuist_web/live/quarantined_tests_live.html.heex:258
+#: lib/tuist_web/live/test_case_live.ex:431
+#: lib/tuist_web/live/test_case_live.ex:460
+#: lib/tuist_web/live/test_case_live.html.heex:75
+#: lib/tuist_web/live/test_cases_live.ex:75
+#: lib/tuist_web/live/test_cases_live.html.heex:575
 #, elixir-autogen, elixir-format
-msgid "Number of individual test runs marked as flaky during the period."
+msgid "Muted"
+msgstr ""
+
+#: lib/tuist_web/live/flaky_tests_live.html.heex:125
+#: lib/tuist_web/live/flaky_tests_live.html.heex:289
+#, elixir-autogen, elixir-format
+msgid "Flaky test case runs"
+msgstr ""
+
+#: lib/tuist_web/live/flaky_tests_live.html.heex:154
+#, elixir-autogen, elixir-format
+msgid "Number of test runs (build-level test invocations) that contained at least one flaky test case. Each test run is counted once even if it contained many flaky executions."
 msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:96
 #, elixir-autogen, elixir-format
-msgid "Number of test cases currently flagged as flaky at each point in the period."
+msgid "Number of unique test cases currently flagged as flaky at the end of the period. Each test case is counted at most once, regardless of how often it flaked."
+msgstr ""
+
+#: lib/tuist_web/live/flaky_tests_live.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "Total number of individual test case executions marked as flaky in the period. A single test case can be counted many times if it flaked across multiple runs."
 msgstr ""

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -420,7 +420,7 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:369
+#: lib/tuist_web/live/flaky_tests_live.html.heex:375
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:206
 #: lib/tuist_web/live/shards_live.html.heex:531
 #: lib/tuist_web/live/test_case_live.html.heex:495
@@ -474,22 +474,20 @@ msgstr ""
 msgid "Flaky Tests"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:337
-#: lib/tuist_web/live/flaky_tests_live.html.heex:344
-#: lib/tuist_web/live/flaky_tests_live.html.heex:420
+#: lib/tuist_web/live/flaky_tests_live.html.heex:343
+#: lib/tuist_web/live/flaky_tests_live.html.heex:350
+#: lib/tuist_web/live/flaky_tests_live.html.heex:426
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:94
-#: lib/tuist_web/live/flaky_tests_live.html.heex:287
 #: lib/tuist_web/live/test_run_live.html.heex:356
 #, elixir-autogen, elixir-format
 msgid "Flaky test cases"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:152
-#: lib/tuist_web/live/flaky_tests_live.html.heex:288
+#: lib/tuist_web/live/flaky_tests_live.html.heex:155
+#: lib/tuist_web/live/flaky_tests_live.html.heex:293
 #: lib/tuist_web/live/tests_live.html.heex:133
 #: lib/tuist_web/live/tests_live.html.heex:542
 #, elixir-autogen, elixir-format
@@ -577,9 +575,9 @@ msgstr ""
 msgid "Last Status"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:336
-#: lib/tuist_web/live/flaky_tests_live.html.heex:360
-#: lib/tuist_web/live/flaky_tests_live.html.heex:434
+#: lib/tuist_web/live/flaky_tests_live.html.heex:342
+#: lib/tuist_web/live/flaky_tests_live.html.heex:366
+#: lib/tuist_web/live/flaky_tests_live.html.heex:440
 #, elixir-autogen, elixir-format
 msgid "Last flaky run"
 msgstr ""
@@ -703,7 +701,7 @@ msgstr ""
 msgid "No data"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:310
+#: lib/tuist_web/live/flaky_tests_live.html.heex:316
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:150
 #: lib/tuist_web/live/test_cases_live.html.heex:458
 #: lib/tuist_web/live/test_cases_live.html.heex:672
@@ -721,7 +719,7 @@ msgstr ""
 msgid "No failures detected"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:472
+#: lib/tuist_web/live/flaky_tests_live.html.heex:478
 #, elixir-autogen, elixir-format
 msgid "No flaky tests"
 msgstr ""
@@ -936,7 +934,7 @@ msgstr ""
 msgid "Scheme:"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:325
+#: lib/tuist_web/live/flaky_tests_live.html.heex:331
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:171
 #: lib/tuist_web/live/shards_live.html.heex:523
 #: lib/tuist_web/live/test_case_live.html.heex:460
@@ -1026,7 +1024,7 @@ msgstr ""
 msgid "Slowest test cases"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:340
+#: lib/tuist_web/live/flaky_tests_live.html.heex:346
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:185
 #: lib/tuist_web/live/test_case_live.html.heex:474
 #: lib/tuist_web/live/test_cases_live.html.heex:490
@@ -1078,9 +1076,9 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:335
-#: lib/tuist_web/live/flaky_tests_live.html.heex:352
-#: lib/tuist_web/live/flaky_tests_live.html.heex:392
+#: lib/tuist_web/live/flaky_tests_live.html.heex:341
+#: lib/tuist_web/live/flaky_tests_live.html.heex:358
+#: lib/tuist_web/live/flaky_tests_live.html.heex:398
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:181
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:197
 #: lib/tuist_web/live/quarantined_tests_live.html.heex:229
@@ -1723,12 +1721,12 @@ msgid "Muted"
 msgstr ""
 
 #: lib/tuist_web/live/flaky_tests_live.html.heex:125
-#: lib/tuist_web/live/flaky_tests_live.html.heex:289
+#: lib/tuist_web/live/flaky_tests_live.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Flaky test case runs"
 msgstr ""
 
-#: lib/tuist_web/live/flaky_tests_live.html.heex:154
+#: lib/tuist_web/live/flaky_tests_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Number of test runs (build-level test invocations) that contained at least one flaky test case. Each test run is counted once even if it contained many flaky executions."
 msgstr ""
@@ -1741,4 +1739,10 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Total number of individual test case executions marked as flaky in the period. A single test case can be counted many times if it flaked across multiple runs."
+msgstr ""
+
+#: lib/tuist_web/live/flaky_tests_live.html.heex:94
+#: lib/tuist_web/live/flaky_tests_live.html.heex:292
+#, elixir-autogen, elixir-format
+msgid "Flagged flaky test cases"
 msgstr ""

--- a/server/test/tuist/tests/analytics_test.exs
+++ b/server/test/tuist/tests/analytics_test.exs
@@ -2005,6 +2005,139 @@ defmodule Tuist.Tests.AnalyticsTest do
     end
   end
 
+  describe "flaky_test_case_runs_analytics/2" do
+    test "returns zero when no flaky test case runs exist" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+
+      # When
+      got =
+        Analytics.flaky_test_case_runs_analytics(
+          project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-04-30 23:59:59Z]
+        )
+
+      # Then
+      assert got.count == 0
+      assert Enum.all?(got.values, &(&1 == 0))
+    end
+
+    test "counts every flaky test case execution in the period and ignores non-flaky runs" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+      test_case_id = UUIDv7.generate()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        is_flaky: true,
+        ran_at: ~N[2024-04-10 09:00:00.000000],
+        inserted_at: ~N[2024-04-10 09:00:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        is_flaky: true,
+        ran_at: ~N[2024-04-15 09:00:00.000000],
+        inserted_at: ~N[2024-04-15 09:00:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_case_id: test_case_id,
+        is_flaky: false,
+        ran_at: ~N[2024-04-15 10:00:00.000000],
+        inserted_at: ~N[2024-04-15 10:00:00.000000]
+      )
+
+      RunsFixtures.optimize_test_case_runs()
+
+      # When
+      got =
+        Analytics.flaky_test_case_runs_analytics(
+          project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-04-30 23:59:59Z]
+        )
+
+      # Then
+      assert got.count == 2
+    end
+
+    test "excludes runs outside the date range" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        ran_at: ~N[2024-03-15 09:00:00.000000],
+        inserted_at: ~N[2024-03-15 09:00:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        ran_at: ~N[2024-04-15 09:00:00.000000],
+        inserted_at: ~N[2024-04-15 09:00:00.000000]
+      )
+
+      RunsFixtures.optimize_test_case_runs()
+
+      # When
+      got =
+        Analytics.flaky_test_case_runs_analytics(
+          project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-04-30 23:59:59Z]
+        )
+
+      # Then
+      assert got.count == 1
+    end
+
+    test "honors the is_ci filter" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        is_ci: true,
+        ran_at: ~N[2024-04-10 09:00:00.000000],
+        inserted_at: ~N[2024-04-10 09:00:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        is_ci: false,
+        ran_at: ~N[2024-04-15 09:00:00.000000],
+        inserted_at: ~N[2024-04-15 09:00:00.000000]
+      )
+
+      RunsFixtures.optimize_test_case_runs()
+
+      base_opts = [start_datetime: ~U[2024-04-01 00:00:00Z], end_datetime: ~U[2024-04-30 23:59:59Z]]
+
+      # When
+      any_env = Analytics.flaky_test_case_runs_analytics(project.id, base_opts)
+      ci_only = Analytics.flaky_test_case_runs_analytics(project.id, Keyword.put(base_opts, :is_ci, true))
+      local_only = Analytics.flaky_test_case_runs_analytics(project.id, Keyword.put(base_opts, :is_ci, false))
+
+      # Then
+      assert any_env.count == 2
+      assert ci_only.count == 1
+      assert local_only.count == 1
+    end
+  end
+
   describe "flaky_tests_analytics/2" do
     test "returns zero when no test cases are flagged as flaky" do
       # Given

--- a/server/test/tuist/tests/analytics_test.exs
+++ b/server/test/tuist/tests/analytics_test.exs
@@ -2136,6 +2136,49 @@ defmodule Tuist.Tests.AnalyticsTest do
       assert ci_only.count == 1
       assert local_only.count == 1
     end
+
+    test "computes trend by comparing the current period to the equivalent prior period" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-04-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+
+      # One flaky run in the prior 30-day window
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        ran_at: ~N[2024-03-10 09:00:00.000000],
+        inserted_at: ~N[2024-03-10 09:00:00.000000]
+      )
+
+      # Two flaky runs in the current 30-day window
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        ran_at: ~N[2024-04-05 09:00:00.000000],
+        inserted_at: ~N[2024-04-05 09:00:00.000000]
+      )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        is_flaky: true,
+        ran_at: ~N[2024-04-20 09:00:00.000000],
+        inserted_at: ~N[2024-04-20 09:00:00.000000]
+      )
+
+      RunsFixtures.optimize_test_case_runs()
+
+      # When
+      got =
+        Analytics.flaky_test_case_runs_analytics(
+          project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-04-30 23:59:59Z]
+        )
+
+      # Then
+      assert got.count == 2
+      assert got.trend == 100.0
+    end
   end
 
   describe "flaky_tests_analytics/2" do

--- a/server/test/tuist_web/live/flaky_tests_live_test.exs
+++ b/server/test/tuist_web/live/flaky_tests_live_test.exs
@@ -147,7 +147,7 @@ defmodule TuistWeb.FlakyTestsLiveTest do
       refute has_element?(lv, "#flaky-tests-table", "testOldFlaky")
     end
 
-    test "renders flaky tests and flaky runs widgets", %{
+    test "renders flaky test cases, test case runs, and test runs widgets", %{
       conn: conn,
       organization: organization,
       project: project
@@ -164,8 +164,9 @@ defmodule TuistWeb.FlakyTestsLiveTest do
 
       # Then
       render_async(lv, 2000)
-      assert has_element?(lv, "#widget-flaky-tests")
-      assert has_element?(lv, "#widget-flaky-runs")
+      assert has_element?(lv, "#widget-flaky-test-cases")
+      assert has_element?(lv, "#widget-flaky-test-case-runs")
+      assert has_element?(lv, "#widget-flaky-test-runs")
     end
   end
 


### PR DESCRIPTION

<img width="1003" height="540" alt="image" src="https://github.com/user-attachments/assets/904cae14-c0c5-4bc2-b131-a91261421919" />


> Disambiguate the metrics on the Flaky Tests page so users can tell apart "test cases flagged as flaky", "individual flaky executions", and "builds that contained flakiness". The previous "Flaky Runs" widget was actually counting `test_runs.is_flaky` (build level) while the table column with the same name counted per-test-case executions, which made the headline numbers impossible to relate.

### What changed

The Flaky Tests page now shows three widgets instead of two, each at a clearly named granularity:

| Widget | Source | Granularity |
|--------|--------|-------------|
| **Flaky test cases** | event replay over `test_case_events` | unique test cases flagged at end-of-period |
| **Flaky test case runs** | `flaky_test_case_runs` MV | every `is_flaky=true` test case execution |
| **Flaky test runs** | `test_runs` table where `is_flaky=true` | build-level invocations that contained flakiness |

Behind the scenes:

- `Tuist.Tests.Analytics.flaky_test_case_runs_analytics/2` is new — it queries the `flaky_test_case_runs` materialized view directly (much faster than scanning `test_case_runs`) and returns the same `%{trend, count, values, dates}` shape as the existing analytics functions.
- The LiveView now loads three separate analytics async, with assigns `:flaky_test_cases_analytics`, `:flaky_test_case_runs_analytics`, `:flaky_test_runs_analytics`.
- Tooltips on each widget explicitly describe the unit being counted, so the relationship between the numbers is self-explanatory (e.g. *N test cases × M executions × K builds*).
- `normalize_selected_widget/1` maps legacy `?analytics-selected-widget=flaky_tests|flaky_runs` URLs to `flaky_test_cases` / `flaky_test_runs` respectively, so existing bookmarks land on the same metric they pointed at before.
- `test_run_analytics/2` is unchanged and still used by `tests_live.ex` and `test_runs_live.ex`, where build-level granularity is correct.

### How to test locally

1. `mise run dev` from `server/` and sign in as `tuistrocks@tuist.dev` / `tuistrocks`.
2. Navigate to a project's Flaky Tests page (`/<account>/<project>/tests/flaky-tests`).
3. Verify three widgets render: Flaky test cases, Flaky test case runs, Flaky test runs.
4. Click each widget and confirm the chart switches to its time series with a distinct line color (flaky / primary / tertiary).
5. Hover the info icon on each widget — the tooltip should explain the granularity.
6. Toggle the environment dropdown (Any / CI / Local) and the date picker; all three widgets and their charts should respect both filters.
7. Visit `/.../tests/flaky-tests?analytics-selected-widget=flaky_runs` — the "Flaky test runs" widget should be selected (legacy URL mapping).
8. `mix test test/tuist_web/live/flaky_tests_live_test.exs test/tuist/tests/analytics_test.exs` — 8 LiveView tests + 8 flaky analytics tests (5 new) should pass.

### Notes for reviewers

- `dashboard_tests.pot` shows widespread line-number-only churn from `mix gettext.extract` re-emitting positions. The substantive changes are the three new tooltip strings and one rename — everything else is noise from re-extraction. The other dashboard `.pot` files were intentionally reverted to keep this PR focused on `dashboard_tests`.