### PR TITLE
chore(server): speed up preview image build + push

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -248,6 +248,11 @@ jobs:
           submodules: false
       - id: tag
         run: echo "image_tag=sha-${{ needs.resolve.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
+      - id: apt-bust
+        # Date-granular bust for the runner-base apt-upgrade layer. Previews
+        # don't need per-commit security patches; relaxing to daily lets
+        # successive pushes on the same PR reuse the apt layer.
+        run: echo "value=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - uses: namespacelabs/nscloud-setup-buildx-action@v0
       - uses: docker/login-action@v3
         with:
@@ -264,11 +269,7 @@ jobs:
           build-args: |
             TUIST_HOSTED=1
             MIX_ENV=prod
-            APT_CACHE_BUST=${{ needs.resolve.outputs.ref }}
-          # Share the same cache scope as the managed-env builds — same image,
-          # same Dockerfile, layers are interchangeable.
-          cache-from: type=gha,scope=server-cluster
-          cache-to: type=gha,mode=max,scope=server-cluster
+            APT_CACHE_BUST=${{ steps.apt-bust.outputs.value }}
 
   deploy:
     name: Deploy ${{ needs.resolve.outputs.release }}


### PR DESCRIPTION
## Summary

- Drop `cache-from`/`cache-to: type=gha,scope=server-cluster` from the preview-deploy build. No other server image build writes to that scope, so `cache-from` was fetching mostly empty cache and `cache-to` was uploading multi-GB layers to GitHub's cache backend on every push for nothing. The Namespace volume-backed BuildKit cache (already in use via `namespace-profile-default-with-volume` + `nscloud-setup-buildx-action`) is what every other server image build relies on.
- Switch `APT_CACHE_BUST` from per-commit ref to a per-day date string. Previews don't need per-commit security patches, and this lets successive pushes within the same PR reuse the `runner-base` apt-upgrade layer.

## Test plan

- [ ] Trigger a preview deploy on a labeled PR; confirm "Build + push" finishes faster than the current baseline and that the "exporting cache" phase no longer dominates the run.
- [ ] Push a follow-up commit to the same PR same day; confirm the apt-upgrade layer is cached and the build is incrementally faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)