### PR TITLE
docs(server): clarify Blick rule on ClickHouse read/write repos

### DIFF
--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -61,9 +61,16 @@ Tenant-owned schemas include at least: `Bundle`, `Run`, `Cache`,
 
 ## 3. ClickHouse `IngestRepo` is write-only
 
-`Tuist.IngestRepo` is the analytics ClickHouse repo. ClickHouse is the
-analytics DB, and we treat it as **write-only from application code** —
-reads happen out of band.
+There are **two** ClickHouse repos in this codebase, and they are not
+interchangeable. Be precise about which one a call uses before flagging.
+
+- **`Tuist.IngestRepo`** — write-only ingest path. Application code must
+  not read from it; reads happen out of band.
+- **`Tuist.ClickHouseRepo`** — the read-only ClickHouse repo (declared
+  with `read_only: true` in `server/lib/tuist/clickhouse_repo.ex`). This
+  is the **legitimate** path for analytics reads from application code.
+  `server/lib/tuist/tests/analytics.ex`,
+  `server/lib/tuist/builds/analytics.ex`, etc. all read through it.
 
 ### Flag (Severity: high)
 
@@ -72,7 +79,17 @@ reads happen out of band.
   `Tuist.IngestRepo.exists?/1`, or `Tuist.IngestRepo.aggregate/3`.
 - Any `from(... ) |> Tuist.IngestRepo.<read fn>`.
 
-The fix is almost always to read from `Tuist.Repo` (PostgreSQL) instead.
+The fix is almost always to read through `Tuist.ClickHouseRepo` (for
+ClickHouse-only data) or `Tuist.Repo` (PostgreSQL).
+
+### Do not flag
+
+- `Tuist.ClickHouseRepo.all/1`, `Tuist.ClickHouseRepo.one/1`,
+  `Tuist.ClickHouseRepo.aggregate/3`, or any other read through
+  `ClickHouseRepo`. That repo exists specifically for application reads.
+  Do **not** confuse it with `IngestRepo`.
+- Writes via `Tuist.IngestRepo.insert/2` / `insert_all/2,3` — those are
+  the intended use.
 
 ---
 

--- a/.blick/skills/tuist-elixir-review/SKILL.md
+++ b/.blick/skills/tuist-elixir-review/SKILL.md
@@ -67,10 +67,7 @@ interchangeable. Be precise about which one a call uses before flagging.
 - **`Tuist.IngestRepo`** — write-only ingest path. Application code must
   not read from it; reads happen out of band.
 - **`Tuist.ClickHouseRepo`** — the read-only ClickHouse repo (declared
-  with `read_only: true` in `server/lib/tuist/clickhouse_repo.ex`). This
-  is the **legitimate** path for analytics reads from application code.
-  `server/lib/tuist/tests/analytics.ex`,
-  `server/lib/tuist/builds/analytics.ex`, etc. all read through it.
+  with `read_only: true` in `server/lib/tuist/clickhouse_repo.ex`).
 
 ### Flag (Severity: high)
 


### PR DESCRIPTION
### Summary

Blick's `tuist-elixir-review` skill rule #3 ("ClickHouse `IngestRepo` is write-only") was triggering false positives on legitimate `Tuist.ClickHouseRepo` reads — see [#10521 (comment 3159525172)](https://github.com/tuist/tuist/pull/10521#discussion_r3159525172) and [#10521 (comment 3159525174)](https://github.com/tuist/tuist/pull/10521#discussion_r3159525174). The rule's intent is to forbid reads from `Tuist.IngestRepo` only; `Tuist.ClickHouseRepo` is declared `read_only: true` in [server/lib/tuist/clickhouse_repo.ex](server/lib/tuist/clickhouse_repo.ex) and is the canonical analytics read path used by `analytics.ex` files across the server.

### Changes

- Rewrite rule #3 to open with an explicit two-repo callout (`IngestRepo` write-only vs `ClickHouseRepo` read-only).
- Point at `analytics.ex` files as canonical examples of legitimate `ClickHouseRepo` reads.
- Add a **Do not flag** section that explicitly excludes `ClickHouseRepo.*` reads and tells the reviewer not to confuse the two repos.
- Recommend `ClickHouseRepo` (alongside `Tuist.Repo`) as the fix target for ClickHouse-only data.

### How to test locally

- Skim [.blick/skills/tuist-elixir-review/SKILL.md](.blick/skills/tuist-elixir-review/SKILL.md) — rule #3 should now read unambiguously.
- Next Blick run on a PR that reads through `Tuist.ClickHouseRepo` should not flag those calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)