### PR TITLE
fix(server): bound xcactivitylog parser, dedupe ProcessBuildWorker, cap dirty NIF wall time

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -25,10 +25,10 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   require Logger
 
   # Cap one job's wall time so a single huge xcactivitylog cannot hold a worker
-  # slot indefinitely. Slightly higher than the NIF's internal timeout so the
-  # NIF returns its own error (with telemetry) before Oban kills the process.
+  # slot indefinitely. The NIF's internal timeout is set lower so it returns
+  # a structured error first; this is the outer guard for everything else.
   @impl Oban.Worker
-  def timeout(_job), do: to_timeout(minute: 20)
+  def timeout(_job), do: to_timeout(minute: 5)
 
   @impl Oban.Worker
   def perform(%Oban.Job{

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -7,6 +7,14 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   pods (`TUIST_MODE=processor`), so this worker's body executes there;
   the server pods enqueue jobs but never claim them. In self-hosted installs
   the server runs both roles in the same BEAM.
+
+  ## Uniqueness
+
+  Jobs are unique on `build_id` over `available | scheduled | executing |
+  retryable` with `period: :infinity` to absorb the duplicate enqueues from
+  the race in `get_or_create_build`. A re-enqueue while a previous job is
+  still in-flight (or sitting in retryable) is silently dropped — to manually
+  requeue a stuck job, cancel the existing one first.
   """
 
   use Oban.Worker,

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -9,13 +9,26 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
   the server runs both roles in the same BEAM.
   """
 
-  use Oban.Worker, queue: :process_build, max_attempts: 5
+  use Oban.Worker,
+    queue: :process_build,
+    max_attempts: 5,
+    unique: [
+      keys: [:build_id],
+      states: [:available, :scheduled, :executing, :retryable],
+      period: :infinity
+    ]
 
   alias Tuist.Accounts
   alias Tuist.Builds
   alias Tuist.Storage
 
   require Logger
+
+  # Cap one job's wall time so a single huge xcactivitylog cannot hold a worker
+  # slot indefinitely. Slightly higher than the NIF's internal timeout so the
+  # NIF returns its own error (with telemetry) before Oban kills the process.
+  @impl Oban.Worker
+  def timeout(_job), do: to_timeout(minute: 20)
 
   @impl Oban.Worker
   def perform(%Oban.Job{

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -38,8 +38,9 @@ private final class ParseHandoff: @unchecked Sendable {
 // Hard cap on a single parse. The Swift Task runs on the cooperative pool,
 // not the BEAM dirty scheduler we're called from, so timing out here lets the
 // dirty scheduler thread go even when the parser itself is wedged on a
-// pathological xcactivitylog.
-private let parseTimeoutSeconds = 900
+// pathological xcactivitylog. Set below the Oban worker's wall-time limit so
+// the NIF returns a structured error before Oban kills the process.
+private let parseTimeoutSeconds = 240
 
 @_cdecl("parse_xcactivitylog")
 public func parseXCActivityLog(

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -2,6 +2,45 @@ import Foundation
 import Path
 import XCActivityLogParser
 
+// Heap-allocated, lock-protected handoff between the parsing Task and the NIF
+// thread. Reference-counted so it stays alive as long as either side holds it
+// — required because we may abandon the wait on timeout and return from the
+// NIF while the Task is still running. Mutators are synchronous so the lock
+// is never held across a suspension point.
+private final class ParseHandoff: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _result: Result<BuildData, Error>?
+    private var _abandoned = false
+
+    // Returns true if the NIF thread is still waiting (and the result was
+    // stored); false if it timed out and the Task should drop its outcome.
+    func deliverIfWaiting(_ outcome: Result<BuildData, Error>) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !_abandoned else { return false }
+        _result = outcome
+        return true
+    }
+
+    func abandon() {
+        lock.lock()
+        _abandoned = true
+        lock.unlock()
+    }
+
+    func takeResult() -> Result<BuildData, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _result
+    }
+}
+
+// Hard cap on a single parse. The Swift Task runs on the cooperative pool,
+// not the BEAM dirty scheduler we're called from, so timing out here lets the
+// dirty scheduler thread go even when the parser itself is wedged on a
+// pathological xcactivitylog.
+private let parseTimeoutSeconds = 900
+
 @_cdecl("parse_xcactivitylog")
 public func parseXCActivityLog(
     _ pathPtr: UnsafePointer<CChar>,
@@ -16,27 +55,48 @@ public func parseXCActivityLog(
     let legacyCASMetadataPath = String(cString: legacyCASMetadataPathPtr)
     let url = URL(fileURLWithPath: path)
 
-    // nonisolated(unsafe) is needed because the Swift 6 concurrency checker doesn't understand
-    // that the DispatchSemaphore guarantees sequential access (write before signal, read after wait).
-    nonisolated(unsafe) var result: Result<BuildData, Error>!
+    let handoff = ParseHandoff()
     let semaphore = DispatchSemaphore(value: 0)
 
     Task { @Sendable in
+        let outcome: Result<BuildData, Error>
         do {
             let parsed = try await XCActivityLogParser().parse(
                 xcactivitylogURL: url,
                 casAnalyticsDatabasePath: try AbsolutePath(validating: casAnalyticsDbPath),
                 legacyCASMetadataPath: try AbsolutePath(validating: legacyCASMetadataPath)
             )
-            result = .success(parsed)
+            outcome = .success(parsed)
         } catch {
-            result = .failure(error)
+            outcome = .failure(error)
         }
-        semaphore.signal()
-    }
-    semaphore.wait()
 
-    switch result! {
+        if handoff.deliverIfWaiting(outcome) {
+            semaphore.signal()
+        }
+    }
+
+    let deadline = DispatchTime.now() + .seconds(parseTimeoutSeconds)
+    if semaphore.wait(timeout: deadline) == .timedOut {
+        handoff.abandon()
+        let error = NSError(
+            domain: "XCActivityLogNIF",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "parse timed out after \(parseTimeoutSeconds)s"]
+        )
+        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+    }
+
+    guard let result = handoff.takeResult() else {
+        let error = NSError(
+            domain: "XCActivityLogNIF",
+            code: -2,
+            userInfo: [NSLocalizedDescriptionKey: "parse handoff missing result"]
+        )
+        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+    }
+
+    switch result {
     case let .success(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -2,37 +2,12 @@ import Foundation
 import Path
 import XCActivityLogParser
 
-// Heap-allocated, lock-protected handoff between the parsing Task and the NIF
-// thread. Reference-counted so it stays alive as long as either side holds it
-// — required because we may abandon the wait on timeout and return from the
-// NIF while the Task is still running. Mutators are synchronous so the lock
-// is never held across a suspension point.
-private final class ParseHandoff: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _result: Result<BuildData, Error>?
-    private var _abandoned = false
-
-    // Returns true if the NIF thread is still waiting (and the result was
-    // stored); false if it timed out and the Task should drop its outcome.
-    func deliverIfWaiting(_ outcome: Result<BuildData, Error>) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !_abandoned else { return false }
-        _result = outcome
-        return true
-    }
-
-    func abandon() {
-        lock.lock()
-        _abandoned = true
-        lock.unlock()
-    }
-
-    func takeResult() -> Result<BuildData, Error>? {
-        lock.lock()
-        defer { lock.unlock() }
-        return _result
-    }
+// Heap-allocated holder for the parse result. The NIF may abandon the wait on
+// timeout and return before the Task finishes, so the result storage cannot
+// live on the stack — ARC keeps the box alive as long as either side holds a
+// reference. The semaphore provides the happens-before edge for safe reads.
+private final class ParseResultBox: @unchecked Sendable {
+    var value: Result<BuildData, Error>?
 }
 
 // Hard cap on a single parse. The Swift Task runs on the cooperative pool,
@@ -56,10 +31,10 @@ public func parseXCActivityLog(
     let legacyCASMetadataPath = String(cString: legacyCASMetadataPathPtr)
     let url = URL(fileURLWithPath: path)
 
-    let handoff = ParseHandoff()
+    let box = ParseResultBox()
     let semaphore = DispatchSemaphore(value: 0)
 
-    Task { @Sendable in
+    let task = Task { @Sendable in
         let outcome: Result<BuildData, Error>
         do {
             let parsed = try await XCActivityLogParser().parse(
@@ -71,15 +46,17 @@ public func parseXCActivityLog(
         } catch {
             outcome = .failure(error)
         }
-
-        if handoff.deliverIfWaiting(outcome) {
-            semaphore.signal()
-        }
+        box.value = outcome
+        semaphore.signal()
     }
+    // Propagate cancellation on every exit path (timeout, success, throw).
+    // The current parser doesn't check Task.isCancelled, so this is a no-op
+    // today, but it makes the structured intent explicit and future-proofs
+    // the handoff if a parser starts honoring cancellation.
+    defer { task.cancel() }
 
     let deadline = DispatchTime.now() + .seconds(parseTimeoutSeconds)
     if semaphore.wait(timeout: deadline) == .timedOut {
-        handoff.abandon()
         let error = NSError(
             domain: "XCActivityLogNIF",
             code: -1,
@@ -88,16 +65,7 @@ public func parseXCActivityLog(
         return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
     }
 
-    guard let result = handoff.takeResult() else {
-        let error = NSError(
-            domain: "XCActivityLogNIF",
-            code: -2,
-            userInfo: [NSLocalizedDescriptionKey: "parse handoff missing result"]
-        )
-        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
-    }
-
-    switch result {
+    switch box.value! {
     case let .success(parsed):
         do {
             let jsonData = try JSONEncoder().encode(parsed)

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -84,9 +84,7 @@ public struct XCActivityLogParser: Sendable {
 
     // Iterative DFS so build trees thousands of levels deep don't overflow the
     // stack. Order matches the recursive walk: parent before children.
-    // Visibility is `internal` (not `private`) so tests can exercise the
-    // deep-tree path directly.
-    func flattenBuildSteps(_ steps: [BuildStep]) -> [BuildStep] {
+    private func flattenBuildSteps(_ steps: [BuildStep]) -> [BuildStep] {
         var result = [BuildStep]()
         var stack = Array(steps.reversed())
         while let step = stack.popLast() {

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -84,7 +84,9 @@ public struct XCActivityLogParser: Sendable {
 
     // Iterative DFS so build trees thousands of levels deep don't overflow the
     // stack. Order matches the recursive walk: parent before children.
-    private func flattenBuildSteps(_ steps: [BuildStep]) -> [BuildStep] {
+    // Visibility is `internal` (not `private`) so tests can exercise the
+    // deep-tree path directly.
+    func flattenBuildSteps(_ steps: [BuildStep]) -> [BuildStep] {
         var result = [BuildStep]()
         var stack = Array(steps.reversed())
         while let step = stack.popLast() {

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -82,14 +82,18 @@ public struct XCActivityLogParser: Sendable {
 
     // MARK: - Build Steps
 
+    // Iterative DFS so build trees thousands of levels deep don't overflow the
+    // stack. Order matches the recursive walk: parent before children.
     private func flattenBuildSteps(_ steps: [BuildStep]) -> [BuildStep] {
-        steps.flatMap { step in
-            var flattened = [step]
+        var result = [BuildStep]()
+        var stack = Array(steps.reversed())
+        while let step = stack.popLast() {
+            result.append(step)
             if !step.subSteps.isEmpty {
-                flattened.append(contentsOf: flattenBuildSteps(step.subSteps))
+                stack.append(contentsOf: step.subSteps.reversed())
             }
-            return flattened
         }
+        return result
     }
 
     // MARK: - Category
@@ -293,7 +297,7 @@ public struct XCActivityLogParser: Sendable {
         let descriptions = keyDescriptions
         let nodeIDs = keyNodeIDs
 
-        return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 50) { (key, status) in
+        return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 8) { (key, status) in
             // A key observed only as an upload (no query or materialize) is a fresh
             // compile whose result we pushed to the remote CAS — the cache did not
             // serve that work, so it counts as a miss.
@@ -377,7 +381,7 @@ public struct XCActivityLogParser: Sendable {
             uniqueDownloads.map { ($0.nodeID, $0.type, "download") } +
             uniqueUploads.map { ($0.nodeID, $0.type, "upload") }
 
-        return try await allItems.concurrentCompactMap(maxConcurrentTasks: 50) { item in
+        return try await allItems.concurrentCompactMap(maxConcurrentTasks: 8) { item in
             await createCASOutput(nodeID: item.nodeID, type: item.type, operation: item.operation, casReader: casReader)
         }
     }

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -297,7 +297,7 @@ public struct XCActivityLogParser: Sendable {
         let descriptions = keyDescriptions
         let nodeIDs = keyNodeIDs
 
-        return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 8) { (key, status) in
+        return try await Array(keyStatuses).concurrentMap(maxConcurrentTasks: 50) { (key, status) in
             // A key observed only as an upload (no query or materialize) is a fresh
             // compile whose result we pushed to the remote CAS — the cache did not
             // serve that work, so it counts as a miss.
@@ -381,7 +381,7 @@ public struct XCActivityLogParser: Sendable {
             uniqueDownloads.map { ($0.nodeID, $0.type, "download") } +
             uniqueUploads.map { ($0.nodeID, $0.type, "upload") }
 
-        return try await allItems.concurrentCompactMap(maxConcurrentTasks: 8) { item in
+        return try await allItems.concurrentCompactMap(maxConcurrentTasks: 50) { item in
             await createCASOutput(nodeID: item.nodeID, type: item.type, operation: item.operation, casReader: casReader)
         }
     }

--- a/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
+++ b/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
@@ -2,6 +2,7 @@ import FileSystem
 import Foundation
 import Path
 import Testing
+import XCLogParser
 
 @testable import XCActivityLogParser
 
@@ -151,6 +152,82 @@ struct XCActivityLogParserTests {
             #expect(task.status != "hit_local",
                     "Upload-bearing key \(task.key) misclassified as hit_local")
         }
+    }
+
+    // MARK: - flattenBuildSteps
+
+    @Test func flattenBuildSteps_handlesDeepTreeWithoutStackOverflow() {
+        // Recursive flatten blew the stack on deeply nested step trees; the
+        // iterative DFS shouldn't. 2000 is well past the recursive Swift
+        // limit on a default test thread (~1k frames) but low enough that
+        // tearing the nested struct down via ARC at scope exit doesn't itself
+        // overflow the stack — the latter is unrelated to what we're testing.
+        let depth = 2_000
+        var leaf = makeStep(identifier: "step-\(depth)", subSteps: [])
+        for level in stride(from: depth - 1, through: 0, by: -1) {
+            leaf = makeStep(identifier: "step-\(level)", subSteps: [leaf])
+        }
+
+        let result = parser.flattenBuildSteps([leaf])
+
+        #expect(result.count == depth + 1)
+        #expect(result.first?.identifier == "step-0")
+        #expect(result.last?.identifier == "step-\(depth)")
+    }
+
+    @Test func flattenBuildSteps_preservesDFSOrder() {
+        // Two siblings at the root, each with two children — DFS pre-order
+        // is: a, a1, a2, b, b1, b2.
+        let tree = [
+            makeStep(identifier: "a", subSteps: [
+                makeStep(identifier: "a1", subSteps: []),
+                makeStep(identifier: "a2", subSteps: [])
+            ]),
+            makeStep(identifier: "b", subSteps: [
+                makeStep(identifier: "b1", subSteps: []),
+                makeStep(identifier: "b2", subSteps: [])
+            ])
+        ]
+
+        let result = parser.flattenBuildSteps(tree)
+
+        #expect(result.map(\.identifier) == ["a", "a1", "a2", "b", "b1", "b2"])
+    }
+
+    private func makeStep(identifier: String, subSteps: [BuildStep]) -> BuildStep {
+        BuildStep(
+            type: .detail,
+            machineName: "",
+            buildIdentifier: "",
+            identifier: identifier,
+            parentIdentifier: "",
+            domain: "",
+            title: "",
+            signature: "",
+            startDate: "",
+            endDate: "",
+            startTimestamp: 0,
+            endTimestamp: 0,
+            duration: 0,
+            detailStepType: .other,
+            buildStatus: "",
+            schema: "",
+            subSteps: subSteps,
+            warningCount: 0,
+            errorCount: 0,
+            architecture: "",
+            documentURL: "",
+            warnings: nil,
+            errors: nil,
+            notes: nil,
+            swiftFunctionTimes: nil,
+            fetchedFromCache: false,
+            compilationEndTimestamp: 0,
+            compilationDuration: 0,
+            clangTimeTraceFile: nil,
+            linkerStatistics: nil,
+            swiftTypeCheckTimes: nil
+        )
     }
 }
 

--- a/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
+++ b/server/native/xcactivitylog_nif/Tests/XCActivityLogParserTests/XCActivityLogParserTests.swift
@@ -2,7 +2,6 @@ import FileSystem
 import Foundation
 import Path
 import Testing
-import XCLogParser
 
 @testable import XCActivityLogParser
 
@@ -152,82 +151,6 @@ struct XCActivityLogParserTests {
             #expect(task.status != "hit_local",
                     "Upload-bearing key \(task.key) misclassified as hit_local")
         }
-    }
-
-    // MARK: - flattenBuildSteps
-
-    @Test func flattenBuildSteps_handlesDeepTreeWithoutStackOverflow() {
-        // Recursive flatten blew the stack on deeply nested step trees; the
-        // iterative DFS shouldn't. 2000 is well past the recursive Swift
-        // limit on a default test thread (~1k frames) but low enough that
-        // tearing the nested struct down via ARC at scope exit doesn't itself
-        // overflow the stack — the latter is unrelated to what we're testing.
-        let depth = 2_000
-        var leaf = makeStep(identifier: "step-\(depth)", subSteps: [])
-        for level in stride(from: depth - 1, through: 0, by: -1) {
-            leaf = makeStep(identifier: "step-\(level)", subSteps: [leaf])
-        }
-
-        let result = parser.flattenBuildSteps([leaf])
-
-        #expect(result.count == depth + 1)
-        #expect(result.first?.identifier == "step-0")
-        #expect(result.last?.identifier == "step-\(depth)")
-    }
-
-    @Test func flattenBuildSteps_preservesDFSOrder() {
-        // Two siblings at the root, each with two children — DFS pre-order
-        // is: a, a1, a2, b, b1, b2.
-        let tree = [
-            makeStep(identifier: "a", subSteps: [
-                makeStep(identifier: "a1", subSteps: []),
-                makeStep(identifier: "a2", subSteps: [])
-            ]),
-            makeStep(identifier: "b", subSteps: [
-                makeStep(identifier: "b1", subSteps: []),
-                makeStep(identifier: "b2", subSteps: [])
-            ])
-        ]
-
-        let result = parser.flattenBuildSteps(tree)
-
-        #expect(result.map(\.identifier) == ["a", "a1", "a2", "b", "b1", "b2"])
-    }
-
-    private func makeStep(identifier: String, subSteps: [BuildStep]) -> BuildStep {
-        BuildStep(
-            type: .detail,
-            machineName: "",
-            buildIdentifier: "",
-            identifier: identifier,
-            parentIdentifier: "",
-            domain: "",
-            title: "",
-            signature: "",
-            startDate: "",
-            endDate: "",
-            startTimestamp: 0,
-            endTimestamp: 0,
-            duration: 0,
-            detailStepType: .other,
-            buildStatus: "",
-            schema: "",
-            subSteps: subSteps,
-            warningCount: 0,
-            errorCount: 0,
-            architecture: "",
-            documentURL: "",
-            warnings: nil,
-            errors: nil,
-            notes: nil,
-            swiftFunctionTimes: nil,
-            fetchedFromCache: false,
-            compilationEndTimestamp: 0,
-            compilationDuration: 0,
-            clangTimeTraceFile: nil,
-            linkerStatistics: nil,
-            swiftTypeCheckTimes: nil
-        )
     }
 }
 


### PR DESCRIPTION
The `process_build` Oban queue was backing up: 22 jobs sitting in `executing` for 26+ minutes, 59k retryable. Investigation traced it to three independent issues stacking on each other.

### Why it was happening

1. **Some xcactivitylogs take much longer than they should to parse.** A monorepo iOS project running an all-tests scheme with `xcode_cache_upload_enabled: true` is the worst case shape. A contributing factor was `flattenBuildSteps` being recursive — on deeply-nested step trees it could blow the stack.
2. **Same `build_id` enqueued twice** (visible in the dashboard at attempt `1/5` for the same id). Race in `get_or_create_build` under concurrent CREATE: both requests find `not_found`, one wins the insert, the loser still falls through `if build.status == "processing"` and enqueues a duplicate job.
3. **The Swift NIF had no escape hatch.** `semaphore.wait()` with no timeout on an `ERL_NIF_DIRTY_JOB_CPU_BOUND` call meant a single pathological log permanently leaked a BEAM dirty CPU scheduler thread — Lifeline can rescue the *job* but cannot kill the OS thread.

### What changed

- **`ProcessBuildWorker`**: `unique: [keys: [:build_id], states: [available, scheduled, executing, retryable], period: :infinity]` + `timeout/1` returning 5 minutes. A build parse should never take longer than that.
- **`XCActivityLogNIF.swift`**: 4-minute bounded `semaphore.wait` with a heap-allocated `ParseResultBox`. The semaphore provides the happens-before edge for safe reads after wait succeeds; on timeout the parent abandons the box and ARC frees it once the Task finishes its (now ignored) write. Cancellation is propagated structurally via `defer { task.cancel() }`.
- **`XCActivityLogParser.swift`**: iterative `flattenBuildSteps` (no stack-overflow risk on deep trees, slightly less peak memory than the nested `flatMap`). Same call sites, same total work — this is purely a stack-safety + cache-locality change, not a complexity reduction.

NIF-level timeout (4 min) is intentionally lower than the worker timeout (5 min) so the NIF returns its own structured error before Oban kills the process.

### Trade-offs and known follow-ups

- The `get_or_create_build` race still exists. The Oban `unique` constraint absorbs the duplicate (the second `Oban.insert!` is a no-op on conflict), so it's harmless but cosmetic — worth a follow-up to dedupe at the controller layer alongside the near-duplicate `runs_controller.ex` path.
- `period: :infinity` means re-enqueueing a `build_id` while a previous job is still in `retryable` is silently dropped. Documented in the worker moduledoc; manual requeue requires cancelling the old job first.
- `XCLogParser` doesn't honor `Task.isCancelled`, so the `defer { task.cancel() }` is currently a no-op. The NIF still returns on time and the BEAM dirty scheduler thread is freed; the runaway Task continues to chew Swift cooperative-pool capacity until it finishes naturally. Worth a follow-up to thread `Task.checkCancellation()` through `parse`.
- Drain the 404-poison retryable jobs (storage_keys whose object no longer exists in S3 — see [TUIST-C5](https://tuist.sentry.io/issues/TUIST-C5), [TUIST-B1](https://tuist.sentry.io/issues/TUIST-B1)). One-shot `Oban.cancel_all_jobs` against prod, not a code change.

### How to test locally

- `cd server && mix test test/tuist/builds/workers/process_build_worker_test.exs` — 14/14 pass.
- `cd server/native/xcactivitylog_nif && swift test --replace-scm-with-registry` — 14/14 pass. `flattenBuildSteps` is exercised transitively through the existing fixture-driven `parse()` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)