### PR TITLE
fix(server): zero-downtime canary deploys to unblock CLI canary tests

### DIFF
--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -93,7 +93,9 @@ struct TuistCacheEECanaryAcceptanceTests {
         TuistTest.expectLogs("cacheable tasks (100%)")
     }
 
+    // FIXME(#10528): Fails consistently on CI against canary; quarantined until diagnosed.
     @Test(
+        .disabled("Quarantined: see https://github.com/tuist/tuist/issues/10528"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
@@ -136,7 +138,9 @@ struct TuistCacheEECanaryAcceptanceTests {
         try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
     }
 
+    // FIXME(#10528): Fails consistently on CI against canary; quarantined until diagnosed.
     @Test(
+        .disabled("Quarantined: see https://github.com/tuist/tuist/issues/10528"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -93,9 +93,7 @@ struct TuistCacheEECanaryAcceptanceTests {
         TuistTest.expectLogs("cacheable tasks (100%)")
     }
 
-    // FIXME(#10528): Fails consistently on CI against canary; quarantined until diagnosed.
     @Test(
-        .disabled("Quarantined: see https://github.com/tuist/tuist/issues/10528"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,
@@ -138,9 +136,7 @@ struct TuistCacheEECanaryAcceptanceTests {
         try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
     }
 
-    // FIXME(#10528): Fails consistently on CI against canary; quarantined until diagnosed.
     @Test(
-        .disabled("Quarantined: see https://github.com/tuist/tuist/issues/10528"),
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),
         .withMockedNoora,

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -20,13 +20,6 @@ server:
   podDisruptionBudget:
     enabled: false
 
-  # Inherit the chart-default surge strategy. The previous terminate-first
-  # override (maxSurge: 0, maxUnavailable: 1) made ingress-nginx 503 on
-  # CLI test traffic during the ~30s boot window of every canary deploy,
-  # because replicaCount: 1 leaves no healthy upstream. The surge pod's
-  # memory request below is sized so it can co-schedule with the existing
-  # pod on the 2-worker canary nodepool.
-
   # ingress-nginx fronts the server on port 443 with a Cloudflare Origin
   # CA cert (synced into the tuist-tls-cloudflare-origin Secret out-of-
   # band; 15-year validity). Cloudflare is set to Full (strict) SSL.
@@ -36,12 +29,9 @@ server:
     host: canary.tuist.dev
     tlsSecretName: tuist-tls-cloudflare-origin
 
-  # Single pod outside of rolling deploys, so no anti-affinity here. The
-  # request is intentionally well below the steady-state working set
-  # (~700 MiB observed); the limit keeps the live pod with headroom. The
-  # 2-worker nodepool's free-memory budget is too tight for two 512 MiB
-  # requests to co-schedule, which is why the previous strategy override
-  # existed.
+  # Request sized so a surge pod (chart-default maxSurge: 1) co-schedules
+  # alongside the live pod on the 2-worker canary nodepool. Steady-state
+  # working set is ~700 MiB; the 2 GiB limit absorbs that under load.
   resources:
     requests:
       cpu: "250m"

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -20,11 +20,12 @@ server:
   podDisruptionBudget:
     enabled: false
 
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+  # Inherit the chart-default surge strategy. The previous terminate-first
+  # override (maxSurge: 0, maxUnavailable: 1) made ingress-nginx 503 on
+  # CLI test traffic during the ~30s boot window of every canary deploy,
+  # because replicaCount: 1 leaves no healthy upstream. The surge pod's
+  # memory request below is sized so it can co-schedule with the existing
+  # pod on the 2-worker canary nodepool.
 
   # ingress-nginx fronts the server on port 443 with a Cloudflare Origin
   # CA cert (synced into the tuist-tls-cloudflare-origin Secret out-of-
@@ -35,15 +36,16 @@ server:
     host: canary.tuist.dev
     tlsSecretName: tuist-tls-cloudflare-origin
 
-  # Canary is always a single pod, so no anti-affinity here.
-  # Requests are sized so a rolling deploy's surge pod (maxSurge: 1) fits
-  # alongside the existing pod on the canary nodepool's two workers — at
-  # 1 GiB each they don't both fit. Limits stay generous so the live pod
-  # has headroom under load.
+  # Single pod outside of rolling deploys, so no anti-affinity here. The
+  # request is intentionally well below the steady-state working set
+  # (~700 MiB observed); the limit keeps the live pod with headroom. The
+  # 2-worker nodepool's free-memory budget is too tight for two 512 MiB
+  # requests to co-schedule, which is why the previous strategy override
+  # existed.
   resources:
     requests:
       cpu: "250m"
-      memory: "512Mi"
+      memory: "256Mi"
     limits:
       cpu: "2000m"
       memory: "2Gi"


### PR DESCRIPTION
## Summary

`multiplatform_app_module_cache` and `multiplatform_app_selective_testing` in `TuistCacheEECanaryAcceptanceTests` were failing on CI with `.unknownError(503)` from canary. The 503s came from ingress-nginx returning Service Unavailable when there was no healthy upstream pod — confirmed in the canary ingress-nginx access logs as `503 ... [] - - - -` (empty upstream, 0.000 latency) for `xctest/...` user-agent traffic during canary deploy windows.

Root cause: the canary used `maxSurge: 0, maxUnavailable: 1` (terminate-first), introduced in #10517 because a `maxSurge: 1` surge pod failed to schedule with `Insufficient memory` on the 2-worker canary nodepool. With `replicaCount: 1` and terminate-first, every deploy left ingress-nginx with no upstream during the new pod's ~30s boot window, and CLI test traffic during that window 503'd. The sibling `generated_project_with_caching_enabled` test does fewer canary calls and was less likely to overlap a deploy window, which matches the observed flake-vs-fail asymmetry.

The fix:
- Drop the canary's strategy override so it inherits the chart default (`maxSurge: 1, maxUnavailable: 0`), giving a Ready new pod before the old one terminates.
- Lower the canary server's `resources.requests.memory` from 512 MiB to 256 MiB so the surge pod can co-schedule on the constrained nodepool. The 2 GiB limit is unchanged, so the live pod's steady-state headroom is preserved (kubelet observed ~700 MiB working set).

## Verification

- `helm template tuist infra/helm/tuist -f values-managed-common.yaml -f values-managed-canary.yaml` renders the server Deployment with `maxSurge: 1, maxUnavailable: 0` and `memory: 256Mi` request.
- After this lands, the next canary deploy should roll without dropping traffic; subsequent CLI runs should not see `unknownError(503)` for the multiplatform tests.

## Test plan

- [ ] Merge, watch the canary deploy roll without 503s in ingress-nginx logs.
- [ ] Re-run a CLI PR's `Acceptance Tests (1)` shard and confirm `multiplatform_app_*` tests pass twice in a row.

Closes #10528.