### PR TITLE
fix(server): make processor pods leader-ineligible in Oban

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -417,24 +417,19 @@ oban_queues =
     true -> base_queues ++ [process_build_queue]
   end
 
-# Cron is leader-only: whichever Oban node wins the leader election runs the
-# crontab. With multiple pod roles in the same Oban cluster (server + processor)
-# the leader can land on either. Configure the same crontab everywhere so
-# scheduled jobs fire regardless of which pod is currently leader; the *jobs*
-# are then claimed by whichever pod runs the matching queue. Pruner + Lifeline
-# are also leader-only; both work fine on either pod since the tuist_processor
-# DB role has the necessary INSERT/UPDATE/DELETE on oban_jobs.
+# Leader-only Oban work (Cron, Pruner, Lifeline, Oban.Met.Reporter) runs on
+# whichever node wins the peer election. Server pods are always running and
+# carry the full DB role, so we make them the only leader-eligible nodes by
+# setting `peer: false` on processor pods. Oban normalises that to the
+# Isolated peer with `leader?: false`, so leader-only plugins start there but
+# stay idle.
 #
-# Oban.Met is the exception: its leader-only Reporter runs `CREATE OR REPLACE
-# FUNCTION public.oban_count_estimate(...)` on every checkpoint, which the
-# tuist_processor role can't do (USAGE only on schema public, see
-# infra/supabase/tuist-processor-role.sql). Disable auto-start on processor
-# pods so the supervisor doesn't attach there; server pods keep reporting and
-# the dashboard view is unaffected.
-if Tuist.Environment.processor_mode?() do
-  config :oban_met, auto_start: false
-end
-
+# Why not let the processor become leader? The tuist_processor role is
+# least-privilege (USAGE only on schema public, see
+# infra/supabase/tuist-processor-role.sql). Oban.Met.Reporter's leader path
+# runs `CREATE OR REPLACE FUNCTION public.oban_count_estimate(...)` on every
+# checkpoint, which the role can't execute and which crashes the Reporter
+# repeatedly when the processor wins the election.
 config :tuist, Oban,
   queues: oban_queues,
   plugins: [
@@ -456,6 +451,10 @@ config :tuist, Oban,
          else: []
        )}
   ]
+
+if Tuist.Environment.processor_mode?() do
+  config :tuist, Oban, peer: false
+end
 
 # Guardian
 config :tuist, Tuist.Guardian,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -424,6 +424,17 @@ oban_queues =
 # are then claimed by whichever pod runs the matching queue. Pruner + Lifeline
 # are also leader-only; both work fine on either pod since the tuist_processor
 # DB role has the necessary INSERT/UPDATE/DELETE on oban_jobs.
+#
+# Oban.Met is the exception: its leader-only Reporter runs `CREATE OR REPLACE
+# FUNCTION public.oban_count_estimate(...)` on every checkpoint, which the
+# tuist_processor role can't do (USAGE only on schema public, see
+# infra/supabase/tuist-processor-role.sql). Disable auto-start on processor
+# pods so the supervisor doesn't attach there; server pods keep reporting and
+# the dashboard view is unaffected.
+if Tuist.Environment.processor_mode?() do
+  config :oban_met, auto_start: false
+end
+
 config :tuist, Oban,
   queues: oban_queues,
   plugins: [


### PR DESCRIPTION
Fixes [TUIST-D9](https://tuist.sentry.io/issues/TUIST-D9): `Postgrex.Error: ERROR 42501 (insufficient_privilege) permission denied for schema public`.

### What

Set `peer: false` on Oban for pods running with `TUIST_MODE=processor`, so processor pods never win the peer election.

### Why

`Oban.Met.Reporter` runs leader-only and, on every checkpoint, executes `CREATE OR REPLACE FUNCTION public.oban_count_estimate(...)` to install the helper used for cheap row-count estimates. Processor pods connect as the least-privilege `tuist_processor` Postgres role (`infra/supabase/tuist-processor-role.sql`) which only has `USAGE` on schema `public`, no `CREATE`. When the processor wins the peer election the checkpoint crashes and the Reporter GenServer terminates repeatedly.

Other reasonable fixes and why they were rejected:

- **Grant `CREATE ON SCHEMA public` to `tuist_processor`** — widens the role's blast radius (lets the processor squat any object name in `public`) and undermines the deliberate least-privilege design of the role file. Also requires an out-of-band `psql` step against Supabase as superuser before deploy.
- **`oban_met, auto_start: false` on processor pods** — works, but loses two real signals: the processor's `Examiner` no longer reports its executing-job counts to the cluster (so Oban Web's "executing now" tile under-counts `:process_build`), and global `full_count` goes stale during processor-leadership windows.
- **`reporter: [auto_migrate: false, estimate_limit: :infinity]`** — also works, keeps Met running everywhere, but adds an implicit dependency on a server pod having created the function at some prior point.

`peer: false` is the cleanest of the four: Oban normalises it to the Isolated peer with `leader?: false`, so all leader-only plugins (Pruner, Lifeline, Cron, Met.Reporter) start on the processor but idle there. Server pods, which already have to be running for the system to be useful, become the sole leader-eligible nodes and continue running everything they ran before.

### How to test locally

- `TUIST_MODE=processor iex -S mix phx.server` and confirm `Oban.Peer.leader?(Oban) == false` and stays false.
- Default mode (no `TUIST_MODE`): `Oban.Peer.leader?(Oban) == true` for the single node, as before.
- Verify Cron jobs still fire on a server pod (the crontab is configured everywhere, but only the leader fires it; with this change that's always a server pod).

### Reviewer notes

- Single-config change in `server/config/runtime.exs`; no schema or dependency changes.
- The crontab block was previously justified as "configure the same crontab everywhere so scheduled jobs fire regardless of which pod is currently leader". That's still safe — the crontab is identical on both pod types and the only fireable leader is now a server pod.