### PR TITLE
fix(cli): add TuistHTTP to TuistConfigLoader cross-platform deps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -294,6 +294,7 @@ var tuistConfigLoaderDependencies: [Target.Dependency] = [
     mockableDependency,
     "TuistConfig",
     "TuistConstants",
+    "TuistHTTP",
     "TuistRootDirectoryLocator",
     tomlDecoderDependency,
 ]
@@ -383,7 +384,6 @@ tuistHTTPDependencies.append(contentsOf: ["TuistSupport", "TuistHAR"])
 tuistCASDependencies.append(contentsOf: ["TuistCache", "TuistCASAnalytics"])
 tuistConfigLoaderDependencies.append(contentsOf: [
     "TuistLoader", "TuistCore", "TuistAlert", "TuistSupport",
-    "TuistHTTP",
     "ProjectDescription",
 ])
 tuistConfigLoaderTestDependencies.append(contentsOf: [


### PR DESCRIPTION
## Summary
- The Linux release build broke on `main` ([run 25102499723](https://github.com/tuist/tuist/actions/runs/25102499723/job/73555594539)) with `no such module 'TuistHTTP'` while compiling `TuistConfigLoader`.
- [ConfigLoader.swift](cli/Sources/TuistConfigLoader/ConfigLoader.swift) unconditionally `import`s `TuistHTTP`, but the dependency was only registered inside the macOS-only branch of `Package.swift`. `TuistHTTP` and its base deps are cross-platform, so move it into the base `tuistConfigLoaderDependencies` array.

## Test plan
- [x] `swift build --replace-scm-with-registry --target TuistConfigLoader` succeeds locally
- [ ] CI Linux release jobs (x86_64 + aarch64) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)