### PR TITLE
fix(cli): keep static framework xcstrings on main target Resources phase

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -94,22 +94,32 @@ public struct ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this
                 buildableFolders: resourceBuildableFolders
             )
             modifiedTarget.sources = target.sources.filter { $0.path.extension != "metal" }
-            // Asset catalogs and string catalogs are added to the main target's Sources build
-            // phase so Xcode generates typed symbols. This mirrors SwiftPM's PIF builder:
+            // Asset catalogs are added to the main target's Sources build phase so Xcode
+            // generates typed asset symbols. This mirrors SwiftPM's PIF builder:
             //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/XCBuildSupport/PIFBuilder.swift#L944-L952
-            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L345-L360
-            // Both are also compiled into the companion resource bundle via its Resources phase.
-            // The companion bundle declares PACKAGE_RESOURCE_TARGET_KIND = "resource" (above)
-            // so Xcode treats it as a pure resource container and skips string extraction.
-            // The main target carries PACKAGE_RESOURCE_TARGET_KIND = "regular" (below) so Xcode
-            // runs extraction here where the Swift source references live.
-            let codeGeneratingResourceExtensions: Set<String> = ["xcassets", "xcstrings"]
+            //   - https://github.com/swiftlang/swift-package-manager/blob/main/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift#L347-L353
+            // They are also compiled into the companion resource bundle via its Resources phase.
+            let assetCatalogExtensions: Set<String> = ["xcassets"]
             for resource in target.resources.resources {
-                if let ext = resource.path.extension, codeGeneratingResourceExtensions.contains(ext) {
+                if let ext = resource.path.extension, assetCatalogExtensions.contains(ext) {
                     modifiedTarget.sources.append(SourceFile(path: resource.path))
                 }
             }
-            modifiedTarget.resources.resources = originalTargetExplicitResources
+            // String catalogs (.xcstrings) stay on the main target's Resources phase so Xcode
+            // runs localization extraction and stale-string detection in the same target where
+            // the Swift sources live. They are also kept on the companion bundle's Resources
+            // phase so the catalog is compiled to .strings for Bundle.module lookups at runtime.
+            // PACKAGE_RESOURCE_BUNDLE_NAME (set on the main target below) makes swift-build's
+            // XCStringsCompiler.shouldCompileCatalog skip catalog compilation here, so the
+            // catalog is only compiled once, inside the companion bundle.
+            // See: https://github.com/swiftlang/swift-build/blob/main/Sources/SWBApplePlatform/XCStringsCompiler.swift
+            // The buildable-folders path arrives at the same shape via the partition logic,
+            // which routes shared entries (xcstrings) into originalTargetExplicitResources.
+            var explicitResources = originalTargetExplicitResources
+            explicitResources.append(
+                contentsOf: target.resources.resources.filter { $0.path.extension == "xcstrings" }
+            )
+            modifiedTarget.resources.resources = explicitResources
             modifiedTarget.copyFiles = []
             modifiedTarget.buildableFolders = remainingBuildableFolders
             modifiedTarget.dependencies.append(.target(

--- a/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -1104,7 +1104,7 @@ struct ResourcesProjectMapperTests {
     }
 
     @Test
-    func mapWhenStaticTargetHasXcstringsAddsThemToSourcesAndBundle() async throws {
+    func mapWhenStaticTargetHasXcstringsKeepsThemOnMainResourcesAndBundle() async throws {
         // Given
         let resources: [ResourceFileElement] = [
             .file(path: "/Resources/Localizable.xcstrings"),
@@ -1119,18 +1119,21 @@ struct ResourcesProjectMapperTests {
         let (gotProject, _) = try await subject.map(project: project)
 
         // Then
-        let gotTarget = try #require(gotProject.targets.values.sorted().last)
-        #expect(gotTarget.resources.resources.isEmpty)
-        let xcstringsSources = gotTarget.sources.filter { $0.path.extension == "xcstrings" }
-        #expect(xcstringsSources.count == 1)
         let expectedXcstringsPath = try AbsolutePath(validating: "/Resources/Localizable.xcstrings")
-        #expect(xcstringsSources.first?.path == expectedXcstringsPath)
+        let gotTarget = try #require(gotProject.targets.values.sorted().last)
+
+        // xcstrings is kept on the main target's Resources phase (mirrors the buildable-folders
+        // path) so Xcode runs string extraction in the same target where Swift sources live.
+        #expect(gotTarget.resources.resources == [.file(path: expectedXcstringsPath)])
+        // xcstrings is NOT in the main target's Sources phase. The Sources-phase placement only
+        // works when STRING_CATALOG_GENERATE_SYMBOLS=YES, which swift-build auto-enables only
+        // for SwiftPM packages, and Tuist-generated projects do not get that default.
+        #expect(gotTarget.sources.contains(where: { $0.path.extension == "xcstrings" }) == false)
 
         let resourcesTarget = try #require(gotProject.targets.values.sorted().first)
         #expect(resourcesTarget.product == .bundle)
         let companionXcstrings = resourcesTarget.resources.resources.filter { $0.path.extension == "xcstrings" }
-        #expect(companionXcstrings.count == 1)
-        #expect(companionXcstrings.first?.path == expectedXcstringsPath)
+        #expect(companionXcstrings == [.file(path: expectedXcstringsPath)])
         let companionOtherResources = resourcesTarget.resources.resources.filter { $0.path.extension != "xcstrings" }
         #expect(companionOtherResources.count == 1)
     }


### PR DESCRIPTION
## Summary

Aligns the group-based `target.resources` path with the buildable-folders path so `.xcstrings` end up on the main target's **Resources** phase (not Sources) for static frameworks. Closes the regression reported in the latest comments on #10325.

## Why this was broken

The current code (post #10423) places `.xcstrings` on the main target's **Sources** phase and on the companion resource bundle's Resources phase. With `PACKAGE_RESOURCE_BUNDLE_NAME` set on the main target (intentional, blocks the duplicate compile), swift-build's `XCStringsCompiler.shouldCompileCatalog` returns false. The Sources-phase placement is then only useful via the symbol-generation path, which is gated by `STRING_CATALOG_GENERATE_SYMBOLS`.

`STRING_CATALOG_GENERATE_SYMBOLS` defaults to `NO` and is auto-enabled by swift-build only for `project.isPackage` projects ([Settings.swift:4381-4385](https://github.com/swiftlang/swift-build/blob/main/Sources/SWBCore/Settings/Settings.swift#L4381-L4385)). Tuist-generated `.xcodeproj`s are not packages, so the Sources placement effectively does nothing for them.

The buildable-folders path was already routing `.xcstrings` to the main target's **Resources** phase via the partition logic (`originalTargetExplicitResources`), which is why Kai's update on #10325 said buildable folders worked but source/resource folders did not. adarhef's repro on #10325 (`target.resources` glob, no buildable folders) hits the broken path.

## What changes

In `ResourcesProjectMapper.mapTarget`, when the target is a static framework or a target without native resource support:

- `.xcassets` continues to be appended to the main target's Sources phase (typed asset symbols, unchanged).
- `.xcstrings` from `target.resources.resources` is now appended to `originalTargetExplicitResources` and assigned to `modifiedTarget.resources.resources`. This mirrors the shape produced by the buildable-folders partition.
- `.xcstrings` is still kept on the companion bundle's Resources phase, so `Bundle.module` lookups continue to resolve at runtime (the #10420 fix is preserved).
- `PACKAGE_RESOURCE_BUNDLE_NAME` and `PACKAGE_RESOURCE_TARGET_KIND` settings are unchanged, so the catalog is compiled exactly once (inside the companion bundle).

## Reproduction and verification

Used the [TuistReproduction.zip](https://github.com/user-attachments/files/27197369/TuistReproduction.zip) from adarhef's comment on #10325 (single static framework, `sources` + `resources` globs, `Localizable.xcstrings` under `Resources/`).

Diff of generated `.xcodeproj` between **before** and **after** (only the xcstrings entries change):

```
PBXResourcesBuildPhase (main target):
+ 32C5A55AB9D244854E919F62 /* Localizable.xcstrings in Resources */,

PBXSourcesBuildPhase (main target):
- DC945D9A387AADDBD3F91170 /* Localizable.xcstrings in Sources */,
```

`xcodebuild build` of the framework with the fix produces:

- `TuistReproduction_MyFramework.bundle/Contents/Resources/en.lproj/Localizable.strings` (catalog compiled once, in the bundle)
- No `Localizable.strings` inside `MyFramework.framework`
- One `CompileXCStrings` task in `target 'TuistReproduction_MyFramework'` (the bundle), zero in the main target

## Test plan

- [x] Unit test in `ResourcesProjectMapperTests` updated to assert the new shape (`mapWhenStaticTargetHasXcstringsKeepsThemOnMainResourcesAndBundle`)
- [x] Built `tuist` from this branch and regenerated adarhef's repro; `.pbxproj` matches the expected shape
- [x] Built the framework target and confirmed `Localizable.strings` is in the companion bundle and not in the framework
- [ ] Acceptance test `ios_app_with_static_framework_with_xcstrings` (would appreciate a CI run)
- [ ] Validate end-to-end in Xcode UI that string extraction / stale marking now runs on the `target.resources` path (manual on a populated catalog)

Refs: #10325, #10420, #10247, #10423, #10445

🤖 Generated with [Claude Code](https://claude.com/claude-code)