### PR TITLE
fix(infra): disable nginx proxy_request_buffering on server ingress

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -33,9 +33,17 @@ server:
   # artifact and grows past 1 MB on big iOS apps). Match the Phoenix
   # Plug.Parsers limit at lib/tuist_web/endpoint.ex so the two stay in
   # lockstep — bump both when bumping either.
+  #
+  # `proxy-request-buffering: off` streams the request body straight to
+  # Bandit instead of spooling it to /tmp/nginx/client-body on the
+  # controller pod. With buffering on, anything over `client-body-buffer-size`
+  # (8–16 KB) hits disk; slow disk reads back to upstream then trip Bandit's
+  # thousand_island read_timeout (15s, runtime.exs) and surface as 502s on
+  # any POST endpoint with a non-trivial body (cache, runs, webhooks).
   ingress:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 
   # All runtime secrets (DATABASE_URL, CLICKHOUSE_URL, S3 creds, Sentry, Stripe,
   # OAuth, Mailgun, etc.) live in priv/secrets/<env>.yml.enc baked into the


### PR DESCRIPTION
> Stops 502s on POST endpoints (cache, runs, webhooks) caused by ingress-nginx disk-buffering request bodies.

### What changed

Added `nginx.ingress.kubernetes.io/proxy-request-buffering: \"off\"` to the server Ingress annotations in `infra/helm/tuist/values-managed-common.yaml`. Applies to staging, canary, and production via the layered values files.

### Why

ingress-nginx defaults to buffering request bodies. When a body exceeds `client-body-buffer-size` (nginx default 8-16 KB), it spools to `/tmp/nginx/client-body/` on the controller pod and then streams from disk to upstream. If the disk-to-upstream delivery is slower than Bandit's `thousand_island.read_timeout` (currently 15s, [server/config/runtime.exs](server/config/runtime.exs)), Bandit closes the connection and nginx returns 502 to the client.

This matched the onset of `Bandit.HTTPError "Body read timeout"` in the server logs and the corresponding 502 spike on `/cache/ac` (and any other POST endpoint with a non-trivial body) right after the ingress-nginx cutover. The data path is the same regardless of what the controller does with the body, which is why the failure was endpoint-agnostic.

Why this option vs. alternatives:
- `proxy-request-buffering: off` removes the failure mode entirely - nginx pipes the body straight to Bandit, no disk spool, no slow-read timeout.
- Bumping `client-body-buffer-size` only widens the threshold; bodies above the new size still spool and can still time out.
- Bumping Bandit's `read_timeout` papers over slow body delivery and ties up Bandit workers longer per request.

### Out of scope

The processor Oban `permission denied for schema public` crash loop is a separate problem and not addressed here.

### How to test locally

This is a managed-cluster ingress annotation; behavior is verified by:
- `helm template tuist infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-{staging,canary,production}.yaml` shows the annotation rendered on the server Ingress in all three envs.
- After deploy, watch for the disappearance of `Bandit.HTTPError "Body read timeout"` log lines and the 502 rate on POST endpoints in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)