### PR TITLE
fix(cli): refresh expired tokens under optionalAuthentication

### DIFF
--- a/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -39,11 +39,21 @@ struct ServerClientAuthenticationMiddleware: ClientMiddleware {
 
         let urlForAuthentication = authenticationURL ?? baseURL
         let config = ServerAuthenticationConfig.current
-        guard let token = try await serverAuthenticationController.authenticationToken(
-            serverURL: urlForAuthentication,
-            refreshIfNeeded: !config.optionalAuthentication
-        )
-        else {
+
+        let token: AuthenticationToken?
+        do {
+            token = try await serverAuthenticationController.authenticationToken(
+                serverURL: urlForAuthentication,
+                refreshIfNeeded: true
+            )
+        } catch {
+            if config.optionalAuthentication {
+                return try await next(request, body, baseURL)
+            }
+            throw error
+        }
+
+        guard let token else {
             if config.optionalAuthentication {
                 return try await next(request, body, baseURL)
             }

--- a/cli/Tests/TuistCacheEETests/Storage/CacheStorageFactoryTests.swift
+++ b/cli/Tests/TuistCacheEETests/Storage/CacheStorageFactoryTests.swift
@@ -145,4 +145,95 @@ struct CacheStorageFactoryTests {
             )
         }
     }
+
+    @Test
+    func refreshes_expired_tokens_when_optional_authentication_is_enabled() async throws {
+        // Regression: with `optionalAuthentication`, the factory used to pass
+        // `refreshIfNeeded: false`, so an expired access token would silently
+        // skip the remote cache even when the user had a valid refresh token in
+        // their credentials. Refresh must be attempted on every call so
+        // authenticated sessions stay live across the access token's TTL.
+        try await withMockedEnvironment {
+            // Given
+            given(serverEnvironmentService).url(configServerURL: .any).willReturn(Constants.URLs.production)
+            let token: AuthenticationToken = .user(
+                accessToken: .test(token: "refreshed-access-token"),
+                refreshToken: .test(token: "refresh-token")
+            )
+            given(serverAuthenticationController).authenticationToken(
+                serverURL: .value(Constants.URLs.production),
+                refreshIfNeeded: .value(true)
+            ).willReturn(token)
+            given(cacheURLStore)
+                .getCacheURL(for: .value(Constants.URLs.production), accountHandle: .value("tuist"))
+                .willReturn(URL(string: "https://cache.example.com")!)
+
+            // When
+            let got = try await subject.cacheStorage(
+                config: .test(
+                    project: .generated(.test(generationOptions: .test(optionalAuthentication: true))),
+                    fullHandle: "tuist/tuist",
+                    url: Constants.URLs.production
+                )
+            )
+
+            // Then
+            #expect((got as? CacheStorage)?.remoteStorage != nil)
+            verify(serverAuthenticationController)
+                .authenticationToken(
+                    serverURL: .value(Constants.URLs.production),
+                    refreshIfNeeded: .value(true)
+                )
+                .called(1)
+        }
+    }
+
+    @Test
+    func swallows_refresh_errors_when_optional_authentication_is_enabled() async throws {
+        // When refresh itself throws (network failure, refresh token revoked,
+        // credentials wiped after a 401), `optionalAuthentication` should fall
+        // through to the warning branch instead of crashing the generate
+        // command. This is the safety valve that motivated the original
+        // skip-refresh shortcut, but without losing the refresh.
+        given(serverEnvironmentService).url(configServerURL: .any).willReturn(Constants.URLs.production)
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(Constants.URLs.production),
+            refreshIfNeeded: .value(true)
+        ).willThrow(RefreshAuthTokenServiceError.unauthorized("Invalid token"))
+
+        // When
+        let got = try await subject.cacheStorage(
+            config: .test(
+                project: .generated(.test(generationOptions: .test(optionalAuthentication: true))),
+                fullHandle: "tuist/tuist",
+                url: Constants.URLs.production
+            )
+        )
+
+        // Then
+        #expect((got as? CacheStorage)?.remoteStorage == nil)
+    }
+
+    @Test
+    func propagates_refresh_errors_when_optional_authentication_is_disabled() async throws {
+        // Without `optionalAuthentication`, a refresh failure must bubble up so
+        // the user gets an actionable error instead of an inexplicably missing
+        // remote cache.
+        given(serverEnvironmentService).url(configServerURL: .any).willReturn(Constants.URLs.production)
+        let error = RefreshAuthTokenServiceError.unauthorized("Invalid token")
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(Constants.URLs.production),
+            refreshIfNeeded: .value(true)
+        ).willThrow(error)
+
+        // When/Then
+        await #expect(throws: error) {
+            try await subject.cacheStorage(
+                config: .test(
+                    fullHandle: "tuist/tuist",
+                    url: Constants.URLs.production
+                )
+            )
+        }
+    }
 }

--- a/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -197,7 +197,7 @@ struct ServerClientAuthenticationMiddlewareTests {
         let response = HTTPResponse(status: 200)
         given(serverAuthenticationController).authenticationToken(
             serverURL: .value(url),
-            refreshIfNeeded: .value(false)
+            refreshIfNeeded: .value(true)
         )
         .willReturn(nil)
         var gotRequest: HTTPRequest!
@@ -220,5 +220,112 @@ struct ServerClientAuthenticationMiddlewareTests {
         // Then
         #expect(gotResponse == response)
         #expect(gotRequest.headerFields == request.headerFields)
+    }
+
+    @Test func refreshes_expired_tokens_when_optional_authentication_is_enabled() async throws {
+        // Regression: with `optionalAuthentication`, the middleware used to skip
+        // the refresh path entirely, so an expired access token would silently
+        // become "no auth header" until the user manually ran `tuist auth login`.
+        // Now refresh is always attempted; falling through to unauthenticated is
+        // reserved for the case where refresh actually fails.
+        let url = URL(string: "https://test.tuist.dev")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
+        let response = HTTPResponse(status: 200)
+        let token: AuthenticationToken? = .user(
+            accessToken: .test(token: "refreshed-access-token"),
+            refreshToken: .test(token: "refresh-token")
+        )
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
+        .willReturn(token)
+        var gotRequest: HTTPRequest!
+
+        // When
+        let (gotResponse, _) = try await ServerAuthenticationConfig.$current.withValue(
+            .init(optionalAuthentication: true)
+        ) {
+            try await subject.intercept(
+                request,
+                body: nil,
+                baseURL: url,
+                operationID: "123"
+            ) { request, body, _ in
+                gotRequest = request
+                return (response, body)
+            }
+        }
+
+        // Then
+        #expect(gotResponse == response)
+        #expect(
+            gotRequest.headerFields ==
+                [
+                    .authorization: "Bearer refreshed-access-token",
+                ]
+        )
+    }
+
+    @Test func swallows_refresh_errors_when_optional_authentication_is_enabled() async throws {
+        // When the refresh attempt itself throws (network failure, refresh token
+        // revoked, credentials wiped after a 401), an `optionalAuthentication`
+        // call site should fall through to the unauthenticated path rather than
+        // surface a hard failure to the caller.
+        let url = URL(string: "https://test.tuist.dev")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
+        let response = HTTPResponse(status: 200)
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
+        .willThrow(RefreshAuthTokenServiceError.unauthorized("Invalid token"))
+        var gotRequest: HTTPRequest!
+
+        // When
+        let (gotResponse, _) = try await ServerAuthenticationConfig.$current.withValue(
+            .init(optionalAuthentication: true)
+        ) {
+            try await subject.intercept(
+                request,
+                body: nil,
+                baseURL: url,
+                operationID: "123"
+            ) { request, body, _ in
+                gotRequest = request
+                return (response, body)
+            }
+        }
+
+        // Then
+        #expect(gotResponse == response)
+        #expect(gotRequest.headerFields == request.headerFields)
+    }
+
+    @Test func propagates_refresh_errors_when_optional_authentication_is_disabled() async throws {
+        // Without `optionalAuthentication`, refresh errors must propagate so the
+        // caller can surface them to the user instead of silently dropping the
+        // request.
+        let url = URL(string: "https://test.tuist.dev")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
+        let response = HTTPResponse(status: 200)
+        let error = RefreshAuthTokenServiceError.unauthorized("Invalid token")
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
+        .willThrow(error)
+
+        // When / Then
+        await #expect(throws: error, performing: {
+            try await subject.intercept(
+                request,
+                body: nil,
+                baseURL: url,
+                operationID: "123"
+            ) { _, _, _ in
+                (response, nil)
+            }
+        })
     }
 }


### PR DESCRIPTION
## Summary

Fixes a regression where the warning `Authentication token for tuist was not found. Skipping using remote cache.` fires every time the access token expires (10-minute TTL) for projects with `optionalAuthentication: true` enabled. Affected users see the warning every few hours and have to re-run `tuist auth login` to recover, even though their refresh token is valid for 28 days and sitting in their credentials file.

The middleware and cache factory both passed `refreshIfNeeded: !optionalAuthentication`, which short-circuited the refresh path entirely and treated expired tokens as "no auth". `optionalAuthentication` should mean *"don't error if there are no credentials"*, not *"don't refresh expired credentials"*.

This change:

- Always attempts the refresh in `ServerClientAuthenticationMiddleware` and `CacheStorageFactory` (via the submodule).
- Catches refresh errors at the call site and falls through to the unauthenticated path when `optionalAuthentication: true`. This preserves the safety valve from the original skip-refresh shortcut without losing valid sessions.
- Without `optionalAuthentication`, refresh errors continue to propagate so the user gets an actionable error.

Submodule companion: tuist/TuistCacheEE#59.

## Test plan

- [x] New tests in `ServerClientAuthenticationMiddlewareTests` covering: refresh-on-expired under optional auth, swallowing refresh errors under optional auth, propagating refresh errors when optional auth is disabled
- [x] New tests in `CacheStorageFactoryTests` mirroring the same three behaviours
- [x] Existing `ServerAuthenticationControllerTests`, `ServerClientAuthenticationMiddlewareTests`, `CacheStorageFactoryTests` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)