### PR TITLE
fix(cache): preserve registry Link header in host nginx

### DIFF
--- a/cache/docker/nginx.conf
+++ b/cache/docker/nginx.conf
@@ -1,3 +1,7 @@
+# Local development only — mounted by cache/docker-compose.yml.
+# Production cache nodes run nginx on the host via NixOS; the equivalent
+# config lives in cache/platform/nginx.nix. Keep the two in sync when
+# changing registry locations, header rewrites, or X-Accel-Redirect paths.
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;

--- a/cache/platform/nginx.nix
+++ b/cache/platform/nginx.nix
@@ -231,6 +231,10 @@
             # Immutable lets clients skip conditional requests entirely.
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header Content-Version $registry_content_version;
+            # Preserve the upstream Link header (set by Phoenix to advertise
+            # alternate registry manifests). X-Accel-Redirect to a static-file
+            # location otherwise drops it.
+            add_header Link $upstream_http_link always;
 
             # CAS artifacts are immutable (content-addressed), so we can
             # cache many more FDs and revalidate less often.
@@ -254,6 +258,10 @@
             # avoid a lookup per download. IPv6 off avoids dual-stack delays.
             resolver 1.1.1.1 ipv6=off valid=300s;
             resolver_timeout 5s;
+            # Capture Phoenix's Link header before proxy_pass replaces
+            # $upstream_http_* with the S3 response's headers (which have
+            # no Link). Re-emitted via add_header below.
+            set $saved_link $upstream_http_link;
             set $download_url $1://$2/$3;
             # Keepalive to S3: HTTP/1.1 + empty Connection reuses TCP
             # connections across consecutive downloads from the same bucket.
@@ -266,6 +274,10 @@
             proxy_ssl_server_name on;
             proxy_pass $download_url$is_args$args;
             add_header Content-Version $registry_content_version;
+            # Re-emit the Link header captured above. Required so SwiftPM
+            # discovers alternate registry manifests when the file is being
+            # streamed from S3 (cold cache node).
+            add_header Link $saved_link always;
             gzip off;
             proxy_request_buffering off;
 


### PR DESCRIPTION
## Summary

- Production cache nodes run nginx on the host (NixOS, configured via `cache/platform/nginx.nix`), not the Kamal-deployed `cache/docker/nginx.conf`. PR #10397 added the `Link`-header preservation to the docker config only, so the fix never reached production.
- Without the `Link` header, SwiftPM never sees alternate manifests like `Package@swift-5.3.swift` and falls back to compiling the legacy root `Package.swift`. For packages like PromiseKit (tools-version 4.0 root), Swift 6 toolchains can't compile it and `tuist install` fails with `Invalid manifest`. This is the regression originally reported in #10360 and re-reported by a customer after #10397 shipped.

## What changed

- `cache/platform/nginx.nix` — `/internal/local/`: `add_header Link $upstream_http_link always;` so the Phoenix-supplied `Link` header survives X-Accel-Redirect to a static file.
- `cache/platform/nginx.nix` — `/internal/remote/`: capture `$upstream_http_link` into `$saved_link` before `proxy_pass` (which would otherwise replace `\$upstream_http_*` with S3's response headers), then re-emit it. Covers cold cache nodes streaming the manifest directly from S3.
- `cache/docker/nginx.conf` — header comment naming `cache/platform/nginx.nix` as the production source of truth, so the same one-sided fix doesn't land again.

The Phoenix-side fixes from #10397 (`Cache.Registry.AlternateManifests` self-heal) are already deployed and were verified quiet in the cache pod logs — Phoenix sets the `Link` header upstream; the host nginx is what was stripping it.

## Diagnosis trail

- Reproduced from outside: `curl -I https://cache-eu-central.tuist.dev/api/registry/swift/mxcl/promisekit/6.18.1/Package.swift` returns no `Link` header on any of the 10 cache origins, on the latest deployed image (`b435844c47…`).
- SSH'd into `cache-eu-central` as `mfort`: `systemctl status nginx` shows nginx running on the host since 2026-03-09, well before #10397 merged. No `Failed to discover alternate manifests` warnings in the Phoenix container logs (the AlternateManifests fallback is doing its job).
- `cache/platform/nginx.nix` had no `add_header Link …` directive in either internal location — the fix from #10397 was missing.

## Deploy notes

- Code-only change here. Production rollout requires running colmena against all 10 cache hosts in `cache/config/deploy.production.yml`. Held back from this PR.
- Verification once deployed: `curl -I https://cache-<region>.tuist.dev/api/registry/swift/mxcl/promisekit/6.18.1/Package.swift` should return a `link:` header with `rel="alternate"; filename="Package@swift-5.3.swift"; swift-tools-version="5.3"`. Then `tuist install` against PromiseKit on Xcode 26.x should succeed.

## Test plan

- [ ] Verify NixOS config evaluates (`nixos-rebuild build` against `cache/platform/`).
- [ ] Deploy to one cache host first, confirm `Link` header is present, only then roll to the rest.
- [ ] Re-run the reproduction from #10360: PromiseKit registry install on Xcode 26.x should resolve to the `Package@swift-5.3.swift` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)