### PR TITLE
ci: enable blick learn self-improvement

### DIFF
--- a/.github/workflows/blick-learn.yml
+++ b/.github/workflows/blick-learn.yml
@@ -1,0 +1,43 @@
+name: blick learn
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: blick-learn
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.4.18"
+  MISE_GITHUB_ATTESTATIONS: 0
+
+jobs:
+  learn:
+    name: Learn
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+
+      - name: Install blick and opencode
+        run: |
+          mise use -g github:tuist/blick
+          mise use -g npm:opencode-ai
+
+      - name: Run blick learn
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+        run: blick learn

--- a/blick.toml
+++ b/blick.toml
@@ -13,3 +13,11 @@ source = "./.blick/skills/tuist-elixir-review"
 [[skills]]
 name = "tuist-swift-review"
 source = "./.blick/skills/tuist-swift-review"
+
+[learn]
+lookback_days = 7
+min_signal = 3
+labels = ["blick-learn"]
+base = "main"
+draft = true
+branch = "blick/learn"

--- a/blick.toml
+++ b/blick.toml
@@ -17,7 +17,8 @@ source = "./.blick/skills/tuist-swift-review"
 [learn]
 lookback_days = 7
 min_signal = 3
-labels = ["blick-learn"]
+team_reviewers = ["tuist/engineering"]
+labels = []
 base = "main"
 draft = true
 branch = "blick/learn"


### PR DESCRIPTION
## Summary
- Adds `[learn]` config to root `blick.toml`
- Adds `.github/workflows/blick-learn.yml` running daily at 07:00 UTC (and on `workflow_dispatch`)

Wires up blick's new [self-improvement feature](https://github.com/tuist/blick#-self-improvement-blick-learn). The workflow opens/updates a rolling draft PR on the `blick/learn` branch proposing tweaks to `blick.toml`, `.blick/skills/**`, and agent instructions based on merged PR review threads (lookback 7 days, min 3 signal threads).

The workflow reuses the same mise + opencode-ai + `FIREWORKS_API_KEY` setup as the existing `blick.yml` review workflow.

## Test plan
- [ ] Trigger via `workflow_dispatch` once merged to confirm the job runs end-to-end
- [ ] Verify a draft PR is opened on `blick/learn` once enough signal accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)