### PR TITLE
fix(server): bound artifact backfill memory and give migration job a memory request

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -90,6 +90,18 @@ server:
     enabled: true
     asHook: true
     backoffLimit: 3
+    # Without a memory request the migration pod is the first thing
+    # kubelet evicts when a node hits the 300Mi pressure threshold,
+    # which is what killed the artifacts-backfill rollout. The limit
+    # bounds a runaway backfill so it self-terminates instead of
+    # taking the node's other pods down with it.
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "1Gi"
+      limits:
+        cpu: "1000m"
+        memory: "2Gi"
 
   # HTTP probes all hit /ready. startupProbe covers the ~30-60s Phoenix boot
   # and the OTel / Sentry init latency we occasionally see in prod.

--- a/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
+++ b/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
@@ -41,13 +41,14 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  # Sized so each batch lands ~100K-200K artifacts in CH (the band
-  # CH ingests most happily) while keeping BEAM memory under ~200MB
-  # even on a tail bundle with hundreds of artifacts. With ~225M
-  # artifacts on production this works out to a few hundred batches,
-  # so the inter-batch throttle below stays a small slice of total
-  # runtime instead of dominating it.
-  @bundle_batch_size 1_000
+  # Bundle artifact counts are heavy-tailed: most bundles have a few
+  # hundred artifacts, but enterprise iOS bundles can carry tens of
+  # thousands. A 1000-bundle batch hit a tail combination that spiked
+  # BEAM memory past 8 GB and got the migration pod OOM-evicted in
+  # production, so keep the batch small enough that even a tail
+  # combination stays bounded. The inter-batch throttle below adds
+  # only a small slice of runtime at this size.
+  @bundle_batch_size 100
   # Matches the throttle other long-running CH backfills use
   # (`BackfillTestRunsFromCommandEvents`, `BackfillFirstRunEvents`):
   # gives live PG/CH traffic breathing room and lets CH merges keep up
@@ -95,6 +96,11 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
             "(running total: #{new_bundle_total} bundles / #{new_artifact_total} artifacts)"
         )
 
+        # The artifact list and its CH-encoded copy are the largest
+        # transient allocations in the loop; force a GC so they're
+        # reclaimed before the next batch instead of accumulating
+        # across iterations of this long-lived migration process.
+        :erlang.garbage_collect()
         Process.sleep(@throttle_ms)
         drain(new_bundle_total, new_artifact_total)
     end


### PR DESCRIPTION
### Context

The artifacts backfill from #10509 has been OOM-evicting on production for the last few rolls — see the failed `helm upgrade` in run [25109336232](https://github.com/tuist/tuist/actions/runs/25109336232). The migration pod (`tuist-tuist-server-migrate-33`) was using ~8.5 GB and the kubelet evicted it once the node hit the 300Mi memory-pressure threshold. Because the Job had `resources: {}` its memory request was 0, so it was the first thing the kubelet picked off.

Two factors compounded:

1. The migration loaded artifacts for 1000 bundles per batch into BEAM at once. Bundle artifact counts are heavy-tailed — most have a few hundred, but enterprise iOS bundles can carry tens of thousands — so a single batch could materialize gigabytes of strings/UUIDs.
2. With no resource request the pod had no priority floor, so the kubelet evicted it ahead of every other pod on the node.

### What changed

- `server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs`
  - `@bundle_batch_size` 1000 → 100 to keep a tail-heavy batch well within the per-pod memory budget.
  - `:erlang.garbage_collect/0` between batches so the encoded artifact list doesn't linger across iterations of this long-lived migration process.
- `infra/helm/tuist/values-managed-common.yaml`
  - `migrationJob.resources` set to request 1Gi / limit 2Gi so the migration pod isn't preferentially evicted, and a runaway backfill self-terminates instead of taking neighbours down with it.

The resume cursor (the `artifacts_replicated_to_ch` flag) is unchanged, so the next run resumes wherever the previous attempts left off.

### How to test locally

The behavioural change is operational — the backfill logic is the same, only batch size and GC cadence differ. Validation:

- `helm template infra/helm/tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml` and confirm the `migrate` Job emits the new `resources` block.
- `cd server && mix format --check-formatted priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs`
- Re-running the production deploy on `main` should let the migration finish under the new 2Gi limit; the next failed-rollback recovery will surface the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)