### PR TITLE
ci(infra): include commit context in Slack failure notifications

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -39,11 +39,20 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+      - name: Build Slack payload
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          SHORT_SHA="${SHA:0:7}"
+          COMMIT_URL="${REPO_URL}/commit/${SHA}"
+          TEXT=$(printf ':x: `%s` failed on main for <%s|tuist%s>: %s\n\n%s' "$WORKFLOW_NAME" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MESSAGE" "$RUN_URL")
+          jq -n --arg text "$TEXT" '{text: $text}' > "$RUNNER_TEMP/slack-payload.json"
       - uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "`${{ github.event.workflow_run.name }}` failed on main: ${{ github.event.workflow_run.html_url }}"
-            }
+          payload-file-path: ${{ runner.temp }}/slack-payload.json

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           SHORT_SHA="${SHA:0:7}"
           COMMIT_URL="${REPO_URL}/commit/${SHA}"
-          TEXT=$(printf ':x: `%s` failed on main for <%s|tuist%s>: %s\n\n%s' "$WORKFLOW_NAME" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MESSAGE" "$RUN_URL")
+          TEXT=$(printf ':x: <%s|%s> failed on main for <%s|tuist%s>: %s' "$RUN_URL" "$WORKFLOW_NAME" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MESSAGE")
           jq -n --arg text "$TEXT" '{text: $text}' > "$RUNNER_TEMP/slack-payload.json"
       - uses: slackapi/slack-github-action@v2
         with:


### PR DESCRIPTION
> Describe here the purpose of your PR.

When a workflow fails on `main`, the Slack notification currently only includes the workflow name and a link to the failing run:

> `Server Production Deployment` failed on main: https://github.com/tuist/tuist/actions/runs/25109336232

This PR mirrors the structure already used by [`notify-deploy-success.yml`](.github/workflows/notify-deploy-success.yml) so the failure message also surfaces the commit message and a clickable short-SHA commit link. The workflow name itself becomes the link to the run, so both pieces of context fit on a single line and the message degrades cleanly when the commit message is empty:

> ❌ **Server Production Deployment** failed on main for **tuistabc1234**: fix(cli): something broke

…where **Server Production Deployment** links to the failing run and **tuistabc1234** links to the commit.

Makes it much faster to spot which change broke `main` without opening the run.

### How to test locally

This is a `workflow_run` notifier — it can only be exercised end-to-end on `main` (the trigger branch is hard-pinned). The `jq` payload construction can be sanity-checked locally:

```bash
WORKFLOW_NAME="Server Production Deployment" \
RUN_URL="https://github.com/tuist/tuist/actions/runs/123" \
COMMIT_MESSAGE="fix(cli): something" \
SHA="abc1234deadbeef" \
REPO_URL="https://github.com/tuist/tuist" \
bash -c '
  SHORT_SHA="${SHA:0:7}"
  COMMIT_URL="${REPO_URL}/commit/${SHA}"
  TEXT=$(printf '\'':x: <%s|%s> failed on main for <%s|tuist%s>: %s'\'' "$RUN_URL" "$WORKFLOW_NAME" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MESSAGE")
  jq -n --arg text "$TEXT" '\''{text: $text}'\''
'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)