### PR TITLE
feat(server): add service.version to OpenTelemetry resource

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -241,9 +241,11 @@ RUN chown nobody /app
 
 ARG MIX_ENV=prod
 ARG TUIST_HOSTED=1
+ARG TUIST_VERSION=0.0.0
 ARG EMBED_CLICKHOUSE=false
 ENV MIX_ENV=$MIX_ENV
 ENV TUIST_HOSTED=$TUIST_HOSTED
+ENV TUIST_VERSION=$TUIST_VERSION
 
 # Swift runtime libs the NIF links against at load time. Small (~20 MB) but
 # carried by every release image because any pod may run in processor mode

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -294,6 +294,7 @@ if Tuist.Environment.error_tracking_enabled?() do
     client: TuistCommon.SentryHTTPClient,
     dsn: Tuist.Environment.sentry_dsn(secrets),
     environment_name: env,
+    release: Tuist.Environment.version(),
     enable_source_code_context: true,
     root_source_code_paths: [File.cwd!()],
     before_send: {Tuist.SentryEventFilter, :before_send}

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -477,7 +477,11 @@ if otel_endpoint do
   config :opentelemetry,
     span_processor: :batch,
     resource: [
-      service: [name: "tuist-server", namespace: "tuist"],
+      service: [
+        name: "tuist-server",
+        namespace: "tuist",
+        version: to_string(Tuist.Environment.version())
+      ],
       deployment: [environment: to_string(env)]
     ]
 

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -182,7 +182,11 @@ defmodule Tuist.Environment do
   end
 
   def version do
-    Application.spec(:tuist)[:vsn]
+    case System.get_env("TUIST_VERSION") do
+      nil -> to_string(Application.spec(:tuist)[:vsn])
+      "" -> to_string(Application.spec(:tuist)[:vsn])
+      version -> version
+    end
   end
 
   def ops_user_handles(secrets \\ secrets()) do


### PR DESCRIPTION
## Summary

- Adds `service.version` to the OTel Resource in `server/config/runtime.exs`, sourced from `Tuist.Environment.version()`.
- Resource attributes are attached automatically to every span, log, and metric the SDK emits — including exception events — so the running version becomes queryable in Grafana without touching individual reporters or span events.

## Why

This is the standard OTel pattern for app version. Setting it on the Resource (vs. on individual span events) avoids conflicting with host-app config and matches what backends like Grafana/Tempo/Honeycomb/Datadog expect.

## Note for reviewer

`Tuist.Environment.version()` currently resolves to `Application.spec(:tuist)[:vsn]`, which is hardcoded to `0.1.0` in `server/mix.exs`. Until that's wired to a real release identifier (git SHA or release tag) at build time, all events will report `0.1.0`. Follow-up worth considering.

## Test plan

- [ ] Deploy to staging and confirm `service.version` shows up as a resource attribute on traces in Grafana
- [ ] Confirm exception events carry the resource attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)