### PR TITLE
fix(server): handle :email_taken in OAuth choose-username flow

### DIFF
--- a/server/lib/tuist_web/controllers/auth_controller.ex
+++ b/server/lib/tuist_web/controllers/auth_controller.ex
@@ -324,6 +324,19 @@ defmodule TuistWeb.AuthController do
     redirect(conn, to: ~p"/users/log_in")
   end
 
+  def cancel_pending_signup(conn, _params) do
+    conn
+    |> delete_session(:pending_oauth_signup)
+    |> put_flash(
+      :error,
+      dgettext(
+        "dashboard_auth",
+        "An account with this email already exists. Please log in instead."
+      )
+    )
+    |> redirect(to: ~p"/users/log_in")
+  end
+
   defp oauth_failure_message(%Ueberauth.Failure{errors: errors}) do
     case errors do
       [%Error{message_key: "access_denied"} | _] ->

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -118,6 +118,20 @@ defmodule TuistWeb.ChooseUsernameLive do
 
         {:noreply, socket}
 
+      {:error, :email_taken} ->
+        socket =
+          socket
+          |> put_flash(
+            :error,
+            dgettext(
+              "dashboard_auth",
+              "An account with this email already exists. Please log in instead."
+            )
+          )
+          |> redirect(to: ~p"/users/log_in")
+
+        {:noreply, socket}
+
       {:error, errors} when is_map(errors) ->
         error = Map.get(errors, :name)
 

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -119,18 +119,7 @@ defmodule TuistWeb.ChooseUsernameLive do
         {:noreply, socket}
 
       {:error, :email_taken} ->
-        socket =
-          socket
-          |> put_flash(
-            :error,
-            dgettext(
-              "dashboard_auth",
-              "An account with this email already exists. Please log in instead."
-            )
-          )
-          |> redirect(to: ~p"/users/log_in")
-
-        {:noreply, socket}
+        {:noreply, redirect(socket, to: ~p"/auth/cancel-pending-signup")}
 
       {:error, errors} when is_map(errors) ->
         error = Map.get(errors, :name)

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -760,6 +760,7 @@ defmodule TuistWeb.Router do
   scope "/auth", TuistWeb do
     pipe_through [:browser_app]
     get "/complete-signup", AuthController, :complete_signup
+    get "/cancel-pending-signup", AuthController, :cancel_pending_signup
   end
 
   scope "/users/auth", TuistWeb do

--- a/server/test/tuist_web/live/choose_username_live_test.exs
+++ b/server/test/tuist_web/live/choose_username_live_test.exs
@@ -159,6 +159,32 @@ defmodule TuistWeb.ChooseUsernameLiveTest do
       assert html =~ "has already been taken"
     end
 
+    test "redirects to log in when email is already taken", %{conn: conn} do
+      existing_user = user_fixture()
+
+      oauth_data = %{
+        "provider" => "google",
+        "uid" => "unique-uid-#{System.unique_integer([:positive])}",
+        "email" => existing_user.email,
+        "provider_organization_id" => nil,
+        "oauth_return_url" => nil
+      }
+
+      {:ok, lv, _html} =
+        conn
+        |> init_test_session(%{"pending_oauth_signup" => oauth_data})
+        |> live(~p"/users/choose-username")
+
+      username = "newhandle#{System.unique_integer([:positive])}"
+
+      result =
+        lv
+        |> form("#choose-username-form", account: %{name: username})
+        |> render_submit()
+
+      assert {:error, {:redirect, %{to: "/users/log_in"}}} = result
+    end
+
     test "shows error when username contains invalid characters", %{conn: conn} do
       oauth_data = %{
         "provider" => "google",

--- a/server/test/tuist_web/live/choose_username_live_test.exs
+++ b/server/test/tuist_web/live/choose_username_live_test.exs
@@ -182,7 +182,7 @@ defmodule TuistWeb.ChooseUsernameLiveTest do
         |> form("#choose-username-form", account: %{name: username})
         |> render_submit()
 
-      assert {:error, {:redirect, %{to: "/users/log_in"}}} = result
+      assert {:error, {:redirect, %{to: "/auth/cancel-pending-signup"}}} = result
     end
 
     test "shows error when username contains invalid characters", %{conn: conn} do


### PR DESCRIPTION
## Summary
- `TuistWeb.ChooseUsernameLive.handle_event/3` was missing an `{:error, :email_taken}` clause, so OAuth signups with an already-registered email crashed with `CaseClauseError` (Sentry issue 116346590).
- On `:email_taken`, the LiveView now redirects to a new `AuthController.cancel_pending_signup` action that clears `:pending_oauth_signup` from the session, flashes a message, and redirects to `/users/log_in`. This mirrors the pattern in `user_registration_live.ex` while also cleaning up the stale cookie key.
- Added a regression test in `choose_username_live_test.exs`.

> [!NOTE]
> **Assumed root cause: stale `pending_oauth_signup` cookie.**
> The OAuth callback already routes existing-email users to `link_existing_user_and_log_in`, so reaching `:email_taken` here means the email was registered *between* the OAuth callback and the form submit. The most likely path: a user starts OAuth signup, lands on `/users/choose-username`, abandons the tab, later registers via password or another OAuth provider, then returns to the old tab and submits. A simultaneous-signup race is possible but rare. We only have one Sentry event so we can't confirm conclusively, but the fix is correct under both interpretations and additionally clears the stale session key so the failure can't repeat for the same user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)