### PR TITLE
revert: stop sharing Mix _build across worktrees

### DIFF
--- a/cache/mix.exs
+++ b/cache/mix.exs
@@ -6,7 +6,6 @@ defmodule Cache.MixProject do
       app: :cache,
       version: "0.1.0",
       elixir: "~> 1.18",
-      build_path: build_path(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [check_cwd: false],
       start_permanent: Mix.env() == :prod,
@@ -24,13 +23,6 @@ defmodule Cache.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "cache")
-    end
-  end
 
   defp deps do
     [

--- a/mise/utilities/dev_instance_env.sh
+++ b/mise/utilities/dev_instance_env.sh
@@ -36,43 +36,7 @@ resolve_git_path() {
   fi
 }
 
-resolve_git_common_dir() {
-  local git_dir=""
-
-  if command -v git >/dev/null 2>&1 && git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git_dir="$(
-      git -C "${PROJECT_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null ||
-        git -C "${PROJECT_ROOT}" rev-parse --git-common-dir 2>/dev/null ||
-        true
-    )"
-
-    if [[ -n "${git_dir}" && "${git_dir}" != /* ]]; then
-      git_dir="${PROJECT_ROOT}/${git_dir#./}"
-    fi
-  fi
-
-  if [[ -n "${git_dir}" ]]; then
-    printf '%s' "${git_dir}"
-  else
-    printf '%s' "${PROJECT_ROOT}/.git"
-  fi
-}
-
-stable_hash() {
-  local input="$1"
-
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "${input}" | shasum -a 256 | awk '{print substr($1, 1, 12)}'
-  elif command -v sha256sum >/dev/null 2>&1; then
-    printf '%s' "${input}" | sha256sum | awk '{print substr($1, 1, 12)}'
-  else
-    printf '%s' "${input}" | cksum | awk '{print $1}'
-  fi
-}
-
 INSTANCE_FILE="$(resolve_git_path "tuist-dev-instance" "${ROOT_INSTANCE_FILE}")"
-COMMON_GIT_DIR="$(resolve_git_common_dir)"
-MIX_BUILD_ROOT_KEY="$(stable_hash "${COMMON_GIT_DIR}")"
 
 validate_suffix() {
   local suffix="$1"
@@ -129,7 +93,6 @@ project_basename="$(basename "${PROJECT_ROOT}")"
 project_hostname="$(printf '%s' "${project_basename}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/^-*//; s/-*$//')"
 
 export TUIST_DEV_INSTANCE="${suffix}"
-export TUIST_MIX_BUILD_ROOT="${CACHE_ROOT}/mix/${MIX_BUILD_ROOT_KEY}"
 export TUIST_SERVER_PORT="$((8080 + suffix))"
 export TUIST_SERVER_HOSTNAME="${project_hostname}.localhost"
 export TUIST_SERVER_URL="http://localhost:${TUIST_SERVER_PORT}"

--- a/noora/mix.exs
+++ b/noora/mix.exs
@@ -7,7 +7,6 @@ defmodule Noora.MixProject do
       description: "A component library for Phoenix LiveView applications",
       version: "0.81.0",
       elixir: "~> 1.16",
-      build_path: build_path(),
       elixirc_options: [check_cwd: false],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -20,13 +19,6 @@ defmodule Noora.MixProject do
     [
       extra_applications: [:logger]
     ]
-  end
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "noora")
-    end
   end
 
   defp deps do

--- a/noora/storybook/mix.exs
+++ b/noora/storybook/mix.exs
@@ -6,7 +6,6 @@ defmodule NooraStorybook.MixProject do
       app: :noora_storybook,
       version: "0.1.0",
       elixir: "~> 1.14",
-      build_path: build_path(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [check_cwd: false],
       start_permanent: Mix.env() == :prod,
@@ -25,13 +24,6 @@ defmodule NooraStorybook.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "noora/storybook")
-    end
-  end
 
   defp deps do
     [

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -6,7 +6,6 @@ defmodule Tuist.MixProject do
       app: :tuist,
       version: "0.1.0",
       elixir: "~> 1.19",
-      build_path: build_path(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [check_cwd: false],
       test_paths: ["test"],
@@ -33,13 +32,6 @@ defmodule Tuist.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support", "credo"]
   defp elixirc_paths(:dev), do: ["lib", "credo"]
   defp elixirc_paths(_), do: ["lib"]
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "server")
-    end
-  end
 
   # Specifies your project dependencies.
   #

--- a/tuist_common/mix.exs
+++ b/tuist_common/mix.exs
@@ -6,7 +6,6 @@ defmodule TuistCommon.MixProject do
       app: :tuist_common,
       version: "0.1.0",
       elixir: "~> 1.16",
-      build_path: build_path(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [check_cwd: false],
       start_permanent: Mix.env() == :prod,
@@ -23,13 +22,6 @@ defmodule TuistCommon.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support", "credo"]
   defp elixirc_paths(:dev), do: ["lib", "credo"]
   defp elixirc_paths(_), do: ["lib"]
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "tuist_common")
-    end
-  end
 
   defp deps do
     [

--- a/xcode_processor/mise/tasks/build-release.sh
+++ b/xcode_processor/mise/tasks/build-release.sh
@@ -4,17 +4,9 @@
 #MISE raw=true
 set -euo pipefail
 
-release_dir() {
-    if [ -n "${TUIST_MIX_BUILD_ROOT:-}" ]; then
-        printf '%s\n' "${TUIST_MIX_BUILD_ROOT}/xcode_processor/prod/rel/xcode_processor"
-    else
-        printf '%s\n' "_build/prod/rel/xcode_processor"
-    fi
-}
-
 echo "==> Building Elixir release..."
 MIX_ENV=prod mix deps.get --only prod
 MIX_ENV=prod mix compile
 MIX_ENV=prod mix release --overwrite
 
-echo "==> Release built at $(release_dir)/"
+echo "==> Release built at _build/prod/rel/xcode_processor/"

--- a/xcode_processor/mise/tasks/deploy.sh
+++ b/xcode_processor/mise/tasks/deploy.sh
@@ -7,14 +7,6 @@
 #USAGE }
 set -euo pipefail
 
-release_dir() {
-    if [ -n "${TUIST_MIX_BUILD_ROOT:-}" ]; then
-        printf '%s\n' "${TUIST_MIX_BUILD_ROOT}/xcode_processor/prod/rel/xcode_processor"
-    else
-        printf '%s\n' "_build/prod/rel/xcode_processor"
-    fi
-}
-
 HOST="${usage_host?}"
 ENVIRONMENT="${usage_environment?}"
 DEPLOY_USER="github-actions"
@@ -33,7 +25,7 @@ SCP_CMD="scp ${SSH_OPTS}"
 echo "==> Building release..."
 mise run build-release
 
-RELEASE_DIR="$(release_dir)"
+RELEASE_DIR="_build/prod/rel/xcode_processor"
 TARBALL="xcode_processor-${SHORT_SHA}.tar.gz"
 
 echo "==> Packaging release..."

--- a/xcode_processor/mix.exs
+++ b/xcode_processor/mix.exs
@@ -6,7 +6,6 @@ defmodule XcodeProcessor.MixProject do
       app: :xcode_processor,
       version: "0.1.0",
       elixir: "~> 1.18",
-      build_path: build_path(),
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [check_cwd: false],
       start_permanent: Mix.env() == :prod,
@@ -24,13 +23,6 @@ defmodule XcodeProcessor.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
-
-  defp build_path do
-    case System.get_env("TUIST_MIX_BUILD_ROOT") do
-      root when root in [nil, ""] -> "_build"
-      root -> Path.join(root, "xcode_processor")
-    end
-  end
 
   defp deps do
     [


### PR DESCRIPTION
## Summary

Reverts the cross-worktree Mix `_build` sharing introduced in #10385. Each worktree now compiles into its local `_build` directory again.

## Why

Sharing a single `_build` root via `TUIST_MIX_BUILD_ROOT` (keyed off `git --git-common-dir`) caused cross-worktree locking and related issues when multiple worktrees were active at the same time. The cost of redundant compilation across worktrees is preferable to the contention the shared root introduced.

## Changes

- Drop `TUIST_MIX_BUILD_ROOT` export and the `git-common-dir` hashing helpers from \`mise/utilities/dev_instance_env.sh\`.
- Remove the \`build_path/0\` overrides from \`server\`, \`cache\`, \`tuist_common\`, \`noora\`, \`noora/storybook\`, and \`xcode_processor\` \`mix.exs\` files.
- Restore hardcoded \`_build/prod/rel/xcode_processor\` paths in the xcode_processor build/deploy scripts.

## Test plan

- [ ] \`mise run dev\` still starts the server in a worktree
- [ ] \`mix compile\` in the server uses the local \`_build/\`
- [ ] xcode_processor \`mise run build-release\` still produces a release at \`_build/prod/rel/xcode_processor\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)