### PR TITLE
fix(cli): stabilize cache EE canary acceptance test

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -231,6 +231,7 @@ public enum Module: String, CaseIterable {
                 dependencies: [
                     .target(name: Module.alert.targetName),
                     .target(name: Module.cacheCommand.targetName),
+                    .target(name: Module.configLoader.targetName),
                     .target(name: Module.core.targetName),
                     .target(name: Module.environment.targetName),
                     .target(name: Module.environmentTesting.targetName),

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -37,7 +37,10 @@ struct TuistCacheEECanaryAcceptanceTests {
         let environment = try #require(Environment.mocked)
 
         try await withShortStateDirectory(fileSystem: fileSystem) { stateDirectory in
+            let previousStateDirectory = environment.stateDirectory
             environment.stateDirectory = stateDirectory
+            defer { environment.stateDirectory = previousStateDirectory }
+
             let fixtureFullHandle = try #require(TuistTest.fixtureFullHandle)
 
             try await fileSystem.writeText(

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -1,11 +1,14 @@
 import FileSystem
 import FileSystemTesting
 import Foundation
+import Logging
 import Path
 import Testing
 import TuistAcceptanceTesting
 import TuistBuildCommand
 import TuistCacheCommand
+import TuistConfigLoader
+import TuistCore
 import TuistEnvironment
 import TuistEnvironmentTesting
 import TuistGenerateCommand
@@ -160,8 +163,17 @@ struct TuistCacheEECanaryAcceptanceTests {
             ]
         )
 
-        // Selective test results are persisted asynchronously
-        try await Task.sleep(nanoseconds: 7_000_000_000)
+        let unchangedTestTargetName = "MultiPlatformTransitiveDynamicFrameworkTests"
+        let unchangedTestHash = try await selectiveTestingHash(
+            for: unchangedTestTargetName,
+            fixtureDirectory: fixtureDirectory
+        )
+        try await waitForRemoteSelectiveTestResult(
+            targetName: unchangedTestTargetName,
+            hash: unchangedTestHash,
+            fixtureDirectory: fixtureDirectory,
+            fileSystem: fileSystem
+        )
 
         // When: Clean selective testing data
         try await TuistTest.run(
@@ -198,6 +210,61 @@ struct TuistCacheEECanaryAcceptanceTests {
         TuistTest.expectLogs(
             "The following targets have not changed since the last successful run and will be skipped: MultiPlatformTransitiveDynamicFrameworkTests"
         )
+    }
+
+    private func selectiveTestingHash(
+        for targetName: String,
+        fixtureDirectory: AbsolutePath
+    ) async throws -> String {
+        try await TuistTest.run(HashSelectiveTestingCommand.self, ["--path", fixtureDirectory.pathString])
+
+        let prefix = "\(targetName) - "
+        let output = Logger.testingLogHandler.collected[.info, <=]
+        let line = try #require(
+            output
+                .split(separator: "\n")
+                .reversed()
+                .first(where: { $0.hasPrefix(prefix) }),
+            "Selective testing hash for \(targetName) was not found in logs: \(output)"
+        )
+        return String(line.dropFirst(prefix.count))
+    }
+
+    /// Remote selective-test results become visible asynchronously on canary. Poll the same cache
+    /// lookup the second `tuist test` run depends on instead of sleeping for a fixed duration.
+    private func waitForRemoteSelectiveTestResult(
+        targetName: String,
+        hash: String,
+        fixtureDirectory: AbsolutePath,
+        fileSystem: FileSysteming
+    ) async throws {
+        let config = try await ConfigLoader().loadConfig(path: fixtureDirectory)
+        let cacheStorage = try await CacheStorageFactory().cacheStorage(config: config)
+        let expectedItem = CacheStorableItem(name: targetName, hash: hash)
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(60))
+
+        while true {
+            try await cleanLocalSelectiveTestsCache(fileSystem: fileSystem)
+            let fetchedItems = try await cacheStorage.fetch(Set([expectedItem]), cacheCategory: .selectiveTests)
+            if fetchedItems.keys.contains(where: { $0.hash == hash }) {
+                return
+            }
+
+            try #require(
+                clock.now < deadline,
+                "Remote selective test result for \(targetName) with hash \(hash) did not become available"
+            )
+            try await Task.sleep(for: .seconds(1))
+        }
+    }
+
+    private func cleanLocalSelectiveTestsCache(fileSystem: FileSysteming) async throws {
+        let directory = try CacheDirectoriesProvider().cacheDirectory(for: .selectiveTests)
+        if try await fileSystem.exists(directory) {
+            try await fileSystem.remove(directory)
+        }
+        try await fileSystem.makeDirectory(at: directory)
     }
 
     /// The cache server exposes a Unix-domain socket under the state directory. macOS limits the full

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -16,7 +16,6 @@ import TuistSupport
 import TuistTestCommand
 import TuistTesting
 import XcodeProj
-
 @testable import TuistCacheEE
 @testable import TuistKit
 
@@ -33,64 +32,64 @@ struct TuistCacheEECanaryAcceptanceTests {
         let fileSystem = FileSystem()
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let environment = try #require(Environment.mocked)
-        environment.stateDirectory = try await fileSystem.currentWorkingDirectory()
-        let fixtureFullHandle = try #require(TuistTest.fixtureFullHandle)
 
-        try await fileSystem.writeText(
-            """
-            import ProjectDescription
+        try await withShortStateDirectory(fileSystem: fileSystem) { stateDirectory in
+            environment.stateDirectory = stateDirectory
+            let fixtureFullHandle = try #require(TuistTest.fixtureFullHandle)
 
-            let tuist = Tuist(
-                fullHandle: "\(fixtureFullHandle)",
-                url: "\(Environment.current.variables["TUIST_URL"] ?? "https://canary.tuist.dev")",
-                project: .tuist(
-                    generationOptions: .options(
-                        enableCaching: true
+            try await fileSystem.writeText(
+                """
+                import ProjectDescription
+
+                let tuist = Tuist(
+                    fullHandle: "\(fixtureFullHandle)",
+                    url: "\(Environment.current.variables["TUIST_URL"] ?? "https://canary.tuist.dev")",
+                    project: .tuist(
+                        generationOptions: .options(
+                            enableCaching: true
+                        )
                     )
                 )
+                """,
+                at: fixtureDirectory.appending(components: "Tuist.swift"),
+                options: Set([.overwrite])
             )
-            """,
-            at: fixtureDirectory.appending(components: "Tuist.swift"),
-            options: Set([.overwrite])
-        )
 
-        let backgroundTask = Task {
-            while !Task.isCancelled {
-                try await TuistTest.run(
-                    CacheStartCommand.self,
-                    [fixtureFullHandle, "--url", Environment.current.variables["TUIST_URL"] ?? "https://canary.tuist.dev"]
-                )
+            let remoteCacheServicePath = environment.stateDirectory
+                .appending(component: "\(fixtureFullHandle.replacingOccurrences(of: "/", with: "_")).sock")
+            try #require(
+                remoteCacheServicePath.pathString.utf8.count < 104,
+                "Unix-domain socket path is too long: \(remoteCacheServicePath.pathString)"
+            )
+
+            try await withCacheServer(
+                fullHandle: fixtureFullHandle,
+                socketPath: remoteCacheServicePath,
+                fileSystem: fileSystem
+            ) {
+                try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
+                resetUI()
+
+                let arguments = [
+                    "-scheme", "App",
+                    "-destination", "generic/platform=iOS Simulator",
+                    "-project", xcodeprojPath.pathString,
+                    "-derivedDataPath", temporaryDirectory.pathString,
+                    "CODE_SIGN_IDENTITY=",
+                    "CODE_SIGNING_REQUIRED=NO",
+                    "CODE_SIGNING_ALLOWED=NO",
+                    "COMPILATION_CACHE_REMOTE_SERVICE_PATH=\(remoteCacheServicePath.pathString)",
+                ]
+                try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
+                TuistTest.expectLogs("cacheable tasks (0%)")
+                resetUI()
+
+                try await fileSystem.remove(temporaryDirectory)
+
+                try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
+                TuistTest.expectLogs("cacheable tasks (100%)")
             }
         }
-
-        defer {
-            backgroundTask.cancel()
-        }
-
-        let remoteCacheServicePath = environment.stateDirectory
-            .appending(component: "\(fixtureFullHandle.replacingOccurrences(of: "/", with: "_")).sock")
-
-        try await TuistTest.run(GenerateCommand.self, ["--path", fixtureDirectory.pathString, "--no-open"])
-        resetUI()
-
-        let arguments = [
-            "-scheme", "App",
-            "-destination", "generic/platform=iOS Simulator",
-            "-project", xcodeprojPath.pathString,
-            "-derivedDataPath", temporaryDirectory.pathString,
-            "CODE_SIGN_IDENTITY=",
-            "CODE_SIGNING_REQUIRED=NO",
-            "CODE_SIGNING_ALLOWED=NO",
-            "COMPILATION_CACHE_REMOTE_SERVICE_PATH=\(remoteCacheServicePath.pathString)",
-        ]
-        try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
-        TuistTest.expectLogs("cacheable tasks (0%)")
-        resetUI()
-
-        try await fileSystem.remove(temporaryDirectory)
-
-        try await TuistTest.run(XcodeBuildBuildCommand.self, arguments)
-        TuistTest.expectLogs("cacheable tasks (100%)")
     }
 
     @Test(
@@ -199,5 +198,75 @@ struct TuistCacheEECanaryAcceptanceTests {
         TuistTest.expectLogs(
             "The following targets have not changed since the last successful run and will be skipped: MultiPlatformTransitiveDynamicFrameworkTests"
         )
+    }
+
+    /// The cache server exposes a Unix-domain socket under the state directory. macOS limits the full
+    /// socket path length, so acceptance tests use a short state directory to keep the socket path valid.
+    private func makeShortStateDirectory(fileSystem: FileSysteming) async throws -> AbsolutePath {
+        let directory = try AbsolutePath(validating: "/tmp")
+            .appending(component: "tuist-cache-\(UUID().uuidString.prefix(8).lowercased())")
+        try await fileSystem.makeDirectory(at: directory)
+        return directory
+    }
+
+    private func withShortStateDirectory(
+        fileSystem: FileSysteming,
+        operation: (AbsolutePath) async throws -> Void
+    ) async throws {
+        let directory = try await makeShortStateDirectory(fileSystem: fileSystem)
+
+        do {
+            try await operation(directory)
+        } catch {
+            try? await fileSystem.remove(directory)
+            throw error
+        }
+
+        try? await fileSystem.remove(directory)
+    }
+
+    private func withCacheServer(
+        fullHandle: String,
+        socketPath: AbsolutePath,
+        fileSystem: FileSysteming,
+        operation: () async throws -> Void
+    ) async throws {
+        let cacheServerTask = Task {
+            try await TuistTest.run(
+                CacheStartCommand.self,
+                [fullHandle, "--url", Environment.current.variables["TUIST_URL"] ?? "https://canary.tuist.dev"]
+            )
+        }
+
+        do {
+            try await waitForCacheServer(at: socketPath, fileSystem: fileSystem)
+            try await operation()
+        } catch {
+            await stopCacheServer(cacheServerTask)
+            throw error
+        }
+
+        await stopCacheServer(cacheServerTask)
+    }
+
+    private func stopCacheServer(_ task: Task<Void, Error>) async {
+        task.cancel()
+        _ = await task.result
+    }
+
+    private func waitForCacheServer(
+        at socketPath: AbsolutePath,
+        fileSystem: FileSysteming
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(30))
+
+        while try await !fileSystem.exists(socketPath) {
+            try #require(
+                clock.now < deadline,
+                "Cache server did not create socket at \(socketPath.pathString)"
+            )
+            try await Task.sleep(for: .milliseconds(100))
+        }
     }
 }


### PR DESCRIPTION
## Summary

This stabilizes `TuistCacheEECanaryAcceptanceTests` while keeping the acceptance suite parallel. The changes make the tests wait on the real readiness signals they depend on instead of relying on CI timing:

- use a short, unique state directory for the local cache server
- document the Unix-domain socket path-length constraint on the helper that creates that directory
- assert that the derived socket path stays below the macOS limit
- wait until the cache server socket exists before invoking Xcode
- cancel and await the cache server task before cleaning up its state directory
- restore the mocked state directory before the fixture trait deletes the project, organization, and session
- clean up temporary state through `FileSystem`
- replace the fixed selective-testing sleep with polling for the exact remote selective-test cache item

## Root Cause

The failing canary job exposed several independent timing/path issues in the same suite. They were related because they all showed up in `TuistCacheEECanaryAcceptanceTests`, but they had different failure modes and needed targeted fixes.

### Local Cache Server Socket

`generated_project_with_caching_enabled` starts a local cache server, then points Xcode at the server through `COMPILATION_CACHE_REMOTE_SERVICE_PATH`. That path is derived from `Environment.stateDirectory` plus the project handle.

The test previously used the current working directory as the state directory. In CI, that can be a long checkout/worktree path. macOS Unix-domain sockets have a small fixed path-length limit, so the derived socket path could be too long depending on the runner path. The test also started Xcode immediately after spawning the cache server task, so even when the path was valid, Xcode could try to connect before the server had bound the socket.

There was one more lifecycle race: the test cancelled the cache server task but did not await it before deleting the state directory. The server owns SQLite state under that directory, so cleanup could remove files while the server was still shutting down.

### Fixture Cleanup After State Directory Override

The follow-up CI run still failed after the socket readiness and selective-test polling changes. The remaining failure came from the way `generated_project_with_caching_enabled` overrides the mocked `Environment.stateDirectory`.

The fixture trait wraps the test body with remote setup and teardown: it logs in, creates an organization, creates a project, runs the test, then deletes the project, deletes the organization, and logs out. The test body now temporarily points `Environment.stateDirectory` at a short `/tmp/tuist-cache-*` directory so the cache server socket path stays under the macOS limit.

That override must be scoped to the cache-server part of the test only. Without restoring the previous mocked state directory, the fixture trait's teardown commands run after the short directory has been removed. Those commands still use the same mocked environment, so cleanup can try to read/write session state under a deleted directory. That explains why the generated-project test could pass its Xcode assertions locally but still fail once the wrapper cleanup ran in CI, especially on retries.

### Remote Selective-Test Cache Visibility

After the first fix, the next failing CI run showed `multiplatform_app_selective_testing` still failing. That test runs `tuist test`, waits seven seconds, clears the local selective-test cache, mutates one target, and expects the second `tuist test` run to skip `MultiPlatformTransitiveDynamicFrameworkTests` by reading the previous result from canary.

The seven-second sleep was only approximating an asynchronous server-side write. The first `tuist test` command can finish before the remote selective-test record is visible through the cache storage lookup used by the second command. On a busy CI/canary path, the test could clear its local cache and start the second run before the remote item was fetchable, so the unchanged test target was not skipped.

## Why This Solution

We keep Swift Testing's normal scheduling and avoid serializing the suite. Serializing would reduce pressure on shared state, but it would not fix either readiness bug and would make the acceptance shard slower.

For the local cache server case, the test now owns a short `/tmp/tuist-cache-*` state directory. That keeps the socket path valid regardless of checkout length, and the explicit socket-length assertion makes the platform constraint obvious if the path shape changes later. The test waits for the socket file before invoking Xcode and awaits server cancellation before removing the directory, so setup and teardown are tied to observable lifecycle events.

The short state directory is also restored before the test body returns. That leaves the fixture trait's project/org/session cleanup using the original mocked environment state directory that still exists for the lifetime of the fixture scope.

For the selective-testing case, the test now computes the expected hash for `MultiPlatformTransitiveDynamicFrameworkTests` and polls `CacheStorage.fetch` for that exact `.selectiveTests` item. It clears the local selective-test cache between poll attempts so a local hit cannot mask remote readiness. The second `tuist test` run only starts once the same remote lookup it depends on can succeed.

This keeps the suite parallel while making each test synchronize with the resource it actually needs.

## Testing

- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 TUIST_FILESYSTEM_BACKEND=swift-file-system xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -only-testing TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests -derivedDataPath /tmp/tuist-ee-acceptance-derived-data-selective-poll CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO -retry-tests-on-failure -test-iterations 2`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 TUIST_FILESYSTEM_BACKEND=swift-file-system xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -only-testing TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests -derivedDataPath /tmp/tuist-ee-acceptance-derived-data-isolated CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO -retry-tests-on-failure -test-iterations 2`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -only-testing TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests -derivedDataPath /tmp/tuist-ee-acceptance-derived-data-parallel-2 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=1 xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -only-testing TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests -derivedDataPath /tmp/tuist-ee-acceptance-derived-data-parallel-3 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= COMPILATION_CACHE_ENABLE_CACHING=NO`
- `TUIST_EE=1 TUIST_ENABLE_CACHING=true tuist inspect dependencies --only implicit`
- `xcrun swiftc -parse -parse-as-library cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift`
- `swiftformat --lint cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift`
- `git diff --check`
