### PR TITLE
fix(server): prevent canary deploy migration hook timeout

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -188,6 +188,37 @@ jobs:
           mkdir -p "$(dirname "$KUBECONFIG")"
           echo "${{ secrets.KUBECONFIG }}" | base64 -d > "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
+      - name: Recover interrupted Helm release
+        run: |
+          set -euo pipefail
+
+          status="$(
+            helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE" 2>/dev/null |
+              awk '/^STATUS:/ { print $2 }' ||
+              true
+          )"
+          case "$status" in
+            pending-install|pending-upgrade|pending-rollback)
+              echo "Release $HELM_RELEASE_NAME is $status; rolling back to the last deployed revision before upgrading."
+              helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20
+
+              deployed_revision="$(
+                helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 20 |
+                  awk '$0 ~ /[[:space:]]deployed[[:space:]]/ { revision = $1 } END { print revision }'
+              )"
+
+              if [ -z "$deployed_revision" ]; then
+                echo "No deployed revision found for $HELM_RELEASE_NAME in $NAMESPACE."
+                exit 1
+              fi
+
+              helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
+                --namespace "$NAMESPACE" --wait --timeout 10m
+              ;;
+            *)
+              echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."
+              ;;
+          esac
       - name: helm upgrade --install
         # App secrets never pass through --set: the chart runs in
         # `server.managedSecrets: true` mode, which reads DATABASE_URL /

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -43,6 +43,9 @@ on:
       commit_sha:
         description: Commit SHA to deploy (defaults to the event's SHA)
         required: false
+      image_tag:
+        description: Pre-built image tag to deploy instead of building
+        required: false
   workflow_call:
     inputs:
       environment:

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -40,6 +40,15 @@ server:
       cpu: "2000m"
       memory: "2Gi"
 
+  # The migration hook runs before Helm can roll any workload pods, so it must
+  # fit next to the steady-state canary server, processor, Redis, and telemetry
+  # pods. Keep the production-sized limit, but use a lower request so the
+  # short-lived hook doesn't sit Pending until Helm's 60m timeout.
+  migrationJob:
+    resources:
+      requests:
+        memory: "512Mi"
+
   extraEnv:
     # Selects which priv/secrets/<env>.yml.enc file the app decrypts at
     # boot. Image is env-agnostic (built with MIX_ENV=prod); this flag

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -3,8 +3,9 @@
 # traffic flows through cert-manager + Cloudflare DNS-01 TLS and an ingress-nginx
 # LoadBalancer backed by the cloud provider's managed LB.
 #
-# This file is layered under values-managed-staging.yaml / values-managed-production.yaml;
-# those overlays tune replica count, host names, and any environment-specific knobs.
+# This file is layered under values-managed-staging.yaml /
+# values-managed-canary.yaml / values-managed-production.yaml; those overlays
+# tune replica count, host names, and any environment-specific knobs.
 
 global:
   commonLabels:
@@ -90,11 +91,12 @@ server:
     enabled: true
     asHook: true
     backoffLimit: 3
-    # Without a memory request the migration pod is the first thing
-    # kubelet evicts when a node hits the 300Mi pressure threshold,
-    # which is what killed the artifacts-backfill rollout. The limit
-    # bounds a runaway backfill so it self-terminates instead of
-    # taking the node's other pods down with it.
+    # Keep a non-zero memory request so the migration pod isn't the first
+    # thing kubelet evicts under node pressure. Production has room for this
+    # default; staging/canary override the request lower so the pre-upgrade
+    # hook still schedules on their smaller two-worker clusters. The limit
+    # bounds a runaway backfill so it self-terminates instead of taking the
+    # node's other pods down with it.
     resources:
       requests:
         cpu: "250m"

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -71,6 +71,14 @@ server:
       cpu: "1000m"
       memory: "1536Mi"
 
+  # The migration hook is an extra pod that starts before Helm can terminate
+  # any existing workload pod. Use a low request so it schedules on staging's
+  # two-worker cluster, while the common 2Gi limit still caps backfill spikes.
+  migrationJob:
+    resources:
+      requests:
+        memory: "512Mi"
+
 objectStorage:
   external:
     buckets:


### PR DESCRIPTION
## Summary
- lower staging/canary migration hook memory requests to 512Mi while keeping the shared 2Gi limit
- keep production at the 1Gi migration request
- add deploy preflight recovery for interrupted Helm releases stuck in pending-* states
- allow manual server deployments to reuse an existing image tag so recovery deploys can skip rebuilding

## Verification
- helm lint infra/helm/tuist with canary, staging, and production overlays
- helm template confirms canary migration job requests 512Mi and limits 2Gi
- direct canary deploy succeeded: https://github.com/tuist/tuist/actions/runs/25122059592

## Notes
The original canary timeout was caused by the migration hook pod staying Pending with 1Gi requested memory, not by the artifact backfill itself. A canceled unpatched run also left Helm revision 72 in pending-upgrade; the successful canary run recovered that by rolling back to revision 71 before upgrading to revision 74.