### PR TITLE
fix(server): unblock canary migration hook scheduling

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -223,13 +223,11 @@ jobs:
               ;;
           esac
       - name: Clean up stale migration Jobs
-        # The migration Job used to embed `.Release.Revision` in its name
-        # (`server-migrate-77`, `server-migrate-78`, …), so the hook's
-        # `before-hook-creation` delete policy never matched and Jobs piled
-        # up on the cluster across deploys. The chart now uses a stable
-        # name; sweep every revision-suffixed Job from the prior template
-        # before invoking helm so their Pending pods stop fighting the new
-        # hook for scheduler attention.
+        # The chart's pre-upgrade migration hook is named
+        # `tuist-tuist-server-migrate` (stable across revisions). Any
+        # `tuist-tuist-server-migrate-<n>` Jobs in the namespace are
+        # orphans whose Pending pods would otherwise compete with the new
+        # hook for scheduler attention; sweep them before invoking helm.
         run: |
           set -euo pipefail
 

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -222,6 +222,36 @@ jobs:
               echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."
               ;;
           esac
+      - name: Clean up stale migration Jobs
+        # The migration Job used to embed `.Release.Revision` in its name
+        # (`server-migrate-77`, `server-migrate-78`, …), so the hook's
+        # `before-hook-creation` delete policy never matched and Jobs piled
+        # up on the cluster across deploys. The chart now uses a stable
+        # name; sweep every revision-suffixed Job from the prior template
+        # before invoking helm so their Pending pods stop fighting the new
+        # hook for scheduler attention.
+        run: |
+          set -euo pipefail
+
+          stale_jobs="$(
+            kubectl -n "$NAMESPACE" get jobs \
+              -l app.kubernetes.io/component=server-migration \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
+              grep -E '-[0-9]+$' || true
+          )"
+
+          if [ -z "$stale_jobs" ]; then
+            echo "No revision-suffixed migration Jobs to clean up."
+            exit 0
+          fi
+
+          echo "Deleting stale migration Jobs:"
+          echo "$stale_jobs"
+          # `--ignore-not-found` covers a rare race where helm's hook gets
+          # deleted between the list and delete calls. Cascade=foreground
+          # so dependent pods (Pending or otherwise) go with the Job.
+          echo "$stale_jobs" | xargs -r kubectl -n "$NAMESPACE" delete job \
+            --ignore-not-found --cascade=foreground --timeout=2m
       - name: helm upgrade --install
         # App secrets never pass through --set: the chart runs in
         # `server.managedSecrets: true` mode, which reads DATABASE_URL /

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -6,11 +6,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  {{- if .Values.server.migrationJob.asHook }}
-  name: {{ include "tuist.componentName" (dict "root" . "component" "server-migrate") }}-{{ .Release.Revision }}
-  {{- else }}
+  # Stable name across revisions so the `before-hook-creation` delete
+  # policy below actually deletes the previous Job (and its pods) before
+  # the new one is created. The previous template appended the release
+  # revision to the name, so the policy never matched and old Jobs
+  # accumulated on the cluster across deploys, with their Pending pods
+  # competing with the new hook for scheduler attention.
   name: {{ include "tuist.componentName" (dict "root" . "component" "server-migrate") }}
-  {{- end }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: server-migration

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -7,11 +7,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   # Stable name across revisions so the `before-hook-creation` delete
-  # policy below actually deletes the previous Job (and its pods) before
-  # the new one is created. The previous template appended the release
-  # revision to the name, so the policy never matched and old Jobs
-  # accumulated on the cluster across deploys, with their Pending pods
-  # competing with the new hook for scheduler attention.
+  # policy below matches and deletes the prior Job (and its Pending pods)
+  # before the new hook schedules.
   name: {{ include "tuist.componentName" (dict "root" . "component" "server-migrate") }}
   labels:
     {{- include "tuist.labels" . | nindent 4 }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -40,14 +40,21 @@ server:
       cpu: "2000m"
       memory: "2Gi"
 
-  # The migration hook runs before Helm can roll any workload pods, so it must
-  # fit next to the steady-state canary server, processor, Redis, and telemetry
-  # pods. Keep the production-sized limit, but use a lower request so the
-  # short-lived hook doesn't sit Pending until Helm's 60m timeout.
+  # The migration hook runs before Helm can roll any workload pods, so it
+  # must fit next to the steady-state canary server, processor, Redis, and
+  # telemetry pods. `Tuist.Release.migrate` only loads the app config and
+  # runs Ecto migrations (no Phoenix endpoint, no Oban, pool size 1), so
+  # peak working set is around 150-250Mi. Match the canary server's request
+  # so the hook fits whenever the server fits, and keep the common 2Gi
+  # limit to absorb a long-running data backfill spike. 512Mi was still
+  # too high for the 2-worker canary cluster after k8s-monitoring,
+  # ingress-nginx, and ESO claimed the rest of the headroom: pods sat
+  # Pending until Helm's 60m timeout.
   migrationJob:
     resources:
       requests:
-        memory: "512Mi"
+        cpu: "100m"
+        memory: "200Mi"
 
   extraEnv:
     # Selects which priv/secrets/<env>.yml.enc file the app decrypts at

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -42,14 +42,11 @@ server:
 
   # The migration hook runs before Helm can roll any workload pods, so it
   # must fit next to the steady-state canary server, processor, Redis, and
-  # telemetry pods. `Tuist.Release.migrate` only loads the app config and
-  # runs Ecto migrations (no Phoenix endpoint, no Oban, pool size 1), so
-  # peak working set is around 150-250Mi. Match the canary server's request
-  # so the hook fits whenever the server fits, and keep the common 2Gi
-  # limit to absorb a long-running data backfill spike. 512Mi was still
-  # too high for the 2-worker canary cluster after k8s-monitoring,
-  # ingress-nginx, and ESO claimed the rest of the headroom: pods sat
-  # Pending until Helm's 60m timeout.
+  # telemetry pods on the 2-worker cluster. `Tuist.Release.migrate` only
+  # loads the app config and runs Ecto migrations (no Phoenix endpoint, no
+  # Oban, pool size 1), so peak working set is around 150-250Mi. Match the
+  # canary server's request so the hook fits whenever the server fits;
+  # keep the common 2Gi limit to absorb a long-running data backfill spike.
   migrationJob:
     resources:
       requests:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -71,13 +71,17 @@ server:
       cpu: "1000m"
       memory: "1536Mi"
 
-  # The migration hook is an extra pod that starts before Helm can terminate
-  # any existing workload pod. Use a low request so it schedules on staging's
-  # two-worker cluster, while the common 2Gi limit still caps backfill spikes.
+  # The migration hook is an extra pod that starts before Helm can
+  # terminate any existing workload pod. `Tuist.Release.migrate` only loads
+  # the app config and runs Ecto migrations (no Phoenix endpoint, no Oban,
+  # pool size 1), so peak working set is around 150-250Mi. Match the
+  # staging server's shape so the hook fits whenever the server fits; the
+  # common 2Gi limit still caps backfill spikes.
   migrationJob:
     resources:
       requests:
-        memory: "512Mi"
+        cpu: "100m"
+        memory: "200Mi"
 
 objectStorage:
   external:


### PR DESCRIPTION
## Summary
- Lower the canary/staging pre-upgrade migration Job memory request from 512Mi to 200Mi. The 512Mi from [tuist#10550](https://github.com/tuist/tuist/pull/10550) was still too high for the 2-worker canary cluster after k8s-monitoring, ingress-nginx, and ESO claimed the headroom, so the hook pod sat Pending for 60m until Helm's atomic timeout fired (latest failure: [run 25122377486](https://github.com/tuist/tuist/actions/runs/25122377486/job/73628474793)). `Tuist.Release.migrate` only loads the app config and runs Ecto migrations (no Phoenix endpoint, no Oban, pool size 1), so peak working set is ~150-250Mi; matching the canary server's request keeps the hook scheduleable wherever the server is.
- Drop `.Release.Revision` from the migration Job name in the chart. With a revision-suffixed name the `before-hook-creation` delete policy never matched, so failed Jobs and their Pending pods accumulated on every deploy (the failing run had `migrate-70`, `-72`, `-75`, `-77` all stuck). The chart now uses a stable name so each new hook deletes its predecessor before scheduling.
- Add a workflow step that sweeps the orphaned revision-suffixed migration Jobs left behind by the prior template, so the canary cluster recovers cleanly on the first deploy after this lands.

## Test plan
- [x] `helm template` renders the chart for staging, canary, and production with the new request and stable Job name.
- [x] `helm lint` clean.
- [ ] Canary deploy completes within the 60m atomic window (verified by this run).
- [ ] After this lands, only one `tuist-tuist-server-migrate` Job exists in `tuist-canary` post-deploy (no revision-suffixed leftovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)