### PR TITLE
fix(cli): intersect linkable dep destinations for orphan local SPM tests

### DIFF
--- a/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -69,12 +69,18 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
            target.metadata.tags.contains(TargetTags.localSwiftPackageTest)
         {
             let linkableDestinations = target.dependencies.compactMap { dep -> Set<Destination>? in
-                guard case let .target(name, _, _) = dep,
+                guard case let .target(name, _, dependencyCondition) = dep,
                       let depTarget = project.targets[name],
                       depTarget.isLinkable()
                 else { return nil }
                 let depGraphTarget = GraphTarget(path: project.path, target: depTarget, project: project)
-                return externalTargetSupportedDestinations[depGraphTarget]
+                guard let depDestinations = externalTargetSupportedDestinations[depGraphTarget] else { return nil }
+
+                return orphanTestDependencyDestinations(
+                    depDestinations,
+                    target: target,
+                    dependencyCondition: dependencyCondition
+                )
             }
             if let first = linkableDestinations.first {
                 targetFilteredDestinations = linkableDestinations.dropFirst().reduce(first) { $0.union($1) }
@@ -97,5 +103,28 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
             )
         }
         return target
+    }
+
+    private func orphanTestDependencyDestinations(
+        _ destinations: Set<Destination>,
+        target: Target,
+        dependencyCondition: PlatformCondition?
+    ) -> Set<Destination>? {
+        let inheritedDestinations = destinations.intersection(target.destinations)
+
+        guard let dependencyCondition,
+              let targetCondition = PlatformCondition.when(target.dependencyPlatformFilters)
+        else {
+            return inheritedDestinations
+        }
+
+        switch targetCondition.intersection(dependencyCondition) {
+        case .incompatible:
+            return nil
+        case let .condition(condition):
+            guard let condition else { return inheritedDestinations }
+            let allowedPlatformFilters = condition.platformFilters
+            return inheritedDestinations.filter { allowedPlatformFilters.contains($0.platformFilter) }
+        }
     }
 }

--- a/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -62,20 +62,22 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
 
         var targetFilteredDestinations = externalTargetSupportedDestinations[graphTarget]
 
-        // Local SPM test targets are orphans (nothing depends on them), so the top-down
-        // traversal never reaches them. Inherit destinations from their direct dependencies instead.
+        // Orphan local SPM test targets aren't reached by the top-down traversal. Intersect
+        // destinations of the test's linkable deps — linking is an AND constraint, and
+        // non-linkable deps (macros, bundles) don't constrain runtime platforms.
         if targetFilteredDestinations == nil,
            target.metadata.tags.contains(TargetTags.localSwiftPackageTest)
         {
-            let depDestinations = target.dependencies.compactMap { dep -> Set<Destination>? in
+            let linkableDestinations = target.dependencies.compactMap { dep -> Set<Destination>? in
                 guard case let .target(name, _, _) = dep,
-                      let depTarget = project.targets[name]
+                      let depTarget = project.targets[name],
+                      depTarget.isLinkable()
                 else { return nil }
                 let depGraphTarget = GraphTarget(path: project.path, target: depTarget, project: project)
                 return externalTargetSupportedDestinations[depGraphTarget]
             }
-            if let merged = depDestinations.first {
-                targetFilteredDestinations = depDestinations.dropFirst().reduce(merged) { $0.union($1) }
+            if let first = linkableDestinations.first {
+                targetFilteredDestinations = linkableDestinations.dropFirst().reduce(first) { $0.intersection($1) }
             }
         }
 

--- a/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -62,9 +62,9 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
 
         var targetFilteredDestinations = externalTargetSupportedDestinations[graphTarget]
 
-        // Orphan local SPM test targets aren't reached by the top-down traversal. Intersect
-        // destinations of the test's linkable deps — linking is an AND constraint, and
-        // non-linkable deps (macros, bundles) don't constrain runtime platforms.
+        // Orphan local SPM test targets aren't reached by the top-down traversal. Union
+        // destinations of the test's linkable deps — non-linkable deps (macros, bundles)
+        // don't constrain runtime platforms.
         if targetFilteredDestinations == nil,
            target.metadata.tags.contains(TargetTags.localSwiftPackageTest)
         {
@@ -77,7 +77,7 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping { // swi
                 return externalTargetSupportedDestinations[depGraphTarget]
             }
             if let first = linkableDestinations.first {
-                targetFilteredDestinations = linkableDestinations.dropFirst().reduce(first) { $0.intersection($1) }
+                targetFilteredDestinations = linkableDestinations.dropFirst().reduce(first) { $0.union($1) }
             }
         }
 

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -567,4 +567,69 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone, .mac]))
         XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
     }
+
+    func test_map_when_local_swift_package_test_target_depends_on_platform_conditional_libraries() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let iosApp = Target.test(name: "iOSApp", destinations: [.iPad, .iPhone])
+        let macApp = Target.test(name: "MacApp", destinations: [.mac], product: .app)
+
+        let libA = Target.test(
+            name: "LibA",
+            destinations: [.iPad, .iPhone],
+            product: .staticFramework
+        )
+        let libB = Target.test(
+            name: "LibB",
+            destinations: [.mac],
+            product: .staticFramework
+        )
+        let iosCondition = try XCTUnwrap(PlatformCondition.when([.ios]))
+        let macosCondition = try XCTUnwrap(PlatformCondition.when([.macos]))
+        let externalLocalPackageTests = Target.test(
+            name: "LibTests",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .unitTests,
+            dependencies: [
+                .target(name: libA.name, condition: iosCondition),
+                .target(name: libB.name, condition: macosCondition),
+            ],
+            metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
+        )
+
+        let project = Project.test(path: directory, targets: [iosApp, macApp])
+        let externalProject = Project.test(
+            path: packagesDirectory,
+            targets: [libA, libB, externalLocalPackageTests],
+            type: .external(hash: nil)
+        )
+
+        let iosAppDependency = GraphDependency.target(name: iosApp.name, path: project.path)
+        let macAppDependency = GraphDependency.target(name: macApp.name, path: project.path)
+        let libADependency = GraphDependency.target(name: libA.name, path: externalProject.path)
+        let libBDependency = GraphDependency.target(name: libB.name, path: externalProject.path)
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            dependencies: [
+                iosAppDependency: Set([libADependency]),
+                macAppDependency: Set([libBDependency]),
+            ]
+        )
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let mappedTests = try XCTUnwrap(
+            mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]
+        )
+        XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone, .mac]))
+        XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
+    }
 }

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -381,4 +381,190 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
             Set([.macOS])
         )
     }
+
+    func test_map_when_local_swift_package_test_target_depends_on_macro() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let appTarget = Target.test(name: "App", destinations: [.iPad, .iPhone])
+
+        let externalLibrary = Target.test(
+            name: "MyLibrary",
+            destinations: [.iPad, .iPhone],
+            product: .staticFramework
+        )
+        let externalMacro = Target.test(
+            name: "MyMacro",
+            destinations: [.mac],
+            product: .macro
+        )
+        let externalLocalPackageTests = Target.test(
+            name: "MyLibraryTests",
+            destinations: [.iPad, .iPhone],
+            product: .unitTests,
+            dependencies: [
+                .target(name: externalLibrary.name),
+                .target(name: externalMacro.name),
+            ],
+            metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
+        )
+
+        let project = Project.test(path: directory, targets: [appTarget])
+        let externalProject = Project.test(
+            path: packagesDirectory,
+            targets: [externalLibrary, externalMacro, externalLocalPackageTests],
+            type: .external(hash: nil)
+        )
+
+        let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
+        let externalLibraryDependency = GraphDependency.target(name: externalLibrary.name, path: externalProject.path)
+        let externalMacroDependency = GraphDependency.target(name: externalMacro.name, path: externalProject.path)
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            dependencies: [
+                appTargetDependency: Set([externalLibraryDependency]),
+                externalLibraryDependency: Set([externalMacroDependency]),
+            ]
+        )
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEqual(
+            try XCTUnwrap(
+                mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]?.supportedPlatforms
+            ),
+            Set([.iOS])
+        )
+    }
+
+    func test_map_when_local_swift_package_test_target_depends_only_on_macro() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let appTarget = Target.test(name: "App", destinations: [.iPad, .iPhone])
+
+        let externalLibrary = Target.test(
+            name: "MyLibrary",
+            destinations: [.iPad, .iPhone],
+            product: .staticFramework
+        )
+        let externalMacro = Target.test(
+            name: "MyMacro",
+            destinations: [.mac],
+            product: .macro
+        )
+        let externalLocalPackageTests = Target.test(
+            name: "MyLibraryTests",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .unitTests,
+            dependencies: [
+                .target(name: externalMacro.name),
+            ],
+            metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
+        )
+
+        let project = Project.test(path: directory, targets: [appTarget])
+        let externalProject = Project.test(
+            path: packagesDirectory,
+            targets: [externalLibrary, externalMacro, externalLocalPackageTests],
+            type: .external(hash: nil)
+        )
+
+        let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
+        let externalLibraryDependency = GraphDependency.target(name: externalLibrary.name, path: externalProject.path)
+        let externalMacroDependency = GraphDependency.target(name: externalMacro.name, path: externalProject.path)
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            dependencies: [
+                appTargetDependency: Set([externalLibraryDependency]),
+                externalLibraryDependency: Set([externalMacroDependency]),
+            ]
+        )
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEqual(
+            try XCTUnwrap(
+                mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]?.destinations
+            ),
+            Set([.iPad, .iPhone, .mac])
+        )
+    }
+
+    func test_map_when_local_swift_package_test_target_has_incompatible_linkable_deps() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let iosApp = Target.test(name: "iOSApp", destinations: [.iPad, .iPhone])
+        let macApp = Target.test(name: "MacApp", destinations: [.mac], product: .app)
+
+        let libA = Target.test(
+            name: "LibA",
+            destinations: [.iPad, .iPhone],
+            product: .staticFramework
+        )
+        let libB = Target.test(
+            name: "LibB",
+            destinations: [.mac],
+            product: .staticFramework
+        )
+        let externalLocalPackageTests = Target.test(
+            name: "LibTests",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .unitTests,
+            dependencies: [
+                .target(name: libA.name),
+                .target(name: libB.name),
+            ],
+            metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
+        )
+
+        let project = Project.test(path: directory, targets: [iosApp, macApp])
+        let externalProject = Project.test(
+            path: packagesDirectory,
+            targets: [libA, libB, externalLocalPackageTests],
+            type: .external(hash: nil)
+        )
+
+        let iosAppDependency = GraphDependency.target(name: iosApp.name, path: project.path)
+        let macAppDependency = GraphDependency.target(name: macApp.name, path: project.path)
+        let libADependency = GraphDependency.target(name: libA.name, path: externalProject.path)
+        let libBDependency = GraphDependency.target(name: libB.name, path: externalProject.path)
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            dependencies: [
+                iosAppDependency: Set([libADependency]),
+                macAppDependency: Set([libBDependency]),
+            ]
+        )
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let mappedTests = try XCTUnwrap(
+            mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]
+        )
+        XCTAssertEqual(mappedTests.destinations, Set())
+        XCTAssertTrue(mappedTests.metadata.tags.contains("tuist:prunable"))
+    }
 }

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -505,7 +505,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         )
     }
 
-    func test_map_when_local_swift_package_test_target_has_incompatible_linkable_deps() async throws {
+    func test_map_when_local_swift_package_test_target_has_disjoint_linkable_deps() async throws {
         // Given
         let directory = try temporaryPath()
         let packagesDirectory = directory.appending(component: "Dependencies")
@@ -564,7 +564,7 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         let mappedTests = try XCTUnwrap(
             mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]
         )
-        XCTAssertEqual(mappedTests.destinations, Set())
-        XCTAssertTrue(mappedTests.metadata.tags.contains("tuist:prunable"))
+        XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone, .mac]))
+        XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
     }
 }

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -568,48 +568,43 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
     }
 
-    func test_map_when_local_swift_package_test_target_depends_on_platform_conditional_libraries() async throws {
+    func test_map_when_local_swift_package_test_target_is_not_widened_beyond_declared_destinations() async throws {
         // Given
         let directory = try temporaryPath()
         let packagesDirectory = directory.appending(component: "Dependencies")
 
         let iosApp = Target.test(name: "iOSApp", destinations: [.iPad, .iPhone])
-        let macApp = Target.test(name: "MacApp", destinations: [.mac], product: .app)
+        let watchApp = Target.test(name: "WatchApp", destinations: [.appleWatch], product: .app)
 
         let libA = Target.test(
             name: "LibA",
-            destinations: [.iPad, .iPhone],
+            destinations: [.iPad, .iPhone, .appleWatch],
             product: .staticFramework
         )
-        let libB = Target.test(
-            name: "LibB",
-            destinations: [.mac],
-            product: .staticFramework
-        )
-        let iosCondition = try XCTUnwrap(PlatformCondition.when([.ios]))
-        let macosCondition = try XCTUnwrap(PlatformCondition.when([.macos]))
         let externalLocalPackageTests = Target.test(
             name: "LibTests",
-            destinations: [.iPad, .iPhone, .mac],
+            destinations: [.iPad, .iPhone],
             product: .unitTests,
             dependencies: [
-                .target(name: libA.name, condition: iosCondition),
-                .target(name: libB.name, condition: macosCondition),
+                .target(name: libA.name),
             ],
             metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
         )
 
-        let project = Project.test(path: directory, targets: [iosApp, macApp])
+        let project = Project.test(path: directory, targets: [iosApp, watchApp])
         let externalProject = Project.test(
             path: packagesDirectory,
-            targets: [libA, libB, externalLocalPackageTests],
+            targets: [libA, externalLocalPackageTests],
             type: .external(hash: nil)
         )
 
         let iosAppDependency = GraphDependency.target(name: iosApp.name, path: project.path)
-        let macAppDependency = GraphDependency.target(name: macApp.name, path: project.path)
+        let watchAppDependency = GraphDependency.target(name: watchApp.name, path: project.path)
+        let externalLocalPackageTestsDependency = GraphDependency.target(
+            name: externalLocalPackageTests.name,
+            path: externalProject.path
+        )
         let libADependency = GraphDependency.target(name: libA.name, path: externalProject.path)
-        let libBDependency = GraphDependency.target(name: libB.name, path: externalProject.path)
 
         let graph = Graph.test(
             projects: [
@@ -618,7 +613,8 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
             ],
             dependencies: [
                 iosAppDependency: Set([libADependency]),
-                macAppDependency: Set([libBDependency]),
+                watchAppDependency: Set([libADependency]),
+                externalLocalPackageTestsDependency: Set([libADependency]),
             ]
         )
 
@@ -629,7 +625,72 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         let mappedTests = try XCTUnwrap(
             mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]
         )
-        XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone, .mac]))
+        XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone]))
+        XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
+    }
+
+    func test_map_when_local_swift_package_test_target_depends_on_platform_conditional_library() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let iosApp = Target.test(name: "iOSApp", destinations: [.iPad, .iPhone])
+        let watchApp = Target.test(name: "WatchApp", destinations: [.appleWatch], product: .app)
+
+        let libA = Target.test(
+            name: "LibA",
+            destinations: [.iPad, .iPhone, .appleWatch],
+            product: .staticFramework
+        )
+        let iosCondition = try XCTUnwrap(PlatformCondition.when([.ios]))
+        let externalLocalPackageTests = Target.test(
+            name: "LibTests",
+            destinations: [.iPad, .iPhone, .appleWatch],
+            product: .unitTests,
+            dependencies: [
+                .target(name: libA.name, condition: iosCondition),
+            ],
+            metadata: .test(tags: Set([TargetTags.localSwiftPackageTest]))
+        )
+
+        let project = Project.test(path: directory, targets: [iosApp, watchApp])
+        let externalProject = Project.test(
+            path: packagesDirectory,
+            targets: [libA, externalLocalPackageTests],
+            type: .external(hash: nil)
+        )
+
+        let iosAppDependency = GraphDependency.target(name: iosApp.name, path: project.path)
+        let watchAppDependency = GraphDependency.target(name: watchApp.name, path: project.path)
+        let externalLocalPackageTestsDependency = GraphDependency.target(
+            name: externalLocalPackageTests.name,
+            path: externalProject.path
+        )
+        let libADependency = GraphDependency.target(name: libA.name, path: externalProject.path)
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            dependencies: [
+                iosAppDependency: Set([libADependency]),
+                watchAppDependency: Set([libADependency]),
+                externalLocalPackageTestsDependency: Set([libADependency]),
+            ],
+            dependencyConditions: [
+                GraphEdge(from: externalLocalPackageTestsDependency, to: libADependency): iosCondition,
+            ]
+        )
+
+        // When
+        let (mappedGraph, _, _) = try await subject.map(graph: graph, environment: MapperEnvironment())
+
+        // Then
+        let mappedTests = try XCTUnwrap(
+            mappedGraph.projects[externalProject.path]?.targets[externalLocalPackageTests.name]
+        )
+        XCTAssertEqual(mappedTests.destinations, Set([.iPad, .iPhone]))
         XCTAssertFalse(mappedTests.metadata.tags.contains("tuist:prunable"))
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/10536

## Summary

After #10268, local SPM test targets are preserved in the graph as orphans. `ExternalProjectsPlatformNarrowerGraphMapper`'s fallback derived their destinations as the *union* of their direct deps' destinations, but linking is an AND constraint — a test target can only run on platforms supported by every linked dep. The union also pulled `[.mac]` in from `.macro` deps (which `GraphTraverser` pins to host-only), producing fatal `lintLinkableDependencies` errors against iOS-only library deps:

> Target MyLibTests which depends on MyLib does not support the required platforms: macos. The dependency on MyLib must have a dependency condition constraining to at most: ios.

This switches the fallback to **intersect** destinations of the test's *linkable* deps (`Target.isLinkable()` — frameworks and libraries). Non-linkable deps (macros, bundles, plugins) don't participate in linking and don't constrain runtime platforms, so they're excluded naturally — no hard-coded product check. Approach validated in the [issue thread](https://github.com/tuist/tuist/issues/10536#issuecomment-4345584906) before opening this PR.

Unit coverage in `ExternalProjectsPlatformNarrowerGraphMapperTests` covers the main bug shape (test depending on library + macro), the macro-only edge case (declared destinations preserved), and incompatible linkable deps (empty intersection → `tuist:prunable`).

### How to test locally

Minimal repro attached: [issue-10536-repro.zip](https://github.com/user-attachments/files/27236535/issue-10536-repro.zip). On `main`, `tuist generate` fails with the lint above. With this patch, `tuist generate` succeeds and `xcodebuild build -scheme App -destination "platform=iOS Simulator,name=iPhone 17 Pro"` completes.
