### PR TITLE
fix(server): emit Prometheus metrics on processor pods

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -114,7 +114,7 @@ defmodule Tuist.Environment do
     prometheus_enabled = System.get_env("TUIST_PROMETHEUS_ENABLED")
 
     if is_nil(prometheus_enabled) do
-      not dev?() and not test?() and web?()
+      not dev?() and not test?()
     else
       truthy?(prometheus_enabled)
     end


### PR DESCRIPTION
> Make ProcessBuildWorker (and any other Oban workers running on processor pods) visible in Grafana.

`Tuist.Environment.prometheus_enabled?/0` gated PromEx on `web?()`, so processor-mode pods booted with `Tuist.PromEx` disabled. Two consequences:

1. The PromEx `/metrics` HTTP server on `:9091` never bound, so the Alloy scraper had nothing to read despite the `prometheus.io/scrape: \"true\"` annotation on the processor Deployment.
2. The `[:oban, :job, :stop]` telemetry handlers from `Tuist.Oban.PromExPlugin` were never attached, so `tuist_oban_job_queue_time_milliseconds_bucket` (and the matching execution-time / attempts buckets) were never emitted for `Tuist.Builds.Workers.ProcessBuildWorker` — the worker only runs on processor pods after the `:process_build` queue split.

Net effect: the Oban Grafana dashboard showed `CommentWorker`, `AlertEvaluationWorker`, `AutomationScheduler`, `ProcessXcresultWorker`, etc., but `ProcessBuildWorker` was silently absent, and any alerts on its queue time would never fire.

Fix: drop the `web?()` constraint. PromEx is a separate HTTP server, distinct from the Phoenix endpoint, so it should run on every non-dev/non-test pod regardless of `TUIST_MODE`. Both server and processor pods now expose `/metrics` and emit Oban telemetry, matching what the Helm scrape annotations and dashboards already expect.

### How to test locally

Set `TUIST_MODE=processor` and `TUIST_PROMETHEUS_ENABLED=1`, boot the release, and confirm `curl localhost:9091/metrics` returns the Prometheus exposition format. After enqueueing a build, `tuist_oban_job_queue_time_milliseconds_bucket{worker=\"Tuist.Builds.Workers.ProcessBuildWorker\"}` should be present in the output.