### PR TITLE
fix(server): stream artifact backfill to bound migration memory

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -46,7 +46,7 @@ server:
   # loads the app config and runs Ecto migrations (no Phoenix endpoint, no
   # Oban, pool size 1), so peak working set is around 150-250Mi. Match the
   # canary server's request so the hook fits whenever the server fits;
-  # keep the common 2Gi limit to absorb a long-running data backfill spike.
+  # the common 4Gi limit absorbs long-running data-backfill spikes.
   migrationJob:
     resources:
       requests:

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -94,16 +94,18 @@ server:
     # Keep a non-zero memory request so the migration pod isn't the first
     # thing kubelet evicts under node pressure. Production has room for this
     # default; staging/canary override the request lower so the pre-upgrade
-    # hook still schedules on their smaller two-worker clusters. The limit
-    # bounds a runaway backfill so it self-terminates instead of taking the
-    # node's other pods down with it.
+    # hook still schedules on their smaller two-worker clusters. The 4Gi
+    # limit gives the artifact backfill (which streams chunks but still
+    # carries the BEAM, the PG cursor, and the CH client) headroom over
+    # its tens-of-MB working set, while still bounding a runaway so it
+    # self-terminates instead of taking the node's other pods down.
     resources:
       requests:
         cpu: "250m"
         memory: "1Gi"
       limits:
         cpu: "1000m"
-        memory: "2Gi"
+        memory: "4Gi"
 
   # HTTP probes all hit /ready. startupProbe covers the ~30-60s Phoenix boot
   # and the OTel / Sentry init latency we occasionally see in prod.

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -76,7 +76,7 @@ server:
   # the app config and runs Ecto migrations (no Phoenix endpoint, no Oban,
   # pool size 1), so peak working set is around 150-250Mi. Match the
   # staging server's shape so the hook fits whenever the server fits; the
-  # common 2Gi limit still caps backfill spikes.
+  # common 4Gi limit still caps backfill spikes.
   migrationJob:
     resources:
       requests:

--- a/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
+++ b/server/priv/ingest_repo/migrations/20260428120000_backfill_artifacts_from_postgres.exs
@@ -41,14 +41,18 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  # Bundle artifact counts are heavy-tailed: most bundles have a few
-  # hundred artifacts, but enterprise iOS bundles can carry tens of
-  # thousands. A 1000-bundle batch hit a tail combination that spiked
-  # BEAM memory past 8 GB and got the migration pod OOM-evicted in
-  # production, so keep the batch small enough that even a tail
-  # combination stays bounded. The inter-batch throttle below adds
-  # only a small slice of runtime at this size.
+  # Bundle batch sizes the resume cursor (the `artifacts_replicated_to_ch`
+  # flag is flipped per-batch). Artifact streaming below decouples peak
+  # BEAM memory from the batch's total artifact count, so the bundle
+  # batch can stay large enough to keep wall time inside the deploy
+  # hook's 60-minute window without risking OOM on a tail batch.
   @bundle_batch_size 100
+  # Caps the artifact list (and its CH-encoded copy) the migration holds
+  # at any moment. A 1000-bundle batch with a heavy tail spiked BEAM
+  # memory past 8 GB and OOM-evicted the migration pod in production;
+  # streaming through 5K-row chunks keeps peak working set in the tens
+  # of MB regardless of how heavy a bundle batch turns out to be.
+  @artifact_chunk_size 5_000
   # Matches the throttle other long-running CH backfills use
   # (`BackfillTestRunsFromCommandEvents`, `BackfillFirstRunEvents`):
   # gives live PG/CH traffic breathing room and lets CH merges keep up
@@ -96,11 +100,6 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
             "(running total: #{new_bundle_total} bundles / #{new_artifact_total} artifacts)"
         )
 
-        # The artifact list and its CH-encoded copy are the largest
-        # transient allocations in the loop; force a GC so they're
-        # reclaimed before the next batch instead of accumulating
-        # across iterations of this long-lived migration process.
-        :erlang.garbage_collect()
         Process.sleep(@throttle_ms)
         drain(new_bundle_total, new_artifact_total)
     end
@@ -112,18 +111,9 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
         :done
 
       bundle_ids ->
-        artifacts = fetch_artifacts(bundle_ids)
-
-        if artifacts != [] do
-          IngestRepo.insert_all("artifacts", artifacts,
-            types: @ch_types,
-            timeout: :infinity,
-            log: false
-          )
-        end
-
+        artifacts_count = stream_and_insert_artifacts(bundle_ids)
         mark_replicated(bundle_ids)
-        {length(bundle_ids), length(artifacts)}
+        {length(bundle_ids), artifacts_count}
     end
   end
 
@@ -137,23 +127,55 @@ defmodule Tuist.IngestRepo.Migrations.BackfillArtifactsFromPostgres do
     |> Repo.all(timeout: :infinity)
   end
 
-  defp fetch_artifacts(bundle_ids) do
-    from(a in "artifacts",
-      where: a.bundle_id in ^bundle_ids,
-      select: %{
-        id: a.id,
-        bundle_id: a.bundle_id,
-        artifact_type: a.artifact_type,
-        path: a.path,
-        size: a.size,
-        shasum: a.shasum,
-        artifact_id: a.artifact_id,
-        inserted_at: a.inserted_at,
-        updated_at: a.updated_at
-      }
-    )
-    |> Repo.all(timeout: :infinity, log: false)
-    |> Enum.map(&encode_for_ch/1)
+  # Streams the bundle batch's artifacts from Postgres in chunks of
+  # `@artifact_chunk_size`, encoding and inserting each chunk into
+  # ClickHouse before reading the next. Postgres opens a server-side
+  # cursor for the duration of the surrounding transaction, so the
+  # BEAM never holds more than one chunk at once even when the batch
+  # spans bundles with tens of thousands of artifacts each.
+  defp stream_and_insert_artifacts(bundle_ids) do
+    query =
+      from(a in "artifacts",
+        where: a.bundle_id in ^bundle_ids,
+        select: %{
+          id: a.id,
+          bundle_id: a.bundle_id,
+          artifact_type: a.artifact_type,
+          path: a.path,
+          size: a.size,
+          shasum: a.shasum,
+          artifact_id: a.artifact_id,
+          inserted_at: a.inserted_at,
+          updated_at: a.updated_at
+        }
+      )
+
+    {:ok, count} =
+      Repo.transaction(
+        fn ->
+          query
+          |> Repo.stream(max_rows: @artifact_chunk_size)
+          |> Stream.chunk_every(@artifact_chunk_size)
+          |> Enum.reduce(0, fn chunk, acc ->
+            encoded = Enum.map(chunk, &encode_for_ch/1)
+
+            IngestRepo.insert_all("artifacts", encoded,
+              types: @ch_types,
+              timeout: :infinity,
+              log: false
+            )
+
+            # Force a GC between chunks so the encoded list and the raw
+            # row chunk are reclaimed before the cursor pulls the next
+            # page, instead of accumulating across iterations.
+            :erlang.garbage_collect()
+            acc + length(encoded)
+          end)
+        end,
+        timeout: :infinity
+      )
+
+    count
   end
 
   defp mark_replicated(bundle_ids) do


### PR DESCRIPTION
## Summary

The artifact backfill migration (`BackfillArtifactsFromPostgres`) loaded every artifact for the 100-bundle cursor batch into memory at once via `Repo.all`. Production has tail bundle batches whose combined artifact count exceeds the 2Gi pre-upgrade hook memory limit and OOM-evicts the migration pod, blocking the production deploy ([failing run](https://github.com/tuist/tuist/actions/runs/25153146675/job/73736475351)).

- Switch to `Repo.stream` inside a transaction so Postgres pages artifacts in 5K-row chunks; the BEAM only ever holds one chunk and its CH-encoded copy at a time, regardless of how heavy a bundle batch turns out to be.
- Keep the 100-bundle cursor batch (it sizes the resume cursor and the per-batch flag flip) so wall time stays inside the 60-minute deploy hook window.
- Bump the common migration-job memory limit from 2Gi to 4Gi as belt-and-suspenders headroom for the BEAM, the PG cursor, and the CH client; staging/canary keep their lower memory requests so the hook still schedules on their two-worker clusters.

## Verification

- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix format --check-formatted` (migration)
- `mise exec -- helm lint infra/helm/tuist/ -f values-managed-common.yaml -f values-managed-production.yaml`
- `helm template` confirms the production / canary / staging migration jobs all render `limits.memory: 4Gi`, with canary/staging still requesting 200Mi.

## Test plan

- [ ] Canary deploy succeeds (already passing pre-fix; sanity check the streaming change)
- [ ] Production deploy completes the migration to drain the ~225M backfill candidates without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)