### PR TITLE
fix(server): allow test_case_id filter on test-case runs by test_run_id

### DIFF
--- a/server/lib/tuist/tests/test_case_run_by_test_run.ex
+++ b/server/lib/tuist/tests/test_case_run_by_test_run.ex
@@ -13,7 +13,7 @@ defmodule Tuist.Tests.TestCaseRunByTestRun do
 
   @derive {
     Flop.Schema,
-    filterable: [:test_run_id, :name, :status, :is_flaky, :is_new, :duration, :project_id],
+    filterable: [:test_run_id, :name, :status, :is_flaky, :is_new, :duration, :project_id, :test_case_id],
     sortable: [:inserted_at, :duration, :name, :ran_at]
   }
 

--- a/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/test_case_runs_controller_test.exs
@@ -54,6 +54,37 @@ defmodule TuistWeb.API.TestCaseRunsControllerTest do
       assert run["git_branch"] == "main"
     end
 
+    test "lists runs filtered by both test_run_id and test_case_id", %{conn: conn, user: user, project: project} do
+      # Given
+      test_run_id = UUIDv7.generate()
+      test_case_id = UUIDv7.generate()
+
+      matching_run =
+        RunsFixtures.test_case_run_fixture(
+          project_id: project.id,
+          test_run_id: test_run_id,
+          test_case_id: test_case_id
+        )
+
+      RunsFixtures.test_case_run_fixture(
+        project_id: project.id,
+        test_run_id: test_run_id,
+        test_case_id: UUIDv7.generate()
+      )
+
+      # When
+      conn =
+        get(
+          conn,
+          "/api/projects/#{user.account.name}/#{project.name}/tests/test-cases/runs?test_run_id=#{test_run_id}&test_case_id=#{test_case_id}"
+        )
+
+      # Then
+      response = json_response(conn, :ok)
+      assert length(response["test_case_runs"]) == 1
+      assert hd(response["test_case_runs"])["id"] == matching_run.id
+    end
+
     test "passes flaky filter to service", %{conn: conn, user: user, project: project} do
       # Given
       test_case_id = UUIDv7.generate()


### PR DESCRIPTION
### Context

A request like `GET /api/projects/:account/:project/tests/test-cases/runs?test_run_id=...&test_case_id=...` was crashing in production with:

```
Flop.InvalidParamsError: invalid Flop parameters
```

`list_test_case_runs/2` routes any query with a `test_run_id` filter to the `test_case_runs_by_test_run` materialized view. That MV's Flop schema didn't include `:test_case_id` in `filterable`, so Flop rejected the params before reaching ClickHouse — even though the column exists in the MV.

### Changes

- Add `:test_case_id` to `Tuist.Tests.TestCaseRunByTestRun`'s `filterable` list.
- Add a controller regression test that exercises the failing combination (`test_run_id` + `test_case_id` together).

### How to test locally

```bash
cd server
TUIST_HOSTED=1 mix test test/tuist_web/controllers/api/test_case_runs_controller_test.exs
```

The new test in the first describe block hits the test-run MV path with both filters and asserts only the matching run is returned.