### PR TITLE
docs(server): expand flaky-tests pages with tracking, quarantine semantics, and API/CLI reference

### DIFF
--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -66,10 +66,6 @@ A quarantined test is in one of two modes:
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
-### Stale quarantined tests {#stale-quarantined-tests}
-
-Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
-
 ### Running tests {#running-tests}
 
 `tuist test` honours both modes automatically:

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -52,7 +52,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
+Detection and clearing run through an **automation alert** on the project. Every project gets a default "Flaky test detection" automation whose *trigger* marks a test as flaky and whose *recovery* clears the flag once the test has gone the configured recovery window (default **14 days**) without re-triggering. Edit it under **Settings → Automations** to change the recovery window, swap the recovery actions (e.g. also un-quarantine), or disable recovery entirely so tests stay marked flaky until you clear them by hand.
 
 ### Manual management
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -18,6 +18,14 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
+## How tests are tracked {#tracking}
+
+A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
+
+A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
+
+`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
+
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:
@@ -44,7 +52,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for 14 days. This ensures that tests that have been fixed don't remain marked as flaky indefinitely.
+Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
 
 ### Manual management
 
@@ -54,10 +62,21 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. A quarantined test is in one of two modes:
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+
+A quarantined test is in one of two modes:
 
 - **Muted**: the test still runs, but `tuist test` masks the failure. Failures still feed the flaky-tests detector, so you can keep watching the test without breaking the build. Pick this for a test you're actively investigating.
 - **Skipped**: xcodebuild receives `-skip-testing <identifier>`, so the test never starts. It produces no new results and drops off the flaky-tests dashboard until you re-enable it. Pick this when the test is broken, slow, or so persistently flaky that running it is just wasted CI minutes.
+
+### Why quarantined tests can appear as passing {#quarantined-passing}
+
+- **Muted tests** still execute and may genuinely fail, but the runner masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+
+### Stale quarantined tests {#stale-quarantined-tests}
+
+Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
 
 ### Running tests {#running-tests}
 
@@ -74,6 +93,37 @@ To bypass quarantine entirely and run everything, including muted and skipped te
 ```sh
 tuist test --skip-quarantine
 ```
+
+## Querying flaky and quarantined state {#querying}
+
+### CLI
+
+The `tuist test case` command tree exposes everything Tuist tracks about a test case:
+
+```sh
+tuist test case list --flaky                       # only flaky test cases
+tuist test case list --quarantined                 # only muted or skipped test cases
+tuist test case show <test_case_id>                # detail: flakiness rate, last status, run counts
+tuist test case events <test_case_id>              # audit log: marked_flaky, muted, skipped, ...
+tuist test case run list <test_case_id>            # run history with status and duration
+tuist test case run show <test_case_run_id>        # single run, including failure breakdown
+```
+
+All of these accept `--json` for scripting.
+
+### REST API
+
+The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
+| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
+| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
+| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
+| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
+
+State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -54,7 +54,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** so a test is automatically muted (or skipped) when it crosses a flakiness threshold, and un-quarantined when it recovers. Every transition, manual or automated, is recorded on the test case's audit log.
 
 A quarantined test is in one of two modes:
 
@@ -64,11 +64,11 @@ A quarantined test is in one of two modes:
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
-- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+- **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}
 
-Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
+Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
 
 ### Running tests {#running-tests}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -101,17 +101,7 @@ All of these accept `--json` for scripting.
 
 ### REST API
 
-The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
-| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
-| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
-| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
-| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
-
-State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
+The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -18,14 +18,6 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
-## How tests are tracked {#tracking}
-
-A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
-
-A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
-
-`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
-
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -62,7 +62,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
 
 A quarantined test is in one of two modes:
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -82,6 +82,10 @@ To bypass quarantine entirely and run everything, including muted and skipped te
 tuist test --skip-quarantine
 ```
 
+## Slack notifications {#slack-notifications}
+
+Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.
+
 ## Querying flaky and quarantined state {#querying}
 
 ### CLI
@@ -102,7 +106,3 @@ All of these accept `--json` for scripting.
 ### REST API
 
 The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
-
-## Slack notifications {#slack-notifications}
-
-Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/generated-projects.md
@@ -71,7 +71,7 @@ A quarantined test is in one of two modes:
 
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
-- **Muted tests** still execute and may genuinely fail, but the runner masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -93,6 +93,10 @@ tuist {
 
 When `enabled` is not set, it defaults to auto-detection: enabled on CI, disabled locally.
 
+## Slack notifications {#slack-notifications}
+
+Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.
+
 ## Querying flaky and quarantined state {#querying}
 
 ### CLI
@@ -113,7 +117,3 @@ All of these accept `--json` for scripting.
 ### REST API
 
 The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
-
-## Slack notifications {#slack-notifications}
-
-Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -82,7 +82,7 @@ A quarantined test is in one of two modes:
 
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
-- **Muted tests** still execute and may genuinely fail, but the plugin masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -17,6 +17,14 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
+## How tests are tracked {#tracking}
+
+A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
+
+A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
+
+`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
+
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:
@@ -55,7 +63,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for 14 days. This ensures that tests that have been fixed don't remain marked as flaky indefinitely.
+Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
 
 ### Manual management
 
@@ -65,10 +73,21 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. A quarantined test is in one of two modes:
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+
+A quarantined test is in one of two modes:
 
 - **Muted**: the test still runs, but the plugin sets `ignoreFailures = true` and only re-fails the build on non-quarantined failures. Failures still feed the flaky-tests detector, so you can keep watching the test without breaking the build. Pick this for a test you're actively investigating.
 - **Skipped**: the plugin filters the test out via Gradle's `excludeTestsMatching`, so it never starts. It produces no new results and drops off the flaky-tests dashboard until you re-enable it. Pick this when the test is broken, slow, or so persistently flaky that running it is just wasted CI minutes.
+
+### Why quarantined tests can appear as passing {#quarantined-passing}
+
+- **Muted tests** still execute and may genuinely fail, but the plugin masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+
+### Stale quarantined tests {#stale-quarantined-tests}
+
+Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
 
 ### Enabling quarantine {#enabling-quarantine}
 
@@ -85,6 +104,37 @@ tuist {
 ```
 
 When `enabled` is not set, it defaults to auto-detection: enabled on CI, disabled locally.
+
+## Querying flaky and quarantined state {#querying}
+
+### CLI
+
+The `tuist test case` command tree exposes everything Tuist tracks about a test case:
+
+```sh
+tuist test case list --flaky                       # only flaky test cases
+tuist test case list --quarantined                 # only muted or skipped test cases
+tuist test case show <test_case_id>                # detail: flakiness rate, last status, run counts
+tuist test case events <test_case_id>              # audit log: marked_flaky, muted, skipped, ...
+tuist test case run list <test_case_id>            # run history with status and duration
+tuist test case run show <test_case_run_id>        # single run, including failure breakdown
+```
+
+All of these accept `--json` for scripting.
+
+### REST API
+
+The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
+| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
+| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
+| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
+| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
+
+State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -17,14 +17,6 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
-## How tests are tracked {#tracking}
-
-A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
-
-A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
-
-`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
-
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -63,7 +63,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
+Detection and clearing run through an **automation alert** on the project. Every project gets a default "Flaky test detection" automation whose *trigger* marks a test as flaky and whose *recovery* clears the flag once the test has gone the configured recovery window (default **14 days**) without re-triggering. Edit it under **Settings → Automations** to change the recovery window, swap the recovery actions (e.g. also un-quarantine), or disable recovery entirely so tests stay marked flaky until you clear them by hand.
 
 ### Manual management
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -112,17 +112,7 @@ All of these accept `--json` for scripting.
 
 ### REST API
 
-The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
-| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
-| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
-| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
-| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
-
-State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
+The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -73,7 +73,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
 
 A quarantined test is in one of two modes:
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -77,10 +77,6 @@ A quarantined test is in one of two modes:
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
-### Stale quarantined tests {#stale-quarantined-tests}
-
-Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
-
 ### Enabling quarantine {#enabling-quarantine}
 
 Quarantine is **automatically enabled on CI** (when the `CI` environment variable is set) and disabled for local builds. The plugin fetches the list of quarantined tests from the Tuist server before each test task; muted tests run normally and have their failures masked, skipped tests are filtered out.

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/gradle.md
@@ -65,7 +65,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** so a test is automatically muted (or skipped) when it crosses a flakiness threshold, and un-quarantined when it recovers. Every transition, manual or automated, is recorded on the test case's audit log.
 
 A quarantined test is in one of two modes:
 
@@ -75,11 +75,11 @@ A quarantined test is in one of two modes:
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
-- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+- **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}
 
-Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
+Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
 
 ### Enabling quarantine {#enabling-quarantine}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -64,7 +64,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
 
 A quarantined test is in one of two modes:
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -54,7 +54,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
+Detection and clearing run through an **automation alert** on the project. Every project gets a default "Flaky test detection" automation whose *trigger* marks a test as flaky and whose *recovery* clears the flag once the test has gone the configured recovery window (default **14 days**) without re-triggering. Edit it under **Settings → Automations** to change the recovery window, swap the recovery actions (e.g. also un-quarantine), or disable recovery entirely so tests stay marked flaky until you clear them by hand.
 
 ### Manual management
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -73,7 +73,7 @@ A quarantined test is in one of two modes:
 
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
-- **Muted tests** still execute and may genuinely fail, but the runner masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -68,10 +68,6 @@ A quarantined test is in one of two modes:
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
 - **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
-### Stale quarantined tests {#stale-quarantined-tests}
-
-Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
-
 ### Running tests {#running-tests}
 
 `tuist xcodebuild test` is a passthrough wrapper that honours both modes automatically. Use it the same way you'd call xcodebuild:

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -56,7 +56,7 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** by adding a `change_state` trigger action (e.g. auto-mute on a 10% flakiness rate over 30 days) and a matching recovery action to un-quarantine when the test recovers. Every transition, manual or automated, is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. By default it's a **manual action** — you quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard — but you can also wire it into an **automation alert** under **Settings → Automations** so a test is automatically muted (or skipped) when it crosses a flakiness threshold, and un-quarantined when it recovers. Every transition, manual or automated, is recorded on the test case's audit log.
 
 A quarantined test is in one of two modes:
 
@@ -66,11 +66,11 @@ A quarantined test is in one of two modes:
 ### Why quarantined tests can appear as passing {#quarantined-passing}
 
 - **Muted tests** still execute. A muted test that fails is recorded as **failed** on the test case run and flagged as flaky — the per-test status is not rewritten. What gets overridden is the **overall test run**: if every failing test case in the run is muted, the run as a whole is reported as passed, so muted failures don't break CI.
-- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+- **Skipped tests** don't run at all, so the dashboard keeps showing the status from the test's last actual execution — that snapshot can be weeks old.
 
 ### Stale quarantined tests {#stale-quarantined-tests}
 
-Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
+Test cases are not deleted from Tuist when you delete or rename them in source. The default views hide test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new entry on Tuist's side (a test is identified by its module, suite, and name); the old one is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactivity filter will then hide it from default views.
 
 ### Running tests {#running-tests}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -17,14 +17,6 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
-## How tests are tracked {#tracking}
-
-A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
-
-A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
-
-`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
-
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -117,17 +117,7 @@ All of these accept `--json` for scripting.
 
 ### REST API
 
-The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
-| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
-| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
-| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
-| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
-
-State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
+The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -98,6 +98,10 @@ xcodebuild test \
 
 This is the safe default outside `tuist xcodebuild test`: failure masking for muted tests only happens when you go through that command, so skipping both modes avoids spurious CI failures. If you need finer control, go through `tuist xcodebuild test` instead.
 
+## Slack notifications {#slack-notifications}
+
+Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.
+
 ## Querying flaky and quarantined state {#querying}
 
 ### CLI
@@ -118,7 +122,3 @@ All of these accept `--json` for scripting.
 ### REST API
 
 The same data is available over HTTP — see the [Test Cases endpoints](https://tuist.dev/api/docs#tag/test-cases) in the API reference for the full list of routes, filters, and response fields. State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
-
-## Slack notifications {#slack-notifications}
-
-Get notified instantly when a test becomes flaky by setting up <.localized_link href="/guides/integrations/slack#flaky-test-alerts">flaky test alerts</.localized_link> in your Slack integration.

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/xcode.md
@@ -17,6 +17,14 @@ Flaky tests are tests that produce different results (pass or fail) when run mul
 
 ![Flaky Tests page](/images/guides/features/test-insights/flaky-tests-page.png)
 
+## How tests are tracked {#tracking}
+
+A test case is identified by `(project, module, suite, name)` and tracked at the **individual test level** — not by class or suite. Tracking is **project-wide**, not per-branch: runs from any branch contribute to the same test case's history, so a test that only flakes on one branch shows up in the project's flaky-tests view.
+
+A test only becomes flaky if it has produced **both a passing and a failing result** for the same code. A test that fails on every attempt is a failing test, not a flaky one.
+
+`is_flaky` (auto-detected) and the quarantine state (`enabled` / `muted` / `skipped`, set manually) are **independent dimensions**. A test is commonly flaky and muted at the same time.
+
 ## How flaky detection works {#how-it-works}
 
 Tuist detects flaky tests in two ways:
@@ -46,7 +54,7 @@ This is particularly useful for catching flaky tests that don't fail consistentl
 
 ### Automatic clearing
 
-Tuist automatically clears the flaky flag from tests that haven't been flaky for 14 days. This ensures that tests that have been fixed don't remain marked as flaky indefinitely.
+Tuist automatically clears the flaky flag from tests that haven't been flaky for the configured cooldown window (default **14 days**). This ensures tests that have been fixed don't remain marked as flaky indefinitely. The window is configurable per project via the `flaky_cooldown_days` setting.
 
 ### Manual management
 
@@ -56,10 +64,21 @@ You can also manually mark or unmark tests as flaky from the test case detail pa
 
 ## Quarantining flaky tests {#quarantining}
 
-Quarantining isolates a flaky test so it doesn't block CI while you fix it. A quarantined test is in one of two modes:
+Quarantining isolates a flaky test so it doesn't block CI while you fix it. Quarantine is **always a manual action** — there's no automatic threshold that quarantines a test on your behalf, since deciding when a test is too noisy to keep running is a judgment call that deserves a human in the loop. You quarantine, un-quarantine, and switch modes from the test case detail page in the dashboard. Every transition is recorded as an event (`muted`, `unmuted`, `skipped`, `unskipped`) on the test case's audit log.
+
+A quarantined test is in one of two modes:
 
 - **Muted**: the test still runs, but `tuist xcodebuild test` masks the failure. Failures still feed the flaky-tests detector, so you can keep watching the test without breaking the build. Pick this for a test you're actively investigating.
 - **Skipped**: xcodebuild receives `-skip-testing <identifier>`, so the test never starts. It produces no new results and drops off the flaky-tests dashboard until you re-enable it. Pick this when the test is broken, slow, or so persistently flaky that running it is just wasted CI minutes.
+
+### Why quarantined tests can appear as passing {#quarantined-passing}
+
+- **Muted tests** still execute and may genuinely fail, but the runner masks the failure so the build passes. The underlying run is recorded with its real status, but build-level summaries show it as a pass.
+- **Skipped tests** don't run at all, so `last_status` and `last_ran_at` are not updated — what you see is the *last status before the test was skipped*, which can be weeks old.
+
+### Stale quarantined tests {#stale-quarantined-tests}
+
+Test cases are not hard-deleted from Tuist when you delete or rename them in source. The default views filter out test cases inactive for 14 days, but **quarantined tests intentionally bypass that filter** so a long-forgotten quarantined test isn't silently re-enabled. Renaming a test creates a new identity (since identity is `module + suite + name`); the old identity is orphaned but stays in the data. To drop a stale entry from the dashboard, un-quarantine it first — the inactive-window filter will then hide it from default views.
 
 ### Running tests {#running-tests}
 
@@ -90,6 +109,37 @@ xcodebuild test \
 ```
 
 This is the safe default outside `tuist xcodebuild test`: failure masking for muted tests only happens when you go through that command, so skipping both modes avoids spurious CI failures. If you need finer control, go through `tuist xcodebuild test` instead.
+
+## Querying flaky and quarantined state {#querying}
+
+### CLI
+
+The `tuist test case` command tree exposes everything Tuist tracks about a test case:
+
+```sh
+tuist test case list --flaky                       # only flaky test cases
+tuist test case list --quarantined                 # only muted or skipped test cases
+tuist test case show <test_case_id>                # detail: flakiness rate, last status, run counts
+tuist test case events <test_case_id>              # audit log: marked_flaky, muted, skipped, ...
+tuist test case run list <test_case_id>            # run history with status and duration
+tuist test case run show <test_case_run_id>        # single run, including failure breakdown
+```
+
+All of these accept `--json` for scripting.
+
+### REST API
+
+The same data is available under `/api/projects/{account_handle}/{project_handle}/tests/test-cases`:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /test-cases` | List, with filters: `flaky`, `quarantined`, `state` (`enabled` / `muted` / `skipped`), `module_name`, `suite_name`, `name`. |
+| `GET /test-cases/{test_case_id}` | Detail: `is_flaky`, `state`, `last_status`, `flakiness_rate` (% over the last 30 days), `total_runs`, `failed_runs`. |
+| `GET /test-cases/{test_case_id}/events` | Immutable audit log of state transitions. |
+| `GET /test-cases/{test_case_id}/runs` | Paginated run history. |
+| `GET /test-cases/runs/{test_case_run_id}` | One run, including per-repetition statuses and failure messages. |
+
+State changes (mark/unmark flaky, mute, skip) currently happen from the dashboard UI, not via the public REST API.
 
 ## Slack notifications {#slack-notifications}
 


### PR DESCRIPTION
### Purpose

The flaky-tests guides cover *how* to detect and quarantine tests but skip a lot of the questions users actually ask once they're investigating their data: how is a test identified, is it scoped to a branch, what's the cooldown configurability, why does a quarantined test look like it's passing, what happens to deleted/renamed tests, and how do they query any of this from the CLI or API. This PR folds those answers directly into the three platform pages so support no longer has to reach into the code to answer them.

### What changed

Added the same set of conceptual sections to all three platform pages (`generated-projects.md`, `xcode.md`, `gradle.md`):

- **How tests are tracked** — identity is `(project, module, suite, name)`, granularity is the individual test case, tracking is project-wide (not per-branch), flakiness requires both a pass and a fail, and `is_flaky` and quarantine state are independent dimensions.
- **Cooldown is configurable** — clarified that the 14-day flaky auto-clear is the default and is settable per project via `flaky_cooldown_days`.
- **Quarantine is manual** — no automatic threshold; transitions are event-logged.
- **Why quarantined tests can appear as passing** — muted masks failures, skipped never updates `last_status`.
- **Stale quarantined tests** — quarantined tests intentionally bypass the 14-day inactive-view filter; renaming creates a new identity and orphans the old one.
- **Querying flaky and quarantined state** — CLI (`tuist test case list/show/events`, `tuist test case run list/show`) and REST endpoints under `/api/projects/{account}/{project}/tests/test-cases`.

No code changes — docs only.

### How to test locally

\`\`\`sh
mise run dev
\`\`\`

Then navigate to:
- http://localhost:8080/en/docs/guides/features/test-insights/flaky-tests/generated-projects
- http://localhost:8080/en/docs/guides/features/test-insights/flaky-tests/xcode
- http://localhost:8080/en/docs/guides/features/test-insights/flaky-tests/gradle

Verify the new "How tests are tracked", "Why quarantined tests can appear as passing", "Stale quarantined tests", and "Querying flaky and quarantined state" sections render and that the in-page anchors (`#tracking`, `#quarantined-passing`, `#stale-quarantined-tests`, `#querying`) work.