### PR TITLE
fix(server): populate inserted_at when buffering build issues and files

### DIFF
--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -112,6 +112,8 @@ defmodule Tuist.Builds do
   end
 
   defp create_build_files(build, files) do
+    now = :second |> DateTime.utc_now() |> DateTime.to_naive()
+
     files =
       Enum.map(files, fn file_attrs ->
         %{
@@ -127,7 +129,8 @@ defmodule Tuist.Builds do
           path: file_attrs.path,
           target: file_attrs.target,
           project: file_attrs.project,
-          compilation_duration: file_attrs.compilation_duration
+          compilation_duration: file_attrs.compilation_duration,
+          inserted_at: now
         }
       end)
 
@@ -142,6 +145,8 @@ defmodule Tuist.Builds do
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp create_build_issues(build, issues) do
+    now = :second |> DateTime.utc_now() |> DateTime.to_naive()
+
     issues =
       Enum.map(issues, fn issue_attrs ->
         %{
@@ -157,7 +162,8 @@ defmodule Tuist.Builds do
           starting_line: issue_attrs.starting_line,
           ending_line: issue_attrs.ending_line,
           starting_column: issue_attrs.starting_column,
-          ending_column: issue_attrs.ending_column
+          ending_column: issue_attrs.ending_column,
+          inserted_at: now
         }
       end)
 


### PR DESCRIPTION
## Summary
- `create_build_issues/2` and `create_build_files/2` build the maps fed to `BuildIssue.Buffer.insert_all/1` / `BuildFile.Buffer.insert_all/1` (introduced in [#10556](https://github.com/tuist/tuist/pull/10556)). Both schemas declare `timestamps(updated_at: false)`, and the buffer's `write_through_row/2` (active in test mode via `config :tuist, Tuist.Ingestion.Bufferable, write_through_repo: true`) iterates over every schema field with `Map.fetch!/2`, so the missing `:inserted_at` key crashed `RunsController.create` with a `KeyError`.
- The other helpers in the same module (`build_targets`, `cacheable_tasks`, `cas_outputs`, `machine_metrics`) already populate `inserted_at` either directly or via their changeset; this aligns the two stragglers with that pattern.
- Fixes the failing build on main: https://github.com/tuist/tuist/actions/runs/25159004561/job/73748175462 (`test/tuist_web/controllers/api/runs_controller_test.exs:242`).

## Test plan
- [ ] CI server test job goes green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)