### PR TITLE
fix(cli): restore previous macOS runner for CLI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,7 +633,7 @@ jobs:
     name: Release CLI
     needs: check-releases
     if: needs.check-releases.outputs.cli-should-release == 'true'
-    runs-on: namespace-profile-macos-xcode-26
+    runs-on: namespace-profile-default-macos
     timeout-minutes: 50
     env:
       GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- move the `Release CLI` job back to `namespace-profile-default-macos`
- keep the rest of the Xcode 26.4.1 workflow changes untouched
- preserve the existing `.xcode-version-releases` pin used by the CLI release job

## Why
The `Release CLI` job still selects Xcode from `.xcode-version-releases`, which is currently pinned to `26.0` for release compatibility. After the workflow moved that job to `namespace-profile-macos-xcode-26`, the runner no longer exposed `/Applications/Xcode_26.0.app`, so the job failed in `Select Xcode` before any build steps ran.

Switching this single job back to the previous macOS runner restores the image that was already compatible with the CLI release pin and keeps the fix narrowly scoped.

## Validation
- parsed `.github/workflows/release.yml` with Ruby `YAML.load_file`
- inspected the failing Actions job log for `Release CLI`
- confirmed the diff only changes the `runs-on` value for the `Release CLI` job