### PR TITLE
fix(cli): fix macro copy phase output collision on macOS consumer targets

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -511,11 +511,6 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
     ) throws {
         if directSwiftMacroExecutables.isEmpty { return }
 
-        // macOS-exclusive consumers: script body is a no-op (src == dest once
-        // `$EFFECTIVE_PLATFORM_NAME` is empty) and the declared output would
-        // collide with the macro target's `Ld` step on the same path.
-        if target.isExclusiveTo(.macOS) { return }
-
         let copySwiftMacrosBuildPhase = PBXShellScriptBuildPhase(name: "Copy Swift Macro executable into $BUILT_PRODUCT_DIR")
 
         let executableNames = directSwiftMacroExecutables.compactMap {
@@ -552,10 +547,11 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         }
 
         if target.supports(.macOS) {
-            // Reached only for mixed-destination consumers (macOS-exclusive returned
-            // above). The phase is still needed to populate `Debug-<platform>/<exe>`
-            // for non-macOS slices, but declared outputs would collide on this
-            // target's own macOS slice — so omit them.
+            // Any consumer that supports macOS still needs the phase because the
+            // compiler/editor load plugin executables from `Debug...`, even when
+            // the active configuration is not Debug. Declared outputs would collide
+            // on native macOS builds where `$EFFECTIVE_PLATFORM_NAME` is empty, so
+            // omit them and always run the phase instead.
             copySwiftMacrosBuildPhase.alwaysOutOfDate = true
         } else {
             copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in

--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -91,6 +91,7 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
         try generateCopySwiftMacroExecutableScriptBuildPhase(
             directSwiftMacroExecutables: directSwiftMacroExecutables,
+            target: target,
             pbxTarget: pbxTarget,
             pbxproj: pbxproj
         )
@@ -504,10 +505,16 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
 
     private func generateCopySwiftMacroExecutableScriptBuildPhase(
         directSwiftMacroExecutables: [GraphDependencyReference],
+        target: Target,
         pbxTarget: PBXTarget,
         pbxproj: PBXProj
     ) throws {
         if directSwiftMacroExecutables.isEmpty { return }
+
+        // macOS-exclusive consumers: script body is a no-op (src == dest once
+        // `$EFFECTIVE_PLATFORM_NAME` is empty) and the declared output would
+        // collide with the macro target's `Ld` step on the same path.
+        if target.isExclusiveTo(.macOS) { return }
 
         let copySwiftMacrosBuildPhase = PBXShellScriptBuildPhase(name: "Copy Swift Macro executable into $BUILT_PRODUCT_DIR")
 
@@ -544,11 +551,19 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             ]
         }
 
-        copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
-            [
-                "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",
-                "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)",
-            ]
+        if target.supports(.macOS) {
+            // Reached only for mixed-destination consumers (macOS-exclusive returned
+            // above). The phase is still needed to populate `Debug-<platform>/<exe>`
+            // for non-macOS slices, but declared outputs would collide on this
+            // target's own macOS slice — so omit them.
+            copySwiftMacrosBuildPhase.alwaysOutOfDate = true
+        } else {
+            copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
+                [
+                    "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",
+                    "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)",
+                ]
+            }
         }
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2218,7 +2218,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_doesNotGenerateShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
+    ) func generateLinks_generatesAlwaysOutOfDateShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
         // Given
         let app = Target.test(name: "app", platform: .macOS, product: .app)
         let macroFramework = Target.test(name: "framework", platform: .macOS, product: .staticFramework)
@@ -2254,7 +2254,8 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase == nil)
+        #expect(buildPhase?.outputPaths == [])
+        #expect(buildPhase?.alwaysOutOfDate == true)
     }
 
     @Test(

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2211,6 +2211,94 @@ struct BuildPhaseGeneratorTests {
                     "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)",
                 ]
         )
+        #expect(buildPhase?.alwaysOutOfDate == false)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateLinks_doesNotGenerateShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
+        // Given
+        let app = Target.test(name: "app", platform: .macOS, product: .app)
+        let macroFramework = Target.test(name: "framework", platform: .macOS, product: .staticFramework)
+        let macroExecutable = Target.test(name: "macro", platform: .macOS, product: .macro)
+        let project = Project.test(targets: [app, macroFramework, macroExecutable])
+        let fileElements = createProductFileElements(for: [app, macroFramework, macroExecutable])
+        let pbxproj = PBXProj()
+        let pbxTarget = PBXNativeTarget(name: app.name)
+
+        let graph = Graph.test(path: project.path, projects: [project.path: project], dependencies: [
+            .target(name: app.name, path: project.path): Set([.target(name: macroFramework.name, path: project.path)]),
+            .target(name: macroFramework.name, path: project.path): Set([.target(
+                name: macroExecutable.name,
+                path: project.path
+            )]),
+            .target(name: macroExecutable.name, path: project.path): Set([]),
+        ])
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try await subject.generateBuildPhases(
+            path: "/Project",
+            target: macroFramework,
+            graphTraverser: graphTraverser,
+            pbxTarget: pbxTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = pbxTarget
+            .buildPhases
+            .compactMap { $0 as? PBXShellScriptBuildPhase }
+            .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
+
+        #expect(buildPhase == nil)
+    }
+
+    @Test(
+        .withMockedSwiftVersionProvider,
+        .withMockedXcodeController,
+        .inTemporaryDirectory
+    ) func generateLinks_generatesAlwaysOutOfDateShellScriptBuildPhase_when_macroFrameworkIsMixedDestination() async throws {
+        // Given
+        let app = Target.test(name: "app", destinations: [.iPhone, .mac], product: .app)
+        let macroFramework = Target.test(name: "framework", destinations: [.iPhone, .mac], product: .staticFramework)
+        let macroExecutable = Target.test(name: "macro", platform: .macOS, product: .macro)
+        let project = Project.test(targets: [app, macroFramework, macroExecutable])
+        let fileElements = createProductFileElements(for: [app, macroFramework, macroExecutable])
+        let pbxproj = PBXProj()
+        let pbxTarget = PBXNativeTarget(name: app.name)
+
+        let graph = Graph.test(path: project.path, projects: [project.path: project], dependencies: [
+            .target(name: app.name, path: project.path): Set([.target(name: macroFramework.name, path: project.path)]),
+            .target(name: macroFramework.name, path: project.path): Set([.target(
+                name: macroExecutable.name,
+                path: project.path
+            )]),
+            .target(name: macroExecutable.name, path: project.path): Set([]),
+        ])
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try await subject.generateBuildPhases(
+            path: "/Project",
+            target: macroFramework,
+            graphTraverser: graphTraverser,
+            pbxTarget: pbxTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let buildPhase = pbxTarget
+            .buildPhases
+            .compactMap { $0 as? PBXShellScriptBuildPhase }
+            .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
+
+        #expect(buildPhase?.outputPaths == [])
+        #expect(buildPhase?.alwaysOutOfDate == true)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
On a macOS native build of a target that consumes a Swift macro, Xcode emits warnings such as:

```
unexpected mutating task ('PhaseScriptExecution Copy\ Swift\ Macro\ executable\ into\ \$BUILT_PRODUCT_DIR …/Database.build/Script-….sh') with no relation to prior mutator ('Ld …/Build/Products/Debug/DatabaseMacros normal')

unexpected mutating task ('CodeSign …/Build/Products/Debug/DatabaseMacros') with no relation to prior mutator ('PhaseScriptExecution Copy\ Swift\ Macro\ executable\ into\ \$BUILT_PRODUCT_DIR …')
```

**Root cause:** the `Copy Swift Macro executable into $BUILT_PRODUCT_DIR` script declared `outputPaths` that collapse to `$BUILD_DIR/Debug/<exe>` on macOS native builds (empty `$EFFECTIVE_PLATFORM_NAME`) — the same path the macro target's `Ld` step writes. Xcode sees two unrelated mutators (script in consumer target, link in macro target) on one path with no declared dep edge and flags it. The script's `if src != dest` guard (added in #9995) keeps the on-disk artifact correct, but the declared output is misleading.

This PR splits phase generation by consumer destination:

- **macOS-exclusive consumer** → skip the phase entirely. The script body is a no-op (`src == dest` once the platform suffix collapses) and the macro target's `Ld` step has already placed the file at the expected path.
- **Mixed-destination consumer that supports macOS** (e.g. `destinations: [.iPhone, .mac]`) → still generate the phase, since it's needed to copy the host-built macro into `Debug-<platform>/<exe>` for non-macOS slices. Set `alwaysOutOfDate = true` instead of declaring `outputPaths` so the macOS slice of the same target doesn't trip the collision. Same pattern used elsewhere for always-run scripts whose outputs aren't consumed by the build graph (e.g. Crashlytics dSYM upload).
- **Non-macOS consumer** → unchanged. `$EFFECTIVE_PLATFORM_NAME` is non-empty so the collision doesn't occur.

### How to test locally

1. Generate any project where a target consumes a Swift macro on macOS (e.g. a target that uses `@Observable` via a macro package, or a SwiftSyntax-based macro target).
2. Build the consuming target for macOS in Xcode.
3. Before this change: build log shows `unexpected mutating task … with no relation to prior mutator …` warnings around the `Copy Swift Macro executable …` script and the macro target's `Ld` / `CodeSign` steps.
4. After this change: those warnings are gone, and the macro is still copied into `$BUILT_PRODUCT_DIR` for non-macOS slices.

`cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift` covers all three branches: existing iOS-only test asserts `outputPaths` are declared and `alwaysOutOfDate == false`; a new test asserts no phase is generated for macOS-exclusive consumers; another asserts `alwaysOutOfDate == true` with empty `outputPaths` for `[.iPhone, .mac]` consumers.