### PR TITLE
fix(server): swap processor pool from cpx51 to cpx62 (unavailable in fsn1)

### DIFF
--- a/infra/k8s/syself/workload-cluster-production.yaml
+++ b/infra/k8s/syself/workload-cluster-production.yaml
@@ -64,7 +64,7 @@ spec:
           variables:
             overrides:
               - name: workerMachineTypeHcloud
-                value: cpx51
+                value: cpx62
     variables:
       - name: region
         value: fsn1


### PR DESCRIPTION
### Why

[de9029e3](https://github.com/tuist/tuist/commit/de9029e32ed637df03549fa892fbe06beb33c1c6) introduced a dedicated `md-processor` MachineDeployment running 2 × `cpx51` for xcactivitylog parsing, but `cpx51` is no longer offered in `fsn1-dc14`. Provisioning failed with:

```
ServerCreateFailedIrrecoverableError: failed to create HCloud server in "fsn1"
  (type "cpx51"): unsupported location for server type
```

That blocked every production helm rollout from landing (the new `nodeSelector: pool=processor` had no satisfying nodes), which in turn caused the artifact-backfill migration job to be killed mid-flight by every subsequent deploy attempt and turned today's release into a multi-hour cascade.

### What

Swap `cpx51` → `cpx62` on `md-processor`. Same 16 shared vCPU / 32 GiB tier on Hetzner's newer x86 generation, available in `fsn1`, and €50/mo per node vs €71/mo for `cpx51` — the processor pool now lands ~€10/mo under the original cost estimate in [de9029e3](https://github.com/tuist/tuist/commit/de9029e32ed637df03549fa892fbe06beb33c1c6).

### Already applied

The mgmt-cluster apply ran by hand to unblock production today:

```
KUBECONFIG=~/.kube/tuist-syself-mgmt.yaml \
  kubectl apply -f infra/k8s/syself/workload-cluster-production.yaml
```

This PR brings the repo back in sync with the live cluster spec.

### How to test locally

Diff-only change, no local test path. Verified live: `md-processor` MachineDeployment provisions cleanly with `cpx62`, both new nodes register with `node.cluster.x-k8s.io/pool=processor`, and the previously-Pending processor pods scheduled immediately.