### PR TITLE
fix(server): hard-spread processor pods one per node in managed production

### DIFF
--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -41,15 +41,18 @@ spec:
       serviceAccountName: {{ include "tuist.componentServiceAccountName" (dict "root" . "component" "server") }}
       terminationGracePeriodSeconds: {{ .Values.processor.terminationGracePeriodSeconds }}
       {{- include "tuist.podScheduling" . | nindent 6 }}
-      # Soft anti-affinity: the scheduler prefers one replica per node so a
-      # worker VM loss still leaves a healthy pod. Falls back to co-locating
-      # during a rolling deploy (maxSurge=1, maxUnavailable=0) when only two
-      # worker nodes exist.
+      # Spread one replica per node. Default whenUnsatisfiable=ScheduleAnyway
+      # keeps the constraint advisory so a 1-node cluster (preview / self-host
+      # on a small footprint) still schedules; managed envs override to
+      # DoNotSchedule for hard separation. nodeTaintsPolicy=Honor excludes a
+      # draining node from the topology so a single-node failure under
+      # DoNotSchedule doesn't deadlock the replacement pod.
       {{- if .Values.processor.topologySpread.enabled }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: {{ .Values.processor.topologySpread.whenUnsatisfiable | default "ScheduleAnyway" }}
+          nodeTaintsPolicy: Honor
           labelSelector:
             matchLabels:
               {{- include "tuist.componentLabels" (dict "root" . "component" "processor") | nindent 14 }}

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -137,26 +137,19 @@ processor:
   nodeSelector:
     node.cluster.x-k8s.io/pool: processor
 
-  # Pod anti-affinity so the two replicas never land on the same worker.
-  # Without this two processor pods can co-locate on one cpx51 node and the
-  # combined 24Gi limits exceed the 32Gi node, OOMing the BEAM under load.
-  # Soft (preferred) so a single-node failure still schedules; the scheduler
-  # falls back to co-locating only when the alternative is Pending pods.
-  # The chart's default topologySpreadConstraints would express the same
-  # intent, but stacking both mechanisms can fight in edge cases, so we
-  # disable the spread in the managed env and rely on this block alone
-  # (matches the server deployment pattern above).
+  # Hard one-replica-per-node spread. Soft preferred-anti-affinity wasn't
+  # enough — when the new ReplicaSet was rolling out and only one cpx62
+  # node was Ready yet, both pods landed on it and stayed stacked even
+  # after the second node came up; combined ~10 cores of work on one
+  # 16-vCPU node halved effective parsing throughput while the other
+  # node sat idle. DoNotSchedule + nodeTaintsPolicy=Honor (set in the
+  # template) makes the separation enforced without deadlocking under
+  # node drain — a tainted node is excluded from the topology so the
+  # replacement pod can still land on the surviving worker.
   topologySpread:
-    enabled: false
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: processor
-            topologyKey: kubernetes.io/hostname
+    enabled: true
+    whenUnsatisfiable: DoNotSchedule
+  affinity: {}
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -219,9 +219,12 @@ processor:
       maxSurge: 1
       maxUnavailable: 0
   topologySpread:
-    # Prefer one replica per Kubernetes node; ScheduleAnyway keeps the surge
-    # pod from being stuck pending during a deploy on a 2-node cluster.
+    # Spread one replica per Kubernetes node. Default whenUnsatisfiable is
+    # ScheduleAnyway so a 1-node cluster (preview / small self-host) still
+    # schedules; override to DoNotSchedule on multi-node clusters where
+    # co-location would degrade throughput (managed production does this).
     enabled: true
+    whenUnsatisfiable: ScheduleAnyway
   affinity: {}
   # Optional nodeSelector to pin processor pods to a dedicated node pool.
   # The managed cluster sets `node.cluster.x-k8s.io/pool: processor` on


### PR DESCRIPTION
### Why

After the cpx62 pool came up in [#10567](https://github.com/tuist/tuist/pull/10567), both processor pods ended up stacked on the same `md-processor` node:

```
tuist-md-processor-wkvjd-kklbp-2gjvc   CPU 100m  (0%)   mem 852Mi  (3%)   ← idle
tuist-md-processor-wkvjd-kklbp-xrg62   CPU 9874m (62%)  mem 14568Mi (51%) ← both pods here
```

Each pod was pulling ~5 cores out of one node's 16, so effective parsing capacity was roughly half what we provisioned. That surfaced as builds taking >2min to be processed even on the freshly provisioned dedicated pool.

The chart's pod anti-affinity in `values-managed-production.yaml` was `preferredDuringSchedulingIgnoredDuringExecution` — soft. When the rolling deploy first kicked off, only one cpx62 node was Ready, so both pods schedulered onto it; once the second node came up, nothing rebalanced. The comment said "anti-affinity so the two replicas never land on the same worker" but the actual rule didn't enforce it.

### What

- **Production**: switch `processor.topologySpread` to `enabled: true` with `whenUnsatisfiable: DoNotSchedule`. Drop the now-redundant `affinity.podAntiAffinity` block.
- **Template**: add `nodeTaintsPolicy: Honor` to the spread constraint so a tainted (draining / unschedulable) node is excluded from the topology calculation — otherwise `DoNotSchedule` would deadlock the replacement pod under single-node failure.
- **Chart default**: stays `whenUnsatisfiable: ScheduleAnyway` so 1-node preview and small self-host clusters keep scheduling.

### How to test locally

Diff-only chart change. Render confirms the constraint:

```sh
helm template tuist infra/helm/tuist \
  -f infra/helm/tuist/values-managed-common.yaml \
  -f infra/helm/tuist/values-managed-production.yaml \
  --set server.image.tag=test \
  --show-only templates/processor-deployment.yaml
```

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    nodeTaintsPolicy: Honor
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: tuist
        app.kubernetes.io/instance: tuist
        app.kubernetes.io/component: processor
```

Default render (no overrides, `processor.enabled=true`) still shows `whenUnsatisfiable: ScheduleAnyway`, so the change is backward-compatible for self-hosters.

### Follow-up worth considering

The `server` deployment in production has the same soft-anti-affinity pattern (`preferredDuringSchedulingIgnoredDuringExecution`), so it could stack the same way. It's running on dedicated-vCPU `ccx23` so contention is less acute, but the same hardening would apply — left out of this PR to keep the change focused.