### PR TITLE
fix(server): linearize xcactivitylog determineCategory loop

### DIFF
--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -125,19 +125,27 @@ public struct XCActivityLogParser: Sendable {
 
         let targetIdentifiers = buildTargetIdentifiers(from: steps)
         var targetsCompiledCount = [String: Int]()
+        var targetFilesCount = [String: Int]()
         for target in targetSteps {
             targetsCompiledCount[target.identifier] = 0
+            targetFilesCount[target.identifier] = 0
         }
 
-        for step in buildSteps where !step.fetchedFromCache {
+        // Tally both totals and not-fetched-from-cache counts per target in a
+        // single pass. Filtering buildSteps once per target is O(targets * buildSteps),
+        // which dominates parse time on logs with ~1k targets and ~100k build steps.
+        for step in buildSteps {
             guard let targetID = targetIdentifiers[step.identifier] else { continue }
-            targetsCompiledCount[targetID, default: 0] += 1
+            targetFilesCount[targetID, default: 0] += 1
+            if !step.fetchedFromCache {
+                targetsCompiledCount[targetID, default: 0] += 1
+            }
         }
 
         var cleanCount = 0
         for (target, filesCompiledCount) in targetsCompiledCount {
-            let targetFilesCount = buildSteps.filter { targetIdentifiers[$0.identifier] == target }.count
-            if filesCompiledCount == targetFilesCount && filesCompiledCount > 0 {
+            let total = targetFilesCount[target] ?? 0
+            if filesCompiledCount == total && filesCompiledCount > 0 {
                 cleanCount += 1
             }
         }


### PR DESCRIPTION
### Why

The xcactivitylog parser's `determineCategory` step had a per-target filter over all build steps, making it `O(targets × buildSteps)`. On large archives (~1k targets / ~100k build steps) that's ~80M closure invocations just for category detection — easily 100+ seconds on production CPU, which pushes builds past the 5-minute Oban worker timeout from #10525 and clogs the `:process_build` queue.

### What

Tally per-target totals in a single linear pass over `buildSteps`, then look up O(1) inside the per-target loop. Same result, linear instead of quadratic.

### Local measurements (release build, M-series)

A 25 MB compressed / 358 MB uncompressed archive (964 targets, 142k steps):

| Phase | Before | After |
|---|---|---|
| `parseActivityLogInURL` (third-party SLF decoder) | 39s | 39s |
| `ParserBuildSteps.parse` | 6s | 6s |
| **`determineCategory`** | **119s** | **1.6s** |
| `extractFiles` / `analyze*` / rest | ~5s | ~5s |
| **Total parse** | **167s** | **51s** |

`determineCategory` is ~74× faster, total parse ~3.3× faster. The remaining 39s is the third-party `XCLogParser` SLF decoder and is linear in file size.

A small archive (26 targets, 7k steps) is unchanged in behavior and stays at ~3s.

### How to test locally

```bash
cd server/native/xcactivitylog_nif
swift test --replace-scm-with-registry -c release
```

All 12 existing parser tests pass, including `cleanBuild_parsesSuccessfully`, `incrementalBuild_detectsIncrementalCategory`, `xcode26CASCleanBuild_detectsCleanCategory`, and `xcode26CASIncrementalBuild_detectsIncrementalCategory`, which exercise the modified code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)