### PR TITLE
ci(server): re-add Swift Tests job for xcactivitylog NIF

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -42,6 +42,23 @@ defaults:
     working-directory: server
 
 jobs:
+  swift-test:
+    name: Swift Tests (XCActivityLogParser)
+    runs-on: namespace-profile-macos-xcode-26
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    defaults:
+      run:
+        working-directory: server/native/xcactivitylog_nif
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore SwiftPM Cache
+        uses: actions/cache@v4
+        with:
+          path: server/native/xcactivitylog_nif/.build
+          key: xcactivitylog-nif-swiftpm-${{ hashFiles('server/native/xcactivitylog_nif/Package.resolved') }}
+      - name: Run tests
+        run: swift test --replace-scm-with-registry
   gettext:
     name: Gettext
     runs-on: namespace-profile-default-with-volume


### PR DESCRIPTION
## Summary

When the standalone `processor` app was collapsed into the server release as an Oban consumer ([43597c5958](https://github.com/tuist/tuist/commit/43597c5958)), the old `.github/workflows/processor.yml` was deleted. That workflow contained a `Swift Tests (XCActivityLogParser)` job that ran the NIF's 12 Swift tests on every change. The NIF code itself moved to `server/native/xcactivitylog_nif/`, but no equivalent job was added to `server.yml`, so the Swift NIF code has had **no CI coverage** since the move.

This PR restores that job under `server.yml`:

- Scoped to `server/native/xcactivitylog_nif` via per-job `defaults.working-directory` (the file's top-level default is `server`).
- Caches `.build` keyed by `Package.resolved`, matching the old setup.
- Runs `swift test --replace-scm-with-registry`.
- Uses `namespace-profile-macos-xcode-26`, the same runner the existing `xcresult_nif` build job uses in `xcode-processor.yml`.

The existing `paths` filter on `server.yml` (`server/**`) already covers the NIF directory, so no path-trigger changes are needed.

Locally, all 12 tests pass in ~0.5s (after a one-shot ~47s SwiftPM build), exercising the same code paths covered by [#10569](https://github.com/tuist/tuist/pull/10569) and other recent NIF changes.

## Test plan

- [ ] CI: the new `Swift Tests (XCActivityLogParser)` job appears on this PR and passes.
- [ ] Cache key restores correctly on a follow-up push (no full rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)