### PR TITLE
feat(server): autoscale processor pool on Oban queue depth

### DIFF
--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -25,3 +25,11 @@ dependencies:
     version: 0.10.4
     repository: https://charts.external-secrets.io
     condition: external-secrets.enabled
+  - name: keda
+    version: 2.16.0
+    repository: https://kedacore.github.io/charts
+    condition: keda.enabled
+  - name: cluster-autoscaler
+    version: 9.43.2
+    repository: https://kubernetes.github.io/autoscaler
+    condition: cluster-autoscaler.enabled

--- a/infra/helm/platform/README.md
+++ b/infra/helm/platform/README.md
@@ -10,6 +10,8 @@ Platform-level Helm umbrella chart installed **once per Kubernetes cluster** tha
 | `ingress-nginx` | Ingress controller backed by a cloud LoadBalancer |
 | `external-dns` | Sync Ingress / Service hostnames into Cloudflare DNS |
 | `external-secrets` | Pull secrets from external stores (1Password, SOPS, etc.) into the cluster |
+| `keda` | Event-driven pod autoscaler (used by the processor Deployment to scale on Oban queue depth) |
+| `cluster-autoscaler` | Cluster API node-group autoscaler (off by default — see "Cluster autoscaler" below) |
 | `ClusterIssuer` | Shared Let's Encrypt issuer wired to Cloudflare DNS-01 |
 
 ## Bootstrap
@@ -44,8 +46,19 @@ helm template platform infra/helm/platform | kubectl apply --dry-run=client -f -
 helm lint infra/helm/platform
 ```
 
+## Cluster autoscaler
+
+`cluster-autoscaler` is wired in via the `clusterapi` provider so it can grow / shrink the workload cluster's `MachineDeployments` based on Pending Pods. It pairs with the processor Deployment's KEDA `ScaledObject` (in `infra/helm/tuist/`): KEDA scales replicas on Oban queue depth, the new replicas go Pending under `DoNotSchedule` topology spread, and CA reacts by adding nodes to the `md-processor` pool up to its annotation-declared max-size.
+
+It's **disabled by default** because it has bootstrap prereqs that aren't reproducible from this chart alone. To enable it for an environment, follow the runbook in [`infra/k8s/syself-onboarding.md`](../../k8s/syself-onboarding.md) under "Cluster autoscaler bootstrap" — TL;DR:
+
+1. Apply [`infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml`](../../k8s/syself/processor-autoscaler-mgmt-rbac.yaml) on the Syself **management** cluster (requires Syself OIDC permission to create SA / Role / RoleBinding in `org-tuist`).
+2. Extract the SA's token, package it as a kubeconfig, and create the `cluster-autoscaler-mgmt-kubeconfig` Secret in the workload cluster's `platform` namespace.
+3. Re-run `helm upgrade platform ... --set cluster-autoscaler.enabled=true`.
+
 ## Notes
 
 - The ingress-nginx LoadBalancer is annotated for Hetzner Cloud (Nuremberg region) by default. Adjust `ingress-nginx.controller.service.annotations` when the cluster lands on a different provider.
 - external-dns is scoped by `txtOwnerId: tuist-platform` — one cluster, one TXT prefix. Run it with `policy: sync` only if you're happy with it deleting DNS records that aren't tracked by any Ingress.
 - cert-manager CRDs are installed by the subchart (`installCRDs: true`). If another tool manages them, turn that off.
+- KEDA and `cluster-autoscaler` are declared as chart dependencies but are independent: KEDA is on by default; cluster-autoscaler is off and requires the management-cluster bootstrap above before flipping on.

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -84,6 +84,78 @@ external-secrets:
   webhook:
     port: 9443
 
+# KEDA drives event-based pod autoscaling (currently consumed by the
+# processor Deployment in the tuist chart, which scales on Oban
+# queue depth via the Postgres scaler). Self-hosters who don't need
+# event-based scaling can leave this on; the operator is idle until a
+# ScaledObject points at a workload.
+keda:
+  enabled: true
+
+# cluster-autoscaler-clusterapi grows / shrinks the workload cluster's
+# MachineDeployments based on Pending Pods. Pairs with KEDA: KEDA scales
+# replicas on queue depth, the new replicas go Pending under DoNotSchedule
+# (one processor pod per node), CA notices the unschedulable Pod and adds a
+# node from the md-processor pool up to the annotation-declared max-size.
+#
+# Disabled by default because it has hard prereqs that aren't reproducible
+# without operator action:
+#
+#   1. The MachineDeployment(s) to be scaled must be annotated with
+#      `cluster.x-k8s.io/cluster-api-autoscaler-node-group-{min,max}-size`.
+#      For production these live on `md-processor` in
+#      infra/k8s/syself/workload-cluster-production.yaml.
+#
+#   2. CA in two-cluster mode (workload pod, management API) requires a
+#      ServiceAccount on the SYSELF MANAGEMENT cluster with permission to
+#      get/list/watch + patch MachineDeployments and the Cluster topology.
+#      Manifest: infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml.
+#      Syself's default OIDC users CANNOT create ServiceAccounts in
+#      org-tuist — request the perms via support, then apply the manifest.
+#      See infra/k8s/syself-onboarding.md "Cluster autoscaler bootstrap".
+#
+#   3. The SA token from (2) must be packaged as a kubeconfig and stored
+#      as a Secret in the workload cluster's `platform` namespace. CA
+#      reads it via `--cloud-config` to talk to the management API.
+#
+# Once those land, flip `enabled: true` per environment (overlay) and run
+# `helm upgrade platform`.
+cluster-autoscaler:
+  enabled: false
+  cloudProvider: clusterapi
+  # Two-cluster mode: CA's management-cluster client uses a kubeconfig
+  # mounted from a Secret; its workload-cluster client uses the in-cluster
+  # SA. The Secret is created out-of-band (see syself-onboarding.md) so the
+  # token never lands in values / helm history.
+  clusterAPIMode: kubeconfig-incluster
+  clusterAPIWorkloadKubeconfigPath: /etc/kubernetes/value
+  clusterAPIConfigMapsNamespace: platform
+  extraArgs:
+    # Identifies which MachineDeployments belong to the Tuist workload
+    # cluster so CA only manages those (the management cluster may host
+    # other clusters' CRs).
+    node-group-auto-discovery: clusterapi:clusterName=tuist
+    # CAPI-recommended scale-down timing. Default is 10m for unneeded;
+    # the processor parses can run up to ~20m, so we wait longer to avoid
+    # racing a long-running parse off its node.
+    scale-down-unneeded-time: 30m
+    scale-down-delay-after-add: 10m
+    scale-down-utilization-threshold: "0.4"
+    # Cluster-autoscaler refuses to evict pods that have local storage
+    # unless this is set. The processor's emptyDir for /tmp counts.
+    skip-nodes-with-local-storage: "false"
+  # Mount the management-cluster kubeconfig from a Secret created by hand
+  # (see syself-onboarding.md). The chart maps this through
+  # /etc/kubernetes/value when `clusterAPIMode: kubeconfig-incluster`.
+  extraVolumes:
+    - name: mgmt-kubeconfig
+      secret:
+        secretName: cluster-autoscaler-mgmt-kubeconfig
+  extraVolumeMounts:
+    - name: mgmt-kubeconfig
+      mountPath: /etc/kubernetes
+      readOnly: true
+
 # Whether to emit the ClusterIssuer template below. Turn off if you manage
 # cert-manager issuers with a separate GitOps process.
 clusterIssuer:

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- include "tuist.labels" . | nindent 4 }}
     app.kubernetes.io/component: processor
 spec:
+  {{- if not .Values.processor.autoscaling.enabled }}
   replicas: {{ .Values.processor.replicaCount }}
+  {{- end }}
   strategy:
     {{- toYaml .Values.processor.strategy | nindent 4 }}
   selector:

--- a/infra/helm/tuist/templates/processor-scaledobject.yaml
+++ b/infra/helm/tuist/templates/processor-scaledobject.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.processor.enabled .Values.processor.autoscaling.enabled }}
+{{- $secretName := include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
+{{- $processorSecretName := ternary (include "tuist.componentName" (dict "root" . "component" "processor-external-secrets")) $secretName .Values.processor.managedSecrets }}
+# KEDA reads DATABASE_URL out of the same Secret the processor pods use.
+# When `processor.managedSecrets` is true the URL is composed by the
+# processor-external-secrets ExternalSecret; otherwise it lives in the
+# chart-managed app-secrets Secret. Either way the key is the same.
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "processor-keda-auth") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: processor
+spec:
+  secretTargetRef:
+    - parameter: connection
+      name: {{ $processorSecretName }}
+      key: processor-database-url
+---
+# Drives the processor Deployment's replica count from Oban queue depth.
+# Postgres is already the coordination plane for the workers, so KEDA just
+# follows the same source of truth — no extra metric pipeline, no Prometheus
+# adapter. Replicas are bounded by [minReplicaCount, maxReplicaCount];
+# under DoNotSchedule topology spread on managed clusters, scaling above
+# the available node count parks excess pods Pending until cluster-autoscaler
+# adds a node.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "processor") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: processor
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tuist.componentName" (dict "root" . "component" "processor") }}
+  pollingInterval: {{ .Values.processor.autoscaling.pollingInterval }}
+  cooldownPeriod: {{ .Values.processor.autoscaling.cooldownPeriod }}
+  minReplicaCount: {{ .Values.processor.autoscaling.minReplicaCount }}
+  maxReplicaCount: {{ .Values.processor.autoscaling.maxReplicaCount }}
+  triggers:
+    - type: postgresql
+      metadata:
+        # `available` = unclaimed jobs ready now; `scheduled` = jobs whose
+        # scheduled_at has passed but haven't been picked up yet. `executing`
+        # is excluded on purpose — it would prevent scale-down (every replica
+        # at full concurrency keeps that count high even when no backlog
+        # remains).
+        query: >-
+          SELECT count(*) FROM oban_jobs
+          WHERE queue = 'process_build'
+          AND state IN ('available', 'scheduled')
+        targetQueryValue: "{{ .Values.processor.autoscaling.targetQueryValue }}"
+      authenticationRef:
+        name: {{ include "tuist.componentName" (dict "root" . "component" "processor-keda-auth") }}
+{{- end }}

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -151,7 +151,14 @@ server:
 processor:
   enabled: true
   replicaCount: 2
-  queueConcurrency: 5
+  # Per-pod parse parallelism. cpx62 worker has 16 vCPU / 32 GiB; the pod
+  # limits below carve out 12 vCPU / 24 GiB and one pod sits per node under
+  # DoNotSchedule. At concurrency 5 we measured ~5 cores / ~9 GiB resident
+  # under load, leaving more than half the node's capacity unused. 8 is the
+  # next conservative step: ~8 cores / ~14 GiB peak (well under the 24 GiB
+  # limit and the BEAM's 12 dirty-CPU schedulers). Raise further only after
+  # confirming memory stays under ~70% of the limit at peak.
+  queueConcurrency: 8
   managedSecrets: true
   externalSecrets:
     refreshInterval: "1h"

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -106,17 +106,18 @@ processor:
       value: prod
     - name: TUIST_OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://k8s-monitoring-alloy-receiver.observability.svc.cluster.local:4317
-  # Sized for the dedicated cpx51 processor pool (16 vCPU / 32 GiB shared
-  # vCPU per node). With anti-affinity pinning one replica per node, each
+  # Sized for the dedicated cpx62 processor pool (16 vCPU / 32 GiB shared
+  # vCPU per node). With DoNotSchedule pinning one replica per node, each
   # pod owns the whole node minus kube-system overhead; we leave ~4 GiB
   # and ~4 vCPU as headroom. The Swift parser holds ~3-4x the .xcactivitylog
   # file size in memory while building the BuildStep tree and JSON-encoding
-  # the result; at queueConcurrency=5 most realistic builds fit comfortably
-  # in 24 GiB. If we ever start seeing OOMKills again the next move is
-  # either to lower queueConcurrency, bump pod memory, or reintroduce a
-  # per-archive size cap in Tuist.Processor.BuildProcessor.
+  # the result; at queueConcurrency=8 (set in values-managed-common.yaml)
+  # peak usage is ~14 GiB, comfortably under 24 GiB. If we ever start seeing
+  # OOMKills again the next move is either to lower queueConcurrency, bump
+  # pod memory, or reintroduce a per-archive size cap in
+  # Tuist.Processor.BuildProcessor.
   # CPU limit at 12 cores lets the BEAM run ~12 dirty-CPU schedulers,
-  # so all 5 NIF parses run on dedicated dirty schedulers without
+  # so all 8 NIF parses run on dedicated dirty schedulers without
   # serializing on scheduler availability the way they did at 4 cores.
   resources:
     requests:
@@ -126,11 +127,11 @@ processor:
       cpu: "12000m"
       memory: "24Gi"
 
-  # Pin processor pods to the dedicated cpx51 pool provisioned by
+  # Pin processor pods to the dedicated cpx62 pool provisioned by
   # md-processor in workload-cluster-production.yaml. The label is set on
   # the MachineDeployment metadata; CAPI propagates it to each node's
   # registration. Without this the pods could land on the cheaper ccx23
-  # general pool that doesn't have the memory headroom 5 concurrent parses
+  # general pool that doesn't have the memory headroom 8 concurrent parses
   # need. Syself's ClusterClass v6 doesn't expose a taint variable, so we
   # rely on nodeSelector alone — server pods stay on the general pool via
   # their own anti-affinity, not via taint isolation.
@@ -150,6 +151,20 @@ processor:
     enabled: true
     whenUnsatisfiable: DoNotSchedule
   affinity: {}
+
+  # KEDA scales replicas on Oban queue depth (process_build queue,
+  # state IN ('available','scheduled')). minReplicaCount = the steady-state
+  # node count so quiet periods keep two warm pods; maxReplicaCount is
+  # bounded by the md-processor MachineDeployment's max-replica setting in
+  # workload-cluster-production.yaml — overshooting it just parks pods
+  # Pending under DoNotSchedule until cluster-autoscaler grows the pool.
+  # targetQueryValue ≈ queueConcurrency: backlog of 16 → 2 replicas,
+  # 32 → 4, 64 → 6 (capped).
+  autoscaling:
+    enabled: true
+    minReplicaCount: 2
+    maxReplicaCount: 6
+    targetQueryValue: 8
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -246,6 +246,31 @@ processor:
   # before SIGKILL. Oban.Plugins.Lifeline reclaims anything that was still
   # running at the deadline.
   terminationGracePeriodSeconds: 1260
+  # KEDA-driven horizontal autoscaling on Oban queue depth. When enabled,
+  # the chart emits a ScaledObject + TriggerAuthentication that point at the
+  # processor's Postgres (same DATABASE_URL the workers use). KEDA queries
+  # `oban_jobs` for available + scheduled jobs on the :process_build queue
+  # and scales the Deployment between min/max replicas, dividing the queue
+  # depth by `targetQueryValue` to pick a replica count.
+  #
+  # Requires the KEDA operator to be installed cluster-wide (e.g., via the
+  # platform chart) so the keda.sh CRDs exist. Self-host: leave disabled
+  # unless you have KEDA installed; fall back to `replicaCount` for static
+  # sizing.
+  autoscaling:
+    enabled: false
+    minReplicaCount: 2
+    maxReplicaCount: 6
+    # HPA target: divide queue depth by this to pick a replica count.
+    # Roughly = queueConcurrency. With queueConcurrency=8, 16 queued jobs
+    # → 2 replicas; 32 queued → 4; 64 queued → ceiling at maxReplicaCount.
+    targetQueryValue: 8
+    # How often KEDA runs the Postgres query (seconds).
+    pollingInterval: 30
+    # How long the ScaledObject keeps replicas after the query drops to
+    # zero (seconds). 5 min keeps capacity warm across small lulls and
+    # avoids scale-down churn between bursts.
+    cooldownPeriod: 300
   # Build archives are unzipped into the pod's /tmp. Scale to match the
   # largest archive plus headroom for CAS metadata. 16 GiB gives ~3 GiB per
   # slot at queueConcurrency = 5, which is enough for any realistic build

--- a/infra/k8s/syself-onboarding.md
+++ b/infra/k8s/syself-onboarding.md
@@ -475,6 +475,73 @@ gh workflow run preview-deploy.yml \
 
 The workflow scales the worker pool up if needed (~3–5 min cold start), labels/taints the new node, runs `helm upgrade --install`, and posts the URL back to the PR. The hourly `preview-sweep.yml` workflow handles deletion + scale-down.
 
+## 9.8 Cluster autoscaler bootstrap (production processor pool)
+
+Wires `cluster-autoscaler-clusterapi` (deployed by the platform chart) to the production workload cluster's `md-processor` MachineDeployment, so the processor node pool grows / shrinks with KEDA-driven replica changes. **Production only** — staging / canary keep a fixed two-node pool.
+
+Same caveat as 9.6: this requires `create serviceaccounts,roles,rolebindings` in `org-tuist` on the management cluster. Syself's default OIDC users don't have those — open a support ticket first.
+
+```bash
+# 1. Apply RBAC on the MANAGEMENT cluster.
+sed 's/__ORG_NS__/org-tuist/g' \
+  infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml \
+  | kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml apply -f -
+
+# 2. Extract the SA token (the Secret was created alongside the SA).
+export MGMT_TOKEN=$(kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml \
+  -n org-tuist get secret processor-autoscaler-token \
+  -o jsonpath='{.data.token}' | base64 -d)
+export MGMT_SERVER=$(kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml \
+  config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')
+export MGMT_CA=$(kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml \
+  config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
+# 3. Build a kubeconfig pointing at the management API as the
+#    processor-autoscaler SA, and ship it as a Secret on the WORKLOAD cluster.
+cat <<EOF > /tmp/ca-mgmt-kubeconfig.yaml
+apiVersion: v1
+kind: Config
+clusters:
+  - name: mgmt
+    cluster:
+      server: $MGMT_SERVER
+      certificate-authority-data: $MGMT_CA
+contexts:
+  - name: ca
+    context: { cluster: mgmt, user: processor-autoscaler, namespace: org-tuist }
+users:
+  - name: processor-autoscaler
+    user: { token: $MGMT_TOKEN }
+current-context: ca
+EOF
+
+kubectl --kubeconfig ~/.kube/tuist-prod.yaml -n platform create secret generic \
+  cluster-autoscaler-mgmt-kubeconfig \
+  --from-file=value=/tmp/ca-mgmt-kubeconfig.yaml
+shred -u /tmp/ca-mgmt-kubeconfig.yaml
+
+# 4. Re-run the platform chart with cluster-autoscaler enabled.
+helm upgrade --install platform infra/helm/platform \
+  -n platform \
+  -f infra/helm/platform/values-hetzner.yaml \
+  --set cluster-autoscaler.enabled=true
+```
+
+The `md-processor` MD's `cluster-api-autoscaler-node-group-{min,max}-size` annotations (in `workload-cluster-production.yaml`) declare the pool's bounds (currently 2..6). When the queue drains, CA reaps idle nodes after `--scale-down-unneeded-time` (30m, set in the platform values to give long-running parses room).
+
+**Verifying it works:**
+```bash
+# Watch CA's view of the node group.
+kubectl --kubeconfig ~/.kube/tuist-prod.yaml -n platform logs \
+  -l app.kubernetes.io/name=cluster-autoscaler -f \
+  | grep md-processor
+
+# Force a scale event by enqueuing test process_build jobs and watching the
+# MachineDeployment's replica count.
+kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml -n org-tuist get \
+  machinedeployment -l cluster.x-k8s.io/cluster-name=tuist -w
+```
+
 ## 10. Teardown
 
 Workload cluster:

--- a/infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml
+++ b/infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml
@@ -1,0 +1,94 @@
+# ServiceAccount and Role for cluster-autoscaler-clusterapi to read + scale
+# the production workload cluster's MachineDeployments. Lives in the SYSELF
+# MANAGEMENT cluster (where the Cluster / MachineDeployment / Machine CRs
+# live), NOT in the workload cluster — CA is deployed in the workload cluster
+# and points at this SA via a kubeconfig mounted from a Secret.
+#
+# Permissions are intentionally minimal:
+#   - get / patch / update the `tuist` Cluster + its MachineDeployments
+#     (so CA can change spec.topology.workers.machineDeployments[*].replicas
+#     and the corresponding MD's spec.replicas during scale events).
+#   - get / list / watch MachineDeployments + MachineSets + Machines (so CA
+#     can observe node-group state, including replica counts, ready
+#     conditions, and pending-machine status).
+#   - patch / annotate Machines (CA marks specific Machines for deletion via
+#     the `cluster.x-k8s.io/delete-machine` annotation when scaling down,
+#     instead of relying on the MD's default eviction order).
+#
+# Apply against the management cluster ONCE per env (production here):
+#
+#   sed 's/__ORG_NS__/org-tuist/g' \
+#     infra/k8s/syself/processor-autoscaler-mgmt-rbac.yaml \
+#     | kubectl --kubeconfig ~/.kube/tuist-syself-mgmt.yaml apply -f -
+#
+# Then extract the SA token from the management cluster and ship it as a
+# kubeconfig Secret on the workload cluster — see
+# infra/k8s/syself-onboarding.md "Cluster autoscaler bootstrap".
+#
+# Prerequisite: Syself's OIDC user MUST have permission to create
+# serviceaccounts / roles / rolebindings in the org-tuist namespace. This is
+# NOT granted by default; open a Syself support ticket if applying this
+# returns a Forbidden error. See section 9.6 of syself-onboarding.md.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: processor-autoscaler
+  namespace: __ORG_NS__
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: processor-autoscaler-token
+  namespace: __ORG_NS__
+  annotations:
+    kubernetes.io/service-account.name: processor-autoscaler
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: processor-autoscaler
+  namespace: __ORG_NS__
+rules:
+  # Read the production Cluster and patch its topology to scale the
+  # md-processor MachineDeployment via spec.topology.workers...replicas.
+  # ClusterClass-managed clusters require the topology patch (changing
+  # the MD spec directly is reverted by the topology controller).
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [clusters]
+    resourceNames: [tuist]
+    verbs: [get, patch, update]
+  # Read MD/MS/Machine state. CA's clusterapi provider polls these to map
+  # the node group to its current replicas + machine list.
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [machinedeployments, machinesets, machines]
+    verbs: [get, list, watch]
+  # Patch MachineDeployments so CA can update `spec.replicas` directly when
+  # the topology controller is unavailable (CAPI fallback path), and update
+  # the autoscaler annotations on the MD if min/max are reconciled. Patch
+  # Machines so CA can mark specific Machines with
+  # `cluster.x-k8s.io/delete-machine` during scale-down.
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [machinedeployments, machines]
+    verbs: [patch, update]
+  # Optional but recommended: scale subresource on MachineDeployments lets
+  # CA use the standard /scale endpoint, which is the preferred path on
+  # CAPI versions where it's enabled.
+  - apiGroups: [cluster.x-k8s.io]
+    resources: [machinedeployments/scale]
+    verbs: [get, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: processor-autoscaler
+  namespace: __ORG_NS__
+roleRef:
+  kind: Role
+  name: processor-autoscaler
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: processor-autoscaler
+    namespace: __ORG_NS__

--- a/infra/k8s/syself/workload-cluster-production.yaml
+++ b/infra/k8s/syself/workload-cluster-production.yaml
@@ -46,7 +46,7 @@ spec:
             labels:
               node.cluster.x-k8s.io/pool: general
         # Dedicated processor pool: xcactivitylog parsing only. Shared-vCPU
-        # is acceptable here because parsing is async batch work, and cpx51
+        # is acceptable here because parsing is async batch work, and cpx62
         # gives us ~3× the cores per euro of ccx33. The pool label below
         # is what `processor.nodeSelector` in values-managed-production.yaml
         # targets; the prefix is required by Syself's ClusterClass v6 to
@@ -54,11 +54,25 @@ spec:
         # registration (only `node-role.kubernetes.io/`,
         # `node-restriction.kubernetes.io/`, and `node.cluster.x-k8s.io/`
         # prefixes are allowed through).
+        #
+        # cluster-autoscaler annotations: cluster-autoscaler-clusterapi
+        # picks up MDs that carry these annotations and treats them as a
+        # node group with the declared min/max bounds. KEDA scales the
+        # processor Deployment up to maxReplicaCount; under DoNotSchedule
+        # topology spread, each extra replica needs its own node, so CA
+        # follows along by adding cpx62s up to max-size. When the queue
+        # drains and KEDA rolls back, CA reaps idle nodes after
+        # --scale-down-unneeded-time (default 10m). max-size = 6 matches
+        # `processor.autoscaling.maxReplicaCount` in values-managed-
+        # production.yaml; keep them in lockstep when bumping either.
         - class: workeramd64hcloud
           name: md-processor
           replicas: 2
           failureDomain: fsn1
           metadata:
+            annotations:
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "2"
+              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "6"
             labels:
               node.cluster.x-k8s.io/pool: processor
           variables:


### PR DESCRIPTION
> Replaces the static 2-replica processor pool with KEDA-driven horizontal autoscaling on Oban queue depth, plus the manifests + runbook to wire cluster-autoscaler against the Hetzner `md-processor` MachineDeployment when management-cluster RBAC permits it.

## Summary

Three layered changes so the build-processor fleet grows and shrinks with the queue instead of provisioning for peak:

1. **`queueConcurrency: 5 → 8`** in `values-managed-common.yaml`. Observed prod pods at concurrency 5 used ~5/12 cores and ~9/24 GiB; 8 lifts peak to ~14 GiB, comfortably under the 24 GiB limit and within the BEAM's 12 dirty-CPU schedulers. Stale `cpx51` / "5 concurrent" carryovers in the production overlay were updated to match the cpx62 pool.

2. **KEDA + Postgres scaler.** Adds the `keda` chart as a platform dependency (enabled by default). The Tuist chart emits a `TriggerAuthentication` + `ScaledObject` for the processor when `processor.autoscaling.enabled` is set; production overlay flips it on with `min=2 / max=6 / targetQueryValue=8`. The trigger counts `oban_jobs` in `(available, scheduled)` on `process_build` and divides by `targetQueryValue` to pick replica count. Reuses the `processor-database-url` Secret so KEDA hits Postgres via the same least-privilege role the workers do. The processor Deployment now omits `replicas:` when autoscaling is on (matches the existing `server-deployment.yaml` pattern), so HPA owns replica count without Helm fighting it on every reconcile.

3. **`cluster-autoscaler-clusterapi`, wired but disabled by default.** Annotates `md-processor` with `cluster-api-autoscaler-node-group-{min,max}-size: 2..6` so CA picks it up as a node group. Adds the chart dep with a two-cluster (`kubeconfig-incluster`) config reading management-cluster creds from an out-of-band Secret. Ships the management-cluster RBAC manifest (SA + Role + token Secret) following the existing `preview-mgmt-rbac.yaml` pattern, plus a new section 9.8 in `syself-onboarding.md` walking through bootstrap. Disabled because Syself OIDC users can't `create serviceaccounts,roles,rolebindings` in `org-tuist` without a support ticket — same gate that blocks the preview elastic-scaling flow.

## Why

The processor queue has been clogging during build spikes. The recent #10568 work locked in one-fat-pod-per-node via `DoNotSchedule`, so static `replicaCount: 2` is a hard ceiling on parse parallelism. KEDA on queue depth + CA on the MD gives elastic capacity scoped to actual demand.

## Operational rollout

1. Merge → next prod deploy picks up `queueConcurrency: 8`.
2. `helm dep update infra/helm/platform && helm upgrade platform ...` → installs KEDA. Without CA the ScaledObject can scale to 6 replicas under load, but only 2 schedule (DoNotSchedule + 2 nodes); the rest stay Pending. Acceptable as a debuggable signal.
3. Open a Syself ticket for `create serviceaccounts,roles,rolebindings` on `org-tuist` (same gate as 9.6).
4. When granted, follow 9.8 → flip `cluster-autoscaler.enabled=true` → CA spins extra cpx62s on demand.

## How to test locally

- `helm lint infra/helm/tuist --values .../values-managed-common.yaml --values .../values-managed-production.yaml --set server.image.tag=test` — clean.
- `helm template tuist infra/helm/tuist -f values-managed-common.yaml -f values-managed-production.yaml --set server.image.tag=test` — verify the rendered processor `Deployment` no longer carries `replicas:`, and that `ScaledObject` + `TriggerAuthentication` are emitted with the expected query and Secret reference.
- `helm lint infra/helm/platform -f values-hetzner.yaml` — clean (warns about un-fetched chart deps until `helm dep update`, expected).

## Reviewer notes

- Chart deps `keda` and `cluster-autoscaler` need `helm dep update` before the next platform upgrade. Worth scripting into the deploy workflow if it isn't already.
- KEDA's `cooldownPeriod: 300` keeps replicas warm across small lulls; bump if scale-down churn is observed.
- The CA scale-down timing (`scale-down-unneeded-time: 30m`) is set generously because parses can run up to ~20m; tighten once we have enough data.
- `targetQueryValue: 8` mirrors `queueConcurrency: 8` so backlog of 16 → 2 replicas, 32 → 4, 64 → ceiling at 6. Adjust together if either changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)