### PR TITLE
fix(server): make preview storage ephemeral

### DIFF
--- a/infra/helm/tuist/templates/cache-deployment.yaml
+++ b/infra/helm/tuist/templates/cache-deployment.yaml
@@ -145,11 +145,19 @@ spec:
         {{- end }}
       volumes:
         - name: storage
+          {{- if .Values.cache.storage.pvc.create }}
           persistentVolumeClaim:
             claimName: {{ include "tuist.componentName" (dict "root" . "component" "cache-storage") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: data
+          {{- if .Values.cache.data.pvc.create }}
           persistentVolumeClaim:
             claimName: {{ include "tuist.componentName" (dict "root" . "component" "cache-data") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: socket
           emptyDir: {}
         {{- if .Values.cache.nginx.enabled }}

--- a/infra/helm/tuist/templates/clickhouse.yaml
+++ b/infra/helm/tuist/templates/clickhouse.yaml
@@ -83,9 +83,14 @@ spec:
           resources:
             {{- toYaml .Values.clickhouse.embedded.resources | nindent 12 }}
       volumes:
+        {{- if not .Values.clickhouse.embedded.persistence.create }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "tuist.componentName" (dict "root" . "component" "clickhouse-config") }}
+  {{- if .Values.clickhouse.embedded.persistence.create }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -98,6 +103,7 @@ spec:
         {{- if .Values.clickhouse.embedded.persistence.storageClassName }}
         storageClassName: {{ .Values.clickhouse.embedded.persistence.storageClassName }}
         {{- end }}
+  {{- end }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/infra/helm/tuist/templates/object-storage.yaml
+++ b/infra/helm/tuist/templates/object-storage.yaml
@@ -73,6 +73,12 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.objectStorage.embedded.resources | nindent 12 }}
+      {{- if not .Values.objectStorage.embedded.persistence.create }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.objectStorage.embedded.persistence.create }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -85,6 +91,7 @@ spec:
         {{- if .Values.objectStorage.embedded.persistence.storageClassName }}
         storageClassName: {{ .Values.objectStorage.embedded.persistence.storageClassName }}
         {{- end }}
+  {{- end }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/infra/helm/tuist/templates/postgresql.yaml
+++ b/infra/helm/tuist/templates/postgresql.yaml
@@ -72,10 +72,20 @@ spec:
             {{- toYaml .Values.postgresql.embedded.resources | nindent 12 }}
       {{- if and .Values.cache.enabled (eq .Values.postgresql.mode "embedded") }}
       volumes:
+        {{- if not .Values.postgresql.embedded.persistence.create }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
         - name: init-scripts
           configMap:
             name: {{ include "tuist.componentName" (dict "root" . "component" "postgresql-init") }}
       {{- end }}
+      {{- if and (not .Values.postgresql.embedded.persistence.create) (not (and .Values.cache.enabled (eq .Values.postgresql.mode "embedded"))) }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.embedded.persistence.create }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -88,4 +98,5 @@ spec:
         {{- if .Values.postgresql.embedded.persistence.storageClassName }}
         storageClassName: {{ .Values.postgresql.embedded.persistence.storageClassName }}
         {{- end }}
+  {{- end }}
 {{- end }}

--- a/infra/helm/tuist/values-preview.yaml
+++ b/infra/helm/tuist/values-preview.yaml
@@ -9,6 +9,10 @@
 #
 # Apply with:
 #   helm install pr-1234 infra/helm/tuist -f infra/helm/tuist/values-preview.yaml
+#
+# Preview state is intentionally ephemeral: the workloads are disposable and
+# using node-local storage avoids the flaky CSI attach/format path that was
+# stalling short-lived preview releases.
 global:
   nodeSelector:
     role: preview
@@ -81,18 +85,20 @@ cache:
   # boot via templates/postgresql-init.yaml).
   enabled: true
   replicaCount: 1
+  podSecurityContext:
+    fsGroup: 990
   storage:
     pvc:
-      size: 5Gi
+      create: false
   data:
     pvc:
-      size: 2Gi
+      create: false
 
 postgresql:
   mode: embedded
   embedded:
     persistence:
-      size: 2Gi
+      create: false
     resources:
       requests:
         cpu: 50m
@@ -104,7 +110,7 @@ clickhouse:
   mode: embedded
   embedded:
     persistence:
-      size: 5Gi
+      create: false
     resources:
       requests:
         cpu: 100m
@@ -119,7 +125,7 @@ objectStorage:
   mode: embedded
   embedded:
     persistence:
-      size: 5Gi
+      create: false
 
 observability:
   enabled: false

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -345,6 +345,7 @@ postgresql:
     username: tuist
     password: tuist
     persistence:
+      create: true
       storageClassName: ""
       accessModes:
         - ReadWriteOnce
@@ -368,6 +369,7 @@ clickhouse:
     username: default
     password: ""
     persistence:
+      create: true
       storageClassName: ""
       accessModes:
         - ReadWriteOnce
@@ -440,6 +442,7 @@ objectStorage:
     rootPassword: minio1234
     region: auto
     persistence:
+      create: true
       storageClassName: ""
       accessModes:
         - ReadWriteOnce


### PR DESCRIPTION
## Summary

This makes preview deployments use ephemeral node-local storage instead of PVC-backed storage for the embedded cache, PostgreSQL, ClickHouse, and object storage workloads.

It also sets `fsGroup: 990` for the preview cache pod so the non-root cache process can write to its mounted directories.

## Root cause

The failing preview deploy run timed out inside `helm upgrade --install` while several embedded preview dependencies were hitting repeated `FailedMount` errors during the CSI disk format path on fresh Hetzner volumes.

At the same time, the server pod itself was healthy and serving `/ready`, which pointed to the short-lived preview storage path as the blocker rather than the application image.

## Why this fix

Preview environments are disposable, so they do not need durable volumes.

By rendering the preview overlay with `emptyDir` storage, the deploy no longer depends on PVC provisioning, attach, or format completing before Helm can finish the release.

## Validation

- `helm template pr-1234 infra/helm/tuist -f infra/helm/tuist/values-preview.yaml --set server.ingress.enabled=true --set server.ingress.host=pr-1234.preview.tuist.dev --set server.appUrl=https://pr-1234.preview.tuist.dev`
- `helm lint infra/helm/tuist`
- `helm lint infra/helm/tuist -f infra/helm/tuist/values-preview.yaml --set server.ingress.enabled=true --set server.ingress.host=pr-1234.preview.tuist.dev --set server.appUrl=https://pr-1234.preview.tuist.dev`
- `helm template durable infra/helm/tuist`
