### PR TITLE
fix(cli): use stamp file for macro copy phase to keep incremental rebuilds

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -532,12 +532,6 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
             fi
             """
         }
-        copySwiftMacrosBuildPhase.shellScript = """
-        #  This build phase serves two purposes:
-        #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
-        #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
-        \(copyLines.joined(separator: "\n"))
-        """
 
         copySwiftMacrosBuildPhase.inputPaths = executableNames.flatMap {
             [
@@ -547,13 +541,28 @@ struct BuildPhaseGenerator: BuildPhaseGenerating {
         }
 
         if target.supports(.macOS) {
-            // Any consumer that supports macOS still needs the phase because the
-            // compiler/editor load plugin executables from `Debug...`, even when
-            // the active configuration is not Debug. Declared outputs would collide
-            // on native macOS builds where `$EFFECTIVE_PLATFORM_NAME` is empty, so
-            // omit them and always run the phase instead.
-            copySwiftMacrosBuildPhase.alwaysOutOfDate = true
+            // Declaring the actual destination paths as outputs would collide with
+            // the macro target's `Ld` step on native macOS builds (where
+            // `$EFFECTIVE_PLATFORM_NAME` is empty and both write to
+            // `$BUILD_DIR/Debug/<exe>`). Use a stamp file under `$DERIVED_FILE_DIR`
+            // (per-target / per-configuration / per-platform) so Xcode's
+            // incremental up-to-date check still works without colliding.
+            copySwiftMacrosBuildPhase.shellScript = """
+            #  This build phase serves two purposes:
+            #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
+            #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
+            \(copyLines.joined(separator: "\n"))
+            mkdir -p "$DERIVED_FILE_DIR"
+            touch "$DERIVED_FILE_DIR/copy-swift-macro.stamp"
+            """
+            copySwiftMacrosBuildPhase.outputPaths = ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"]
         } else {
+            copySwiftMacrosBuildPhase.shellScript = """
+            #  This build phase serves two purposes:
+            #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
+            #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
+            \(copyLines.joined(separator: "\n"))
+            """
             copySwiftMacrosBuildPhase.outputPaths = executableNames.flatMap { executable in
                 [
                     "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\(executable)",

--- a/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -2218,7 +2218,7 @@ struct BuildPhaseGeneratorTests {
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesAlwaysOutOfDateShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
+    ) func generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS() async throws {
         // Given
         let app = Target.test(name: "app", platform: .macOS, product: .app)
         let macroFramework = Target.test(name: "framework", platform: .macOS, product: .staticFramework)
@@ -2254,15 +2254,16 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase?.outputPaths == [])
-        #expect(buildPhase?.alwaysOutOfDate == true)
+        #expect(buildPhase?.outputPaths == ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"])
+        #expect(buildPhase?.alwaysOutOfDate == false)
+        #expect(buildPhase?.shellScript?.contains("touch \"$DERIVED_FILE_DIR/copy-swift-macro.stamp\"") == true)
     }
 
     @Test(
         .withMockedSwiftVersionProvider,
         .withMockedXcodeController,
         .inTemporaryDirectory
-    ) func generateLinks_generatesAlwaysOutOfDateShellScriptBuildPhase_when_macroFrameworkIsMixedDestination() async throws {
+    ) func generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsMixedDestination() async throws {
         // Given
         let app = Target.test(name: "app", destinations: [.iPhone, .mac], product: .app)
         let macroFramework = Target.test(name: "framework", destinations: [.iPhone, .mac], product: .staticFramework)
@@ -2298,8 +2299,9 @@ struct BuildPhaseGeneratorTests {
             .compactMap { $0 as? PBXShellScriptBuildPhase }
             .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
-        #expect(buildPhase?.outputPaths == [])
-        #expect(buildPhase?.alwaysOutOfDate == true)
+        #expect(buildPhase?.outputPaths == ["$(DERIVED_FILE_DIR)/copy-swift-macro.stamp"])
+        #expect(buildPhase?.alwaysOutOfDate == false)
+        #expect(buildPhase?.shellScript?.contains("touch \"$DERIVED_FILE_DIR/copy-swift-macro.stamp\"") == true)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Follow-up to [#10566](https://github.com/tuist/tuist/pull/10566): replace `alwaysOutOfDate = true` on the macro copy phase for macOS-supporting consumers with a stamp file output under `$DERIVED_FILE_DIR`.

`alwaysOutOfDate = true` silences the mutator-collision warning by dropping declared outputs entirely, but it also forces the phase to rerun on every build of every slice (including non-macOS slices where the original up-to-date check would have worked). Using a stamp file as the declared output preserves Xcode's incremental up-to-date check while avoiding the collision: `$DERIVED_FILE_DIR` is per-target / per-configuration / per-platform, so the stamp can't collide with the macro target's `Ld` step on native macOS builds, and can't collide across consumer targets.

The script body now ends with a `mkdir -p` + `touch` of the stamp. The non-macOS branch (e.g. iOS-only consumer) is unchanged, since the original platform-suffixed `outputPaths` were correct there.

Discussed on [#10566](https://github.com/tuist/tuist/pull/10566#issuecomment-4354138731).

## Test plan
- [x] `BuildPhaseGeneratorTests` (48 tests) pass, including:
  - `generateLinks_generatesAShellScriptBuildPhase_when_targetIsAMacroFramework` (iOS-only, unchanged)
  - `generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsExclusiveToMacOS`
  - `generateLinks_generatesStampFileShellScriptBuildPhase_when_macroFrameworkIsMixedDestination`
- [ ] Generate a project with a macOS-exclusive macro consumer, build for macOS, confirm:
  - No `unexpected mutating task` warning around the copy script.
  - Incremental rebuild without source changes is a no-op for the script (stamp newer than inputs).
- [ ] Same for a mixed-destination (`[.iPhone, .mac]`) macro consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)