### PR TITLE
perf(server): drop ClickHouse FINAL on hot ReplacingMergeTree id lookups

### DIFF
--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -91,8 +91,17 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
 
   defp load_all_test_case_ids(_project_id, false), do: []
 
+  # `project_id` is the leading sort key; `DISTINCT` on `id` collapses
+  # duplicate row versions from unmerged parts cheaply, avoiding the
+  # multi-part full-row merge `FINAL` would force.
   defp load_all_test_case_ids(project_id, _recovery_enabled) do
-    ClickHouseRepo.all(from(tc in TestCase, hints: ["FINAL"], where: tc.project_id == ^project_id, select: tc.id))
+    ClickHouseRepo.all(
+      from(tc in TestCase,
+        where: tc.project_id == ^project_id,
+        distinct: true,
+        select: tc.id
+      )
+    )
   end
 
   defp parse_window(window) when is_binary(window) do

--- a/server/lib/tuist/builds.ex
+++ b/server/lib/tuist/builds.ex
@@ -35,12 +35,19 @@ defmodule Tuist.Builds do
     ClickHouseRepo.one(from(b in Build, where: b.inserted_at >= ^twenty_four_hours_ago, select: count())) || 0
   end
 
+  # `ORDER BY inserted_at DESC LIMIT 1` picks the latest version of the row
+  # without the multi-part merge `FINAL` would force; the `proj_by_id`
+  # projection lets the lookup binary-search to a single granule.
   def get_build(id) do
     with {:ok, uuid} <- Ecto.UUID.cast(id),
          build when not is_nil(build) <-
-           Build
-           |> from(hints: ["FINAL"], where: [id: ^uuid])
-           |> ClickHouseRepo.one() do
+           ClickHouseRepo.one(
+             from(b in Build,
+               where: b.id == ^uuid,
+               order_by: [desc: b.inserted_at],
+               limit: 1
+             )
+           ) do
       {:ok, build}
     else
       _ -> {:error, :not_found}

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -186,7 +186,6 @@ defmodule Tuist.Tests do
 
         query =
           from(t in Test,
-            hints: ["FINAL"],
             where: t.id == ^uuid,
             order_by: [desc: t.inserted_at],
             limit: 1
@@ -2152,12 +2151,18 @@ defmodule Tuist.Tests do
   defp mark_test_case_runs_as_flaky(runs) when is_list(runs) do
     ids = runs |> Enum.map(& &1.id) |> Enum.uniq()
 
-    # FINAL is required because `test_case_runs` is a ReplacingMergeTree:
-    # without it, a run that has already been re-inserted (e.g. previously
-    # marked flaky) can return multiple versions for the same id until the
-    # merge collapses them, and we'd re-insert every version.
+    # `test_case_runs` is a ReplacingMergeTree, so a re-inserted run can
+    # return multiple versions per id until the background merge collapses
+    # them. We dedupe in Elixir on a small result set so the `proj_by_id`
+    # projection (binary search on `id`) is used; `FINAL` would disable it
+    # and force a full part scan with an in-memory merge.
     full_runs =
-      ClickHouseRepo.all(from(tcr in TestCaseRun, hints: ["FINAL"], where: tcr.id in ^ids))
+      from(tcr in TestCaseRun,
+        where: tcr.id in ^ids,
+        order_by: [desc: tcr.inserted_at]
+      )
+      |> ClickHouseRepo.all()
+      |> Enum.uniq_by(& &1.id)
 
     updated_runs =
       Enum.map(full_runs, fn run ->

--- a/server/priv/ingest_repo/migrations/20260430120002_add_id_projection_to_build_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260430120002_add_id_projection_to_build_runs.exs
@@ -1,0 +1,46 @@
+defmodule Tuist.IngestRepo.Migrations.AddIdProjectionToBuildRuns do
+  @moduledoc """
+  Adds a `proj_by_id` projection to `build_runs` so single-row lookups by
+  `id` (e.g. `Tuist.Builds.get_build/1`) binary-search to a single granule
+  instead of scanning the table.
+
+  `build_runs` is `ORDER BY (project_id, id)`, so `WHERE id = ?` without
+  `project_id` cannot use the primary key. The projection is ordered by
+  `id` alone, giving point lookups roughly the cost of one granule read.
+
+  Mirrors `proj_by_id` on `test_case_runs`. Materialization happens in the
+  follow-up migration so the metadata change can propagate before the
+  slower part rewrite runs.
+  """
+  use Ecto.Migration
+
+  def up do
+    # ReplacingMergeTree rejects ADD PROJECTION unless the table opts into
+    # rebuilding projections during deduplicating merges.
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    ADD PROJECTION IF NOT EXISTS proj_by_id (
+      SELECT *
+      ORDER BY id
+    )
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE build_runs DROP PROJECTION IF EXISTS proj_by_id"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'throw'
+    """
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260430120003_materialize_id_projection_on_build_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260430120003_materialize_id_projection_on_build_runs.exs
@@ -1,0 +1,23 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeIdProjectionOnBuildRuns do
+  @moduledoc """
+  Materializes `proj_by_id` across all existing parts of `build_runs`. The
+  preceding migration only recorded the projection definition; this one
+  does the part rewrite.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE build_runs
+    MATERIALIZE PROJECTION proj_by_id
+    """
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260430120004_add_id_projection_to_test_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260430120004_add_id_projection_to_test_runs.exs
@@ -1,0 +1,46 @@
+defmodule Tuist.IngestRepo.Migrations.AddIdProjectionToTestRuns do
+  @moduledoc """
+  Adds a `proj_by_id` projection to `test_runs` so single-row lookups by
+  `id` (e.g. `Tuist.Tests.get_test/2`) binary-search to a single granule
+  instead of scanning the table.
+
+  `test_runs` is `ORDER BY (project_id, id)`, so `WHERE id = ?` without
+  `project_id` cannot use the primary key. The projection is ordered by
+  `id` alone, giving point lookups roughly the cost of one granule read.
+
+  Mirrors `proj_by_id` on `test_case_runs`. Materialization happens in the
+  follow-up migration so the metadata change can propagate before the
+  slower part rewrite runs.
+  """
+  use Ecto.Migration
+
+  def up do
+    # ReplacingMergeTree rejects ADD PROJECTION unless the table opts into
+    # rebuilding projections during deduplicating merges.
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'
+    """
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_runs
+    ADD PROJECTION IF NOT EXISTS proj_by_id (
+      SELECT *
+      ORDER BY id
+    )
+    """
+  end
+
+  def down do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute "ALTER TABLE test_runs DROP PROJECTION IF EXISTS proj_by_id"
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_runs
+    MODIFY SETTING deduplicate_merge_projection_mode = 'throw'
+    """
+  end
+end

--- a/server/priv/ingest_repo/migrations/20260430120005_materialize_id_projection_on_test_runs.exs
+++ b/server/priv/ingest_repo/migrations/20260430120005_materialize_id_projection_on_test_runs.exs
@@ -1,0 +1,23 @@
+defmodule Tuist.IngestRepo.Migrations.MaterializeIdProjectionOnTestRuns do
+  @moduledoc """
+  Materializes `proj_by_id` across all existing parts of `test_runs`. The
+  preceding migration only recorded the projection definition; this one
+  does the part rewrite.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute """
+    ALTER TABLE test_runs
+    MATERIALIZE PROJECTION proj_by_id
+    """
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
### Why

`FINAL` on `build_runs`, `test_runs`, `test_case_runs` and `test_cases` forces ClickHouse to read every active part and merge rows in memory at query time, and disables projection use. Under steady traffic this was the dominant CPU draw on the analytics ClickHouse instance — top offenders measured over a 3h window:

| Query | Executions | Avg CPU cores | Total CPU·s |
|---|---|---|---|
| `SELECT … FROM build_runs FINAL WHERE id = ?` | 2,974 | 0.90 | **2,673** |
| `SELECT id FROM test_cases FINAL WHERE project_id = ?` | 33,297 | 0.02 | 741 |
| `SELECT … FROM test_runs FINAL WHERE id = ?` | 416 | 0.90 | 376 |
| `SELECT … FROM test_case_runs FINAL WHERE id IN (?)` | 132 | 1.06 | 139 |

Two concurrent `test_case_runs FINAL` scans were also peaking at ~4.17 cores combined while each held ~893 MiB RAM — the FINAL merge was buffering full rows in memory.

### What

- `Tuist.Builds.get_build/1`: drop `FINAL`, use `ORDER BY inserted_at DESC LIMIT 1`. The schema's existing dedup convention.
- `Tuist.Tests.get_test/2`: drop the redundant `FINAL` (already had `ORDER BY DESC LIMIT 1`).
- `Tuist.Tests.mark_test_case_runs_as_flaky/1`: drop `FINAL`, dedupe with `Enum.uniq_by/2` on a small id list. The existing `proj_by_id` projection on `test_case_runs` is now used.
- `Tuist.Automations.Monitors.FlakyTestsMonitor.load_all_test_case_ids/2`: drop `FINAL`, use `DISTINCT` on `tc.id` over the `project_id` PK prefix.
- New `proj_by_id` projections on `build_runs` and `test_runs` (mirroring `test_case_runs`) so `WHERE id = ?` lookups binary-search to a single granule. Each projection is split across an `ADD` + `MATERIALIZE` migration to match the established pattern.

Expected savings ≈ 3,929 CPU·s / 3h (≈0.36 cores sustained) plus elimination of the 4-core peak from concurrent FINAL scans. Once the projections materialize on prod data, the remaining table-scan cost on `build_runs` / `test_runs` lookups drops to one granule per id.

### Why projections (with `deduplicate_merge_projection_mode = 'rebuild'`) over an MV

For `WHERE id = ?` the lookup is a single column with no shape difference from the source, so both options yield the same data layout — the choice is purely structural.

- **Picked**: projection ordered by `id`. Transparent to readers (`get_build/1` / `get_test/2` keep their existing query shape), the optimizer picks the projection automatically when `FINAL` isn't in play, and it matches the most recent precedent in the repo (`proj_by_id` on `test_case_runs` since Jan, `proj_by_project_is_ci_branch_ran_at` on `test_module_runs` / `test_suite_runs` since Apr — no fallout).
- **Considered**: a `build_runs_by_id` / `test_runs_by_id` MV, ReplacingMergeTree(`inserted_at`) ordered by `id`. Cleaner separation and avoids changing source-table settings, but requires a parallel Ecto schema and a query-site change for what is otherwise the same on-disk layout. We use this pattern when the secondary view has a meaningfully different shape (denormalization, a different engine, etc. — `test_case_runs_by_test_run`, `test_case_runs_by_commit`); for a pure id index it's extra surface area for no read-side benefit.
- **`'rebuild'` vs `'drop'` / `'ignore'`**: only `'rebuild'` preserves correctness on a ReplacingMergeTree. `'drop'` discards projection rows on dedup merges (queries miss data); `'ignore'` keeps un-deduplicated rows in the projection (queries return stale/duplicate rows). The trade-off `'rebuild'` makes is extra merge-time CPU/IO on the source — acceptable for these tables given the read-side win.

### How to test locally

- `mix test test/tuist/builds_test.exs` — covers `get_build/1` happy path + invalid/missing id.
- `mix test test/tuist/tests_test.exs` — covers `get_test/2`, cross-run flakiness (exercises `mark_test_case_runs_as_flaky/1`).
- `mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs` — exercises the flaky-tests monitor.
- The four new ingest_repo migrations apply with `mix ecto.migrate -r Tuist.IngestRepo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)