### PR TITLE
fix(server): coalesce automation actions to avoid stale-read race

### DIFF
--- a/server/lib/tuist/automations/action_executor.ex
+++ b/server/lib/tuist/automations/action_executor.ex
@@ -24,7 +24,7 @@ defmodule Tuist.Automations.ActionExecutor do
   def execute_actions(actions, automation, entity) when is_list(actions) do
     {merged_attrs, remaining_actions} = partition_actions(actions, entity)
 
-    with :ok <- apply_merged_attrs(entity, merged_attrs) do
+    with :ok <- apply_merged_attrs(entity, automation, merged_attrs) do
       run_remaining(remaining_actions, automation, entity)
     end
   end
@@ -47,10 +47,10 @@ defmodule Tuist.Automations.ActionExecutor do
   defp test_case_attr_change(%{"type" => "change_state", "state" => state}), do: {:state, state}
   defp test_case_attr_change(_), do: :pass
 
-  defp apply_merged_attrs(_entity, attrs) when map_size(attrs) == 0, do: :ok
+  defp apply_merged_attrs(_entity, _automation, attrs) when map_size(attrs) == 0, do: :ok
 
-  defp apply_merged_attrs(%{type: :test_case, id: id} = entity, attrs) do
-    case Tests.update_test_case(id, attrs) do
+  defp apply_merged_attrs(%{type: :test_case, id: id} = entity, automation, attrs) do
+    case Tests.update_test_case(id, attrs, project_id: Map.get(automation, :project_id)) do
       {:ok, _} ->
         :ok
 

--- a/server/lib/tuist/automations/action_executor.ex
+++ b/server/lib/tuist/automations/action_executor.ex
@@ -6,17 +6,62 @@ defmodule Tuist.Automations.ActionExecutor do
   e.g. `%{type: :test_case, id: "uuid"}`. This abstraction allows
   the automation engine to operate on different entity types in the
   future (builds, bundles, etc.) without changing the dispatch layer.
+
+  When the entity is a `:test_case`, all attribute-mutating actions in the
+  list (`add_label`/`remove_label` for the `flaky` label and `change_state`)
+  are coalesced into a single `Tests.update_test_case/2` call. Each call
+  re-inserts the full row by reading from ClickHouse first, so dispatching
+  them sequentially could revert earlier writes when the read had not yet
+  observed them.
   """
-  alias Tuist.Automations.Actions.AddLabelAction
-  alias Tuist.Automations.Actions.ChangeStateAction
-  alias Tuist.Automations.Actions.RemoveLabelAction
   alias Tuist.Automations.Actions.SendSlackAction
+  alias Tuist.Tests
 
   require Logger
 
   def execute_actions([], _automation, _entity), do: :ok
 
   def execute_actions(actions, automation, entity) when is_list(actions) do
+    {merged_attrs, remaining_actions} = partition_actions(actions, entity)
+
+    with :ok <- apply_merged_attrs(entity, merged_attrs) do
+      run_remaining(remaining_actions, automation, entity)
+    end
+  end
+
+  defp partition_actions(actions, %{type: :test_case}) do
+    actions
+    |> Enum.reduce({%{}, []}, fn action, {attrs, others} ->
+      case test_case_attr_change(action) do
+        {key, value} -> {Map.put(attrs, key, value), others}
+        :pass -> {attrs, [action | others]}
+      end
+    end)
+    |> then(fn {attrs, others} -> {attrs, Enum.reverse(others)} end)
+  end
+
+  defp partition_actions(actions, _entity), do: {%{}, actions}
+
+  defp test_case_attr_change(%{"type" => "add_label", "label" => "flaky"}), do: {:is_flaky, true}
+  defp test_case_attr_change(%{"type" => "remove_label", "label" => "flaky"}), do: {:is_flaky, false}
+  defp test_case_attr_change(%{"type" => "change_state", "state" => state}), do: {:state, state}
+  defp test_case_attr_change(_), do: :pass
+
+  defp apply_merged_attrs(_entity, attrs) when map_size(attrs) == 0, do: :ok
+
+  defp apply_merged_attrs(%{type: :test_case, id: id} = entity, attrs) do
+    case Tests.update_test_case(id, attrs) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Automation test_case attribute update failed for #{entity.type} #{entity.id}: #{inspect(reason)}")
+
+        {:error, reason}
+    end
+  end
+
+  defp run_remaining(actions, automation, entity) do
     Enum.reduce_while(actions, :ok, fn action, _acc ->
       case execute_action(action, automation, entity) do
         :ok ->
@@ -30,20 +75,12 @@ defmodule Tuist.Automations.ActionExecutor do
     end)
   end
 
-  defp execute_action(%{"type" => "change_state"} = action, _automation, entity) do
-    ChangeStateAction.execute(entity, action)
-  end
-
   defp execute_action(%{"type" => "send_slack"} = action, automation, entity) do
     SendSlackAction.execute(automation, entity, action)
   end
 
-  defp execute_action(%{"type" => "add_label"} = action, _automation, entity) do
-    AddLabelAction.execute(entity, action)
-  end
-
-  defp execute_action(%{"type" => "remove_label"} = action, _automation, entity) do
-    RemoveLabelAction.execute(entity, action)
+  defp execute_action(%{"type" => type}, _automation, _entity) when type in ["add_label", "remove_label"] do
+    :ok
   end
 
   defp execute_action(unknown_action, _automation, _entity) do

--- a/server/lib/tuist/automations/action_executor.ex
+++ b/server/lib/tuist/automations/action_executor.ex
@@ -24,7 +24,7 @@ defmodule Tuist.Automations.ActionExecutor do
   def execute_actions(actions, automation, entity) when is_list(actions) do
     {merged_attrs, remaining_actions} = partition_actions(actions, entity)
 
-    with :ok <- apply_merged_attrs(entity, automation, merged_attrs) do
+    with :ok <- apply_merged_attrs(entity, merged_attrs) do
       run_remaining(remaining_actions, automation, entity)
     end
   end
@@ -47,10 +47,10 @@ defmodule Tuist.Automations.ActionExecutor do
   defp test_case_attr_change(%{"type" => "change_state", "state" => state}), do: {:state, state}
   defp test_case_attr_change(_), do: :pass
 
-  defp apply_merged_attrs(_entity, _automation, attrs) when map_size(attrs) == 0, do: :ok
+  defp apply_merged_attrs(_entity, attrs) when map_size(attrs) == 0, do: :ok
 
-  defp apply_merged_attrs(%{type: :test_case, id: id} = entity, automation, attrs) do
-    case Tests.update_test_case(id, attrs, project_id: Map.get(automation, :project_id)) do
+  defp apply_merged_attrs(%{type: :test_case, id: id} = entity, attrs) do
+    case Tests.update_test_case(id, attrs) do
       {:ok, _} ->
         :ok
 

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -749,19 +749,14 @@ defmodule Tuist.Tests do
   ## Parameters
   - `test_case_id` - the test case UUID to update
   - `update_attrs` - map with `:is_flaky` boolean and/or `:state` (`"enabled"` | `"muted"` | `"skipped"`)
-  - `opts` - optional keyword list:
-    - `:actor_id` (account_id for user actions, nil for system)
-    - `:project_id` (when set, the update is rejected with `{:error, :not_found}` if the
-      test case does not belong to that project — defense-in-depth against cross-tenant writes)
+  - `opts` - optional keyword list with `:actor_id` (account_id for user actions, nil for system)
   """
   def update_test_case(test_case_id, update_attrs, opts \\ []) when is_map(update_attrs) do
     valid_keys = [:is_flaky, :state]
     filtered_attrs = Map.take(update_attrs, valid_keys)
     actor_id = Keyword.get(opts, :actor_id)
-    expected_project_id = Keyword.get(opts, :project_id)
 
-    with {:ok, test_case} <- get_test_case_by_id(test_case_id),
-         :ok <- ensure_project_match(test_case, expected_project_id) do
+    with {:ok, test_case} <- get_test_case_by_id(test_case_id) do
       attrs =
         test_case
         |> Map.from_struct()
@@ -776,10 +771,6 @@ defmodule Tuist.Tests do
       {:ok, Map.merge(test_case, filtered_attrs)}
     end
   end
-
-  defp ensure_project_match(_test_case, nil), do: :ok
-  defp ensure_project_match(%{project_id: pid}, pid), do: :ok
-  defp ensure_project_match(_test_case, _expected), do: {:error, :not_found}
 
   defp create_events_for_test_case_changes(test_case_id, old_test_case, new_attrs, actor_id) do
     event_types = determine_test_case_events(old_test_case, new_attrs)

--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -749,14 +749,19 @@ defmodule Tuist.Tests do
   ## Parameters
   - `test_case_id` - the test case UUID to update
   - `update_attrs` - map with `:is_flaky` boolean and/or `:state` (`"enabled"` | `"muted"` | `"skipped"`)
-  - `opts` - optional keyword list with `:actor_id` (account_id for user actions, nil for system)
+  - `opts` - optional keyword list:
+    - `:actor_id` (account_id for user actions, nil for system)
+    - `:project_id` (when set, the update is rejected with `{:error, :not_found}` if the
+      test case does not belong to that project — defense-in-depth against cross-tenant writes)
   """
   def update_test_case(test_case_id, update_attrs, opts \\ []) when is_map(update_attrs) do
     valid_keys = [:is_flaky, :state]
     filtered_attrs = Map.take(update_attrs, valid_keys)
     actor_id = Keyword.get(opts, :actor_id)
+    expected_project_id = Keyword.get(opts, :project_id)
 
-    with {:ok, test_case} <- get_test_case_by_id(test_case_id) do
+    with {:ok, test_case} <- get_test_case_by_id(test_case_id),
+         :ok <- ensure_project_match(test_case, expected_project_id) do
       attrs =
         test_case
         |> Map.from_struct()
@@ -771,6 +776,10 @@ defmodule Tuist.Tests do
       {:ok, Map.merge(test_case, filtered_attrs)}
     end
   end
+
+  defp ensure_project_match(_test_case, nil), do: :ok
+  defp ensure_project_match(%{project_id: pid}, pid), do: :ok
+  defp ensure_project_match(_test_case, _expected), do: {:error, :not_found}
 
   defp create_events_for_test_case_changes(test_case_id, old_test_case, new_attrs, actor_id) do
     event_types = determine_test_case_events(old_test_case, new_attrs)

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -1,76 +1,98 @@
 defmodule Tuist.Automations.ActionExecutorTest do
-  use TuistTestSupport.Cases.DataCase, async: true
+  # Integration test: drives ActionExecutor through the real
+  # Tests.update_test_case down to ClickHouse so the merged-attrs path
+  # (the fix for the read-modify-write race) is verified end-to-end.
+  use TuistTestSupport.Cases.DataCase, async: false
   use Mimic
 
   alias Tuist.Automations.ActionExecutor
   alias Tuist.Automations.Actions.SendSlackAction
+  alias Tuist.IngestRepo
   alias Tuist.Tests
+  alias Tuist.Tests.TestCase
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.RunsFixtures
 
-  setup do
-    entity = %{type: :test_case, id: Ecto.UUID.generate()}
-    %{automation: %{name: "Auto", project_id: 1}, entity: entity}
+  defp insert_test_case(attrs) do
+    project = ProjectsFixtures.project_fixture()
+    test_case = RunsFixtures.test_case_fixture([project_id: project.id] ++ attrs)
+    IngestRepo.insert_all(TestCase, [test_case |> Map.from_struct() |> Map.delete(:__meta__)])
+    test_case
   end
 
-  test "no-ops on empty action list", %{automation: automation, entity: entity} do
-    reject(&Tests.update_test_case/2)
-    assert :ok = ActionExecutor.execute_actions([], automation, entity)
+  defp automation, do: %{name: "Auto", project_id: 1}
+
+  defp event_types(test_case_id) do
+    {events, _meta} = Tests.list_test_case_events(test_case_id)
+    Enum.map(events, & &1.event_type)
   end
 
-  test "applies change_state through a single update_test_case call", %{
-    automation: automation,
-    entity: %{id: id} = entity
-  } do
-    expect(Tests, :update_test_case, fn ^id, %{state: "muted"} -> {:ok, %{}} end)
+  test "no-ops on empty action list" do
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [],
+               automation(),
+               %{type: :test_case, id: Ecto.UUID.generate()}
+             )
+  end
+
+  test "applies change_state and writes the new state to ClickHouse" do
+    test_case = insert_test_case(state: "enabled")
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "change_state", "state" => "muted"}],
-               automation,
+               automation(),
+               %{type: :test_case, id: test_case.id}
+             )
+
+    assert {:ok, %{state: "muted"}} = Tests.get_test_case_by_id(test_case.id)
+    assert "muted" in event_types(test_case.id)
+  end
+
+  test "dispatches send_slack to SendSlackAction" do
+    entity = %{type: :test_case, id: Ecto.UUID.generate()}
+
+    expect(SendSlackAction, :execute, fn _automation, ^entity, %{"type" => "send_slack"} -> :ok end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [%{"type" => "send_slack", "channel" => "C1", "message" => "hi"}],
+               automation(),
                entity
              )
   end
 
-  test "dispatches send_slack to SendSlackAction", %{automation: automation, entity: entity} do
-    reject(&Tests.update_test_case/2)
-    expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} -> :ok end)
-
-    ActionExecutor.execute_actions(
-      [%{"type" => "send_slack", "channel" => "C1", "message" => "hi"}],
-      automation,
-      entity
-    )
-  end
-
-  test "applies add_label flaky as is_flaky: true", %{automation: automation, entity: %{id: id} = entity} do
-    expect(Tests, :update_test_case, fn ^id, %{is_flaky: true} -> {:ok, %{}} end)
+  test "applies add_label flaky as is_flaky: true" do
+    test_case = insert_test_case(is_flaky: false)
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "add_label", "label" => "flaky"}],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: true}} = Tests.get_test_case_by_id(test_case.id)
+    assert "marked_flaky" in event_types(test_case.id)
   end
 
-  test "applies remove_label flaky as is_flaky: false", %{automation: automation, entity: %{id: id} = entity} do
-    expect(Tests, :update_test_case, fn ^id, %{is_flaky: false} -> {:ok, %{}} end)
+  test "applies remove_label flaky as is_flaky: false" do
+    test_case = insert_test_case(is_flaky: true)
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "remove_label", "label" => "flaky"}],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: false}} = Tests.get_test_case_by_id(test_case.id)
+    assert "unmarked_flaky" in event_types(test_case.id)
   end
 
-  test "coalesces add_label flaky and change_state into one update_test_case call", %{
-    automation: automation,
-    entity: %{id: id} = entity
-  } do
-    expect(Tests, :update_test_case, fn ^id, attrs ->
-      assert attrs == %{is_flaky: true, state: "muted"}
-      {:ok, %{}}
-    end)
+  test "coalesces add_label flaky + change_state into one update emitting both events" do
+    test_case = insert_test_case(is_flaky: false, state: "enabled")
 
     assert :ok =
              ActionExecutor.execute_actions(
@@ -78,19 +100,19 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: true, state: "muted"}} = Tests.get_test_case_by_id(test_case.id)
+
+    types = event_types(test_case.id)
+    assert "marked_flaky" in types
+    assert "muted" in types
   end
 
-  test "coalesces recovery actions (remove_label flaky + change_state enabled) into one call", %{
-    automation: automation,
-    entity: %{id: id} = entity
-  } do
-    expect(Tests, :update_test_case, fn ^id, attrs ->
-      assert attrs == %{is_flaky: false, state: "enabled"}
-      {:ok, %{}}
-    end)
+  test "coalesces recovery actions (remove_label flaky + change_state enabled) into one update emitting both events" do
+    test_case = insert_test_case(is_flaky: true, state: "muted")
 
     assert :ok =
              ActionExecutor.execute_actions(
@@ -98,19 +120,19 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "remove_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "enabled"}
                ],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: false, state: "enabled"}} = Tests.get_test_case_by_id(test_case.id)
+
+    types = event_types(test_case.id)
+    assert "unmarked_flaky" in types
+    assert "unmuted" in types
   end
 
-  test "later attribute actions override earlier ones in the merged update", %{
-    automation: automation,
-    entity: %{id: id} = entity
-  } do
-    expect(Tests, :update_test_case, fn ^id, attrs ->
-      assert attrs == %{is_flaky: false}
-      {:ok, %{}}
-    end)
+  test "later attribute actions override earlier ones in the merged update" do
+    test_case = insert_test_case(is_flaky: false)
 
     assert :ok =
              ActionExecutor.execute_actions(
@@ -118,23 +140,21 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "remove_label", "label" => "flaky"}
                ],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: false}} = Tests.get_test_case_by_id(test_case.id)
+    refute "marked_flaky" in event_types(test_case.id)
   end
 
-  test "runs slack action after the merged attribute update", %{
-    automation: automation,
-    entity: %{id: id} = entity
-  } do
+  test "runs slack action after the merged attribute write is visible" do
+    test_case = insert_test_case(is_flaky: false, state: "enabled")
+    entity = %{type: :test_case, id: test_case.id}
     test_pid = self()
 
-    expect(Tests, :update_test_case, fn ^id, %{is_flaky: true, state: "muted"} ->
-      send(test_pid, :update_called)
-      {:ok, %{}}
-    end)
-
-    expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} ->
+    expect(SendSlackAction, :execute, fn _automation, ^entity, %{"type" => "send_slack"} ->
+      assert {:ok, %{is_flaky: true, state: "muted"}} = Tests.get_test_case_by_id(test_case.id)
       send(test_pid, :slack_called)
       :ok
     end)
@@ -146,16 +166,14 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation,
+               automation(),
                entity
              )
 
-    assert_received :update_called
     assert_received :slack_called
   end
 
-  test "halts and returns error when update_test_case fails", %{automation: automation, entity: %{id: id} = entity} do
-    expect(Tests, :update_test_case, fn ^id, _attrs -> {:error, :not_found} end)
+  test "halts and returns error when the test case does not exist" do
     reject(&SendSlackAction.execute/3)
 
     assert {:error, :not_found} =
@@ -164,13 +182,13 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
                ],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: Ecto.UUID.generate()}
              )
   end
 
-  test "no-ops add_label / remove_label with non-flaky labels", %{automation: automation, entity: entity} do
-    reject(&Tests.update_test_case/2)
+  test "no-ops add_label / remove_label with non-flaky labels" do
+    test_case = insert_test_case(is_flaky: false, state: "enabled")
 
     assert :ok =
              ActionExecutor.execute_actions(
@@ -178,20 +196,26 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "slow"},
                  %{"type" => "remove_label", "label" => "slow"}
                ],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: false, state: "enabled"}} = Tests.get_test_case_by_id(test_case.id)
+    assert event_types(test_case.id) == []
   end
 
-  test "silently skips unknown action types", %{automation: automation, entity: entity} do
-    reject(&Tests.update_test_case/2)
+  test "silently skips unknown action types without touching the row" do
+    test_case = insert_test_case(is_flaky: false, state: "enabled")
     reject(&SendSlackAction.execute/3)
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "fly_to_moon"}],
-               automation,
-               entity
+               automation(),
+               %{type: :test_case, id: test_case.id}
              )
+
+    assert {:ok, %{is_flaky: false, state: "enabled"}} = Tests.get_test_case_by_id(test_case.id)
+    assert event_types(test_case.id) == []
   end
 end

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -17,7 +17,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     test_case
   end
 
-  defp automation, do: %{name: "Auto", project_id: 1}
+  defp automation_for(%{project_id: project_id}), do: %{name: "Auto", project_id: project_id}
 
   defp event_types(test_case_id) do
     {events, _meta} = Tests.list_test_case_events(test_case_id)
@@ -28,7 +28,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [],
-               automation(),
+               %{name: "Auto", project_id: 0},
                %{type: :test_case, id: Ecto.UUID.generate()}
              )
   end
@@ -39,7 +39,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "change_state", "state" => "muted"}],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -49,13 +49,14 @@ defmodule Tuist.Automations.ActionExecutorTest do
 
   test "dispatches send_slack to SendSlackAction" do
     entity = %{type: :test_case, id: Ecto.UUID.generate()}
+    automation = %{name: "Auto", project_id: 0}
 
-    expect(SendSlackAction, :execute, fn _automation, ^entity, %{"type" => "send_slack"} -> :ok end)
+    expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} -> :ok end)
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "send_slack", "channel" => "C1", "message" => "hi"}],
-               automation(),
+               automation,
                entity
              )
   end
@@ -66,7 +67,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "add_label", "label" => "flaky"}],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -80,7 +81,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "remove_label", "label" => "flaky"}],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -97,7 +98,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -117,7 +118,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "remove_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "enabled"}
                ],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -137,7 +138,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "remove_label", "label" => "flaky"}
                ],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -163,7 +164,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation(),
+               automation_for(test_case),
                entity
              )
 
@@ -179,9 +180,29 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
                ],
-               automation(),
+               %{name: "Auto", project_id: 0},
                %{type: :test_case, id: Ecto.UUID.generate()}
              )
+  end
+
+  test "rejects writes when the test case belongs to another project" do
+    test_case = insert_test_case(is_flaky: false, state: "enabled")
+    other_project = ProjectsFixtures.project_fixture()
+    reject(&SendSlackAction.execute/3)
+
+    assert {:error, :not_found} =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "flaky"},
+                 %{"type" => "change_state", "state" => "muted"},
+                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
+               ],
+               %{name: "Auto", project_id: other_project.id},
+               %{type: :test_case, id: test_case.id}
+             )
+
+    assert {:ok, %{is_flaky: false, state: "enabled"}} = Tests.get_test_case_by_id(test_case.id)
+    assert event_types(test_case.id) == []
   end
 
   test "no-ops add_label / remove_label with non-flaky labels" do
@@ -193,7 +214,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "slow"},
                  %{"type" => "remove_label", "label" => "slow"}
                ],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -208,7 +229,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "fly_to_moon"}],
-               automation(),
+               automation_for(test_case),
                %{type: :test_case, id: test_case.id}
              )
 

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -17,7 +17,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     test_case
   end
 
-  defp automation_for(%{project_id: project_id}), do: %{name: "Auto", project_id: project_id}
+  defp automation, do: %{name: "Auto", project_id: 1}
 
   defp event_types(test_case_id) do
     {events, _meta} = Tests.list_test_case_events(test_case_id)
@@ -28,7 +28,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [],
-               %{name: "Auto", project_id: 0},
+               automation(),
                %{type: :test_case, id: Ecto.UUID.generate()}
              )
   end
@@ -39,7 +39,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "change_state", "state" => "muted"}],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -49,14 +49,13 @@ defmodule Tuist.Automations.ActionExecutorTest do
 
   test "dispatches send_slack to SendSlackAction" do
     entity = %{type: :test_case, id: Ecto.UUID.generate()}
-    automation = %{name: "Auto", project_id: 0}
 
-    expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} -> :ok end)
+    expect(SendSlackAction, :execute, fn _automation, ^entity, %{"type" => "send_slack"} -> :ok end)
 
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "send_slack", "channel" => "C1", "message" => "hi"}],
-               automation,
+               automation(),
                entity
              )
   end
@@ -67,7 +66,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "add_label", "label" => "flaky"}],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -81,7 +80,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "remove_label", "label" => "flaky"}],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -98,7 +97,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -118,7 +117,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "remove_label", "label" => "flaky"},
                  %{"type" => "change_state", "state" => "enabled"}
                ],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -138,7 +137,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "remove_label", "label" => "flaky"}
                ],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -164,7 +163,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"},
                  %{"type" => "change_state", "state" => "muted"}
                ],
-               automation_for(test_case),
+               automation(),
                entity
              )
 
@@ -180,29 +179,9 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "flaky"},
                  %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
                ],
-               %{name: "Auto", project_id: 0},
+               automation(),
                %{type: :test_case, id: Ecto.UUID.generate()}
              )
-  end
-
-  test "rejects writes when the test case belongs to another project" do
-    test_case = insert_test_case(is_flaky: false, state: "enabled")
-    other_project = ProjectsFixtures.project_fixture()
-    reject(&SendSlackAction.execute/3)
-
-    assert {:error, :not_found} =
-             ActionExecutor.execute_actions(
-               [
-                 %{"type" => "add_label", "label" => "flaky"},
-                 %{"type" => "change_state", "state" => "muted"},
-                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
-               ],
-               %{name: "Auto", project_id: other_project.id},
-               %{type: :test_case, id: test_case.id}
-             )
-
-    assert {:ok, %{is_flaky: false, state: "enabled"}} = Tests.get_test_case_by_id(test_case.id)
-    assert event_types(test_case.id) == []
   end
 
   test "no-ops add_label / remove_label with non-flaky labels" do
@@ -214,7 +193,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
                  %{"type" => "add_label", "label" => "slow"},
                  %{"type" => "remove_label", "label" => "slow"}
                ],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 
@@ -229,7 +208,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
     assert :ok =
              ActionExecutor.execute_actions(
                [%{"type" => "fly_to_moon"}],
-               automation_for(test_case),
+               automation(),
                %{type: :test_case, id: test_case.id}
              )
 

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -3,10 +3,8 @@ defmodule Tuist.Automations.ActionExecutorTest do
   use Mimic
 
   alias Tuist.Automations.ActionExecutor
-  alias Tuist.Automations.Actions.AddLabelAction
-  alias Tuist.Automations.Actions.ChangeStateAction
-  alias Tuist.Automations.Actions.RemoveLabelAction
   alias Tuist.Automations.Actions.SendSlackAction
+  alias Tuist.Tests
 
   setup do
     entity = %{type: :test_case, id: Ecto.UUID.generate()}
@@ -14,20 +12,26 @@ defmodule Tuist.Automations.ActionExecutorTest do
   end
 
   test "no-ops on empty action list", %{automation: automation, entity: entity} do
+    reject(&Tests.update_test_case/2)
     assert :ok = ActionExecutor.execute_actions([], automation, entity)
   end
 
-  test "dispatches change_state to ChangeStateAction", %{automation: automation, entity: entity} do
-    expect(ChangeStateAction, :execute, fn ^entity, %{"state" => "muted"} -> :ok end)
+  test "applies change_state through a single update_test_case call", %{
+    automation: automation,
+    entity: %{id: id} = entity
+  } do
+    expect(Tests, :update_test_case, fn ^id, %{state: "muted"} -> {:ok, %{}} end)
 
-    ActionExecutor.execute_actions(
-      [%{"type" => "change_state", "state" => "muted"}],
-      automation,
-      entity
-    )
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [%{"type" => "change_state", "state" => "muted"}],
+               automation,
+               entity
+             )
   end
 
   test "dispatches send_slack to SendSlackAction", %{automation: automation, entity: entity} do
+    reject(&Tests.update_test_case/2)
     expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} -> :ok end)
 
     ActionExecutor.execute_actions(
@@ -37,32 +41,151 @@ defmodule Tuist.Automations.ActionExecutorTest do
     )
   end
 
-  test "dispatches add_label to AddLabelAction", %{automation: automation, entity: entity} do
-    expect(AddLabelAction, :execute, fn ^entity, %{"label" => "flaky"} -> :ok end)
-    ActionExecutor.execute_actions([%{"type" => "add_label", "label" => "flaky"}], automation, entity)
+  test "applies add_label flaky as is_flaky: true", %{automation: automation, entity: %{id: id} = entity} do
+    expect(Tests, :update_test_case, fn ^id, %{is_flaky: true} -> {:ok, %{}} end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [%{"type" => "add_label", "label" => "flaky"}],
+               automation,
+               entity
+             )
   end
 
-  test "dispatches remove_label to RemoveLabelAction", %{automation: automation, entity: entity} do
-    expect(RemoveLabelAction, :execute, fn ^entity, %{"label" => "flaky"} -> :ok end)
-    ActionExecutor.execute_actions([%{"type" => "remove_label", "label" => "flaky"}], automation, entity)
+  test "applies remove_label flaky as is_flaky: false", %{automation: automation, entity: %{id: id} = entity} do
+    expect(Tests, :update_test_case, fn ^id, %{is_flaky: false} -> {:ok, %{}} end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [%{"type" => "remove_label", "label" => "flaky"}],
+               automation,
+               entity
+             )
   end
 
-  test "executes multiple actions in order", %{automation: automation, entity: entity} do
-    expect(AddLabelAction, :execute, fn ^entity, %{"label" => "flaky"} -> :ok end)
-    expect(ChangeStateAction, :execute, fn ^entity, %{"state" => "muted"} -> :ok end)
+  test "coalesces add_label flaky and change_state into one update_test_case call", %{
+    automation: automation,
+    entity: %{id: id} = entity
+  } do
+    expect(Tests, :update_test_case, fn ^id, attrs ->
+      assert attrs == %{is_flaky: true, state: "muted"}
+      {:ok, %{}}
+    end)
 
-    ActionExecutor.execute_actions(
-      [%{"type" => "add_label", "label" => "flaky"}, %{"type" => "change_state", "state" => "muted"}],
-      automation,
-      entity
-    )
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "flaky"},
+                 %{"type" => "change_state", "state" => "muted"}
+               ],
+               automation,
+               entity
+             )
+  end
+
+  test "coalesces recovery actions (remove_label flaky + change_state enabled) into one call", %{
+    automation: automation,
+    entity: %{id: id} = entity
+  } do
+    expect(Tests, :update_test_case, fn ^id, attrs ->
+      assert attrs == %{is_flaky: false, state: "enabled"}
+      {:ok, %{}}
+    end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "remove_label", "label" => "flaky"},
+                 %{"type" => "change_state", "state" => "enabled"}
+               ],
+               automation,
+               entity
+             )
+  end
+
+  test "later attribute actions override earlier ones in the merged update", %{
+    automation: automation,
+    entity: %{id: id} = entity
+  } do
+    expect(Tests, :update_test_case, fn ^id, attrs ->
+      assert attrs == %{is_flaky: false}
+      {:ok, %{}}
+    end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "flaky"},
+                 %{"type" => "remove_label", "label" => "flaky"}
+               ],
+               automation,
+               entity
+             )
+  end
+
+  test "runs slack action after the merged attribute update", %{
+    automation: automation,
+    entity: %{id: id} = entity
+  } do
+    test_pid = self()
+
+    expect(Tests, :update_test_case, fn ^id, %{is_flaky: true, state: "muted"} ->
+      send(test_pid, :update_called)
+      {:ok, %{}}
+    end)
+
+    expect(SendSlackAction, :execute, fn ^automation, ^entity, %{"type" => "send_slack"} ->
+      send(test_pid, :slack_called)
+      :ok
+    end)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "flaky"},
+                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"},
+                 %{"type" => "change_state", "state" => "muted"}
+               ],
+               automation,
+               entity
+             )
+
+    assert_received :update_called
+    assert_received :slack_called
+  end
+
+  test "halts and returns error when update_test_case fails", %{automation: automation, entity: %{id: id} = entity} do
+    expect(Tests, :update_test_case, fn ^id, _attrs -> {:error, :not_found} end)
+    reject(&SendSlackAction.execute/3)
+
+    assert {:error, :not_found} =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "flaky"},
+                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
+               ],
+               automation,
+               entity
+             )
+  end
+
+  test "no-ops add_label / remove_label with non-flaky labels", %{automation: automation, entity: entity} do
+    reject(&Tests.update_test_case/2)
+
+    assert :ok =
+             ActionExecutor.execute_actions(
+               [
+                 %{"type" => "add_label", "label" => "slow"},
+                 %{"type" => "remove_label", "label" => "slow"}
+               ],
+               automation,
+               entity
+             )
   end
 
   test "silently skips unknown action types", %{automation: automation, entity: entity} do
-    reject(&ChangeStateAction.execute/2)
+    reject(&Tests.update_test_case/2)
     reject(&SendSlackAction.execute/3)
-    reject(&AddLabelAction.execute/2)
-    reject(&RemoveLabelAction.execute/2)
 
     assert :ok =
              ActionExecutor.execute_actions(

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -2,7 +2,7 @@ defmodule Tuist.Automations.ActionExecutorTest do
   # Integration test: drives ActionExecutor through the real
   # Tests.update_test_case down to ClickHouse so the merged-attrs path
   # (the fix for the read-modify-write race) is verified end-to-end.
-  use TuistTestSupport.Cases.DataCase, async: false
+  use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
   alias Tuist.Automations.ActionExecutor

--- a/server/test/tuist/automations/action_executor_test.exs
+++ b/server/test/tuist/automations/action_executor_test.exs
@@ -1,7 +1,4 @@
 defmodule Tuist.Automations.ActionExecutorTest do
-  # Integration test: drives ActionExecutor through the real
-  # Tests.update_test_case down to ClickHouse so the merged-attrs path
-  # (the fix for the read-modify-write race) is verified end-to-end.
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 


### PR DESCRIPTION
## Summary

- Sequential `Tests.update_test_case/2` calls each ran a read-modify-write against ClickHouse, so back-to-back automation actions on the same test case (e.g. `add_label flaky` then `change_state muted`) could see a stale read and silently revert a field set by the previous action — leaving the audit log without the corresponding `marked_flaky`/`muted` event.
- Recovery actions then could not emit `unmarked_flaky` because the events log no longer recorded the test as flaky, so dashboards (event-derived count) and the quarantined-tests list (state-derived) drifted apart.
- `ActionExecutor` now coalesces all attribute-mutating actions (`add_label`/`remove_label flaky`, `change_state`) for a single `execute_actions/3` call into one merged `update_test_case` call. Non-attribute actions (`send_slack`, no-op labels, unknown types) keep their sequential semantics and run after the merged write.

## Why

`update_test_case` re-inserts the full row from a ClickHouse read each time. With two sequential calls, the second read may not observe the first insert (separate connection pool, eventual visibility), so it pulls a stale snapshot and merges only its own field — wiping the previous action's change. One merged write per dispatch eliminates the race entirely.

## Test plan

- [ ] `mix test test/tuist/automations/action_executor_test.exs` (12 tests, all passing locally)
- [ ] `mix test test/tuist/automations/workers/alert_evaluation_worker_test.exs test/tuist/automations/actions/` (23 tests, all passing locally)
- [ ] Existing merged-attrs coverage in `test/tuist/tests_test.exs` ("creates multiple events when both is_flaky and state change") continues to verify the `Tests.update_test_case` end of the path

## Reviewer notes

- Already-corrupted state in projects affected before this fix (test cases stuck as `marked_flaky` in events while `is_flaky=false` on the row, plus the related dashboard 7-vs-1 mismatch) is **not** healed by this PR — the prevention path is fixed, but historical drift needs a separate one-off reconciliation.
- The per-action handler modules (`AddLabelAction`, `RemoveLabelAction`, `ChangeStateAction`) are unchanged so their direct callers and integration tests still work; the executor just no longer routes through them for attribute mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)