### PR TITLE
fix(server): handle HTML comments in markdown conversion

### DIFF
--- a/server/lib/tuist_web/utilities/html_to_markdown.ex
+++ b/server/lib/tuist_web/utilities/html_to_markdown.ex
@@ -71,6 +71,8 @@ defmodule TuistWeb.Utilities.HtmlToMarkdown do
     {tag, normalized_attrs, absolutize_urls(children, base_uri)}
   end
 
+  defp absolutize_urls(node, _base_uri), do: node
+
   defp maybe_absolute_url(nil, _base_uri), do: nil
   defp maybe_absolute_url("", _base_uri), do: ""
 

--- a/server/test/tuist_web/utilities/html_to_markdown_test.exs
+++ b/server/test/tuist_web/utilities/html_to_markdown_test.exs
@@ -77,4 +77,29 @@ defmodule TuistWeb.Utilities.HtmlToMarkdownTest do
 
     assert markdown == "[Broken link](http://[bad)"
   end
+
+  test "ignores HTML comments while absolutizing URLs" do
+    html = """
+    <html>
+      <head>
+        <title>Customers</title>
+      </head>
+      <body>
+        <main>
+          <!--<section><a href="/hidden">Hidden</a></section>-->
+          <p><a href="/customers/example-studios">Read the story</a>.</p>
+        </main>
+      </body>
+    </html>
+    """
+
+    markdown = HtmlToMarkdown.convert(html, request_url: "https://tuist.dev/customers")
+
+    assert markdown ==
+             String.trim_trailing("""
+             # Customers
+
+             [Read the story](https://tuist.dev/customers/example-studios).
+             """)
+  end
 end


### PR DESCRIPTION
## Summary

Fixes `TUIST-E3`, a production `FunctionClauseError` raised while negotiating a markdown response for `GET /customers`.

The `/customers` LiveView includes an HTML comment inside the selected `<main>` content. When an agent requests `Accept: text/markdown`, `MarkdownNegotiationPlug` renders the HTML response and sends it through `HtmlToMarkdown.convert/2`. That converter walks the Floki parse tree to turn relative `href`, `src`, and `poster` values into absolute URLs before handing the HTML to `html2markdown`.

The tree walker only handled lists, text nodes, and three-element HTML element tuples. Floki represents comments as a different node shape, so the walker crashed when it reached the commented section with a request URL present.

## How

- Adds a catch-all `absolutize_urls/2` clause that preserves unsupported or metadata-like Floki nodes instead of raising.
- Keeps the existing behavior for lists, text, and HTML elements, including URL absolutization for `href`, `src`, and `poster` attributes.
- Adds a regression test with an HTML comment inside `<main>` and a relative customer link to verify comments are ignored while URLs are still absolutized.

## Testing

- `MIX_ENV=test mix run --no-start -e 'ExUnit.start(); Code.require_file("test/tuist_web/utilities/html_to_markdown_test.exs")'`
- `mix format lib/tuist_web/utilities/html_to_markdown.ex test/tuist_web/utilities/html_to_markdown_test.exs`
- `git diff --check`
