### PR TITLE
fix(cli): disable HAR recording for cache daemon

### DIFF
--- a/cli/Sources/TuistHAR/HAR.swift
+++ b/cli/Sources/TuistHAR/HAR.swift
@@ -413,10 +413,11 @@ public enum HAR { // swiftlint:disable:this type_body_length
     /// Encodes a HAR log to JSON data.
     public static func encode(_ log: Log) throws -> Data {
         let encoder = JSONEncoder()
+        let formatter = dateFormatter
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .custom { date, encoder in
             var container = encoder.singleValueContainer()
-            try container.encode(dateFormatter.string(from: date))
+            try container.encode(formatter.string(from: date))
         }
         return try encoder.encode(["log": log])
     }
@@ -424,10 +425,11 @@ public enum HAR { // swiftlint:disable:this type_body_length
     /// Decodes a HAR log from JSON data.
     public static func decode(from data: Data) throws -> Log {
         let decoder = JSONDecoder()
+        let formatter = dateFormatter
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
-            if let date = dateFormatter.date(from: dateString) {
+            if let date = formatter.date(from: dateString) {
                 return date
             }
             let fallbackFormatter = ISO8601DateFormatter()

--- a/cli/Sources/TuistKit/Commands/Cache/CacheStartCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheStartCommand.swift
@@ -2,7 +2,9 @@ import ArgumentParser
 import Path
 import TuistSupport
 
-public struct CacheStartCommand: AsyncParsableCommand {
+public struct CacheStartCommand: AsyncParsableCommand, HARRecordingCommand {
+    public var shouldRecordHAR: Bool { false }
+
     public init() {}
     public static let configuration = CommandConfiguration(
         commandName: "cache-start",

--- a/cli/Sources/TuistSupport/HARRecordingCommand.swift
+++ b/cli/Sources/TuistSupport/HARRecordingCommand.swift
@@ -1,0 +1,3 @@
+public protocol HARRecordingCommand {
+    var shouldRecordHAR: Bool { get }
+}

--- a/cli/Sources/tuist/Dependencies.swift
+++ b/cli/Sources/tuist/Dependencies.swift
@@ -9,7 +9,6 @@ import TuistServer
 
 #if os(macOS)
     import TuistExtension
-    import TuistHAR
     import TuistKit
     import TuistLoader
     import TuistSupport
@@ -80,26 +79,23 @@ func initNoora(jsonThroughNoora: Bool = false) -> Noora {
         sessionController.scheduleMaintenance(stateDirectory: Environment.current.stateDirectory)
 
         let logger = Logger(label: "dev.tuist.cli", factory: loggerHandler)
-        let harRecorder = HARRecorder(filePath: sessionPaths.networkFilePath)
 
         try await withAdditionalMiddlewares {
             try await withInitializedManifestLoader {
                 try await ServerAuthenticationConfig.$current.withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
                     try await Noora.$current.withValue(initNoora()) {
                         try await Logger.$current.withValue(logger) {
-                            try await HARRecorder.$current.withValue(harRecorder) {
-                                try await ServerCredentialsStore.$current
-                                    .withValue(ServerCredentialsStore(backend: .fileSystem)) {
-                                        try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
-                                            try await Extension.$hashCacheService
-                                                .withValue(HashCacheCommandService()) {
-                                                    try await withCacheService {
-                                                        try await action(sessionPaths)
-                                                    }
+                            try await ServerCredentialsStore.$current
+                                .withValue(ServerCredentialsStore(backend: .fileSystem)) {
+                                    try await CachedValueStore.$current.withValue(CachedValueStore(backend: .fileSystem)) {
+                                        try await Extension.$hashCacheService
+                                            .withValue(HashCacheCommandService()) {
+                                                try await withCacheService {
+                                                    try await action(sessionPaths)
                                                 }
-                                        }
+                                            }
                                     }
-                            }
+                                }
                         }
                     }
                 }

--- a/cli/Sources/tuist/TuistCLI.swift
+++ b/cli/Sources/tuist/TuistCLI.swift
@@ -8,7 +8,8 @@ private enum TuistCLI {
         try await initDependencies { sessionPaths in
             try await TuistCommand.main(
                 logFilePath: sessionPaths.logFilePath,
-                sessionDirectory: sessionPaths.sessionDirectory
+                sessionDirectory: sessionPaths.sessionDirectory,
+                networkFilePath: sessionPaths.networkFilePath
             )
         }
     }

--- a/cli/Sources/tuist/TuistCommand.swift
+++ b/cli/Sources/tuist/TuistCommand.swift
@@ -26,6 +26,7 @@ import TuistVersionCommand
 
 #if os(macOS)
     import TuistCore
+    import TuistHAR
     import TuistHTTP
     import TuistKit
     import TuistLoader
@@ -143,6 +144,7 @@ public struct TuistCommand: AsyncParsableCommand {
     public static func main(
         logFilePath: AbsolutePath,
         sessionDirectory: AbsolutePath,
+        networkFilePath: AbsolutePath,
         _ arguments: [String]? = nil,
         parseAsRoot: ((_ arguments: [String]?) throws -> ParsableCommand) = Self.parseAsRoot
     ) async throws {
@@ -164,6 +166,7 @@ public struct TuistCommand: AsyncParsableCommand {
                 let config = try await ConfigLoader().loadConfig(path: path)
                 let serverURL = try ServerEnvironmentService().url(configServerURL: config.url)
                 let command = try parseAsRoot(processedArguments)
+                let shouldRecordHAR = (command as? HARRecordingCommand)?.shouldRecordHAR ?? true
 
                 executeCommand = {
                     logFilePathDisplayStrategy =
@@ -180,12 +183,17 @@ public struct TuistCommand: AsyncParsableCommand {
                         && processedArguments.first != "analytics-upload"
                     let optionalAuthentication = config.project.optionalAuthentication
                     let runTrackableCommand = {
-                        try await trackableCommand.run(
-                            fullHandle: config.fullHandle,
-                            serverURL: serverURL,
-                            shouldTrackAnalytics: shouldTrackAnalytics,
-                            optionalAuthentication: optionalAuthentication
-                        )
+                        try await withHARRecorder(
+                            networkFilePath: networkFilePath,
+                            shouldRecordHAR: shouldRecordHAR
+                        ) {
+                            try await trackableCommand.run(
+                                fullHandle: config.fullHandle,
+                                serverURL: serverURL,
+                                shouldTrackAnalytics: shouldTrackAnalytics,
+                                optionalAuthentication: optionalAuthentication
+                            )
+                        }
                     }
                     if let nooraReadyCommand = command as? NooraReadyCommand {
                         let jsonThroughNoora = nooraReadyCommand.jsonThroughNoora
@@ -201,7 +209,12 @@ public struct TuistCommand: AsyncParsableCommand {
             } catch {
                 parsingError = error
                 executeCommand = {
-                    try await executeTask(with: processedArguments)
+                    try await withHARRecorder(
+                        networkFilePath: networkFilePath,
+                        shouldRecordHAR: true
+                    ) {
+                        try await executeTask(with: processedArguments)
+                    }
                 }
             }
 
@@ -350,6 +363,18 @@ public struct TuistCommand: AsyncParsableCommand {
                 arguments: processedArguments,
                 tuistBinaryPath: processArguments()!.first!
             )
+        }
+
+        private static func withHARRecorder(
+            networkFilePath: AbsolutePath,
+            shouldRecordHAR: Bool,
+            _ action: () async throws -> Void
+        ) async throws {
+            let harRecorder: HARRecorder? =
+                shouldRecordHAR ? HARRecorder(filePath: networkFilePath) : nil
+            try await HARRecorder.$current.withValue(harRecorder) {
+                try await action()
+            }
         }
     #endif
 


### PR DESCRIPTION
## Summary
This PR addresses a high-CPU issue observed in a long-lived `tuist cache-start` process. The sampled process was not spending CPU in Xcode CAS request handling itself. The hot path was Tuist HAR recording: each recorded request caused the daemon session `network.har` to be encoded and persisted again, and that session can live for days when launched by launchd.

The fix makes HAR recording an explicit command capability and has the hidden cache daemon opt out of it. Normal short-lived commands continue to record HAR by default.

## Problem
Tuist creates a per-session `network.har` file to help debug network activity. That makes sense for normal CLI invocations, but `cache-start` is a long-running daemon used by Xcode Compilation Cache. If it inherits the regular session HAR recorder, the HAR file can grow for the lifetime of the daemon and be rewritten repeatedly as requests pass through the process.

The provided CPU sample showed the busy thread in:

`HARRecordingMiddleware.intercept -> HARRecorder.persist() -> HAR.encode(_) -> JSONEncoder.encode`

Most NIO threads were parked in `kevent`, which points away from a CAS proxy busy loop and toward HAR serialization work. The sample also showed heavy formatter churn while encoding HAR date fields.

## Approach
- Added `HARRecordingCommand`, a command-level marker that mirrors the existing command capability pattern used for Noora readiness.
- Updated `CacheStartCommand` to conform to `HARRecordingCommand` and return `shouldRecordHAR == false`.
- Moved HAR recorder installation out of dependency bootstrap and into `TuistCommand`, after the command has been parsed and its HAR preference is known.
- Kept the default as `true` for commands that do not conform, preserving existing HAR recording behavior for regular CLI commands.
- Reused one ISO8601 formatter per HAR encode/decode operation to reduce the formatter churn visible in the sample.

## Why this shape
This avoids command-name string checks in dependency initialization and keeps the policy with the command that owns the behavior. It also gives future long-lived or background commands a clear opt-out point without special-casing them in global bootstrap code.

## Testing
- `git diff --check`
- `tuist generate tuist TuistHAR TuistHARTests TuistKit TuistSupport ProjectDescription --no-open`
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -derivedDataPath .build/DerivedData`

The `xcodebuild` build succeeded. The remaining output was existing warnings unrelated to this change.