### PR TITLE
fix(server): Make GitHub app setup idempotent

### DIFF
--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -1093,6 +1093,25 @@ defmodule Tuist.VCS do
   end
 
   @doc """
+  Creates a GitHub app installation or returns the existing installation for the account.
+  """
+  def create_or_get_github_app_installation(%{installation_id: installation_id, account_id: account_id} = attrs) do
+    installation_id = to_string(installation_id)
+    attrs = Map.put(attrs, :installation_id, installation_id)
+
+    case Repo.get_by(GitHubAppInstallation, installation_id: installation_id) do
+      nil ->
+        create_github_app_installation(attrs)
+
+      %GitHubAppInstallation{account_id: ^account_id} = github_app_installation ->
+        {:ok, github_app_installation}
+
+      %GitHubAppInstallation{} ->
+        {:error, :installation_already_connected}
+    end
+  end
+
+  @doc """
   Gets repositories for a GitHub app installation.
   """
   def get_github_app_installation_repositories(%GitHubAppInstallation{installation_id: installation_id}) do

--- a/server/lib/tuist_web/controllers/github_app_setup_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_setup_controller.ex
@@ -18,7 +18,7 @@ defmodule TuistWeb.GitHubAppSetupController do
          {:ok, account_id} <- extract_account_id(params),
          {:ok, account} <- Accounts.get_account_by_id(account_id),
          {:ok, _github_app_installation} <-
-           VCS.create_github_app_installation(%{account_id: account.id, installation_id: installation_id}) do
+           VCS.create_or_get_github_app_installation(%{account_id: account.id, installation_id: installation_id}) do
       redirect(conn, to: ~p"/#{account.name}/integrations")
     else
       {:error, :missing_installation_id} ->
@@ -29,6 +29,9 @@ defmodule TuistWeb.GitHubAppSetupController do
 
       {:error, :invalid_state_token} ->
         raise BadRequestError, dgettext("dashboard", "Invalid installation request. Please try again.")
+
+      {:error, :installation_already_connected} ->
+        raise BadRequestError, dgettext("dashboard", "This GitHub app installation is already connected.")
     end
   end
 

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3010,6 +3010,77 @@ defmodule Tuist.VCSTest do
     end
   end
 
+  describe "create_or_get_github_app_installation/1" do
+    test "creates a GitHub app installation when it does not exist" do
+      # Given
+      account = AccountsFixtures.account_fixture()
+      installation_id = "54321"
+
+      # When
+      result =
+        VCS.create_or_get_github_app_installation(%{
+          account_id: account.id,
+          installation_id: installation_id
+        })
+
+      # Then
+      assert {:ok, github_app_installation} = result
+      assert github_app_installation.account_id == account.id
+      assert github_app_installation.installation_id == installation_id
+    end
+
+    test "returns the existing GitHub app installation for the same account" do
+      # Given
+      account = AccountsFixtures.account_fixture()
+      installation_id = "12345"
+
+      {:ok, github_app_installation} =
+        VCS.create_github_app_installation(%{
+          account_id: account.id,
+          installation_id: installation_id
+        })
+
+      # When
+      result =
+        VCS.create_or_get_github_app_installation(%{
+          account_id: account.id,
+          installation_id: installation_id
+        })
+
+      # Then
+      assert {:ok, existing_installation} = result
+      assert existing_installation.id == github_app_installation.id
+      assert existing_installation.account_id == account.id
+      assert existing_installation.installation_id == installation_id
+    end
+
+    test "does not reconnect an existing GitHub app installation to a different account" do
+      # Given
+      connected_account = AccountsFixtures.account_fixture()
+      other_account = AccountsFixtures.account_fixture()
+      installation_id = "12345"
+
+      {:ok, github_app_installation} =
+        VCS.create_github_app_installation(%{
+          account_id: connected_account.id,
+          installation_id: installation_id
+        })
+
+      # When
+      result =
+        VCS.create_or_get_github_app_installation(%{
+          account_id: other_account.id,
+          installation_id: installation_id
+        })
+
+      # Then
+      assert result == {:error, :installation_already_connected}
+      assert {:ok, existing_installation} = VCS.get_github_app_installation_by_installation_id(installation_id)
+      assert existing_installation.id == github_app_installation.id
+      assert existing_installation.account_id == connected_account.id
+    end
+  end
+
   describe "get_github_app_installation_repositories/1" do
     test "returns all repositories from single page with caching" do
       # Given

--- a/server/test/tuist_web/controllers/github_app_setup_controller_test.exs
+++ b/server/test/tuist_web/controllers/github_app_setup_controller_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.GitHubAppSetupControllerTest do
   alias Tuist.Accounts
   alias Tuist.VCS
   alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.VCSFixtures
   alias TuistWeb.Errors.BadRequestError
 
   describe "GET /integrations/github/setup" do
@@ -30,6 +31,34 @@ defmodule TuistWeb.GitHubAppSetupControllerTest do
         })
 
       assert redirected_to(conn) == "/#{account.name}/integrations"
+    end
+
+    test "returns BadRequestError when installation is already connected to a different account", %{conn: conn} do
+      connected_account = AccountsFixtures.account_fixture()
+      selected_account = AccountsFixtures.account_fixture()
+      installation_id = "12345"
+      state_token = "valid_token"
+
+      VCSFixtures.github_app_installation_fixture(
+        account_id: connected_account.id,
+        installation_id: installation_id
+      )
+
+      expect(VCS, :verify_github_state_token, fn ^state_token ->
+        {:ok, selected_account.id}
+      end)
+
+      expect(Accounts, :get_account_by_id, fn account_id ->
+        assert account_id == selected_account.id
+        {:ok, selected_account}
+      end)
+
+      assert_raise BadRequestError, "This GitHub app installation is already connected.", fn ->
+        get(conn, ~p"/integrations/github/setup", %{
+          "installation_id" => installation_id,
+          "state" => state_token
+        })
+      end
     end
 
     test "raises BadRequestError when installation_id is missing", %{conn: conn} do


### PR DESCRIPTION
## Summary

Makes the GitHub App setup callback idempotent for an installation that is already connected to the same Tuist account. This lets a retried or repeated setup callback complete without failing on the unique `installation_id` constraint.

If the installation is already connected to a different Tuist account, the callback now returns a bad request instead of moving the installation. That keeps cross-account reconciliation as an explicit support/admin action.

## Root Cause

A customer can have the Tuist GitHub App installed in GitHub while the Tuist integrations page still shows "Install GitHub App" if the setup callback did not persist the installation for the selected Tuist account, or if the callback is replayed for an installation Tuist already knows about. The previous create-only path was not idempotent.

## Changes

- Added `VCS.create_or_get_github_app_installation/1`.
- Updated the GitHub setup controller to use the idempotent create-or-get path.
- Added coverage for new installs, duplicate callbacks for the same account, and callbacks for installations already connected elsewhere.

## Validation

- `mix test test/tuist_web/controllers/github_app_setup_controller_test.exs test/tuist/vcs_test.exs:3011 test/tuist/vcs_test.exs:3032 test/tuist/vcs_test.exs:3054`
- `git diff --check`