### PR TITLE
fix(app): recover from stale iOS auth tokens

### DIFF
--- a/app/Project.swift
+++ b/app/Project.swift
@@ -224,6 +224,7 @@ let project = Project(
             sources: ["Sources/TuistErrorHandling/**"],
             dependencies: [
                 .project(target: "TuistServer", path: "../"),
+                .project(target: "TuistLogging", path: "../"),
                 .project(target: "TuistHTTP", path: "../"),
                 .external(name: "OpenAPIRuntime"),
             ]
@@ -248,6 +249,8 @@ let project = Project(
             sources: ["Sources/TuistAuthentication/**"],
             dependencies: [
                 .project(target: "TuistServer", path: "../"),
+                .project(target: "TuistHTTP", path: "../"),
+                .project(target: "TuistLogging", path: "../"),
                 .target(name: "TuistAppStorage"),
             ]
         ),

--- a/app/Sources/TuistAuthentication/AuthenticationService.swift
+++ b/app/Sources/TuistAuthentication/AuthenticationService.swift
@@ -3,6 +3,8 @@ import CryptoKit
 import Foundation
 import SwiftUI
 import TuistAppStorage
+import TuistHTTP
+import TuistLogging
 import TuistServer
 
 public enum AuthenticationError: LocalizedError {
@@ -54,6 +56,9 @@ public final class AuthenticationService: ObservableObject {
         self.deleteAccountService = deleteAccountService
 
         authenticationState = (try? appStorage.get(AuthenticationStateKey.self)) ?? .loggedOut
+        Logger.current.notice(
+            "Initialized authentication service with state: \(authenticationState.logDescription)"
+        )
 
         startCredentialsListener()
     }
@@ -67,8 +72,14 @@ public final class AuthenticationService: ObservableObject {
             for await credentials in ServerCredentialsStore.current.credentialsChanged {
                 await MainActor.run {
                     do {
+                        Logger.current.notice(
+                            "Received credentials change: hasCredentials=\(credentials != nil)"
+                        )
                         try updateAuthenticationState(with: credentials)
                     } catch {
+                        Logger.current.error(
+                            "Failed to update authentication state from credentials change: \(error.localizedDescription)"
+                        )
                         authenticationState = .loggedOut
                         try? appStorage.set(AuthenticationStateKey.self, value: .loggedOut)
                     }
@@ -81,8 +92,10 @@ public final class AuthenticationService: ObservableObject {
         if let credentials {
             let account = try extractAccount(from: credentials.accessToken)
             authenticationState = .loggedIn(account: account)
+            Logger.current.notice("Authentication state updated to logged in")
         } else {
             authenticationState = .loggedOut
+            Logger.current.notice("Authentication state updated to logged out")
         }
 
         try? appStorage.set(AuthenticationStateKey.self, value: authenticationState)
@@ -101,7 +114,17 @@ public final class AuthenticationService: ObservableObject {
     }
 
     public func signOut() async {
-        try! await ServerCredentialsStore.current.delete(serverURL: serverEnvironmentService.url())
+        Logger.current.notice(
+            "Signing out and deleting credentials for server: \(serverEnvironmentService.url().absoluteString)"
+        )
+        do {
+            try await ServerCredentialsStore.current.delete(serverURL: serverEnvironmentService.url())
+        } catch {
+            Logger.current.error(
+                "Failed to delete credentials when signing out: \(error.localizedDescription)"
+            )
+        }
+
         await MainActor.run {
             try? updateAuthenticationState(with: nil)
         }
@@ -149,6 +172,7 @@ public final class AuthenticationService: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addRequestIDHeader()
         ClientFeatureFlags.addHeader(to: &request)
 
         let parameters = [
@@ -168,6 +192,13 @@ public final class AuthenticationService: ObservableObject {
         if httpResponse.statusCode == 200 {
             try await handleTokenResponse(data)
         } else {
+            Logger.current.error(
+                """
+                Email and password sign in token exchange failed with status code: \(httpResponse.statusCode), \
+                requestID: \(request.requestID ?? "unknown"), \
+                responseRequestID: \(httpResponse.requestID ?? "unknown")
+                """
+            )
             throw AuthenticationError.tokenExchangeFailed(statusCode: httpResponse.statusCode)
         }
     }
@@ -181,6 +212,7 @@ public final class AuthenticationService: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addRequestIDHeader()
         ClientFeatureFlags.addHeader(to: &request)
 
         let parameters = [
@@ -200,6 +232,13 @@ public final class AuthenticationService: ObservableObject {
         if httpResponse.statusCode == 200 {
             try await handleTokenResponse(data)
         } else {
+            Logger.current.error(
+                """
+                Apple sign in token exchange failed with status code: \(httpResponse.statusCode), \
+                requestID: \(request.requestID ?? "unknown"), \
+                responseRequestID: \(httpResponse.requestID ?? "unknown")
+                """
+            )
             throw AuthenticationError.tokenExchangeFailed(statusCode: httpResponse.statusCode)
         }
     }
@@ -292,6 +331,7 @@ public final class AuthenticationService: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.addRequestIDHeader()
         ClientFeatureFlags.addHeader(to: &request)
 
         let parameters = [
@@ -317,6 +357,13 @@ public final class AuthenticationService: ObservableObject {
         if httpResponse.statusCode == 200 {
             try await handleTokenResponse(data)
         } else {
+            Logger.current.error(
+                """
+                OAuth token exchange failed with status code: \(httpResponse.statusCode), \
+                requestID: \(request.requestID ?? "unknown"), \
+                responseRequestID: \(httpResponse.requestID ?? "unknown")
+                """
+            )
             throw AuthenticationError.tokenExchangeFailed(statusCode: httpResponse.statusCode)
         }
     }
@@ -339,6 +386,18 @@ public final class AuthenticationService: ObservableObject {
             ),
             serverURL: serverEnvironmentService.url()
         )
+        Logger.current.notice("Stored authentication credentials from token response")
+    }
+}
+
+extension AuthenticationState {
+    fileprivate var logDescription: String {
+        switch self {
+        case .loggedIn:
+            return "loggedIn"
+        case .loggedOut:
+            return "loggedOut"
+        }
     }
 }
 

--- a/app/Sources/TuistErrorHandling/ErrorHandling.swift
+++ b/app/Sources/TuistErrorHandling/ErrorHandling.swift
@@ -1,6 +1,7 @@
 import OpenAPIRuntime
 import SwiftUI
 import TuistHTTP
+import TuistLogging
 import TuistServer
 
 struct ErrorAlert: Identifiable {
@@ -16,6 +17,9 @@ public final class ErrorHandling: ObservableObject {
     public func handle(error: Error) {
         if let clientError = error as? ClientError {
             if clientError.underlyingError is ClientAuthenticationError {
+                Logger.current.error(
+                    "Client authentication error received. Deleting stored credentials. Error: \(clientError.underlyingError.localizedDescription)"
+                )
                 Task {
                     try await ServerCredentialsStore.current.delete(
                         serverURL: ServerEnvironmentService().url()
@@ -23,9 +27,13 @@ public final class ErrorHandling: ObservableObject {
                 }
                 return
             }
+            Logger.current.error(
+                "Client error received: \(clientError.underlyingError.localizedDescription)"
+            )
             currentAlert = ErrorAlert(message: clientError.underlyingError.localizedDescription)
             return
         } else {
+            Logger.current.error("Error received: \(error.localizedDescription)")
             currentAlert = ErrorAlert(message: error.localizedDescription)
         }
     }

--- a/cli/Sources/TuistHTTP/RequestIDHeader.swift
+++ b/cli/Sources/TuistHTTP/RequestIDHeader.swift
@@ -1,0 +1,38 @@
+import Foundation
+import HTTPTypes
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+public enum RequestIDHeader {
+    public static let name = "x-request-id"
+}
+
+extension HTTPRequest {
+    public var requestID: String? {
+        guard let requestIDHeaderName = HTTPField.Name(RequestIDHeader.name) else { return nil }
+        return headerFields[requestIDHeaderName]
+    }
+
+    public mutating func addRequestIDHeader(_ requestID: String = UUID().uuidString) {
+        guard let requestIDHeaderName = HTTPField.Name(RequestIDHeader.name) else { return }
+        headerFields[requestIDHeaderName] = requestID
+    }
+}
+
+extension URLRequest {
+    public var requestID: String? {
+        value(forHTTPHeaderField: RequestIDHeader.name)
+    }
+
+    public mutating func addRequestIDHeader(_ requestID: String = UUID().uuidString) {
+        setValue(requestID, forHTTPHeaderField: RequestIDHeader.name)
+    }
+}
+
+extension HTTPURLResponse {
+    public var requestID: String? {
+        value(forHTTPHeaderField: RequestIDHeader.name)
+    }
+}

--- a/cli/Sources/TuistHTTP/RequestIdMiddleware.swift
+++ b/cli/Sources/TuistHTTP/RequestIdMiddleware.swift
@@ -14,8 +14,7 @@ public struct RequestIdMiddleware: ClientMiddleware {
         next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
     ) async throws -> (HTTPResponse, HTTPBody?) {
         var request = request
-        guard let httpFieldName = HTTPField.Name("x-request-id") else { return try await next(request, body, baseURL) }
-        request.headerFields.append(.init(name: httpFieldName, value: UUID().uuidString))
+        request.addRequestIDHeader()
         return try await next(request, body, baseURL)
     }
 }

--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -1,6 +1,7 @@
 import Foundation
 import HTTPTypes
 import OpenAPIRuntime
+import TuistLogging
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -51,6 +52,19 @@ public struct TuistURLSessionTransport: ClientTransport {
 
         let responseHeaders = buildHTTPFields(from: httpResponse)
         let httpResponseObj = HTTPResponse(status: .init(code: httpResponse.statusCode), headerFields: responseHeaders)
+
+        if httpResponse.statusCode >= 400 {
+            Logger.current.error(
+                """
+                Received HTTP error response. Status: \(httpResponse.statusCode), method: \(request.method.rawValue), \
+                baseURL: \(baseURL.absoluteString), path: \(request.path ?? ""), \
+                requestID: \(request.requestID ?? "unknown"), \
+                responseRequestID: \(httpResponse.requestID ?? "unknown"), \
+                contentType: \(httpResponse.value(forHTTPHeaderField: "content-type") ?? "unknown"), \
+                contentLength: \(httpResponse.value(forHTTPHeaderField: "content-length") ?? "unknown")
+                """
+            )
+        }
 
         let responseBody: HTTPBody? = data.isEmpty ? nil : HTTPBody(data)
 

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -327,6 +327,14 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
             Logger.current.debug("Refreshing authentication token for \(serverURL) if needed")
         #endif
 
+        if forceRefresh, locking {
+            return try await cachedValueStore.getValue(
+                key: forceRefreshLockKey(serverURL: serverURL)
+            ) {
+                try await executeRefresh(serverURL: serverURL, forceRefresh: true)
+            }
+        }
+
         let fetchActionResult = { () async throws -> AuthenticationToken? in
             switch try await tokenStatus(serverURL: serverURL, forceRefresh: false) {
             case let .valid(token):
@@ -366,9 +374,9 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                         case .project:
                             return (token, nil as Date?)
                         case let .account(accessToken):
-                            return (token, accessToken.expiryDate)
+                            return (token, cacheExpirationDate(for: accessToken))
                         case let .user(accessToken: accessToken, refreshToken: _):
-                            return (token, accessToken.expiryDate)
+                            return (token, cacheExpirationDate(for: accessToken))
                         }
                     }
                 #else
@@ -394,9 +402,9 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                     case .project:
                         return (token, nil as Date?)
                     case let .account(accessToken):
-                        return (token, accessToken.expiryDate)
+                        return (token, cacheExpirationDate(for: accessToken))
                     case let .user(accessToken: accessToken, refreshToken: _):
-                        return (token, accessToken.expiryDate)
+                        return (token, cacheExpirationDate(for: accessToken))
                     }
                 }
             #else
@@ -540,7 +548,7 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                 upToDateToken = token
             case let .account(accessToken):
                 upToDateToken = token
-                expiresAt = accessToken.expiryDate
+                expiresAt = cacheExpirationDate(for: accessToken)
             case let .user(
                 accessToken, refreshToken
             ):
@@ -571,18 +579,18 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                     #if canImport(TuistSupport)
                         Logger.current.debug("Access token refreshed for \(serverURL)")
                     #endif
+                    let accessToken = try JWT.parse(tokens.accessToken)
                     upToDateToken = .user(
-                        accessToken: try JWT.parse(tokens.accessToken),
+                        accessToken: accessToken,
                         refreshToken: try JWT.parse(tokens.refreshToken)
                     )
-                    expiresAt = try JWT.parse(tokens.accessToken)
-                        .expiryDate
+                    expiresAt = cacheExpirationDate(for: accessToken)
                 } else {
                     upToDateToken = .user(
                         accessToken: accessToken,
                         refreshToken: refreshToken
                     )
-                    expiresAt = accessToken.expiryDate
+                    expiresAt = cacheExpirationDate(for: accessToken)
                 }
             }
 
@@ -608,6 +616,14 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
         "token_\(serverURL.absoluteString)"
     }
 
+    private func forceRefreshLockKey(serverURL: URL) async throws -> String {
+        guard let token = try await fetchTokenFromStore(serverURL: serverURL) else {
+            return "\(lockKey(serverURL: serverURL))_force_refresh_absent"
+        }
+
+        return "\(lockKey(serverURL: serverURL))_force_refresh_\(stableHash(token.value))"
+    }
+
     private func fetchTokenFromStore(serverURL: URL) async throws -> AuthenticationToken? {
         let credentials: ServerCredentials? = try await ServerCredentialsStore.current.read(
             serverURL: serverURL
@@ -623,6 +639,17 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
                 )
             }
         }
+    }
+
+    private func stableHash(_ value: String) -> String {
+        let hash = value.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+
+    private func cacheExpirationDate(for token: JWT) -> Date {
+        token.expiryDate.addingTimeInterval(-30)
     }
 
     private func environmentToken() async throws -> AuthenticationToken? {

--- a/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
+++ b/cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift
@@ -1,6 +1,5 @@
 import Foundation
 import HTTPTypes
-import Logging
 import OpenAPIRuntime
 import TuistHTTP
 
@@ -59,11 +58,12 @@ struct ServerClientAuthenticationMiddleware: ClientMiddleware {
             }
             throw ClientAuthenticationError.notAuthenticated
         }
-        request.headerFields.append(
-            .init(
-                name: .authorization, value: "Bearer \(token.value)"
-            )
-        )
+        addAuthorizationHeader(to: &request, token: token)
+
         return try await next(request, body, baseURL)
+    }
+
+    private func addAuthorizationHeader(to request: inout HTTPRequest, token: AuthenticationToken) {
+        request.headerFields[.authorization] = "Bearer \(token.value)"
     }
 }

--- a/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift
@@ -328,4 +328,44 @@ struct ServerClientAuthenticationMiddlewareTests {
             }
         })
     }
+
+    @Test func returns_unauthorized_response_without_retrying() async throws {
+        // Given
+        let url = URL(string: "https://test.tuist.dev")!
+        let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/api/projects")
+        let token: AuthenticationToken = .user(
+            accessToken: .test(token: "access-token"),
+            refreshToken: .test(token: "refresh-token")
+        )
+        given(serverAuthenticationController).authenticationToken(
+            serverURL: .value(url),
+            refreshIfNeeded: .value(true)
+        )
+        .willReturn(token)
+
+        var requestCount = 0
+
+        // When
+        let (response, _) = try await subject.intercept(
+            request,
+            body: nil,
+            baseURL: url,
+            operationID: "listProjects"
+        ) { _, _, _ in
+            requestCount += 1
+            return (HTTPResponse(status: .init(code: 401)), nil)
+        }
+
+        // Then
+        #expect(response.status.code == 401)
+        #expect(requestCount == 1)
+        verify(serverAuthenticationController)
+            .refreshToken(
+                serverURL: .any,
+                inBackground: .any,
+                locking: .any,
+                forceInProcessLock: .any
+            )
+            .called(0)
+    }
 }

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -8,6 +8,7 @@ import TuistTesting
 
 @testable import TuistServer
 
+// swiftlint:disable:next type_body_length
 struct ServerAuthenticationControllerTests {
     struct TestError: Error, Equatable {}
 
@@ -354,7 +355,54 @@ struct ServerAuthenticationControllerTests {
     @Test(
         .withMockedEnvironment(),
         .withMockedDependencies()
-    ) func executeRefresh_sets_cache_expiration_based_on_access_token() async throws {
+    ) mutating func force_refresh_refreshes_non_expired_user_token() async throws {
+        let date = Date()
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: refreshAuthTokenService,
+            cachedValueStore: CachedValueStore()
+        )
+        try await Date.$now.withValue({ date }) {
+            // Given
+            let serverURL: URL = .test()
+            let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+            let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(+600), typ: "access")
+            let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+            let refreshedAccessToken = try JWT.make(expiryDate: date.addingTimeInterval(+1200), typ: "access")
+            let refreshedRefreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+7200), typ: "refresh")
+            let storeCredentials: ServerCredentials = .test(
+                accessToken: accessToken.token,
+                refreshToken: refreshToken.token
+            )
+            let refreshedTokens = ServerAuthenticationTokens(
+                accessToken: refreshedAccessToken.token,
+                refreshToken: refreshedRefreshToken.token
+            )
+
+            given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+            given(serverCredentialsStore).store(credentials: .any, serverURL: .value(serverURL)).willReturn()
+            given(refreshAuthTokenService)
+                .refreshTokens(serverURL: .value(serverURL), refreshToken: .value(refreshToken.token))
+                .willReturn(refreshedTokens)
+
+            // When
+            try await subject.refreshToken(
+                serverURL: serverURL,
+                inBackground: false,
+                locking: true,
+                forceInProcessLock: true
+            )
+
+            // Then
+            verify(refreshAuthTokenService)
+                .refreshTokens(serverURL: .value(serverURL), refreshToken: .value(refreshToken.token))
+                .called(1)
+        }
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) func executeRefresh_sets_cache_expiration_before_access_token_expiry() async throws {
         let date = Date(timeIntervalSince1970: TimeInterval(Int(Date().timeIntervalSince1970)))
         try await Date.$now.withValue({ date }) {
             // Given
@@ -375,8 +423,95 @@ struct ServerAuthenticationControllerTests {
 
             // Then
             let expiresAt = try #require(result?.expiresAt)
-            #expect(expiresAt == date.addingTimeInterval(+600))
+            #expect(expiresAt == date.addingTimeInterval(+570))
         }
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func cached_token_expires_before_refresh_buffer_so_long_running_process_refreshes() async throws {
+        let realNow = Date(timeIntervalSince1970: TimeInterval(Int(Date().timeIntervalSince1970)))
+        let firstRequestTime = realNow.addingTimeInterval(-20)
+        let accessTokenExpiryDate = realNow.addingTimeInterval(+20)
+        let refreshedTokens = try Self.makeTokens(date: realNow)
+        let countingRefreshService = CountingRefreshAuthTokenService(tokens: refreshedTokens)
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: countingRefreshService,
+            cachedValueStore: CachedValueStore(backend: .inSystemProcess)
+        )
+
+        // Given
+        let serverURL: URL = .test()
+        let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+        let accessToken = try JWT.make(expiryDate: accessTokenExpiryDate, typ: "access")
+        let refreshToken = try JWT.make(expiryDate: realNow.addingTimeInterval(+3600), typ: "refresh")
+        let storeCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token
+        )
+
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+        given(serverCredentialsStore).store(credentials: .any, serverURL: .value(serverURL)).willReturn()
+
+        // When
+        let firstToken = try await Date.$now.withValue({ firstRequestTime }) {
+            try await subject.inProcessLockedRefresh(serverURL: serverURL, forceRefresh: false)
+        }
+        let secondToken = try await Date.$now.withValue({ realNow }) {
+            try await subject.inProcessLockedRefresh(serverURL: serverURL, forceRefresh: false)
+        }
+
+        // Then
+        #expect(firstToken?.value == accessToken.token)
+        #expect(secondToken?.value == refreshedTokens.accessToken)
+        #expect(await countingRefreshService.callCount == 1)
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func concurrent_force_refreshes_for_same_token_coalesce_into_single_request() async throws {
+        let date = Date()
+        let countingRefreshService = CountingRefreshAuthTokenService(
+            tokens: try Self.makeTokens(date: date)
+        )
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: countingRefreshService,
+            cachedValueStore: CachedValueStore(backend: .inSystemProcess)
+        )
+        let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+        let serverURL: URL = .test()
+
+        let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(+600), typ: "access")
+        let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+        let storeCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token
+        )
+
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+        given(serverCredentialsStore).store(credentials: .any, serverURL: .value(serverURL)).willReturn()
+
+        let subjectCopy = subject!
+        try await Date.$now.withValue({ date }) {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0 ..< 10 {
+                    group.addTask {
+                        try await subjectCopy.refreshToken(
+                            serverURL: serverURL,
+                            inBackground: false,
+                            locking: true,
+                            forceInProcessLock: true
+                        )
+                    }
+                }
+                try await group.waitForAll()
+            }
+        }
+
+        let callCount = await countingRefreshService.callCount
+        #expect(callCount == 1, "Expected forced refreshes for the same token to coalesce, got \(callCount) calls")
     }
 
     @Test(


### PR DESCRIPTION
## Summary

Fixes the long-running iOS app auth-cache window where credentials could look usable locally while the app was still close enough to access-token expiry to hit a server-side `401`.

## Context

The device log and Grafana correlation point to `GET /api/projects` returning `401` at the same time the app showed an authentication alert. The server uses 10-minute access tokens, and the client already treats a token as expired in the last 30 seconds. The long-running app, however, also keeps authentication results in an in-process cache whose expiration matched the JWT's exact expiry. That left a window where the refresh logic could consider the token stale, but the cache could still hand back the old access token.

That explains why this is much easier to hit in the app than in the CLI. The CLI usually starts a fresh process and checks credentials on first use through the auth middleware. The app keeps running and can keep the in-process cache warm across foreground/background transitions.

This intentionally does not add a generic `401` retry in `ServerClientAuthenticationMiddleware`. The fix stays scoped to the cache/refresh mismatch that explains the app-vs-CLI difference.

## Changes

- Aligns auth cache expiration with the existing 30-second token refresh buffer, so cached user/account tokens expire before the JWT's exact expiry.
- Coalesces locked forced refreshes by the token being replaced, avoiding multiple concurrent refreshes for the same stale token.
- Keeps middleware behavior explicit: server-side `401` responses are returned without retrying.
- Adds `x-request-id` helpers for `HTTPRequest`, `URLRequest`, and `HTTPURLResponse`, and reuses them from request creation and error logging.
- Adds iOS authentication diagnostics around state changes, credential storage/deletion, token exchange failures, and HTTP errors.

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistServerTests/ServerAuthenticationControllerTests -only-testing TuistServerTests/ServerClientAuthenticationMiddlewareTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/pepicrft/.superconductor/worktrees/tuist/sc-superfluid-meissner-6b98 mise x swiftformat -- swiftformat cli/Sources/TuistServer/Client/ServerAuthenticationController.swift cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift --lint`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/pepicrft/.superconductor/worktrees/tuist/sc-superfluid-meissner-6b98 mise x swiftlint -- swiftlint lint --quiet --config .swiftlint.yml cli/Sources/TuistServer/Client/ServerAuthenticationController.swift cli/Sources/TuistServer/Client/ServerClientAuthenticationMiddleware.swift cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift cli/Tests/TuistServerTests/Client/ServerClientAuthenticationMiddlewareTests.swift`
- `xcodebuild build -workspace TuistApp.xcworkspace -scheme TuistApp CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
