### PR TITLE
fix(server): speed up xcactivitylog parse and surface real NIF errors

### DIFF
--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift
@@ -57,12 +57,7 @@ public func parseXCActivityLog(
 
     let deadline = DispatchTime.now() + .seconds(parseTimeoutSeconds)
     if semaphore.wait(timeout: deadline) == .timedOut {
-        let error = NSError(
-            domain: "XCActivityLogNIF",
-            code: -1,
-            userInfo: [NSLocalizedDescriptionKey: "parse timed out after \(parseTimeoutSeconds)s"]
-        )
-        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+        return writeMessage("parse timed out after \(parseTimeoutSeconds)s", outputPtr: outputPtr, outputLen: outputLen)
     }
 
     switch box.value! {
@@ -77,25 +72,27 @@ public func parseXCActivityLog(
             outputLen.pointee = Int32(jsonData.count)
             return 0
         } catch {
-            return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+            return writeMessage(error.localizedDescription, outputPtr: outputPtr, outputLen: outputLen)
         }
     case let .failure(error):
-        return writeError(error, outputPtr: outputPtr, outputLen: outputLen)
+        return writeMessage(error.localizedDescription, outputPtr: outputPtr, outputLen: outputLen)
     }
 }
 
-private func writeError(
-    _ error: Error,
+// Writes a plain UTF-8 error message into the output buffer. The C bridge
+// surfaces the bytes as an Erlang binary in `{:error, <<message>>}`, so a
+// raw string is enough — no JSON wrapping needed on this path.
+private func writeMessage(
+    _ message: String,
     outputPtr: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     outputLen: UnsafeMutablePointer<Int32>
 ) -> Int32 {
-    let errorJSON = "{\"error\": \"\(error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\""))\"}"
-    let data = Array(errorJSON.utf8)
-    let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: data.count)
-    for (i, byte) in data.enumerated() {
+    let bytes = Array(message.utf8)
+    let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: max(bytes.count, 1))
+    for (i, byte) in bytes.enumerated() {
         buffer[i] = CChar(bitPattern: byte)
     }
     outputPtr.pointee = buffer
-    outputLen.pointee = Int32(data.count)
+    outputLen.pointee = Int32(bytes.count)
     return 1
 }

--- a/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
+++ b/server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift
@@ -188,13 +188,7 @@ public struct XCActivityLogParser: Sendable {
             let warnings = step.warnings ?? []
             for notice in errors + warnings {
                 let issueType: String = notice.severity == 1 ? "warning" : "error"
-                var message = notice.detail
-                if var detail = notice.detail {
-                    if let r = detail.range(of: "warning: ") { detail = String(detail[r.upperBound...]) }
-                    if let r = detail.range(of: "error: ") { detail = String(detail[r.upperBound...]) }
-                    if let r = detail.range(of: " ^~") { detail = String(detail[..<r.lowerBound]) }
-                    message = detail
-                }
+
                 let key = "\(step.signature):\(notice.startingLineNumber):\(notice.startingColumnNumber):\(issueType)"
                 guard !seen.contains(key) else { continue }
                 seen.insert(key)
@@ -212,7 +206,7 @@ public struct XCActivityLogParser: Sendable {
                     signature: step.signature,
                     step_type: stepTypeString(from: step.signature),
                     path: path,
-                    message: message.flatMap { $0.count > 1000 ? String($0.prefix(1000)) + "..." : $0 },
+                    message: notice.detail.flatMap(cleanIssueDetail),
                     starting_line: Int(notice.startingLineNumber),
                     ending_line: Int(notice.endingLineNumber),
                     starting_column: Int(notice.startingColumnNumber),
@@ -221,6 +215,53 @@ public struct XCActivityLogParser: Sendable {
             }
         }
         return result
+    }
+
+    // Cap raw detail before searching: pathological diagnostics (e.g. macro
+    // expansion errors) can be megabytes, and `range(of:)` is linear in the
+    // input even with `.literal`. We truncate to the final 1000-char message
+    // limit anyway, plus headroom for the preamble we strip below. UTF-16
+    // length is O(1) on native strings; grapheme `count` is not.
+    private static let issueDetailSearchCap = 4096
+    private static let issueMessageCap = 1000
+
+    private func cleanIssueDetail(_ raw: String) -> String {
+        var detail = raw
+        if detail.utf16.count > Self.issueDetailSearchCap {
+            let cap = detail.utf16.index(
+                detail.utf16.startIndex,
+                offsetBy: Self.issueDetailSearchCap,
+                limitedBy: detail.utf16.endIndex
+            ) ?? detail.utf16.endIndex
+            // Round to a Unicode scalar boundary; bail to the original string
+            // if the cap landed inside a surrogate pair (rare, but cheap to
+            // handle correctly).
+            detail = String.Index(cap, within: detail).map { String(detail[..<$0]) } ?? detail
+        }
+        // `.literal` skips canonical equivalence so the search runs on raw
+        // UTF-16 code units instead of grapheme clusters — this is what
+        // takes the parse from minutes to seconds on builds with thousands
+        // of diagnostics.
+        if let r = detail.range(of: "warning: ", options: .literal) {
+            detail = String(detail[r.upperBound...])
+        }
+        if let r = detail.range(of: "error: ", options: .literal) {
+            detail = String(detail[r.upperBound...])
+        }
+        if let r = detail.range(of: " ^~", options: .literal) {
+            detail = String(detail[..<r.lowerBound])
+        }
+        if detail.utf16.count > Self.issueMessageCap {
+            let cap = detail.utf16.index(
+                detail.utf16.startIndex,
+                offsetBy: Self.issueMessageCap,
+                limitedBy: detail.utf16.endIndex
+            ) ?? detail.utf16.endIndex
+            if let stringIdx = String.Index(cap, within: detail) {
+                detail = String(detail[..<stringIdx]) + "..."
+            }
+        }
+        return detail
     }
 
     // MARK: - Files

--- a/server/native/xcactivitylog_nif/nif_bridge.c
+++ b/server/native/xcactivitylog_nif/nif_bridge.c
@@ -75,8 +75,27 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     free(cas_db_path);
     free(legacy_cas_path);
 
-    if (result != 0 || output == NULL) {
+    if (result != 0) {
+        /* Swift writes a UTF-8 error message into `output`; surface it as a
+         * binary so the Elixir caller can log the actual reason instead of
+         * a bare `:parse_failed` atom. Fall back to that atom only when the
+         * Swift side returned no message at all (allocation failure, etc). */
+        if (output != NULL && output_len > 0) {
+            ERL_NIF_TERM message_binary;
+            unsigned char *bin_data = enif_make_new_binary(env, output_len, &message_binary);
+            memcpy(bin_data, output, output_len);
+            free(output);
+            return enif_make_tuple2(env, enif_make_atom(env, "error"), message_binary);
+        }
         if (output) free(output);
+        return enif_make_tuple2(
+            env,
+            enif_make_atom(env, "error"),
+            enif_make_atom(env, "parse_failed")
+        );
+    }
+
+    if (output == NULL) {
         return enif_make_tuple2(
             env,
             enif_make_atom(env, "error"),

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -179,7 +179,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
       expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
 
       expect(BuildProcessor, :process_build, fn _path, _ ->
-        {:error, {:parse_failed, "NIF not loaded"}}
+        {:error, "NIF not loaded"}
       end)
 
       expect(Tuist.Builds, :create_build, fn attrs ->
@@ -187,7 +187,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
         {:ok, %{id: build.id}}
       end)
 
-      assert {:error, {:parse_failed, "NIF not loaded"}} =
+      assert {:error, "NIF not loaded"} =
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
@@ -258,7 +258,7 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
       expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
 
       expect(BuildProcessor, :process_build, fn _, _ ->
-        {:error, {:parse_failed, "boom"}}
+        {:error, "boom"}
       end)
 
       expect(Tuist.Builds, :create_build, fn _attrs -> {:ok, %{id: build.id}} end)


### PR DESCRIPTION
### Purpose

A specific build (10 MB xcactivitylog, 277 targets) was failing every Oban retry with `(Oban.PerformError) … failed with {:error, :parse_failed}` and no further diagnostic. Two unrelated bugs combined to produce that:

1. **`extractIssues` was pathologically slow.** Each notice's full `detail` was scanned three times by grapheme-aware `String.range(of:)`. On a build with thousands of diagnostics this exceeded the 240 s Swift-side parse timeout, even in release mode.
2. **The C bridge was throwing the Swift error message away.** When the Swift parser failed (timeout or otherwise), it wrote a UTF-8 error string into the output buffer and returned non-zero. `nif_bridge.c` ignored that buffer and returned a bare `:parse_failed` atom — operators saw no reason at all.

### What changed

- `extractIssues` (`server/native/xcactivitylog_nif/Sources/XCActivityLogParser/XCActivityLogParser.swift`):
  - Dedup check moved ahead of the string work — duplicates skip the searches entirely.
  - New `cleanIssueDetail` helper caps raw `detail` at 4 KB up front using UTF-16 length (O(1), unlike grapheme `count`), then runs `range(of:options: .literal)` so the search is on raw code units instead of normalized grapheme clusters.
  - Final 1000-char message cap also goes through the UTF-16 view.
- C bridge (`server/native/xcactivitylog_nif/nif_bridge.c`): on `result != 0`, surface `output` as an Erlang binary in `{:error, <<message>>}`. Reserve the bare `:parse_failed` atom for the rare case where Swift returned no buffer (allocation failure).
- Swift NIF entry (`server/native/xcactivitylog_nif/Sources/XCActivityLogNIF/XCActivityLogNIF.swift`): `writeMessage` writes a plain UTF-8 string instead of JSON-wrapping it — the C side hands it through verbatim.
- `process_build_worker_test.exs`: mocks updated to the realistic `{:error, "..."}` shape so the worker's permanent-failure log line shows the actual reason.

### How to test locally

The most direct check is the existing test suite plus a one-off run against any 10 MB+ xcactivitylog:

```bash
cd server/native/xcactivitylog_nif
swift test --replace-scm-with-registry          # 12 parser tests
./build.sh                                      # rebuild .so / .dylib
cd ../..
mix test test/tuist/builds/workers/process_build_worker_test.exs
```

For a perf check on a large archive that previously timed out: parse went from "stuck past 2:37 in release mode" (sample showed 100 % time in `extractIssues` at lines 193 + 195) to **18.04 s** with identical output (`targets=277 issues=1000 status=failure duration=290820`). Same 240 s NIF timeout still in place — that build now finishes well under it.

Reviewer note: the `priv/native/` directory is built by `build.sh` / the Dockerfile and isn't tracked, so no binary changes in the diff.