### PR TITLE
docs(server): clarify module cache and Xcode cache can be combined

### DIFF
--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -9,7 +9,7 @@
 
 Build artifacts are not shared across environments, forcing you to rebuild the same code over and over. Tuist's caching feature shares artifacts remotely so your team and CI get faster builds without rebuilding what has already been built.
 
-Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole modules with prebuilt binaries while the Xcode cache reuses compilation artifacts for whatever still gets compiled.
+Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole modules with prebuilt binaries before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
 
 <HomeCards>
     <HomeCard

--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -9,7 +9,7 @@
 
 Build artifacts are not shared across environments, forcing you to rebuild the same code over and over. Tuist's caching feature shares artifacts remotely so your team and CI get faster builds without rebuilding what has already been built.
 
-Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole modules with prebuilt binaries before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
+Pick the caching solution that matches your build system:
 
 <HomeCards>
     <HomeCard

--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -9,7 +9,7 @@
 
 Build artifacts are not shared across environments, forcing you to rebuild the same code over and over. Tuist's caching feature shares artifacts remotely so your team and CI get faster builds without rebuilding what has already been built.
 
-Pick the caching solution that matches your build system:
+Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole targets with prebuilt binaries while the Xcode cache reuses compilation artifacts for whatever still gets compiled.
 
 <HomeCards>
     <HomeCard

--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -9,7 +9,7 @@
 
 Build artifacts are not shared across environments, forcing you to rebuild the same code over and over. Tuist's caching feature shares artifacts remotely so your team and CI get faster builds without rebuilding what has already been built.
 
-Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole targets with prebuilt binaries while the Xcode cache reuses compilation artifacts for whatever still gets compiled.
+Pick the caching solution that matches your build system. For Xcode projects, the module cache and the Xcode cache work at different granularity levels and can be used together; the module cache replaces whole modules with prebuilt binaries while the Xcode cache reuses compilation artifacts for whatever still gets compiled.
 
 <HomeCards>
     <HomeCard

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (like Bazel) caches build outputs keyed by their inputs.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (like Bazel) caches build outputs keyed by their inputs.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs for whatever still gets compiled.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs during the build.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -17,6 +17,12 @@
 
 Tuist Module Cache provides a powerful way to optimize build times by caching your modules as binaries (`.xcframework`s) and sharing them across different environments. This capability allows you to leverage previously generated binaries, reducing the need for repeated compilation and speeding up the development process.
 
+> [!TIP]
+> **Combine with the Xcode cache**
+>
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole targets (typically external dependencies) with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+
+
 ## Warming {#warming}
 
 Tuist efficiently <.localized_link href="/guides/features/projects/hashing">utilizes hashes</.localized_link> for each target in the dependency graph to detect changes. Utilizing this data, it builds and assigns unique identifiers to binaries derived from these targets. At the time of graph generation, Tuist then seamlessly substitutes the original targets with their corresponding binary versions.

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole targets (typically external dependencies) with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/module-cache.md
+++ b/server/priv/docs/en/guides/features/cache/module-cache.md
@@ -20,7 +20,7 @@ Tuist Module Cache provides a powerful way to optimize build times by caching yo
 > [!TIP]
 > **Combine with the Xcode cache**
 >
-> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs for whatever still gets compiled.
+> The module cache and the <.localized_link href="/guides/features/cache/xcode-cache">Xcode cache</.localized_link> are complementary because they work at different granularity levels. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs.
 
 
 ## Warming {#warming}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs for whatever still gets compiled.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs.
 
 
 ## Setup {#setup}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs during the build.
 
 
 ## Setup {#setup}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole targets (typically external dependencies) with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
 
 
 ## Setup {#setup}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (like Bazel) caches build outputs keyed by their inputs.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache reuses compilation outputs for whatever still gets compiled.
 
 
 ## Setup {#setup}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -11,6 +11,12 @@ Tuist provides support for the Xcode compilation cache, which allows teams to sh
 
 The Xcode cache was introduced in Xcode 26. You might also see it referred to as the Xcode build cache; it reuses compilation artifacts keyed by their inputs, and Tuist's remote cache makes those artifacts shareable across machines.
 
+> [!TIP]
+> **Combine with the module cache**
+>
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole targets (typically external dependencies) with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+
+
 ## Setup {#setup}
 
 > [!WARNING]

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s, while the Xcode cache reuses compilation artifacts at the object level for everything the build system still compiles. Using both together is the recommended setup, and it's how we cache `tuist/tuist` itself.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
 
 
 ## Setup {#setup}

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -14,7 +14,7 @@ The Xcode cache was introduced in Xcode 26. You might also see it referred to as
 > [!TIP]
 > **Combine with the module cache**
 >
-> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (similar to Bazel) reuses build action outputs keyed by the content of their inputs for whatever the build system still has to compile.
+> The Xcode cache and the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> work at different granularity levels and complement each other. The module cache replaces whole modules with prebuilt `.xcframework`s before the build runs, while the Xcode cache (like Bazel) caches build outputs keyed by their inputs.
 
 
 ## Setup {#setup}


### PR DESCRIPTION
> Describe here the purpose of your PR.

A user asked in Slack whether the module cache and Xcode cache can be used together. The docs presented the two as a "pick one" choice with no cross-reference between the pages, so the answer wasn't discoverable.

This adds a short TIP block to:

- `cache/module-cache.md` — right after the intro
- `cache/xcode-cache.md` — symmetric block so the relationship is reachable from either page

Each note explains that the two caches work at different granularity levels: the module cache replaces whole modules with prebuilt ` .xcframework`s before the build runs, while the Xcode cache reuses compilation outputs during the build.

Only the English source content was changed; translation files will sync through Weblate.

### How to test locally

- `mise run dev` from `server/` and visit the Module cache and Xcode cache pages to confirm the new copy renders and the cross-links resolve.