### PR TITLE
fix(server): re-populate tab data after refreshing a test run

### DIFF
--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -127,44 +127,16 @@ defmodule TuistWeb.TestRunLive do
     {:noreply, socket}
   end
 
-  def handle_info({:test_created, test}, %{assigns: %{run: run, selected_project: project}} = socket) do
+  def handle_info({:test_created, test}, %{assigns: %{run: run}} = socket) do
     if test.id == run.id do
-      case Tests.get_test(run.id, preload: [:ran_by_account, :build_run, :gradle_build, :shard_plan, :run_destinations]) do
-        {:ok, refreshed_run} ->
-          refreshed_run = Map.put(refreshed_run, :project, project)
-
-          {:noreply,
-           socket
-           |> assign(:run, refreshed_run)
-           |> assign_initial_analytics_state()
-           |> assign_initial_test_cases_state()
-           |> assign_initial_failures_state()
-           |> assign_initial_flaky_runs_state()}
-
-        {:error, :not_found} ->
-          {:noreply, socket}
-      end
+      {:noreply, reload_run_state(socket)}
     else
       {:noreply, socket}
     end
   end
 
-  def handle_event("refresh_test_run", _params, %{assigns: %{run: run, selected_project: project}} = socket) do
-    case Tests.get_test(run.id, preload: [:ran_by_account, :build_run, :gradle_build, :shard_plan, :run_destinations]) do
-      {:ok, refreshed_run} ->
-        refreshed_run = Map.put(refreshed_run, :project, project)
-
-        {:noreply,
-         socket
-         |> assign(:run, refreshed_run)
-         |> assign_initial_analytics_state()
-         |> assign_initial_test_cases_state()
-         |> assign_initial_failures_state()
-         |> assign_initial_flaky_runs_state()}
-
-      {:error, :not_found} ->
-        {:noreply, socket}
-    end
+  def handle_event("refresh_test_run", _params, socket) do
+    {:noreply, reload_run_state(socket)}
   end
 
   def handle_event("search-selective-testing", %{"search" => search}, socket) do
@@ -296,6 +268,25 @@ defmodule TuistWeb.TestRunLive do
       end
     else
       "asc"
+    end
+  end
+
+  defp reload_run_state(%{assigns: %{run: run, selected_project: project, selected_tab: selected_tab, uri: uri}} = socket) do
+    case Tests.get_test(run.id, preload: [:ran_by_account, :build_run, :gradle_build, :shard_plan, :run_destinations]) do
+      {:ok, refreshed_run} ->
+        refreshed_run = Map.put(refreshed_run, :project, project)
+        params = URI.decode_query(uri.query || "")
+
+        socket
+        |> assign(:run, refreshed_run)
+        |> assign_initial_analytics_state()
+        |> assign_initial_test_cases_state()
+        |> assign_initial_failures_state()
+        |> assign_initial_flaky_runs_state()
+        |> assign_tab_data(selected_tab, params)
+
+      {:error, :not_found} ->
+        socket
     end
   end
 

--- a/server/test/tuist_web/live/test_run_live_test.exs
+++ b/server/test/tuist_web/live/test_run_live_test.exs
@@ -487,4 +487,26 @@ defmodule TuistWeb.TestRunLiveTest do
       assert has_element?(lv, "#shard-balance-table", "Pending")
     end
   end
+
+  describe "refresh_test_run event" do
+    test "re-renders without raising when refreshing a non-processing run", %{
+      conn: conn,
+      organization: organization,
+      project: project
+    } do
+      # Given - a finished test run rendered on the overview tab (test-cases sub-tab is the default)
+      {:ok, test_run} = RunsFixtures.test_fixture(project_id: project.id)
+
+      {:ok, lv, _html} =
+        live(conn, ~p"/#{organization.account.name}/#{project.name}/tests/test-runs/#{test_run.id}")
+
+      # When - the LiveView re-fetches the run after the run has finished processing.
+      # This mirrors handle_info({:test_created, ...}) and the manual refresh flow,
+      # which both reset the test_cases_meta assign back to %{}.
+      html = render_hook(lv, "refresh_test_run")
+
+      # Then - the page re-renders without raising a KeyError on @test_cases_meta.total_pages
+      assert html =~ "test-cases-card"
+    end
+  end
 end


### PR DESCRIPTION
Fixes Sentry [TUIST-E5](https://tuist.sentry.io/issues/117497861/).

### What changed

- Extracted `reload_run_state/1` from the duplicated `:test_created` and `refresh_test_run` handlers in `TestRunLive`. After refetching the run and resetting the per-tab initial state, the helper now decodes the cached URI and re-runs `assign_tab_data(selected_tab, params)` so per-tab assigns (e.g. `test_cases_meta`) get re-populated for the currently selected tab.
- Added a regression test that fires `refresh_test_run` and asserts the page re-renders without raising — this reproduced the exact stack trace prior to the fix.

### Why

Both handlers reset every per-tab assign back to `%{}` via `assign_initial_*_state/1` but never re-loaded tab data. Once the run transitioned out of `processing`, the overview's pagination evaluated `@test_cases_meta.total_pages` against an empty map and raised `KeyError`.

### How to test locally

```sh
cd server && mix test test/tuist_web/live/test_run_live_test.exs
```