### PR TITLE
fix(server): recover xcresult parsing when bundle wrapper is missing

### DIFF
--- a/xcode_processor/lib/xcode_processor/xcresult_processor.ex
+++ b/xcode_processor/lib/xcode_processor/xcresult_processor.ex
@@ -269,10 +269,17 @@ defmodule XcodeProcessor.XCResultProcessor do
   end
 
   defp find_xcresult(temp_dir) do
-    temp_dir
-    |> Path.join("**/*.xcresult")
-    |> Path.wildcard()
-    |> List.first()
+    case temp_dir |> Path.join("**/*.xcresult") |> Path.wildcard() |> List.first() do
+      # Some archives extract directly to bundle contents without a wrapping
+      # `.xcresult` directory (e.g. AppleArchive payloads compressed without
+      # the base directory preserved). Treat the temp dir as the bundle when
+      # `Info.plist` is present at its root.
+      nil ->
+        if File.exists?(Path.join(temp_dir, "Info.plist")), do: temp_dir, else: nil
+
+      path ->
+        path
+    end
   end
 
   defp cleanup_temp(temp_dir) do

--- a/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
+++ b/xcode_processor/test/xcode_processor/xcresult_processor_test.exs
@@ -352,6 +352,41 @@ defmodule XcodeProcessor.XCResultProcessorTest do
       assert {:ok, ^parsed_data} = XCResultProcessor.process("some/key.aar")
     end
 
+    test "treats temp dir as the bundle when archive lacks an .xcresult wrapper" do
+      fixture_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "xcresult_legacy_fixture_#{:erlang.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(fixture_dir)
+      fixture_path = Path.join(fixture_dir, "fixture.aar")
+      File.write!(fixture_path, <<0x62, 0x76, 0x78, 0x32, "fake-aar-body">>)
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      parsed_data = %{"tests" => [%{"name" => "testLegacy", "status" => "passed"}]}
+
+      stub(ExAws.S3, :download_file, fn _bucket, _key, dest_path ->
+        File.cp!(fixture_path, dest_path)
+        %ExAws.Operation.S3{http_method: :get, bucket: "tuist", path: "key"}
+      end)
+
+      expect(ExAws, :request, fn _ -> {:ok, :done} end)
+
+      expect(XcodeProcessor.XCResultNIF, :decompress_archive, fn _archive_path, temp_dir ->
+        File.write!(Path.join(temp_dir, "Info.plist"), "fake-plist")
+        File.mkdir_p!(Path.join(temp_dir, "Data"))
+        :ok
+      end)
+
+      expect(XcodeProcessor.XCResultNIF, :parse, fn xcresult_path, _root ->
+        assert File.exists?(Path.join(xcresult_path, "Info.plist"))
+        {:ok, parsed_data}
+      end)
+
+      assert {:ok, ^parsed_data} = XCResultProcessor.process("some/key.aar")
+    end
+
     test "surfaces NIF decompression failures for AppleArchive payloads" do
       fixture_dir =
         Path.join(


### PR DESCRIPTION
## Summary

The `xcode_processor` extracts each uploaded archive into a temp dir and then globs `**/*.xcresult` to locate the bundle. Some payloads extract flat — `Info.plist`, `Data/`, and `quarantined_tests.json` land at the temp dir root with **no wrapping `.xcresult` directory** — and the glob returns `nil`, so processing fails with `{:error, :xcresult_not_found}` even though every byte of the bundle is on disk. The Oban worker retries 5 times and then discards the job, permanently losing the test run.

This PR adds a fallback: if the glob misses, check whether the temp dir itself looks like an xcresult bundle (i.e. `Info.plist` exists at its root) and, if so, treat the temp dir as the bundle path. Downstream callers (`parse_xcresult`, `read_quarantined_tests`) only need the bundle root, so the rest of the pipeline is unchanged. If neither a `.xcresult` directory nor a top-level `Info.plist` is found, we still return `:xcresult_not_found` as before.

```elixir
defp find_xcresult(temp_dir) do
  case temp_dir |> Path.join("**/*.xcresult") |> Path.wildcard() |> List.first() do
    nil ->
      if File.exists?(Path.join(temp_dir, "Info.plist")), do: temp_dir, else: nil

    path ->
      path
  end
end
```

## Affected CLI versions

The flat layout is produced by macOS CLI builds compiled between **`d4d635602f` (Apr 24)** — which introduced the AppleArchive (`.aar`) upload path — and **`03e1669cc1` (Apr 26)** — which added `preservesBaseDirectory: true` to the AppleArchive `compress` call. Without that flag, AppleArchive walks the bundle directory and writes its children directly, so the wrapper is missing from the resulting archive.

Released versions in that window:

- `4.186.0`
- `4.186.1`
- `4.186.2`

Fixed in `4.187.0` and later. Anything older than `4.186.0` uses the legacy PKZIP path (`FileArchiver.zip`) which has always preserved the wrapper, and anything from `4.187.0` onward preserves it via the new flag — so only those three releases produce the broken layout. Users still on those builds keep emitting affected uploads, and prior to this PR every one of those test runs was dropped on the floor.

## How this was found

A `Tuist.Tests.Workers.ProcessXcresultWorker` job exhausted all 5 attempts with `xcresult_not_found`, but the 90 MB `result_bundle.zip` object was clearly present in S3. Inspecting the file showed magic bytes `pbze` (AppleArchive, despite the `.zip` extension), and decompression with `aa extract` produced `Info.plist`, `Data/`, and `quarantined_tests.json` at the top level — confirming the missing-wrapper layout from a `4.186.x` client.

## Test plan

- [x] New unit test: `treats temp dir as the bundle when archive lacks an .xcresult wrapper` — stubs the AppleArchive NIF to drop `Info.plist` at temp_dir root and asserts `parse` is called with the temp dir as the bundle path.
- [x] `mix test test/xcode_processor/xcresult_processor_test.exs` — 12/12 passing.
- [x] **End-to-end against a real failing archive**: built the Swift NIF + C bridge locally, pointed `XCResultProcessor.process_local/2` at an actual affected file, and got `{:ok, parsed}` with 5 test modules / 370 test cases / status `"failure"` — exactly the data the original job would have persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)