### PR TITLE
fix(server): render English iframe template on localized blog routes

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_blog_iframe_controller.ex
@@ -16,18 +16,13 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeController do
         |> send_resp(200, "")
 
       id ->
-        # Extract the blog post path from the request
-        path = conn.request_path
-
-        # Convert path to template name
-        # e.g., "/blog/2025/11/6/zero-to-many/iframe.html?id=lone_wolf"
-        # becomes "blog_2025_11_6_zero_to_many_lone_wolf"
+        # Build template name from route params so the locale prefix in the
+        # request path doesn't leak into the template lookup.
+        # e.g., year=2025, month=11, day=6, slug=zero-to-many, id=lone_wolf
+        # becomes :blog_2025_11_6_zero_to_many_lone_wolf
         template =
-          path
-          |> String.trim_leading("/")
-          |> String.replace("/iframe.html", "")
-          |> String.replace(~r/[-\/]/, "_")
-          |> Kernel.<>("_#{id}")
+          "blog_#{params["year"]}_#{params["month"]}_#{params["day"]}_#{params["slug"]}_#{id}"
+          |> String.replace("-", "_")
           |> String.to_atom()
 
         # Render the template directly without LiveView

--- a/server/test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs
@@ -19,5 +19,15 @@ defmodule TuistWeb.Marketing.MarketingBlogIframeControllerTest do
       assert response(conn, 200) =~ "viz-container"
       assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
     end
+
+    test "renders the English template when accessed via a localized route", %{conn: conn} do
+      # When
+      conn =
+        get(conn, "/zh_Hans/blog/2025/11/17/smart-before-fast/iframe.html?id=complexity_wall")
+
+      # Then
+      assert response(conn, 200) =~ "viz-container"
+      assert get_resp_header(conn, "content-type") == ["text/html; charset=utf-8"]
+    end
   end
 end


### PR DESCRIPTION
> Fixes the runtime error rendering blog post iframes on localized routes (e.g., `/zh_Hans/blog/...`).

The blog iframe controller built the template name from `conn.request_path`, which includes the locale prefix. Since iframe templates are not localized (one English template per blog post), the lookup failed with:

```
ArgumentError: no "zh_Hans_blog_2025_11_17_smart_before_fast_complexity_wall" html template defined for TuistWeb.Marketing.MarketingHTML
```

The controller now builds the template atom from the route params (`year`, `month`, `day`, `slug`, `id`), so the same English template renders regardless of the URL's locale prefix.

### How to test locally

1. Start the server with multiple locales: `mise run dev`
2. Visit `http://localhost:8080/zh_Hans/blog/2025/11/17/smart-before-fast/iframe.html?id=complexity_wall` and confirm the visualization renders.
3. Run the controller tests:
   ```
   cd server && mix test test/tuist_web/controllers/marketing_blog_iframe_controller_test.exs
   ```
