### PR TITLE
fix(cli): preserve pruned test plan metadata

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -967,12 +967,11 @@ public struct TestService { // swiftlint:disable:this type_body_length
         schemes: [Scheme],
         testPlanConfiguration: TestPlanConfiguration?
     ) -> SelectiveTestingGraph {
-        let attemptedTestPlans = attemptedTestPlans(
-            schemes: schemes,
-            testPlanConfiguration: testPlanConfiguration
-        )
-
         guard let initialGraph = mapperEnvironment.initialGraph else {
+            let attemptedTestPlans = attemptedTestPlans(
+                schemes: schemes,
+                testPlanConfiguration: testPlanConfiguration
+            )
             return SelectiveTestingGraph(
                 testTargetHashes: [:],
                 attemptedTestPlans: attemptedTestPlans
@@ -984,6 +983,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
         let matchingSchemes = initialSchemes.filter { initialScheme in
             schemes.contains(where: { $0.name == initialScheme.name })
         }
+        let attemptedTestPlans = attemptedTestPlans(
+            schemes: matchingSchemes,
+            testPlanConfiguration: testPlanConfiguration
+        )
         let allTestTargets = matchingSchemes.flatMap {
             testActionTargetReferences(scheme: $0, testPlanConfiguration: testPlanConfiguration, action: .build)
         }

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4460,6 +4460,106 @@ final class TestServiceTests: TuistUnitTestCase {
         XCTAssertEqual(writtenGraph.attemptedTestPlans.sorted(), ["Regression", "Smoke"])
     }
 
+    func test_run_build_writesOriginalTestPlanNames_whenSelectiveTestingPrunesPlanFromGeneratedScheme() async throws {
+        // Given
+        givenGenerator()
+        let path = try temporaryPath()
+        let bundleName = "MyApp.xctestproducts"
+        let testProductsPath = path.appending(component: bundleName)
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let projectPath = path.appending(component: "Project")
+        let smokeTestPlanPath = projectPath.appending(components: "TestPlans", "Smoke.xctestplan")
+        let integrationTestPlanPath = projectPath.appending(components: "TestPlans", "IntegrationTestSuite.xctestplan")
+        let smokeTarget = TestableTarget(target: TargetReference(projectPath: projectPath, name: "SmokeTests"))
+        let integrationTarget = TestableTarget(target: TargetReference(projectPath: projectPath, name: "IntegrationTests"))
+        let initialScheme = Scheme.test(
+            name: "TestScheme",
+            testAction: .test(
+                testPlans: [
+                    .init(path: smokeTestPlanPath, testTargets: [smokeTarget], isDefault: true),
+                    .init(path: integrationTestPlanPath, testTargets: [integrationTarget], isDefault: false),
+                ]
+            )
+        )
+        let generatedScheme = Scheme.test(
+            name: "TestScheme",
+            testAction: .test(
+                testPlans: [
+                    .init(path: smokeTestPlanPath, testTargets: [smokeTarget], isDefault: true),
+                ]
+            )
+        )
+        let initialGraph: Graph = .test(
+            workspace: .test(schemes: [.test(name: "App-Workspace")]),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [.test(name: "SmokeTests"), .test(name: "IntegrationTests")],
+                    schemes: [initialScheme]
+                ),
+            ]
+        )
+        let generatedGraph: Graph = .test(
+            workspace: .test(schemes: [.test(name: "App-Workspace")]),
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [.test(name: "SmokeTests")],
+                    schemes: [generatedScheme]
+                ),
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraph = initialGraph
+        environment.targetTestHashes = [
+            projectPath: [
+                "SmokeTests": "hash-smoke",
+                "IntegrationTests": "hash-integration",
+            ],
+        ]
+
+        given(generator)
+            .generateWithGraph(path: .any, options: .any)
+            .willProduce { path, _ in
+                (path, generatedGraph, environment)
+            }
+        given(buildGraphInspector)
+            .testableSchemes(graphTraverser: .any)
+            .willReturn([generatedScheme])
+        given(buildGraphInspector)
+            .testableTarget(
+                scheme: .any,
+                testPlan: .any,
+                testTargets: .any,
+                skipTestTargets: .any,
+                graphTraverser: .any,
+                action: .any
+            )
+            .willProduce { scheme, _, _, _, _, _ in
+                GraphTarget.test(target: Target.test(name: scheme.name))
+            }
+        given(buildGraphInspector)
+            .workspaceSchemes(graphTraverser: .any)
+            .willReturn([])
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        // When
+        try await testRun(
+            schemeName: "TestScheme",
+            path: path,
+            action: .build,
+            passthroughXcodeBuildArguments: ["-testProductsPath", bundleName]
+        )
+
+        // Then
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        let writtenGraph: SelectiveTestingGraph = try await fileSystem.readJSONFile(at: graphPath)
+        XCTAssertEqual(writtenGraph.attemptedTestPlans.sorted(), ["IntegrationTestSuite", "Smoke"])
+    }
+
     fileprivate func testRun(
         runId: String = "run-id",
         schemeName: String? = nil,


### PR DESCRIPTION
## Summary

Fixes the selective-testing metadata embedded into `.xctestproducts` during `tuist test --build-only`.

When selective testing prunes an entire test plan before Xcode emits `.xctestproducts`, the generated scheme can no longer contain that plan. The previous metadata writer derived `attemptedTestPlans` from the post-pruning schemes, so a later `tuist test --without-building --test-plan ...` could not distinguish a fully cached plan from an unknown plan and fell through to `xcodebuild`, which failed because the `.xctestrun` was absent.

This changes the metadata writer to derive attempted test plans from the original graph captured before pruning, while still filtering to the schemes that were selected for the generated build.

## Changes

- Preserve attempted test plan names from the pre-pruning graph when writing `selective-testing-graph.json`.
- Add regression coverage for a scheme where `IntegrationTestSuite` is present in the initial graph but fully pruned from the generated scheme.

## Validation

- `tuist generate tuist TuistKit TuistKitTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TestServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`

Result: `71 tests, 0 failures`.
