### PR TITLE
fix(cli): preserve whitespace in plist template for Array-root scalars

### DIFF
--- a/cli/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/cli/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -21,7 +21,7 @@ extension SynthesizedResourceInterfaceTemplates {
       {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
       {%- set containsAny %}{%- call typesContainAny document.metadata -%}{% endset %}
       {% if document.metadata.type == "Array" %}
-      {{accessModifier}} {% if containsAny %}nonisolated(unsafe) {%+ endif %}static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+      {{accessModifier}} {%+ if containsAny %}nonisolated(unsafe) {%+ endif %}static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
       {% elif document.metadata.type == "Dictionary" %}
       {% for key,value in document.metadata.properties %}
       {{accessModifier}} {%+ call propertyBlock key value document.data %}

--- a/cli/Tests/TuistGeneratorTests/Utils/SynthesizedResourceInterfacesGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Utils/SynthesizedResourceInterfacesGeneratorTests.swift
@@ -120,12 +120,52 @@ struct SynthesizedResourceInterfacesGeneratorTests {
         """)
     }
 
+    @Test(.inTemporaryDirectory)
+    func render_plistWithArrayOfScalars_producesValidSpacing() async throws {
+        let rendered = try renderPlist(
+            named: "InjectedKeyNames",
+            rootObject: [
+                "api_key",
+                "secret_token",
+                "base_url",
+            ] as [Any]
+        )
+
+        #expect(rendered == """
+        // swiftlint:disable:this file_name
+        // swiftlint:disable all
+        // swift-format-ignore-file
+        // swiftformat:disable all
+        // Generated using tuist — https://github.com/tuist/tuist
+
+        import Foundation
+
+        // swiftlint:disable superfluous_disable_command
+        // swiftlint:disable file_length
+
+        // MARK: - Plist Files
+
+        // swiftlint:disable identifier_name line_length number_separator type_body_length
+        public enum InjectedKeyNames: Sendable {
+            public static let items: [String] = [#"api_key"#, #"secret_token"#, #"base_url"#]
+        }
+        // swiftlint:enable identifier_name line_length number_separator type_body_length
+        // swiftformat:enable all
+        // swiftlint:enable all
+
+        """)
+    }
+
     private func renderPlist(named name: String, content: [String: Any]) throws -> String {
+        try renderPlist(named: name, rootObject: content)
+    }
+
+    private func renderPlist(named name: String, rootObject: Any) throws -> String {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let plistPath = temporaryDirectory.appending(component: "\(name).plist")
 
         let plistData = try PropertyListSerialization.data(
-            fromPropertyList: content,
+            fromPropertyList: rootObject,
             format: .xml,
             options: 0
         )


### PR DESCRIPTION
## Summary

- Fix a whitespace bug in the plist resource synthesizer where Array-root plists with scalar elements (e.g. `[String]`) produce `publicstatic` instead of `public static` in generated Swift code
- The bug is in `PlistsTemplate.swift` line 24: Stencil's `.smart` trim eats the space between `{{accessModifier}}` and `static` when the `nonisolated(unsafe)` branch is skipped. Changing `{% if` to `{%+ if` preserves the preceding space.
- Add a test covering Array-root scalar plists, which was previously untested

Storied commit, first commit is a failing test for verification. 

I suspect the regression might have been introduced here: https://github.com/tuist/tuist/pull/10195 (Anecdotally, the date this was merged roughly lines up with when I noticed the bad syntax being generated).

## Test plan

- [x] New test `render_plistWithArrayOfScalars_producesValidSpacing` fails before the fix and passes after
- [x] All existing `SynthesizedResourceInterfacesGeneratorTests` continue to pass