### PR TITLE
fix(cli): support PackageDescription context

### DIFF
--- a/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -25,6 +25,7 @@ public class CachedManifestLoader: ManifestLoading {
     private let tuistVersion: String
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
+    private let packageDescriptionContextProvider = PackageDescriptionContextProvider()
     private let helpersCache: ThreadSafe<[AbsolutePath: Task<String, any Error>]> = ThreadSafe([:])
     private let pluginsHashCache: ThreadSafe<Task<String?, any Error>?> = ThreadSafe(nil)
     private let cacheDirectory: ThrowableCaching<AbsolutePath>
@@ -186,7 +187,7 @@ public class CachedManifestLoader: ManifestLoading {
     ) async throws -> Hashes {
         let manifestHash = try calculateManifestHash(for: manifest, at: manifestPath)
         let helpersHash = try await calculateHelpersHash(at: path)
-        let environmentHash = calculateEnvironmentHash()
+        let environmentHash = try calculateEnvironmentHash(for: manifest, manifestPath: manifestPath)
         let disableSandboxHash = "\(disableSandbox)".md5
 
         return Hashes(
@@ -234,12 +235,22 @@ public class CachedManifestLoader: ManifestLoading {
             .md5
     }
 
-    private func calculateEnvironmentHash() -> String? {
-        let tuistEnvVariables = Environment.current.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
-        guard !tuistEnvVariables.isEmpty else {
+    private func calculateEnvironmentHash(for manifest: Manifest, manifestPath: AbsolutePath) throws -> String? {
+        let environmentVariables: [String: String]
+        if case .packageSettings = manifest {
+            environmentVariables = Environment.current.variables
+            return try packageDescriptionContextProvider.cacheHash(
+                packageManifestPath: manifestPath,
+                environment: environmentVariables
+            )
+        } else {
+            environmentVariables = Environment.current.manifestLoadingVariables
+        }
+        let manifestEnvironmentVariables = environmentVariables.map { "\($0.key)=\($0.value)" }.sorted()
+        guard !manifestEnvironmentVariables.isEmpty else {
             return nil
         }
-        return tuistEnvVariables.joined(separator: "-").md5
+        return manifestEnvironmentVariables.joined(separator: "-").md5
     }
 
     private func cachedPath(for manifestPath: AbsolutePath) throws -> AbsolutePath {

--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -108,6 +108,80 @@ public protocol ManifestLoading {
     func register(plugins: Plugins) throws
 }
 
+struct PackageDescriptionContextProvider {
+    private let encoder = JSONEncoder()
+
+    func arguments(packageManifestPath: AbsolutePath) throws -> [String] {
+        ["-context", try encodedContext(packageManifestPath: packageManifestPath)]
+    }
+
+    func cacheHash(packageManifestPath: AbsolutePath, environment: [String: String]) throws -> String? {
+        var components = environment.map { "\($0.key)=\($0.value)" }
+        components.append("context=\(try encodedContext(packageManifestPath: packageManifestPath))")
+        return components.sorted().joined(separator: "-").md5
+    }
+
+    private func encodedContext(packageManifestPath: AbsolutePath) throws -> String {
+        let contextModel = PackageDescriptionContextModel(
+            packageDirectory: packageManifestPath.parentDirectory.pathString,
+            gitInformation: gitInformation(at: packageManifestPath.parentDirectory)
+        )
+        let data = try encoder.encode(contextModel)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func gitInformation(at packageDirectory: AbsolutePath) -> PackageDescriptionContextModel.GitInformation? {
+        do {
+            let currentCommit = try System.shared.capture([
+                "git",
+                "-C",
+                packageDirectory.pathString,
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let currentTag = try? System.shared.capture([
+                "git",
+                "-C",
+                packageDirectory.pathString,
+                "describe",
+                "--exact-match",
+                "--tags",
+            ])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let status = try System.shared.capture([
+                "git",
+                "-C",
+                packageDirectory.pathString,
+                "status",
+                "-s",
+            ])
+
+            return PackageDescriptionContextModel.GitInformation(
+                currentTag: currentTag?.isEmpty == false ? currentTag : nil,
+                currentCommit: currentCommit,
+                hasUncommittedChanges: !status.isEmpty
+            )
+        } catch {
+            return nil
+        }
+    }
+}
+
+private struct PackageDescriptionContextModel: Encodable {
+    let packageDirectory: String
+    let gitInformation: GitInformation?
+
+    struct GitInformation: Encodable {
+        let currentTag: String?
+        let currentCommit: String
+        let hasUncommittedChanges: Bool
+    }
+}
+
 // swiftlint:disable:next type_body_length
 public class ManifestLoader: ManifestLoading {
     @TaskLocal public static var current: ManifestLoading = CachedManifestLoader()
@@ -123,6 +197,7 @@ public class ManifestLoader: ManifestLoading {
     let manifestFilesLocator: ManifestFilesLocating
     let environment: Environmenting
     private let decoder: JSONDecoder
+    private let packageDescriptionContextProvider: PackageDescriptionContextProvider
     private var plugins: Plugins = .none
     private let cacheDirectoriesProvider: CacheDirectoriesProviding
     private let projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactoring
@@ -162,6 +237,7 @@ public class ManifestLoader: ManifestLoading {
         self.swiftPackageManagerController = swiftPackageManagerController
         self.packageInfoLoader = packageInfoLoader
         self.fileSystem = fileSystem
+        packageDescriptionContextProvider = PackageDescriptionContextProvider()
         decoder = JSONDecoder()
     }
 
@@ -337,7 +413,7 @@ public class ManifestLoader: ManifestLoading {
             let string = try System.shared.capture(
                 arguments,
                 verbose: false,
-                environment: Environment.current.manifestLoadingVariables
+                environment: manifestLoadingEnvironment(for: manifest)
             )
 
             guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken, options: .literal),
@@ -467,6 +543,9 @@ public class ManifestLoader: ManifestLoading {
         arguments.append(contentsOf: projectDescriptionHelperArguments)
         arguments.append(contentsOf: packageDescriptionArguments)
         arguments.append(path.pathString)
+        if case .packageSettings = manifest {
+            arguments.append(contentsOf: try packageDescriptionContextProvider.arguments(packageManifestPath: path))
+        }
 
         if !disableSandbox {
             #if os(macOS)
@@ -503,6 +582,14 @@ public class ManifestLoader: ManifestLoading {
             #endif
         } else {
             return arguments
+        }
+    }
+
+    private func manifestLoadingEnvironment(for manifest: Manifest) -> [String: String] {
+        if case .packageSettings = manifest {
+            return Environment.current.variables
+        } else {
+            return Environment.current.manifestLoadingVariables
         }
     }
 

--- a/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
@@ -1,6 +1,7 @@
 import FileSystem
 import Foundation
 import TuistConstants
+import TuistEnvironment
 import XcodeGraph
 import XCTest
 
@@ -202,6 +203,68 @@ final class ManifestLoaderTests: TuistTestCase {
                 ]
             )
         )
+    }
+
+    func test_loadPackageSettings_withPackageDescriptionContext() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let content = """
+        // swift-tools-version: 5.9
+        import PackageDescription
+
+        let demoContextValue = Context.environment["DEMO_CONTEXT_VALUE"]
+        let demoPackageDirectory = Context.packageDirectory
+
+        #if TUIST
+        import ProjectDescription
+
+        let packageSettings = PackageSettings(
+            targetSettings: [
+                "DemoKit": [
+                    "DEMO_CONTEXT_VALUE": .string(demoContextValue ?? "missing"),
+                    "DEMO_PACKAGE_DIRECTORY": .string(demoPackageDirectory),
+                ],
+            ]
+        )
+
+        #endif
+
+        let package = Package(
+            name: "DemoKit",
+            targets: [
+                .target(name: "DemoKit"),
+            ]
+        )
+
+        """
+
+        let manifestPath = temporaryPath.appending(
+            component: Manifest.package.fileName(temporaryPath)
+        )
+        try await fileSystem.makeDirectory(at: temporaryPath.appending(component: Constants.tuistDirectoryName))
+        try await fileSystem.writeText(content, at: manifestPath)
+        let variables = ProcessInfo.processInfo.environment.merging(
+            ["DEMO_CONTEXT_VALUE": "hello"],
+            uniquingKeysWith: { _, new in new }
+        )
+
+        // When
+        try await Environment.$current.withValue(Environment(variables: variables)) {
+            let got = try await ManifestLoader().loadPackageSettings(at: temporaryPath, disableSandbox: true)
+
+            // Then
+            XCTAssertEqual(
+                got,
+                .init(
+                    targetSettings: [
+                        "DemoKit": .settings(base: [
+                            "DEMO_CONTEXT_VALUE": "hello",
+                            "DEMO_PACKAGE_DIRECTORY": .string(temporaryPath.pathString),
+                        ]),
+                    ]
+                )
+            )
+        }
     }
 
     func test_loadPackageBaseProductType() async throws {


### PR DESCRIPTION
## Summary

Fixes Package.swift evaluation when manifests access `PackageDescription.Context` while Tuist loads `PackageSettings`.

Tuist already links SwiftPM's `PackageDescription` runtime for package settings manifests, but it did not provide SwiftPM's `-context` argument. Any access to `Context.environment`, `Context.packageDirectory`, or `Context.gitInformation` therefore triggered `ContextModel.decode()` and crashed manifest evaluation before Tuist could surface a useful error.

## Changes

- Encode a SwiftPM-compatible manifest context with `packageDirectory` and best-effort `gitInformation`.
- Pass that context as `-context` when evaluating `Package.swift` for `PackageSettings`.
- Evaluate package settings manifests with the current process environment so `Context.environment` matches SwiftPM behavior.
- Include the package context and environment in the package settings manifest cache key.
- Add a regression test for `Context.environment` and `Context.packageDirectory`.

Fixes #10616.

## Validation

- `mise run cli:lint --fix`
- `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/ManifestLoaderTests/test_loadPackageSettings_withPackageDescriptionContext CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Reproduced the attached DemoKit sample with the built Tuist binary: `DEMO_CONTEXT_VALUE=hello tuist generate --no-open`
