### PR TITLE
fix(cli): support PackageDescription context

### DIFF
--- a/cli/Sources/TuistGit/GitController.swift
+++ b/cli/Sources/TuistGit/GitController.swift
@@ -44,6 +44,9 @@ public protocol GitControlling {
     /// Return the current commit SHA
     func currentCommitSHA(workingDirectory: AbsolutePath) throws -> String
 
+    /// Return whether git is available in the current environment.
+    func isGitAvailable() -> Bool
+
     /// Return the current tag if HEAD points exactly to one.
     func currentTag(workingDirectory: AbsolutePath) throws -> String?
 
@@ -117,10 +120,15 @@ public struct GitController: GitControlling {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    public func isGitAvailable() -> Bool {
+        system.commandExists("git")
+    }
+
     public func currentTag(workingDirectory: AbsolutePath) throws -> String? {
-        let tag = try capture(command: "git", "-C", workingDirectory.pathString, "describe", "--tags", "--exact-match")
+        let tag = try? capture(command: "git", "-C", workingDirectory.pathString, "describe", "--tags", "--exact-match")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return tag.isEmpty ? nil : tag
+        guard let tag, !tag.isEmpty else { return nil }
+        return tag
     }
 
     public func hasUncommittedChanges(workingDirectory: AbsolutePath) throws -> Bool {

--- a/cli/Sources/TuistGit/GitController.swift
+++ b/cli/Sources/TuistGit/GitController.swift
@@ -44,6 +44,12 @@ public protocol GitControlling {
     /// Return the current commit SHA
     func currentCommitSHA(workingDirectory: AbsolutePath) throws -> String
 
+    /// Return the current tag if HEAD points exactly to one.
+    func currentTag(workingDirectory: AbsolutePath) throws -> String?
+
+    /// Return whether the git working tree has uncommitted changes.
+    func hasUncommittedChanges(workingDirectory: AbsolutePath) throws -> Bool
+
     /// Return the git URL origin
     func urlOrigin(workingDirectory: AbsolutePath) throws -> String
 
@@ -109,6 +115,18 @@ public struct GitController: GitControlling {
     public func currentCommitSHA(workingDirectory: AbsolutePath) throws -> String {
         try capture(command: "git", "-C", workingDirectory.pathString, "rev-parse", "HEAD")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func currentTag(workingDirectory: AbsolutePath) throws -> String? {
+        let tag = try capture(command: "git", "-C", workingDirectory.pathString, "describe", "--tags", "--exact-match")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return tag.isEmpty ? nil : tag
+    }
+
+    public func hasUncommittedChanges(workingDirectory: AbsolutePath) throws -> Bool {
+        let status = try capture(command: "git", "-C", workingDirectory.pathString, "status", "--porcelain")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return !status.isEmpty
     }
 
     public func hasUrlOrigin(workingDirectory: AbsolutePath) throws -> Bool {

--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -5,6 +5,7 @@ import Path
 import ProjectDescription
 import TuistCore
 import TuistEnvironment
+import TuistGit
 import TuistLogging
 import TuistSupport
 import XcodeGraph
@@ -51,6 +52,17 @@ public enum ManifestLoaderError: FatalError, Equatable {
         case .manifestLoadingFailed:
             return .abort
         }
+    }
+}
+
+private struct PackageDescriptionContext: Encodable {
+    let packageDirectory: String
+    let gitInformation: GitInformation?
+
+    struct GitInformation: Encodable {
+        let currentTag: String?
+        let currentCommit: String
+        let hasUncommittedChanges: Bool
     }
 }
 
@@ -129,6 +141,7 @@ public class ManifestLoader: ManifestLoading {
     private let swiftPackageManagerController: SwiftPackageManagerControlling
     private let packageInfoLoader: PackageInfoLoading
     private let fileSystem: FileSysteming
+    private let gitController: GitControlling
 
     // MARK: - Init
 
@@ -140,7 +153,8 @@ public class ManifestLoader: ManifestLoading {
             projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactory(),
             manifestFilesLocator: ManifestFilesLocator(),
             swiftPackageManagerController: SwiftPackageManagerController(),
-            packageInfoLoader: PackageInfoLoader()
+            packageInfoLoader: PackageInfoLoader(),
+            gitController: GitController()
         )
     }
 
@@ -152,7 +166,8 @@ public class ManifestLoader: ManifestLoading {
         manifestFilesLocator: ManifestFilesLocating,
         swiftPackageManagerController: SwiftPackageManagerControlling,
         packageInfoLoader: PackageInfoLoading,
-        fileSystem: FileSysteming = FileSystem()
+        fileSystem: FileSysteming = FileSystem(),
+        gitController: GitControlling = GitController()
     ) {
         self.environment = environment
         self.resourceLocator = resourceLocator
@@ -162,6 +177,7 @@ public class ManifestLoader: ManifestLoading {
         self.swiftPackageManagerController = swiftPackageManagerController
         self.packageInfoLoader = packageInfoLoader
         self.fileSystem = fileSystem
+        self.gitController = gitController
         decoder = JSONDecoder()
     }
 
@@ -467,6 +483,18 @@ public class ManifestLoader: ManifestLoading {
         arguments.append(contentsOf: projectDescriptionHelperArguments)
         arguments.append(contentsOf: packageDescriptionArguments)
         arguments.append(path.pathString)
+        if case .packageSettings = manifest {
+            // PackageDescription.Context expects SwiftPM's manifest runtime context argument.
+            let context = PackageDescriptionContext(
+                packageDirectory: path.parentDirectory.pathString,
+                gitInformation: packageDescriptionContextGitInformation(at: path.parentDirectory)
+            )
+            let data = try JSONEncoder().encode(context)
+            arguments.append(contentsOf: [
+                "-context",
+                String(decoding: data, as: UTF8.self),
+            ])
+        }
 
         if !disableSandbox {
             #if os(macOS)
@@ -503,6 +531,20 @@ public class ManifestLoader: ManifestLoading {
             #endif
         } else {
             return arguments
+        }
+    }
+
+    private func packageDescriptionContextGitInformation(at packageDirectory: AbsolutePath) -> PackageDescriptionContext
+        .GitInformation?
+    {
+        do {
+            return PackageDescriptionContext.GitInformation(
+                currentTag: try? gitController.currentTag(workingDirectory: packageDirectory),
+                currentCommit: try gitController.currentCommitSHA(workingDirectory: packageDirectory),
+                hasUncommittedChanges: try gitController.hasUncommittedChanges(workingDirectory: packageDirectory)
+            )
+        } catch {
+            return nil
         }
     }
 

--- a/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -55,17 +55,6 @@ public enum ManifestLoaderError: FatalError, Equatable {
     }
 }
 
-private struct PackageDescriptionContext: Encodable {
-    let packageDirectory: String
-    let gitInformation: GitInformation?
-
-    struct GitInformation: Encodable {
-        let currentTag: String?
-        let currentCommit: String
-        let hasUncommittedChanges: Bool
-    }
-}
-
 @Mockable
 public protocol ManifestLoading {
     /// Loads the Tuist.swift in the given directory.
@@ -487,7 +476,7 @@ public class ManifestLoader: ManifestLoading {
             // PackageDescription.Context expects SwiftPM's manifest runtime context argument.
             let context = PackageDescriptionContext(
                 packageDirectory: path.parentDirectory.pathString,
-                gitInformation: packageDescriptionContextGitInformation(at: path.parentDirectory)
+                gitInformation: try packageDescriptionContextGitInformation(at: path.parentDirectory)
             )
             let data = try JSONEncoder().encode(context)
             arguments.append(contentsOf: [
@@ -534,18 +523,20 @@ public class ManifestLoader: ManifestLoading {
         }
     }
 
-    private func packageDescriptionContextGitInformation(at packageDirectory: AbsolutePath) -> PackageDescriptionContext
+    private func packageDescriptionContextGitInformation(at packageDirectory: AbsolutePath) throws -> PackageDescriptionContext
         .GitInformation?
     {
-        do {
-            return PackageDescriptionContext.GitInformation(
-                currentTag: try? gitController.currentTag(workingDirectory: packageDirectory),
-                currentCommit: try gitController.currentCommitSHA(workingDirectory: packageDirectory),
-                hasUncommittedChanges: try gitController.hasUncommittedChanges(workingDirectory: packageDirectory)
-            )
-        } catch {
+        guard gitController.isGitAvailable(),
+              gitController.isInGitRepository(workingDirectory: packageDirectory)
+        else {
             return nil
         }
+
+        return PackageDescriptionContext.GitInformation(
+            currentTag: try gitController.currentTag(workingDirectory: packageDirectory),
+            currentCommit: try gitController.currentCommitSHA(workingDirectory: packageDirectory),
+            hasUncommittedChanges: try gitController.hasUncommittedChanges(workingDirectory: packageDirectory)
+        )
     }
 
     private func macOSSandboxProfile(

--- a/cli/Sources/TuistLoader/Models/PackageDescriptionContext.swift
+++ b/cli/Sources/TuistLoader/Models/PackageDescriptionContext.swift
@@ -1,0 +1,10 @@
+struct PackageDescriptionContext: Encodable {
+    let packageDirectory: String
+    let gitInformation: GitInformation?
+
+    struct GitInformation: Encodable {
+        let currentTag: String?
+        let currentCommit: String
+        let hasUncommittedChanges: Bool
+    }
+}

--- a/cli/Tests/TuistGitTests/GitControllerTests.swift
+++ b/cli/Tests/TuistGitTests/GitControllerTests.swift
@@ -133,6 +133,66 @@ struct GitControllerTests {
         #expect(gitCommitSHA == "5e17254d4a3c14454ecab6575b4a44d6685d3865")
     }
 
+    @Test(.inTemporaryDirectory) func test_currentTag() throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        system.succeedCommand(
+            ["git", "-C", path.pathString, "describe", "--tags", "--exact-match"],
+            output: "1.2.3\n"
+        )
+
+        // When
+        let tag = try subject.currentTag(workingDirectory: path)
+
+        // Then
+        #expect(tag == "1.2.3")
+    }
+
+    @Test(.inTemporaryDirectory) func currentTag_when_empty() throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        system.succeedCommand(
+            ["git", "-C", path.pathString, "describe", "--tags", "--exact-match"],
+            output: "\n"
+        )
+
+        // When
+        let tag = try subject.currentTag(workingDirectory: path)
+
+        // Then
+        #expect(tag == nil)
+    }
+
+    @Test(.inTemporaryDirectory) func hasUncommittedChanges_when_status_has_output() throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        system.succeedCommand(
+            ["git", "-C", path.pathString, "status", "--porcelain"],
+            output: " M Package.swift\n"
+        )
+
+        // When
+        let hasUncommittedChanges = try subject.hasUncommittedChanges(workingDirectory: path)
+
+        // Then
+        #expect(hasUncommittedChanges == true)
+    }
+
+    @Test(.inTemporaryDirectory) func hasUncommittedChanges_when_status_is_empty() throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        system.succeedCommand(
+            ["git", "-C", path.pathString, "status", "--porcelain"],
+            output: "\n"
+        )
+
+        // When
+        let hasUncommittedChanges = try subject.hasUncommittedChanges(workingDirectory: path)
+
+        // Then
+        #expect(hasUncommittedChanges == false)
+    }
+
     @Test(.inTemporaryDirectory) func test_urlOrigin() throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistGitTests/GitControllerTests.swift
+++ b/cli/Tests/TuistGitTests/GitControllerTests.swift
@@ -133,6 +133,34 @@ struct GitControllerTests {
         #expect(gitCommitSHA == "5e17254d4a3c14454ecab6575b4a44d6685d3865")
     }
 
+    @Test func isGitAvailable_when_git_exists() {
+        // Given
+        system.whichStub = { name in
+            #expect(name == "git")
+            return "/usr/bin/git"
+        }
+
+        // When
+        let isGitAvailable = subject.isGitAvailable()
+
+        // Then
+        #expect(isGitAvailable == true)
+    }
+
+    @Test func isGitAvailable_when_git_does_not_exist() {
+        // Given
+        system.whichStub = { name in
+            #expect(name == "git")
+            return nil
+        }
+
+        // When
+        let isGitAvailable = subject.isGitAvailable()
+
+        // Then
+        #expect(isGitAvailable == false)
+    }
+
     @Test(.inTemporaryDirectory) func test_currentTag() throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory)
@@ -148,13 +176,10 @@ struct GitControllerTests {
         #expect(tag == "1.2.3")
     }
 
-    @Test(.inTemporaryDirectory) func currentTag_when_empty() throws {
+    @Test(.inTemporaryDirectory) func currentTag_when_head_does_not_point_to_a_tag() throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory)
-        system.succeedCommand(
-            ["git", "-C", path.pathString, "describe", "--tags", "--exact-match"],
-            output: "\n"
-        )
+        system.errorCommand(["git", "-C", path.pathString, "describe", "--tags", "--exact-match"])
 
         // When
         let tag = try subject.currentTag(workingDirectory: path)

--- a/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
@@ -1,7 +1,10 @@
 import FileSystem
 import Foundation
+import Mockable
 import TuistConstants
+import TuistCore
 import TuistEnvironment
+import TuistGit
 import XcodeGraph
 import XCTest
 @testable import TuistLoader
@@ -207,12 +210,24 @@ final class ManifestLoaderTests: TuistTestCase {
     func test_loadPackageSettings_withPackageDescriptionContextEnvironment() async throws {
         // Given
         let temporaryPath = try temporaryPath()
+        let gitController = MockGitControlling()
+        subject = ManifestLoader(
+            environment: Environment.current,
+            resourceLocator: ResourceLocator(),
+            cacheDirectoriesProvider: CacheDirectoriesProvider(),
+            projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactory(),
+            manifestFilesLocator: ManifestFilesLocator(),
+            swiftPackageManagerController: SwiftPackageManagerController(),
+            packageInfoLoader: PackageInfoLoader(),
+            gitController: gitController
+        )
         let content = """
         // swift-tools-version: 6.1
         import PackageDescription
 
         let demoContextValue = Context.environment["TUIST_DEMO_CONTEXT_VALUE"]
-        let hasGitInformation = Context.gitInformation?.currentCommit.isEmpty == false &&
+        let hasGitInformation = Context.gitInformation?.currentTag == "1.2.3" &&
+            Context.gitInformation?.currentCommit == "abc123" &&
             Context.gitInformation?.hasUncommittedChanges == false
 
         #if TUIST
@@ -241,11 +256,21 @@ final class ManifestLoaderTests: TuistTestCase {
             encoding: .utf8
         )
 
-        try System.shared.run(["git", "-C", temporaryPath.pathString, "init"])
-        try System.shared.run(["git", "-C", temporaryPath.pathString, "config", "user.email", "tuist@example.com"])
-        try System.shared.run(["git", "-C", temporaryPath.pathString, "config", "user.name", "Tuist"])
-        try System.shared.run(["git", "-C", temporaryPath.pathString, "add", "Package.swift"])
-        try System.shared.run(["git", "-C", temporaryPath.pathString, "commit", "-m", "Initial commit"])
+        given(gitController)
+            .isGitAvailable()
+            .willReturn(true)
+        given(gitController)
+            .isInGitRepository(workingDirectory: .value(temporaryPath))
+            .willReturn(true)
+        given(gitController)
+            .currentTag(workingDirectory: .value(temporaryPath))
+            .willReturn("1.2.3")
+        given(gitController)
+            .currentCommitSHA(workingDirectory: .value(temporaryPath))
+            .willReturn("abc123")
+        given(gitController)
+            .hasUncommittedChanges(workingDirectory: .value(temporaryPath))
+            .willReturn(false)
 
         let variables = Environment.current.variables.merging(
             ["TUIST_DEMO_CONTEXT_VALUE": "enabled"],

--- a/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/ManifestLoaderTests.swift
@@ -1,9 +1,9 @@
 import FileSystem
 import Foundation
 import TuistConstants
+import TuistEnvironment
 import XcodeGraph
 import XCTest
-
 @testable import TuistLoader
 @testable import TuistSupport
 @testable import TuistTesting
@@ -190,6 +190,72 @@ final class ManifestLoaderTests: TuistTestCase {
 
         // When
         let got = try await subject.loadPackageSettings(at: temporaryPath, disableSandbox: true)
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .init(
+                targetSettings: [
+                    "TargetA": .settings(base: [
+                        "OTHER_LDFLAGS": "-ObjC",
+                    ]),
+                ]
+            )
+        )
+    }
+
+    func test_loadPackageSettings_withPackageDescriptionContextEnvironment() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let content = """
+        // swift-tools-version: 6.1
+        import PackageDescription
+
+        let demoContextValue = Context.environment["TUIST_DEMO_CONTEXT_VALUE"]
+        let hasGitInformation = Context.gitInformation?.currentCommit.isEmpty == false &&
+            Context.gitInformation?.hasUncommittedChanges == false
+
+        #if TUIST
+        import ProjectDescription
+
+        let packageSettings = PackageSettings(
+            targetSettings: demoContextValue == "enabled" && hasGitInformation ? ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]] : [:]
+        )
+
+        #endif
+
+        let package = Package(
+            name: "PackageName",
+            dependencies: []
+        )
+
+        """
+
+        let manifestPath = temporaryPath.appending(
+            component: Manifest.package.fileName(temporaryPath)
+        )
+        try await fileSystem.makeDirectory(at: temporaryPath.appending(component: Constants.tuistDirectoryName))
+        try content.write(
+            to: manifestPath.url,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try System.shared.run(["git", "-C", temporaryPath.pathString, "init"])
+        try System.shared.run(["git", "-C", temporaryPath.pathString, "config", "user.email", "tuist@example.com"])
+        try System.shared.run(["git", "-C", temporaryPath.pathString, "config", "user.name", "Tuist"])
+        try System.shared.run(["git", "-C", temporaryPath.pathString, "add", "Package.swift"])
+        try System.shared.run(["git", "-C", temporaryPath.pathString, "commit", "-m", "Initial commit"])
+
+        let variables = Environment.current.variables.merging(
+            ["TUIST_DEMO_CONTEXT_VALUE": "enabled"],
+            uniquingKeysWith: { $1 }
+        )
+
+        // When
+        let got = try await Environment.$current.withValue(Environment(variables: variables)) {
+            try await subject.loadPackageSettings(at: temporaryPath, disableSandbox: true)
+        }
 
         // Then
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

- Pass SwiftPM-compatible `-context` metadata when Tuist evaluates `Package.swift` for package settings.
- Populate `Context.gitInformation` best-effort using TuistGit, matching SwiftPM manifest loading behavior.
- Add coverage for `Context.environment`, `Context.gitInformation`, and the new GitController helpers.

## Root cause

Tuist links `PackageDescription` while evaluating `Package.swift`, but it did not pass SwiftPM’s manifest runtime `-context` argument. Accessing `PackageDescription.Context` therefore crashed while decoding `ContextModel`.

## Validation

- `tuist generate tuist TuistLoader TuistLoaderTests TuistGit TuistGitTests ProjectDescription --no-open`
- `swift build --target TuistGit --target TuistLoader --replace-scm-with-registry`
- Direct DemoKit manifest runtime invocation with `-context` including `gitInformation` dumps `PackageSettings` without crashing.

Fixes #10616
