### PR TITLE
fix(server): add favicon head links

### DIFF
--- a/server/lib/tuist_web.ex
+++ b/server/lib/tuist_web.ex
@@ -21,7 +21,9 @@ defmodule TuistWeb do
   alias Plug.Conn
   alias TuistWeb.Controller
 
-  def static_paths, do: ~w(assets fonts images favicon.ico js css .well-known marketing app apidocs skills docs)
+  def static_paths,
+    do:
+      ~w(assets fonts images favicon.ico favicon-16x16.png favicon-32x32.png apple-touch-icon.png android-chrome-192x192.png android-chrome-512x512.png site.webmanifest browserconfig.xml mstile-150x150.png js css .well-known marketing app apidocs skills docs)
 
   def router do
     quote do

--- a/server/lib/tuist_web/components/layout_components.ex
+++ b/server/lib/tuist_web/components/layout_components.ex
@@ -6,6 +6,14 @@ defmodule TuistWeb.LayoutComponents do
 
   import TuistWeb.CSP, only: [get_csp_nonce: 0]
 
+  def head_favicon_links(assigns) do
+    ~H"""
+    <link rel="icon" href={~p"/favicon.ico"} sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href={~p"/favicon-32x32.png"} />
+    <link rel="icon" type="image/png" sizes="16x16" href={~p"/favicon-16x16.png"} />
+    """
+  end
+
   attr(:current_user, :map, default: nil)
 
   def head_plain_script(assigns) do

--- a/server/lib/tuist_web/components/layouts/app.html.heex
+++ b/server/lib/tuist_web/components/layouts/app.html.heex
@@ -29,6 +29,7 @@
     <.live_title>
       {assigns[:head_title] || "Tuist"}
     </.live_title>
+    <TuistWeb.LayoutComponents.head_favicon_links />
     <TuistWeb.LayoutComponents.head_meta_meta_tags {assigns} />
     <TuistWeb.LayoutComponents.head_x_meta_tags {assigns} />
     

--- a/server/lib/tuist_web/controllers/api_html/docs.html.heex
+++ b/server/lib/tuist_web/controllers/api_html/docs.html.heex
@@ -4,6 +4,7 @@
     <title>API Documentation · Tuist</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <TuistWeb.LayoutComponents.head_favicon_links />
     <!-- Meta Meta Tags -->
     <meta property="og:url" content={Tuist.Environment.app_url(path: "/")} />
     <meta property="og:type" content="website" />

--- a/server/lib/tuist_web/docs/layouts/root.html.heex
+++ b/server/lib/tuist_web/docs/layouts/root.html.heex
@@ -8,6 +8,7 @@
     <.live_title>
       {assigns[:page_title] || assigns[:head_title] || "Tuist"}
     </.live_title>
+    <TuistWeb.LayoutComponents.head_favicon_links />
     <TuistWeb.LayoutComponents.head_meta_meta_tags {assigns} />
     <TuistWeb.LayoutComponents.head_x_meta_tags {assigns} />
     <!-- Assets -->

--- a/server/lib/tuist_web/marketing/layouts/root.html.heex
+++ b/server/lib/tuist_web/marketing/layouts/root.html.heex
@@ -8,6 +8,7 @@
     <.live_title>
       {assigns[:head_title] || "Tuist"}
     </.live_title>
+    <TuistWeb.LayoutComponents.head_favicon_links />
     <TuistWeb.LayoutComponents.head_meta_meta_tags {assigns} />
     <TuistWeb.LayoutComponents.head_x_meta_tags {assigns} />
     <!-- Language alternates for SEO -->

--- a/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
   A plug that authorizes API actions.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Authorization
   alias TuistWeb.Authentication

--- a/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
   A plug that authorizes API actions.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Accounts
   alias Tuist.Billing

--- a/server/lib/tuist_web/plugs/loader_plug.ex
+++ b/server/lib/tuist_web/plugs/loader_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.Plugs.LoaderPlug do
   This plug is responsible for loading (and caching) the resources pointed by the path or body parameters.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Accounts
   alias Tuist.CommandEvents


### PR DESCRIPTION
## Summary

Advertise the existing server favicon assets from every server layout.

Add a shared `head_favicon_links` component and render it from the app, marketing, docs, and API docs root layouts. The component links the existing `/favicon.ico`, `/favicon-32x32.png`, and `/favicon-16x16.png` assets.

Also add the existing 16px and 32px PNG favicon files to the Phoenix static path allowlist so those linked files are served. No favicon image assets are changed in this PR.

The CI run also exposed duplicate `use TuistWeb, :verified_routes` calls in plugs that already `use TuistWeb, :controller`. Those redundant calls have been removed because `:controller` already injects verified routes.

## Root Cause

The root domain had the favicon files, but the server layouts were not advertising them in `<head>`. Some clients and favicon crawlers therefore kept resolving the stale wrench favicon.

## Validation

- `mise exec -- mix format --check-formatted lib/tuist_web/plugs/api/authorization/authorization_plug.ex lib/tuist_web/plugs/api/authorization/billing_plug.ex lib/tuist_web/plugs/loader_plug.ex lib/tuist_web.ex lib/tuist_web/components/layout_components.ex lib/tuist_web/components/layouts/app.html.heex lib/tuist_web/docs/layouts/root.html.heex lib/tuist_web/marketing/layouts/root.html.heex lib/tuist_web/controllers/api_html/docs.html.heex`
- `mise exec -- mix compile --warnings-as-errors`
- Verified the PR diff no longer changes any favicon image assets