### PR TITLE
fix(infra): unblock production deploy + fail-fast guards

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -158,6 +158,17 @@ jobs:
           op document get "kubeconfig: tuist-${{ inputs.environment }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        # Fail fast if the 1P-stored kubeconfig points at an unreachable
+        # apiserver. Without this, the next step would hang for `--timeout`
+        # on a phantom kubeconfig (e.g. a torn-down validation cluster
+        # whose LB IP got reassigned to another tenant) and we'd find out
+        # only after a partial helm rollout.
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
       - name: helm dependency update
         run: helm dependency update "$OBSERVABILITY_CHART_PATH"
       - name: helm upgrade --install k8s-monitoring
@@ -204,6 +215,16 @@ jobs:
           op document get "kubeconfig: tuist-${{ inputs.environment }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        # Fail fast if the 1P-stored kubeconfig points at an unreachable
+        # apiserver. Without this, helm upgrade would hang for `--timeout`
+        # against a phantom endpoint and partially mutate cluster state
+        # before erroring.
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
       - name: Recover interrupted Helm release
         run: |
           set -euo pipefail

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -26,11 +26,9 @@ name: Server Deployment
 #   OP_SERVICE_ACCOUNT_TOKEN (per GitHub Environment server-k8s-<env>) -
 #     1Password service-account token scoped read-only to the
 #     tuist-k8s-<env> vault, where the cluster's kubeconfig is stored
-#     as a Document item named `kubeconfig: <cluster-name>` (matches
-#     the Cluster CR's metadata.name: `tuist` for production,
-#     `tuist-<env>` otherwise). Each environment's secret value is the
-#     SA token for that environment's vault — staging deploys can't
-#     read canary/production kubeconfigs.
+#     as a Document item named `kubeconfig: tuist-<env>`. Each
+#     environment's secret value is the SA token for that environment's
+#     vault — staging deploys can't read canary/production kubeconfigs.
 # App secrets live inside the cluster (MASTER_KEY via ESO, DATABASE_URL /
 # ClickHouse / Tigris keys in priv/secrets/<env>.yml.enc baked into the
 # image).
@@ -157,7 +155,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}" \
+          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability
@@ -214,7 +212,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}" \
+          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -26,9 +26,11 @@ name: Server Deployment
 #   OP_SERVICE_ACCOUNT_TOKEN (per GitHub Environment server-k8s-<env>) -
 #     1Password service-account token scoped read-only to the
 #     tuist-k8s-<env> vault, where the cluster's kubeconfig is stored
-#     as a Document item named `kubeconfig: tuist-<env>`. Each
-#     environment's secret value is the SA token for that environment's
-#     vault — staging deploys can't read canary/production kubeconfigs.
+#     as a Document item named `kubeconfig: <cluster-name>` (matches
+#     the Cluster CR's metadata.name: `tuist` for production,
+#     `tuist-<env>` otherwise). Each environment's secret value is the
+#     SA token for that environment's vault — staging deploys can't
+#     read canary/production kubeconfigs.
 # App secrets live inside the cluster (MASTER_KEY via ESO, DATABASE_URL /
 # ClickHouse / Tigris keys in priv/secrets/<env>.yml.enc baked into the
 # image).
@@ -155,7 +157,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
+          op document get "kubeconfig: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability
@@ -212,7 +214,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-${{ inputs.environment }}" \
+          op document get "kubeconfig: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}" \
             --vault "tuist-k8s-${{ inputs.environment }}" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -26,6 +26,37 @@ clusters/
 └── cluster-preview.yaml
 ```
 
+## Recovering from a stuck bootstrap
+
+If a cluster's first kubeadm-init phase fails partway (one CP machine
+joins, another stays `Provisioned` with `apiserver pod not healthy
+yet`), `kubectl apply -f cluster-<env>.yaml` is a no-op: the spec
+already matches and CAPI controllers won't act.
+
+KCP refuses to remediate while etcd quorum is unverifiable (correct
+safety posture: deleting the only "maybe working" CP would lose etcd
+permanently). MachineHealthCheck for workers reads conditions through
+the workload apiserver, which is dead, so it sees stale-healthy data
+and never triggers either. The cluster sits there indefinitely.
+
+The escape hatch is delete-and-recreate. Backing Hetzner servers may or
+may not still exist; caph treats `404` from Hetzner as "already
+deleted" and clears its finalizer either way, so the cascade is safe:
+
+```bash
+KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl -n org-tuist \
+  delete cluster tuist-<env>
+KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl apply -f \
+  infra/k8s/clusters/cluster-<env>.yaml
+mise run k8s:bootstrap-workload tuist-<env> <env>
+```
+
+The bootstrap script is the only thing that brings the cluster from
+"ControlPlaneInitialized=True" to "ready for traffic" (Cilium, HCCM,
+ingress-nginx, ESO, the Cloudflare origin TLS Secret, and the 1P
+kubeconfig upload that the CI deploy workflow relies on). The Cluster
+CR alone does not.
+
 ## Target shape per cluster
 
 | Cluster | CP | Workers |

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -26,37 +26,6 @@ clusters/
 └── cluster-preview.yaml
 ```
 
-## Recovering from a stuck bootstrap
-
-If a cluster's first kubeadm-init phase fails partway (one CP machine
-joins, another stays `Provisioned` with `apiserver pod not healthy
-yet`), `kubectl apply -f cluster-<env>.yaml` is a no-op: the spec
-already matches and CAPI controllers won't act.
-
-KCP refuses to remediate while etcd quorum is unverifiable (correct
-safety posture: deleting the only "maybe working" CP would lose etcd
-permanently). MachineHealthCheck for workers reads conditions through
-the workload apiserver, which is dead, so it sees stale-healthy data
-and never triggers either. The cluster sits there indefinitely.
-
-The escape hatch is delete-and-recreate. Backing Hetzner servers may or
-may not still exist; caph treats `404` from Hetzner as "already
-deleted" and clears its finalizer either way, so the cascade is safe:
-
-```bash
-KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl -n org-tuist \
-  delete cluster tuist-<env>
-KUBECONFIG=~/.kube/tuist-mgmt.yaml kubectl apply -f \
-  infra/k8s/clusters/cluster-<env>.yaml
-mise run k8s:bootstrap-workload tuist-<env> <env>
-```
-
-The bootstrap script is the only thing that brings the cluster from
-"ControlPlaneInitialized=True" to "ready for traffic" (Cilium, HCCM,
-ingress-nginx, ESO, the Cloudflare origin TLS Secret, and the 1P
-kubeconfig upload that the CI deploy workflow relies on). The Cluster
-CR alone does not.
-
 ## Target shape per cluster
 
 | Cluster | CP | Workers |

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -283,26 +283,10 @@ KUBECONFIG="$WL_KUBECONFIG" kubectl -n "$APP_NAMESPACE" create secret tls tuist-
 rm -f "$CERT_TMP" "$KEY_TMP"
 
 # ---------------------------------------------------------------------------
-log "Step 12/12: upload workload kubeconfig to 1Password + report LB IP"
-
-# Stash the freshly-minted workload kubeconfig in the per-env vault
-# so CI (server-deployment.yml) can read it via the per-env
-# OP_SERVICE_ACCOUNT_TOKEN. Idempotent: if the item exists, replace
-# the file contents; if not, create.
-KUBECONFIG_ITEM="kubeconfig: ${CLUSTER_NAME}"
-KUBECONFIG_VAULT="tuist-k8s-${ENV}"
-if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" >/dev/null 2>&1; then
-  echo "Existing 1P item found; replacing the document"
-  EXISTING_ID=$(op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --format json | jq -r '.id')
-  op item delete "$EXISTING_ID" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --archive
-fi
-op document create "$WL_KUBECONFIG" \
-  --title "$KUBECONFIG_ITEM" \
-  --account tuist.1password.com --vault "$KUBECONFIG_VAULT"
-
-echo
+log "Step 12/12: smoke ingress + upload workload kubeconfig to 1Password"
 
 # Wait for HCCM to provision the LB and write the IP back.
+echo -n "Waiting for ingress-nginx LB IP"
 for i in $(seq 1 60); do
   LB_IP=$(KUBECONFIG="$WL_KUBECONFIG" kubectl -n platform get svc -l app.kubernetes.io/name=ingress-nginx \
     -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
@@ -319,6 +303,52 @@ if [ -z "${LB_IP:-}" ]; then
   err "  KUBECONFIG=$WL_KUBECONFIG kubectl -n kube-system logs -l app.kubernetes.io/name=hcloud-cloud-controller-manager"
   exit 1
 fi
+
+# Smoke: the ingress LB actually serves HTTP. Any non-zero status (including
+# 404 from ingress-nginx's default backend) proves the full path
+# Hetzner-LB -> Service -> ingress-nginx pod is wired. Connection failures
+# here mean the cluster is structurally incomplete despite earlier helm
+# successes, and uploading the kubeconfig to 1P would hand CI a target
+# that can't actually serve traffic.
+echo -n "Probing https://$LB_IP/ "
+SMOKE_HTTP=000
+for i in $(seq 1 30); do
+  SMOKE_HTTP=$(curl -sS -k --connect-timeout 5 --max-time 10 \
+    -o /dev/null -w "%{http_code}" "https://$LB_IP/" 2>/dev/null || echo "000")
+  if [ "$SMOKE_HTTP" != "000" ]; then
+    break
+  fi
+  printf '.'
+  sleep 5
+done
+echo
+
+if [ "$SMOKE_HTTP" = "000" ]; then
+  err "ingress LB $LB_IP did not return HTTP after ~2.5min, refusing to publish kubeconfig to 1P."
+  err "The cluster looks structurally incomplete. Investigate:"
+  err "  KUBECONFIG=$WL_KUBECONFIG kubectl -n platform get svc,pods -l app.kubernetes.io/name=ingress-nginx"
+  exit 1
+fi
+echo "ingress LB responded HTTP $SMOKE_HTTP. Routing is healthy."
+
+# Stash the freshly-minted workload kubeconfig in the per-env vault
+# so CI (server-deployment.yml) can read it via the per-env
+# OP_SERVICE_ACCOUNT_TOKEN. Idempotent: if the item exists, replace
+# the file contents; if not, create. Only runs after the smoke above
+# passes, so a stale kubeconfig never overwrites a working one when
+# bootstrap is invoked against a half-built cluster.
+KUBECONFIG_ITEM="kubeconfig: ${CLUSTER_NAME}"
+KUBECONFIG_VAULT="tuist-k8s-${ENV}"
+if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" >/dev/null 2>&1; then
+  echo "Existing 1P item found; replacing the document"
+  EXISTING_ID=$(op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --format json | jq -r '.id')
+  op item delete "$EXISTING_ID" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" --archive
+fi
+op document create "$WL_KUBECONFIG" \
+  --title "$KUBECONFIG_ITEM" \
+  --account tuist.1password.com --vault "$KUBECONFIG_VAULT"
+
+echo
 
 cat <<DONE
 

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -337,7 +337,12 @@ echo "ingress LB responded HTTP $SMOKE_HTTP. Routing is healthy."
 # the file contents; if not, create. Only runs after the smoke above
 # passes, so a stale kubeconfig never overwrites a working one when
 # bootstrap is invoked against a half-built cluster.
-KUBECONFIG_ITEM="kubeconfig: ${CLUSTER_NAME}"
+# Doc name follows env, not cluster_name, so the deploy workflow can
+# look up `kubeconfig: tuist-${env}` uniformly across all environments.
+# Production's Cluster CR uses metadata.name=tuist (no env suffix), but
+# we still store its kubeconfig as `kubeconfig: tuist-production` to
+# keep the workflow's lookup pattern simple.
+KUBECONFIG_ITEM="kubeconfig: tuist-${ENV}"
 KUBECONFIG_VAULT="tuist-k8s-${ENV}"
 if op item get "$KUBECONFIG_ITEM" --account tuist.1password.com --vault "$KUBECONFIG_VAULT" >/dev/null 2>&1; then
   echo "Existing 1P item found; replacing the document"


### PR DESCRIPTION
## Summary

Three workflow/script changes that turn silent deploys-into-the-void into loud upfront failures, plus aligning the production kubeconfig 1P doc name so the workflow lookup stays uniform across envs.

- **Production kubeconfig 1P doc name**. Production deploys were failing with `\"kubeconfig: tuist-production\" isn't an item in the tuist-k8s-production vault` because the bootstrap script keyed the 1P document name off the Cluster CR's `metadata.name` (`tuist` for production), while the workflow's lookup pattern used the deploy env (`tuist-${env}`). Renamed the existing 1P doc to `kubeconfig: tuist-production`, updated [infra/mise/tasks/k8s/bootstrap-workload.sh](https://github.com/tuist/tuist/blob/main/infra/mise/tasks/k8s/bootstrap-workload.sh) to use the env-based name going forward, kept [.github/workflows/server-deployment.yml](https://github.com/tuist/tuist/blob/main/.github/workflows/server-deployment.yml)'s lookup uniform (`kubeconfig: tuist-${{ inputs.environment }}` for every env). Same convention the vault names already use (`tuist-k8s-${env}`).
- **Reachability guard** after both `Load kubeconfig from 1Password` steps: `kubectl --request-timeout=10s get --raw /version`. Surfaces a stale or stranger-tenant kubeconfig as a CI failure in seconds instead of letting `helm upgrade` partially mutate cluster state before timing out.
- **Bootstrap-script smoke gate** in [infra/mise/tasks/k8s/bootstrap-workload.sh](https://github.com/tuist/tuist/blob/main/infra/mise/tasks/k8s/bootstrap-workload.sh): discover the ingress LB IP first, probe it with curl until any HTTP response (even 404) comes back, and only then upload the workload kubeconfig to 1P. A bootstrap exit 0 now means \"this cluster can route traffic\", not just \"Cilium and ingress-nginx installed\".

## Why

Today the deploy pipeline hit two silent failures that this PR catches:

1. The canary deploy rolled out against a half-bootstrapped self-managed cluster, partially mutated state, then exited \"green\" while customers got 500s. Subsequent runs failed mid-rollout with `Kubernetes cluster unreachable: EOF` because the kubeconfig API LB IP had been reassigned by Hetzner to another tenant. A 10-second pre-flight on `/version` would have failed those runs at second five with a clear message.
2. The bootstrap script reported success on a cluster whose ingress LB existed but whose Hetzner-LB-to-pod path wasn't actually wired, and uploaded that kubeconfig to 1P, putting CI in a stuck state.

Separately, the production hotfix unblocks today's failing prod deploy ([run 25382524128](https://github.com/tuist/tuist/actions/runs/25382524128)).

## Test plan

- [x] Bootstrap-script smoke gate exercised on staging: `bash bootstrap-workload.sh tuist-staging staging` printed `ingress LB responded HTTP 404. Routing is healthy.` before uploading to 1P.
- [x] 1P rename validated: `op document get \"kubeconfig: tuist-production\" --vault tuist-k8s-production` returns the same content the old `kubeconfig: tuist` doc held; old name no longer resolves.
- [ ] After merge: next push to `main` triggers `Server Production Deployment`, production deploy reaches `kubeconfig: tuist-production` cleanly, helm upgrade lands on the new self-managed production cluster.
- [ ] After merge: faulted-kubeconfig dispatch (manually point a vault doc at unreachable IP, run workflow_dispatch) errors at the new step within 10 seconds without touching helm state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)