### PR TITLE
fix(server): remove duplicate use TuistWeb, :verified_routes in plugs

### DIFF
--- a/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/authorization_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.API.Authorization.AuthorizationPlug do
   A plug that authorizes API actions.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Authorization
   alias TuistWeb.Authentication

--- a/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
+++ b/server/lib/tuist_web/plugs/api/authorization/billing_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.API.Authorization.BillingPlug do
   A plug that authorizes API actions.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Accounts
   alias Tuist.Billing

--- a/server/lib/tuist_web/plugs/loader_plug.ex
+++ b/server/lib/tuist_web/plugs/loader_plug.ex
@@ -3,7 +3,6 @@ defmodule TuistWeb.Plugs.LoaderPlug do
   This plug is responsible for loading (and caching) the resources pointed by the path or body parameters.
   """
   use TuistWeb, :controller
-  use TuistWeb, :verified_routes
 
   alias Tuist.Accounts
   alias Tuist.CommandEvents


### PR DESCRIPTION
## Summary
- Three plug modules called both `use TuistWeb, :controller` and `use TuistWeb, :verified_routes`. Since `:controller` already injects `verified_routes()` (see [tuist_web.ex:66](https://github.com/tuist/tuist/blob/main/server/lib/tuist_web.ex#L66)), the second `use` invokes `use Phoenix.VerifiedRoutes` twice.
- Phoenix's duplicate-use guard now raises `RuntimeError: duplicate call to "use Phoenix.VerifiedRoutes" found, make sure it is used only once per module`, breaking `mix compile --warnings-as-errors` in the production Docker build on `main` ([failing run](https://github.com/tuist/tuist/actions/runs/25385361216/job/74444820328#step:7:1464)).
- Removes the redundant `use TuistWeb, :verified_routes` from `authorization_plug.ex`, `billing_plug.ex`, and `loader_plug.ex`.

## Test plan
- [ ] `Build server image` job on this PR passes (was failing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)