### PR TITLE
chore(server): Serve OpenAI Apps challenge

### DIFF
--- a/server/lib/tuist_web/controllers/well_known_controller.ex
+++ b/server/lib/tuist_web/controllers/well_known_controller.ex
@@ -7,6 +7,7 @@ defmodule TuistWeb.WellKnownController do
   alias TuistWeb.AgentSkillsDiscovery
   alias TuistWeb.RequestOrigin
 
+  @openai_apps_challenge_token "YoBqoSMoA-RuEX8RMuCKrLnPCXDYUsYtKg-yjFBHmDQ"
   @mcp_path "/mcp"
   @oauth_token_path "/oauth2/token"
   @oauth_authorize_path "/oauth2/authorize"
@@ -24,6 +25,16 @@ defmodule TuistWeb.WellKnownController do
 
   def agent_skills_index(conn, _params) do
     json(conn, AgentSkillsDiscovery.index())
+  end
+
+  def openai_apps_challenge(conn, _params) do
+    if Environment.tuist_hosted?() do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(:ok, @openai_apps_challenge_token)
+    else
+      send_resp(conn, :not_found, "")
+    end
   end
 
   @doc """

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -412,6 +412,7 @@ defmodule TuistWeb.Router do
     get "/oauth-protected-resource/*resource_path", WellKnownController, :oauth_protected_resource
     get "/jwks.json", WellKnownController, :jwks
     get "/mcp/server-card.json", WellKnownController, :mcp_server_card
+    get "/openai-apps-challenge", WellKnownController, :openai_apps_challenge
     get "/apple-app-site-association", WellKnownController, :apple_app_site_association
     get "/assetlinks.json", WellKnownController, :assetlinks
   end

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -119,6 +119,25 @@ defmodule TuistWeb.WellKnownControllerTest do
     end
   end
 
+  describe "GET /.well-known/openai-apps-challenge" do
+    test "returns the OpenAI Apps challenge token for Tuist-hosted deployments", %{conn: conn} do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+
+      conn = get(conn, "/.well-known/openai-apps-challenge")
+
+      assert response(conn, 200) == "YoBqoSMoA-RuEX8RMuCKrLnPCXDYUsYtKg-yjFBHmDQ"
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+
+    test "returns not found for on-premise deployments", %{conn: conn} do
+      expect(Environment, :tuist_hosted?, fn -> false end)
+
+      conn = get(conn, "/.well-known/openai-apps-challenge")
+
+      assert response(conn, 404) == ""
+    end
+  end
+
   describe "GET /.well-known/openid_configuration" do
     test "returns the OpenID configuration", %{conn: conn} do
       issuer = "https://test.example.com"


### PR DESCRIPTION
## Summary

- Add a hosted-only `/.well-known/openai-apps-challenge` endpoint for OpenAI Apps domain verification.
- Return the public OpenAI challenge token directly from code so no runtime secret rollout is needed.
- Cover both Tuist-hosted and on-premise behavior in controller tests.

## Validation

- `git diff --check`
- `mise exec -- mix deps.get && mise exec -- mix format lib/tuist_web/controllers/well_known_controller.ex lib/tuist_web/router.ex test/tuist_web/controllers/well_known_controller_test.exs`
- `mise exec -- mix test test/tuist_web/controllers/well_known_controller_test.exs` could not complete locally because `mix deps.get` updates the out-of-date lockfile to Phoenix 1.8.6, which then fails compiling existing `billing_plug.ex` with duplicate `use Phoenix.VerifiedRoutes`.
