### PR TITLE
fix(server): humanize scatter chart truncation date

### DIFF
--- a/server/lib/tuist_web/components/scatter_chart.ex
+++ b/server/lib/tuist_web/components/scatter_chart.ex
@@ -49,14 +49,15 @@ defmodule TuistWeb.Components.ScatterChart do
   end
 
   @doc """
-  Returns a human-readable representation of the scatter result's oldest entry, or
-  an empty string when the result is not truncated. Callers pass this into their
-  localized truncation message via `dgettext(..., date: scatter_oldest_entry_iso(...))`.
+  Returns a locale-neutral, human-readable representation of the scatter result's
+  oldest entry, or an empty string when the result is not truncated. The format
+  uses digits only (no locale-specific month names) so it composes safely with
+  any translated truncation message via `dgettext(..., date: scatter_oldest_entry_formatted(...))`.
   """
-  def scatter_oldest_entry_iso({:scatter, %{oldest_entry: %NaiveDateTime{} = entry}}),
-    do: Calendar.strftime(entry, "%b %d, %Y %H:%M")
+  def scatter_oldest_entry_formatted({:scatter, %{oldest_entry: %NaiveDateTime{} = entry}}),
+    do: Calendar.strftime(entry, "%Y-%m-%d %H:%M")
 
-  def scatter_oldest_entry_iso(_), do: ""
+  def scatter_oldest_entry_formatted(_), do: ""
 
   defp scatter?(%{result: {:scatter, _}, loading: loading}), do: !loading
   defp scatter?(_), do: false

--- a/server/lib/tuist_web/components/scatter_chart.ex
+++ b/server/lib/tuist_web/components/scatter_chart.ex
@@ -49,11 +49,13 @@ defmodule TuistWeb.Components.ScatterChart do
   end
 
   @doc """
-  Returns the ISO8601 representation of the scatter result's oldest entry, or
+  Returns a human-readable representation of the scatter result's oldest entry, or
   an empty string when the result is not truncated. Callers pass this into their
   localized truncation message via `dgettext(..., date: scatter_oldest_entry_iso(...))`.
   """
-  def scatter_oldest_entry_iso({:scatter, %{oldest_entry: %NaiveDateTime{} = entry}}), do: NaiveDateTime.to_iso8601(entry)
+  def scatter_oldest_entry_iso({:scatter, %{oldest_entry: %NaiveDateTime{} = entry}}),
+    do: Calendar.strftime(entry, "%b %d, %Y %H:%M")
+
   def scatter_oldest_entry_iso(_), do: ""
 
   defp scatter?(%{result: {:scatter, _}, loading: loading}), do: !loading

--- a/server/lib/tuist_web/live/gradle_cache_live.html.heex
+++ b/server/lib/tuist_web/live/gradle_cache_live.html.heex
@@ -428,7 +428,7 @@
           dgettext(
             "dashboard_gradle",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset.",
-            date: scatter_oldest_entry_iso(@cache_hit_rate_chart.result)
+            date: scatter_oldest_entry_formatted(@cache_hit_rate_chart.result)
           )
         }
       />

--- a/server/lib/tuist_web/live/module_cache_live.html.heex
+++ b/server/lib/tuist_web/live/module_cache_live.html.heex
@@ -465,7 +465,7 @@
           dgettext(
             "dashboard_cache",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset.",
-            date: scatter_oldest_entry_iso(@cache_hit_rate_chart.result)
+            date: scatter_oldest_entry_formatted(@cache_hit_rate_chart.result)
           )
         }
       />

--- a/server/lib/tuist_web/live/tests_live.html.heex
+++ b/server/lib/tuist_web/live/tests_live.html.heex
@@ -415,7 +415,7 @@
           dgettext(
             "dashboard_tests",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering by scheme or other properties to narrow down the dataset.",
-            date: scatter_oldest_entry_iso(@test_run_duration_chart.result)
+            date: scatter_oldest_entry_formatted(@test_run_duration_chart.result)
           )
         }
       />
@@ -816,7 +816,7 @@
           dgettext(
             "dashboard_tests",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering to narrow down the dataset.",
-            date: scatter_oldest_entry_iso(@selective_testing_chart.result)
+            date: scatter_oldest_entry_formatted(@selective_testing_chart.result)
           )
         }
       />

--- a/server/lib/tuist_web/live/xcode_builds_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_builds_live.html.heex
@@ -504,7 +504,7 @@
           dgettext(
             "dashboard_builds",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try filtering by scheme, configuration, or other properties to narrow down the dataset.",
-            date: scatter_oldest_entry_iso(@build_duration_chart.result)
+            date: scatter_oldest_entry_formatted(@build_duration_chart.result)
           )
         }
       />

--- a/server/lib/tuist_web/live/xcode_cache_live.html.heex
+++ b/server/lib/tuist_web/live/xcode_cache_live.html.heex
@@ -407,7 +407,7 @@
           dgettext(
             "dashboard_cache",
             "The 10,000 entry limit has been reached, data is only included up to %{date}. Try narrowing the date range to see more recent data.",
-            date: scatter_oldest_entry_iso(@cache_hit_rate_chart.result)
+            date: scatter_oldest_entry_formatted(@cache_hit_rate_chart.result)
           )
         }
       />


### PR DESCRIPTION
## Summary

- The truncation banner on scatter plots (Builds, Tests, Module Cache, Xcode Cache, Gradle Cache) showed the cutoff date in raw ISO8601 form with microseconds (e.g. `2026-04-21T13:28:14.632654`).
- Switched `scatter_oldest_entry_iso/1` to use `Calendar.strftime/2` with `%b %d, %Y %H:%M`, matching how dates are formatted elsewhere in the codebase. The banner now reads e.g. `Apr 21, 2026 13:28`.

## Test plan

- [ ] Open a project with >10k builds and verify the truncation banner under the build duration scatter plot displays the human-friendly date.
- [ ] Confirm the same on Tests, Module Cache, Xcode Cache, and Gradle Cache scatter plots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)