### PR TITLE
fix(cli): duplicate selective testing log messages and improve skip reason clarity

### DIFF
--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -488,9 +488,19 @@ public struct TestService { // swiftlint:disable:this type_body_length
             mapperEnvironment: mapperEnvironment,
             graph: graph,
             action: action,
+            requestedTestTargets: testTargets,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
-        ), action == .build {
-            try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+        ) {
+            if action == .build {
+                try await outputEmptyShardMatrixIfNeeded(isSharding: isSharding, action: action)
+            } else {
+                let timer = clock.startTimer()
+                try await uploadSkippedTestSummary(
+                    schemeName: schemes.first?.name,
+                    config: config,
+                    timer: timer
+                )
+            }
             return
         }
 
@@ -1121,21 +1131,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                     ).isEmpty
                 }
 
-        if !shouldRunTest(
-            for: schemes,
-            testPlanConfiguration: testPlanConfiguration,
-            mapperEnvironment: mapperEnvironment,
-            graph: graph,
-            action: action,
-            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
-        ) {
-            if action != .build {
-                try await uploadSkippedTestSummary(
-                    schemeName: schemes.first?.name,
-                    config: config,
-                    timer: timer
-                )
-            }
+        guard !testSchemes.isEmpty else {
             return
         }
 
@@ -1292,6 +1288,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
         mapperEnvironment: MapperEnvironment,
         graph: Graph,
         action: XcodeBuildTestAction,
+        requestedTestTargets: [TestIdentifier] = [],
         passthroughXcodeBuildArguments: [String] = []
     ) -> Bool {
         let testActionTargets = testActionTargets(
@@ -1301,18 +1298,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
             action: action
         )
         .map(\.target)
-
-        let skippedTestTargets = initialTestTargets(
-            mapperEnvironment: mapperEnvironment,
-            schemes: schemes,
-            testPlanConfiguration: testPlanConfiguration,
-            action: action
-        )
-        .filter { target in
-            !testActionTargets.contains(where: {
-                $0.bundleId == target.target.bundleId
-            })
-        }
 
         let testSchemes =
             schemes
@@ -1327,10 +1312,26 @@ public struct TestService { // swiftlint:disable:this type_body_length
             return false
         }
 
-        if !skippedTestTargets.isEmpty {
+        let requestedTargetNames = Set(requestedTestTargets.map(\.target))
+        let skippedBySelectiveTesting = initialTestTargets(
+            mapperEnvironment: mapperEnvironment,
+            schemes: schemes,
+            testPlanConfiguration: testPlanConfiguration,
+            action: action
+        )
+        .filter { target in
+            !testActionTargets.contains(where: {
+                $0.bundleId == target.target.bundleId
+            })
+        }
+        .filter { target in
+            requestedTargetNames.isEmpty || requestedTargetNames.contains(target.target.name)
+        }
+
+        if !skippedBySelectiveTesting.isEmpty {
             Logger.current
                 .notice(
-                    "The following targets have not changed since the last successful run and will be skipped: \(skippedTestTargets.map(\.target.name).sorted().joined(separator: ", "))"
+                    "The following targets have not changed since the last successful run and will be skipped: \(skippedBySelectiveTesting.map(\.target.name).sorted().joined(separator: ", "))"
                 )
         }
 

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -2000,6 +2000,333 @@ final class TestServiceTests: TuistUnitTestCase {
         }
     }
 
+    func test_run_tests_when_part_is_cached_only_logs_requested_targets_as_skipped() async throws {
+        try await withMockedDependencies {
+            // Given
+            // TargetA, TargetB, TargetC are in the scheme.
+            // TargetB and TargetC are cached.
+            // User passes --test-targets TargetA TargetB (not TargetC).
+            // Only TargetB should appear in the "will be skipped" message.
+            givenGenerator()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(.default)
+            given(buildGraphInspector)
+                .testableSchemes(graphTraverser: .any)
+                .willReturn([])
+
+            let projectPath = try temporaryPath().appending(component: "ProjectOne")
+            let scheme = Scheme.test(
+                name: "ProjectScheme",
+                testAction: .test(
+                    targets: [
+                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                    ]
+                )
+            )
+
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([scheme])
+            given(buildGraphInspector)
+                .testableTarget(
+                    scheme: .any,
+                    testPlan: .any,
+                    testTargets: .any,
+                    skipTestTargets: .any,
+                    graphTraverser: .any,
+                    action: .any
+                )
+                .willReturn(.test())
+
+            var environment = MapperEnvironment()
+            environment.initialGraph = .test(
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [
+                            .test(name: "TargetA", bundleId: "io.tuist.TargetA"),
+                            .test(name: "TargetB", bundleId: "io.tuist.TargetB"),
+                            .test(name: "TargetC", bundleId: "io.tuist.TargetC"),
+                        ],
+                        schemes: [
+                            .test(
+                                name: "ProjectScheme",
+                                testAction: .test(
+                                    targets: [
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetB")),
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetC")),
+                                    ]
+                                )
+                            ),
+                        ]
+                    ),
+                ]
+            )
+            environment.targetTestHashes = [
+                projectPath: [
+                    "TargetA": "hash-a",
+                    "TargetB": "hash-b",
+                    "TargetC": "hash-c",
+                ],
+            ]
+            environment.targetTestCacheItems = [
+                projectPath: [
+                    "TargetB": .test(source: .local, cacheCategory: .selectiveTests),
+                    "TargetC": .test(source: .remote, cacheCategory: .selectiveTests),
+                ],
+            ]
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in
+                    (
+                        path,
+                        .test(
+                            projects: [
+                                projectPath: .test(
+                                    path: projectPath,
+                                    targets: [
+                                        .test(name: "TargetA"),
+                                    ],
+                                    schemes: [scheme]
+                                ),
+                            ]
+                        ),
+                        environment
+                    )
+                }
+
+            // When
+            try await testRun(
+                path: try temporaryPath(),
+                testTargets: [
+                    try TestIdentifier(string: "TargetA"),
+                    try TestIdentifier(string: "TargetB"),
+                ]
+            )
+
+            // Then
+            XCTAssertEqual(testedSchemes, ["ProjectScheme"])
+            // Only TargetB should be reported as skipped (it was requested and cached).
+            // TargetC should NOT appear (it was cached but not requested).
+            XCTAssertStandardOutput(
+                pattern:
+                "The following targets have not changed since the last successful run and will be skipped: TargetB"
+            )
+            XCTAssertStandardOutputNotContains("TargetC")
+        }
+    }
+
+    func test_run_tests_when_part_is_cached_does_not_log_duplicate_messages() async throws {
+        try await withMockedDependencies {
+            // Given
+            givenGenerator()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(.default)
+            given(buildGraphInspector)
+                .testableSchemes(graphTraverser: .any)
+                .willReturn([])
+
+            let projectPath = try temporaryPath().appending(component: "ProjectOne")
+            let scheme = Scheme.test(
+                name: "ProjectScheme",
+                testAction: .test(
+                    targets: [
+                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                    ]
+                )
+            )
+
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([scheme])
+            given(buildGraphInspector)
+                .testableTarget(
+                    scheme: .any,
+                    testPlan: .any,
+                    testTargets: .any,
+                    skipTestTargets: .any,
+                    graphTraverser: .any,
+                    action: .any
+                )
+                .willReturn(.test())
+
+            var environment = MapperEnvironment()
+            environment.initialGraph = .test(
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [
+                            .test(name: "TargetA", bundleId: "io.tuist.TargetA"),
+                            .test(name: "TargetB", bundleId: "io.tuist.TargetB"),
+                        ],
+                        schemes: [
+                            .test(
+                                name: "ProjectScheme",
+                                testAction: .test(
+                                    targets: [
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetB")),
+                                    ]
+                                )
+                            ),
+                        ]
+                    ),
+                ]
+            )
+            environment.targetTestHashes = [
+                projectPath: [
+                    "TargetA": "hash-a",
+                    "TargetB": "hash-b",
+                ],
+            ]
+            environment.targetTestCacheItems = [
+                projectPath: [
+                    "TargetB": .test(source: .local, cacheCategory: .selectiveTests),
+                ],
+            ]
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in
+                    (
+                        path,
+                        .test(
+                            projects: [
+                                projectPath: .test(
+                                    path: projectPath,
+                                    targets: [
+                                        .test(name: "TargetA"),
+                                    ],
+                                    schemes: [scheme]
+                                ),
+                            ]
+                        ),
+                        environment
+                    )
+                }
+
+            // When
+            try await testRun(path: try temporaryPath())
+
+            // Then — verify the "Testing" message appears exactly once (no duplicates)
+            let standardOutput = Logger.testingLogHandler.collected[.info, <=]
+            let searchString = "Testing the following targets: TargetA"
+            let occurrences = standardOutput.components(separatedBy: searchString).count - 1
+            XCTAssertEqual(
+                occurrences, 1,
+                "Expected 'Testing the following targets' to appear exactly once, but it appeared \(occurrences) times"
+            )
+        }
+    }
+
+    func test_run_tests_when_no_test_targets_filter_logs_all_cached_as_skipped() async throws {
+        try await withMockedDependencies {
+            // Given
+            // No --test-targets passed. All cached targets in the scheme should be reported as skipped.
+            givenGenerator()
+            given(configLoader)
+                .loadConfig(path: .any)
+                .willReturn(.default)
+            given(buildGraphInspector)
+                .testableSchemes(graphTraverser: .any)
+                .willReturn([])
+
+            let projectPath = try temporaryPath().appending(component: "ProjectOne")
+            let scheme = Scheme.test(
+                name: "ProjectScheme",
+                testAction: .test(
+                    targets: [
+                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                    ]
+                )
+            )
+
+            given(buildGraphInspector)
+                .workspaceSchemes(graphTraverser: .any)
+                .willReturn([scheme])
+            given(buildGraphInspector)
+                .testableTarget(
+                    scheme: .any,
+                    testPlan: .any,
+                    testTargets: .any,
+                    skipTestTargets: .any,
+                    graphTraverser: .any,
+                    action: .any
+                )
+                .willReturn(.test())
+
+            var environment = MapperEnvironment()
+            environment.initialGraph = .test(
+                projects: [
+                    projectPath: .test(
+                        path: projectPath,
+                        targets: [
+                            .test(name: "TargetA", bundleId: "io.tuist.TargetA"),
+                            .test(name: "TargetB", bundleId: "io.tuist.TargetB"),
+                            .test(name: "TargetC", bundleId: "io.tuist.TargetC"),
+                        ],
+                        schemes: [
+                            .test(
+                                name: "ProjectScheme",
+                                testAction: .test(
+                                    targets: [
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetA")),
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetB")),
+                                        .test(target: TargetReference(projectPath: projectPath, name: "TargetC")),
+                                    ]
+                                )
+                            ),
+                        ]
+                    ),
+                ]
+            )
+            environment.targetTestHashes = [
+                projectPath: [
+                    "TargetA": "hash-a",
+                    "TargetB": "hash-b",
+                    "TargetC": "hash-c",
+                ],
+            ]
+            environment.targetTestCacheItems = [
+                projectPath: [
+                    "TargetB": .test(source: .local, cacheCategory: .selectiveTests),
+                    "TargetC": .test(source: .remote, cacheCategory: .selectiveTests),
+                ],
+            ]
+            given(generator)
+                .generateWithGraph(path: .any, options: .any)
+                .willProduce { path, _ in
+                    (
+                        path,
+                        .test(
+                            projects: [
+                                projectPath: .test(
+                                    path: projectPath,
+                                    targets: [
+                                        .test(name: "TargetA"),
+                                    ],
+                                    schemes: [scheme]
+                                ),
+                            ]
+                        ),
+                        environment
+                    )
+                }
+
+            // When — no testTargets filter
+            try await testRun(path: try temporaryPath())
+
+            // Then — both TargetB and TargetC should appear as skipped
+            XCTAssertStandardOutput(
+                pattern:
+                "The following targets have not changed since the last successful run and will be skipped: TargetB, TargetC"
+            )
+            XCTAssertEqual(testedSchemes, ["ProjectScheme"])
+        }
+    }
+
     func test_run_tests_with_skipped_targets() async throws {
         // Given
         given(configLoader)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -12,6 +12,8 @@ import TuistCore
 import TuistGenerator
 import TuistGit
 import TuistLoader
+import TuistLoggerTesting
+import TuistLogging
 import TuistServer
 import TuistSupport
 import TuistXCActivityLog


### PR DESCRIPTION
> Describe here the purpose of your PR.
## Purpose

  Fixes two issues with `tuist test` selective testing log output:

  1. **Duplicate log messages**: `shouldRunTest` was called twice in the test execution flow — once in
   the outer orchestration function and again inside `testSchemes()`. Both calls emitted the same
  "will be skipped" and "Testing the following targets" notices, resulting in duplicate output.

  2. **Misleading skip reason**: All skipped targets were reported as "have not changed since the last
   successful run" regardless of whether they were actually cached or simply not included in the
  `--test-targets` filter. A target not in `--test-targets` would appear in the skip message even
  though it was never requested.

  ### Changes

  - Removed the redundant `shouldRunTest` call from `testSchemes()`, replaced with a simple `guard
  !testSchemes.isEmpty` check
  - Moved `uploadSkippedTestSummary` handling to the single remaining call site
  - Added `requestedTestTargets` parameter to scope the skip message to only targets the user actually
   requested
  - When `--test-targets` is passed, the "skipped" list + "testing" list now adds up to exactly what
  was requested

  ### Before
  The following targets have not changed since the last successful run and will be skipped: <every
  target in the scheme not being tested, including ones never requested>
  Testing the following targets: A, B, C
  The following targets have not changed since the last successful run and will be skipped:
  Testing the following targets: A, B, C

  ### After
  The following targets have not changed since the last successful run and will be skipped: D, E
  Testing the following targets: A, B, C

  Where `--test-targets A B C D E` was passed and D, E had cache hits.

> Document how to test your changes locally

  1. Run `tuist test --test-targets TargetA TargetB TargetC` on a project with selective testing
  enabled
  2. Verify log messages appear only once (no duplicates)
  3. Verify the "will be skipped" list only contains targets from your `--test-targets` input that
  were cached, not unrelated targets from the scheme
  4. Verify that the skipped list + testing list = your `--test-targets` input
  5. Run `tuist test` without `--test-targets` and verify all cached scheme targets are reported as
  skipped

3 new tests:                                                                                                          
                                                            
  1. `test_run_tests_when_part_is_cached_only_logs_requested_targets_as_skipped` — Verifies that when --test-targets      
  TargetA TargetB is passed but TargetB and TargetC are both cached, only TargetB (which was requested) appears in the  
  "will be skipped" message. TargetC should not appear.                                                                 
  2. `test_run_tests_when_part_is_cached_does_not_log_duplicate_messages` — Verifies that "Testing the following targets" 
  appears exactly once in the log output (the original bug was it appeared twice).
  3. `test_run_tests_when_no_test_targets_filter_logs_all_cached_as_skipped` — Verifies that when no --test-targets is
  passed, all cached targets in the scheme (TargetB, TargetC) appear in the skip message.