### PR TITLE
feat(server): add MCP setup tools

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -15,14 +15,15 @@ Sensitive authentication data (passwords, tokens) are excluded from exports.
 
 ### Account & User Data
 - User profiles (email, active/inactive status, account settings, preferred locale)
-- Organization memberships and roles
+- Organization records (account handle/name, creator relationship, and timestamps)
+- Organization memberships and roles (user, organization, role, and timestamps)
 - Account billing information and subscriptions
 - API tokens, SCIM-scoped account tokens, and project tokens (existence, scopes, names, timestamps, and last-used metadata only; token values and hashes are excluded)
 - Custom cache endpoint configurations
 - Organization SSO configuration metadata, including the configured SSO provider, provider URL, and full OAuth2 endpoint URLs
 
 ### Projects & Development
-- Project information (names, settings, repositories)
+- Project information (account relationship, handle/name, build system, default branch, visibility/settings, repositories, and timestamps)
 - Command events (CLI usage, build data, performance metrics)
 - Cache events and cache action items
 - Test cases and test execution results

--- a/server/lib/tuist/mcp/components/prompts/integrate_gradle_project.ex
+++ b/server/lib/tuist/mcp/components/prompts/integrate_gradle_project.ex
@@ -1,0 +1,164 @@
+defmodule Tuist.MCP.Components.Prompts.IntegrateGradleProject do
+  @moduledoc """
+  Guides you through integrating Tuist into an existing Gradle project.
+  """
+
+  use Tuist.MCP.Prompt,
+    name: "integrate_gradle_project",
+    arguments: [
+      %{name: "account_handle", description: "The Tuist account or organization handle."},
+      %{name: "project_handle", description: "The Tuist project handle."},
+      %{
+        name: "features",
+        description:
+          "Optional comma-separated feature list. Supported values: remote_cache, build_insights, test_insights, flaky_tests, test_sharding."
+      }
+    ]
+
+  @impl EMCP.Prompt
+  def description, do: "Guides you through integrating Tuist into an existing Gradle project."
+
+  @impl EMCP.Prompt
+  def template(_conn, args) do
+    account_handle = Map.get(args, "account_handle")
+    project_handle = Map.get(args, "project_handle")
+    features = Map.get(args, "features")
+
+    %{
+      messages: [
+        Tuist.MCP.Prompt.message(prompt_text(account_handle, project_handle, features))
+      ]
+    }
+  end
+
+  defp prompt_text(account_handle, project_handle, features) do
+    project =
+      if account_handle && project_handle,
+        do: "`#{account_handle}/#{project_handle}`",
+        else: "the target Tuist project"
+
+    feature_instruction =
+      case features do
+        value when is_binary(value) and value != "" ->
+          "The user requested these features: `#{value}`. Integrate those features and skip unrelated optional setup."
+
+        _ ->
+          "Ask the user which supported Tuist Gradle features they want, or infer the smallest useful set from their request before editing."
+      end
+
+    """
+    # Integrate Tuist Gradle Project
+
+    Help the user integrate Tuist into an existing Gradle project for #{project}.
+
+    ## Workflow
+
+    1. Confirm the project handle. If the Tuist organization or project does not exist yet, use `create_organization` and `create_project` with `build_system=gradle`.
+    2. Install the Tuist Gradle plugin in the Gradle project following the repository's existing plugin-management style.
+    3. Configure the Tuist plugin with the project full handle, preferably through `tuist.toml` so the CLI and Gradle plugin share the same project identity.
+    4. #{feature_instruction}
+
+    ## Supported integrations
+
+    ### Remote build cache
+
+    Enable Gradle's build cache in `gradle.properties`:
+
+    ```properties
+    org.gradle.caching=true
+    ```
+
+    Configure remote cache uploads. Prefer local read-only cache usage and CI uploads:
+
+    ```kotlin
+    tuist {
+        buildCache {
+            push = System.getenv("CI") != null
+        }
+    }
+    ```
+
+    On CI, authenticate with a Tuist token before running Gradle, and disable the local Gradle build cache on CI:
+
+    ```kotlin
+    buildCache {
+        local {
+            isEnabled = System.getenv("CI") == null
+        }
+    }
+    ```
+
+    Verify task cache behavior by running a Gradle build first, then use `list_gradle_builds` to find the uploaded build and `list_gradle_build_tasks` to inspect task cache outcomes.
+
+    ### Build insights
+
+    Build insights are available once the Tuist Gradle plugin is applied. Use `uploadInBackground` when the user wants explicit upload behavior:
+
+    ```kotlin
+    tuist {
+        uploadInBackground = false
+    }
+    ```
+
+    The default behavior uploads in the background locally and in the foreground on CI.
+
+    ### Test insights
+
+    Test insights are collected automatically from Gradle `Test` tasks once the Tuist Gradle plugin is applied. No additional configuration is needed beyond plugin setup unless the user wants to tune `uploadInBackground`.
+
+    ### Flaky tests and quarantine
+
+    Tuist detects flaky tests from retries and cross-run history. If the project does not already retry tests, suggest adding the Gradle Test Retry plugin:
+
+    ```kotlin
+    plugins {
+        id("org.gradle.test-retry") version "1.6.2"
+    }
+
+    tasks.test {
+        retry {
+            maxRetries = 3
+            maxFailures = 5
+            failOnPassedAfterRetry = false
+        }
+    }
+    ```
+
+    Quarantine is enabled automatically on CI and disabled locally. Configure it explicitly only when requested:
+
+    ```kotlin
+    tuist {
+        testQuarantine {
+            enabled = true
+        }
+    }
+    ```
+
+    ### Test sharding
+
+    Use test sharding when the user wants to distribute Gradle tests across CI runners. Add a CI build phase that prepares shard plans:
+
+    ```sh
+    ./gradlew tuistPrepareTestShards -PtuistShardMax=5
+    ```
+
+    Then run each test shard with `TUIST_SHARD_INDEX` set:
+
+    ```sh
+    TUIST_SHARD_INDEX=0 ./gradlew test
+    ```
+
+    Tune sharding with `-PtuistShardMax`, `-PtuistShardMin`, and `-PtuistShardMaxDuration`. Let Tuist derive the shard reference from CI unless the workflow needs `TUIST_SHARD_REFERENCE`.
+
+    ## Verification
+
+    After implementing the selected features, run the smallest relevant Gradle verification:
+    - Plugin setup or build insights: run a normal Gradle build.
+    - Remote cache: run a clean build twice before calling `list_gradle_builds` and `list_gradle_build_tasks` to inspect cache task behavior.
+    - Test insights, flaky tests, or quarantine: run the relevant `Test` task.
+    - Test sharding: run `tuistPrepareTestShards` and one shard execution command.
+
+    Keep the implementation aligned with the user's Gradle DSL (`settings.gradle`, `settings.gradle.kts`, `build.gradle`, or `build.gradle.kts`) and avoid rewriting unrelated build logic.
+    """
+  end
+end

--- a/server/lib/tuist/mcp/components/prompts/integrate_xcode_project.ex
+++ b/server/lib/tuist/mcp/components/prompts/integrate_xcode_project.ex
@@ -1,0 +1,199 @@
+defmodule Tuist.MCP.Components.Prompts.IntegrateXcodeProject do
+  @moduledoc """
+  Guides you through integrating Tuist into an Xcode project.
+  """
+
+  use Tuist.MCP.Prompt,
+    name: "integrate_xcode_project",
+    arguments: [
+      %{name: "account_handle", description: "The Tuist account or organization handle."},
+      %{name: "project_handle", description: "The Tuist project handle."},
+      %{
+        name: "features",
+        description:
+          "Optional comma-separated feature list. Supported values: xcode_cache, build_insights, test_insights, test_sharding."
+      }
+    ]
+
+  @impl EMCP.Prompt
+  def description, do: "Guides you through integrating Tuist into an Xcode project."
+
+  @impl EMCP.Prompt
+  def template(_conn, args) do
+    account_handle = Map.get(args, "account_handle")
+    project_handle = Map.get(args, "project_handle")
+    features = Map.get(args, "features")
+
+    %{
+      messages: [
+        Tuist.MCP.Prompt.message(prompt_text(account_handle, project_handle, features))
+      ]
+    }
+  end
+
+  defp prompt_text(account_handle, project_handle, features) do
+    {project, socket_path} =
+      if account_handle && project_handle do
+        {"`#{account_handle}/#{project_handle}`", "$HOME/.local/state/tuist/#{account_handle}_#{project_handle}.sock"}
+      else
+        {"the target Tuist project", "$HOME/.local/state/tuist/your_org_your_project.sock"}
+      end
+
+    feature_instruction =
+      case features do
+        value when is_binary(value) and value != "" ->
+          "The user requested these features: `#{value}`. Integrate those features and skip unrelated optional setup."
+
+        _ ->
+          "Ask the user which supported Tuist Xcode features they want, or infer the smallest useful set from their request before editing."
+      end
+
+    """
+    # Integrate Tuist Xcode Project
+
+    Help the user integrate Tuist into an Xcode project for #{project}.
+
+    ## Workflow
+
+    1. Confirm the project handle. If the Tuist organization or project does not exist yet, use `create_organization` and `create_project` with `build_system=xcode`.
+    2. Ensure the project has a `Tuist.swift` with `fullHandle` set to the Tuist project.
+    3. Determine whether this is a Tuist-generated project, a manually maintained Xcode project, or a workspace, and preserve the user's existing build invocation style.
+    4. #{feature_instruction}
+
+    ## Supported integrations
+
+    ### Xcode cache
+
+    Run `tuist setup cache` locally and in CI before any `xcodebuild`, `tuist xcodebuild`, `tuist test`, or `tuist cache warm` invocation. This starts the local cache service that Xcode talks to through a socket.
+
+    For Tuist-generated projects, prefer enabling cache generation in `Tuist.swift`:
+
+    ```swift
+    import ProjectDescription
+
+    let tuist = Tuist(
+        fullHandle: "your-org/your-project",
+        project: .tuist(
+            generationOptions: .options(
+                enableCaching: true
+            )
+        )
+    )
+    ```
+
+    For manually maintained Xcode projects, add these build settings:
+
+    ```text
+    COMPILATION_CACHE_ENABLE_CACHING = YES
+    COMPILATION_CACHE_REMOTE_SERVICE_PATH = #{socket_path}
+    COMPILATION_CACHE_ENABLE_PLUGIN = YES
+    COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS = YES
+    ```
+
+    Configure upload policy. Prefer CI uploads and local read-only mode when reproducibility matters:
+
+    ```swift
+    import ProjectDescription
+
+    let tuist = Tuist(
+        fullHandle: "your-org/your-project",
+        cache: .cache(
+            upload: Environment.isCI
+        ),
+        project: .tuist(
+            generationOptions: .options(
+                enableCaching: true
+            )
+        )
+    )
+    ```
+
+    Verify by running a clean Xcode build first, then inspect cache behavior through `list_xcode_builds`, `list_xcode_build_cache_tasks`, and `list_xcode_build_cas_outputs`.
+
+    ### Build insights
+
+    Build insights are driven by `tuist inspect build`, usually from a shared scheme post-action. For Xcodebuild-driven CI, use `tuist xcodebuild` when invoking `xcodebuild` actions and include `-resultBundlePath` so Tuist can analyze the build artifacts.
+
+    ```sh
+    tuist xcodebuild build \
+      -scheme MyScheme \
+      -workspace MyWorkspace.xcworkspace \
+      -destination 'platform=iOS Simulator,name=iPhone 16' \
+      -resultBundlePath .tuist-result-bundles/build.xcresult
+    ```
+
+    If the user wants machine metrics, run `tuist setup insights` before building. Verify by running a build, then use `list_xcode_builds`, `get_xcode_build`, `list_xcode_build_targets`, and `list_xcode_build_issues`.
+
+    ### Test insights
+
+    Test insights are driven by `tuist inspect test`, usually from a shared scheme test post-action. Generated projects with auto-generated schemes include the post-action by default unless test insights are disabled.
+
+    Prefer a scheme post-action over running `tuist inspect test` as a standalone command when the project needs accurate scheme attribution. The scheme is part of Tuist's test insight and flakiness context, so running the inspect command from the scheme post-action lets Tuist attribute uploaded results to the scheme that produced them. A standalone `tuist inspect test` command can still upload results when the required result bundle exists, but it may lose that scheme context.
+
+    For manually maintained Xcode schemes, add a test post-action that runs:
+
+    ```sh
+    tuist inspect test
+    ```
+
+    If the project uses Mise, use Mise's absolute path in the post-action because Xcode does not inherit the shell `PATH`:
+
+    ```sh
+    # -C ensures that Mise loads the configuration from the Mise configuration
+    # file in the project's root directory.
+    $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect test
+    ```
+
+    Ensure the post-action inherits build settings from a target so `$SRCROOT` points at the project root.
+
+    On CI, use `tuist xcodebuild test` or add `-resultBundlePath` to the existing `xcodebuild test` invocation so the result bundle exists for inspection.
+
+    Verify by running a test action first, then inspect uploaded results through `list_test_runs`, `get_test_run`, `list_test_module_runs`, `list_test_suite_runs`, and `list_test_case_runs`.
+
+    ### Test sharding
+
+    Use test sharding when the user wants to distribute Xcode tests across CI runners. Test sharding requires test insights so Tuist can use historical timing data for balancing.
+
+    For manually maintained Xcode projects, create the shard plan with `tuist xcodebuild build-for-testing`:
+
+    ```sh
+    tuist xcodebuild build-for-testing \
+      -scheme MyScheme \
+      -destination 'platform=iOS Simulator,name=iPhone 16' \
+      --shard-total 5
+    ```
+
+    Then execute each shard with `tuist xcodebuild test` and a shard index:
+
+    ```sh
+    TUIST_SHARD_INDEX=0 tuist xcodebuild test \
+      -scheme MyScheme \
+      -destination 'platform=iOS Simulator,name=iPhone 16'
+    ```
+
+    For generated projects, create the shard plan with:
+
+    ```sh
+    tuist test --build-only --shard-total 5
+    ```
+
+    Then execute each shard with:
+
+    ```sh
+    TUIST_SHARD_INDEX=0 tuist test --without-building
+    ```
+
+    Tune sharding with `--shard-min`, `--shard-max`, `--shard-total`, `--shard-max-duration`, `--shard-granularity`, `--shard-reference`, and `--shard-archive-path`. Let Tuist derive the shard reference from CI unless the workflow needs `TUIST_SHARD_REFERENCE`.
+
+    ## Verification
+
+    After implementing the selected features, run the smallest relevant Xcode verification:
+    - Xcode cache: run a clean build before calling cache-related MCP tools.
+    - Build insights: run a build before calling build-related MCP tools.
+    - Test insights: run a test action before calling test-related MCP tools.
+    - Test sharding: run the shard build phase and one shard execution command.
+
+    Do not remove existing Xcode project settings unless they conflict with the selected Tuist integrations. Keep changes scoped to Tuist configuration, scheme post-actions, cache build settings, and CI bootstrap.
+    """
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/add_organization_member.ex
+++ b/server/lib/tuist/mcp/components/tools/add_organization_member.ex
@@ -1,0 +1,98 @@
+defmodule Tuist.MCP.Components.Tools.AddOrganizationMember do
+  @moduledoc """
+  Add an existing Tuist user to an organization.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "add_organization_member",
+    title: "Add Organization Member",
+    read_only_hint: false,
+    destructive_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "organization_handle" => %{
+          "type" => "string",
+          "description" => "The organization handle."
+        },
+        "email" => %{
+          "type" => "string",
+          "description" => "The email of an existing Tuist user to add."
+        },
+        "role" => %{
+          "type" => "string",
+          "enum" => ["user", "admin"],
+          "description" => "The member role. Defaults to user."
+        }
+      },
+      "required" => ["organization_handle", "email"]
+    }
+
+  alias Tuist.Accounts
+  alias Tuist.Authorization
+
+  @impl EMCP.Tool
+  def description, do: "Add an existing Tuist user to an organization."
+
+  def execute(%{assigns: %{current_user: user}}, %{"organization_handle" => organization_handle, "email" => email} = args)
+      when is_binary(organization_handle) and is_binary(email) do
+    role = Map.get(args, "role", "user")
+    organization_account = accessible_organization_account(user, organization_handle)
+
+    cond do
+      is_nil(organization_account) ->
+        {:error, not_authorized_error()}
+
+      Authorization.authorize(:member_update, user, organization_account.account) != :ok ->
+        {:error, not_authorized_error()}
+
+      role not in ["user", "admin"] ->
+        {:error, "role must be either user or admin."}
+
+      true ->
+        add_member(organization_account.organization, organization_account.account, email, role)
+    end
+  end
+
+  def execute(_conn, _args), do: {:error, "You must authenticate as a user to add organization members."}
+
+  defp accessible_organization_account(user, organization_handle) do
+    user
+    |> Accounts.get_user_organization_accounts()
+    |> Enum.find(&(&1.account.name == organization_handle))
+  end
+
+  defp add_member(organization, account, email, role) do
+    with {:ok, member} <- Accounts.get_user_by_email(email),
+         :ok <- upsert_member_role(member, organization, role) do
+      {:ok,
+       %{
+         id: member.id,
+         email: member.email,
+         name: member.account.name,
+         organization_handle: account.name,
+         role: role
+       }}
+    else
+      {:error, :not_found} -> {:error, "User #{email} was not found."}
+    end
+  end
+
+  defp upsert_member_role(member, organization, role) do
+    role = String.to_existing_atom(role)
+
+    case Accounts.get_user_role_in_organization(member, organization) do
+      nil -> Accounts.add_user_to_organization(member, organization, role: role)
+      _current_role -> update_member_role(member, organization, role)
+    end
+  end
+
+  defp update_member_role(member, organization, role) do
+    case Accounts.update_user_role_in_organization(member, organization, role) do
+      {:ok, _role} -> :ok
+      result -> result
+    end
+  end
+
+  defp not_authorized_error, do: "The authenticated subject is not authorized to perform this action."
+end

--- a/server/lib/tuist/mcp/components/tools/create_organization.ex
+++ b/server/lib/tuist/mcp/components/tools/create_organization.ex
@@ -1,0 +1,45 @@
+defmodule Tuist.MCP.Components.Tools.CreateOrganization do
+  @moduledoc """
+  Create a Tuist organization for the authenticated user.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "create_organization",
+    title: "Create Organization",
+    read_only_hint: false,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "handle" => %{
+          "type" => "string",
+          "description" => "The organization handle to create."
+        }
+      },
+      "required" => ["handle"]
+    }
+
+  alias Tuist.Accounts
+  alias Tuist.MCP.Formatter
+
+  @impl EMCP.Tool
+  def description, do: "Create a Tuist organization for the authenticated user."
+
+  def execute(%{assigns: %{current_user: user}}, %{"handle" => handle}) when is_binary(handle) do
+    case Accounts.create_organization(%{name: handle, creator: user}) do
+      {:ok, organization} ->
+        Tuist.Analytics.organization_create(handle, user)
+
+        {:ok,
+         %{
+           id: organization.id,
+           name: organization.account.name,
+           account_handle: organization.account.name
+         }}
+
+      {:error, changeset} ->
+        {:error, Formatter.changeset_errors(changeset)}
+    end
+  end
+
+  def execute(_conn, _args), do: {:error, "You must authenticate as a user to create organizations."}
+end

--- a/server/lib/tuist/mcp/components/tools/create_project.ex
+++ b/server/lib/tuist/mcp/components/tools/create_project.ex
@@ -1,0 +1,94 @@
+defmodule Tuist.MCP.Components.Tools.CreateProject do
+  @moduledoc """
+  Create a Tuist project under an account the authenticated user can access.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "create_project",
+    title: "Create Project",
+    read_only_hint: false,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The account or organization handle that will own the project."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The project handle to create."
+        },
+        "build_system" => %{
+          "type" => "string",
+          "enum" => ["xcode", "gradle"],
+          "description" => "The project's build system. Defaults to xcode."
+        }
+      },
+      "required" => ["account_handle", "project_handle"]
+    }
+
+  alias Tuist.Accounts
+  alias Tuist.Authorization
+  alias Tuist.MCP.Formatter
+  alias Tuist.Projects
+
+  @impl EMCP.Tool
+  def description, do: "Create a Tuist project under an account the authenticated user can access."
+
+  def execute(
+        %{assigns: %{current_user: user}},
+        %{"account_handle" => account_handle, "project_handle" => project_handle} = args
+      )
+      when is_binary(account_handle) and is_binary(project_handle) do
+    build_system = Map.get(args, "build_system", "xcode")
+    create_project(user, account_handle, project_handle, build_system)
+  end
+
+  def execute(_conn, _args), do: {:error, "You must authenticate as a user to create projects."}
+
+  defp create_project(user, account_handle, project_handle, build_system) do
+    account = accessible_account(user, account_handle)
+
+    cond do
+      is_nil(account) ->
+        {:error, not_authorized_error()}
+
+      Authorization.authorize(:project_create, user, account) != :ok ->
+        {:error, not_authorized_error()}
+
+      true ->
+        case Projects.create_project(%{name: project_handle, account: account},
+               build_system: build_system
+             ) do
+          {:ok, project} ->
+            {:ok,
+             %{
+               id: project.id,
+               name: project.name,
+               account_handle: account.name,
+               full_handle: "#{account.name}/#{project.name}",
+               build_system: to_string(project.build_system),
+               default_branch: project.default_branch
+             }}
+
+          {:error, changeset} ->
+            {:error, Formatter.changeset_errors(changeset)}
+        end
+    end
+  end
+
+  defp accessible_account(user, account_handle) do
+    own_account = Accounts.get_account_from_user(user)
+
+    organization_accounts =
+      user
+      |> Accounts.get_user_organization_accounts()
+      |> Enum.map(& &1.account)
+
+    [own_account | organization_accounts]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.find(&(&1.name == account_handle))
+  end
+
+  defp not_authorized_error, do: "The authenticated subject is not authorized to perform this action."
+end

--- a/server/lib/tuist/mcp/formatter.ex
+++ b/server/lib/tuist/mcp/formatter.ex
@@ -22,4 +22,11 @@ defmodule Tuist.MCP.Formatter do
   end
 
   def iso8601(other, _opts), do: to_string(other)
+
+  def changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> Enum.flat_map(fn {_key, value} -> value end)
+    |> Enum.join(", ")
+  end
 end

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -3,8 +3,11 @@ defmodule Tuist.MCP.Server do
 
   use EMCP.Server,
     name: "tuist",
-    version: "1.6.1",
+    version: "1.7.0",
     tools: [
+      Tuist.MCP.Components.Tools.CreateOrganization,
+      Tuist.MCP.Components.Tools.CreateProject,
+      Tuist.MCP.Components.Tools.AddOrganizationMember,
       Tuist.MCP.Components.Tools.ListXcodeBuilds,
       Tuist.MCP.Components.Tools.GetXcodeBuild,
       Tuist.MCP.Components.Tools.ListXcodeBuildTargets,
@@ -44,6 +47,8 @@ defmodule Tuist.MCP.Server do
       Tuist.MCP.Components.Prompts.CompareTestCase,
       Tuist.MCP.Components.Prompts.CompareGenerations,
       Tuist.MCP.Components.Prompts.CompareCacheRuns,
-      Tuist.MCP.Components.Prompts.AnalyzeSelectiveTesting
+      Tuist.MCP.Components.Prompts.AnalyzeSelectiveTesting,
+      Tuist.MCP.Components.Prompts.IntegrateGradleProject,
+      Tuist.MCP.Components.Prompts.IntegrateXcodeProject
     ]
 end

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -11,7 +11,8 @@
 MCP makes LLM-powered applications such as [Claude](https://claude.ai/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), and editors like [Zed](https://zed.dev), [Cursor](https://www.cursor.com), or [VS Code](https://code.visualstudio.com) interoperable with external services and data sources.
 
 Tuist hosts a server-side MCP endpoint at `https://tuist.dev/mcp`. By connecting your MCP client to it, AI agents can access your Tuist project data, including test insights, flaky test analysis, and more.
-The current MCP tools are read-only and scoped to authenticated Tuist project data. They do not publish to external services or perform destructive actions.
+Most MCP tools are read-only and scoped to authenticated Tuist project data. Account setup tools can create organizations, create projects, and add existing users to organizations when the authenticated user has the required permissions.
+The account setup tools require user authentication. They are not available to project tokens or account tokens.
 
 ## MCP vs Skills
 
@@ -115,6 +116,9 @@ The following tools are available through the Tuist MCP server:
 
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
+| `create_organization` | Create a Tuist organization for the authenticated user. | `handle` |
+| `create_project` | Create a Tuist project under an account the authenticated user can access. | `account_handle`, `project_handle` |
+| `add_organization_member` | Add an existing Tuist user to an organization. | `organization_handle`, `email` |
 | `list_projects` | List all projects accessible to the authenticated user. | None |
 
 #### Xcode builds
@@ -185,5 +189,34 @@ The following tools are available through the Tuist MCP server:
 | `compare_test_case` | Guides you through comparing a test case's behavior across two branches or time periods. |
 | `compare_generations` | Guides you through comparing two generation runs to identify performance regressions and module cache changes. |
 | `compare_cache_runs` | Guides you through comparing two cache runs to identify cache effectiveness changes and target-level regressions. |
+| `integrate_gradle_project` | Guides you through integrating Tuist into an existing Gradle project. Supports remote build cache, build insights, test insights, flaky test detection and quarantine, and test sharding. |
+| `integrate_xcode_project` | Guides you through integrating Tuist into an existing Xcode project. Supports Xcode cache, build insights, test insights, and test sharding. |
 
-All prompts accept `account_handle` and `project_handle` to scope the investigation to a specific project. The comparison prompts also accept `base` and `head` arguments to specify the two items to compare (by ID, dashboard URL, or branch name).
+All prompts accept `account_handle` and `project_handle` to scope the investigation to a specific project. The comparison prompts also accept `base` and `head` arguments to specify the two items to compare (by ID, dashboard URL, or branch name). `integrate_gradle_project` also accepts `features`, a comma-separated list of Gradle integrations to apply: `remote_cache`, `build_insights`, `test_insights`, `flaky_tests`, and `test_sharding`. `integrate_xcode_project` accepts `features` with `xcode_cache`, `build_insights`, `test_insights`, and `test_sharding`.
+
+#### Gradle integration prompt features
+
+The `integrate_gradle_project` prompt documents every Gradle integration that the Tuist Gradle plugin supports:
+
+| Feature | What the agent configures |
+|---------|---------------------------|
+| `remote_cache` | Enables Gradle's build cache, configures Tuist remote cache upload policy, and recommends CI-only uploads with local read-only usage. |
+| `build_insights` | Applies the Tuist Gradle plugin and configures build analytics upload behavior when needed. |
+| `test_insights` | Applies the Tuist Gradle plugin so Gradle `Test` task results are uploaded automatically. |
+| `flaky_tests` | Guides setup for flaky test detection, optional Gradle Test Retry plugin usage, and test quarantine configuration. |
+| `test_sharding` | Adds the CI workflow for `tuistPrepareTestShards`, shard matrix generation, and `TUIST_SHARD_INDEX` based test execution. |
+
+When `features` is omitted, the prompt asks the agent to clarify which integrations the user wants or infer the smallest useful set from the request before editing the Gradle project.
+
+#### Xcode integration prompt features
+
+The `integrate_xcode_project` prompt documents every Xcode integration that Tuist supports:
+
+| Feature | What the agent configures |
+|---------|---------------------------|
+| `xcode_cache` | Configures `tuist setup cache`, generated-project cache settings, manual Xcode cache build settings, and CI-only cache upload policy. |
+| `build_insights` | Configures `tuist inspect build`, `tuist xcodebuild`, `-resultBundlePath`, and optional machine metrics through `tuist setup insights`. |
+| `test_insights` | Configures `tuist inspect test`, scheme test post-actions, and result bundle generation for CI test runs. |
+| `test_sharding` | Adds the Xcode or generated-project shard planning and shard execution workflow with `TUIST_SHARD_INDEX`. |
+
+When `features` is omitted, the prompt asks the agent to clarify which integrations the user wants or infer the smallest useful set from the request before editing the Xcode project.

--- a/server/test/tuist/mcp/components/prompts/prompts_test.exs
+++ b/server/test/tuist/mcp/components/prompts/prompts_test.exs
@@ -9,6 +9,8 @@ defmodule Tuist.MCP.Components.Prompts.PromptsTest do
   alias Tuist.MCP.Components.Prompts.CompareTestCase
   alias Tuist.MCP.Components.Prompts.CompareTestRuns
   alias Tuist.MCP.Components.Prompts.FixFlakyTest
+  alias Tuist.MCP.Components.Prompts.IntegrateGradleProject
+  alias Tuist.MCP.Components.Prompts.IntegrateXcodeProject
   alias Tuist.Projects
 
   describe "fix_flaky_test" do
@@ -170,6 +172,54 @@ defmodule Tuist.MCP.Components.Prompts.PromptsTest do
       assert text =~ "Compare Cache Runs"
       assert text =~ "cr-base-id"
       assert text =~ "cr-head-id"
+    end
+  end
+
+  describe "integrate_gradle_project" do
+    test "returns prompt messages" do
+      result =
+        IntegrateGradleProject.template(nil, %{
+          "account_handle" => "acme",
+          "project_handle" => "android",
+          "features" => "remote_cache,test_sharding"
+        })
+
+      assert %{messages: messages} = result
+      assert length(messages) == 1
+      text = hd(messages).content.text
+      assert text =~ "Integrate Tuist Gradle Project"
+      assert text =~ "`acme/android`"
+      assert text =~ "create_project"
+      assert text =~ "org.gradle.caching=true"
+      assert text =~ "running a Gradle build first"
+      assert text =~ "tuistPrepareTestShards"
+      assert text =~ "remote_cache,test_sharding"
+    end
+  end
+
+  describe "integrate_xcode_project" do
+    test "returns prompt messages" do
+      result =
+        IntegrateXcodeProject.template(nil, %{
+          "account_handle" => "acme",
+          "project_handle" => "ios",
+          "features" => "xcode_cache,test_sharding"
+        })
+
+      assert %{messages: messages} = result
+      assert length(messages) == 1
+      text = hd(messages).content.text
+      assert text =~ "Integrate Tuist Xcode Project"
+      assert text =~ "`acme/ios`"
+      assert text =~ "xcode_cache,test_sharding"
+      assert text =~ "tuist setup cache"
+      assert text =~ "$HOME/.local/state/tuist/acme_ios.sock"
+      assert text =~ "tuist inspect build"
+      assert text =~ "tuist inspect test"
+      assert text =~ "accurate scheme attribution"
+      assert text =~ "$HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect test"
+      assert text =~ "tuist xcodebuild build-for-testing"
+      assert text =~ "tuist test --build-only --shard-total 5"
     end
   end
 end

--- a/server/test/tuist/mcp/components/tools/add_organization_member_test.exs
+++ b/server/test/tuist/mcp/components/tools/add_organization_member_test.exs
@@ -1,0 +1,129 @@
+defmodule Tuist.MCP.Components.Tools.AddOrganizationMemberTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+
+  alias Tuist.Accounts
+  alias Tuist.MCP.Components.Tools.AddOrganizationMember
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  describe "add_organization_member" do
+    test "adds an existing user to an organization" do
+      creator = AccountsFixtures.user_fixture()
+      member = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: creator)
+
+      conn = %Plug.Conn{assigns: %{current_user: creator}}
+
+      result =
+        AddOrganizationMember.call(conn, %{
+          "organization_handle" => organization.account.name,
+          "email" => member.email,
+          "role" => "admin"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+
+      assert %{
+               "email" => email,
+               "organization_handle" => organization_handle,
+               "role" => "admin"
+             } = JSON.decode!(text)
+
+      assert email == member.email
+      assert organization_handle == organization.account.name
+    end
+
+    test "updates the role of an existing organization member" do
+      creator = AccountsFixtures.user_fixture()
+      member = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: creator)
+      :ok = Accounts.add_user_to_organization(member, organization, role: :user)
+
+      conn = %Plug.Conn{assigns: %{current_user: creator}}
+
+      result =
+        AddOrganizationMember.call(conn, %{
+          "organization_handle" => organization.account.name,
+          "email" => member.email,
+          "role" => "admin"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      assert %{"role" => "admin"} = JSON.decode!(text)
+      assert Accounts.get_user_role_in_organization(member, organization).name == "admin"
+    end
+
+    test "rejects regular organization members" do
+      creator = AccountsFixtures.user_fixture()
+      member = AccountsFixtures.user_fixture()
+      added_member = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: creator)
+      :ok = Accounts.add_user_to_organization(member, organization, role: :user)
+
+      conn = %Plug.Conn{assigns: %{current_user: member}}
+
+      result =
+        AddOrganizationMember.call(conn, %{
+          "organization_handle" => organization.account.name,
+          "email" => added_member.email
+        })
+
+      assert %{
+               "content" => [
+                 %{
+                   "text" => "The authenticated subject is not authorized to perform this action.",
+                   "type" => "text"
+                 }
+               ],
+               "isError" => true
+             } = result
+    end
+
+    test "rejects users outside the organization" do
+      creator = AccountsFixtures.user_fixture()
+      outsider = AccountsFixtures.user_fixture()
+      member = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(creator: creator)
+
+      conn = %Plug.Conn{assigns: %{current_user: outsider}}
+
+      result =
+        AddOrganizationMember.call(conn, %{
+          "organization_handle" => organization.account.name,
+          "email" => member.email
+        })
+
+      assert %{
+               "content" => [
+                 %{
+                   "text" => "The authenticated subject is not authorized to perform this action.",
+                   "type" => "text"
+                 }
+               ],
+               "isError" => true
+             } = result
+    end
+
+    test "does not reveal missing organizations" do
+      user = AccountsFixtures.user_fixture()
+      member = AccountsFixtures.user_fixture()
+
+      conn = %Plug.Conn{assigns: %{current_user: user}}
+
+      result =
+        AddOrganizationMember.call(conn, %{
+          "organization_handle" => "missing-organization-#{TuistTestSupport.Utilities.unique_integer()}",
+          "email" => member.email
+        })
+
+      assert %{
+               "content" => [
+                 %{
+                   "text" => "The authenticated subject is not authorized to perform this action.",
+                   "type" => "text"
+                 }
+               ],
+               "isError" => true
+             } = result
+    end
+  end
+end

--- a/server/test/tuist/mcp/components/tools/create_organization_test.exs
+++ b/server/test/tuist/mcp/components/tools/create_organization_test.exs
@@ -1,0 +1,29 @@
+defmodule Tuist.MCP.Components.Tools.CreateOrganizationTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+
+  alias Tuist.MCP.Components.Tools.CreateOrganization
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  describe "create_organization" do
+    test "creates an organization for the authenticated user" do
+      user = AccountsFixtures.user_fixture()
+      handle = "acme-mcp-#{TuistTestSupport.Utilities.unique_integer()}"
+
+      conn = %Plug.Conn{assigns: %{current_user: user}}
+      result = CreateOrganization.call(conn, %{"handle" => handle})
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      assert %{"name" => ^handle, "account_handle" => ^handle} = JSON.decode!(text)
+    end
+
+    test "returns account changeset errors" do
+      user = AccountsFixtures.user_fixture()
+
+      conn = %Plug.Conn{assigns: %{current_user: user}}
+      result = CreateOrganization.call(conn, %{"handle" => "acme.mcp"})
+
+      assert %{"content" => [%{"type" => "text", "text" => text}], "isError" => true} = result
+      assert text == "must contain only alphanumeric characters"
+    end
+  end
+end

--- a/server/test/tuist/mcp/components/tools/create_project_test.exs
+++ b/server/test/tuist/mcp/components/tools/create_project_test.exs
@@ -1,0 +1,75 @@
+defmodule Tuist.MCP.Components.Tools.CreateProjectTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+
+  alias Tuist.MCP.Components.Tools.CreateProject
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  describe "create_project" do
+    test "creates a project under an accessible account" do
+      user = AccountsFixtures.user_fixture()
+      project_handle = "mcp-project-#{TuistTestSupport.Utilities.unique_integer()}"
+
+      conn = %Plug.Conn{assigns: %{current_user: user}}
+
+      result =
+        CreateProject.call(conn, %{
+          "account_handle" => user.account.name,
+          "project_handle" => project_handle,
+          "build_system" => "gradle"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+
+      assert %{
+               "account_handle" => account_handle,
+               "build_system" => "gradle",
+               "full_handle" => full_handle,
+               "name" => ^project_handle
+             } = JSON.decode!(text)
+
+      assert account_handle == user.account.name
+      assert full_handle == "#{user.account.name}/#{project_handle}"
+    end
+
+    test "returns project changeset errors" do
+      user = AccountsFixtures.user_fixture()
+      project_handle = "mcp-project-#{TuistTestSupport.Utilities.unique_integer()}"
+
+      conn = %Plug.Conn{assigns: %{current_user: user}}
+
+      result =
+        CreateProject.call(conn, %{
+          "account_handle" => user.account.name,
+          "project_handle" => project_handle,
+          "build_system" => "unknown"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => "is invalid"}], "isError" => true} =
+               result
+    end
+
+    test "does not reveal inaccessible accounts" do
+      owner = AccountsFixtures.user_fixture()
+      outsider = AccountsFixtures.user_fixture()
+      project_handle = "mcp-project-#{TuistTestSupport.Utilities.unique_integer()}"
+
+      conn = %Plug.Conn{assigns: %{current_user: outsider}}
+
+      result =
+        CreateProject.call(conn, %{
+          "account_handle" => owner.account.name,
+          "project_handle" => project_handle
+        })
+
+      assert %{
+               "content" => [
+                 %{
+                   "text" => "The authenticated subject is not authorized to perform this action.",
+                   "type" => "text"
+                 }
+               ],
+               "isError" => true
+             } = result
+    end
+  end
+end

--- a/server/test/tuist/mcp/components/tools/list_projects_test.exs
+++ b/server/test/tuist/mcp/components/tools/list_projects_test.exs
@@ -1,0 +1,35 @@
+defmodule Tuist.MCP.Components.Tools.ListProjectsTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+
+  alias Tuist.MCP.Components.Tools.ListProjects
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+  alias TuistTestSupport.Fixtures.ProjectsFixtures
+
+  describe "list_projects" do
+    test "returns results" do
+      user = AccountsFixtures.user_fixture()
+      project = ProjectsFixtures.project_fixture(account: user.account)
+
+      conn = %Plug.Conn{assigns: %{current_subject: user}}
+
+      result = ListProjects.call(conn, %{})
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+
+      assert [
+               %{
+                 "account_handle" => account_handle,
+                 "build_system" => "xcode",
+                 "full_handle" => full_handle,
+                 "id" => project_id,
+                 "name" => project_name
+               }
+             ] = JSON.decode!(text)
+
+      assert account_handle == user.account.name
+      assert full_handle == "#{user.account.name}/#{project.name}"
+      assert project_id == project.id
+      assert project_name == project.name
+    end
+  end
+end

--- a/server/test/tuist/mcp/server_test.exs
+++ b/server/test/tuist/mcp/server_test.exs
@@ -1,9 +1,10 @@
 defmodule Tuist.MCP.ServerTest do
   use TuistTestSupport.Cases.ConnCase, async: true
-  use Mimic
 
+  alias Tuist.MCP.Components.Tools.AddOrganizationMember
+  alias Tuist.MCP.Components.Tools.CreateOrganization
+  alias Tuist.MCP.Components.Tools.CreateProject
   alias Tuist.MCP.Server
-  alias Tuist.Projects
 
   describe "server/0" do
     test "returns a server with all tools" do
@@ -11,6 +12,9 @@ defmodule Tuist.MCP.ServerTest do
 
       tool_names = server.tools |> Map.keys() |> Enum.sort()
 
+      assert "create_organization" in tool_names
+      assert "create_project" in tool_names
+      assert "add_organization_member" in tool_names
       assert "list_xcode_builds" in tool_names
       assert "get_xcode_build" in tool_names
       assert "list_xcode_build_targets" in tool_names
@@ -47,15 +51,20 @@ defmodule Tuist.MCP.ServerTest do
         assert is_binary(annotations[:title]) and annotations[:title] != "",
                "tool #{name} is missing a non-empty :title annotation"
 
-        assert annotations[:readOnlyHint] == true,
-               "tool #{name} must declare readOnlyHint: true"
+        assert is_boolean(annotations[:readOnlyHint]),
+               "tool #{name} must declare readOnlyHint"
 
         assert annotations[:openWorldHint] == false,
                "tool #{name} must declare openWorldHint: false"
 
-        assert annotations[:destructiveHint] == false,
-               "tool #{name} must declare destructiveHint: false"
+        assert is_boolean(annotations[:destructiveHint]),
+               "tool #{name} must declare destructiveHint"
       end
+
+      assert CreateOrganization.annotations()[:readOnlyHint] == false
+      assert CreateProject.annotations()[:readOnlyHint] == false
+      assert AddOrganizationMember.annotations()[:readOnlyHint] == false
+      assert AddOrganizationMember.annotations()[:destructiveHint] == true
     end
 
     test "returns a server with all prompts" do
@@ -70,17 +79,8 @@ defmodule Tuist.MCP.ServerTest do
       assert "compare_test_case" in prompt_names
       assert "compare_generations" in prompt_names
       assert "compare_cache_runs" in prompt_names
-    end
-
-    test "list_projects tool returns results" do
-      stub(Projects, :list_accessible_projects, fn _subject, _opts -> [] end)
-
-      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
-
-      result = Tuist.MCP.Components.Tools.ListProjects.call(conn, %{})
-
-      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
-      assert JSON.decode!(text) == []
+      assert "integrate_gradle_project" in prompt_names
+      assert "integrate_xcode_project" in prompt_names
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds MCP write tools for account setup so authenticated users can create organizations, create projects, and add existing users to organizations.

Adds MCP prompts for integrating Tuist into Gradle and Xcode projects. The Gradle prompt lets agents choose from every supported integration: remote cache, build insights, test insights, flaky test detection and quarantine, and test sharding.

Updates the MCP documentation and server tests to cover the new tools, prompts, and review hints.

## Validation

- `MIX_ENV=test mise x -- mix ecto.reset && mise x -- mix format test/tuist/mcp/server_test.exs && mise x -- mix test test/tuist/mcp/server_test.exs test/tuist/mcp/components/prompts/prompts_test.exs`
- `git diff --check`
