### PR TITLE
fix(gradle): drop self-applied dev.tuist plugin from gradle/settings.gradle.kts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1383,10 +1383,6 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Update version in settings.gradle.kts
-        run: |
-          sed -i 's/id("dev.tuist") version ".*"/id("dev.tuist") version "${{ needs.check-releases.outputs.gradle-next-version-number }}"/' gradle/settings.gradle.kts
-
       - name: Tag Gradle release
         run: |
           TAG=${{ needs.check-releases.outputs.gradle-next-version }}
@@ -1423,7 +1419,6 @@ jobs:
           name: gradle-artifacts
           path: |
             gradle/CHANGELOG.md
-            gradle/settings.gradle.kts
             gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt
           retention-days: 1
 
@@ -2032,7 +2027,6 @@ jobs:
             sed -i 's/public static let gradlePluginVersion = ".*"/public static let gradlePluginVersion = "${{ needs.check-releases.outputs.gradle-next-version-number }}"/' cli/Sources/TuistConstants/Constants.swift
             sed -i 's/id("dev.tuist") version ".*"/id("dev.tuist") version "${{ needs.check-releases.outputs.gradle-next-version-number }}"/' android/settings.gradle.kts
             git add gradle/CHANGELOG.md
-            git add gradle/settings.gradle.kts
             git add gradle/src/main/kotlin/dev/tuist/gradle/TuistBuildCache.kt || true
             git add cli/Sources/TuistConstants/Constants.swift
             git add android/settings.gradle.kts

--- a/gradle/settings.gradle.kts
+++ b/gradle/settings.gradle.kts
@@ -1,9 +1,5 @@
 rootProject.name = "tuist-gradle-plugin"
 
-plugins {
-    id("dev.tuist") version "0.9.3"
-}
-
 buildCache {
     local {
         isEnabled = System.getenv("CI") == null


### PR DESCRIPTION
## Summary
- The Gradle plugin's own build dogfooded itself with `id(\"dev.tuist\") version \"0.9.3\"` in `gradle/settings.gradle.kts`. The plugin was resolved from the Gradle Plugin Portal.
- The Gradle cache acceptance e2e test runs from `examples/gradle/simple_android_app`, which uses `includeBuild(\"../../../gradle\")`. That makes Gradle load the included build's settings and try to resolve the very plugin it's about to compile — any plugin portal hiccup breaks the e2e test (see [run 25427291451](https://github.com/tuist/tuist/actions/runs/25427291451/job/74584012586): three HTTP 500s on the POM lookup → `Plugin [id: 'dev.tuist', version: '0.9.3'] was not found`).
- Drop the self-application. The legitimate dogfood in `android/settings.gradle.kts` is unaffected (nothing `includeBuild`s the android project). Release workflow updated to stop rewriting the removed line.

## Test plan
- [ ] Gradle Cache Acceptance check passes on this branch
- [ ] Release workflow still bumps `android/settings.gradle.kts` and `cli/Sources/TuistConstants/Constants.swift` on a Gradle release