### PR TITLE
fix(server): truncate bundle timestamps to second precision in API responses

### DIFF
--- a/server/lib/tuist/bundles.ex
+++ b/server/lib/tuist/bundles.ex
@@ -168,9 +168,20 @@ defmodule Tuist.Bundles do
     end)
   end
 
+  # Drop the microsecond precision the CH `DateTime64(6)` column carries
+  # so the API response renders as `2026-05-06T11:12:36Z` rather than
+  # `2026-05-06T11:12:36.000000Z`. The Swift CLI decodes `inserted_at`
+  # with `ISO8601DateFormatter` configured for `.withInternetDateTime`,
+  # which rejects fractional seconds and turned every `createBundle`
+  # response into a client-side decoding error after the CH cutover.
+  # The pre-CH PG column was `:utc_datetime` (second precision), so
+  # truncating here also restores the historical wire format.
   defp from_naive_usec(nil), do: nil
-  defp from_naive_usec(%DateTime{} = dt), do: dt
-  defp from_naive_usec(%NaiveDateTime{} = ndt), do: DateTime.from_naive!(ndt, "Etc/UTC")
+  defp from_naive_usec(%DateTime{} = dt), do: DateTime.truncate(dt, :second)
+
+  defp from_naive_usec(%NaiveDateTime{} = ndt) do
+    ndt |> DateTime.from_naive!("Etc/UTC") |> DateTime.truncate(:second)
+  end
 
   defp decode_bundles(bundles) when is_list(bundles), do: Enum.map(bundles, &decode_bundle/1)
 

--- a/server/test/tuist/bundles_test.exs
+++ b/server/test/tuist/bundles_test.exs
@@ -217,6 +217,13 @@ defmodule Tuist.BundlesTest do
       assert bundle.type == :app
       assert bundle.supported_platforms == [:ios, :ios_simulator]
       assert %DateTime{} = bundle.inserted_at
+      # Second precision so Jason renders `2026-05-06T11:12:36Z` rather
+      # than `2026-05-06T11:12:36.000000Z`. The Swift CLI's default
+      # `ISO8601DateFormatter` rejects fractional seconds, so leaking
+      # the CH `DateTime64(6)` precision into the API response broke
+      # `tuist inspect bundle` after the CH cutover.
+      assert bundle.inserted_at.microsecond == {0, 0}
+      assert bundle.updated_at.microsecond == {0, 0}
     end
 
     test "raises if an artifact type is invalid" do

--- a/server/test/tuist_web/controllers/api/bundles_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/bundles_controller_test.exs
@@ -78,6 +78,40 @@ defmodule TuistWeb.API.BundlesControllerTest do
       assert Enum.map(bundle.artifacts, & &1.size) == [1024]
     end
 
+    test "renders inserted_at without fractional seconds so the Swift CLI can decode it", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      # Given — minimal valid params; exercise is the response wire format.
+      bundle_params = %{
+        "bundle" => %{
+          "app_bundle_id" => "com.example.app",
+          "name" => "Test Bundle",
+          "install_size" => 1024,
+          "supported_platforms" => ["ios"],
+          "version" => "1.0.0",
+          "type" => "app",
+          "artifacts" => []
+        }
+      }
+
+      # When
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/projects/#{project.account.name}/#{project.name}/bundles", bundle_params)
+
+      # Then — must match `yyyy-MM-ddTHH:mm:ssZ` exactly, since the CLI's
+      # default `ISO8601DateFormatter` (configured with
+      # `.withInternetDateTime`) rejects anything with a fractional
+      # second component, which broke `tuist inspect bundle` after the
+      # CH cutover bumped the column to `DateTime64(6)`.
+      assert %{"inserted_at" => inserted_at} = json_response(conn, :ok)
+      assert inserted_at =~ ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/
+    end
+
     test "creates a bundle with git metadata", %{conn: conn, user: user, project: project} do
       # Given
       bundle_params = %{


### PR DESCRIPTION
### Why

After [#10615](https://github.com/tuist/tuist/pull/10615) cut bundles over to ClickHouse, the `inserted_at` column moved from PG `:utc_datetime` (second precision) to CH `DateTime64(6)`. Jason then started rendering the field as `2026-05-06T11:12:36.000000Z` instead of `2026-05-06T11:12:36Z`.

The Swift CLI decodes `Bundle.inserted_at` with `ISO8601DateFormatter` configured for `.withInternetDateTime`, which rejects fractional seconds. The result was that every `createBundle` (and the corresponding list/get) response failed client-side decoding with `"The data couldn't be read because it isn't in the correct format"`, which is what `tuist inspect bundle` was hitting in the App workflow's Device Build job.

[#10638](https://github.com/tuist/tuist/pull/10638) fixed a different failure mode on the same path (CH read-after-write lag turning the response into a 500), so the underlying decoding error survived the previous fix.

### What

- `from_naive_usec/1` truncates to second precision at the CH→domain boundary in `decode_bundle/1`, restoring the pre-cutover wire format for every `Bundle` response (`createBundle`, `listBundles`, `getBundle`).
- Extends the existing read-after-write-lag unit test to assert `bundle.inserted_at.microsecond == {0, 0}`.
- Adds a controller test that pins the JSON `inserted_at` to `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\$` exactly so a future precision regression fails loudly.

### How to test locally

- `cd server && mix test test/tuist/bundles_test.exs test/tuist_web/controllers/api/bundles_controller_test.exs` (controller suite needs `TUIST_HOSTED=1` to bypass the on-prem license plug, same as CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)