### PR TITLE
chore: enable Kura cache endpoints

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -25,6 +25,7 @@
     MISE_CONFIG_ROOT = "{{config_root}}"
     _.source = ["{{config_root}}/mise/utilities/dev_instance_env.sh", "{{config_root}}/mise/utilities/cache_ee_env.sh"]
     TUIST_CACHE_CONCURRENCY_LIMIT="none"
+    TUIST_FEATURE_FLAG_KURA = "1"
     TUIST_FILESYSTEM_BACKEND = "swift-file-system"
     # Elixir recommends half of the number of cores: https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/
     MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4

--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -190,6 +190,46 @@ defmodule TuistWeb.API.CacheControllerTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
+    test "returns the tuist account Kura endpoints when the client sends the KURA feature flag", %{
+      conn: conn
+    } do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      organization = AccountsFixtures.organization_fixture(name: "tuist", creator: user)
+      account = organization.account
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://default-cache.example.com"
+        })
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache-1.example.com",
+          technology: :kura
+        })
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache-2.example.com",
+          technology: :kura
+        })
+
+      conn =
+        conn
+        |> Authentication.put_current_user(user)
+        |> Plug.Conn.put_req_header(Headers.client_feature_flags_header(), "KURA")
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=tuist")
+
+      # Then
+      response = json_response(conn, 200)
+
+      assert Enum.sort(response["endpoints"]) ==
+               Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
+    end
+
     test "returns empty list when Kura is requested without account-specific endpoints", %{
       conn: conn
     } do


### PR DESCRIPTION
## Summary
- Opt in local mise environments to the Kura cache endpoint feature flag with `TUIST_FEATURE_FLAG_KURA=1`.
- This lets Gradle and Tuist CLI cache clients request account-specific Kura endpoints through the existing feature flag header.
- Add server coverage that verifies `account_handle=tuist` returns only Kura endpoints when the client sends `KURA`.

## Validation
- `mise exec -- env | rg 'TUIST_FEATURE_FLAG_KURA|TUIST_SERVER_URL|TUIST_CACHE_SERVER_URL'`\n- `mise exec -- ./gradlew test --tests 'dev.tuist.gradle.TuistHttpClientsTest.retrofit clients include enabled feature flags in the header when present' --tests 'dev.tuist.gradle.TuistHttpClientTest.openConnection sets enabled feature flags header'` from `gradle/`\n- `mise exec -- tuist install`\n- `mise exec -- tuist generate tuist ProjectDescription --no-open` exercised module cache fetching, but the remote cache returned `Missing required response body` for artifacts and Tuist fell back to project generation.\n- `mise exec -- swift test --replace-scm-with-registry --filter 'CacheURLStoreTests/separates_cached_endpoints_when_kura_feature_flag_is_enabled'`\n- `mise exec -- ./gradlew :app:assembleDebug --build-cache --info` from `examples/gradle/simple_android_app` passed after accepting/installing the Android SDK packages. Remote Tuist cache was configured, but disabled during the build because this shell is not authenticated with Tuist.\n- `mise exec -- mix test test/tuist_web/controllers/api/cache_controller_test.exs` from `server/`\n- Authenticated production API request to `https://tuist.dev/api/cache/endpoints?account_handle=tuist` with `x-tuist-feature-flags: KURA` returned `https://tuist-eu-1.kura.tuist.dev` and `https://tuist-us-1.kura.tuist.dev`.\n- The same authenticated production API request without the feature flag returned the default `cache-*.tuist.dev` endpoints.\n- `mise exec -- sh -lc 'tuist cache config tuist/tuist --url https://tuist.dev --force-refresh --json | jq "del(.token)"'` returned a selected Kura endpoint.\n- `mise exec -- sh -lc 'env -u TUIST_FEATURE_FLAG_KURA tuist cache config tuist/tuist --url https://tuist.dev --force-refresh --json | jq "del(.token)"'` returned a selected default cache endpoint.\n\n## Notes\n- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace ...` could not run because the generated schemes in this checkout are not configured for the test action, so I used SwiftPM for the narrow CLI cache endpoint test.