### PR TITLE
fix(cli): skip run metadata upload when no auth is available

### DIFF
--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -41,6 +41,7 @@ public class TrackableCommand {
     private let commandEventFactory: CommandEventFactory
     private let backgroundProcessRunner: BackgroundProcessRunning
     private let uploadAnalyticsService: UploadAnalyticsServicing
+    private let serverAuthenticationController: ServerAuthenticationControlling
     private let fileSystem: FileSysteming
     private let sessionDirectory: AbsolutePath
 
@@ -51,6 +52,7 @@ public class TrackableCommand {
         commandEventFactory: CommandEventFactory = CommandEventFactory(),
         backgroundProcessRunner: BackgroundProcessRunning = BackgroundProcessRunner(),
         uploadAnalyticsService: UploadAnalyticsServicing = UploadAnalyticsService(),
+        serverAuthenticationController: ServerAuthenticationControlling = ServerAuthenticationController(),
         fileSystem: FileSysteming = FileSystem(),
         sessionDirectory: AbsolutePath
     ) {
@@ -60,6 +62,7 @@ public class TrackableCommand {
         self.commandEventFactory = commandEventFactory
         self.backgroundProcessRunner = backgroundProcessRunner
         self.uploadAnalyticsService = uploadAnalyticsService
+        self.serverAuthenticationController = serverAuthenticationController
         self.fileSystem = fileSystem
         self.sessionDirectory = sessionDirectory
     }
@@ -94,7 +97,8 @@ public class TrackableCommand {
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
                             serverURL: serverURL,
-                            ranAt: ranAt
+                            ranAt: ranAt,
+                            usesOptionalAuthentication: usesOptionalAuthentication
                         )
                     }
                 } catch {
@@ -107,7 +111,8 @@ public class TrackableCommand {
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
                             serverURL: serverURL,
-                            ranAt: ranAt
+                            ranAt: ranAt,
+                            usesOptionalAuthentication: usesOptionalAuthentication
                         )
                     }
                     throw error
@@ -124,8 +129,16 @@ public class TrackableCommand {
         runMetadataStorage: RunMetadataStorage,
         fullHandle: String,
         serverURL: URL,
-        ranAt: Date
+        ranAt: Date,
+        usesOptionalAuthentication: Bool
     ) async throws {
+        if usesOptionalAuthentication {
+            let hasToken = try await hasAuthenticationToken(serverURL: serverURL)
+            if !hasToken {
+                Logger.current.debug("Skipping run metadata upload: no authentication credentials available.")
+                return
+            }
+        }
         let durationInSeconds = timer.stop()
         let durationInMs = Int(durationInSeconds * 1000)
         let configuration = type(of: command).configuration
@@ -199,6 +212,18 @@ public class TrackableCommand {
                 ],
                 environment: ProcessInfo.processInfo.environment
             )
+        }
+    }
+
+    private func hasAuthenticationToken(serverURL: URL) async throws -> Bool {
+        do {
+            let token = try await serverAuthenticationController.authenticationToken(
+                serverURL: serverURL,
+                refreshIfNeeded: false
+            )
+            return token != nil
+        } catch {
+            return false
         }
     }
 

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -97,8 +97,7 @@ public class TrackableCommand {
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
                             serverURL: serverURL,
-                            ranAt: ranAt,
-                            usesOptionalAuthentication: usesOptionalAuthentication
+                            ranAt: ranAt
                         )
                     }
                 } catch {
@@ -111,8 +110,7 @@ public class TrackableCommand {
                             runMetadataStorage: runMetadataStorage,
                             fullHandle: fullHandle,
                             serverURL: serverURL,
-                            ranAt: ranAt,
-                            usesOptionalAuthentication: usesOptionalAuthentication
+                            ranAt: ranAt
                         )
                     }
                     throw error
@@ -129,12 +127,14 @@ public class TrackableCommand {
         runMetadataStorage: RunMetadataStorage,
         fullHandle: String,
         serverURL: URL,
-        ranAt: Date,
-        usesOptionalAuthentication: Bool
+        ranAt: Date
     ) async throws {
-        if usesOptionalAuthentication {
-            let hasToken = try await hasAuthenticationToken(serverURL: serverURL)
-            if !hasToken {
+        if ServerAuthenticationConfig.current.optionalAuthentication {
+            let token = try? await serverAuthenticationController.authenticationToken(
+                serverURL: serverURL,
+                refreshIfNeeded: false
+            )
+            if token == nil {
                 Logger.current.debug("Skipping run metadata upload: no authentication credentials available.")
                 return
             }
@@ -212,18 +212,6 @@ public class TrackableCommand {
                 ],
                 environment: ProcessInfo.processInfo.environment
             )
-        }
-    }
-
-    private func hasAuthenticationToken(serverURL: URL) async throws -> Bool {
-        do {
-            let token = try await serverAuthenticationController.authenticationToken(
-                serverURL: serverURL,
-                refreshIfNeeded: false
-            )
-            return token != nil
-        } catch {
-            return false
         }
     }
 

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -17,11 +17,15 @@ final class TrackableCommandTests: TuistTestCase {
     private var subject: TrackableCommand!
     private var backgroundProcessRunner: MockBackgroundProcessRunning!
     private var gitController: MockGitControlling!
+    private var serverAuthenticationController: MockServerAuthenticationControlling!
+    private var uploadAnalyticsService: MockUploadAnalyticsServicing!
 
     override func setUp() {
         super.setUp()
         gitController = MockGitControlling()
         backgroundProcessRunner = MockBackgroundProcessRunning()
+        serverAuthenticationController = MockServerAuthenticationControlling()
+        uploadAnalyticsService = MockUploadAnalyticsServicing()
         given(backgroundProcessRunner)
             .runInBackground(.any, environment: .any)
             .willReturn()
@@ -32,12 +36,18 @@ final class TrackableCommandTests: TuistTestCase {
         given(gitController)
             .gitInfo(workingDirectory: .any)
             .willReturn(.test())
+
+        given(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .willReturn(.test())
     }
 
     override func tearDown() {
         subject = nil
         gitController = nil
         backgroundProcessRunner = nil
+        serverAuthenticationController = nil
+        uploadAnalyticsService = nil
         super.tearDown()
     }
 
@@ -61,6 +71,8 @@ final class TrackableCommandTests: TuistTestCase {
                 gitController: gitController
             ),
             backgroundProcessRunner: backgroundProcessRunner,
+            uploadAnalyticsService: uploadAnalyticsService,
+            serverAuthenticationController: serverAuthenticationController,
             sessionDirectory: temporaryPath
         )
     }
@@ -158,6 +170,51 @@ final class TrackableCommandTests: TuistTestCase {
         // Then
         let recordedValues = await recorder.values()
         XCTAssertEqual(recordedValues, [true])
+    }
+
+    func test_whenOptionalAuthenticationIsEnabled_andNoToken_skipsForegroundUpload() async throws {
+        // Given
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any, refreshIfNeeded: .any)
+            .willReturn(nil)
+        try makeSubject(analyticsRequired: true)
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true,
+            optionalAuthentication: true
+        )
+
+        // Then
+        verify(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .called(0)
+        verify(backgroundProcessRunner)
+            .runInBackground(.any, environment: .any)
+            .called(0)
+    }
+
+    func test_whenOptionalAuthenticationIsEnabled_andTokenIsAvailable_uploadsRunMetadata() async throws {
+        // Given
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any, refreshIfNeeded: .any)
+            .willReturn(.project("token"))
+        try makeSubject(analyticsRequired: true)
+
+        // When
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true,
+            optionalAuthentication: true
+        )
+
+        // Then
+        verify(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .called(1)
     }
 
     func test_whenOptionalAuthenticationIsEnabled_background_upload_does_not_add_a_flag() async throws {


### PR DESCRIPTION
## Summary

- Reported in [#10622 (comment)](https://github.com/tuist/tuist/pull/10622#issuecomment-4388843412): fork PRs can't authenticate, so `tuist test` on the fork-acceptance CI job logs `Failed to upload run metadata: unauthorized(...)` for every command.
- Short-circuit the foreground upload in `TrackableCommand` when the project opts into `optionalAuthentication` and no stored token is available. The upload was already optional in that mode; we just stop firing a request we know will 401.
- Adds two tests covering the skip path and the happy path with a token present.

## Test plan

- [x] `xcodebuild test ... -only-testing TuistKitTests/TrackableCommandTests`