### PR TITLE
fix(cli): make multi-process token refresh resilient to slow peers and rotation races

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1843,6 +1843,7 @@ public enum Module: String, CaseIterable {
                     .target(name: Module.constants.targetName),
                     .target(name: Module.environment.targetName),
                     .target(name: Module.opener.targetName),
+                    .target(name: Module.process.targetName, condition: .when([.macos])),
                     .target(name: Module.uniqueIDGenerator.targetName),
                     .target(name: Module.xcodeGraph.targetName),
                     .external(name: "OpenAPIRuntime"),

--- a/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
+++ b/cli/Sources/TuistServer/Client/ServerAuthenticationController.swift
@@ -104,7 +104,7 @@ public enum AuthenticationToken: Equatable, CustomStringConvertible {
         func withLock<T>(
             lockfilePath: AbsolutePath,
             serverURL: URL,
-            maxAttempts: Int = 10,
+            maxAttempts: Int = 30,
             retryInterval: UInt64 = 500, // Milliseconds
             action: (_ complete: () async throws -> Void) async throws -> Void,
             fetchActionResult: () async throws -> T?
@@ -278,14 +278,32 @@ public struct ServerAuthenticationController: ServerAuthenticationControlling {
     private func deletingCredentialsOnUnauthorizedError<T>(
         serverURL: URL, action: () async throws -> T
     ) async throws -> T {
+        // Snapshot the refresh token before the action so we can detect a peer
+        // process rotating it while our refresh request was in flight. Without
+        // this, two parallel `tuist` invocations can race: the slower one POSTs
+        // a now-revoked refresh token, the server responds 401, and we used to
+        // wipe the credentials file even though the on-disk credentials had
+        // already been refreshed by the peer.
+        let refreshTokenBeforeAction = try? await ServerCredentialsStore.current
+            .read(serverURL: serverURL)?.refreshToken
         do {
             return try await action()
         } catch let error as RefreshAuthTokenServiceError {
             if case .unauthorized = error {
-                #if canImport(TuistSupport)
-                    Logger.current.debug("Deleting the credentials for \(serverURL)")
-                #endif
-                try? await ServerCredentialsStore.current.delete(serverURL: serverURL)
+                let refreshTokenAfterAction = try? await ServerCredentialsStore.current
+                    .read(serverURL: serverURL)?.refreshToken
+                if refreshTokenBeforeAction != refreshTokenAfterAction {
+                    #if canImport(TuistSupport)
+                        Logger.current.debug(
+                            "Refresh token for \(serverURL) was rotated by another process; preserving credentials"
+                        )
+                    #endif
+                } else {
+                    #if canImport(TuistSupport)
+                        Logger.current.debug("Deleting the credentials for \(serverURL)")
+                    #endif
+                    try? await ServerCredentialsStore.current.delete(serverURL: serverURL)
+                }
             }
             throw error
         } catch {

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -1,5 +1,7 @@
+import FileSystem
 import Foundation
 import Mockable
+import Path
 import Testing
 import TuistConstants
 import TuistEnvironment
@@ -622,6 +624,67 @@ struct ServerAuthenticationControllerTests {
 
         let callCount = await countingRefreshService.callCount
         #expect(callCount == 1, "Expected coalesced callers to issue exactly one refresh, got \(callCount) calls")
+    }
+
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func background_refresh_times_out_when_lockfile_holder_does_not_finish_in_time() async throws {
+        // Reproducer for https://tuist.dev users hitting "The refreshing of the access and refresh
+        // token pair for the URL https://tuist.dev failed after 5 seconds."
+        //
+        // The default CLI flow takes the (.expired, true, true) branch (background refresh with
+        // locking) which polls for at most maxAttempts*retryInterval = 10*500ms = 5s waiting for
+        // a `tuist auth refresh-token` subprocess to write the new credentials. If another
+        // process is already refreshing (its `auth-locks` lockfile is fresh, < 10s old) the
+        // current process just polls — and times out if the holder doesn't finish in time.
+        //
+        // We pre-create a fresh lockfile to simulate an in-flight peer subprocess that never
+        // completes. That deterministically drives the polling loop to its 5s timeout without
+        // needing a real subprocess.
+        let date = Date()
+        let serverURL: URL = .test()
+
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: refreshAuthTokenService,
+            cachedValueStore: CachedValueStore(backend: .fileSystem)
+        )
+
+        let serverCredentialsStore = try #require(ServerCredentialsStore.mocked)
+        let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+        let refreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+3600), typ: "refresh")
+        let storeCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: refreshToken.token
+        )
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willReturn(storeCredentials)
+
+        let fileSystem = FileSystem()
+        let key = "token_\(serverURL.absoluteString)"
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        let lockfilePath = Environment.current.stateDirectory
+            .appending(component: "auth-locks")
+            .appending(component: "\(key).lock")
+        try await fileSystem.makeDirectory(at: lockfilePath.parentDirectory)
+        try await fileSystem.touch(lockfilePath)
+
+        // When/Then
+        let subjectCopy = subject!
+        try await Date.$now.withValue({ date }) {
+            try await ServerAuthenticationConfig.$current
+                .withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
+                    await #expect(
+                        throws: ServerAuthenticationControllerError.timedOut(
+                            seconds: 5,
+                            serverURL: serverURL
+                        )
+                    ) {
+                        try await subjectCopy.authenticationToken(serverURL: serverURL)
+                    }
+                }
+        }
     }
 
     private static func makeTokens(date: Date) throws -> ServerAuthenticationTokens {

--- a/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
+++ b/cli/Tests/TuistServerTests/Utilities/ServerAuthenticationControllerTests.swift
@@ -5,6 +5,7 @@ import Path
 import Testing
 import TuistConstants
 import TuistEnvironment
+import TuistProcess
 import TuistSupport
 import TuistTesting
 
@@ -630,23 +631,31 @@ struct ServerAuthenticationControllerTests {
         .withMockedEnvironment(),
         .withMockedDependencies()
     ) mutating func background_refresh_times_out_when_lockfile_holder_does_not_finish_in_time() async throws {
-        // Reproducer for https://tuist.dev users hitting "The refreshing of the access and refresh
-        // token pair for the URL https://tuist.dev failed after 5 seconds."
+        // Regression test for users hitting "The refreshing of the access and refresh token pair
+        // for the URL https://tuist.dev failed after N seconds."
         //
         // The default CLI flow takes the (.expired, true, true) branch (background refresh with
-        // locking) which polls for at most maxAttempts*retryInterval = 10*500ms = 5s waiting for
+        // locking) which polls for at most maxAttempts*retryInterval = 30*500ms = 15s waiting for
         // a `tuist auth refresh-token` subprocess to write the new credentials. If another
         // process is already refreshing (its `auth-locks` lockfile is fresh, < 10s old) the
-        // current process just polls — and times out if the holder doesn't finish in time.
+        // current process just polls and times out if the holder doesn't finish in time.
         //
         // We pre-create a fresh lockfile to simulate an in-flight peer subprocess that never
-        // completes. That deterministically drives the polling loop to its 5s timeout without
+        // completes. That deterministically drives the polling loop to its 15s timeout without
         // needing a real subprocess.
         let date = Date()
         let serverURL: URL = .test()
 
+        // The polling loop now extends past the 10s lockfile-staleness window,
+        // so the controller will eventually try to spawn a refresh subprocess
+        // via `BackgroundProcessRunning`. Stub it out with a no-op so the test
+        // doesn't try to launch the test runner binary as `tuist auth refresh-token`.
+        let backgroundProcessRunner = MockBackgroundProcessRunning()
+        given(backgroundProcessRunner).runInBackground(.any, environment: .any).willReturn()
+
         subject = ServerAuthenticationController(
             refreshAuthTokenService: refreshAuthTokenService,
+            backgroundProcessRunner: backgroundProcessRunner,
             cachedValueStore: CachedValueStore(backend: .fileSystem)
         )
 
@@ -677,7 +686,7 @@ struct ServerAuthenticationControllerTests {
                 .withValue(ServerAuthenticationConfig(backgroundRefresh: true)) {
                     await #expect(
                         throws: ServerAuthenticationControllerError.timedOut(
-                            seconds: 5,
+                            seconds: 15,
                             serverURL: serverURL
                         )
                     ) {
@@ -687,6 +696,74 @@ struct ServerAuthenticationControllerTests {
         }
     }
 
+    @Test(
+        .withMockedEnvironment(),
+        .withMockedDependencies()
+    ) mutating func unauthorized_refresh_does_not_delete_credentials_when_peer_rotated_them() async throws {
+        // When two `tuist` processes race on a token refresh, the slower one
+        // ends up POSTing an already-rotated refresh token and the server
+        // returns 401. The credentials file on disk has already been updated
+        // by the peer with valid tokens, so wiping it is what surfaces as
+        // "Token for Tuist was not found" on the next invocation. This test
+        // pins the fix: detect that the on-disk refresh token has changed
+        // since we started the action and preserve the rotated credentials.
+        let date = Date()
+        subject = ServerAuthenticationController(
+            refreshAuthTokenService: refreshAuthTokenService,
+            cachedValueStore: CachedValueStore()
+        )
+        let serverCredentialsStore = MockServerCredentialsStoring()
+        let serverURL: URL = .test()
+
+        let accessToken = try JWT.make(expiryDate: date.addingTimeInterval(-100), typ: "access")
+        let staleRefreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+60), typ: "refresh")
+        let rotatedRefreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+120), typ: "refresh")
+
+        let staleCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: staleRefreshToken.token
+        )
+        let rotatedCredentials: ServerCredentials = .test(
+            accessToken: accessToken.token,
+            refreshToken: rotatedRefreshToken.token
+        )
+
+        let credentialsBox = TestStore<ServerCredentials?>(staleCredentials)
+        given(serverCredentialsStore).read(serverURL: .value(serverURL)).willProduce { _ in
+            credentialsBox.value
+        }
+        given(serverCredentialsStore).delete(serverURL: .value(serverURL)).willReturn()
+
+        let unauthorizedError = RefreshAuthTokenServiceError.unauthorized("Refresh token revoked")
+        given(refreshAuthTokenService)
+            .refreshTokens(serverURL: .value(serverURL), refreshToken: .any)
+            .willProduce { _, _ in
+                // Simulate a peer process rotating the refresh token on disk
+                // while our request was in flight, then the server rejecting
+                // our request because we used the now-revoked token.
+                credentialsBox.value = rotatedCredentials
+                throw unauthorizedError
+            }
+
+        try await ServerCredentialsStore.$current.withValue(serverCredentialsStore) {
+            try await Date.$now.withValue({ date }) {
+                await #expect(throws: unauthorizedError, performing: {
+                    try await subject.refreshToken(
+                        serverURL: serverURL,
+                        inBackground: false,
+                        locking: true,
+                        forceInProcessLock: true
+                    )
+                })
+            }
+        }
+
+        verify(serverCredentialsStore)
+            .delete(serverURL: .value(serverURL))
+            .called(0)
+        #expect(credentialsBox.value == rotatedCredentials)
+    }
+
     private static func makeTokens(date: Date) throws -> ServerAuthenticationTokens {
         let newAccessToken = try JWT.make(expiryDate: date.addingTimeInterval(+600), typ: "access")
         let newRefreshToken = try JWT.make(expiryDate: date.addingTimeInterval(+7200), typ: "refresh")
@@ -694,6 +771,28 @@ struct ServerAuthenticationControllerTests {
             accessToken: newAccessToken.token,
             refreshToken: newRefreshToken.token
         )
+    }
+}
+
+private final class TestStore<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: T
+
+    init(_ value: T) {
+        _value = value
+    }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
     }
 }
 


### PR DESCRIPTION
> Describe here the purpose of your PR.

Fixes two related failures users hit when running multiple `tuist` commands in parallel (or in rapid succession after the 10-minute access token TTL expires):

1. **`The refreshing of the access and refresh token pair for the URL https://tuist.dev failed after 5 seconds.`** — the polling budget in the background-refresh path was too short.
2. **`Token for Tuist was not found. Run 'tuist auth login' to authenticate yourself.`** on the next invocation — when two refresh subprocesses race, the slower one POSTs an already-rotated refresh token, gets 401, and the credentials file gets wiped even though the peer just wrote valid tokens to it.

These reproduce reliably for teams that run scripts like `tuist install && tuist generate && tuist cache` back-to-back; they have been intermittent ("once every 1-2 weeks") for individuals.

### Root cause

The default CLI flow takes the `(.expired, true, true)` branch in `ServerAuthenticationController.authenticationTokenRefreshingIfNeeded` (background refresh + locking). It spawns `tuist auth refresh-token` as a subprocess and then polls the credentials file via `FileSystemLockActor`:

- The polling default was `maxAttempts: 10 × retryInterval: 500ms = 5s`. That is not enough for a cold-start subprocess plus an HTTPS round-trip on busy machines, so the parent times out and surfaces error #1.
- The server [revokes the old refresh token](https://github.com/tuist/tuist/blob/main/server/lib/tuist/authentication.ex) on every successful refresh. When two subprocesses race on the same refresh token, the slower one's request is rejected with 401, and `deletingCredentialsOnUnauthorizedError` was unconditionally wiping `~/.local/state/tuist/credentials/...`, producing error #2 on the next invocation.

### Changes

1. **Bump `FileSystemLockActor.withLock` default `maxAttempts` from 10 to 30** in `cli/Sources/TuistServer/Client/ServerAuthenticationController.swift`. Polling timeout goes from 5s to 15s, matching the in-process `fileSystemLocked` path that was already at 30 attempts.
2. **Re-read credentials before deleting on 401** in `deletingCredentialsOnUnauthorizedError`. Snapshot the on-disk refresh token before the action; on `unauthorized`, only delete if the token is unchanged. If a peer rotated it, the freshly-written credentials are valid.

### End-to-end behaviour after the fix

`deletingCredentialsOnUnauthorizedError` still re-throws the `unauthorized` error to its immediate caller — it only stops the wiping. That is intentional and sufficient for the user-visible flow:

- The losing subprocess (`tuist auth refresh-token`, hidden internal command, `shouldDisplay: false`, never invoked directly by users) throws unauthorized and exits non-zero. Its stderr is `/dev/null` per `BackgroundProcessRunner`.
- The parent process is meanwhile polling `fetchActionResult` in `FileSystemLockActor.performLocked`, which reads the on-disk credentials via `tokenStatus`.
- Before this PR: subprocess wiped credentials, parent reads `nil`, polling exhausts, user sees both errors.
- After this PR: subprocess preserves the peer's freshly-written tokens, parent reads `.valid(token)`, polling exits successfully, **no error surfaces to the user**.

The "still throws" part of the API contract only matters for `tuist auth refresh-token` invoked directly, which is not a user-facing command.

### Tests

- Updates `background_refresh_times_out_when_lockfile_holder_does_not_finish_in_time` to assert the new 15s timeout. The polling loop now extends past the 10s lockfile-staleness window so the test stubs `BackgroundProcessRunning` to keep it from spawning a real subprocess.
- Adds `unauthorized_refresh_does_not_delete_credentials_when_peer_rotated_them` which simulates a peer rotating credentials mid-refresh and asserts that `delete(serverURL:)` is **not** called and the rotated credentials remain on disk.
- Adds `TuistProcess` to the `TuistServerTests` target dependencies so it can use `MockBackgroundProcessRunning` from `TuistProcess`.

### How to test locally

\`\`\`
mise exec -- tuist install
TUIST_EE=1 mise exec -- tuist generate TuistServerTests TuistServer --no-open
xcodebuild test-without-building -workspace Tuist.xcworkspace -scheme Tuist-Workspace \\
  -only-testing 'TuistServerTests/ServerAuthenticationControllerTests' \\
  CODE_SIGNING_ALLOWED=NO
\`\`\`

Expected: 18 tests pass; the regression reproducer takes ~15.5s, the new rotation test runs in milliseconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)