### PR TITLE
fix(server): restore main CI checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -785,7 +785,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-cli-release-${{ hashFiles('.xcode-version-releases') }}-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
@@ -884,7 +884,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: linux-${{ matrix.arch }}-cli-release-${{ hashFiles('Package.resolved') }}
+          key: linux-${{ matrix.arch }}-cli-release-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
 
       - name: Update version in Constants.swift
         run: |
@@ -1037,7 +1037,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .build
-          key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-app-${{ hashFiles('Package.swift') }}-${{ hashFiles('Package.resolved') }}
       - name: Update version
         working-directory: app
         run: |
@@ -1966,7 +1966,7 @@ jobs:
           # values-managed-common.yaml carries multiple `tag:` lines.
           # Anchor the substitution to the xcresult-processor's
           # repository line so only that block's tag is rewritten.
-          sed -i '/repository: ghcr.io\/tuist\/tuist-xcresult-processor/,/tag:/{
+          sed -i '' '/repository: ghcr.io\/tuist\/tuist-xcresult-processor/,/tag:/{
             s|tag: "[^"]*"|tag: "${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"|
           }' infra/helm/tuist/values-managed-common.yaml
 

--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -5,6 +5,8 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
 
   use Tuist.MCP.Tool,
     name: "update_test_case",
+    title: "Update Test Case",
+    read_only_hint: false,
     schema: %{
       "type" => "object",
       "properties" => %{

--- a/server/test/tuist_web/live/builds_live_test.exs
+++ b/server/test/tuist_web/live/builds_live_test.exs
@@ -8,6 +8,11 @@ defmodule TuistWeb.BuildsLiveTest do
 
   alias TuistTestSupport.Fixtures.RunsFixtures
 
+  # render_async/2 is LiveViewTest's first-party hook for waiting on async assigns.
+  # The builds widgets still cross analytics-backed async work that can be slower on CI,
+  # so keep an explicit timeout until we have a deterministic non-time-based drain.
+  @render_async_timeout 1_000
+
   test "renders empty view when no builds are available", %{
     conn: conn,
     organization: organization,
@@ -37,7 +42,7 @@ defmodule TuistWeb.BuildsLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{project.account.name}/#{project.name}/builds")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     # Then
     assert has_element?(lv, "span", "AppOne")
@@ -64,7 +69,7 @@ defmodule TuistWeb.BuildsLiveTest do
         ~p"/#{project.account.name}/#{project.name}/builds?analytics-selected-widget=build-duration"
       )
 
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     # Then
     assert has_element?(lv, ".tuist-chart-type-toggle")
@@ -96,7 +101,7 @@ defmodule TuistWeb.BuildsLiveTest do
 
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{project.account.name}/#{project.name}/builds")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     # Then
     assert has_element?(lv, "#widget-build-success-rate")
@@ -109,7 +114,7 @@ defmodule TuistWeb.BuildsLiveTest do
     project: project
   } do
     {:ok, lv, _html} = live(conn, ~p"/#{project.account.name}/#{project.name}/builds")
-    render_async(lv)
+    render_async(lv, @render_async_timeout)
 
     assert has_element?(lv, "#builds-analytics-scheme-dropdown [data-part='search-input']")
   end


### PR DESCRIPTION
## Summary
- use LiveViewTest.render_async/2 in BuildsLiveTest so async assigns settle through the first-party test API
- add missing MCP tool metadata for update_test_case so production Docker compile passes with warnings-as-errors
- invalidate release .build caches when Package.swift changes and use macOS-compatible sed for the xcresult image pin bump

## Tests
- MIX_ENV=test TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_codex_7250_green TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_codex_7250_green mix ecto.reset
- MIX_ENV=test TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_codex_7250_green TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_codex_7250_green mix test test/tuist_web/live/builds_live_test.exs --warnings-as-errors
- MIX_ENV=test mix compile --warnings-as-errors
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
- tested the xcresult image-pin sed against a temp copy of infra/helm/tuist/values-managed-common.yaml