### PR TITLE
chore: disable Kura cache endpoints

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,6 @@
     MISE_CONFIG_ROOT = "{{config_root}}"
     _.source = ["{{config_root}}/mise/utilities/dev_instance_env.sh", "{{config_root}}/mise/utilities/cache_ee_env.sh"]
     TUIST_CACHE_CONCURRENCY_LIMIT="none"
-    TUIST_FEATURE_FLAG_KURA = "1"
     TUIST_FILESYSTEM_BACKEND = "swift-file-system"
     # Elixir recommends half of the number of cores: https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/
     MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4


### PR DESCRIPTION
## Summary
- Removes the \`TUIST_FEATURE_FLAG_KURA\` env var from \`mise.toml\` (added in #10648).

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)