### PR TITLE
fix(capi-scaleway): unblock first-time macOS-fleet helm rollouts

### DIFF
--- a/.github/workflows/hccm-deployment.yml
+++ b/.github/workflows/hccm-deployment.yml
@@ -1,0 +1,91 @@
+name: HCCM Deployment
+
+# Roll the hcloud-cloud-controller-manager chart values onto every
+# workload cluster on push to main. HCCM lives in kube-system and was
+# previously only installed during fresh-cluster onboarding via
+# `mise run k8s:bootstrap-workload`. That meant edits to
+# infra/k8s/mgmt/bootstrap/hccm-values.yaml had no effect on existing
+# clusters until someone re-ran bootstrap by hand — easy to forget,
+# and the kind of drift that bites at the worst possible time
+# (e.g. a CCM controller pruning Mac mini Nodes during a deploy).
+#
+# Idempotent. The matrix runs all environments in parallel: HCCM is
+# a workload-level component, blast radius is per-cluster, and the
+# change is a thin chart upgrade — no need for a canary→production
+# cascade like the application server has.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infra/k8s/mgmt/bootstrap/hccm-values.yaml
+      - .github/workflows/hccm-deployment.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: HCCM (${{ matrix.environment }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Per-cluster fixed region — sourced from
+        # infra/k8s/clusters/cluster-<env>.yaml's `region` topology
+        # variable. All workload clusters live in fsn1 today; spreading
+        # across regions is just a matter of overriding `region` per
+        # entry below — the chart's HCLOUD_LOAD_BALANCERS_LOCATION env
+        # follows.
+        include:
+          - environment: canary
+            region: fsn1
+          - environment: staging
+            region: fsn1
+          - environment: production
+            region: fsn1
+    runs-on: namespace-profile-default
+    environment:
+      name: server-k8s-${{ matrix.environment }}
+    # Hold the same lane as server-deployment.yml's deploy + observability
+    # jobs so HCCM upgrades and server rollouts can't race for the kube
+    # apiserver on the same cluster.
+    concurrency:
+      group: server-deploy-${{ matrix.environment }}
+      cancel-in-progress: false
+    timeout-minutes: 10
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3.2.0
+        with:
+          install_args: "helm kubectl"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-${{ matrix.environment }}" \
+            --vault "tuist-k8s-${{ matrix.environment }}" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        # Same pre-flight as server-deployment.yml — fail fast if the
+        # 1P-stored kubeconfig points at a phantom apiserver instead
+        # of letting helm hang for the full --timeout.
+        run: |
+          set -euo pipefail
+          API="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+          echo "Reaching apiserver at $API"
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: helm upgrade --install hccm
+        run: |
+          helm repo add hcloud https://charts.hetzner.cloud >/dev/null
+          helm repo update hcloud >/dev/null
+          helm upgrade --install hccm hcloud/hcloud-cloud-controller-manager \
+            --namespace kube-system \
+            -f infra/k8s/mgmt/bootstrap/hccm-values.yaml \
+            --set "env.HCLOUD_LOAD_BALANCERS_LOCATION.value=${{ matrix.region }}" \
+            --wait --timeout 3m

--- a/infra/k8s/mgmt/bootstrap/hccm-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hccm-values.yaml
@@ -5,10 +5,14 @@
 #   --set 'env.HCLOUD_LOAD_BALANCERS_LOCATION.value=<region>'
 # The bootstrap script reads `region` from the Cluster CR variables.
 #
-# Expects the `hetzner` Secret in kube-system with key `hcloud`
-# (the workload Hetzner project token; same Secret the ClusterClass
-# already provisions in `org-tuist`, but HCCM lives on the workload
-# cluster so we re-create it there at bootstrap time).
+# HCLOUD_TOKEN comes from the chart's default secretKeyRef
+# (kube-system/hcloud, key `token`), which caph (the CAPI Hetzner
+# provider) provisions in the workload cluster at cluster
+# bring-up — it carries the workload-project Hetzner token plus the
+# robot credentials and apiserver coordinates. The unrelated
+# `hetzner` Secret that bootstrap-workload.sh stamps in kube-system
+# is left over from an earlier wiring and is not consumed by HCCM
+# or hcloud-csi today; both pick up the chart-default reference.
 
 # Disable the cloud-node-lifecycle controller. Default behaviour
 # walks every Node, calls cloudprovider.Instances.InstanceExists()

--- a/infra/k8s/mgmt/bootstrap/hccm-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hccm-values.yaml
@@ -10,6 +10,23 @@
 # already provisions in `org-tuist`, but HCCM lives on the workload
 # cluster so we re-create it there at bootstrap time).
 
+# Disable the cloud-node-lifecycle controller. Default behaviour
+# walks every Node, calls cloudprovider.Instances.InstanceExists()
+# against the Hetzner API, and deletes any Node where that returns
+# false. Mac mini Nodes joined by tart-kubelet carry providerID
+# `scw-applesilicon://...`, which the Hetzner API can't recognise —
+# so HCCM treats them as ghosts and prunes them the moment
+# tart-kubelet skips a heartbeat. CAPI's MachineHealthCheck handles
+# dead Hetzner Linux nodes, and the Scaleway Apple Silicon CAPI
+# provider owns Mac mini lifecycle via finalizers on the
+# ScalewayAppleSiliconMachine CR, so dropping this controller
+# doesn't leave anything orphaned.
+#
+# `*` expands to the chart-default controller set; the leading `-`
+# disables a single controller by name.
+args:
+  controllers: "*,-cloud-node-lifecycle"
+
 env:
   HCLOUD_LOAD_BALANCERS_ENABLED:
     value: "true"

--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -3,8 +3,9 @@
 # (Tigris is the object store; Postgres is on Supabase). Future-proofs
 # the cluster so a new workload that wants a PVC just gets one.
 #
-# Expects the `hetzner` Secret in kube-system with key `hcloud`
-# (same Secret HCCM uses).
+# HCLOUD_TOKEN comes from the chart's default secretKeyRef
+# (kube-system/hcloud, key `token`), which caph provisions when it
+# brings the workload cluster up — same Secret HCCM reads.
 
 # Default StorageClass uses Hetzner volumes (block storage in fsn1).
 storageClasses:

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -201,14 +201,25 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 		}
 	}
 
-	if err := r.Tart.Run(ctx, vmName, []string{"env:" + envDir + ":ro"}); err != nil {
-		return fmt.Errorf("tart run: %w", err)
-	}
-
+	// Record the Pod ↔ VM mapping before kicking the VM off so the
+	// rest of the system (deletePod, GC, recoverState) can keep
+	// track of it even if `tart run` exits oddly. Without this an
+	// early-exit Run leaves the VM Tart-side without a Store entry,
+	// and the GC loop would happily reap it on the next pass —
+	// exactly the orphan we used to clean up reactively.
 	r.Store.Put(pod.Namespace, pod.Name, &Entry{
 		VMName:  vmName,
 		StartTS: metav1.Now(),
 	})
+
+	if err := r.Tart.Run(ctx, vmName, []string{"env:" + envDir + ":ro"}); err != nil {
+		// Roll back the Store entry — the VM either never started
+		// (cmd.Start error) or `tart run` exited immediately, so
+		// there is no live VM for podStatus to observe and no
+		// background process for deletePod to tear down.
+		r.Store.Delete(pod.Namespace, pod.Name)
+		return fmt.Errorf("tart run: %w", err)
+	}
 	return nil
 }
 

--- a/infra/tart-kubelet/internal/podagent/reconciler.go
+++ b/infra/tart-kubelet/internal/podagent/reconciler.go
@@ -128,6 +128,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	// If a previous reconcile recorded a RunHandle and the
+	// `tart run` process has since exited (e.g. the guest crashed
+	// 30s into a multi-minute boot, well past Run's 5s sanity
+	// window), surface it as a Pod failure right here. Without this
+	// check podStatus would just keep returning Pending on the IP
+	// poll forever and helm --wait would hang for the full
+	// --timeout. Marking the Pod Failed lets the owning ReplicaSet
+	// schedule a replacement Pod with a fresh VM.
+	if entry := r.Store.Get(pod.Namespace, pod.Name); entry != nil && entry.Run != nil {
+		if exitErr, exited := entry.Run.Exited(); exited {
+			logger.Info("tart run exited; marking pod failed",
+				"vm", entry.VMName, "log", entry.Run.LogPath, "err", exitErr)
+			_ = r.deleteByKey(ctx, pod.Namespace, pod.Name)
+			_ = r.publishStatus(ctx, pod, &corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Reason:  "TartRunExited",
+				Message: fmt.Sprintf("tart run exited: %v (see %s)", exitErr, entry.Run.LogPath),
+			})
+			return ctrl.Result{}, nil
+		}
+	}
+
 	if err := r.createPod(ctx, pod); err != nil {
 		logger.Error(err, "create failed; will retry")
 		// Surface the failure to the API server immediately so
@@ -207,12 +229,14 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 	// early-exit Run leaves the VM Tart-side without a Store entry,
 	// and the GC loop would happily reap it on the next pass —
 	// exactly the orphan we used to clean up reactively.
-	r.Store.Put(pod.Namespace, pod.Name, &Entry{
+	entry := &Entry{
 		VMName:  vmName,
 		StartTS: metav1.Now(),
-	})
+	}
+	r.Store.Put(pod.Namespace, pod.Name, entry)
 
-	if err := r.Tart.Run(ctx, vmName, []string{"env:" + envDir + ":ro"}); err != nil {
+	handle, err := r.Tart.Run(ctx, vmName, []string{"env:" + envDir + ":ro"})
+	if err != nil {
 		// Roll back the Store entry — the VM either never started
 		// (cmd.Start error) or `tart run` exited immediately, so
 		// there is no live VM for podStatus to observe and no
@@ -220,6 +244,7 @@ func (r *Reconciler) createPod(ctx context.Context, pod *corev1.Pod) error {
 		r.Store.Delete(pod.Namespace, pod.Name)
 		return fmt.Errorf("tart run: %w", err)
 	}
+	entry.Run = handle
 	return nil
 }
 
@@ -322,9 +347,17 @@ func VMNameForPod(pod *corev1.Pod) string {
 // === In-memory Pod ↔ VM map ================================================
 
 // Entry is the kubelet-side bookkeeping for one running Pod.
+//
+// Run is the handle to the backgrounded `tart run` process. It is
+// nil for entries materialised by recoverState after a kubelet
+// restart — those VMs are still running on the host but the
+// process is no longer a child of this kubelet, so we can't observe
+// its exit. The reconciler treats `Run == nil` as "trust IP probe
+// alone" and skips the post-launch exit check.
 type Entry struct {
 	VMName  string
 	StartTS metav1.Time
+	Run     *tart.RunHandle
 }
 
 // Store is a tiny thread-safe map. Backed by in-memory state — on

--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -91,9 +91,17 @@ func (c *Client) Set(ctx context.Context, name string, cpu, memoryMB int) error 
 	return err
 }
 
-// Run starts a VM in the background and returns once it has obtained
-// an IP (proxy for "booted enough to talk to"). The VM keeps running
-// until Stop or Delete.
+// Run launches a VM in the background and returns as soon as the
+// `tart run` process is alive. It does NOT wait for the guest to
+// obtain an IP — that's the reconciler's job (via Tart.IP, polled
+// from podStatus). Decoupling makes the VM lifecycle bound by the
+// Pod lifecycle rather than by an arbitrary in-process timeout: a
+// slow-but-still-booting guest stays alive across reconcile passes
+// and the Pod transitions to Running the moment configd hands out
+// a DHCP lease, however many minutes that takes. Helm's own
+// `--wait --timeout` is the right place for a top-level deadline;
+// having a second one inside Run that destroyed the VM on expiry
+// just forced re-clones and re-boots that hit the same wall.
 //
 // Tart 2.32 quirks accommodated here:
 //   - `tart run` is foreground-only. We start it directly from Go with
@@ -107,8 +115,6 @@ func (c *Client) Set(ctx context.Context, name string, cpu, memoryMB int) error 
 //   - We deliberately do NOT use `nohup` — it requires a controlling
 //     TTY to detach from, and launchd-spawned processes don't have
 //     one. With Setsid we don't need it.
-//   - `tart get` doesn't update on-disk state for backgrounded VMs, so
-//     we poll `tart ip --wait` instead of state.
 func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) error {
 	if err := os.MkdirAll(c.LogDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir log dir: %w", err)
@@ -140,48 +146,26 @@ func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) erro
 	// Close our own fd; the child holds its own dup. Reap the
 	// process so it doesn't go zombie if it exits before we Stop it.
 	_ = logFile.Close()
-	go func() { _ = cmd.Wait() }()
 
-	// 8 min covers a cold-boot macOS guest: first-boot of a freshly
-	// pulled Tart image runs Apple's setup pipeline (firstboot
-	// services, DiskCryptor unseal, ResearchKit prefs, etc.) before
-	// configd negotiates a vmnet DHCP lease — observed at 3-5 min on
-	// M2-M Mac minis. Setting this to 2 min meant every clean retry
-	// after TartCreateFailed re-cloned the image and re-cold-booted
-	// from zero, so retries hit the same wall instead of converging.
-	// 8 min still bounds the goroutine so a genuinely wedged VM
-	// (e.g. configd never starts) surfaces as TartCreateFailed
-	// rather than blocking the reconcile worker indefinitely.
-	const ipWaitTimeout = 8 * time.Minute
-	deadline := time.Now().Add(ipWaitTimeout)
-	for time.Now().Before(deadline) {
-		select {
-		case <-ctx.Done():
-			c.cleanupAfterFailedRun(name)
-			return ctx.Err()
-		case <-time.After(3 * time.Second):
-		}
-		if ip, err := c.IP(ctx, name); err == nil && ip != "" {
-			return nil
-		}
+	// Watch the process briefly so an immediate failure (missing
+	// image, malformed --dir, Tart admission error) surfaces here
+	// instead of stranding the Pod in Pending while podStatus polls
+	// an IP that will never come. 5s is long enough to catch the
+	// fast-fail cases (<1s in practice) without delaying the happy
+	// path meaningfully — the guest will be cold-booting for minutes
+	// either way.
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
+	select {
+	case err := <-waitErr:
+		return fmt.Errorf("tart run %s exited immediately: %w (see %s)", name, err, logPath)
+	case <-ctx.Done():
+		// Parent ctx cancelled. The Setsid-detached process keeps
+		// running; recoverState rebinds it after a kubelet restart.
+		return ctx.Err()
+	case <-time.After(5 * time.Second):
+		return nil
 	}
-	c.cleanupAfterFailedRun(name)
-	return fmt.Errorf("tart run %s: VM did not obtain an IP in %s", name, ipWaitTimeout)
-}
-
-// cleanupAfterFailedRun stops + deletes a VM whose Run() couldn't
-// confirm an IP. Without this the Setsid-detached `tart run` keeps
-// running on the host: each reconcile retry would orphan another VM
-// of the same name (which actually fails the next clone), or — once
-// names diverge — pile them up until disk fills. Best-effort: log via
-// the wrapped errors but never fail the parent error path on cleanup
-// errors, because the caller already has a more informative reason.
-func (c *Client) cleanupAfterFailedRun(name string) {
-	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	_ = c.Stop(stopCtx, name, 10*time.Second)
-	_ = c.Delete(stopCtx, name)
-	_ = c.CleanupVMUserData(name)
 }
 
 // Stop gracefully halts a VM.
@@ -313,4 +297,3 @@ func escapeEnvValue(v string) string {
 	v = strings.ReplaceAll(v, "\r", `\r`)
 	return v
 }
-

--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -91,17 +91,59 @@ func (c *Client) Set(ctx context.Context, name string, cpu, memoryMB int) error 
 	return err
 }
 
-// Run launches a VM in the background and returns as soon as the
-// `tart run` process is alive. It does NOT wait for the guest to
-// obtain an IP — that's the reconciler's job (via Tart.IP, polled
-// from podStatus). Decoupling makes the VM lifecycle bound by the
-// Pod lifecycle rather than by an arbitrary in-process timeout: a
-// slow-but-still-booting guest stays alive across reconcile passes
-// and the Pod transitions to Running the moment configd hands out
-// a DHCP lease, however many minutes that takes. Helm's own
-// `--wait --timeout` is the right place for a top-level deadline;
-// having a second one inside Run that destroyed the VM on expiry
-// just forced re-clones and re-boots that hit the same wall.
+// RunHandle exposes the lifecycle of a backgrounded `tart run`
+// process. The reconciler stashes one in its Store entry alongside
+// the VM name so subsequent reconciles can detect a process that
+// exited *after* the launch sanity check window without depending
+// on the IP poll alone.
+type RunHandle struct {
+	// Name is the Tart VM name the process was started for.
+	Name string
+
+	// LogPath is where the process's stdout/stderr was redirected.
+	// Surfaced in error messages so operators can `tail` it.
+	LogPath string
+
+	done    chan struct{}
+	exitErr error
+}
+
+// Done returns a channel that is closed once the process exits.
+// Useful for callers that want to block; Exited() is the
+// non-blocking variant.
+func (h *RunHandle) Done() <-chan struct{} { return h.done }
+
+// Exited reports whether the `tart run` process has terminated. The
+// returned error is whatever cmd.Wait observed — a nil err with
+// ok=true means a clean exit (rare for a long-lived VM process,
+// usually a sign of an internal Tart shutdown). Safe for concurrent
+// use: writes to exitErr happen-before close(done) in the launcher
+// goroutine, and reads happen after the receive on done returns.
+func (h *RunHandle) Exited() (err error, ok bool) {
+	select {
+	case <-h.done:
+		return h.exitErr, true
+	default:
+		return nil, false
+	}
+}
+
+// Run launches a VM in the background and returns a handle as soon
+// as the `tart run` process is alive. It does NOT wait for the
+// guest to obtain an IP — that's the reconciler's job (via Tart.IP,
+// polled from podStatus). Decoupling makes the VM lifecycle bound
+// by the Pod lifecycle rather than by an arbitrary in-process
+// timeout: a slow-but-still-booting guest stays alive across
+// reconcile passes and the Pod transitions to Running the moment
+// configd hands out a DHCP lease, however many minutes that takes.
+// Helm's own `--wait --timeout` is the right place for a top-level
+// deadline; an inner one that destroyed the VM on expiry just
+// forced re-clones and re-boots that hit the same wall.
+//
+// The returned RunHandle reports later exits (after the 5s sanity
+// window). Callers MUST poll handle.Exited() each reconcile so a
+// process that drops, say, 30s in surfaces as a Pod failure rather
+// than stranding helm on an IP poll that will never succeed.
 //
 // Tart 2.32 quirks accommodated here:
 //   - `tart run` is foreground-only. We start it directly from Go with
@@ -115,9 +157,9 @@ func (c *Client) Set(ctx context.Context, name string, cpu, memoryMB int) error 
 //   - We deliberately do NOT use `nohup` — it requires a controlling
 //     TTY to detach from, and launchd-spawned processes don't have
 //     one. With Setsid we don't need it.
-func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) error {
+func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) (*RunHandle, error) {
 	if err := os.MkdirAll(c.LogDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir log dir: %w", err)
+		return nil, fmt.Errorf("mkdir log dir: %w", err)
 	}
 
 	args := []string{"run", name, "--no-graphics"}
@@ -128,7 +170,7 @@ func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) erro
 	logPath := filepath.Join(c.LogDir, name+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("open vm log: %w", err)
+		return nil, fmt.Errorf("open vm log: %w", err)
 	}
 
 	// Bare exec.Command (NOT CommandContext) so the parent ctx
@@ -141,11 +183,26 @@ func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) erro
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
-		return fmt.Errorf("start tart run: %w", err)
+		return nil, fmt.Errorf("start tart run: %w", err)
 	}
-	// Close our own fd; the child holds its own dup. Reap the
-	// process so it doesn't go zombie if it exits before we Stop it.
+	// Close our own fd; the child holds its own dup. The launcher
+	// goroutine reaps the process via cmd.Wait so it doesn't go
+	// zombie if it exits before we Stop it.
 	_ = logFile.Close()
+
+	handle := &RunHandle{
+		Name:    name,
+		LogPath: logPath,
+		done:    make(chan struct{}),
+	}
+	// Single launcher goroutine owns cmd.Wait for the lifetime of
+	// the process. Writing exitErr before close(done) gives readers
+	// of Exited() a happens-before relationship on the field — no
+	// extra mutex needed.
+	go func() {
+		handle.exitErr = cmd.Wait()
+		close(handle.done)
+	}()
 
 	// Watch the process briefly so an immediate failure (missing
 	// image, malformed --dir, Tart admission error) surfaces here
@@ -153,18 +210,17 @@ func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) erro
 	// an IP that will never come. 5s is long enough to catch the
 	// fast-fail cases (<1s in practice) without delaying the happy
 	// path meaningfully — the guest will be cold-booting for minutes
-	// either way.
-	waitErr := make(chan error, 1)
-	go func() { waitErr <- cmd.Wait() }()
+	// either way. Slower exits are caught by the reconciler via
+	// handle.Exited() on subsequent passes.
 	select {
-	case err := <-waitErr:
-		return fmt.Errorf("tart run %s exited immediately: %w (see %s)", name, err, logPath)
+	case <-handle.done:
+		return nil, fmt.Errorf("tart run %s exited immediately: %w (see %s)", name, handle.exitErr, logPath)
 	case <-ctx.Done():
 		// Parent ctx cancelled. The Setsid-detached process keeps
 		// running; recoverState rebinds it after a kubelet restart.
-		return ctx.Err()
+		return nil, ctx.Err()
 	case <-time.After(5 * time.Second):
-		return nil
+		return handle, nil
 	}
 }
 

--- a/infra/tart-kubelet/internal/tart/tart_test.go
+++ b/infra/tart-kubelet/internal/tart/tart_test.go
@@ -1,10 +1,12 @@
 package tart
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStageEnvFile(t *testing.T) {
@@ -69,5 +71,87 @@ func TestShellEscape(t *testing.T) {
 func TestEscapeEnvValue(t *testing.T) {
 	if got := escapeEnvValue("a\nb\rc"); got != `a\nb\rc` {
 		t.Fatalf("got %q", got)
+	}
+}
+
+// TestRunHandleExitedAfterSanityWindow simulates the case the
+// reviewer flagged: `tart run` returns from the 5s sanity window,
+// then the underlying process exits later. The handle must report
+// that exit so the reconciler can transition the Pod to Failed
+// instead of stranding helm on an indefinite IP poll.
+func TestRunHandleExitedAfterSanityWindow(t *testing.T) {
+	dir := t.TempDir()
+	// Substitute a tiny shell script for the `tart` binary that
+	// exits ~0.5s after launch — long enough to pass Run's 5s
+	// sanity check would be nicer, but we don't want to slow tests
+	// to multi-seconds. Use a 100ms exit, then assert handle
+	// eventually reports Exited.
+	binPath := filepath.Join(dir, "fake-tart")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nsleep 0.1\nexit 7\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Client{
+		Binary:      binPath,
+		UserDataDir: filepath.Join(dir, "userdata"),
+		LogDir:      filepath.Join(dir, "logs"),
+	}
+
+	// Patch the sanity-check window so the test doesn't sleep 5s.
+	// We can't override the const without touching production code,
+	// so we rely on the script exiting WITHIN the 5s window — which
+	// means Run will surface it as an immediate-exit error rather
+	// than returning a handle. To exercise the post-window exit
+	// path we'd need DI on the timeout; for now lock in the
+	// immediate-exit contract, which is the lower bound of the
+	// behaviour the reviewer asked us to preserve.
+	handle, err := c.Run(context.Background(), "test-vm", nil)
+	if err == nil {
+		t.Fatalf("expected immediate-exit error, got handle=%v", handle)
+	}
+	if !strings.Contains(err.Error(), "exited immediately") {
+		t.Fatalf("expected immediate-exit error, got %q", err)
+	}
+}
+
+// TestRunHandleExitedTracksProcess covers the post-sanity-window
+// path: Run returns a handle, and a later cmd.Wait result is
+// observable through handle.Exited().
+func TestRunHandleExitedTracksProcess(t *testing.T) {
+	dir := t.TempDir()
+	// `sleep 6` outlives the 5s sanity window — Run will return a
+	// handle. The script then exits with code 0, which the
+	// launcher goroutine must surface through handle.Exited().
+	binPath := filepath.Join(dir, "fake-tart")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nsleep 6\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Client{
+		Binary:      binPath,
+		UserDataDir: filepath.Join(dir, "userdata"),
+		LogDir:      filepath.Join(dir, "logs"),
+	}
+
+	handle, err := c.Run(context.Background(), "test-vm", nil)
+	if err != nil {
+		t.Fatalf("unexpected immediate-exit: %v", err)
+	}
+	if handle == nil {
+		t.Fatal("expected non-nil handle")
+	}
+	if _, exited := handle.Exited(); exited {
+		t.Fatal("handle reported exited inside sanity window")
+	}
+
+	// Wait for the script's `sleep 6` plus a small margin, then
+	// confirm the handle has flipped.
+	select {
+	case <-handle.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("handle.Done() never closed")
+	}
+	if _, exited := handle.Exited(); !exited {
+		t.Fatal("handle did not report exited after process death")
 	}
 }


### PR DESCRIPTION
## Summary

The first canary deploy that actually exercised `macosFleet.enabled=true` ([run 25441924886](https://github.com/tuist/tuist/actions/runs/25441924886/job/74637244699)) hung on `helm upgrade --install --wait` because two independent bugs compounded — the deploy worked on staging only because staging's xcresult-processor Pod was already happy from a previous bring-up that today's revisions didn't touch.

### Bug 1 — tart-kubelet destroys the VM after 8 min, then re-clones from scratch

`tart.Client.Run` blocked up to 8 min for the guest to obtain a DHCP lease, then called `cleanupAfterFailedRun` (stop + delete the VM) on timeout. Each reconcile retry then re-pulled, re-cloned, and re-cold-booted from zero — converging on the same wall. On canary's M4-S Mac mini the first-boot pipeline didn't get past 8 min and the deploy never made progress.

Fix: `Run` now returns as soon as `tart run` is alive (with a 5s sanity check that catches fast-fail cases). IP polling moves entirely to `podStatus`, so the Pod stays Pending across as many reconciles as the guest needs and transitions to Running the moment configd hands out a lease. Helm's `--wait --timeout 90m` is the right place for a top-level deadline; an inner one just forced waste. The Store entry is recorded before `Run` so `deletePod` and the GC keep tracking the VM through any partially-started state.

### Bug 2 — Hetzner CCM evicts Mac mini Nodes

Within ~30s of tart-kubelet missing a heartbeat (because of bug 1 wedging the host), the workload cluster's hcloud-cloud-controller-manager fired its `cloud-node-lifecycle` controller, called `cloudprovider.Instances.InstanceExists()` for the `scw-applesilicon://fr-par-1/...` providerID, got `false`, and deleted the Node. The `ScalewayAppleSiliconMachine` CR was still `Ready` but the kube `Node` was gone, so a fresh xcresult-processor Pod had nowhere to land.

Fix: pass `--controllers=*,-cloud-node-lifecycle` to HCCM. CAPI's `MachineHealthCheck` already covers dead Hetzner Linux nodes; Mac mini lifecycle is owned by the Scaleway Apple Silicon CAPI provider's finalizers on the CR. The `cloud-node-lifecycle` controller wasn't carrying weight we relied on.

### Closing the deploy gap

The HCCM values file was previously only applied when someone re-ran `mise run k8s:bootstrap-workload` by hand, so chart edits silently failed to propagate. The new `.github/workflows/hccm-deployment.yml` fires on push to main when `infra/k8s/mgmt/bootstrap/hccm-values.yaml` changes and runs `helm upgrade --install hccm` in parallel against canary, staging, and production. Shares the existing `server-deploy-<env>` concurrency lane so HCCM upgrades can't interleave with a server rollout.

The PR title is scoped `fix(capi-scaleway):` so `release.yml` cuts a new operator semver, rebuilds the operator image with the new tart-kubelet binary baked in, and rewrites `macosFleet.image.tag` in `values-managed-common.yaml` automatically. The follow-up release-bump commit is what flows the new tart-kubelet onto the Mac minis.

## Test plan

- [ ] After merge, `HCCM Deployment` workflow runs in parallel against canary/staging/production. Confirm the `hccm` Helm release in each cluster's `kube-system` rolls to a new revision and the `--controllers=*,-cloud-node-lifecycle` arg shows up in `kubectl -n kube-system describe deploy hcloud-cloud-controller-manager`.
- [ ] `release.yml` cuts a `capi-scaleway@<n>` release and opens an auto-bump commit/PR rewriting `macosFleet.image.tag` in `values-managed-common.yaml`. Merge that.
- [ ] Re-trigger the canary server deploy. Confirm `helm upgrade` completes (Mac mini Node stays Ready throughout, xcresult-processor Pod transitions Pending → Running once the guest's IP shows up) instead of hanging on first-time bring-up.
- [ ] `go test ./infra/tart-kubelet/...` (already green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)