### PR TITLE
perf(server): add project_id to flaky test_case_runs queries

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -2233,9 +2233,10 @@ defmodule Tuist.Tests do
   @doc """
   Returns the count of unique flaky run groups (scheme + commit_sha) for a test case.
   """
-  def get_flaky_runs_groups_count_for_test_case(test_case_id) do
+  def get_flaky_runs_groups_count_for_test_case(project_id, test_case_id) do
     query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         select: fragment("count(DISTINCT (scheme, git_commit_sha))")
@@ -2247,11 +2248,12 @@ defmodule Tuist.Tests do
   @doc """
   Returns a map of test_case_id => count of unique flaky run groups for multiple test cases.
   """
-  def get_flaky_runs_groups_counts_for_test_cases([]), do: %{}
+  def get_flaky_runs_groups_counts_for_test_cases(_project_id, []), do: %{}
 
-  def get_flaky_runs_groups_counts_for_test_cases(test_case_ids) do
+  def get_flaky_runs_groups_counts_for_test_cases(project_id, test_case_ids) do
     query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id in ^test_case_ids,
         where: tcr.is_flaky == true,
         group_by: tcr.test_case_id,
@@ -2267,13 +2269,14 @@ defmodule Tuist.Tests do
   Fetches flaky runs for a specific test case, grouped by scheme and commit SHA.
   Returns paginated groups, each containing all runs with their failures.
   """
-  def list_flaky_runs_for_test_case(test_case_id, params \\ %{}) do
+  def list_flaky_runs_for_test_case(project_id, test_case_id, params \\ %{}) do
     page = Map.get(params, :page, 1)
     page_size = Map.get(params, :page_size, 20)
     offset = (page - 1) * page_size
 
     groups_query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         group_by: [tcr.scheme, tcr.git_commit_sha],
@@ -2292,6 +2295,7 @@ defmodule Tuist.Tests do
 
     flaky_runs_query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.is_flaky == true,
         order_by: [desc: tcr.ran_at]
@@ -2343,7 +2347,7 @@ defmodule Tuist.Tests do
         }
       end)
 
-    total_count = get_flaky_runs_groups_count_for_test_case(test_case_id)
+    total_count = get_flaky_runs_groups_count_for_test_case(project_id, test_case_id)
 
     meta = %{
       total_count: total_count,
@@ -2358,6 +2362,7 @@ defmodule Tuist.Tests do
   def get_flaky_run_group_for_test_case_run(test_case_run) do
     flaky_runs_query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^test_case_run.project_id,
         where: tcr.test_case_id == ^test_case_run.test_case_id,
         where: tcr.git_commit_sha == ^test_case_run.git_commit_sha,
         where: tcr.scheme == ^test_case_run.scheme,
@@ -2494,6 +2499,7 @@ defmodule Tuist.Tests do
   defp get_cross_run_flaky_runs(_test_run_id, []), do: []
 
   defp get_cross_run_flaky_runs(test_run_id, current_flaky_runs) do
+    project_ids = current_flaky_runs |> Enum.map(& &1.project_id) |> Enum.uniq()
     test_case_ids = current_flaky_runs |> Enum.map(& &1.test_case_id) |> Enum.uniq()
 
     commit_shas =
@@ -2507,9 +2513,10 @@ defmodule Tuist.Tests do
     else
       query =
         from(tcr in TestCaseRun,
+          where: tcr.project_id in ^project_ids,
+          where: tcr.test_case_id in ^test_case_ids,
           where: tcr.test_run_id != ^test_run_id,
           where: tcr.git_commit_sha in ^commit_shas,
-          where: tcr.test_case_id in ^test_case_ids,
           where: tcr.is_flaky == true,
           order_by: [desc: tcr.ran_at]
         )

--- a/server/lib/tuist/tests/analytics.ex
+++ b/server/lib/tuist/tests/analytics.ex
@@ -1261,11 +1261,12 @@ defmodule Tuist.Tests.Analytics do
   Calculates the ratio of flaky runs to total runs in the last 30 days.
   Returns 0.0 if there are no flaky runs or no data.
   """
-  def get_test_case_flakiness_rate(%TestCase{id: test_case_id}) do
+  def get_test_case_flakiness_rate(%TestCase{id: test_case_id, project_id: project_id}) do
     thirty_days_ago = DateTime.add(DateTime.utc_now(), -30, :day)
 
     query =
       from(tcr in TestCaseRun,
+        where: tcr.project_id == ^project_id,
         where: tcr.test_case_id == ^test_case_id,
         where: tcr.inserted_at >= ^thirty_days_ago,
         select: %{

--- a/server/lib/tuist_web/live/test_case_live.ex
+++ b/server/lib/tuist_web/live/test_case_live.ex
@@ -335,7 +335,7 @@ defmodule TuistWeb.TestCaseLive do
       {:ok, %{analytics: Analytics.test_case_analytics_by_id(test_case_id)}}
     end)
     |> assign_async([:flakiness_rate, :flaky_runs_grouped, :flaky_runs_meta], fn ->
-      {flaky_runs_grouped, flaky_runs_meta} = Tests.list_flaky_runs_for_test_case(test_case_id)
+      {flaky_runs_grouped, flaky_runs_meta} = Tests.list_flaky_runs_for_test_case(project.id, test_case_id)
 
       {:ok,
        %{

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -4969,7 +4969,7 @@ defmodule Tuist.TestsTest do
     end
   end
 
-  describe "get_flaky_runs_groups_count_for_test_case/1" do
+  describe "get_flaky_runs_groups_count_for_test_case/2" do
     test "returns 0 when no flaky runs exist" do
       project = ProjectsFixtures.project_fixture()
 
@@ -4990,7 +4990,7 @@ defmodule Tuist.TestsTest do
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
 
-      count = Tests.get_flaky_runs_groups_count_for_test_case(test_case.id)
+      count = Tests.get_flaky_runs_groups_count_for_test_case(project.id, test_case.id)
       assert count == 0
     end
 
@@ -5058,16 +5058,17 @@ defmodule Tuist.TestsTest do
       RunsFixtures.optimize_test_case_runs()
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
-      count = Tests.get_flaky_runs_groups_count_for_test_case(test_case.id)
+      count = Tests.get_flaky_runs_groups_count_for_test_case(project.id, test_case.id)
 
       # 2 groups: (default_scheme, commit1) and (default_scheme, commit2)
       assert count == 2
     end
   end
 
-  describe "get_flaky_runs_groups_counts_for_test_cases/1" do
+  describe "get_flaky_runs_groups_counts_for_test_cases/2" do
     test "returns empty map for empty list" do
-      result = Tests.get_flaky_runs_groups_counts_for_test_cases([])
+      project = ProjectsFixtures.project_fixture()
+      result = Tests.get_flaky_runs_groups_counts_for_test_cases(project.id, [])
       assert result == %{}
     end
 
@@ -5092,7 +5093,7 @@ defmodule Tuist.TestsTest do
       {[test_case_run | _], _} =
         Tests.list_test_case_runs(%{filters: [%{field: :test_run_id, op: :==, value: test.id}]})
 
-      result = Tests.get_flaky_runs_groups_counts_for_test_cases([test_case_run.test_case_id])
+      result = Tests.get_flaky_runs_groups_counts_for_test_cases(project.id, [test_case_run.test_case_id])
       assert result == %{}
     end
 
@@ -5198,7 +5199,7 @@ defmodule Tuist.TestsTest do
         Tests.list_test_case_runs(%{filters: [%{field: :test_run_id, op: :==, value: test2.id}]})
 
       result =
-        Tests.get_flaky_runs_groups_counts_for_test_cases([
+        Tests.get_flaky_runs_groups_counts_for_test_cases(project.id, [
           test_case_run_1.test_case_id,
           test_case_run_2.test_case_id
         ])
@@ -5272,7 +5273,7 @@ defmodule Tuist.TestsTest do
         Tests.list_test_case_runs(%{filters: [%{field: :test_run_id, op: :==, value: non_flaky_test.id}]})
 
       result =
-        Tests.get_flaky_runs_groups_counts_for_test_cases([
+        Tests.get_flaky_runs_groups_counts_for_test_cases(project.id, [
           flaky_run.test_case_id,
           non_flaky_run.test_case_id
         ])
@@ -5283,7 +5284,7 @@ defmodule Tuist.TestsTest do
     end
   end
 
-  describe "list_flaky_runs_for_test_case/2" do
+  describe "list_flaky_runs_for_test_case/3" do
     test "returns empty list with meta when no flaky runs exist" do
       project = ProjectsFixtures.project_fixture()
 
@@ -5304,7 +5305,7 @@ defmodule Tuist.TestsTest do
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
 
-      {groups, meta} = Tests.list_flaky_runs_for_test_case(test_case.id)
+      {groups, meta} = Tests.list_flaky_runs_for_test_case(project.id, test_case.id)
 
       assert groups == []
       assert meta.total_count == 0
@@ -5351,7 +5352,7 @@ defmodule Tuist.TestsTest do
       RunsFixtures.optimize_test_case_runs()
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
-      {groups, meta} = Tests.list_flaky_runs_for_test_case(test_case.id)
+      {groups, meta} = Tests.list_flaky_runs_for_test_case(project.id, test_case.id)
 
       assert length(groups) == 1
       assert meta.total_count == 1
@@ -5407,13 +5408,13 @@ defmodule Tuist.TestsTest do
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
 
-      {page1, meta1} = Tests.list_flaky_runs_for_test_case(test_case.id, %{page: 1, page_size: 2})
+      {page1, meta1} = Tests.list_flaky_runs_for_test_case(project.id, test_case.id, %{page: 1, page_size: 2})
       assert length(page1) == 2
       assert meta1.total_count == 3
       assert meta1.total_pages == 2
       assert meta1.current_page == 1
 
-      {page2, meta2} = Tests.list_flaky_runs_for_test_case(test_case.id, %{page: 2, page_size: 2})
+      {page2, meta2} = Tests.list_flaky_runs_for_test_case(project.id, test_case.id, %{page: 2, page_size: 2})
       assert length(page2) == 1
       assert meta2.current_page == 2
     end
@@ -5482,7 +5483,7 @@ defmodule Tuist.TestsTest do
       RunsFixtures.optimize_test_case_runs()
 
       {[test_case], _} = Tests.list_test_cases(project.id, %{})
-      {groups, _} = Tests.list_flaky_runs_for_test_case(test_case.id)
+      {groups, _} = Tests.list_flaky_runs_for_test_case(project.id, test_case.id)
 
       assert length(groups) == 2
       assert Enum.at(groups, 0).git_commit_sha == "newer_commit"


### PR DESCRIPTION
### Summary

Six queries against the `test_case_runs` ClickHouse table filtered by `test_case_id` (or other columns) without `project_id`. The table's `ORDER BY (project_id, test_case_id, ran_at, id)` means a missing `project_id` defeats prefix matching, so ClickHouse falls back from binary search to generic exclusion search and scans most granules.

### Pre-fix prod impact (last 7 days)

A Grafana `query_log` analysis surfaced what these queries actually cost in production:

| Function | Executions (7d) | p50 | p90 | p99 | Avg rows / bytes read per query |
|---|---|---|---|---|---|
| `get_test_case_flakiness_rate` | **4,939** | — | **185ms** | — | **5.29M rows / 88 MiB** |
| `get_flaky_runs_groups_count_for_test_case` | 347 | 42ms | 77ms | 174ms | 2.81M rows / 37.7 MiB |
| `list_flaky_runs_for_test_case` (groups) | 296 | 46ms | 138ms | 324ms | 2.82M rows / 37.8 MiB |
| `get_flaky_runs_groups_counts_for_test_cases` | not in window | — | — | — | — |
| `list_flaky_runs_for_test_case` (runs) | not in window | — | — | — | — |
| `get_flaky_run_group_for_test_case_run` | not in window | — | — | — | — |
| `get_cross_run_flaky_runs` | not in window | — | — | — | — |

`get_test_case_flakiness_rate` alone read **~26 billion rows / ~430 GiB** across the 7-day window. Each call reads more data than is justified for a single test case's flakiness rate; the cumulative impact dwarfs the other five queries combined.

The four "not in window" entries are tied to UI flows (paginated flaky-runs list on the test-case detail page, single test-case-run detail page) that get less traffic than the dashboard widget driving the flakiness rate. The fix still applies — they just won't show as much delta until someone opens those pages.

### Functions updated

`lib/tuist/tests.ex`:

- `get_flaky_runs_groups_count_for_test_case/1` → `/2`
- `get_flaky_runs_groups_counts_for_test_cases/1` → `/2`
- `list_flaky_runs_for_test_case/2` → `/3`
- `get_flaky_run_group_for_test_case_run/1` — pulls `project_id` from the existing struct argument
- `get_cross_run_flaky_runs/2` (private) — derives `project_ids` from the `current_flaky_runs` it already has

`lib/tuist/tests/analytics.ex`:

- `get_test_case_flakiness_rate/1` — pulls `project_id` from the `%TestCase{}` pattern match (no caller change)

`lib/tuist_web/live/test_case_live.ex` updated to pass `project.id` to `list_flaky_runs_for_test_case/3`. All other callers already had the full struct.

### How to test locally

`EXPLAIN indexes = 1` against local ClickHouse, same shape for every fixed query:

| | Search algorithm | Granules scanned |
|---|---|---|
| Before (no `project_id`) | generic exclusion search | 14/16 → 13 (after bloom) |
| After (with `project_id`) | **binary search** | **2/16 → 1 (after bloom)** |

Run the affected suites:

```sh
cd server
mix test test/tuist/tests_test.exs --only describe:"get_flaky_runs_groups_count_for_test_case/2" \
  --only describe:"get_flaky_runs_groups_counts_for_test_cases/2" \
  --only describe:"list_flaky_runs_for_test_case/3" \
  --only describe:"get_flaky_runs_for_test_run/1" \
  --only describe:"get_flaky_run_group_for_test_case_run/1"
mix test test/tuist/tests/analytics_test.exs --only describe:"get_test_case_flakiness_rate/1"
mix test test/tuist_web/live/test_case_live_test.exs
```

All 36 + 6 tests pass; `mix format --check-formatted` and `mix credo` clean.

### Post-deploy verification

Run against prod ClickHouse — should drop to zero (or near zero) rows once the deploy lands. Filter on the `tables` array so MV-backed queries (`test_case_runs_by_test_run`, `test_case_runs_active_daily_stats`, etc.) don't appear as false positives:

```sql
SELECT normalizeQuery(query), count(), round(quantile(0.9)(query_duration_ms)) AS p90_ms,
       formatReadableQuantity(avg(read_rows)) AS avg_read_rows
FROM system.query_log
PREWHERE event_date >= today() - 1
WHERE type = 'QueryFinish' AND query_kind = 'Select'
  AND has(tables, 'default.test_case_runs')
  AND query LIKE '%is_flaky%'
  AND query NOT LIKE '%project_id%'
GROUP BY 1 ORDER BY p90_ms DESC
```

A pre-fix run of this query (1-day window) returned 3 normalized shapes against the base `test_case_runs` table — matching #1 (`get_flaky_runs_groups_count_for_test_case`), #3a (`list_flaky_runs_for_test_case` groups), and `get_test_case_flakiness_rate`. Post-deploy, all three should fall out of the result set.

### Out of scope

The original report also flagged three full-table-scan probe queries (`SELECT * FROM <mv> ORDER BY <ts> DESC LIMIT 5`) on `test_case_branch_presence`, `test_case_runs_by_shard_id`, and `test_case_run_daily_stats_per_case`. Those are alert-rule probes (Grafana fingerprint `ffeb6l2ax5qtcf`) and don't appear anywhere in this repo — they need to be fixed in the Grafana alert rule definition by adding a bounded `WHERE` clause (e.g. `WHERE ran_at >= now() - INTERVAL 1 DAY`).

The reported `test_cases FINAL` JOIN is already resolved (MissingSeries) and the existing `FINAL` usage on `test_cases` is intentional — it's a `ReplacingMergeTree(inserted_at)` storing denormalized state, and `project_id` is already the leading PK column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)