### PR TITLE
chore(cli): wire up Windows feasibility build in CI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -442,3 +442,42 @@ jobs:
         with:
           path: .build
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+  # Feasibility-only signal for Windows. Allowed to fail while the platform is
+  # being brought up; the goal is to surface concrete blockers in CI rather
+  # than gate PRs. Once it goes consistently green, drop continue-on-error.
+  cli-windows-build:
+    name: Windows Build (feasibility)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    continue-on-error: true
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Swift
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-6.2-release
+          tag: 6.2-RELEASE
+      - name: Print Swift version
+        run: swift --version
+      - name: Restore cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: windows-cli-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            windows-cli-${{ hashFiles('Package.swift') }}-
+      - name: Resolve dependencies
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: swift package resolve --replace-scm-with-registry
+      - name: Build tuist CLI
+        run: swift build --target tuist --replace-scm-with-registry --force-resolved-versions
+      - name: Save cache
+        if: github.ref == 'refs/heads/main'
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -453,6 +453,8 @@ jobs:
     continue-on-error: true
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
+      - name: Enable git long paths
+        run: git config --system core.longpaths true
       - uses: actions/checkout@v4
       - name: Set up Swift
         uses: compnerd/gha-setup-swift@main

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,14 @@ let xcodeMetadataDependency: Target.Dependency = "XcodeMetadata"
 let xcodeGraphMapperDependency: Target.Dependency = "XcodeGraphMapper"
 let xcodeProjDependency: Target.Dependency = .product(name: "XcodeProj", package: "tuist.XcodeProj")
 let mockableDependency: Target.Dependency = .product(name: "Mockable", package: "kolos65.Mockable")
-let zipFoundationDependency: Target.Dependency = .product(name: "ZIPFoundation", package: "tuist.ZIPFoundation")
+// ZIPFoundation pulls in CZlib, which has no system zlib shim on Windows.
+// The CLI doesn't actually import ZIPFoundation (zipping goes through the
+// FileSystem package), so we drop it on Windows.
+let zipFoundationDependency: Target.Dependency = .product(
+    name: "ZIPFoundation",
+    package: "tuist.ZIPFoundation",
+    condition: .when(platforms: [.macOS, .linux])
+)
 let stencilDependency: Target.Dependency = .product(name: "Stencil", package: "stencilproject.Stencil")
 let graphVizDependency: Target.Dependency = .product(name: "GraphViz", package: "tuist.GraphViz")
 let differenceDependency: Target.Dependency = .product(name: "Difference", package: "krzysztofzablocki.Difference")

--- a/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectBundleCommand.swift
@@ -1,3 +1,4 @@
+#if canImport(Rosalind)
 import ArgumentParser
 import FileSystem
 import Foundation
@@ -83,3 +84,4 @@ public struct InspectBundleCommand: AsyncParsableCommand {
         #endif
     }
 }
+#endif

--- a/cli/Sources/TuistInspectCommand/Commands/InspectCommand.swift
+++ b/cli/Sources/TuistInspectCommand/Commands/InspectCommand.swift
@@ -4,9 +4,10 @@ public struct InspectCommand: AsyncParsableCommand {
     public init() {}
 
     public static var configuration: CommandConfiguration {
-        var subcommands: [ParsableCommand.Type] = [
-            InspectBundleCommand.self,
-        ]
+        var subcommands: [ParsableCommand.Type] = []
+        #if canImport(Rosalind)
+            subcommands.append(InspectBundleCommand.self)
+        #endif
         #if os(macOS)
             subcommands.append(contentsOf: [
                 InspectDependenciesCommand.self,

--- a/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
@@ -1,3 +1,4 @@
+#if canImport(Rosalind)
 import FileSystem
 import Foundation
 import Noora
@@ -255,3 +256,4 @@ public struct InspectBundleCommandService {
         }
     }
 }
+#endif

--- a/cli/Sources/TuistOpener/Opener.swift
+++ b/cli/Sources/TuistOpener/Opener.swift
@@ -59,7 +59,7 @@ public struct Opener: Opening {
     }
 
     public func open(target: String, wait: Bool) throws {
-        #if os(macOS) || os(Linux)
+        #if os(macOS) || os(Linux) || os(Windows)
             let process = Process()
             #if os(macOS)
                 process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
@@ -71,6 +71,11 @@ public struct Opener: Opening {
             #elseif os(Linux)
                 process.executableURL = URL(fileURLWithPath: "/usr/bin/xdg-open")
                 process.arguments = [target]
+            #elseif os(Windows)
+                // The empty "" is the window title placeholder that `start` requires
+                // when the first quoted argument might otherwise be interpreted as one.
+                process.executableURL = URL(fileURLWithPath: "C:\\Windows\\System32\\cmd.exe")
+                process.arguments = ["/c", "start", "", target]
             #endif
             try process.run()
             if wait {
@@ -84,7 +89,7 @@ public struct Opener: Opening {
     }
 
     public func open(path: AbsolutePath, application: AbsolutePath, wait: Bool) throws {
-        #if os(macOS) || os(Linux)
+        #if os(macOS) || os(Linux) || os(Windows)
             let process = Process()
             #if os(macOS)
                 process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
@@ -93,8 +98,8 @@ public struct Opener: Opening {
                     arguments.insert("-W", at: 0)
                 }
                 process.arguments = arguments
-            #elseif os(Linux)
-                // On Linux, run the application directly with the file as argument
+            #elseif os(Linux) || os(Windows)
+                // Run the application directly with the file as argument.
                 process.executableURL = URL(fileURLWithPath: application.pathString)
                 process.arguments = [path.pathString]
             #endif

--- a/cli/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
+++ b/cli/Sources/TuistServer/Utilities/ServerCredentialsStore.swift
@@ -1,6 +1,6 @@
 import FileSystem
 import Foundation
-#if !os(Linux)
+#if os(macOS)
     import KeychainAccess
 #endif
 #if canImport(TuistEnvironment)
@@ -77,23 +77,15 @@ enum ServerCredentialsStoreError: LocalizedError {
 }
 
 public enum ServerCredentialsStoreBackend: Sendable {
-    #if os(Linux)
-        case fileSystem
-    #else
-        #if os(macOS)
-            case fileSystem
-        #endif
+    case fileSystem
+    #if os(macOS)
         case keychain
     #endif
 }
 
-#if !os(Linux)
+#if os(macOS)
     public final class ServerCredentialsStore: ServerCredentialsStoring, ObservableObject {
-        #if os(macOS)
-            @TaskLocal public static var current: ServerCredentialsStoring = ServerCredentialsStore(backend: .fileSystem)
-        #else
-            @TaskLocal public static var current: ServerCredentialsStoring = ServerCredentialsStore(backend: .keychain)
-        #endif
+        @TaskLocal public static var current: ServerCredentialsStoring = ServerCredentialsStore(backend: .fileSystem)
 
         private let backend: ServerCredentialsStoreBackend
         private let fileSystem: FileSysteming
@@ -127,15 +119,13 @@ public enum ServerCredentialsStoreBackend: Sendable {
                 try keychain(serverURL: serverURL)
                     .comment("Refresh token against \(serverURL.absoluteString)")
                     .set(credentials.accessToken, key: serverURL.absoluteString + "_access_token")
-            #if os(macOS)
-                case .fileSystem:
-                    let path = try credentialsFilePath(serverURL: serverURL)
-                    let data = try JSONEncoder().encode(credentials)
-                    if try await !fileSystem.exists(path.parentDirectory) {
-                        try await fileSystem.makeDirectory(at: path.parentDirectory)
-                    }
-                    try data.write(to: URL(fileURLWithPath: path.pathString), options: .atomic)
-            #endif
+            case .fileSystem:
+                let path = try credentialsFilePath(serverURL: serverURL)
+                let data = try JSONEncoder().encode(credentials)
+                if try await !fileSystem.exists(path.parentDirectory) {
+                    try await fileSystem.makeDirectory(at: path.parentDirectory)
+                }
+                try data.write(to: URL(fileURLWithPath: path.pathString), options: .atomic)
             }
 
             credentialsChangedContinuation.continuation.yield(credentials)
@@ -151,20 +141,11 @@ public enum ServerCredentialsStoreBackend: Sendable {
                     accessToken: accessToken,
                     refreshToken: refreshToken
                 )
-            #if os(macOS)
-                case .fileSystem:
-                    let path = try credentialsFilePath(serverURL: serverURL)
-                    guard try await fileSystem.exists(path) else { return nil }
-                    let data = try await fileSystem.readFile(at: path)
-
-                    // This might fail if we've migrated the schema, which is very unlikely, or if someone modifies the content in
-                    // it
-                    // and the new schema doesn't align with the one that we expect. We could add logic to handle those
-                    // gracefully,
-                    // but since the user can recover from it by signing in again, I think it's ok not to add more complexity
-                    // here.
-                    return try? JSONDecoder().decode(ServerCredentials.self, from: data)
-            #endif
+            case .fileSystem:
+                let path = try credentialsFilePath(serverURL: serverURL)
+                guard try await fileSystem.exists(path) else { return nil }
+                let data = try await fileSystem.readFile(at: path)
+                return try? JSONDecoder().decode(ServerCredentials.self, from: data)
             }
         }
 
@@ -183,34 +164,30 @@ public enum ServerCredentialsStoreBackend: Sendable {
                 let keychain = keychain(serverURL: serverURL)
                 try keychain.remove(serverURL.absoluteString + "_refresh_token")
                 try keychain.remove(serverURL.absoluteString + "_access_token")
-            #if os(macOS)
-                case .fileSystem:
-                    let path = try credentialsFilePath(serverURL: serverURL)
-                    if try await fileSystem.exists(path) {
-                        try await fileSystem.remove(path)
-                    }
-            #endif
+            case .fileSystem:
+                let path = try credentialsFilePath(serverURL: serverURL)
+                if try await fileSystem.exists(path) {
+                    try await fileSystem.remove(path)
+                }
             }
 
             credentialsChangedContinuation.continuation.yield(nil)
         }
 
-        #if os(macOS)
-            fileprivate func credentialsFilePath(serverURL: URL) throws -> AbsolutePath {
-                guard let components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false),
-                      let host = components.host
-                else {
-                    throw ServerCredentialsStoreError.invalidServerURL(serverURL.absoluteString)
-                }
-                let directory = if let configDirectory {
-                    configDirectory
-                } else {
-                    Environment.current.configDirectory
-                }
-                // swiftlint:disable:next force_try
-                return directory.appending(try! RelativePath(validating: "credentials/\(host).json"))
+        fileprivate func credentialsFilePath(serverURL: URL) throws -> AbsolutePath {
+            guard let components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false),
+                  let host = components.host
+            else {
+                throw ServerCredentialsStoreError.invalidServerURL(serverURL.absoluteString)
             }
-        #endif
+            let directory = if let configDirectory {
+                configDirectory
+            } else {
+                Environment.current.configDirectory
+            }
+            // swiftlint:disable:next force_try
+            return directory.appending(try! RelativePath(validating: "credentials/\(host).json"))
+        }
 
         fileprivate func keychain(serverURL: URL) -> Keychain {
             Keychain(server: serverURL, protocolType: .https, authenticationType: .default)
@@ -249,7 +226,13 @@ public enum ServerCredentialsStoreBackend: Sendable {
         }
 
         private static func defaultConfigDirectory() -> AbsolutePath {
-            let homeDirectory = ProcessInfo.processInfo.environment["HOME"] ?? "/tmp"
+            #if os(Windows)
+                let homeDirectory = ProcessInfo.processInfo.environment["USERPROFILE"]
+                    ?? ProcessInfo.processInfo.environment["HOME"]
+                    ?? "C:\\"
+            #else
+                let homeDirectory = ProcessInfo.processInfo.environment["HOME"] ?? "/tmp"
+            #endif
             // swiftlint:disable:next force_try
             return try! AbsolutePath(validating: homeDirectory).appending(component: ".config").appending(component: "tuist")
         }


### PR DESCRIPTION
## Summary

Spike to see how close the CLI is to building on Windows. The CLI already builds on Linux, so the gap is narrower than expected — most of the work is collapsing existing `os(Linux)` / `!os(macOS)` splits to also cover Windows.

- `ServerCredentialsStore` now uses the filesystem backend on every non-macOS platform (Linux + Windows + others); only macOS uses Keychain. Added a `USERPROFILE` fallback for the default config dir on Windows.
- `Opener` got a Windows arm (`cmd /c start ""`).
- `InspectBundleCommand` and its service are gated on `canImport(Rosalind)` since Rosalind is package-conditioned to macOS+Linux. The parent `InspectCommand` only registers it when Rosalind is importable.
- New `cli-windows-build` job in `.github/workflows/cli.yml` running `swift build --target tuist` on `windows-latest` with Swift 6.2. Marked `continue-on-error: true` so it surfaces blockers without gating PRs while bring-up continues.

Generated OpenAPI files (`Types.swift`, `Client.swift`) were intentionally not touched — their `#if os(Linux)` `@preconcurrency` arms may need expansion to Windows once CI surfaces it, but that should be a server-side generator config change.

## Test plan

- [ ] Linux build still passes (no behavior change for Linux)
- [ ] macOS build still passes (verified locally for `TuistOpener`, `TuistServer`, `TuistInspectCommand`)
- [ ] New Windows job runs and reports a concrete first round of compile errors to iterate on

🤖 Generated with [Claude Code](https://claude.com/claude-code)