### PR TITLE
feat(cli): rename Tuist `cache` to `xcodeCache`

### DIFF
--- a/cli/Sources/ProjectDescription/Tuist.swift
+++ b/cli/Sources/ProjectDescription/Tuist.swift
@@ -42,17 +42,25 @@ public struct Tuist: Codable, Equatable, Sendable {
     }
 
     /// Options for configuring the Xcode Cache behavior.
-    public struct Cache: Codable, Equatable, Sendable {
+    public struct XcodeCache: Codable, Equatable, Sendable {
         /// When `true` (default), the local proxy uploads artifacts to the remote cache.
         /// Set to `false` for read-only mode (downloads only, no uploads).
         public let upload: Bool
 
-        /// Creates cache options.
+        /// Creates Xcode Cache options.
         /// - Parameter upload: Whether to upload artifacts to the remote cache. Defaults to `true`.
+        public static func xcodeCache(upload: Bool = true) -> Self {
+            XcodeCache(upload: upload)
+        }
+
+        @available(*, deprecated, renamed: "xcodeCache(upload:)")
         public static func cache(upload: Bool = true) -> Self {
-            Cache(upload: upload)
+            XcodeCache(upload: upload)
         }
     }
+
+    @available(*, deprecated, renamed: "XcodeCache")
+    public typealias Cache = XcodeCache
 
     /// Configures the project Tuist will interact with.
     /// When no project is provided, Tuist defaults to the workspace or project in the current directory.
@@ -68,7 +76,7 @@ public struct Tuist: Codable, Equatable, Sendable {
     public let network: Network
 
     /// The Xcode Cache configuration.
-    public let cache: Cache
+    public let xcodeCache: XcodeCache
 
     /// The base URL that points to the Tuist server.
     public let url: String
@@ -114,7 +122,7 @@ public struct Tuist: Codable, Equatable, Sendable {
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
         self.network = network
-        cache = .cache()
+        xcodeCache = .xcodeCache()
         self.url = url
         dumpIfNeeded(self)
     }
@@ -122,7 +130,7 @@ public struct Tuist: Codable, Equatable, Sendable {
     public init(
         fullHandle: String? = nil,
         inspectOptions: InspectOptions = .options(),
-        cache: Cache = .cache(),
+        xcodeCache: XcodeCache = .xcodeCache(),
         url: String = "https://tuist.dev",
         network: Network = .network(),
         project: TuistProject
@@ -131,8 +139,27 @@ public struct Tuist: Codable, Equatable, Sendable {
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
         self.network = network
-        self.cache = cache
+        self.xcodeCache = xcodeCache
         self.url = url
         dumpIfNeeded(self)
+    }
+
+    @available(*, deprecated, renamed: "init(fullHandle:inspectOptions:xcodeCache:url:network:project:)")
+    public init(
+        fullHandle: String? = nil,
+        inspectOptions: InspectOptions = .options(),
+        cache: XcodeCache,
+        url: String = "https://tuist.dev",
+        network: Network = .network(),
+        project: TuistProject
+    ) {
+        self.init(
+            fullHandle: fullHandle,
+            inspectOptions: inspectOptions,
+            xcodeCache: cache,
+            url: url,
+            network: network,
+            project: project
+        )
     }
 }

--- a/cli/Sources/TuistConfig/Tuist.swift
+++ b/cli/Sources/TuistConfig/Tuist.swift
@@ -21,7 +21,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
         }
     }
 
-    public struct Cache: Equatable, Hashable, Sendable {
+    public struct XcodeCache: Equatable, Hashable, Sendable {
         public let upload: Bool
 
         public init(upload: Bool = true) {
@@ -33,7 +33,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
     public let fullHandle: String?
     public let inspectOptions: InspectOptions
     public let network: Network
-    public let cache: Cache
+    public let xcodeCache: XcodeCache
     public let url: URL
 
     public static var `default`: Tuist {
@@ -41,7 +41,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: .defaultGeneratedProject(),
             fullHandle: nil,
             inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            cache: Cache(),
+            xcodeCache: XcodeCache(),
             url: Constants.URLs.production,
             network: Network()
         )
@@ -51,7 +51,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
         project: TuistProject,
         fullHandle: String?,
         inspectOptions: InspectOptions,
-        cache: Cache = Cache(),
+        xcodeCache: XcodeCache = XcodeCache(),
         url: URL,
         network: Network = Network()
     ) {
@@ -59,7 +59,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
         self.fullHandle = fullHandle
         self.inspectOptions = inspectOptions
         self.network = network
-        self.cache = cache
+        self.xcodeCache = xcodeCache
         self.url = url
     }
 
@@ -82,7 +82,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
             project: TuistProject = .testGeneratedProject(),
             fullHandle: String? = nil,
             inspectOptions: InspectOptions = .init(redundantDependencies: .init(ignoreTagsMatching: [])),
-            cache: Cache = Cache(),
+            xcodeCache: XcodeCache = XcodeCache(),
             url: URL = Constants.URLs.production,
             network: Network = Network()
         ) -> Self {
@@ -90,7 +90,7 @@ public struct Tuist: Equatable, Hashable, Sendable {
                 project: project,
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                cache: cache,
+                xcodeCache: xcodeCache,
                 url: url,
                 network: network
             )

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -61,7 +61,7 @@ struct SetupCacheCommandService {
 
         programArguments.append(contentsOf: ["--url", serverURL.absoluteString])
 
-        if !config.cache.upload {
+        if !config.xcodeCache.upload {
             programArguments.append("--no-upload")
         }
 

--- a/cli/Sources/TuistKit/Services/XcodeBuild/UploadBuildRunService.swift
+++ b/cli/Sources/TuistKit/Services/XcodeBuild/UploadBuildRunService.swift
@@ -118,7 +118,7 @@ public struct UploadBuildRunService: UploadBuildRunServicing {
                 macOSVersion: machineEnvironment.macOSVersion,
                 scheme: scheme ?? Environment.current.schemeName,
                 targets: [],
-                xcodeCacheUploadEnabled: config.cache.upload,
+                xcodeCacheUploadEnabled: config.xcodeCache.upload,
                 xcodeVersion: try await xcodeBuildController.version()?.description,
                 status: .processing,
                 ciRunId: ciInfo?.runId,

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Tuist+ManifestMapper.swift
@@ -39,7 +39,7 @@ extension TuistConfig.Tuist {
         let fullHandle = manifest.fullHandle
         let inspectOptions = InspectOptions.from(manifest: manifest.inspectOptions)
         let network = TuistConfig.Tuist.Network(proxy: manifest.network.proxy)
-        let cache = TuistConfig.Tuist.Cache(upload: manifest.cache.upload)
+        let xcodeCache = TuistConfig.Tuist.XcodeCache(upload: manifest.xcodeCache.upload)
         let urlString = manifest.url
 
         guard let url = URL(string: urlString.dropSuffix("/")) else {
@@ -81,7 +81,7 @@ extension TuistConfig.Tuist {
                 ),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                cache: cache,
+                xcodeCache: xcodeCache,
                 url: url,
                 network: network
             )
@@ -90,7 +90,7 @@ extension TuistConfig.Tuist {
                 project: .xcode(TuistXcodeProjectOptions()),
                 fullHandle: fullHandle,
                 inspectOptions: inspectOptions,
-                cache: cache,
+                xcodeCache: xcodeCache,
                 url: url,
                 network: network
             )

--- a/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
+++ b/cli/Tests/TuistKitTests/Commands/DumpServiceIntegrationTests.swift
@@ -184,9 +184,6 @@ final class DumpServiceTests: TuistTestCase {
             try await subject.run(path: tmpDir.pathString, manifest: .config)
             let expected = """
             {
-              "cache": {
-                "upload": true
-              },
               "fullHandle": "tuist/tuist",
               "inspectOptions": {
                 "redundantDependencies": {
@@ -266,7 +263,10 @@ final class DumpServiceTests: TuistTestCase {
                   ]
                 }
               },
-              "url": "https://tuist.dev"
+              "url": "https://tuist.dev",
+              "xcodeCache": {
+                "upload": true
+              }
             }
             """
 

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -261,7 +261,7 @@ struct SetupCacheCommandServiceTests {
 
         let config = Tuist.test(
             fullHandle: "organization/project",
-            cache: .init(upload: false)
+            xcodeCache: .init(upload: false)
         )
         configLoader.reset()
         given(configLoader)
@@ -292,7 +292,7 @@ struct SetupCacheCommandServiceTests {
 
         let config = Tuist.test(
             fullHandle: "organization/project",
-            cache: .init(upload: true)
+            xcodeCache: .init(upload: true)
         )
         configLoader.reset()
         given(configLoader)

--- a/examples/xcode/generated_project_with_caching_enabled/Tuist.swift
+++ b/examples/xcode/generated_project_with_caching_enabled/Tuist.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 let tuist = Tuist(
     fullHandle: "tuist/tuist",
-    cache: .cache(
+    xcodeCache: .xcodeCache(
         upload: false
     ),
     url: "http://localhost:8080",

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -93,14 +93,14 @@ xcodebuild build -project YourProject.xcodeproj -scheme YourScheme \
 
 ### Cache upload policy {#cache-upload-policy}
 
-By default, the cache service both downloads and uploads artifacts to the remote cache. You can control this with the `cache` option in your `Tuist.swift` file to enable read-only mode, where artifacts are downloaded but never uploaded:
+By default, the cache service both downloads and uploads artifacts to the remote cache. You can control this with the `xcodeCache` option in your `Tuist.swift` file to enable read-only mode, where artifacts are downloaded but never uploaded:
 
 ```swift
 import ProjectDescription
 
 let tuist = Tuist(
     fullHandle: "your-org/your-project",
-    cache: .cache(
+    xcodeCache: .xcodeCache(
         upload: false
     ),
     project: .tuist(
@@ -118,7 +118,7 @@ import ProjectDescription
 
 let tuist = Tuist(
     fullHandle: "your-org/your-project",
-    cache: .cache(
+    xcodeCache: .xcodeCache(
         upload: Environment.isCI
     ),
     project: .tuist(
@@ -217,4 +217,4 @@ A build log that mixes successful `uploaded CAS output` notes with `deadlineExce
 
 ### `uploaded CAS output` appears locally even though uploads are disabled {#uploaded-cas-output-with-upload-disabled}
 
-When `cache: .cache(upload: false)` (or `upload: Environment.isCI` on a non-CI machine) is set, you may still see `note: uploaded CAS output ...` in the build log. `xcodebuild` has no way to skip those calls, so the socket still receives them; the daemon short-circuits the request internally and does not send anything to the Tuist server. The dashboard metrics account for this, so no spurious upload traffic is reported.
+When `xcodeCache: .xcodeCache(upload: false)` (or `upload: Environment.isCI` on a non-CI machine) is set, you may still see `note: uploaded CAS output ...` in the build log. `xcodebuild` has no way to skip those calls, so the socket still receives them; the daemon short-circuits the request internally and does not send anything to the Tuist server. The dashboard metrics account for this, so no spurious upload traffic is reported.


### PR DESCRIPTION
> Describe here the purpose of your PR.

The top-level `Tuist.swift` `cache:` option configures the **Xcode Cache** specifically, but the generic name causes confusion (it gets mixed up with the binary cache, selective testing cache, etc.). This renames it to `xcodeCache:` so the intent is explicit at the call site.

The old `cache:` API is preserved with `@available(*, deprecated, renamed: ...)` so user manifests still compile, with deprecation warnings pointing at the new name. Internal model, manifest mapper, services, tests, the example manifest, and the English Xcode Cache docs are updated.

User-facing change:

```swift
// Old (still works, deprecation warning)
let tuist = Tuist(
    fullHandle: "your-org/your-project",
    cache: .cache(upload: false),
    project: .tuist(...)
)

// New
let tuist = Tuist(
    fullHandle: "your-org/your-project",
    xcodeCache: .xcodeCache(upload: false),
    project: .tuist(...)
)
```

### How to test locally

- Update a `Tuist.swift` to use `xcodeCache: .xcodeCache(upload: false)` and confirm `tuist setup cache` still passes `--no-upload` to the launch agent.
- Update a `Tuist.swift` to use the legacy `cache: .cache(upload: false)` and confirm it compiles with a deprecation warning and behaves identically.
- `tuist dump` on a `Tuist.swift` should show the property under the `xcodeCache` JSON key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)