### PR TITLE
fix(server): add required title to update_test_case MCP tool

### DIFF
--- a/server/lib/tuist/mcp/components/tools/update_test_case.ex
+++ b/server/lib/tuist/mcp/components/tools/update_test_case.ex
@@ -5,6 +5,8 @@ defmodule Tuist.MCP.Components.Tools.UpdateTestCase do
 
   use Tuist.MCP.Tool,
     name: "update_test_case",
+    title: "Update Test Case",
+    read_only_hint: false,
     schema: %{
       "type" => "object",
       "properties" => %{


### PR DESCRIPTION
## Summary

- The `Tuist.MCP.Tool` macro requires a `:title` key, but `update_test_case` was missing one, breaking server Docker image builds with `** (KeyError) key :title not found in:` during `mix compile`.
- Added `title: "Update Test Case"` and `read_only_hint: false` (this tool mutates state) to match the convention used by other mutation tools (e.g. `create_project`, `add_organization_member`).

Failing job: https://github.com/tuist/tuist/actions/runs/25487494667/job/74786754394

## Test plan

- [x] `mix compile --warnings-as-errors` succeeds locally
- [ ] CI server image build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)