### PR TITLE
fix(server): align Slack integration with marketplace requirements

### DIFF
--- a/server/assets/app/js/SelectSlackChannelPopup.js
+++ b/server/assets/app/js/SelectSlackChannelPopup.js
@@ -17,14 +17,8 @@ const SelectSlackChannelPopup = {
         if (this.el.dataset.id) {
           payload.id = this.el.dataset.id;
         }
-        if (event.data.channel_id) {
-          payload.channel_id = event.data.channel_id;
-        }
-        if (event.data.channel_name) {
-          payload.channel_name = event.data.channel_name;
-        }
-        if (event.data.webhook_url) {
-          payload.webhook_url = event.data.webhook_url;
+        if (event.data.channel_token) {
+          payload.channel_token = event.data.channel_token;
         }
         this.pushEvent(eventName, payload);
       }

--- a/server/assets/app/js/SelectSlackChannelPopup.js
+++ b/server/assets/app/js/SelectSlackChannelPopup.js
@@ -23,6 +23,9 @@ const SelectSlackChannelPopup = {
         if (event.data.channel_name) {
           payload.channel_name = event.data.channel_name;
         }
+        if (event.data.webhook_url) {
+          payload.webhook_url = event.data.webhook_url;
+        }
         this.pushEvent(eventName, payload);
       }
     };

--- a/server/data-export.md
+++ b/server/data-export.md
@@ -38,6 +38,11 @@ Sensitive authentication data (passwords, tokens) are excluded from exports.
 - Alert rules (name, category, metric, deviation thresholds, Slack channel configuration, baseline established timestamp)
 - Alert history (triggered alerts with current/previous values, timestamps)
 
+### Slack Integration
+- Account-level Slack installation records (workspace id/name, bot user id; bot access tokens are excluded as authentication secrets)
+- Per-channel Slack webhook destinations stored on projects, alert rules, and project flaky-test settings (channel id, channel name; the encrypted webhook URL itself is excluded as an authentication secret)
+- Per-action Slack webhook destinations stored on automation alerts (channel id, channel name; the encrypted webhook URL embedded in the action payload is excluded as an authentication secret)
+
 ### Analytics Data (ClickHouse)
 The following data is stored in ClickHouse for analytics purposes:
 - **Build runs** (`build_runs` table): Complete build execution data including duration, status, cache statistics, CI metadata, git information, and custom tags
@@ -63,6 +68,7 @@ The following data is stored in ClickHouse for analytics purposes:
 - Encrypted passwords and authentication secrets
 - Account, SCIM-scoped account, and project token values and encrypted token hashes
 - Encrypted SSO client secrets for Okta and custom OAuth2 providers
+- Slack bot access tokens and incoming-webhook URLs (treated as bearer credentials)
 
 ## Binary Files
 

--- a/server/lib/tuist/alerts.ex
+++ b/server/lib/tuist/alerts.ex
@@ -47,7 +47,7 @@ defmodule Tuist.Alerts do
   def get_all_alert_rules do
     AlertRule
     |> Repo.all()
-    |> Repo.preload(project: [account: :slack_installation])
+    |> Repo.preload(project: [:account])
   end
 
   def create_alert(attrs) do

--- a/server/lib/tuist/alerts/alert_rule.ex
+++ b/server/lib/tuist/alerts/alert_rule.ex
@@ -30,6 +30,7 @@ defmodule Tuist.Alerts.AlertRule do
     field :git_branch, :string
     field :slack_channel_id, :string
     field :slack_channel_name, :string
+    field :slack_webhook_url, Tuist.Vault.Binary
     field :scheme, :string, default: ""
     field :bundle_name, :string, default: ""
     field :environment, Ecto.Enum, values: @environments, default: :any
@@ -52,6 +53,7 @@ defmodule Tuist.Alerts.AlertRule do
       :git_branch,
       :slack_channel_id,
       :slack_channel_name,
+      :slack_webhook_url,
       :scheme,
       :bundle_name,
       :environment

--- a/server/lib/tuist/alerts/workers/alert_worker.ex
+++ b/server/lib/tuist/alerts/workers/alert_worker.ex
@@ -66,8 +66,7 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
          slack_channel_id: channel_id,
          project: %{account: %{slack_installation: %{access_token: token}}}
        })
-       when is_binary(channel_id) and is_binary(token),
-       do: true
+       when is_binary(channel_id) and is_binary(token), do: true
 
   defp slack_configured?(_), do: false
 end

--- a/server/lib/tuist/alerts/workers/alert_worker.ex
+++ b/server/lib/tuist/alerts/workers/alert_worker.ex
@@ -30,13 +30,11 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
   end
 
   defp check_and_notify(alert_rule) do
-    alert_rule = Repo.preload(alert_rule, project: [account: :slack_installation])
-
     cond do
       not Alerts.cooldown_elapsed?(alert_rule) ->
         :ok
 
-      is_nil(alert_rule.project.account.slack_installation) ->
+      not webhook_configured?(alert_rule) ->
         :ok
 
       true ->
@@ -49,7 +47,7 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
                 previous_value: result.previous
               })
 
-            alert = Repo.preload(alert, alert_rule: [project: [account: :slack_installation]])
+            alert = Repo.preload(alert, alert_rule: [project: :account])
             :ok = Slack.send_alert(alert)
 
           :ok ->
@@ -57,4 +55,7 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
         end
     end
   end
+
+  defp webhook_configured?(%{slack_webhook_url: url}) when is_binary(url) and url != "", do: true
+  defp webhook_configured?(_), do: false
 end

--- a/server/lib/tuist/alerts/workers/alert_worker.ex
+++ b/server/lib/tuist/alerts/workers/alert_worker.ex
@@ -30,11 +30,13 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
   end
 
   defp check_and_notify(alert_rule) do
+    alert_rule = Repo.preload(alert_rule, project: [account: :slack_installation])
+
     cond do
       not Alerts.cooldown_elapsed?(alert_rule) ->
         :ok
 
-      not webhook_configured?(alert_rule) ->
+      not slack_configured?(alert_rule) ->
         :ok
 
       true ->
@@ -47,7 +49,7 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
                 previous_value: result.previous
               })
 
-            alert = Repo.preload(alert, alert_rule: [project: :account])
+            alert = Repo.preload(alert, alert_rule: [project: [account: :slack_installation]])
             :ok = Slack.send_alert(alert)
 
           :ok ->
@@ -56,6 +58,16 @@ defmodule Tuist.Alerts.Workers.AlertWorker do
     end
   end
 
-  defp webhook_configured?(%{slack_webhook_url: url}) when is_binary(url) and url != "", do: true
-  defp webhook_configured?(_), do: false
+  # Either a per-channel webhook URL (preferred) or a legacy account-level
+  # bot token (with a channel id) is enough to deliver an alert.
+  defp slack_configured?(%{slack_webhook_url: url}) when is_binary(url) and url != "", do: true
+
+  defp slack_configured?(%{
+         slack_channel_id: channel_id,
+         project: %{account: %{slack_installation: %{access_token: token}}}
+       })
+       when is_binary(channel_id) and is_binary(token),
+       do: true
+
+  defp slack_configured?(_), do: false
 end

--- a/server/lib/tuist/automations/actions/send_slack_action.ex
+++ b/server/lib/tuist/automations/actions/send_slack_action.ex
@@ -3,6 +3,7 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
   alias Tuist.Environment
   alias Tuist.Projects
   alias Tuist.Repo
+  alias Tuist.Slack
   alias Tuist.Slack.Client
   alias Tuist.Slack.Installation
   alias Tuist.Tests
@@ -34,12 +35,22 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
     end
   end
 
-  # Prefer the action's webhook URL (captured the next time the user picks
-  # the channel). Fall back to the account-level bot token + channel id for
-  # actions configured before the webhook flow existed.
-  defp deliver(%{"webhook_url" => url}, _project, blocks, _automation, _test_case_id)
-       when is_binary(url) and url != "" do
-    Client.post_to_webhook(url, blocks)
+  # Prefer the action's encrypted webhook URL (captured the next time the
+  # user picks the channel). Fall back to the account-level bot token +
+  # channel id for actions configured before the webhook flow existed.
+  defp deliver(%{"webhook_url_encrypted" => encrypted}, _project, blocks, automation, _test_case_id)
+       when is_binary(encrypted) and encrypted != "" do
+    case Slack.decrypt_webhook_url(encrypted) do
+      {:ok, webhook_url} ->
+        Client.post_to_webhook(webhook_url, blocks)
+
+      {:error, _reason} ->
+        Logger.warning(
+          "Automation #{automation.id} send_slack skipped: webhook URL failed to decrypt"
+        )
+
+        :ok
+    end
   end
 
   defp deliver(%{"channel" => channel}, project, blocks, automation, _test_case_id)

--- a/server/lib/tuist/automations/actions/send_slack_action.ex
+++ b/server/lib/tuist/automations/actions/send_slack_action.ex
@@ -45,9 +45,7 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
         Client.post_to_webhook(webhook_url, blocks)
 
       {:error, _reason} ->
-        Logger.warning(
-          "Automation #{automation.id} send_slack skipped: webhook URL failed to decrypt"
-        )
+        Logger.warning("Automation #{automation.id} send_slack skipped: webhook URL failed to decrypt")
 
         :ok
     end

--- a/server/lib/tuist/automations/actions/send_slack_action.ex
+++ b/server/lib/tuist/automations/actions/send_slack_action.ex
@@ -2,36 +2,28 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
   @moduledoc false
   alias Tuist.Environment
   alias Tuist.Projects
+  alias Tuist.Repo
   alias Tuist.Slack.Client
+  alias Tuist.Slack.Installation
   alias Tuist.Tests
 
   require Logger
 
   def execute(automation, %{type: :test_case, id: test_case_id}, action) do
-    webhook_url = action["webhook_url"]
-
     with {:ok, test_case} <- Tests.get_test_case_by_id(test_case_id),
          project = Projects.get_project_by_id(automation.project_id),
-         false <- is_nil(project),
-         true <- is_binary(webhook_url) and webhook_url != "" do
+         false <- is_nil(project) do
+      project = Repo.preload(project, account: :slack_installation)
       message = interpolate(action["message"], automation, project, test_case)
       blocks = build_blocks(automation, message)
-      Client.post_to_webhook(webhook_url, blocks)
+      deliver(action, project, blocks, automation, test_case_id)
     else
       {:error, :not_found} ->
         Logger.warning("Automation #{automation.id} send_slack skipped: test case #{test_case_id} not found")
-
         :ok
 
       true ->
         Logger.warning("Automation #{automation.id} send_slack skipped: project #{automation.project_id} not found")
-
-        :ok
-
-      false ->
-        Logger.warning(
-          "Automation #{automation.id} send_slack skipped: missing webhook URL for project #{automation.project_id}"
-        )
 
         :ok
 
@@ -40,6 +32,37 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
 
         :ok
     end
+  end
+
+  # Prefer the action's webhook URL (captured the next time the user picks
+  # the channel). Fall back to the account-level bot token + channel id for
+  # actions configured before the webhook flow existed.
+  defp deliver(%{"webhook_url" => url}, _project, blocks, _automation, _test_case_id)
+       when is_binary(url) and url != "" do
+    Client.post_to_webhook(url, blocks)
+  end
+
+  defp deliver(%{"channel" => channel}, project, blocks, automation, _test_case_id)
+       when is_binary(channel) and channel != "" do
+    case project.account.slack_installation do
+      %Installation{access_token: token} ->
+        Client.post_message(token, channel, blocks)
+
+      _ ->
+        Logger.warning(
+          "Automation #{automation.id} send_slack skipped: missing Slack credentials for project #{project.id}"
+        )
+
+        :ok
+    end
+  end
+
+  defp deliver(_action, project, _blocks, automation, _test_case_id) do
+    Logger.warning(
+      "Automation #{automation.id} send_slack skipped: missing channel/webhook configuration for project #{project.id}"
+    )
+
+    :ok
   end
 
   defp interpolate(template, automation, project, test_case) do

--- a/server/lib/tuist/automations/actions/send_slack_action.ex
+++ b/server/lib/tuist/automations/actions/send_slack_action.ex
@@ -2,22 +2,21 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
   @moduledoc false
   alias Tuist.Environment
   alias Tuist.Projects
-  alias Tuist.Repo
   alias Tuist.Slack.Client
-  alias Tuist.Slack.Installation
   alias Tuist.Tests
 
   require Logger
 
-  def execute(automation, %{type: :test_case, id: test_case_id}, %{"channel" => channel} = action) do
+  def execute(automation, %{type: :test_case, id: test_case_id}, action) do
+    webhook_url = action["webhook_url"]
+
     with {:ok, test_case} <- Tests.get_test_case_by_id(test_case_id),
          project = Projects.get_project_by_id(automation.project_id),
          false <- is_nil(project),
-         project = Repo.preload(project, account: :slack_installation),
-         %Installation{access_token: access_token} <- project.account.slack_installation do
+         true <- is_binary(webhook_url) and webhook_url != "" do
       message = interpolate(action["message"], automation, project, test_case)
       blocks = build_blocks(automation, message)
-      Client.post_message(access_token, channel, blocks)
+      Client.post_to_webhook(webhook_url, blocks)
     else
       {:error, :not_found} ->
         Logger.warning("Automation #{automation.id} send_slack skipped: test case #{test_case_id} not found")
@@ -29,9 +28,9 @@ defmodule Tuist.Automations.Actions.SendSlackAction do
 
         :ok
 
-      nil ->
+      false ->
         Logger.warning(
-          "Automation #{automation.id} send_slack skipped: Slack installation missing for project #{automation.project_id}"
+          "Automation #{automation.id} send_slack skipped: missing webhook URL for project #{automation.project_id}"
         )
 
         :ok

--- a/server/lib/tuist/projects/project.ex
+++ b/server/lib/tuist/projects/project.ex
@@ -25,6 +25,7 @@ defmodule Tuist.Projects.Project do
     field :default_previews_visibility, Ecto.Enum, values: [private: 0, public: 1], default: :private
     field :slack_channel_id, :string
     field :slack_channel_name, :string
+    field :slack_webhook_url, Tuist.Vault.Binary
     field :report_frequency, Ecto.Enum, values: [never: 0, daily: 1], default: :never
     field :report_days_of_week, {:array, :integer}, default: []
     field :report_schedule_time, :utc_datetime
@@ -35,6 +36,7 @@ defmodule Tuist.Projects.Project do
     field :flaky_test_alerts_enabled, :boolean, default: false
     field :flaky_test_alerts_slack_channel_id, :string
     field :flaky_test_alerts_slack_channel_name, :string
+    field :flaky_test_alerts_slack_webhook_url, Tuist.Vault.Binary
     field :auto_mark_flaky_tests, :boolean, default: true
     field :auto_mark_flaky_threshold, :integer, default: 1
     field :flaky_cooldown_days, :integer, default: 14
@@ -81,6 +83,7 @@ defmodule Tuist.Projects.Project do
       :default_previews_visibility,
       :slack_channel_id,
       :slack_channel_name,
+      :slack_webhook_url,
       :report_frequency,
       :report_days_of_week,
       :report_schedule_time,
@@ -89,6 +92,7 @@ defmodule Tuist.Projects.Project do
       :flaky_test_alerts_enabled,
       :flaky_test_alerts_slack_channel_id,
       :flaky_test_alerts_slack_channel_name,
+      :flaky_test_alerts_slack_webhook_url,
       :auto_mark_flaky_tests,
       :auto_mark_flaky_threshold,
       :flaky_cooldown_days,

--- a/server/lib/tuist/projects/project.ex
+++ b/server/lib/tuist/projects/project.ex
@@ -10,6 +10,7 @@ defmodule Tuist.Projects.Project do
   alias Tuist.Accounts.User
   alias Tuist.AppBuilds.Preview
   alias Tuist.Projects.VCSConnection
+  alias Tuist.Vault.Binary
 
   @derive {
     Flop.Schema,
@@ -25,7 +26,7 @@ defmodule Tuist.Projects.Project do
     field :default_previews_visibility, Ecto.Enum, values: [private: 0, public: 1], default: :private
     field :slack_channel_id, :string
     field :slack_channel_name, :string
-    field :slack_webhook_url, Tuist.Vault.Binary
+    field :slack_webhook_url, Binary
     field :report_frequency, Ecto.Enum, values: [never: 0, daily: 1], default: :never
     field :report_days_of_week, {:array, :integer}, default: []
     field :report_schedule_time, :utc_datetime
@@ -36,7 +37,7 @@ defmodule Tuist.Projects.Project do
     field :flaky_test_alerts_enabled, :boolean, default: false
     field :flaky_test_alerts_slack_channel_id, :string
     field :flaky_test_alerts_slack_channel_name, :string
-    field :flaky_test_alerts_slack_webhook_url, Tuist.Vault.Binary
+    field :flaky_test_alerts_slack_webhook_url, Binary
     field :auto_mark_flaky_tests, :boolean, default: true
     field :auto_mark_flaky_threshold, :integer, default: 1
     field :flaky_cooldown_days, :integer, default: 14

--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -78,8 +78,10 @@ defmodule Tuist.Slack do
         set: [
           slack_channel_id: nil,
           slack_channel_name: nil,
+          slack_webhook_url: nil,
           flaky_test_alerts_slack_channel_id: nil,
-          flaky_test_alerts_slack_channel_name: nil
+          flaky_test_alerts_slack_channel_name: nil,
+          flaky_test_alerts_slack_webhook_url: nil
         ]
       ]
     )
@@ -93,7 +95,8 @@ defmodule Tuist.Slack do
       update: [
         set: [
           slack_channel_id: nil,
-          slack_channel_name: nil
+          slack_channel_name: nil,
+          slack_webhook_url: nil
         ]
       ]
     )
@@ -190,18 +193,21 @@ defmodule Tuist.Slack do
   Sends an alert notification to Slack.
   """
   def send_alert(%Alert{} = alert) do
+    alert = Repo.preload(alert, alert_rule: [project: [:account]])
+
     %Alert{
       alert_rule: %{
-        slack_channel_id: slack_channel_id,
-        project: %{
-          name: project_name,
-          account: %{name: account_name, slack_installation: %Installation{access_token: access_token}}
-        }
+        slack_webhook_url: webhook_url,
+        project: %{name: project_name, account: %{name: account_name}}
       }
-    } = alert = Repo.preload(alert, alert_rule: [project: [account: :slack_installation]])
+    } = alert
 
-    blocks = build_alert_blocks(alert, account_name, project_name)
-    Client.post_message(access_token, slack_channel_id, blocks)
+    if is_binary(webhook_url) and webhook_url != "" do
+      blocks = build_alert_blocks(alert, account_name, project_name)
+      Client.post_to_webhook(webhook_url, blocks)
+    else
+      :ok
+    end
   end
 
   defp build_alert_blocks(alert, account_name, project_name) do
@@ -460,16 +466,22 @@ defmodule Tuist.Slack do
   Sends a flaky test alert notification to Slack using project-level settings.
   """
   def send_flaky_test_alert(project, test_case, flaky_runs_count, was_auto_quarantined \\ false) do
-    project = Repo.preload(project, account: :slack_installation)
+    project = Repo.preload(project, :account)
 
     %Project{
-      flaky_test_alerts_slack_channel_id: slack_channel_id,
+      flaky_test_alerts_slack_webhook_url: webhook_url,
       name: project_name,
-      account: %{name: account_name, slack_installation: %Installation{access_token: access_token}}
+      account: %{name: account_name}
     } = project
 
-    blocks = build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined)
-    Client.post_message(access_token, slack_channel_id, blocks)
+    if is_binary(webhook_url) and webhook_url != "" do
+      blocks =
+        build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined)
+
+      Client.post_to_webhook(webhook_url, blocks)
+    else
+      :ok
+    end
   end
 
   defp build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined) do

--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -191,24 +191,36 @@ defmodule Tuist.Slack do
 
   @doc """
   Sends an alert notification to Slack.
+
+  Prefers the per-channel `slack_webhook_url`. Destinations created before
+  the webhook flow existed fall back to `chat.postMessage` with the
+  account-level bot token until the user re-selects the channel.
   """
   def send_alert(%Alert{} = alert) do
-    alert = Repo.preload(alert, alert_rule: [project: [:account]])
+    alert = Repo.preload(alert, alert_rule: [project: [account: :slack_installation]])
 
     %Alert{
       alert_rule: %{
         slack_webhook_url: webhook_url,
-        project: %{name: project_name, account: %{name: account_name}}
+        slack_channel_id: channel_id,
+        project: %{name: project_name, account: %{name: account_name} = account}
       }
     } = alert
 
-    if is_binary(webhook_url) and webhook_url != "" do
-      blocks = build_alert_blocks(alert, account_name, project_name)
-      Client.post_to_webhook(webhook_url, blocks)
-    else
-      :ok
-    end
+    blocks = build_alert_blocks(alert, account_name, project_name)
+    deliver(webhook_url, account.slack_installation, channel_id, blocks)
   end
+
+  defp deliver(webhook_url, _installation, _channel_id, blocks) when is_binary(webhook_url) and webhook_url != "" do
+    Client.post_to_webhook(webhook_url, blocks)
+  end
+
+  defp deliver(_webhook_url, %Installation{access_token: token}, channel_id, blocks)
+       when is_binary(token) and is_binary(channel_id) do
+    Client.post_message(token, channel_id, blocks)
+  end
+
+  defp deliver(_webhook_url, _installation, _channel_id, _blocks), do: :ok
 
   defp build_alert_blocks(alert, account_name, project_name) do
     [
@@ -464,24 +476,25 @@ defmodule Tuist.Slack do
 
   @doc """
   Sends a flaky test alert notification to Slack using project-level settings.
+
+  Prefers the per-channel `flaky_test_alerts_slack_webhook_url`; falls back to
+  `chat.postMessage` with the account-level bot token for destinations
+  configured before the webhook flow existed.
   """
   def send_flaky_test_alert(project, test_case, flaky_runs_count, was_auto_quarantined \\ false) do
-    project = Repo.preload(project, :account)
+    project = Repo.preload(project, account: :slack_installation)
 
     %Project{
       flaky_test_alerts_slack_webhook_url: webhook_url,
+      flaky_test_alerts_slack_channel_id: channel_id,
       name: project_name,
-      account: %{name: account_name}
+      account: %{name: account_name} = account
     } = project
 
-    if is_binary(webhook_url) and webhook_url != "" do
-      blocks =
-        build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined)
+    blocks =
+      build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined)
 
-      Client.post_to_webhook(webhook_url, blocks)
-    else
-      :ok
-    end
+    deliver(webhook_url, account.slack_installation, channel_id, blocks)
   end
 
   defp build_flaky_test_alert_blocks(test_case, flaky_runs_count, account_name, project_name, was_auto_quarantined) do

--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -171,29 +171,32 @@ defmodule Tuist.Slack do
   @slack_webhook_prefix "https://hooks.slack.com/services/"
 
   @doc """
-  Signs a `{channel_id, channel_name, webhook_url}` tuple coming back from
-  the Slack OAuth callback so a LiveView can later verify the values came
-  from us (and weren't forged from the browser).
+  Encrypts a `{channel_id, channel_name, webhook_url}` tuple coming back
+  from the Slack OAuth callback so a LiveView can later verify the values
+  came from us. The token is `Phoenix.Token.encrypt/4`-encrypted (not just
+  signed) because the payload includes the webhook URL, which is a bearer
+  credential — a signed-only token would be readable by anyone with access
+  to the page that renders it.
 
   Returns `{:error, :invalid_webhook_url}` if the URL doesn't look like a
   real Slack webhook — a small belt-and-suspenders check on top of the
-  signature.
+  encryption.
   """
   def sign_channel_result(%{webhook_url: webhook_url} = payload) when is_binary(webhook_url) do
     if slack_webhook_url?(webhook_url) do
-      {:ok, Phoenix.Token.sign(TuistWeb.Endpoint, @channel_result_namespace, payload)}
+      {:ok, Phoenix.Token.encrypt(TuistWeb.Endpoint, @channel_result_namespace, payload)}
     else
       {:error, :invalid_webhook_url}
     end
   end
 
   @doc """
-  Verifies a token produced by `sign_channel_result/1`. Re-checks the
+  Decrypts a token produced by `sign_channel_result/1`. Re-checks the
   webhook URL against the Slack host allowlist after decoding so a stolen
   token can't smuggle a non-Slack URL through.
   """
   def verify_channel_result(token) when is_binary(token) do
-    case Phoenix.Token.verify(TuistWeb.Endpoint, @channel_result_namespace, token,
+    case Phoenix.Token.decrypt(TuistWeb.Endpoint, @channel_result_namespace, token,
            max_age: @channel_result_max_age_seconds
          ) do
       {:ok, %{webhook_url: webhook_url} = payload} ->

--- a/server/lib/tuist/slack.ex
+++ b/server/lib/tuist/slack.ex
@@ -71,17 +71,38 @@ defmodule Tuist.Slack do
 
   def slack_installation_topic(account_id), do: "slack_installation:#{account_id}"
 
+  # Only clear destinations that still rely on the bot-token fallback.
+  # Destinations that already migrated to a per-channel webhook keep working
+  # independently of the legacy installation we're tearing down.
   defp clear_project_slack_fields_query(account_id) do
     from(p in Project,
       where: p.account_id == ^account_id,
       update: [
         set: [
-          slack_channel_id: nil,
-          slack_channel_name: nil,
-          slack_webhook_url: nil,
-          flaky_test_alerts_slack_channel_id: nil,
-          flaky_test_alerts_slack_channel_name: nil,
-          flaky_test_alerts_slack_webhook_url: nil
+          slack_channel_id:
+            fragment(
+              "CASE WHEN ? IS NULL THEN NULL ELSE ? END",
+              p.slack_webhook_url,
+              p.slack_channel_id
+            ),
+          slack_channel_name:
+            fragment(
+              "CASE WHEN ? IS NULL THEN NULL ELSE ? END",
+              p.slack_webhook_url,
+              p.slack_channel_name
+            ),
+          flaky_test_alerts_slack_channel_id:
+            fragment(
+              "CASE WHEN ? IS NULL THEN NULL ELSE ? END",
+              p.flaky_test_alerts_slack_webhook_url,
+              p.flaky_test_alerts_slack_channel_id
+            ),
+          flaky_test_alerts_slack_channel_name:
+            fragment(
+              "CASE WHEN ? IS NULL THEN NULL ELSE ? END",
+              p.flaky_test_alerts_slack_webhook_url,
+              p.flaky_test_alerts_slack_channel_name
+            )
         ]
       ]
     )
@@ -92,11 +113,11 @@ defmodule Tuist.Slack do
       join: p in Project,
       on: ar.project_id == p.id,
       where: p.account_id == ^account_id,
+      where: is_nil(ar.slack_webhook_url),
       update: [
         set: [
           slack_channel_id: nil,
-          slack_channel_name: nil,
-          slack_webhook_url: nil
+          slack_channel_name: nil
         ]
       ]
     )
@@ -144,6 +165,86 @@ defmodule Tuist.Slack do
     token_max_age_seconds = 600
     Phoenix.Token.verify(TuistWeb.Endpoint, "slack_state", token, max_age: token_max_age_seconds)
   end
+
+  @channel_result_namespace "slack_channel_result"
+  @channel_result_max_age_seconds 600
+  @slack_webhook_prefix "https://hooks.slack.com/services/"
+
+  @doc """
+  Signs a `{channel_id, channel_name, webhook_url}` tuple coming back from
+  the Slack OAuth callback so a LiveView can later verify the values came
+  from us (and weren't forged from the browser).
+
+  Returns `{:error, :invalid_webhook_url}` if the URL doesn't look like a
+  real Slack webhook — a small belt-and-suspenders check on top of the
+  signature.
+  """
+  def sign_channel_result(%{webhook_url: webhook_url} = payload) when is_binary(webhook_url) do
+    if slack_webhook_url?(webhook_url) do
+      {:ok, Phoenix.Token.sign(TuistWeb.Endpoint, @channel_result_namespace, payload)}
+    else
+      {:error, :invalid_webhook_url}
+    end
+  end
+
+  @doc """
+  Verifies a token produced by `sign_channel_result/1`. Re-checks the
+  webhook URL against the Slack host allowlist after decoding so a stolen
+  token can't smuggle a non-Slack URL through.
+  """
+  def verify_channel_result(token) when is_binary(token) do
+    case Phoenix.Token.verify(TuistWeb.Endpoint, @channel_result_namespace, token,
+           max_age: @channel_result_max_age_seconds
+         ) do
+      {:ok, %{webhook_url: webhook_url} = payload} ->
+        if slack_webhook_url?(webhook_url), do: {:ok, payload}, else: {:error, :invalid_webhook_url}
+
+      {:ok, _other} ->
+        {:error, :invalid}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  def verify_channel_result(_), do: {:error, :invalid}
+
+  @doc """
+  Returns true when the URL is a Slack incoming-webhook URL.
+  """
+  def slack_webhook_url?(url) when is_binary(url), do: String.starts_with?(url, @slack_webhook_prefix)
+  def slack_webhook_url?(_), do: false
+
+  @doc """
+  Encrypts a Slack webhook URL for storage inside JSON columns (e.g.
+  automation action payloads), where Cloak's Ecto types cannot apply.
+
+  The result is base64-encoded ciphertext. Callers MUST validate the URL
+  with `slack_webhook_url?/1` before encrypting.
+  """
+  def encrypt_webhook_url(url) when is_binary(url) do
+    if slack_webhook_url?(url) do
+      {:ok, ciphertext} = Tuist.Vault.encrypt(url)
+      {:ok, Base.encode64(ciphertext)}
+    else
+      {:error, :invalid_webhook_url}
+    end
+  end
+
+  @doc """
+  Decrypts a webhook URL produced by `encrypt_webhook_url/1`.
+  """
+  def decrypt_webhook_url(encoded) when is_binary(encoded) do
+    with {:ok, ciphertext} <- Base.decode64(encoded),
+         {:ok, plaintext} <- Tuist.Vault.decrypt(ciphertext),
+         true <- slack_webhook_url?(plaintext) do
+      {:ok, plaintext}
+    else
+      _ -> {:error, :invalid_webhook_url}
+    end
+  end
+
+  def decrypt_webhook_url(_), do: {:error, :invalid_webhook_url}
 
   def send_message(blocks, opts \\ []) do
     if Environment.tuist_hosted?() and Environment.prod?() do

--- a/server/lib/tuist/slack/AGENTS.md
+++ b/server/lib/tuist/slack/AGENTS.md
@@ -17,14 +17,34 @@ This context owns Slack app installations and reporting workflows.
 
 ## Local end-to-end testing
 
-Slack's OAuth redirect URI must be HTTPS, so `http://localhost:8977/integrations/slack/callback` is rejected. To exercise the real OAuth round-trip against the dev Slack app:
+Slack's OAuth redirect URI must be HTTPS, and the URI Tuist sends to Slack is built by `Tuist.Environment.app_url/1` from `TUIST_SERVER_URL`. By default `mise/utilities/dev_instance_env.sh` exports `TUIST_SERVER_URL=http://localhost:<port>` per worktree, which Slack rejects. To exercise the real OAuth round-trip:
 
-1. `cloudflared tunnel --url http://localhost:8977` — gives you an HTTPS URL like `https://<random>.trycloudflare.com`.
+1. `cloudflared tunnel --url http://localhost:<your-dev-port>` — gives you an HTTPS URL like `https://<random>.trycloudflare.com`. Find your port via `echo $TUIST_SERVER_PORT` inside `mise exec`.
 2. Edit the Tuist Slack app manifest at <https://app.slack.com/app-settings/T061C1JGAHH/A0A52HJQJ9Z/app-manifest> and set `oauth_config.redirect_urls[0]` to `https://<tunnel>.trycloudflare.com/integrations/slack/callback`.
-3. In another terminal, start the server with `TUIST_SERVER_URL=https://<tunnel>.trycloudflare.com mise run dev` so `Tuist.Environment.app_url/1` (which builds the OAuth `redirect_uri`) matches the tunnel and Slack accepts the callback.
-4. Hit the dashboard at the tunnel URL (cookies are origin-scoped, so logging in on `localhost:8977` won't carry over) and exercise the "Select channel" flow.
+3. Start the server with the tunnel URL as `TUIST_SERVER_URL`. The mise env file exports its own value, so override *after* mise sourcing — the simplest path is to bypass `mise run dev` and run the server directly:
+   ```bash
+   eval "$(mise env -s bash)"
+   export TUIST_SERVER_URL=https://<tunnel>.trycloudflare.com
+   mix phx.server
+   ```
+   Phoenix still binds to `127.0.0.1:$TUIST_SERVER_PORT`; cloudflared forwards from there. The OAuth `redirect_uri` Tuist hands Slack now matches the tunnel.
+4. Hit the dashboard at the tunnel URL — **not** `localhost`. Session cookies are origin-scoped, so logging in on `localhost:<port>` won't carry over to the tunnel host, and the OAuth callback would land on a different origin.
 
-Revert the manifest's `redirect_urls` back to `https://tuist.dev/integrations/slack/callback` when you're done, and stop the tunnel. The `priv/secrets/dev.yml.enc` Slack credentials are the dev app's credentials — they're already pointed at the tunnel-via-manifest flow and don't need to be touched for this loop.
+Revert the manifest's `redirect_urls` back to `https://tuist.dev/integrations/slack/callback` when you're done, and stop the tunnel. The `priv/secrets/dev.yml.enc` Slack credentials are the dev app's credentials — they don't need to change for this loop.
+
+Test user creds (from the seed): `tuistrocks@tuist.dev` / `tuistrocks`. If login fails with "Invalid email or password" despite those creds, the password hash in your local DB has drifted from the seed. Reset it with the salted bcrypt the auth path expects:
+
+```bash
+mise exec -- mix run -e '
+  import Ecto.Query
+  Tuist.Environment.decrypt_secrets() |> Tuist.Environment.put_application_secrets()
+  hash = Bcrypt.hash_pwd_salt("tuistrocks" <> Tuist.Environment.secret_key_password())
+  Tuist.Repo.update_all(from(u in "users", where: u.email == "tuistrocks@tuist.dev"),
+    set: [encrypted_password: hash])
+'
+```
+
+The `<> secret_key_password` is required — `Tuist.Accounts.User.valid_password?/2` salts every comparison with it.
 
 ## Related Context
 - Parent business logic: `server/lib/tuist/AGENTS.md`

--- a/server/lib/tuist/slack/AGENTS.md
+++ b/server/lib/tuist/slack/AGENTS.md
@@ -15,6 +15,17 @@ This context owns Slack app installations and reporting workflows.
 ## Guardrails
 - Slack installation data is customer data; update `server/data-export.md` on schema changes.
 
+## Local end-to-end testing
+
+Slack's OAuth redirect URI must be HTTPS, so `http://localhost:8977/integrations/slack/callback` is rejected. To exercise the real OAuth round-trip against the dev Slack app:
+
+1. `cloudflared tunnel --url http://localhost:8977` — gives you an HTTPS URL like `https://<random>.trycloudflare.com`.
+2. Edit the Tuist Slack app manifest at <https://app.slack.com/app-settings/T061C1JGAHH/A0A52HJQJ9Z/app-manifest> and set `oauth_config.redirect_urls[0]` to `https://<tunnel>.trycloudflare.com/integrations/slack/callback`.
+3. In another terminal, start the server with `TUIST_SERVER_URL=https://<tunnel>.trycloudflare.com mise run dev` so `Tuist.Environment.app_url/1` (which builds the OAuth `redirect_uri`) matches the tunnel and Slack accepts the callback.
+4. Hit the dashboard at the tunnel URL (cookies are origin-scoped, so logging in on `localhost:8977` won't carry over) and exercise the "Select channel" flow.
+
+Revert the manifest's `redirect_urls` back to `https://tuist.dev/integrations/slack/callback` when you're done, and stop the tunnel. The `priv/secrets/dev.yml.enc` Slack credentials are the dev app's credentials — they're already pointed at the tunnel-via-manifest flow and don't need to be touched for this loop.
+
 ## Related Context
 - Parent business logic: `server/lib/tuist/AGENTS.md`
 - Web layer: `server/lib/tuist_web/AGENTS.md`

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -106,6 +106,14 @@ defmodule Tuist.Slack.Client do
     :ok
   end
 
+  # 404 from a Slack webhook URL is permanent — the webhook was revoked,
+  # the channel was deleted, or the app was uninstalled from the workspace.
+  # Surface it distinctly so callers can clear the destination instead of
+  # retrying forever.
+  defp handle_webhook_response({:ok, %Req.Response{status: 404}}) do
+    {:error, :webhook_revoked}
+  end
+
   defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
     {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
   end

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -1,14 +1,21 @@
 defmodule Tuist.Slack.Client do
   @moduledoc """
-  Slack API client for OAuth operations and incoming-webhook messaging.
+  Slack API client for OAuth operations and notification delivery.
 
-  Tuist requests only the `incoming-webhook` OAuth scope. Notifications are
-  delivered by POSTing to the webhook URL Slack returns at install time.
+  New OAuth flows request only the `incoming-webhook` scope and notifications
+  are delivered by POSTing to the webhook URL Slack returns at install time
+  (`post_to_webhook/2`).
+
+  Notification destinations created before the webhook flow existed only have
+  a bot token + channel id, so `post_message/3` (chat.postMessage) is kept as
+  a fallback. Each destination upgrades to the webhook path the next time the
+  user re-selects its channel.
   """
 
   alias Tuist.Environment
 
   @oauth_token_url "https://slack.com/api/oauth.v2.access"
+  @chat_post_message_url "https://slack.com/api/chat.postMessage"
 
   @doc """
   Exchanges an OAuth authorization code for an `incoming-webhook` token.
@@ -37,6 +44,24 @@ defmodule Tuist.Slack.Client do
     body = JSON.encode!(%{blocks: blocks, unfurl_links: false, unfurl_media: false})
 
     webhook_url
+    |> Req.post(headers: headers, body: body)
+    |> handle_webhook_response()
+  end
+
+  @doc """
+  Posts a Slack Block Kit message via `chat.postMessage` using a legacy bot
+  token. Kept as a fallback for destinations installed before the webhook
+  flow existed.
+  """
+  def post_message(access_token, channel_id, blocks) do
+    headers = [
+      {"Authorization", "Bearer #{access_token}"},
+      {"Content-Type", "application/json"}
+    ]
+
+    body = JSON.encode!(%{channel: channel_id, blocks: blocks, unfurl_links: false, unfurl_media: false})
+
+    @chat_post_message_url
     |> Req.post(headers: headers, body: body)
     |> handle_post_response()
   end
@@ -77,8 +102,24 @@ defmodule Tuist.Slack.Client do
     {:error, "Request failed: #{inspect(reason)}"}
   end
 
-  defp handle_post_response({:ok, %Req.Response{status: status}}) when status in 200..299 do
+  defp handle_webhook_response({:ok, %Req.Response{status: status}}) when status in 200..299 do
     :ok
+  end
+
+  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
+    {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+  end
+
+  defp handle_webhook_response({:error, reason}) do
+    {:error, "Request failed: #{inspect(reason)}"}
+  end
+
+  defp handle_post_response({:ok, %Req.Response{status: 200, body: %{"ok" => true}}}) do
+    :ok
+  end
+
+  defp handle_post_response({:ok, %Req.Response{status: 200, body: %{"ok" => false, "error" => error}}}) do
+    {:error, error}
   end
 
   defp handle_post_response({:ok, %Req.Response{status: status, body: body}}) do

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -1,15 +1,17 @@
 defmodule Tuist.Slack.Client do
   @moduledoc """
-  Slack API client for OAuth operations and messaging.
+  Slack API client for OAuth operations and incoming-webhook messaging.
+
+  Tuist requests only the `incoming-webhook` OAuth scope. Notifications are
+  delivered by POSTing to the webhook URL Slack returns at install time.
   """
 
   alias Tuist.Environment
 
   @oauth_token_url "https://slack.com/api/oauth.v2.access"
-  @chat_post_message_url "https://slack.com/api/chat.postMessage"
 
   @doc """
-  Exchanges an OAuth authorization code for an access token.
+  Exchanges an OAuth authorization code for an `incoming-webhook` token.
   """
   def exchange_code_for_token(code, redirect_uri) do
     client_id = Environment.slack_client_id()
@@ -28,17 +30,13 @@ defmodule Tuist.Slack.Client do
   end
 
   @doc """
-  Posts a message to a channel using the provided access token.
+  Posts a Slack Block Kit message to the given incoming-webhook URL.
   """
-  def post_message(access_token, channel_id, blocks) do
-    headers = [
-      {"Authorization", "Bearer #{access_token}"},
-      {"Content-Type", "application/json"}
-    ]
+  def post_to_webhook(webhook_url, blocks) when is_binary(webhook_url) do
+    headers = [{"Content-Type", "application/json"}]
+    body = JSON.encode!(%{blocks: blocks, unfurl_links: false, unfurl_media: false})
 
-    body = JSON.encode!(%{channel: channel_id, blocks: blocks, unfurl_links: false, unfurl_media: false})
-
-    @chat_post_message_url
+    webhook_url
     |> Req.post(headers: headers, body: body)
     |> handle_post_response()
   end
@@ -57,7 +55,8 @@ defmodule Tuist.Slack.Client do
 
         Map.put(result, :incoming_webhook, %{
           channel: webhook["channel"],
-          channel_id: webhook["channel_id"]
+          channel_id: webhook["channel_id"],
+          url: webhook["url"]
         })
       else
         result
@@ -78,12 +77,8 @@ defmodule Tuist.Slack.Client do
     {:error, "Request failed: #{inspect(reason)}"}
   end
 
-  defp handle_post_response({:ok, %Req.Response{status: 200, body: %{"ok" => true}}}) do
+  defp handle_post_response({:ok, %Req.Response{status: status}}) when status in 200..299 do
     :ok
-  end
-
-  defp handle_post_response({:ok, %Req.Response{status: 200, body: %{"ok" => false, "error" => error}}}) do
-    {:error, error}
   end
 
   defp handle_post_response({:ok, %Req.Response{status: status, body: body}}) do

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -13,7 +13,6 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   alias Tuist.Projects
   alias Tuist.Projects.Project
   alias Tuist.Repo
-  alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
   alias Tuist.Slack.Reports
 
@@ -26,7 +25,7 @@ defmodule Tuist.Slack.Workers.ReportWorker do
         :ok
 
       project ->
-        project = Repo.preload(project, account: :slack_installation)
+        project = Repo.preload(project, :account)
         send_report(project)
     end
   end
@@ -70,11 +69,10 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   end
 
   defp send_report(project) do
-    with %{account: %{slack_installation: slack_installation}, slack_channel_id: slack_channel_id}
-         when not is_nil(slack_installation) and not is_nil(slack_channel_id) <- project,
+    with %{slack_webhook_url: webhook_url} when is_binary(webhook_url) and webhook_url != "" <- project,
          last_report_at = get_last_report_time(project.id),
          blocks = Reports.report(project, last_report_at: last_report_at),
-         :ok <- SlackClient.post_message(slack_installation.access_token, slack_channel_id, blocks) do
+         :ok <- SlackClient.post_to_webhook(webhook_url, blocks) do
       :ok
     else
       {:error, reason} -> handle_post_report_error(reason, project)
@@ -82,25 +80,18 @@ defmodule Tuist.Slack.Workers.ReportWorker do
     end
   end
 
-  defp handle_post_report_error("account_inactive", project) do
-    Logger.warning("Deleting inactive Slack installation for account #{project.account_id}")
+  defp handle_post_report_error(_reason, project) do
+    Logger.warning("Clearing failing Slack report channel for project #{project.id}")
 
-    case Slack.delete_installation(project.account.slack_installation) do
-      {:ok, _installation} -> {:discard, :account_inactive}
+    case Projects.update_project(project, %{
+           slack_channel_id: nil,
+           slack_channel_name: nil,
+           slack_webhook_url: nil
+         }) do
+      {:ok, _project} -> {:discard, :webhook_failed}
       {:error, reason} -> {:error, reason}
     end
   end
-
-  defp handle_post_report_error("channel_not_found", project) do
-    Logger.warning("Clearing missing Slack report channel for project #{project.id}")
-
-    case Projects.update_project(project, %{slack_channel_id: nil, slack_channel_name: nil}) do
-      {:ok, _project} -> {:discard, :channel_not_found}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp handle_post_report_error(reason, _project), do: {:error, reason}
 
   defp get_last_report_time(project_id) do
     worker_name = to_string(__MODULE__)

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -85,7 +85,8 @@ defmodule Tuist.Slack.Workers.ReportWorker do
 
         case SlackClient.post_to_webhook(webhook_url, blocks) do
           :ok -> :ok
-          {:error, reason} -> handle_webhook_error(reason, project)
+          {:error, :webhook_revoked} -> handle_revoked_webhook(project)
+          {:error, reason} -> {:error, reason}
         end
 
       {:bot_token, %Installation{access_token: token}, channel_id} ->
@@ -113,15 +114,20 @@ defmodule Tuist.Slack.Workers.ReportWorker do
 
   defp configured_destination(_), do: :unconfigured
 
-  defp handle_webhook_error(_reason, project) do
-    Logger.warning("Clearing failing Slack webhook for project #{project.id}")
+  # 404 from Slack means the webhook URL is permanently dead (revoked, or
+  # the channel/app no longer exists). Drop the destination so we stop
+  # retrying — the user will need to re-OAuth the channel to restore
+  # delivery. Transient failures (5xx, network) bubble up as `{:error, _}`
+  # so Oban retries the job.
+  defp handle_revoked_webhook(project) do
+    Logger.warning("Clearing revoked Slack webhook for project #{project.id}")
 
     case Projects.update_project(project, %{
            slack_channel_id: nil,
            slack_channel_name: nil,
            slack_webhook_url: nil
          }) do
-      {:ok, _project} -> {:discard, :webhook_failed}
+      {:ok, _project} -> {:discard, :webhook_revoked}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -5,6 +5,10 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   The cron job finds projects due for reports and enqueues individual
   project-specific jobs. This allows tracking when the last report was
   sent per project via the oban_jobs table.
+
+  Reports prefer the per-channel `slack_webhook_url`. Destinations created
+  before the webhook flow existed fall back to `chat.postMessage` with the
+  account-level bot token.
   """
   use Oban.Worker, max_attempts: 3
 
@@ -13,7 +17,9 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   alias Tuist.Projects
   alias Tuist.Projects.Project
   alias Tuist.Repo
+  alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
+  alias Tuist.Slack.Installation
   alias Tuist.Slack.Reports
 
   require Logger
@@ -25,7 +31,7 @@ defmodule Tuist.Slack.Workers.ReportWorker do
         :ok
 
       project ->
-        project = Repo.preload(project, :account)
+        project = Repo.preload(project, account: :slack_installation)
         send_report(project)
     end
   end
@@ -69,19 +75,46 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   end
 
   defp send_report(project) do
-    with %{slack_webhook_url: webhook_url} when is_binary(webhook_url) and webhook_url != "" <- project,
-         last_report_at = get_last_report_time(project.id),
-         blocks = Reports.report(project, last_report_at: last_report_at),
-         :ok <- SlackClient.post_to_webhook(webhook_url, blocks) do
-      :ok
-    else
-      {:error, reason} -> handle_post_report_error(reason, project)
-      _ -> :ok
+    case configured_destination(project) do
+      :unconfigured ->
+        :ok
+
+      {:webhook, webhook_url} ->
+        last_report_at = get_last_report_time(project.id)
+        blocks = Reports.report(project, last_report_at: last_report_at)
+
+        case SlackClient.post_to_webhook(webhook_url, blocks) do
+          :ok -> :ok
+          {:error, reason} -> handle_webhook_error(reason, project)
+        end
+
+      {:bot_token, %Installation{access_token: token}, channel_id} ->
+        last_report_at = get_last_report_time(project.id)
+        blocks = Reports.report(project, last_report_at: last_report_at)
+
+        case SlackClient.post_message(token, channel_id, blocks) do
+          :ok -> :ok
+          {:error, reason} -> handle_post_message_error(reason, project)
+        end
     end
   end
 
-  defp handle_post_report_error(_reason, project) do
-    Logger.warning("Clearing failing Slack report channel for project #{project.id}")
+  defp configured_destination(%Project{slack_webhook_url: url}) when is_binary(url) and url != "" do
+    {:webhook, url}
+  end
+
+  defp configured_destination(%Project{
+         account: %{slack_installation: %Installation{} = installation},
+         slack_channel_id: channel_id
+       })
+       when is_binary(channel_id) do
+    {:bot_token, installation, channel_id}
+  end
+
+  defp configured_destination(_), do: :unconfigured
+
+  defp handle_webhook_error(_reason, project) do
+    Logger.warning("Clearing failing Slack webhook for project #{project.id}")
 
     case Projects.update_project(project, %{
            slack_channel_id: nil,
@@ -92,6 +125,26 @@ defmodule Tuist.Slack.Workers.ReportWorker do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  defp handle_post_message_error("account_inactive", project) do
+    Logger.warning("Deleting inactive Slack installation for account #{project.account_id}")
+
+    case Slack.delete_installation(project.account.slack_installation) do
+      {:ok, _installation} -> {:discard, :account_inactive}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp handle_post_message_error("channel_not_found", project) do
+    Logger.warning("Clearing missing Slack report channel for project #{project.id}")
+
+    case Projects.update_project(project, %{slack_channel_id: nil, slack_channel_name: nil}) do
+      {:ok, _project} -> {:discard, :channel_not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp handle_post_message_error(reason, _project), do: {:error, reason}
 
   defp get_last_report_time(project_id) do
     worker_name = to_string(__MODULE__)

--- a/server/lib/tuist_web/controllers/slack_oauth_controller.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_controller.ex
@@ -1,10 +1,11 @@
 defmodule TuistWeb.SlackOAuthController do
   @moduledoc """
-  Controller for handling Slack OAuth flow.
+  Controller for handling the Slack OAuth flow.
 
-  Supports two OAuth flows:
-  - Account installation: Installs the Slack app to a workspace
-  - Channel selection: Selects a channel for project reports via incoming-webhook
+  Tuist's integration for Slack only requests the `incoming-webhook` scope. Each
+  destination (project report, alert rule, flaky test alert, automation action)
+  goes through its own channel-selection OAuth flow that returns a single
+  webhook URL bound to the channel the user picked.
   """
 
   use TuistWeb, :controller
@@ -18,7 +19,6 @@ defmodule TuistWeb.SlackOAuthController do
   alias Tuist.Slack.Client, as: SlackClient
   alias TuistWeb.Errors.BadRequestError
 
-  @account_slack_scopes "chat:write,chat:write.public"
   @channel_selection_scopes "incoming-webhook"
 
   def callback(conn, %{"error" => "access_denied", "state" => state_token}) do
@@ -49,19 +49,11 @@ defmodule TuistWeb.SlackOAuthController do
 
   defp handle_access_denied(conn, %{type: type})
        when type in [:alert_channel_selection, :flaky_alert_channel_selection] do
-    render_popup_close(conn, nil, nil)
+    render_popup_close(conn, nil, nil, nil)
   end
 
   defp handle_access_denied(conn, %{type: :channel_selection, account_id: account_id, project_id: project_id}) do
     redirect_after_channel_cancel(conn, account_id, project_id)
-  end
-
-  defp handle_access_denied(conn, %{type: :account_installation, account_id: account_id}) do
-    redirect_after_account_cancel(conn, account_id)
-  end
-
-  defp handle_access_denied(conn, account_id) when is_integer(account_id) do
-    redirect_after_account_cancel(conn, account_id)
   end
 
   defp handle_verified_callback(conn, code, %{type: :alert_channel_selection} = payload) do
@@ -72,16 +64,8 @@ defmodule TuistWeb.SlackOAuthController do
     handle_flaky_alert_channel_selection(conn, code)
   end
 
-  defp handle_verified_callback(conn, code, %{type: :channel_selection}) do
-    handle_channel_selection(conn, code)
-  end
-
-  defp handle_verified_callback(conn, code, %{type: :account_installation, account_id: account_id}) do
-    handle_account_installation(conn, code, account_id)
-  end
-
-  defp handle_verified_callback(conn, code, account_id) when is_integer(account_id) do
-    handle_account_installation(conn, code, account_id)
+  defp handle_verified_callback(conn, code, %{type: :channel_selection} = payload) do
+    handle_channel_selection(conn, code, payload)
   end
 
   defp raise_state_token_error(:expired) do
@@ -95,11 +79,6 @@ defmodule TuistWeb.SlackOAuthController do
   defp raise_state_token_error(:invalid) do
     raise BadRequestError,
           dgettext("dashboard_slack", "Invalid authorization request. Please try again.")
-  end
-
-  def install_url(account_id) do
-    state_token = Slack.generate_state_token(account_id)
-    build_oauth_url(state_token, @account_slack_scopes)
   end
 
   def channel_selection_url(project_id, account_id) do
@@ -130,32 +109,11 @@ defmodule TuistWeb.SlackOAuthController do
       })
   end
 
-  defp handle_account_installation(conn, code, account_id) do
-    with {:ok, account} <- Accounts.get_account_by_id(account_id),
-         {:ok, token_data} <- SlackClient.exchange_code_for_token(code, slack_redirect_uri()),
-         {:ok, _installation} <- create_installation(account, token_data) do
-      redirect(conn, to: ~p"/#{account.name}/integrations")
-    else
-      {:error, :not_found} ->
-        raise BadRequestError, dgettext("dashboard_slack", "Account not found. Please try again.")
-
-      {:error, reason} when is_binary(reason) ->
-        raise BadRequestError,
-              dgettext("dashboard_slack", "Slack authorization failed: %{reason}", reason: reason)
-
-      {:error, %Ecto.Changeset{}} ->
-        raise BadRequestError,
-              dgettext("dashboard_slack", "Failed to save Slack installation. Please try again.")
-    end
-  end
-
-  defp handle_channel_selection(conn, code) do
+  defp handle_channel_selection(conn, code, _payload) do
     case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
-      {:ok, token_data} ->
-        incoming_webhook = token_data.incoming_webhook
-        channel_id = incoming_webhook.channel_id
-        channel_name = String.trim_leading(incoming_webhook.channel, "#")
-        render_popup_close(conn, channel_id, channel_name)
+      {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
+        channel_name = String.trim_leading(channel, "#")
+        render_popup_close(conn, channel_id, channel_name, webhook_url)
 
       {:error, reason} when is_binary(reason) ->
         raise BadRequestError,
@@ -168,7 +126,7 @@ defmodule TuistWeb.SlackOAuthController do
          {:ok, alert_rule} <- Alerts.get_alert_rule(alert_rule_id),
          {:ok, token_data} <- SlackClient.exchange_code_for_token(code, slack_redirect_uri()),
          {:ok, _alert_rule} <- update_alert_rule_channel(alert_rule, token_data) do
-      render_popup_close(conn, nil, nil)
+      render_popup_close(conn, nil, nil, nil)
     else
       {:error, :not_found} ->
         raise BadRequestError, dgettext("dashboard_slack", "Alert rule not found. Please try again.")
@@ -185,11 +143,9 @@ defmodule TuistWeb.SlackOAuthController do
 
   defp handle_alert_channel_selection(conn, code, _payload) do
     case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
-      {:ok, token_data} ->
-        incoming_webhook = token_data.incoming_webhook
-        channel_id = incoming_webhook.channel_id
-        channel_name = String.trim_leading(incoming_webhook.channel, "#")
-        render_popup_close(conn, channel_id, channel_name)
+      {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
+        channel_name = String.trim_leading(channel, "#")
+        render_popup_close(conn, channel_id, channel_name, webhook_url)
 
       {:error, reason} when is_binary(reason) ->
         raise BadRequestError,
@@ -199,11 +155,9 @@ defmodule TuistWeb.SlackOAuthController do
 
   defp handle_flaky_alert_channel_selection(conn, code) do
     case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
-      {:ok, token_data} ->
-        incoming_webhook = token_data.incoming_webhook
-        channel_id = incoming_webhook.channel_id
-        channel_name = String.trim_leading(incoming_webhook.channel, "#")
-        render_popup_close(conn, channel_id, channel_name)
+      {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
+        channel_name = String.trim_leading(channel, "#")
+        render_popup_close(conn, channel_id, channel_name, webhook_url)
 
       {:error, reason} when is_binary(reason) ->
         raise BadRequestError,
@@ -211,25 +165,16 @@ defmodule TuistWeb.SlackOAuthController do
     end
   end
 
-  defp update_alert_rule_channel(alert_rule, token_data) do
-    incoming_webhook = token_data.incoming_webhook
-    channel_name = String.trim_leading(incoming_webhook.channel, "#")
+  defp update_alert_rule_channel(alert_rule, %{
+         incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}
+       }) do
+    channel_name = String.trim_leading(channel, "#")
 
     Alerts.update_alert_rule(alert_rule, %{
-      slack_channel_id: incoming_webhook.channel_id,
-      slack_channel_name: channel_name
+      slack_channel_id: channel_id,
+      slack_channel_name: channel_name,
+      slack_webhook_url: webhook_url
     })
-  end
-
-  defp redirect_after_account_cancel(conn, account_id) do
-    case Accounts.get_account_by_id(account_id) do
-      {:ok, account} ->
-        redirect(conn, to: ~p"/#{account.name}/integrations")
-
-      {:error, :not_found} ->
-        raise BadRequestError,
-              dgettext("dashboard_slack", "Account not found. Please try again.")
-    end
   end
 
   defp redirect_after_channel_cancel(conn, account_id, project_id) do
@@ -247,24 +192,18 @@ defmodule TuistWeb.SlackOAuthController do
     end
   end
 
-  defp create_installation(account, token_data) do
-    Slack.create_installation(%{
-      account_id: account.id,
-      team_id: token_data.team_id,
-      team_name: token_data.team_name,
-      access_token: token_data.access_token,
-      bot_user_id: token_data.bot_user_id
-    })
-  end
-
   defp slack_redirect_uri do
     Environment.app_url(path: ~p"/integrations/slack/callback")
   end
 
-  defp render_popup_close(conn, channel_id, channel_name) do
+  defp render_popup_close(conn, channel_id, channel_name, webhook_url) do
     conn
     |> put_view(TuistWeb.SlackOAuthHTML)
     |> put_layout(false)
-    |> render("popup_close.html", channel_id: channel_id, channel_name: channel_name)
+    |> render("popup_close.html",
+      channel_id: channel_id,
+      channel_name: channel_name,
+      webhook_url: webhook_url
+    )
   end
 end

--- a/server/lib/tuist_web/controllers/slack_oauth_controller.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_controller.ex
@@ -49,7 +49,7 @@ defmodule TuistWeb.SlackOAuthController do
 
   defp handle_access_denied(conn, %{type: type})
        when type in [:alert_channel_selection, :flaky_alert_channel_selection] do
-    render_popup_close(conn, nil, nil, nil)
+    render_popup_close(conn, nil)
   end
 
   defp handle_access_denied(conn, %{type: :channel_selection, account_id: account_id, project_id: project_id}) do
@@ -110,15 +110,7 @@ defmodule TuistWeb.SlackOAuthController do
   end
 
   defp handle_channel_selection(conn, code, _payload) do
-    case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
-      {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
-        channel_name = String.trim_leading(channel, "#")
-        render_popup_close(conn, channel_id, channel_name, webhook_url)
-
-      {:error, reason} when is_binary(reason) ->
-        raise BadRequestError,
-              dgettext("dashboard_slack", "Slack authorization failed: %{reason}", reason: reason)
-    end
+    render_channel_selection(conn, code)
   end
 
   defp handle_alert_channel_selection(conn, code, %{alert_rule_id: alert_rule_id} = payload) do
@@ -126,7 +118,7 @@ defmodule TuistWeb.SlackOAuthController do
          {:ok, alert_rule} <- Alerts.get_alert_rule(alert_rule_id),
          {:ok, token_data} <- SlackClient.exchange_code_for_token(code, slack_redirect_uri()),
          {:ok, _alert_rule} <- update_alert_rule_channel(alert_rule, token_data) do
-      render_popup_close(conn, nil, nil, nil)
+      render_popup_close(conn, nil)
     else
       {:error, :not_found} ->
         raise BadRequestError, dgettext("dashboard_slack", "Alert rule not found. Please try again.")
@@ -142,22 +134,33 @@ defmodule TuistWeb.SlackOAuthController do
   end
 
   defp handle_alert_channel_selection(conn, code, _payload) do
-    case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
-      {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
-        channel_name = String.trim_leading(channel, "#")
-        render_popup_close(conn, channel_id, channel_name, webhook_url)
-
-      {:error, reason} when is_binary(reason) ->
-        raise BadRequestError,
-              dgettext("dashboard_slack", "Slack authorization failed: %{reason}", reason: reason)
-    end
+    render_channel_selection(conn, code)
   end
 
   defp handle_flaky_alert_channel_selection(conn, code) do
+    render_channel_selection(conn, code)
+  end
+
+  defp render_channel_selection(conn, code) do
     case SlackClient.exchange_code_for_token(code, slack_redirect_uri()) do
       {:ok, %{incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}}} ->
         channel_name = String.trim_leading(channel, "#")
-        render_popup_close(conn, channel_id, channel_name, webhook_url)
+
+        case Slack.sign_channel_result(%{
+               channel_id: channel_id,
+               channel_name: channel_name,
+               webhook_url: webhook_url
+             }) do
+          {:ok, token} ->
+            render_popup_close(conn, token)
+
+          {:error, :invalid_webhook_url} ->
+            raise BadRequestError,
+                  dgettext(
+                    "dashboard_slack",
+                    "Slack returned an unexpected webhook URL. Please try again."
+                  )
+        end
 
       {:error, reason} when is_binary(reason) ->
         raise BadRequestError,
@@ -168,13 +171,17 @@ defmodule TuistWeb.SlackOAuthController do
   defp update_alert_rule_channel(alert_rule, %{
          incoming_webhook: %{channel_id: channel_id, channel: channel, url: webhook_url}
        }) do
-    channel_name = String.trim_leading(channel, "#")
+    if Slack.slack_webhook_url?(webhook_url) do
+      channel_name = String.trim_leading(channel, "#")
 
-    Alerts.update_alert_rule(alert_rule, %{
-      slack_channel_id: channel_id,
-      slack_channel_name: channel_name,
-      slack_webhook_url: webhook_url
-    })
+      Alerts.update_alert_rule(alert_rule, %{
+        slack_channel_id: channel_id,
+        slack_channel_name: channel_name,
+        slack_webhook_url: webhook_url
+      })
+    else
+      {:error, :invalid_webhook_url}
+    end
   end
 
   defp redirect_after_channel_cancel(conn, account_id, project_id) do
@@ -196,14 +203,10 @@ defmodule TuistWeb.SlackOAuthController do
     Environment.app_url(path: ~p"/integrations/slack/callback")
   end
 
-  defp render_popup_close(conn, channel_id, channel_name, webhook_url) do
+  defp render_popup_close(conn, channel_token) do
     conn
     |> put_view(TuistWeb.SlackOAuthHTML)
     |> put_layout(false)
-    |> render("popup_close.html",
-      channel_id: channel_id,
-      channel_name: channel_name,
-      webhook_url: webhook_url
-    )
+    |> render("popup_close.html", channel_token: channel_token)
   end
 end

--- a/server/lib/tuist_web/controllers/slack_oauth_html.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_html.ex
@@ -33,6 +33,7 @@ defmodule TuistWeb.SlackOAuthHTML do
           id="channel-data"
           data-channel-id={@channel_id}
           data-channel-name={@channel_name}
+          data-webhook-url={@webhook_url}
           style="display: none;"
         >
         </div>
@@ -40,6 +41,7 @@ defmodule TuistWeb.SlackOAuthHTML do
           const dataEl = document.getElementById("channel-data");
           const channelId = dataEl.dataset.channelId || null;
           const channelName = dataEl.dataset.channelName || null;
+          const webhookUrl = dataEl.dataset.webhookUrl || null;
           const nonce = sessionStorage.getItem("slack_popup_nonce");
           sessionStorage.removeItem("slack_popup_nonce");
           const channel = new BroadcastChannel("oauth_popup");
@@ -48,6 +50,7 @@ defmodule TuistWeb.SlackOAuthHTML do
             success: true,
             channel_id: channelId,
             channel_name: channelName,
+            webhook_url: webhookUrl,
             nonce: nonce
           });
           channel.close();

--- a/server/lib/tuist_web/controllers/slack_oauth_html.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_html.ex
@@ -29,8 +29,7 @@ defmodule TuistWeb.SlackOAuthHTML do
         <div class="message">
           <p>Channel connected successfully. This window will close automatically.</p>
         </div>
-        <div id="channel-data" data-channel-token={@channel_token} style="display: none;">
-        </div>
+        <div id="channel-data" data-channel-token={@channel_token} style="display: none;"></div>
         <script nonce={get_csp_nonce()}>
           const dataEl = document.getElementById("channel-data");
           const channelToken = dataEl.dataset.channelToken || null;

--- a/server/lib/tuist_web/controllers/slack_oauth_html.ex
+++ b/server/lib/tuist_web/controllers/slack_oauth_html.ex
@@ -29,28 +29,18 @@ defmodule TuistWeb.SlackOAuthHTML do
         <div class="message">
           <p>Channel connected successfully. This window will close automatically.</p>
         </div>
-        <div
-          id="channel-data"
-          data-channel-id={@channel_id}
-          data-channel-name={@channel_name}
-          data-webhook-url={@webhook_url}
-          style="display: none;"
-        >
+        <div id="channel-data" data-channel-token={@channel_token} style="display: none;">
         </div>
         <script nonce={get_csp_nonce()}>
           const dataEl = document.getElementById("channel-data");
-          const channelId = dataEl.dataset.channelId || null;
-          const channelName = dataEl.dataset.channelName || null;
-          const webhookUrl = dataEl.dataset.webhookUrl || null;
+          const channelToken = dataEl.dataset.channelToken || null;
           const nonce = sessionStorage.getItem("slack_popup_nonce");
           sessionStorage.removeItem("slack_popup_nonce");
           const channel = new BroadcastChannel("oauth_popup");
           channel.postMessage({
             type: "oauth_complete",
             success: true,
-            channel_id: channelId,
-            channel_name: channelName,
-            webhook_url: webhookUrl,
+            channel_token: channelToken,
             nonce: nonce
           });
           channel.close();

--- a/server/lib/tuist_web/live/integrations_live.ex
+++ b/server/lib/tuist_web/live/integrations_live.ex
@@ -5,7 +5,6 @@ defmodule TuistWeb.IntegrationsLive do
 
   alias Tuist.Authorization
   alias Tuist.Projects
-  alias Tuist.Slack
   alias Tuist.Utilities.DateFormatter
   alias Tuist.VCS
 
@@ -16,9 +15,8 @@ defmodule TuistWeb.IntegrationsLive do
             dgettext("dashboard_integrations", "You are not authorized to perform this action.")
     end
 
-    selected_account = Tuist.Repo.preload(selected_account, [:github_app_installation, :slack_installation, :projects])
+    selected_account = Tuist.Repo.preload(selected_account, [:github_app_installation, :projects])
     github_installation = selected_account.github_app_installation
-    slack_installation = selected_account.slack_installation
     vcs_connections = vcs_connections(selected_account)
 
     socket =
@@ -26,7 +24,6 @@ defmodule TuistWeb.IntegrationsLive do
       |> assign(selected_tab: "integrations")
       |> assign(selected_account: selected_account)
       |> assign(github_app_installation: github_installation)
-      |> assign(slack_installation: slack_installation)
       |> assign(vcs_connections: vcs_connections)
       |> assign(selected_project_id: nil)
       |> assign(selected_repository_full_handle: nil)
@@ -112,17 +109,6 @@ defmodule TuistWeb.IntegrationsLive do
     else
       _ -> {:noreply, socket}
     end
-  end
-
-  @impl true
-  def handle_event("disconnect-slack", _params, %{assigns: assigns} = socket) do
-    %{slack_installation: slack_installation} = assigns
-
-    if slack_installation do
-      {:ok, _} = Slack.delete_installation(slack_installation)
-    end
-
-    {:noreply, assign(socket, slack_installation: nil)}
   end
 
   defp get_available_projects(%{selected_account: selected_account, vcs_connections: vcs_connections}) do

--- a/server/lib/tuist_web/live/integrations_live.html.heex
+++ b/server/lib/tuist_web/live/integrations_live.html.heex
@@ -171,37 +171,4 @@
       </.card_section>
     </div>
   </.card_section>
-  <.card_section :if={Tuist.Environment.slack_configured?()} data-part="slack-card-section">
-    <div data-part="header">
-      <span data-part="title">
-        {dgettext("dashboard_integrations", "Slack")}
-      </span>
-      <span data-part="subtitle">
-        {dgettext(
-          "dashboard_integrations",
-          "Connect Slack to receive project analytics reports"
-        )}
-      </span>
-    </div>
-    <div data-part="content">
-      <div data-part="actions">
-        <.button
-          :if={is_nil(@slack_installation)}
-          label={dgettext("dashboard_integrations", "Connect Slack")}
-          variant="primary"
-          href={TuistWeb.SlackOAuthController.install_url(@selected_account.id)}
-        />
-        <.button
-          :if={not is_nil(@slack_installation)}
-          label={
-            dgettext("dashboard_integrations", "Disconnect from %{team_name}",
-              team_name: @slack_installation.team_name
-            )
-          }
-          variant="secondary"
-          phx-click="disconnect-slack"
-        />
-      </div>
-    </div>
-  </.card_section>
 </div>

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -6,6 +6,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
   alias Tuist.Authorization
   alias Tuist.Automations
   alias Tuist.Environment
+  alias Tuist.Slack
   alias TuistWeb.SlackOAuthController
 
   @impl true
@@ -81,7 +82,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
       "type" => "send_slack",
       "channel" => "",
       "channel_name" => "",
-      "webhook_url" => "",
+      "webhook_url_encrypted" => "",
       "message" => @default_trigger_slack_message
     }
 
@@ -90,7 +91,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
       "type" => "send_slack",
       "channel" => "",
       "channel_name" => "",
-      "webhook_url" => "",
+      "webhook_url_encrypted" => "",
       "message" => @default_recovery_slack_message
     }
 
@@ -204,20 +205,26 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event(
         "trigger_action_channel_selected",
-        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
+        %{"id" => index, "channel_token" => channel_token},
         socket
       ) do
-    index = String.to_integer(index)
+    case verify_and_encrypt(channel_token) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, encrypted_webhook_url: encrypted}} ->
+        index = String.to_integer(index)
 
-    actions =
-      update_action_at(socket.assigns.create_automation_form_trigger_actions, index, fn action ->
-        action
-        |> Map.put("channel", channel_id)
-        |> Map.put("channel_name", channel_name)
-        |> Map.put("webhook_url", webhook_url)
-      end)
+        actions =
+          update_action_at(socket.assigns.create_automation_form_trigger_actions, index, fn action ->
+            action
+            |> Map.put("channel", channel_id)
+            |> Map.put("channel_name", channel_name)
+            |> Map.put("webhook_url_encrypted", encrypted)
+          end)
 
-    {:noreply, assign(socket, create_automation_form_trigger_actions: actions)}
+        {:noreply, assign(socket, create_automation_form_trigger_actions: actions)}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("trigger_action_channel_selected", _params, socket) do
@@ -272,20 +279,26 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event(
         "recovery_action_channel_selected",
-        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
+        %{"id" => index, "channel_token" => channel_token},
         socket
       ) do
-    index = String.to_integer(index)
+    case verify_and_encrypt(channel_token) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, encrypted_webhook_url: encrypted}} ->
+        index = String.to_integer(index)
 
-    actions =
-      update_action_at(socket.assigns.create_automation_form_recovery_actions, index, fn action ->
-        action
-        |> Map.put("channel", channel_id)
-        |> Map.put("channel_name", channel_name)
-        |> Map.put("webhook_url", webhook_url)
-      end)
+        actions =
+          update_action_at(socket.assigns.create_automation_form_recovery_actions, index, fn action ->
+            action
+            |> Map.put("channel", channel_id)
+            |> Map.put("channel_name", channel_name)
+            |> Map.put("webhook_url_encrypted", encrypted)
+          end)
 
-    {:noreply, assign(socket, create_automation_form_recovery_actions: actions)}
+        {:noreply, assign(socket, create_automation_form_recovery_actions: actions)}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("recovery_action_channel_selected", _params, socket) do
@@ -508,4 +521,14 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   defp format_threshold(n) when is_float(n) and trunc(n) == n, do: trunc(n)
   defp format_threshold(n), do: n
+
+  # Decode the signed channel-result token, then encrypt the webhook URL so
+  # we never store it as plaintext inside the action JSON.
+  defp verify_and_encrypt(channel_token) do
+    with {:ok, %{channel_id: channel_id, channel_name: channel_name, webhook_url: webhook_url}} <-
+           Slack.verify_channel_result(channel_token),
+         {:ok, encrypted} <- Slack.encrypt_webhook_url(webhook_url) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, encrypted_webhook_url: encrypted}}
+    end
+  end
 end

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -203,11 +203,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, assign(socket, create_automation_form_trigger_actions: actions)}
   end
 
-  def handle_event(
-        "trigger_action_channel_selected",
-        %{"id" => index, "channel_token" => channel_token},
-        socket
-      ) do
+  def handle_event("trigger_action_channel_selected", %{"id" => index, "channel_token" => channel_token}, socket) do
     case verify_and_encrypt(channel_token) do
       {:ok, %{channel_id: channel_id, channel_name: channel_name, encrypted_webhook_url: encrypted}} ->
         index = String.to_integer(index)
@@ -277,11 +273,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, assign(socket, create_automation_form_recovery_actions: actions)}
   end
 
-  def handle_event(
-        "recovery_action_channel_selected",
-        %{"id" => index, "channel_token" => channel_token},
-        socket
-      ) do
+  def handle_event("recovery_action_channel_selected", %{"id" => index, "channel_token" => channel_token}, socket) do
     case verify_and_encrypt(channel_token) do
       {:ok, %{channel_id: channel_id, channel_name: channel_name, encrypted_webhook_url: encrypted}} ->
         index = String.to_integer(index)

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -5,8 +5,7 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   alias Tuist.Authorization
   alias Tuist.Automations
-  alias Tuist.Repo
-  alias Tuist.Slack
+  alias Tuist.Environment
   alias TuistWeb.SlackOAuthController
 
   @impl true
@@ -21,16 +20,9 @@ defmodule TuistWeb.ProjectAutomationsLive do
             dgettext("dashboard_projects", "You are not authorized to perform this action.")
     end
 
-    selected_account = Repo.preload(selected_account, [:slack_installation])
-    slack_installation = selected_account.slack_installation
-
-    if connected?(socket) do
-      Tuist.PubSub.subscribe(Slack.slack_installation_topic(selected_account.id))
-    end
-
     socket =
       socket
-      |> assign(slack_installation: slack_installation)
+      |> assign(:slack_configured, Environment.slack_configured?())
       |> assign(:head_title, "#{dgettext("dashboard_projects", "Automations")} · #{selected_project.name} · Tuist")
       |> assign(
         :automation_channel_selection_url,
@@ -85,10 +77,22 @@ defmodule TuistWeb.ProjectAutomationsLive do
   @default_recovery_slack_message ":white_check_mark: *{{test_case.name}}* in module `{{test_case.module_name}}` has recovered.\n\n<{{test_case.url}}|View test case>"
 
   defp default_send_slack_action(:trigger),
-    do: %{"type" => "send_slack", "channel" => "", "channel_name" => "", "message" => @default_trigger_slack_message}
+    do: %{
+      "type" => "send_slack",
+      "channel" => "",
+      "channel_name" => "",
+      "webhook_url" => "",
+      "message" => @default_trigger_slack_message
+    }
 
   defp default_send_slack_action(:recovery),
-    do: %{"type" => "send_slack", "channel" => "", "channel_name" => "", "message" => @default_recovery_slack_message}
+    do: %{
+      "type" => "send_slack",
+      "channel" => "",
+      "channel_name" => "",
+      "webhook_url" => "",
+      "message" => @default_recovery_slack_message
+    }
 
   defp automation_to_form(automation) do
     %{
@@ -114,23 +118,6 @@ defmodule TuistWeb.ProjectAutomationsLive do
   @impl true
   def handle_params(_params, _uri, socket) do
     {:noreply, socket}
-  end
-
-  @impl true
-  def handle_info({:slack_installation_changed, %{status: status}}, socket) do
-    selected_account = socket.assigns.selected_account
-
-    slack_installation =
-      case status do
-        :connected ->
-          selected_account = Repo.preload(selected_account, [:slack_installation], force: true)
-          selected_account.slack_installation
-
-        :disconnected ->
-          nil
-      end
-
-    {:noreply, assign(socket, slack_installation: slack_installation)}
   end
 
   @impl true
@@ -217,14 +204,17 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event(
         "trigger_action_channel_selected",
-        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name},
+        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
         socket
       ) do
     index = String.to_integer(index)
 
     actions =
       update_action_at(socket.assigns.create_automation_form_trigger_actions, index, fn action ->
-        action |> Map.put("channel", channel_id) |> Map.put("channel_name", channel_name)
+        action
+        |> Map.put("channel", channel_id)
+        |> Map.put("channel_name", channel_name)
+        |> Map.put("webhook_url", webhook_url)
       end)
 
     {:noreply, assign(socket, create_automation_form_trigger_actions: actions)}
@@ -282,14 +272,17 @@ defmodule TuistWeb.ProjectAutomationsLive do
 
   def handle_event(
         "recovery_action_channel_selected",
-        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name},
+        %{"id" => index, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
         socket
       ) do
     index = String.to_integer(index)
 
     actions =
       update_action_at(socket.assigns.create_automation_form_recovery_actions, index, fn action ->
-        action |> Map.put("channel", channel_id) |> Map.put("channel_name", channel_name)
+        action
+        |> Map.put("channel", channel_id)
+        |> Map.put("channel_name", channel_name)
+        |> Map.put("webhook_url", webhook_url)
       end)
 
     {:noreply, assign(socket, create_automation_form_recovery_actions: actions)}

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -270,7 +270,7 @@
                             </div>
                             <div data-part="slack-action-header-right">
                               <.button
-                                :if={@slack_installation}
+                                :if={@slack_configured}
                                 label={
                                   if action["channel_name"] && action["channel_name"] != "",
                                     do: dgettext("dashboard_projects", "Update channel"),
@@ -284,16 +284,6 @@
                                 data-event="trigger_action_channel_selected"
                                 data-id={index}
                               />
-                              <.link_button
-                                :if={is_nil(@slack_installation)}
-                                href={~p"/#{@selected_account.name}/integrations"}
-                                target="_blank"
-                                label={dgettext("dashboard_projects", "Connect Slack")}
-                                variant="primary"
-                                size="medium"
-                              >
-                                <:icon_right><.external_link /></:icon_right>
-                              </.link_button>
                               <.button
                                 icon_only
                                 size="medium"
@@ -523,7 +513,7 @@
                             </div>
                             <div data-part="slack-action-header-right">
                               <.button
-                                :if={@slack_installation}
+                                :if={@slack_configured}
                                 label={
                                   if action["channel_name"] && action["channel_name"] != "",
                                     do: dgettext("dashboard_projects", "Update channel"),
@@ -537,16 +527,6 @@
                                 data-event="recovery_action_channel_selected"
                                 data-id={index}
                               />
-                              <.link_button
-                                :if={is_nil(@slack_installation)}
-                                href={~p"/#{@selected_account.name}/integrations"}
-                                target="_blank"
-                                label={dgettext("dashboard_projects", "Connect Slack")}
-                                variant="primary"
-                                size="medium"
-                              >
-                                <:icon_right><.external_link /></:icon_right>
-                              </.link_button>
                               <.button
                                 icon_only
                                 size="medium"

--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -5,9 +5,9 @@ defmodule TuistWeb.ProjectNotificationsLive do
 
   alias Tuist.Alerts
   alias Tuist.Authorization
+  alias Tuist.Environment
   alias Tuist.Projects
   alias Tuist.Repo
-  alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
   alias Tuist.Slack.Reports
   alias TuistWeb.SlackOAuthController
@@ -24,16 +24,9 @@ defmodule TuistWeb.ProjectNotificationsLive do
             dgettext("dashboard_projects", "You are not authorized to perform this action.")
     end
 
-    selected_account = Repo.preload(selected_account, [:slack_installation])
-    slack_installation = selected_account.slack_installation
-
-    if connected?(socket) do
-      Tuist.PubSub.subscribe(Slack.slack_installation_topic(selected_account.id))
-    end
-
     socket =
       socket
-      |> assign(slack_installation: slack_installation)
+      |> assign(:slack_configured, Environment.slack_configured?())
       |> assign(:head_title, "#{dgettext("dashboard_projects", "Notifications")} · #{selected_project.name} · Tuist")
       |> assign(
         :slack_channel_selection_url,
@@ -43,23 +36,6 @@ defmodule TuistWeb.ProjectNotificationsLive do
       |> assign_alert_defaults(selected_project)
 
     {:ok, socket}
-  end
-
-  @impl true
-  def handle_info({:slack_installation_changed, %{status: status}}, socket) do
-    selected_account = socket.assigns.selected_account
-
-    slack_installation =
-      case status do
-        :connected ->
-          selected_account = Repo.preload(selected_account, [:slack_installation], force: true)
-          selected_account.slack_installation
-
-        :disconnected ->
-          nil
-      end
-
-    {:noreply, assign(socket, slack_installation: slack_installation)}
   end
 
   defp assign_alert_defaults(socket, project) do
@@ -84,6 +60,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
     |> assign(create_alert_form_environment: "any")
     |> assign(create_alert_form_channel_id: nil)
     |> assign(create_alert_form_channel_name: nil)
+    |> assign(create_alert_form_webhook_url: nil)
     # Metric alert edit forms - one per alert rule
     |> assign(edit_alert_forms: edit_alert_forms)
   end
@@ -100,7 +77,8 @@ defmodule TuistWeb.ProjectNotificationsLive do
       bundle_name: rule.bundle_name || "",
       environment: to_string(rule.environment || :any),
       channel_id: rule.slack_channel_id,
-      channel_name: rule.slack_channel_name
+      channel_name: rule.slack_channel_name,
+      webhook_url: rule.slack_webhook_url
     }
   end
 
@@ -129,11 +107,17 @@ defmodule TuistWeb.ProjectNotificationsLive do
   def handle_event(
         "send_test_slack_report",
         _params,
-        %{assigns: %{selected_project: selected_project, slack_installation: slack_installation}} = socket
+        %{assigns: %{selected_project: selected_project}} = socket
       ) do
-    blocks = Reports.report(selected_project)
+    case selected_project.slack_webhook_url do
+      url when is_binary(url) and url != "" ->
+        blocks = Reports.report(selected_project)
+        :ok = SlackClient.post_to_webhook(url, blocks)
 
-    :ok = SlackClient.post_message(slack_installation.access_token, selected_project.slack_channel_id, blocks)
+      _ ->
+        :ok
+    end
+
     {:noreply, socket}
   end
 
@@ -250,6 +234,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
       |> assign(create_alert_form_environment: "any")
       |> assign(create_alert_form_channel_id: nil)
       |> assign(create_alert_form_channel_name: nil)
+      |> assign(create_alert_form_webhook_url: nil)
 
     {:noreply, socket}
   end
@@ -377,7 +362,8 @@ defmodule TuistWeb.ProjectNotificationsLive do
       bundle_name: assigns.create_alert_form_bundle_name,
       environment: assigns.create_alert_form_environment,
       slack_channel_id: assigns.create_alert_form_channel_id,
-      slack_channel_name: assigns.create_alert_form_channel_name
+      slack_channel_name: assigns.create_alert_form_channel_name,
+      slack_webhook_url: assigns.create_alert_form_webhook_url
     }
 
     {:ok, _alert_rule} = Alerts.create_alert_rule(attrs)
@@ -408,7 +394,8 @@ defmodule TuistWeb.ProjectNotificationsLive do
         bundle_name: form.bundle_name,
         environment: Map.get(form, :environment, "any"),
         slack_channel_id: form.channel_id,
-        slack_channel_name: form.channel_name
+        slack_channel_name: form.channel_name,
+        slack_webhook_url: form.webhook_url
       }
 
       {:ok, _alert_rule} = Alerts.update_alert_rule(alert_rule, attrs)
@@ -458,13 +445,14 @@ defmodule TuistWeb.ProjectNotificationsLive do
 
   def handle_event(
         "oauth_channel_selected",
-        %{"channel_id" => channel_id, "channel_name" => channel_name},
+        %{"channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
         %{assigns: %{selected_project: selected_project}} = socket
       ) do
     {:ok, selected_project} =
       Projects.update_project(selected_project, %{
         slack_channel_id: channel_id,
         slack_channel_name: channel_name,
+        slack_webhook_url: webhook_url,
         report_frequency: :daily
       })
 
@@ -476,15 +464,20 @@ defmodule TuistWeb.ProjectNotificationsLive do
     {:noreply, socket}
   end
 
+  def handle_event("oauth_channel_selected", _params, socket) do
+    {:noreply, socket}
+  end
+
   def handle_event(
         "create_alert_form_channel_selected",
-        %{"channel_id" => channel_id, "channel_name" => channel_name},
+        %{"channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
         socket
       ) do
     socket =
       socket
       |> assign(create_alert_form_channel_id: channel_id)
       |> assign(create_alert_form_channel_name: channel_name)
+      |> assign(create_alert_form_webhook_url: webhook_url)
 
     {:noreply, socket}
   end
@@ -495,13 +488,14 @@ defmodule TuistWeb.ProjectNotificationsLive do
 
   def handle_event(
         "edit_alert_form_channel_selected",
-        %{"id" => id, "channel_id" => channel_id, "channel_name" => channel_name},
+        %{"id" => id, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
         socket
       ) do
     socket =
       socket
       |> update_edit_alert_form(id, :channel_id, channel_id)
       |> update_edit_alert_form(id, :channel_name, channel_name)
+      |> update_edit_alert_form(id, :webhook_url, webhook_url)
 
     {:noreply, socket}
   end

--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -500,11 +500,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
     {:noreply, socket}
   end
 
-  def handle_event(
-        "edit_alert_form_channel_selected",
-        %{"id" => id, "channel_token" => channel_token},
-        socket
-      ) do
+  def handle_event("edit_alert_form_channel_selected", %{"id" => id, "channel_token" => channel_token}, socket) do
     case Slack.verify_channel_result(channel_token) do
       {:ok, %{channel_id: channel_id, channel_name: channel_name, webhook_url: webhook_url}} ->
         socket =

--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -8,6 +8,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
   alias Tuist.Environment
   alias Tuist.Projects
   alias Tuist.Repo
+  alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
   alias Tuist.Slack.Installation
   alias Tuist.Slack.Reports
@@ -450,41 +451,49 @@ defmodule TuistWeb.ProjectNotificationsLive do
 
   def handle_event(
         "oauth_channel_selected",
-        %{"channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
+        %{"channel_token" => channel_token},
         %{assigns: %{selected_project: selected_project}} = socket
       ) do
-    {:ok, selected_project} =
-      Projects.update_project(selected_project, %{
-        slack_channel_id: channel_id,
-        slack_channel_name: channel_name,
-        slack_webhook_url: webhook_url,
-        report_frequency: :daily
-      })
+    case Slack.verify_channel_result(channel_token) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, webhook_url: webhook_url}} ->
+        {:ok, selected_project} =
+          Projects.update_project(selected_project, %{
+            slack_channel_id: channel_id,
+            slack_channel_name: channel_name,
+            slack_webhook_url: webhook_url,
+            report_frequency: :daily
+          })
 
-    socket =
-      socket
-      |> assign(selected_project: selected_project)
-      |> assign_schedule_form_defaults(selected_project)
+        socket =
+          socket
+          |> assign(selected_project: selected_project)
+          |> assign_schedule_form_defaults(selected_project)
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("oauth_channel_selected", _params, socket) do
     {:noreply, socket}
   end
 
-  def handle_event(
-        "create_alert_form_channel_selected",
-        %{"channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
-        socket
-      ) do
-    socket =
-      socket
-      |> assign(create_alert_form_channel_id: channel_id)
-      |> assign(create_alert_form_channel_name: channel_name)
-      |> assign(create_alert_form_webhook_url: webhook_url)
+  def handle_event("create_alert_form_channel_selected", %{"channel_token" => channel_token}, socket) do
+    case Slack.verify_channel_result(channel_token) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, webhook_url: webhook_url}} ->
+        socket =
+          socket
+          |> assign(create_alert_form_channel_id: channel_id)
+          |> assign(create_alert_form_channel_name: channel_name)
+          |> assign(create_alert_form_webhook_url: webhook_url)
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("create_alert_form_channel_selected", _params, socket) do
@@ -493,16 +502,22 @@ defmodule TuistWeb.ProjectNotificationsLive do
 
   def handle_event(
         "edit_alert_form_channel_selected",
-        %{"id" => id, "channel_id" => channel_id, "channel_name" => channel_name, "webhook_url" => webhook_url},
+        %{"id" => id, "channel_token" => channel_token},
         socket
       ) do
-    socket =
-      socket
-      |> update_edit_alert_form(id, :channel_id, channel_id)
-      |> update_edit_alert_form(id, :channel_name, channel_name)
-      |> update_edit_alert_form(id, :webhook_url, webhook_url)
+    case Slack.verify_channel_result(channel_token) do
+      {:ok, %{channel_id: channel_id, channel_name: channel_name, webhook_url: webhook_url}} ->
+        socket =
+          socket
+          |> update_edit_alert_form(id, :channel_id, channel_id)
+          |> update_edit_alert_form(id, :channel_name, channel_name)
+          |> update_edit_alert_form(id, :webhook_url, webhook_url)
 
-    {:noreply, socket}
+        {:noreply, socket}
+
+      {:error, _reason} ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("edit_alert_form_channel_selected", _params, socket) do

--- a/server/lib/tuist_web/live/project_notifications_live.ex
+++ b/server/lib/tuist_web/live/project_notifications_live.ex
@@ -9,6 +9,7 @@ defmodule TuistWeb.ProjectNotificationsLive do
   alias Tuist.Projects
   alias Tuist.Repo
   alias Tuist.Slack.Client, as: SlackClient
+  alias Tuist.Slack.Installation
   alias Tuist.Slack.Reports
   alias TuistWeb.SlackOAuthController
 
@@ -107,14 +108,18 @@ defmodule TuistWeb.ProjectNotificationsLive do
   def handle_event(
         "send_test_slack_report",
         _params,
-        %{assigns: %{selected_project: selected_project}} = socket
+        %{assigns: %{selected_project: selected_project, selected_account: selected_account}} = socket
       ) do
-    case selected_project.slack_webhook_url do
-      url when is_binary(url) and url != "" ->
-        blocks = Reports.report(selected_project)
-        :ok = SlackClient.post_to_webhook(url, blocks)
+    blocks = Reports.report(selected_project)
 
-      _ ->
+    cond do
+      is_binary(selected_project.slack_webhook_url) and selected_project.slack_webhook_url != "" ->
+        :ok = SlackClient.post_to_webhook(selected_project.slack_webhook_url, blocks)
+
+      installation = legacy_installation(selected_account) ->
+        :ok = SlackClient.post_message(installation.access_token, selected_project.slack_channel_id, blocks)
+
+      true ->
         :ok
     end
 
@@ -710,4 +715,11 @@ defmodule TuistWeb.ProjectNotificationsLive do
   defp bundle_size_metric_label(:install_size), do: dgettext("dashboard_projects", "Install size")
   defp bundle_size_metric_label(:download_size), do: dgettext("dashboard_projects", "Download size")
   defp bundle_size_metric_label(_), do: ""
+
+  defp legacy_installation(account) do
+    case Repo.preload(account, :slack_installation).slack_installation do
+      %Installation{} = installation -> installation
+      _ -> nil
+    end
+  end
 end

--- a/server/lib/tuist_web/live/project_notifications_live.html.heex
+++ b/server/lib/tuist_web/live/project_notifications_live.html.heex
@@ -188,7 +188,7 @@
             <.toggle
               id="slack-reports-toggle"
               checked={@slack_reports_enabled}
-              disabled={is_nil(@selected_project.slack_webhook_url)}
+              disabled={is_nil(@selected_project.slack_channel_id)}
               phx-click="toggle_slack_reports"
             />
             <label data-part="label">

--- a/server/lib/tuist_web/live/project_notifications_live.html.heex
+++ b/server/lib/tuist_web/live/project_notifications_live.html.heex
@@ -188,7 +188,7 @@
             <.toggle
               id="slack-reports-toggle"
               checked={@slack_reports_enabled}
-              disabled={is_nil(@slack_installation) || is_nil(@selected_project.slack_channel_id)}
+              disabled={is_nil(@selected_project.slack_webhook_url)}
               phx-click="toggle_slack_reports"
             />
             <label data-part="label">
@@ -196,29 +196,20 @@
             </label>
           </div>
           <.tag
-            :if={@slack_installation && @selected_project.slack_channel_id}
+            :if={@selected_project.slack_channel_id}
             label={"##{@selected_project.slack_channel_name}"}
           />
-          <.link_button
-            :if={is_nil(@slack_installation)}
-            href={~p"/#{@selected_account.name}/integrations"}
-            target="_blank"
-            label={dgettext("dashboard_projects", "Connect Slack")}
-            variant="primary"
-          >
-            <:icon_right><.external_link /></:icon_right>
-          </.link_button>
         </div>
         <div data-part="row-content">
           <.button
-            :if={is_nil(@slack_installation)}
+            :if={!@slack_configured}
             label={dgettext("dashboard_projects", "Select channel")}
             variant="secondary"
             size="medium"
             disabled
           />
           <.button
-            :if={@slack_installation}
+            :if={@slack_configured}
             label={
               if @selected_project.slack_channel_id,
                 do: dgettext("dashboard_projects", "Update channel"),
@@ -281,31 +272,6 @@
                 environment: @create_alert_form_environment
               )}
             </p>
-            <.alert
-              :if={!@slack_installation}
-              status="information"
-              type="secondary"
-              size="medium"
-              data-part="slack-connect-alert"
-              title={
-                dgettext(
-                  "dashboard_projects",
-                  "Connect your Slack account before selecting channels."
-                )
-              }
-            >
-              <:action>
-                <.link_button
-                  :if={is_nil(@slack_installation)}
-                  href={~p"/#{@selected_account.name}/integrations"}
-                  target="_blank"
-                  label={dgettext("dashboard_projects", "Connect Slack")}
-                  variant="secondary"
-                >
-                  <:icon_right><.external_link /></:icon_right>
-                </.link_button>
-              </:action>
-            </.alert>
             <div data-part="alert-form">
               <div data-part="schedule-row">
                 <label data-part="schedule-label">
@@ -511,7 +477,7 @@
                     href={alert_channel_selection_url(@selected_account.id)}
                     phx-hook="SelectSlackChannelPopup"
                     data-event="create_alert_form_channel_selected"
-                    disabled={is_nil(@slack_installation)}
+                    disabled={!@slack_configured}
                   />
                 </div>
               </div>
@@ -611,30 +577,6 @@
                       environment: form[:environment] || rule.environment || "any"
                     )}
                   </p>
-                  <.alert
-                    :if={!@slack_installation}
-                    data-part="slack-connect-alert"
-                    status="information"
-                    type="secondary"
-                    size="medium"
-                    title={
-                      dgettext(
-                        "dashboard_projects",
-                        "Connect your Slack account before selecting channels."
-                      )
-                    }
-                  >
-                    <:action>
-                      <.link_button
-                        href={~p"/#{@selected_account.name}/integrations"}
-                        target="_blank"
-                        label={dgettext("dashboard_projects", "Connect Slack")}
-                        variant="secondary"
-                      >
-                        <:icon_right><.external_link /></:icon_right>
-                      </.link_button>
-                    </:action>
-                  </.alert>
                   <div data-part="alert-form">
                     <div data-part="schedule-row">
                       <label data-part="schedule-label">
@@ -860,7 +802,7 @@
                           label={"##{form[:channel_name] || rule.slack_channel_name}"}
                         />
                         <.button
-                          :if={@slack_installation}
+                          :if={@slack_configured}
                           label={
                             if form[:channel_id] || rule.slack_channel_id,
                               do: dgettext("dashboard_projects", "Update channel"),
@@ -875,7 +817,7 @@
                           data-id={rule.id}
                         />
                         <.button
-                          :if={!@slack_installation}
+                          :if={!@slack_configured}
                           label={dgettext("dashboard_projects", "Select channel")}
                           variant="secondary"
                           size="medium"

--- a/server/priv/docs/en/guides/integrations/slack.md
+++ b/server/priv/docs/en/guides/integrations/slack.md
@@ -9,7 +9,7 @@
 
 Tuist's integration for Slack surfaces build, test, and bundle insights directly in your channels. It turns monitoring from something your team has to remember to do into something that just happens. For example, your team can receive daily summaries of build performance, cache hit rates, or bundle size trends, and instant alerts the moment a key metric regresses or a test becomes flaky.
 
-This page describes what the integration does, how to install it on a per-channel basis, and how Tuist handles your data. For pricing, see the [Tuist pricing page](https://tuist.dev/pricing). For details on how Tuist collects, manages, and stores third-party data, see our [privacy policy](https://tuist.dev/privacy).
+This page describes what the integration does, how to install it on a per-channel basis, and how Tuist handles your data. The integration is free for every Tuist account; for pricing of the underlying Tuist service see the [Tuist pricing page](https://tuist.dev/pricing). For details on how Tuist collects, manages, and stores third-party data, see our [privacy policy](https://tuist.dev/privacy).
 
 ## How the integration works {#how-it-works}
 
@@ -78,7 +78,7 @@ When a test becomes flaky and meets your threshold, you'll receive a notificatio
 
 ## Pricing {#pricing}
 
-Tuist offers a free tier and paid plans. The integration for Slack is available on all paid plans. See the [Tuist pricing page](https://tuist.dev/pricing) for details.
+The integration for Slack is included for free with every Tuist account on every plan, including the free tier. For pricing of the underlying Tuist service, see the [Tuist pricing page](https://tuist.dev/pricing).
 
 ## Privacy and data handling {#privacy}
 

--- a/server/priv/docs/en/guides/integrations/slack.md
+++ b/server/priv/docs/en/guides/integrations/slack.md
@@ -9,7 +9,7 @@
 
 Tuist's integration for Slack surfaces build, test, and bundle insights directly in your channels. It turns monitoring from something your team has to remember to do into something that just happens. For example, your team can receive daily summaries of build performance, cache hit rates, or bundle size trends, and instant alerts the moment a key metric regresses or a test becomes flaky.
 
-This page describes what the integration does, how to install it on a per-channel basis, and how Tuist handles your data. The integration is free for every Tuist account; for pricing of the underlying Tuist service see the [Tuist pricing page](https://tuist.dev/pricing). For details on how Tuist collects, manages, and stores third-party data, see our [privacy policy](https://tuist.dev/privacy).
+This page describes what the integration does, how to install it on a per-channel basis, and how Tuist handles your data. For details on how Tuist collects, manages, and stores third-party data, see our [privacy policy](https://tuist.dev/privacy).
 
 ## How the integration works {#how-it-works}
 
@@ -75,10 +75,6 @@ To create a flaky test alert rule, go to your project's notification settings an
 When a test becomes flaky and meets your threshold, you'll receive a notification with a direct link to investigate the test case:
 
 <img src="/images/guides/integrations/slack/flaky-test-alert.png" alt="An image that shows a Slack flaky test alert message" style="max-width: 500px;" />
-
-## Pricing {#pricing}
-
-The integration for Slack is included for free with every Tuist account on every plan, including the free tier. For pricing of the underlying Tuist service, see the [Tuist pricing page](https://tuist.dev/pricing).
 
 ## Privacy and data handling {#privacy}
 

--- a/server/priv/docs/en/guides/integrations/slack.md
+++ b/server/priv/docs/en/guides/integrations/slack.md
@@ -2,61 +2,54 @@
 {
   "title": "Slack",
   "titleTemplate": ":title | Integrations | Guides | Tuist",
-  "description": "Learn how to integrate Tuist with Slack."
+  "description": "Learn how to use the Tuist integration for Slack."
 }
 ---
-# Slack integration {#slack}
+# Tuist integration for Slack {#slack}
 
-If your organization uses Slack, you can integrate Tuist to surface insights directly in your channels. This turns monitoring from something your team has to remember to do into something that just happens. For example, your team can receive daily summaries of build performance, cache hit rates, or bundle size trends.
+Tuist's integration for Slack surfaces build, test, and bundle insights directly in your channels. It turns monitoring from something your team has to remember to do into something that just happens. For example, your team can receive daily summaries of build performance, cache hit rates, or bundle size trends, and instant alerts the moment a key metric regresses or a test becomes flaky.
+
+This page describes what the integration does, how to install it on a per-channel basis, and how Tuist handles your data. For pricing, see the [Tuist pricing page](https://tuist.dev/pricing). For details on how Tuist collects, manages, and stores third-party data, see our [privacy policy](https://tuist.dev/privacy).
+
+## How the integration works {#how-it-works}
+
+Tuist sends notifications into Slack via Slack's [Incoming Webhooks](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks). The integration only requests the `incoming-webhook` scope. Each notification destination (project report, alert rule, flaky test alert, automation action) corresponds to a single Slack channel that you pick at install time. Slack creates one webhook URL per channel and Tuist stores it to deliver messages.
+
+Tuist never reads messages, member lists, or any other data from your workspace. The integration only writes notifications into the channels you have explicitly authorized.
 
 ## Setup {#setup}
 
-### Connect your Slack workspace {#connect-workspace}
-
-First, connect your Slack workspace to your Tuist account in the `Integrations` tab:
-
-![An image that shows the integrations tab with Slack connection](/images/guides/integrations/slack/integrations.png)
-
-Click **Connect Slack** to authorize Tuist to post messages to your workspace. This will redirect you to Slack's authorization page where you can approve the connection.
-
-> [!NOTE] SLACK ADMIN APPROVAL
-> <!-- -->
-> If your Slack workspace restricts app installations, you may need to request approval from a Slack administrator. Slack will guide you through the approval request process during authorization.
-> <!-- -->
-
 ### Project reports {#project-reports}
 
-After connecting Slack, configure reports for each project in the project settings' notifications tab:
+Project reports deliver a daily summary of your project's build, test, and cache metrics into a Slack channel of your choice.
+
+1. Open your project's notification settings in the Tuist dashboard.
+2. Click **Select Slack channel** and choose the workspace and channel you want Tuist to post into. Slack will ask you to authorize the `incoming-webhook` scope and pick a single channel.
+3. Choose the days of the week and the time of day you want the daily report to arrive.
 
 ![An image that shows the notifications settings with Slack report configuration](/images/guides/integrations/slack/notifications-settings.png)
 
-You can configure:
-- **Channel**: Select which Slack channel receives the reports
-- **Schedule**: Choose which days of the week to receive reports
-- **Time**: Set the time of day
-
-> [!WARNING] PRIVATE CHANNELS
-> <!-- -->
-> For the Tuist Slack app to post messages in a private channel, you must first add the Tuist bot to that channel. In Slack, open the private channel, click the channel name to open settings, select "Integrations", then "Add apps" and search for Tuist.
-> <!-- -->
-
-Once configured, Tuist sends automated daily reports to your selected Slack channel:
+Once configured, Tuist sends automated daily reports to the selected channel:
 
 <img src="/images/guides/integrations/slack/report.png" alt="An image that shows a Slack report message" style="max-width: 500px;" />
 
+> [!NOTE] PRIVATE CHANNELS
+> <!-- -->
+> To post into a private channel, open the channel inside Slack first and add it to the list of channels visible to the integration during the authorization step.
+> <!-- -->
+
 ### Alert rules {#alert-rules}
 
-Get notified in Slack with alert rules when key metrics significantly regress to help you catch slower builds, cache degradation, or test slowdowns as soon as possible, minimizing the impact on your team's productivity.
+Alert rules notify you in Slack when key metrics significantly regress, helping you catch slower builds, cache degradation, or test slowdowns as soon as possible.
 
-To create an alert rule, go to your project's notification settings and click **Add alert rule**:
+To create an alert rule, go to your project's notification settings and click **Add alert rule**. You can configure:
 
-You can configure:
 - **Name**: A descriptive name for the alert
 - **Category**: What to measure (build duration, test duration, or cache hit rate)
 - **Metric**: How to aggregate the data (p50, p90, p99, or average)
 - **Deviation**: The percentage change that triggers an alert
 - **Rolling window**: How many recent runs to compare against
-- **Slack channel**: Where to send the alert
+- **Slack channel**: The destination channel. You authorize the channel through the same `incoming-webhook` flow described above.
 
 For example, you might create an alert that triggers when the p90 build duration increases by more than 20% compared to the previous 100 builds.
 
@@ -71,66 +64,28 @@ When an alert triggers, you'll receive a message like this in your Slack channel
 
 ### Flaky test alerts {#flaky-test-alerts}
 
-Get notified instantly when a test becomes flaky. Unlike metric-based alert rules that compare rolling windows, flaky test alerts trigger the moment Tuist detects a new flaky test, helping you catch test instability before it impacts your team.
+Flaky test alerts trigger the moment Tuist detects a new flaky test, helping you catch test instability before it impacts your team.
 
-To create a flaky test alert rule, go to your project's notification settings and click **Add flaky test alert rule**:
+To create a flaky test alert rule, go to your project's notification settings and click **Add flaky test alert rule**. You can configure:
 
-You can configure:
 - **Name**: A descriptive name for the alert
 - **Trigger threshold**: The minimum number of flaky runs in the last 30 days required to trigger an alert
-- **Slack channel**: Where to send the alert
+- **Slack channel**: The destination channel, authorized through the `incoming-webhook` flow.
 
 When a test becomes flaky and meets your threshold, you'll receive a notification with a direct link to investigate the test case:
 
 <img src="/images/guides/integrations/slack/flaky-test-alert.png" alt="An image that shows a Slack flaky test alert message" style="max-width: 500px;" />
 
-## On-premise installations {#on-premise}
+## Pricing {#pricing}
 
-For on-premise Tuist installations, you'll need to create your own Slack app and configure the necessary environment variables.
+Tuist offers a free tier and paid plans. The integration for Slack is available on all paid plans. See the [Tuist pricing page](https://tuist.dev/pricing) for details.
 
-### Create a Slack app {#create-slack-app}
+## Privacy and data handling {#privacy}
 
-1. Go to the [Slack API Apps page](https://api.slack.com/apps) and click **Create New App**
-2. Choose **From an app manifest** and select the workspace where you want to install the app
-3. Paste the following manifest, replacing the redirect URL with your Tuist server URL:
+Tuist stores the webhook URLs you authorize, the channel name and ID associated with each webhook, and the notification configuration (schedule, thresholds, filters). Tuist does not read any data from your Slack workspace and only writes notifications to channels you have explicitly authorized.
 
-```json
-{
-    "display_information": {
-        "name": "Tuist",
-        "description": "Get regular updates and alerts for your builds, tests, and caching.",
-        "background_color": "#6f2cff"
-    },
-    "features": {
-        "bot_user": {
-            "display_name": "Tuist",
-            "always_online": false
-        }
-    },
-    "oauth_config": {
-        "redirect_urls": [
-            "https://your-tuist-server.com/integrations/slack/callback"
-        ],
-        "scopes": {
-            "bot": [
-                "chat:write",
-                "chat:write.public"
-            ]
-        }
-    },
-    "settings": {
-        "org_deploy_enabled": false,
-        "socket_mode_enabled": false,
-        "token_rotation_enabled": false
-    }
-}
-```
+For the full list of personal and organizational data Tuist stores and how it can be exported or deleted, see our [privacy policy](https://tuist.dev/privacy) and [data export documentation](https://github.com/tuist/tuist/blob/main/server/data-export.md).
 
-4. Review and create the app
+## Disconnecting the integration {#disconnect}
 
-### Configure environment variables {#configure-environment}
-
-Set the following environment variables on your Tuist server:
-
-- `SLACK_CLIENT_ID` - The Client ID from your Slack app's Basic Information page
-- `SLACK_CLIENT_SECRET` - The Client Secret from your Slack app's Basic Information page
+To stop a notification, remove the configured Slack channel from the report, alert rule, or automation action in your Tuist dashboard. To revoke Tuist's access entirely, remove the webhook integration from inside Slack via **Settings & administration → Manage apps**.

--- a/server/priv/docs/en/guides/integrations/slack.md
+++ b/server/priv/docs/en/guides/integrations/slack.md
@@ -76,12 +76,6 @@ When a test becomes flaky and meets your threshold, you'll receive a notificatio
 
 <img src="/images/guides/integrations/slack/flaky-test-alert.png" alt="An image that shows a Slack flaky test alert message" style="max-width: 500px;" />
 
-## Privacy and data handling {#privacy}
-
-Tuist stores the webhook URLs you authorize, the channel name and ID associated with each webhook, and the notification configuration (schedule, thresholds, filters). Tuist does not read any data from your Slack workspace and only writes notifications to channels you have explicitly authorized.
-
-For the full list of personal and organizational data Tuist stores and how it can be exported or deleted, see our [privacy policy](https://tuist.dev/privacy) and [data export documentation](https://github.com/tuist/tuist/blob/main/server/data-export.md).
-
 ## Disconnecting the integration {#disconnect}
 
 To stop a notification, remove the configured Slack channel from the report, alert rule, or automation action in your Tuist dashboard. To revoke Tuist's access entirely, remove the webhook integration from inside Slack via **Settings & administration → Manage apps**.

--- a/server/priv/marketing/pages/privacy.md
+++ b/server/priv/marketing/pages/privacy.md
@@ -64,8 +64,12 @@ We may disclose personal information to third parties, including service provide
 
 ### Your Rights and Controlling Your Personal Information
 
-- **Access**: Request details of the personal information we hold about you.
+You have the right to access, correct, transfer, and request deletion of your personal information. To exercise any of these rights, email us at [contact@tuist.dev](mailto:contact@tuist.dev) from the address associated with your account and tell us which right you wish to exercise. We will respond within 30 days.
+
+- **Access**: Request a copy of the personal information we hold about you.
 - **Correction**: Request corrections to any inaccurate or outdated personal information.
+- **Deletion**: Request that we delete your personal information. Some information may be retained where required by law or for legitimate business purposes (for example, billing records). Account holders can also delete their account at any time from their account settings, which removes the personal information associated with the account.
+- **Data portability**: Request that we transfer a machine-readable copy of your personal information to you or to another service. See our [data export documentation](https://github.com/tuist/tuist/blob/main/server/data-export.md) for the categories of data covered.
 - **Non-discrimination**: Exercise rights without discrimination.
 - **Data Breaches**: Notification in case of data breaches.
 

--- a/server/priv/repo/migrations/20260507120000_add_slack_webhook_url_columns.exs
+++ b/server/priv/repo/migrations/20260507120000_add_slack_webhook_url_columns.exs
@@ -1,0 +1,14 @@
+defmodule Tuist.Repo.Migrations.AddSlackWebhookUrlColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :slack_webhook_url, :binary
+      add :flaky_test_alerts_slack_webhook_url, :binary
+    end
+
+    alter table(:alert_rules) do
+      add :slack_webhook_url, :binary
+    end
+  end
+end

--- a/server/test/support/tuist_test_support/fixtures/alerts_fixtures.ex
+++ b/server/test/support/tuist_test_support/fixtures/alerts_fixtures.ex
@@ -40,7 +40,9 @@ defmodule TuistTestSupport.Fixtures.AlertsFixtures do
       deviation_percentage: Keyword.get(opts, :deviation_percentage, 20.0),
       environment: Keyword.get(opts, :environment, "any"),
       slack_channel_id: Keyword.get(opts, :slack_channel_id, "C#{unique_id}"),
-      slack_channel_name: Keyword.get(opts, :slack_channel_name, "test-channel-#{unique_id}")
+      slack_channel_name: Keyword.get(opts, :slack_channel_name, "test-channel-#{unique_id}"),
+      slack_webhook_url:
+        Keyword.get(opts, :slack_webhook_url, "https://hooks.slack.com/services/T#{unique_id}/B#{unique_id}/x")
     }
 
     category_attrs =

--- a/server/test/tuist/alerts/workers/alert_worker_test.exs
+++ b/server/test/tuist/alerts/workers/alert_worker_test.exs
@@ -9,13 +9,11 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.AlertsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
-  alias TuistTestSupport.Fixtures.SlackFixtures
 
   setup do
     user = %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
-    slack_installation = SlackFixtures.slack_installation_fixture(account_id: account.id)
     project = ProjectsFixtures.project_fixture(account_id: account.id)
-    %{user: user, project: project, account: account, slack_installation: slack_installation}
+    %{user: user, project: project, account: account}
   end
 
   describe "perform/1 with no args (cron mode)" do
@@ -37,9 +35,13 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
   end
 
   describe "perform/1 with alert_rule_id (job mode)" do
-    test "sends alert when threshold is exceeded", %{project: project, slack_installation: slack_installation} do
+    test "sends alert when threshold is exceeded", %{project: project} do
       # Given
-      alert_rule = AlertsFixtures.alert_rule_fixture(project: project)
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          slack_webhook_url: "https://hooks.slack.com/services/T0/B0/abc"
+        )
 
       triggered_result = %{current: 1200.0, previous: 1000.0, deviation: 20.0}
 
@@ -48,7 +50,6 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
 
       expect(Slack, :send_alert, fn alert ->
         assert alert.current_value == 1200.0
-        assert alert.alert_rule.project.account.slack_installation.access_token == slack_installation.access_token
         :ok
       end)
 
@@ -66,7 +67,7 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
       stub(Alerts, :cooldown_elapsed?, fn _alert_rule -> true end)
       expect(Alerts, :evaluate, fn _alert_rule -> :ok end)
 
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
       # When
       result = AlertWorker.perform(%Oban.Job{args: %{"alert_rule_id" => alert_rule.id}})
@@ -82,7 +83,7 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
       stub(Alerts, :cooldown_elapsed?, fn _alert_rule -> false end)
 
       reject(&Alerts.evaluate/1)
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
       # When
       result = AlertWorker.perform(%Oban.Job{args: %{"alert_rule_id" => alert_rule.id}})
@@ -91,20 +92,16 @@ defmodule Tuist.Alerts.Workers.AlertWorkerTest do
       assert result == :ok
     end
 
-    test "returns :ok when slack installation does not exist" do
-      # Given - create a project for an account without slack installation
+    test "returns :ok when alert rule has no webhook url" do
       other_user = AccountsFixtures.user_fixture()
       project = ProjectsFixtures.project_fixture(account_id: other_user.account.id)
-      alert_rule = AlertsFixtures.alert_rule_fixture(project: project)
+      alert_rule = AlertsFixtures.alert_rule_fixture(project: project, slack_webhook_url: nil)
 
-      # No slack installation for this account, so early return before evaluate is called
       reject(&Alerts.evaluate/1)
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
-      # When
       result = AlertWorker.perform(%Oban.Job{args: %{"alert_rule_id" => alert_rule.id}})
 
-      # Then
       assert result == :ok
     end
   end

--- a/server/test/tuist/automations/actions/send_slack_action_test.exs
+++ b/server/test/tuist/automations/actions/send_slack_action_test.exs
@@ -5,15 +5,12 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
   alias Tuist.Automations.Actions.SendSlackAction
   alias Tuist.Projects
   alias Tuist.Slack.Client
-  alias Tuist.Slack.Installation
   alias Tuist.Tests
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
-  alias TuistTestSupport.Fixtures.SlackFixtures
 
   defp setup_project(_) do
     %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
-    SlackFixtures.slack_installation_fixture(account_id: account.id)
     project = ProjectsFixtures.project_fixture(account_id: account.id)
     %{project: project, account: account}
   end
@@ -31,15 +28,15 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
   end
 
   describe "execute/3" do
-    test "posts a message with interpolated variables to the configured channel", %{project: project} do
+    test "posts a message with interpolated variables to the configured webhook", %{project: project} do
       automation = %{name: "Quarantine", project_id: project.id}
       tc = test_case(project.id)
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:ok, tc} end)
 
-      expect(Client, :post_message, fn access_token, channel, blocks ->
-        assert is_binary(access_token)
-        assert channel == "C123"
+      expect(Client, :post_to_webhook, fn webhook_url, blocks ->
+        assert webhook_url == "https://hooks.slack.com/services/T0/B0/abc"
+
         # The header block should contain the automation name.
         assert Enum.any?(blocks, fn block ->
                  get_in(block, [:text, :text]) == ":robot_face: Quarantine"
@@ -62,6 +59,8 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
       action = %{
         "type" => "send_slack",
         "channel" => "C123",
+        "channel_name" => "general",
+        "webhook_url" => "https://hooks.slack.com/services/T0/B0/abc",
         "message" => "Test {{test_case.name}} in {{test_case.module_name}} matched {{automation.name}}"
       }
 
@@ -77,50 +76,53 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
 
       expect(Projects, :get_project_by_id, fn _id -> nil end)
 
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: Ecto.UUID.generate()},
-                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
+                 %{
+                   "type" => "send_slack",
+                   "channel" => "C1",
+                   "webhook_url" => "https://hooks.slack.com/services/T/B/x",
+                   "message" => "hi"
+                 }
                )
     end
 
-    test "no-ops when the project has no Slack installation" do
-      project = ProjectsFixtures.project_fixture()
+    test "no-ops when the action has no webhook URL", %{project: project} do
       automation = %{id: Ecto.UUID.generate(), name: "Auto", project_id: project.id}
       tc = test_case(project.id)
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:ok, tc} end)
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: tc.id},
-                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
+                 %{"type" => "send_slack", "channel" => "C1", "webhook_url" => "", "message" => "hi"}
                )
     end
 
     test "no-ops when the test case is not found" do
-      _project = %{}
       automation = %{id: Ecto.UUID.generate(), name: "Auto", project_id: 1}
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:error, :not_found} end)
-      reject(&Client.post_message/3)
+      reject(&Client.post_to_webhook/2)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: Ecto.UUID.generate()},
-                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
+                 %{
+                   "type" => "send_slack",
+                   "channel" => "C1",
+                   "webhook_url" => "https://hooks.slack.com/services/T/B/x",
+                   "message" => "hi"
+                 }
                )
-    end
-
-    # Suppress unused alias warnings when the helpers above don't reference all aliases in every test.
-    test "Installation alias is referenced", _ctx do
-      assert Installation.__schema__(:source) == "slack_installations"
     end
   end
 end

--- a/server/test/tuist/automations/actions/send_slack_action_test.exs
+++ b/server/test/tuist/automations/actions/send_slack_action_test.exs
@@ -4,10 +4,12 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
 
   alias Tuist.Automations.Actions.SendSlackAction
   alias Tuist.Projects
+  alias Tuist.Slack
   alias Tuist.Slack.Client
   alias Tuist.Tests
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
+  alias TuistTestSupport.Fixtures.SlackFixtures
 
   defp setup_project(_) do
     %{account: account} = AccountsFixtures.user_fixture(preload: [:account])
@@ -28,14 +30,16 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
   end
 
   describe "execute/3" do
-    test "posts a message with interpolated variables to the configured webhook", %{project: project} do
+    test "decrypts the webhook URL and posts the message to it", %{project: project} do
       automation = %{name: "Quarantine", project_id: project.id}
       tc = test_case(project.id)
+      webhook_url = "https://hooks.slack.com/services/T0/B0/abc"
+      {:ok, encrypted} = Slack.encrypt_webhook_url(webhook_url)
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:ok, tc} end)
 
-      expect(Client, :post_to_webhook, fn webhook_url, blocks ->
-        assert webhook_url == "https://hooks.slack.com/services/T0/B0/abc"
+      expect(Client, :post_to_webhook, fn url, blocks ->
+        assert url == webhook_url
 
         # The header block should contain the automation name.
         assert Enum.any?(blocks, fn block ->
@@ -60,8 +64,33 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
         "type" => "send_slack",
         "channel" => "C123",
         "channel_name" => "general",
-        "webhook_url" => "https://hooks.slack.com/services/T0/B0/abc",
+        "webhook_url_encrypted" => encrypted,
         "message" => "Test {{test_case.name}} in {{test_case.module_name}} matched {{automation.name}}"
+      }
+
+      assert :ok = SendSlackAction.execute(automation, %{type: :test_case, id: tc.id}, action)
+    end
+
+    test "falls back to chat.postMessage with the legacy bot token when no encrypted URL is set",
+         %{project: project, account: account} do
+      installation = SlackFixtures.slack_installation_fixture(account_id: account.id)
+      automation = %{name: "Auto", project_id: project.id}
+      tc = test_case(project.id)
+
+      expect(Tests, :get_test_case_by_id, fn _id -> {:ok, tc} end)
+      reject(&Client.post_to_webhook/2)
+
+      expect(Client, :post_message, fn token, channel, _blocks ->
+        assert token == installation.access_token
+        assert channel == "C-LEGACY"
+        :ok
+      end)
+
+      action = %{
+        "type" => "send_slack",
+        "channel" => "C-LEGACY",
+        "webhook_url_encrypted" => "",
+        "message" => "hi"
       }
 
       assert :ok = SendSlackAction.execute(automation, %{type: :test_case, id: tc.id}, action)
@@ -77,32 +106,34 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
       expect(Projects, :get_project_by_id, fn _id -> nil end)
 
       reject(&Client.post_to_webhook/2)
+      reject(&Client.post_message/3)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: Ecto.UUID.generate()},
-                 %{
-                   "type" => "send_slack",
-                   "channel" => "C1",
-                   "webhook_url" => "https://hooks.slack.com/services/T/B/x",
-                   "message" => "hi"
-                 }
+                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
                )
     end
 
-    test "no-ops when the action has no webhook URL", %{project: project} do
+    test "no-ops when the encrypted URL fails to decrypt", %{project: project} do
       automation = %{id: Ecto.UUID.generate(), name: "Auto", project_id: project.id}
       tc = test_case(project.id)
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:ok, tc} end)
       reject(&Client.post_to_webhook/2)
+      reject(&Client.post_message/3)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: tc.id},
-                 %{"type" => "send_slack", "channel" => "C1", "webhook_url" => "", "message" => "hi"}
+                 %{
+                   "type" => "send_slack",
+                   "channel" => "C1",
+                   "webhook_url_encrypted" => "not-real-ciphertext",
+                   "message" => "hi"
+                 }
                )
     end
 
@@ -111,17 +142,13 @@ defmodule Tuist.Automations.Actions.SendSlackActionTest do
 
       expect(Tests, :get_test_case_by_id, fn _id -> {:error, :not_found} end)
       reject(&Client.post_to_webhook/2)
+      reject(&Client.post_message/3)
 
       assert :ok =
                SendSlackAction.execute(
                  automation,
                  %{type: :test_case, id: Ecto.UUID.generate()},
-                 %{
-                   "type" => "send_slack",
-                   "channel" => "C1",
-                   "webhook_url" => "https://hooks.slack.com/services/T/B/x",
-                   "message" => "hi"
-                 }
+                 %{"type" => "send_slack", "channel" => "C1", "message" => "hi"}
                )
     end
   end

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -105,44 +105,31 @@ defmodule Tuist.Slack.ClientTest do
       assert token_data.access_token == "xoxb-test-token"
       assert token_data.incoming_webhook.channel == "#general"
       assert token_data.incoming_webhook.channel_id == "C123456"
+      assert token_data.incoming_webhook.url == "https://hooks.slack.com/services/xxx"
     end
   end
 
-  describe "post_message/3" do
+  describe "post_to_webhook/2" do
     test "returns :ok on successful post" do
       stub(Req, :post, fn _url, _opts ->
-        {:ok,
-         %Req.Response{
-           status: 200,
-           body: %{"ok" => true}
-         }}
+        {:ok, %Req.Response{status: 200, body: "ok"}}
       end)
 
-      result = Client.post_message("xoxb-token", "C123", [%{type: "section", text: "Hello"}])
+      result =
+        Client.post_to_webhook(
+          "https://hooks.slack.com/services/T0/B0/abcd",
+          [%{type: "section", text: "Hello"}]
+        )
 
       assert :ok = result
     end
 
-    test "returns error when Slack API returns error" do
-      stub(Req, :post, fn _url, _opts ->
-        {:ok,
-         %Req.Response{
-           status: 200,
-           body: %{"ok" => false, "error" => "channel_not_found"}
-         }}
-      end)
-
-      result = Client.post_message("xoxb-token", "invalid-channel", [])
-
-      assert {:error, "channel_not_found"} = result
-    end
-
     test "returns error on unexpected status code" do
       stub(Req, :post, fn _url, _opts ->
-        {:ok, %Req.Response{status: 500, body: %{}}}
+        {:ok, %Req.Response{status: 500, body: "boom"}}
       end)
 
-      result = Client.post_message("xoxb-token", "C123", [])
+      result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
 
       assert {:error, message} = result
       assert message =~ "Unexpected status code: 500"
@@ -153,7 +140,7 @@ defmodule Tuist.Slack.ClientTest do
         {:error, %Req.TransportError{reason: :timeout}}
       end)
 
-      result = Client.post_message("xoxb-token", "C123", [])
+      result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
 
       assert {:error, message} = result
       assert message =~ "Request failed"

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -124,7 +124,16 @@ defmodule Tuist.Slack.ClientTest do
       assert :ok = result
     end
 
-    test "returns error on unexpected status code" do
+    test "returns :webhook_revoked on 404 (permanent failure)" do
+      stub(Req, :post, fn _url, _opts ->
+        {:ok, %Req.Response{status: 404, body: "no_service"}}
+      end)
+
+      assert {:error, :webhook_revoked} =
+               Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
+    end
+
+    test "returns error on unexpected status code (transient)" do
       stub(Req, :post, fn _url, _opts ->
         {:ok, %Req.Response{status: 500, body: "boom"}}
       end)

--- a/server/test/tuist/slack_test.exs
+++ b/server/test/tuist/slack_test.exs
@@ -11,6 +11,66 @@ defmodule Tuist.SlackTest do
   alias TuistTestSupport.Fixtures.ProjectsFixtures
   alias TuistTestSupport.Fixtures.SlackFixtures
 
+  describe "slack_webhook_url?/1" do
+    test "accepts canonical Slack webhook URLs" do
+      assert Slack.slack_webhook_url?("https://hooks.slack.com/services/T0/B0/abc")
+    end
+
+    test "rejects URLs from other hosts" do
+      refute Slack.slack_webhook_url?("https://attacker.example.com/hook")
+      refute Slack.slack_webhook_url?("http://hooks.slack.com/services/T0/B0/abc")
+      refute Slack.slack_webhook_url?(nil)
+      refute Slack.slack_webhook_url?(42)
+    end
+  end
+
+  describe "channel-result token signing" do
+    test "round-trips through sign + verify" do
+      payload = %{
+        channel_id: "C123",
+        channel_name: "general",
+        webhook_url: "https://hooks.slack.com/services/T0/B0/abc"
+      }
+
+      assert {:ok, token} = Slack.sign_channel_result(payload)
+      assert {:ok, ^payload} = Slack.verify_channel_result(token)
+    end
+
+    test "refuses to sign a non-Slack URL" do
+      assert {:error, :invalid_webhook_url} =
+               Slack.sign_channel_result(%{
+                 channel_id: "C1",
+                 channel_name: "general",
+                 webhook_url: "https://attacker.example.com/hook"
+               })
+    end
+
+    test "verify rejects garbage tokens" do
+      assert {:error, _} = Slack.verify_channel_result("not-a-real-token")
+      assert {:error, _} = Slack.verify_channel_result(nil)
+    end
+  end
+
+  describe "encrypt_webhook_url/1 + decrypt_webhook_url/1" do
+    test "round-trips a Slack webhook URL" do
+      url = "https://hooks.slack.com/services/T0/B0/secret"
+
+      assert {:ok, encoded} = Slack.encrypt_webhook_url(url)
+      refute encoded =~ "hooks.slack.com"
+      assert {:ok, ^url} = Slack.decrypt_webhook_url(encoded)
+    end
+
+    test "encrypt refuses non-Slack URLs" do
+      assert {:error, :invalid_webhook_url} =
+               Slack.encrypt_webhook_url("https://attacker.example.com/hook")
+    end
+
+    test "decrypt fails cleanly on garbage" do
+      assert {:error, :invalid_webhook_url} = Slack.decrypt_webhook_url("not-base64!")
+      assert {:error, :invalid_webhook_url} = Slack.decrypt_webhook_url(nil)
+    end
+  end
+
   describe "send_message/2" do
     setup do
       stub(Environment, :prod?, fn -> true end)
@@ -150,8 +210,8 @@ defmodule Tuist.SlackTest do
       assert updated_project.slack_channel_name == nil
     end
 
-    test "clears slack fields from alert rules when deleting installation" do
-      # Given
+    test "clears slack fields on legacy alert rules (no webhook URL stored)" do
+      # Given - alert rule that still relies on the bot-token fallback
       user = AccountsFixtures.user_fixture()
       installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
       project = ProjectsFixtures.project_fixture(account_id: user.account.id)
@@ -160,7 +220,8 @@ defmodule Tuist.SlackTest do
         AlertsFixtures.alert_rule_fixture(
           project: project,
           slack_channel_id: "C12345",
-          slack_channel_name: "alerts-channel"
+          slack_channel_name: "alerts-channel",
+          slack_webhook_url: nil
         )
 
       # When
@@ -170,6 +231,31 @@ defmodule Tuist.SlackTest do
       {:ok, updated_alert_rule} = Tuist.Alerts.get_alert_rule(alert_rule.id)
       assert updated_alert_rule.slack_channel_id == nil
       assert updated_alert_rule.slack_channel_name == nil
+    end
+
+    test "preserves alert rules that already migrated to a per-channel webhook" do
+      # Given - alert rule already has its own webhook URL, so deleting the
+      # legacy account-level installation must NOT disable it.
+      user = AccountsFixtures.user_fixture()
+      installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          slack_channel_id: "C99999",
+          slack_channel_name: "ops-alerts",
+          slack_webhook_url: "https://hooks.slack.com/services/T0/B0/migrated"
+        )
+
+      # When
+      {:ok, _} = Slack.delete_installation(installation)
+
+      # Then
+      {:ok, updated_alert_rule} = Tuist.Alerts.get_alert_rule(alert_rule.id)
+      assert updated_alert_rule.slack_channel_id == "C99999"
+      assert updated_alert_rule.slack_channel_name == "ops-alerts"
+      assert updated_alert_rule.slack_webhook_url == "https://hooks.slack.com/services/T0/B0/migrated"
     end
   end
 

--- a/server/test/tuist/slack_test.exs
+++ b/server/test/tuist/slack_test.exs
@@ -272,7 +272,6 @@ defmodule Tuist.SlackTest do
     test "sends alert notification to Slack" do
       # Given
       user = AccountsFixtures.user_fixture()
-      installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
       project = ProjectsFixtures.project_fixture(account_id: user.account.id)
 
       alert_rule =
@@ -281,7 +280,8 @@ defmodule Tuist.SlackTest do
           category: :build_run_duration,
           metric: :p90,
           slack_channel_id: "C12345",
-          slack_channel_name: "alerts"
+          slack_channel_name: "alerts",
+          slack_webhook_url: "https://hooks.slack.com/services/T0/B0/abc"
         )
 
       alert =
@@ -291,9 +291,8 @@ defmodule Tuist.SlackTest do
           previous_value: 1000.0
         )
 
-      expect(Client, :post_message, fn token, channel_id, blocks ->
-        assert token == installation.access_token
-        assert channel_id == "C12345"
+      expect(Client, :post_to_webhook, fn webhook_url, blocks ->
+        assert webhook_url == "https://hooks.slack.com/services/T0/B0/abc"
         assert is_list(blocks)
         assert length(blocks) == 5
         :ok
@@ -329,7 +328,7 @@ defmodule Tuist.SlackTest do
           previous_value: 1000.0
         )
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         header_block = Enum.at(blocks, 0)
         assert header_block.text.text =~ "Alert: MyApp Build Time p90 Increased"
 
@@ -365,7 +364,7 @@ defmodule Tuist.SlackTest do
           previous_value: 2000.0
         )
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         header_block = Enum.at(blocks, 0)
         assert header_block.text.text =~ "Alert: UITests Test Time Average Increased"
 
@@ -401,7 +400,7 @@ defmodule Tuist.SlackTest do
           previous_value: 1_000_000.0
         )
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         metric_block = Enum.at(blocks, 3)
         assert metric_block.text.text =~ "MyApp bundle"
         :ok
@@ -433,7 +432,7 @@ defmodule Tuist.SlackTest do
           previous_value: 1000.0
         )
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         metric_block = Enum.at(blocks, 3)
         assert metric_block.text.text =~ "*Build time"
         :ok
@@ -462,7 +461,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/builds|View builds"
@@ -494,7 +493,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/builds?analytics-build-scheme=MyApp|View builds"
@@ -524,7 +523,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/tests|View tests"
@@ -556,7 +555,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/tests?analytics-test-scheme=UITests|View tests"
@@ -586,7 +585,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/xcode-cache"
@@ -617,7 +616,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/bundles|View bundles"
@@ -649,7 +648,7 @@ defmodule Tuist.SlackTest do
 
       alert = AlertsFixtures.alert_fixture(alert_rule: alert_rule)
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         footer_block = Enum.at(blocks, 4)
         footer_text = hd(footer_block.elements).text
         assert footer_text =~ "/bundles?bundle-size-app=MyApp|View bundles"
@@ -665,14 +664,15 @@ defmodule Tuist.SlackTest do
     test "sends flaky test alert notification to Slack" do
       # Given
       user = AccountsFixtures.user_fixture()
-      installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
+      _installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
 
       {:ok, project} =
         [account_id: user.account.id]
         |> ProjectsFixtures.project_fixture()
         |> Projects.update_project(%{
           flaky_test_alerts_slack_channel_id: "C12345",
-          flaky_test_alerts_slack_channel_name: "flaky-alerts"
+          flaky_test_alerts_slack_channel_name: "flaky-alerts",
+          flaky_test_alerts_slack_webhook_url: "https://hooks.slack.com/services/T0/B0/flaky"
         })
 
       test_case = %{
@@ -682,9 +682,8 @@ defmodule Tuist.SlackTest do
         suite_name: "TestSuite"
       }
 
-      expect(Client, :post_message, fn token, channel_id, blocks ->
-        assert token == installation.access_token
-        assert channel_id == "C12345"
+      expect(Client, :post_to_webhook, fn webhook_url, blocks ->
+        assert webhook_url == "https://hooks.slack.com/services/T0/B0/flaky"
         assert is_list(blocks)
         assert length(blocks) == 5
 
@@ -719,7 +718,8 @@ defmodule Tuist.SlackTest do
         |> ProjectsFixtures.project_fixture()
         |> Projects.update_project(%{
           flaky_test_alerts_slack_channel_id: "C12345",
-          flaky_test_alerts_slack_channel_name: "flaky-alerts"
+          flaky_test_alerts_slack_channel_name: "flaky-alerts",
+          flaky_test_alerts_slack_webhook_url: "https://hooks.slack.com/services/T0/B0/flaky"
         })
 
       test_case = %{
@@ -729,7 +729,7 @@ defmodule Tuist.SlackTest do
         suite_name: nil
       }
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         metric_block = Enum.at(blocks, 4)
         assert metric_block.text.text =~ "1 flaky run"
         refute metric_block.text.text =~ "1 flaky runs"
@@ -753,7 +753,8 @@ defmodule Tuist.SlackTest do
         |> ProjectsFixtures.project_fixture()
         |> Projects.update_project(%{
           flaky_test_alerts_slack_channel_id: "C12345",
-          flaky_test_alerts_slack_channel_name: "flaky-alerts"
+          flaky_test_alerts_slack_channel_name: "flaky-alerts",
+          flaky_test_alerts_slack_webhook_url: "https://hooks.slack.com/services/T0/B0/flaky"
         })
 
       test_case = %{
@@ -763,7 +764,7 @@ defmodule Tuist.SlackTest do
         suite_name: nil
       }
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         test_case_block = Enum.at(blocks, 3)
         refute test_case_block.text.text =~ "Suite:"
         :ok
@@ -786,7 +787,8 @@ defmodule Tuist.SlackTest do
         |> ProjectsFixtures.project_fixture()
         |> Projects.update_project(%{
           flaky_test_alerts_slack_channel_id: "C12345",
-          flaky_test_alerts_slack_channel_name: "flaky-alerts"
+          flaky_test_alerts_slack_channel_name: "flaky-alerts",
+          flaky_test_alerts_slack_webhook_url: "https://hooks.slack.com/services/T0/B0/flaky"
         })
 
       test_case = %{
@@ -796,7 +798,7 @@ defmodule Tuist.SlackTest do
         suite_name: nil
       }
 
-      expect(Client, :post_message, fn _token, _channel_id, blocks ->
+      expect(Client, :post_to_webhook, fn _webhook_url, blocks ->
         # Should have 6 blocks when auto-quarantined (extra info block)
         assert length(blocks) == 6
         quarantine_block = Enum.at(blocks, 5)

--- a/server/test/tuist/slack_test.exs
+++ b/server/test/tuist/slack_test.exs
@@ -305,6 +305,43 @@ defmodule Tuist.SlackTest do
       assert result == :ok
     end
 
+    test "falls back to chat.postMessage with the legacy bot token when no webhook URL is set" do
+      # Given - simulates a destination configured before the webhook flow
+      # was introduced: only the account-level bot token + channel id exist.
+      user = AccountsFixtures.user_fixture()
+      installation = SlackFixtures.slack_installation_fixture(account_id: user.account.id)
+      project = ProjectsFixtures.project_fixture(account_id: user.account.id)
+
+      alert_rule =
+        AlertsFixtures.alert_rule_fixture(
+          project: project,
+          category: :build_run_duration,
+          metric: :p90,
+          slack_channel_id: "C12345",
+          slack_channel_name: "alerts",
+          slack_webhook_url: nil
+        )
+
+      alert =
+        AlertsFixtures.alert_fixture(
+          alert_rule: alert_rule,
+          current_value: 1200.0,
+          previous_value: 1000.0
+        )
+
+      reject(&Client.post_to_webhook/2)
+
+      expect(Client, :post_message, fn token, channel_id, blocks ->
+        assert token == installation.access_token
+        assert channel_id == "C12345"
+        assert is_list(blocks)
+        :ok
+      end)
+
+      # When/Then
+      assert Slack.send_alert(alert) == :ok
+    end
+
     test "includes scheme in build_run_duration title and message" do
       # Given
       user = AccountsFixtures.user_fixture()

--- a/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
+++ b/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
@@ -49,7 +49,7 @@ defmodule TuistWeb.SlackOAuthControllerTest do
       end
     end
 
-    test "renders popup_close template on successful channel selection", %{conn: conn} do
+    test "renders popup_close template with a signed channel token", %{conn: conn} do
       # Given
       project_id = "00000000-0000-0000-0000-000000000001"
       account_id = 1
@@ -75,9 +75,45 @@ defmodule TuistWeb.SlackOAuthControllerTest do
       conn = get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
 
       # Then
-      assert html_response(conn, 200) =~ "Channel connected successfully"
-      assert conn.resp_body =~ "C12345"
-      assert conn.resp_body =~ "general"
+      html = html_response(conn, 200)
+      assert html =~ "Channel connected successfully"
+      # Raw webhook URL must NOT appear in the popup HTML — only the signed token does
+      refute html =~ "hooks.slack.com"
+
+      [_, channel_token] = Regex.run(~r/data-channel-token="([^"]+)"/, html)
+
+      assert {:ok, %{channel_id: "C12345", channel_name: "general", webhook_url: webhook_url}} =
+               Slack.verify_channel_result(channel_token)
+
+      assert webhook_url == "https://hooks.slack.com/services/T12345/B12345/abcdef"
+    end
+
+    test "rejects an exchange that returns a non-Slack webhook URL", %{conn: conn} do
+      # Given
+      project_id = "00000000-0000-0000-0000-000000000001"
+      account_id = 1
+      state_token = Slack.generate_channel_selection_token(project_id, account_id)
+
+      token_data = %{
+        access_token: "xoxb-test-token",
+        team_id: "T12345",
+        team_name: "Test Workspace",
+        bot_user_id: "U12345",
+        incoming_webhook: %{
+          channel: "#general",
+          channel_id: "C12345",
+          url: "https://attacker.example.com/hook"
+        }
+      }
+
+      stub(SlackClient, :exchange_code_for_token, fn _code, _redirect_uri ->
+        {:ok, token_data}
+      end)
+
+      # When/Then
+      assert_raise BadRequestError, ~r/unexpected webhook URL/i, fn ->
+        get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
+      end
     end
   end
 

--- a/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
+++ b/server/test/tuist_web/controllers/slack_oauth_controller_test.exs
@@ -2,43 +2,12 @@ defmodule TuistWeb.SlackOAuthControllerTest do
   use TuistTestSupport.Cases.ConnCase, async: true
   use Mimic
 
-  alias Tuist.Accounts
   alias Tuist.Environment
   alias Tuist.Slack
   alias Tuist.Slack.Client, as: SlackClient
-  alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistWeb.Errors.BadRequestError
 
   describe "GET /integrations/slack/callback" do
-    test "redirects to integrations page on successful OAuth flow", %{conn: conn} do
-      # Given
-      user = AccountsFixtures.user_fixture()
-      account = user.account
-      state_token = Slack.generate_state_token(account.id)
-
-      token_data = %{
-        access_token: "xoxb-test-token",
-        team_id: "T12345",
-        team_name: "Test Workspace",
-        bot_user_id: "U12345"
-      }
-
-      stub(SlackClient, :exchange_code_for_token, fn _code, _redirect_uri ->
-        {:ok, token_data}
-      end)
-
-      # When
-      conn = get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
-
-      # Then
-      assert redirected_to(conn) == "/#{account.name}/integrations"
-
-      {:ok, updated_account} = Accounts.get_account_by_id(account.id, preload: [:slack_installation])
-      assert updated_account.slack_installation.team_id == "T12345"
-      assert updated_account.slack_installation.team_name == "Test Workspace"
-      assert updated_account.slack_installation.bot_user_id == "U12345"
-    end
-
     test "raises BadRequestError when state token is invalid", %{conn: conn} do
       # Given
       invalid_state_token = "invalid_token"
@@ -56,60 +25,6 @@ defmodule TuistWeb.SlackOAuthControllerTest do
       # When/Then
       assert_raise BadRequestError, ~r/Authorization request expired/, fn ->
         get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => "expired_token"})
-      end
-    end
-
-    test "raises BadRequestError when account is not found", %{conn: conn} do
-      # Given
-      non_existent_account_id = 999_999_999
-      state_token = Slack.generate_state_token(non_existent_account_id)
-
-      # When/Then
-      assert_raise BadRequestError, ~r/Account not found/, fn ->
-        get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
-      end
-    end
-
-    test "raises BadRequestError when Slack returns an error", %{conn: conn} do
-      # Given
-      user = AccountsFixtures.user_fixture()
-      account = user.account
-      state_token = Slack.generate_state_token(account.id)
-
-      stub(SlackClient, :exchange_code_for_token, fn _code, _redirect_uri ->
-        {:error, "invalid_code"}
-      end)
-
-      # When/Then
-      assert_raise BadRequestError, ~r/Slack authorization failed: invalid_code/, fn ->
-        get(conn, "/integrations/slack/callback", %{"code" => "invalid_code", "state" => state_token})
-      end
-    end
-
-    test "raises BadRequestError when installation fails to save", %{conn: conn} do
-      # Given
-      user = AccountsFixtures.user_fixture()
-      account = user.account
-      state_token = Slack.generate_state_token(account.id)
-
-      token_data = %{
-        access_token: "xoxb-test-token",
-        team_id: "T12345",
-        team_name: "Test Workspace",
-        bot_user_id: "U12345"
-      }
-
-      stub(SlackClient, :exchange_code_for_token, fn _code, _redirect_uri ->
-        {:ok, token_data}
-      end)
-
-      stub(Slack, :create_installation, fn _attrs ->
-        {:error, %Ecto.Changeset{}}
-      end)
-
-      # When/Then
-      assert_raise BadRequestError, ~r/Failed to save Slack installation/, fn ->
-        get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
       end
     end
 
@@ -133,28 +48,36 @@ defmodule TuistWeb.SlackOAuthControllerTest do
         get(conn, "/integrations/slack/callback", %{"code" => "", "state" => "some_state"})
       end
     end
-  end
 
-  describe "install_url/1" do
-    test "generates correct Slack OAuth URL" do
+    test "renders popup_close template on successful channel selection", %{conn: conn} do
       # Given
-      user = AccountsFixtures.user_fixture()
-      account = user.account
+      project_id = "00000000-0000-0000-0000-000000000001"
+      account_id = 1
+      state_token = Slack.generate_channel_selection_token(project_id, account_id)
 
-      stub(Environment, :slack_client_id, fn -> "test_client_id" end)
-      stub(Environment, :app_url, fn opts -> "https://app.tuist.dev" <> Keyword.get(opts, :path, "") end)
+      token_data = %{
+        access_token: "xoxb-test-token",
+        team_id: "T12345",
+        team_name: "Test Workspace",
+        bot_user_id: "U12345",
+        incoming_webhook: %{
+          channel: "#general",
+          channel_id: "C12345",
+          url: "https://hooks.slack.com/services/T12345/B12345/abcdef"
+        }
+      }
+
+      stub(SlackClient, :exchange_code_for_token, fn _code, _redirect_uri ->
+        {:ok, token_data}
+      end)
 
       # When
-      url = TuistWeb.SlackOAuthController.install_url(account.id)
+      conn = get(conn, "/integrations/slack/callback", %{"code" => "valid_code", "state" => state_token})
 
       # Then
-      assert url =~ "https://slack.com/oauth/v2/authorize?"
-      assert url =~ "client_id=test_client_id"
-      assert url =~ "scope=chat%3Awrite%2Cchat%3Awrite.public"
-      refute url =~ "channels%3Aread"
-      refute url =~ "groups%3Aread"
-      assert url =~ "redirect_uri=https%3A%2F%2Fapp.tuist.dev%2Fintegrations%2Fslack%2Fcallback"
-      assert url =~ "state="
+      assert html_response(conn, 200) =~ "Channel connected successfully"
+      assert conn.resp_body =~ "C12345"
+      assert conn.resp_body =~ "general"
     end
   end
 

--- a/server/test/tuist_web/live/project_notifications_live_test.exs
+++ b/server/test/tuist_web/live/project_notifications_live_test.exs
@@ -138,10 +138,14 @@ defmodule TuistWeb.ProjectNotificationsLiveTest do
       # When: user selects CI environment, sets a channel, then creates the alert rule
       render_hook(lv, "update_create_alert_form_environment", %{"environment" => "ci"})
 
-      render_hook(lv, "create_alert_form_channel_selected", %{
-        "channel_id" => "C123456",
-        "channel_name" => "test-channel"
-      })
+      {:ok, channel_token} =
+        Tuist.Slack.sign_channel_result(%{
+          channel_id: "C123456",
+          channel_name: "test-channel",
+          webhook_url: "https://hooks.slack.com/services/T0/B0/abc"
+        })
+
+      render_hook(lv, "create_alert_form_channel_selected", %{"channel_token" => channel_token})
 
       render_hook(lv, "create_alert_rule", %{})
 


### PR DESCRIPTION
### Summary

Addresses the feedback from the Slack Marketplace review of the Tuist app for Slack — without breaking existing customers' notifications.

- **Privacy policy** now explicitly describes how to request access, deletion, and portability of personal data, with a 30-day SLA and a link to `server/data-export.md` for the data categories covered.
- **Slack docs landing page** is rewritten to describe the actual per-channel `incoming-webhook` flow. The redundant "Connect your Slack workspace" and on-prem "Create a Slack app" sections are removed, and all references to "Slack integration" / "Slack app" are reworded to "integration for Slack" / "app for Slack". Pricing and privacy links are added.
- **OAuth scopes**: Tuist no longer requests `chat:write` or `chat:write.public` in any new flow. The account-level "Connect Slack" install flow is removed from the Integrations tab; every channel selection (project report, alert rule, flaky test alert, automation action) goes through its own `incoming-webhook` OAuth and stores the returned webhook URL. Existing tokens already issued with `chat:write` scopes keep their granted scopes on Slack's side, so they continue to function until the user re-selects the channel.
- **Posting (dual-path, seamless migration)**: a new `Tuist.Slack.Client.post_to_webhook/2` POSTs Block Kit JSON to the per-channel webhook URL. The existing `post_message/3` (chat.postMessage with the bot token) is kept as a fallback. `Slack.send_alert/1`, `Slack.send_flaky_test_alert/4`, the report worker, the alert worker, the `SendSlackAction` automation, and the "send test message" button in the notifications LiveView all prefer the webhook URL and fall back to the bot token when the URL isn't stored yet. Each destination upgrades to the webhook path the next time the user re-selects its channel.
- **Schema**: a new migration adds encrypted `slack_webhook_url` columns to `projects` (project + flaky) and `alert_rules`, using `Tuist.Vault.Binary`. The legacy `slack_installations` table is left in place to keep the bot-token fallback working until customers have organically migrated.
- **LiveViews**: gating switched from `slack_installation` to `slack_configured?` / `slack_channel_id`. The popup-close template, `SelectSlackChannelPopup` JS hook, and corresponding event handlers in the notifications + automations LiveViews now plumb `webhook_url` through.

### Slack app configuration (applied at api.slack.com)

Done outside this PR but tracked here for the reviewer. Only the `incoming-webhook` bot scope is now requested; `chat:write` and `chat:write.public` are removed.

```json
{
    "display_information": {
        "name": "Tuist",
        "description": "Get regular updates and alerts for your Tuist projects",
        "background_color": "#6f2cff",
        "long_description": "The Tuist app for Slack lets you get regular updates and alerts for your Tuist projects.\r\n\r\nAlerts delivered in Slack let you know when your projects regress, such as when build time for the last 100 builds is now 20% longer than for the previous baseline.\r\n\r\nReports delivered in Slack give you a daily analytics summary of your Tuist project, right in a channel of your choice.\r\n\r\nThe integration is free for every Tuist account. For pricing of the underlying Tuist service, see https://tuist.dev/pricing."
    },
    "features": {
        "bot_user": { "display_name": "Tuist", "always_online": false }
    },
    "oauth_config": {
        "redirect_urls": ["https://tuist.dev/integrations/slack/callback"],
        "scopes": { "bot": ["incoming-webhook"] },
        "pkce_enabled": false
    },
    "settings": {
        "org_deploy_enabled": false,
        "socket_mode_enabled": false,
        "token_rotation_enabled": false,
        "is_mcp_enabled": false
    }
}
```

The privacy policy URL (`https://tuist.dev/privacy`) is set on the **Basic Information** page of the Slack app dashboard, not via the manifest — `display_information` does not accept a `privacy_policy_url` key.

Justification recorded for the `incoming-webhook` scope review:

> Tuist uses the `incoming-webhook` scope to deliver Tuist project notifications into a channel the customer explicitly picks during install. After authorization, Tuist posts daily build/test/cache analytics summaries, metric-regression alerts, flaky-test alerts, and automation outcomes to the selected channel via the webhook URL Slack returns at install time. Each install scopes Tuist to the single channel the user chose; Tuist never reads any data from the workspace.

### Migration story for existing customers

Production usage of Slack at the time of writing (count of distinct accounts):

| Slack feature | Accounts |
|---|---|
| Workspace-level installation | 33 |
| Project report destinations | 15 |
| Flaky-test alert destinations | 6 |
| Alert-rule destinations | 5 |

Pre-PR every destination is on the legacy `chat.postMessage` + bot token path; the channel-selection OAuth flow already used `incoming-webhook` scope but discarded the URL Slack returned, so `slack_webhook_url` is `NULL` for 100% of existing destinations.

Per-destination behavior across the deploy:

| Destination state | Before this PR | After this PR |
|---|---|---|
| Bot token + channel id (every existing destination) | Posts via `chat.postMessage` | Falls back to `chat.postMessage` — keeps working unchanged |
| Bot token + channel id, user re-selects channel | Same as above | OAuth re-runs with `incoming-webhook` only; webhook URL captured; future posts go through the webhook |
| Brand-new channel selection | n/a | OAuth runs with `incoming-webhook`; webhook URL captured; posts go through the webhook |

**No flag day.** Customers do not need to do anything to keep their notifications working; the upgrade happens organically the next time they edit a destination. Once the `incoming-webhook` scope passes Slack review, we can also reach out to the long tail of these ~30 accounts so they can re-OAuth proactively, after which the legacy `chat.postMessage` fallback can be removed in a follow-up PR.

### How to test locally

1. Run `mix ecto.migrate` to pick up the new `slack_webhook_url` columns.
2. `mise run dev` and visit `/<account>/integrations` — the Slack card is gone (account-level install is no longer needed).
3. Visit a project's `settings/notifications` and `settings/automations` — the channel-selection buttons are enabled when `Tuist.Environment.slack_configured?/0` is true and no longer require an account-level install. Selecting a channel writes the webhook URL through to the project / alert rule / action.
4. Existing destinations (with a `slack_installation.access_token` but no `slack_webhook_url`) continue to deliver via `chat.postMessage`.
5. `/en/docs/guides/integrations/slack` reflects the webhook-only flow with links to `/pricing` and `/privacy`.
6. Targeted tests:
   ```
   mix test test/tuist/slack_test.exs \
            test/tuist/slack/client_test.exs \
            test/tuist/slack/workers/report_worker_test.exs \
            test/tuist/automations/actions/send_slack_action_test.exs \
            test/tuist/alerts/workers/alert_worker_test.exs \
            test/tuist_web/controllers/slack_oauth_controller_test.exs
   ```
   → 67 pass, 0 failures. Includes a new `send_alert` test pinning the bot-token fallback when `slack_webhook_url` is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



