### PR TITLE
chore(helm): bump operator image to 0.1.0 (IP-wait decouple fix)

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -208,7 +208,7 @@ macosFleet:
     # release.yml has run for this scope, pin to a known-good
     # SHA-tagged build that the standalone
     # capi-provider-scaleway-applesilicon-image.yml workflow pushed.
-    tag: "97abdeb5"
+    tag: "0.1.0"
 
 # Everything below = external. The managed deployment never runs embedded
 # Postgres / ClickHouse / object storage / observability stacks.


### PR DESCRIPTION
## Summary

Manual bump because the auto-bump from #10657 never propagated.

- `release.yml` for [e97f2b41e7](https://github.com/tuist/tuist/commit/e97f2b41e7) failed on BSD sed in `release-xcresult-processor-image` (fixed in #10651), and the new run for [76e55837f1](https://github.com/tuist/tuist/commit/76e55837f1) still has `Release Noora` (Publish to hex.pm) and `Release iOS App` (Upload to App Store Connect) failing. `commit-and-release` requires every per-component release to be success-or-skip, so the auto-bump commit never runs.
- The per-job image push *did* succeed: `ghcr.io/tuist/capi-provider-scaleway-applesilicon:0.1.0` was built from e97f2b41e7 and is in ghcr.
- `values-managed-common.yaml` still pinned `97abdeb5` — the previous tart-kubelet attempt with the 8-min IP-wait. Canary's `helm upgrade --wait` was hanging because the old operator's tart-kubelet kept destroying the Mac mini VM after 8 min and re-cloning, exactly the loop the new fix breaks.

Cancelled the hung canary run [25488340200](https://github.com/tuist/tuist/actions/runs/25488340200) to free the `server-deploy-canary` concurrency lane.

Follow-ups (separate PRs):
- Fix `Release Noora` / `Release iOS App` so future auto-bumps actually fire.
- Consider gating `commit-and-release` per-component instead of an all-or-nothing aggregate so one failing release doesn't strand every other component's bump.

## Test plan

- [ ] On merge, `Server Production Deployment` runs canary with the new operator image; `xcresult-processor` Pod transitions Pending → Running once the Mac mini's guest IP shows up.
- [ ] Acceptance tests pass; production deploy promotes the same image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)