### PR TITLE
ci(server): stream cluster snapshots during helm upgrade

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -323,6 +323,23 @@ jobs:
         # fired, bounding the recovery window.
         timeout-minutes: 95
         run: |
+          # Stream cluster state every 30s while helm waits. helm
+          # --atomic --wait produces no stdout during the wait, so
+          # without this the action log shows nothing for up to 90 min.
+          # The watcher dies via trap when helm exits (either way).
+          (
+            while true; do
+              sleep 30
+              echo "::group::cluster snapshot $(date -u +%H:%M:%SZ)"
+              kubectl -n "$NAMESPACE" get pods -o wide 2>&1 | tail -40 || true
+              echo "--- recent events ---"
+              kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>&1 | tail -20 || true
+              echo "::endgroup::"
+            done
+          ) &
+          watcher_pid=$!
+          trap 'kill "$watcher_pid" 2>/dev/null || true; wait "$watcher_pid" 2>/dev/null || true' EXIT
+
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" --create-namespace \
             -f "$HELM_CHART_PATH/values-managed-common.yaml" \


### PR DESCRIPTION
> Surface live progress during the deploy step so operators don't stare at a blank action log for up to 90 minutes.

`helm upgrade --atomic --wait` is silent on stdout while it polls; the only visibility into an in-progress staging/canary/production deploy was post-mortem diagnostics on `failure()`. This adds a background watcher that prints a collapsible `cluster snapshot` group every 30s — current pod state + the 20 most recent events — and is killed via `trap … EXIT` when helm exits (pass or fail).

### How to test locally

This only takes effect on a real cluster, so the test is to dispatch the workflow:

1. Run **Server Deployment** via `workflow_dispatch` against `staging` (manual trigger from the Actions UI).
2. Watch the **helm upgrade --install** step in the run log — every ~30s a new `cluster snapshot <UTC time>` collapsible group should appear with `kubectl get pods` output and recent events.
3. Confirm the watcher disappears when helm finishes (no orphan output after the helm invocation returns).
4. Verify the diagnostics-on-failure step still runs cleanly if helm rolls back (e.g. by deploying a known-broken image tag).