### PR TITLE
fix(capi-scaleway): keep Aqua session alive for VZ HostKey creation

### DIFF
--- a/infra/macos-host-bootstrap/bootstrap.go
+++ b/infra/macos-host-bootstrap/bootstrap.go
@@ -134,6 +134,9 @@ func Run(ctx context.Context, cfg Config) (string, error) {
 	if err := enableAutoLogin(ctx, client, cfg.SSHUser, cfg.UserPassword); err != nil {
 		return hk.observed(), fmt.Errorf("auto-login: %w", err)
 	}
+	if err := disableIdleSleep(ctx, client); err != nil {
+		return hk.observed(), fmt.Errorf("disable idle sleep: %w", err)
+	}
 	if cfg.NodeName != "" {
 		if err := setHostname(ctx, client, cfg.NodeName); err != nil {
 			return hk.observed(), fmt.Errorf("set hostname: %w", err)
@@ -482,6 +485,49 @@ for i in $(seq 1 30); do
   sleep 1
 done
 `, user, encoded)
+	return runCommand(ctx, client, script)
+}
+
+// disableIdleSleep stops macOS from tearing the user's Aqua session
+// down out from under tart-kubelet. Apple's Virtualization framework
+// needs the auto-login user to hold a live console session at the
+// moment of `tart run`; if the host idle-sleeps, the screensaver
+// triggers an auto-logout, or display-sleep flushes WindowServer,
+// the session goes away and every subsequent VM start fails with
+// `VZErrorDomain Code=-9 / Failed to create new HostKey` until
+// something kicks loginwindow again. tart-kubelet has a runtime
+// preflight that re-establishes the session on demand, but
+// preventing the teardown in the first place avoids the sub-30s
+// reanimation latency on every cold-start Pod and keeps the kubelet
+// from spamming sudo against loginwindow under load.
+//
+// Settings applied:
+//   - `pmset -a sleep 0 displaysleep 0 disksleep 0`: disable host
+//     idle sleep + display blank-out + disk spindown. These are
+//     `-a` (all power sources) because Mac mini servers are AC-only
+//     but we don't trust the default profile selection.
+//   - `com.apple.screensaver idleTime 0`: disable the screensaver.
+//     Without this, even with `displaysleep 0`, the screensaver
+//     timer fires and (depending on host policy) can trigger
+//     auto-logout.
+//   - `com.apple.screensaver askForPassword 0`: don't lock the
+//     screen. Locking destroys the GUI/Aqua session in the same way
+//     a logout does on Tahoe.
+//   - `com.apple.autologout.AutoLogOutDelay 0`: disable auto-logout
+//     after inactivity. This is the policy Apple uses for managed
+//     fleets; off-by-default on consumer Macs but Scaleway-baked
+//     macOS images sometimes ship with it on.
+//
+// Idempotent: every call writes the same values regardless of prior
+// state. Failures here are fatal because there's no point shipping
+// a host that will silently fall over an hour after bootstrap.
+func disableIdleSleep(ctx context.Context, client *ssh.Client) error {
+	script := `set -euo pipefail
+sudo pmset -a sleep 0 displaysleep 0 disksleep 0
+sudo defaults write /Library/Preferences/com.apple.screensaver idleTime -int 0
+sudo defaults write /Library/Preferences/com.apple.screensaver askForPassword -int 0
+sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0
+`
 	return runCommand(ctx, client, script)
 }
 

--- a/infra/tart-kubelet/internal/tart/session.go
+++ b/infra/tart-kubelet/internal/tart/session.go
@@ -1,0 +1,92 @@
+package tart
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// EnsureRealGUISession is the default `Client.EnsureGUISession` hook.
+// It verifies the calling user has a live Aqua (loginwindow/GUI)
+// launchd session and, if not, kicks loginwindow to bring one up.
+//
+// Apple's Virtualization framework refuses to generate a fresh
+// HostKey for a macOS guest unless the calling user holds a console
+// session at the moment of `tart run` — otherwise the VM exits
+// immediately with `VZErrorDomain Code=-9 / Failed to create new
+// HostKey` and the Pod stalls in TartCreateFailed forever. The
+// bootstrap pass at provisioning time configures /etc/kcpassword +
+// autoLoginUser and SIGHUPs loginwindow once, but the Aqua session
+// can be torn down later (idle auto-logout, WindowServer crash,
+// manual logout) and we hit the same wall on every subsequent VM
+// start. Re-establishing the session before each Run makes the
+// kubelet self-healing on this exact failure.
+//
+// Idempotent: when Aqua is already up the call is a single
+// `launchctl print` and returns immediately. Otherwise it sudos a
+// SIGHUP at loginwindow and polls for up to 30s — loginwindow
+// usually respawns and creates the Aqua session in <2s. Loginwindow
+// is the only process restarted; running Tart VMs are unaffected
+// (they live in their own pgid and were detached via Setsid in
+// `Run`).
+//
+// Requires NOPASSWD sudo for the calling user, set up by the
+// bootstrap's `enablePasswordlessSudo`. Without that the sudo
+// invocations would block on a password prompt and this would hang
+// for the full 30s before timing out.
+func EnsureRealGUISession(ctx context.Context) error {
+	uid := os.Getuid()
+	if hasAquaSession(ctx, uid) {
+		return nil
+	}
+	if err := kickLoginwindow(ctx); err != nil {
+		return fmt.Errorf("kick loginwindow: %w", err)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if hasAquaSession(ctx, uid) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("Aqua session for uid %d did not come up within 30s after SIGHUP loginwindow", uid)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+// hasAquaSession reports whether `gui/<uid>` exists with `session =
+// Aqua`. Both the missing-domain case (`Could not print domain: 125`)
+// and a Background-only session return false.
+//
+// `launchctl print gui/<uid>` is gated on root, so we sudo. `-n`
+// (non-interactive) makes the call fail fast if NOPASSWD isn't set
+// rather than blocking.
+func hasAquaSession(ctx context.Context, uid int) bool {
+	cmd := exec.CommandContext(ctx, "sudo", "-n", "launchctl", "print", fmt.Sprintf("gui/%d", uid))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(out, []byte("session = Aqua"))
+}
+
+// kickLoginwindow SIGHUPs loginwindow so it respawns. The respawned
+// process — unlike the boot-time one on a headless host — honors
+// `autoLoginUser` and brings up the Aqua session for that user.
+// Same trick the bootstrap uses; see
+// `bootstrap.enableAutoLogin` for the longer-form rationale.
+func kickLoginwindow(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "sudo", "-n", "killall", "-HUP", "loginwindow")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w (output: %s)", err, bytes.TrimSpace(out))
+	}
+	return nil
+}

--- a/infra/tart-kubelet/internal/tart/tart.go
+++ b/infra/tart-kubelet/internal/tart/tart.go
@@ -36,14 +36,22 @@ type Client struct {
 	// LogDir is where per-VM `tart run` stdout/stderr is redirected.
 	// Defaults to /var/log/tart-vms.
 	LogDir string
+
+	// EnsureGUISession runs before each `tart run` to verify the
+	// calling user holds a live Aqua launchd session — required
+	// for VZ HostKey creation on macOS guests. `New()` wires this
+	// to EnsureRealGUISession; tests construct Client directly and
+	// leave it nil to skip the check.
+	EnsureGUISession func(ctx context.Context) error
 }
 
 // New returns a Client with sensible defaults.
 func New() *Client {
 	return &Client{
-		Binary:      "/usr/local/bin/tart",
-		UserDataDir: "/var/lib/tart-userdata",
-		LogDir:      "/var/log/tart-vms",
+		Binary:           "/usr/local/bin/tart",
+		UserDataDir:      "/var/lib/tart-userdata",
+		LogDir:           "/var/log/tart-vms",
+		EnsureGUISession: EnsureRealGUISession,
 	}
 }
 
@@ -160,6 +168,19 @@ func (h *RunHandle) Exited() (err error, ok bool) {
 func (c *Client) Run(ctx context.Context, name string, sharedDirs []string) (*RunHandle, error) {
 	if err := os.MkdirAll(c.LogDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir log dir: %w", err)
+	}
+
+	// VZ HostKey creation needs a live Aqua session; without it
+	// `tart run` exits in <1s with `VZErrorDomain Code=-9 / Failed
+	// to create new HostKey` and the Pod stalls in
+	// TartCreateFailed. Verify (and reanimate) the session here
+	// rather than after the fact — the 5s sanity window below
+	// would otherwise just observe the immediate exit on every
+	// retry forever.
+	if c.EnsureGUISession != nil {
+		if err := c.EnsureGUISession(ctx); err != nil {
+			return nil, fmt.Errorf("ensure gui session: %w", err)
+		}
 	}
 
 	args := []string{"run", name, "--no-graphics"}

--- a/infra/tart-kubelet/internal/tart/tart_test.go
+++ b/infra/tart-kubelet/internal/tart/tart_test.go
@@ -2,6 +2,7 @@ package tart
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,5 +154,71 @@ func TestRunHandleExitedTracksProcess(t *testing.T) {
 	}
 	if _, exited := handle.Exited(); !exited {
 		t.Fatal("handle did not report exited after process death")
+	}
+}
+
+// TestRunInvokesEnsureGUISessionBeforeStartingTart locks in that the
+// preflight runs before `tart run`. Without it the kubelet ships
+// VMs straight into `Failed to create new HostKey` on hosts whose
+// Aqua session got torn down post-bootstrap.
+func TestRunInvokesEnsureGUISessionBeforeStartingTart(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "fake-tart")
+	// Long-lived stub so Run returns a handle (process outlives the
+	// 5s sanity window) — we want to assert the preflight ran, not
+	// the immediate-exit path which already has coverage above.
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	called := 0
+	c := &Client{
+		Binary:      binPath,
+		UserDataDir: filepath.Join(dir, "userdata"),
+		LogDir:      filepath.Join(dir, "logs"),
+		EnsureGUISession: func(_ context.Context) error {
+			called++
+			return nil
+		},
+	}
+	if _, err := c.Run(context.Background(), "test-vm", nil); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("EnsureGUISession called %d times, want 1", called)
+	}
+}
+
+// TestRunSurfacesEnsureGUISessionFailure locks in that a preflight
+// failure short-circuits Run before `tart run` is started. Without
+// this, the kubelet would launch the VM into a wall and surface a
+// less-actionable error from Tart.
+func TestRunSurfacesEnsureGUISessionFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Sentinel binary that should never run — assert it didn't by
+	// checking no log file was created.
+	binPath := filepath.Join(dir, "fake-tart-must-not-run")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\ntouch \"$0.ran\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sentinel := errors.New("preflight rejected")
+	c := &Client{
+		Binary:      binPath,
+		UserDataDir: filepath.Join(dir, "userdata"),
+		LogDir:      filepath.Join(dir, "logs"),
+		EnsureGUISession: func(_ context.Context) error {
+			return sentinel
+		},
+	}
+	_, err := c.Run(context.Background(), "test-vm", nil)
+	if err == nil {
+		t.Fatal("expected preflight error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error chain doesn't wrap sentinel: %v", err)
+	}
+	if _, statErr := os.Stat(binPath + ".ran"); statErr == nil {
+		t.Fatal("fake tart was executed despite preflight failure")
 	}
 }


### PR DESCRIPTION
## Summary

Canary deploys after #10657 were hanging on the same wall the IP-wait decouple was supposed to break, but for a different reason. Apple's Virtualization framework refuses to mint a fresh HostKey for a macOS guest unless the calling user holds a live **Aqua** (loginwindow/GUI) launchd session at the moment of `tart run`. Without one, every VM exits in <1s with `VZErrorDomain Code=-9 / Failed to create new HostKey` and the Pod stalls in `TartCreateFailed` forever.

The bootstrap pass already configures auto-login + SIGHUPs loginwindow once to bring the session up. What it didn't do is keep the session alive past the boot window or recover when it goes away. Canary's host had no `gui/501` at all when we logged in to investigate — `launchctl print gui/501` returned `Could not print domain: 125`. A single `sudo killall -HUP loginwindow` brought it back in 1s and the deploy went green immediately.

This PR adds two layers so we don't depend on a human kicking loginwindow:

### 1. `disableIdleSleep` at bootstrap

New step in `bootstrap.Run` that turns off the macOS facilities that tear the Aqua session down:
- `pmset -a sleep 0 displaysleep 0 disksleep 0` — host/display/disk idle sleep off (`-a` because Mac mini servers are AC-only but the default profile selection isn't trustworthy).
- `com.apple.screensaver idleTime 0` — screensaver off.
- `com.apple.screensaver askForPassword 0` — no screen lock.
- `.GlobalPreferences com.apple.autologout.AutoLogOutDelay 0` — disable inactivity auto-logout (off-by-default on consumer Macs but Scaleway-baked images sometimes ship with it on).

Failures are fatal — there's no point shipping a host that will silently fall over an hour after bootstrap.

### 2. `tart.Client.EnsureGUISession` preflight

Runtime check that runs before every `tart run`:
- `sudo -n launchctl print gui/$(uid)` → look for `session = Aqua`. If found, return immediately.
- Otherwise `sudo -n killall -HUP loginwindow` and poll for up to 30s.

Self-healing for the cases the bootstrap hardening can't cover: WindowServer crash, manual logout via SSH, OS-update reboot. Idempotent (skip when Aqua's already up). Loginwindow restart doesn't disturb running VMs — they're Setsid-detached and live in their own pgid.

Plumbed as a function field on `Client` (`EnsureGUISession func(ctx context.Context) error`) so existing tests that construct `Client` directly skip it; `New()` wires `EnsureRealGUISession`. Two new tests:
- `TestRunInvokesEnsureGUISessionBeforeStartingTart` — the preflight runs before `tart run`.
- `TestRunSurfacesEnsureGUISessionFailure` — preflight failure short-circuits `Run` without launching tart.

The runtime check uses `sudo -n` and depends on the NOPASSWD sudoers entry the bootstrap already writes via `enablePasswordlessSudo`. Without it both the check and the kick would fail fast on a password prompt.

## Test plan

- [x] `go test ./...` in both `infra/tart-kubelet` and `infra/macos-host-bootstrap`.
- [ ] After merge, `release.yml` cuts a new `capi-scaleway@<n>` and the auto-bump rewrites `macosFleet.image.tag` (now that #10669 unblocks `commit-and-release`).
- [ ] Reboot the canary Mac mini after the new operator image rolls out and confirm `gui/501` comes up at boot without manual SIGHUP, and that the next `xcresult-processor` Pod schedules cleanly without hitting `TartCreateFailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)