### PR TITLE
chore(helm): pin production Mac mini fleet to M2-L

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -173,6 +173,15 @@ xcresultProcessor:
 # xcresult capacity offline.
 macosFleet:
   replicas: 2
+  machine:
+    # M2-L while M4-S is out of stock at Scaleway (fr-par-1) — the
+    # first production rollout failed with `resource server is out
+    # of stock` against the chart default (M4-S). M2-L is the next
+    # SKU up that's been independently stocked when M4 capacity
+    # rotates out, and the M2 generation has its own pool. Flip
+    # back to the chart default once Scaleway restocks M4-S; canary
+    # stays on M4-S so we keep tracking that capacity.
+    type: M2-L
   controlPlane:
     host: api.tuist.dev
 


### PR DESCRIPTION
## Summary

The first production rollout of the k8s-managed Mac mini fleet ([run 25492551965](https://github.com/tuist/tuist/actions/runs/25492551965)) failed with:

\`\`\`
ProvisioningFailed scalewayapplesiliconmachine/tuist-tuist-macos-fleet-0
  Scaleway CreateServer: ... resource server is out of stock
ProvisioningFailed scalewayapplesiliconmachine/tuist-tuist-macos-fleet-1
  Scaleway CreateServer: ... resource server is out of stock
\`\`\`

The chart default is M4-S in fr-par-1 and Scaleway has none at the moment. Canary already came up on M4-S so we know the rest of the stack works — this is just a capacity issue.

Pinning production to **M2-L** until M4-S restocks. M2 runs on a separately-allocated capacity pool from M4, so an M4 stockout doesn't (in our experience) propagate. Staging is already on M2-M for the same reason; canary stays on M4-S so we keep eyes on M4 stock as it rotates back in.

The existing in-cluster `ScalewayAppleSiliconMachine` CRs in production are stuck in `Provisioning`/out-of-stock with no Scaleway server attached — flipping the type re-targets the next CreateServer call, no orphan to clean up.

## Test plan

- [ ] After merge, the production deploy in [run 25492551965](https://github.com/tuist/tuist/actions/runs/25492551965) (or its replacement) re-renders `ScalewayAppleSiliconMachine` with `type: M2-L`, the operator picks up the new spec, CreateServer succeeds, both Mac minis come Ready, and `tuist-tuist-xcresult-processor` Pods schedule.
- [ ] Revert this PR (or open a follow-up) once `tart list` shows healthy on canary's M4-S over a sustained period and Scaleway capacity is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)