### PR TITLE
fix(cli): propagate selective testing and module cache analytics across --build-only / --without-building

### DIFF
--- a/cli/Sources/TuistCore/Analytics/RunMetadata.swift
+++ b/cli/Sources/TuistCore/Analytics/RunMetadata.swift
@@ -2,16 +2,16 @@ import Foundation
 import Path
 import XcodeGraph
 
-/// A snapshot of run metadata captured during the build phase
-/// (`tuist test --build-only`) and restored during the test execution phase
-/// (`tuist test --without-building`) when the two run as separate processes,
-/// typically across CI machines via a shared `.xctestproducts` bundle.
+/// Run metadata captured during the build phase (`tuist test --build-only`) and
+/// restored during the test execution phase (`tuist test --without-building`)
+/// when the two run as separate processes, typically across CI machines via a
+/// shared `.xctestproducts` bundle.
 ///
 /// Persisting this lets the test phase upload the same module-cache,
 /// selective-testing, and build-run analytics that the build phase produced,
 /// so the resulting test run page links back to the build run and surfaces
 /// the cache tabs even when the actual `xcodebuild` invocation runs no tests.
-public struct RunMetadataSnapshot: Codable {
+public struct RunMetadata: Codable {
     public let graph: Graph?
     public let binaryCacheItems: [AbsolutePath: [String: CacheItem]]
     public let selectiveTestingCacheItems: [AbsolutePath: [String: CacheItem]]
@@ -32,5 +32,5 @@ public struct RunMetadataSnapshot: Codable {
         self.buildRunId = buildRunId
     }
 
-    public static let fileName = "run-metadata-snapshot.json"
+    public static let fileName = "run-metadata.json"
 }

--- a/cli/Sources/TuistCore/Analytics/RunMetadataSnapshot.swift
+++ b/cli/Sources/TuistCore/Analytics/RunMetadataSnapshot.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Path
+import XcodeGraph
+
+/// A snapshot of run metadata captured during the build phase
+/// (`tuist test --build-only`) and restored during the test execution phase
+/// (`tuist test --without-building`) when the two run as separate processes,
+/// typically across CI machines via a shared `.xctestproducts` bundle.
+///
+/// Persisting this lets the test phase upload the same module-cache,
+/// selective-testing, and build-run analytics that the build phase produced,
+/// so the resulting test run page links back to the build run and surfaces
+/// the cache tabs even when the actual `xcodebuild` invocation runs no tests.
+public struct RunMetadataSnapshot: Codable {
+    public let graph: Graph?
+    public let binaryCacheItems: [AbsolutePath: [String: CacheItem]]
+    public let selectiveTestingCacheItems: [AbsolutePath: [String: CacheItem]]
+    public let targetContentHashSubhashes: [String: TargetContentHashSubhashes]
+    public let buildRunId: String?
+
+    public init(
+        graph: Graph?,
+        binaryCacheItems: [AbsolutePath: [String: CacheItem]],
+        selectiveTestingCacheItems: [AbsolutePath: [String: CacheItem]],
+        targetContentHashSubhashes: [String: TargetContentHashSubhashes],
+        buildRunId: String?
+    ) {
+        self.graph = graph
+        self.binaryCacheItems = binaryCacheItems
+        self.selectiveTestingCacheItems = selectiveTestingCacheItems
+        self.targetContentHashSubhashes = targetContentHashSubhashes
+        self.buildRunId = buildRunId
+    }
+
+    public static let fileName = "run-metadata-snapshot.json"
+}

--- a/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
+++ b/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
@@ -10,7 +10,11 @@ import XcodeGraph
 public actor RunMetadataStorage {
     @TaskLocal public static var current: RunMetadataStorage = .init()
 
-    public init() {}
+    private let fileSystem: FileSysteming
+
+    public init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
 
     /// A unique ID associated with a specific run
     public var runId: String { Environment.current.processId }
@@ -91,10 +95,7 @@ public actor RunMetadataStorage {
     ///
     /// Failures are logged as warnings; persistence is best-effort and never blocks the
     /// caller's run.
-    public func writeMetadata(
-        to testProductsPath: AbsolutePath,
-        fileSystem: FileSysteming = FileSystem()
-    ) async {
+    public func writeMetadata(to testProductsPath: AbsolutePath) async {
         let runMetadata = RunMetadata(
             graph: graph,
             binaryCacheItems: binaryCacheItems,
@@ -116,10 +117,7 @@ public actor RunMetadataStorage {
     ///
     /// No-op when the file is absent (bundles produced by older Tuist versions). Failures
     /// are logged as warnings and never block the caller's run.
-    public func restoreMetadata(
-        from testProductsPath: AbsolutePath,
-        fileSystem: FileSysteming = FileSystem()
-    ) async {
+    public func restoreMetadata(from testProductsPath: AbsolutePath) async {
         let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
         guard (try? await fileSystem.exists(runMetadataPath)) == true else { return }
         do {

--- a/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
+++ b/cli/Sources/TuistCore/Analytics/RunMetadataStorage.swift
@@ -1,6 +1,8 @@
+import FileSystem
 import Foundation
 import Path
 import TuistEnvironment
+import TuistLogging
 import TuistSupport
 import XcodeGraph
 
@@ -80,5 +82,65 @@ public actor RunMetadataStorage {
     public private(set) var cacheEndpoint: String = ""
     public func update(cacheEndpoint: String) {
         self.cacheEndpoint = cacheEndpoint
+    }
+
+    /// Writes a `RunMetadata` snapshot of the current storage to the `.xctestproducts`
+    /// bundle at `testProductsPath`. Used by the build phase of the split build/test
+    /// topology (`tuist test --build-only`) so the test phase can restore the same
+    /// analytics state when it runs as a separate process.
+    ///
+    /// Failures are logged as warnings; persistence is best-effort and never blocks the
+    /// caller's run.
+    public func writeMetadata(
+        to testProductsPath: AbsolutePath,
+        fileSystem: FileSysteming = FileSystem()
+    ) async {
+        let runMetadata = RunMetadata(
+            graph: graph,
+            binaryCacheItems: binaryCacheItems,
+            selectiveTestingCacheItems: selectiveTestingCacheItems,
+            targetContentHashSubhashes: targetContentHashSubhashes,
+            buildRunId: buildRunId
+        )
+        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
+        do {
+            try await fileSystem.writeAsJSON(runMetadata, at: runMetadataPath)
+        } catch {
+            Logger.current.warning("Failed to persist run metadata: \(error.localizedDescription)")
+        }
+    }
+
+    /// Restores run metadata from a `RunMetadata` JSON file previously written to the
+    /// `.xctestproducts` bundle at `testProductsPath`. Used by the test phase of the split
+    /// build/test topology (`tuist test --without-building -testProductsPath …`).
+    ///
+    /// No-op when the file is absent (bundles produced by older Tuist versions). Failures
+    /// are logged as warnings and never block the caller's run.
+    public func restoreMetadata(
+        from testProductsPath: AbsolutePath,
+        fileSystem: FileSysteming = FileSystem()
+    ) async {
+        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
+        guard (try? await fileSystem.exists(runMetadataPath)) == true else { return }
+        do {
+            let runMetadata: RunMetadata = try await fileSystem.readJSONFile(at: runMetadataPath)
+            if let graph = runMetadata.graph {
+                update(graph: graph)
+            }
+            if !runMetadata.binaryCacheItems.isEmpty {
+                update(binaryCacheItems: runMetadata.binaryCacheItems)
+            }
+            if !runMetadata.selectiveTestingCacheItems.isEmpty {
+                update(selectiveTestingCacheItems: runMetadata.selectiveTestingCacheItems)
+            }
+            if !runMetadata.targetContentHashSubhashes.isEmpty {
+                update(targetContentHashSubhashes: runMetadata.targetContentHashSubhashes)
+            }
+            if let buildRunId = runMetadata.buildRunId {
+                update(buildRunId: buildRunId)
+            }
+        } catch {
+            Logger.current.warning("Failed to restore run metadata: \(error.localizedDescription)")
+        }
     }
 }

--- a/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
+++ b/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
@@ -112,8 +112,13 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
             throw UploadResultBundleServiceError.missingFullHandle
         }
 
-        var buildRunId: String?
-        if let projectDerivedDataDirectory,
+        // Prefer the snapshot-restored buildRunId from RunMetadataStorage (set in the split
+        // build/test topology where the test phase reads the build phase's run-metadata
+        // snapshot). Fall back to the local activity log when the test phase shares
+        // DerivedData with the build phase.
+        var buildRunId: String? = await RunMetadataStorage.current.buildRunId
+        if buildRunId == nil,
+           let projectDerivedDataDirectory,
            let mostRecentActivityLogFile = try await xcActivityLogController.mostRecentActivityLogFile(
                projectDerivedDataDirectory: projectDerivedDataDirectory
            )

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -579,10 +579,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
                 try await fileSystem.writeAsJSON(selectiveTestingGraph, at: selectiveTestingGraphPath)
 
-                await RunMetadataStorage.current.writeMetadata(
-                    to: testProductsPath,
-                    fileSystem: fileSystem
-                )
+                await RunMetadataStorage.current.writeMetadata(to: testProductsPath)
 
                 if isSharding,
                    let fullHandle = config.fullHandle
@@ -671,10 +668,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
-        await RunMetadataStorage.current.restoreMetadata(
-            from: shard.testProductsPath,
-            fileSystem: fileSystem
-        )
+        await RunMetadataStorage.current.restoreMetadata(from: shard.testProductsPath)
 
         var shardPassthroughArguments = passthroughXcodeBuildArguments
         if let xcTestRunPath = shard.xcTestRunPath {
@@ -773,10 +767,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             at: selectiveTestingGraphPath
         )
 
-        await RunMetadataStorage.current.restoreMetadata(
-            from: testProductsPath,
-            fileSystem: fileSystem
-        )
+        await RunMetadataStorage.current.restoreMetadata(from: testProductsPath)
 
         let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
 

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -579,7 +579,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
                 try await fileSystem.writeAsJSON(selectiveTestingGraph, at: selectiveTestingGraphPath)
 
-                try await writeRunMetadataSnapshot(at: testProductsPath)
+                try await writeRunMetadata(at: testProductsPath)
 
                 if isSharding,
                    let fullHandle = config.fullHandle
@@ -668,7 +668,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
-        await restoreRunMetadataSnapshotIfPresent(at: shard.testProductsPath)
+        await restoreRunMetadataIfPresent(at: shard.testProductsPath)
 
         var shardPassthroughArguments = passthroughXcodeBuildArguments
         if let xcTestRunPath = shard.xcTestRunPath {
@@ -767,7 +767,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
             at: selectiveTestingGraphPath
         )
 
-        await restoreRunMetadataSnapshotIfPresent(at: testProductsPath)
+        await restoreRunMetadataIfPresent(at: testProductsPath)
 
         let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
 
@@ -864,46 +864,46 @@ public struct TestService { // swiftlint:disable:this type_body_length
         AlertController.current.success(.alert("The project tests ran successfully"))
     }
 
-    private func writeRunMetadataSnapshot(at testProductsPath: AbsolutePath) async throws {
+    private func writeRunMetadata(at testProductsPath: AbsolutePath) async throws {
         let storage = RunMetadataStorage.current
-        let snapshot = await RunMetadataSnapshot(
+        let runMetadata = await RunMetadata(
             graph: storage.graph,
             binaryCacheItems: storage.binaryCacheItems,
             selectiveTestingCacheItems: storage.selectiveTestingCacheItems,
             targetContentHashSubhashes: storage.targetContentHashSubhashes,
             buildRunId: storage.buildRunId
         )
-        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
+        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
         do {
-            try await fileSystem.writeAsJSON(snapshot, at: snapshotPath)
+            try await fileSystem.writeAsJSON(runMetadata, at: runMetadataPath)
         } catch {
-            Logger.current.warning("Failed to persist run metadata snapshot: \(error.localizedDescription)")
+            Logger.current.warning("Failed to persist run metadata: \(error.localizedDescription)")
         }
     }
 
-    private func restoreRunMetadataSnapshotIfPresent(at testProductsPath: AbsolutePath) async {
-        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
-        guard (try? await fileSystem.exists(snapshotPath)) == true else { return }
+    private func restoreRunMetadataIfPresent(at testProductsPath: AbsolutePath) async {
+        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
+        guard (try? await fileSystem.exists(runMetadataPath)) == true else { return }
         do {
-            let snapshot: RunMetadataSnapshot = try await fileSystem.readJSONFile(at: snapshotPath)
+            let runMetadata: RunMetadata = try await fileSystem.readJSONFile(at: runMetadataPath)
             let storage = RunMetadataStorage.current
-            if let graph = snapshot.graph {
+            if let graph = runMetadata.graph {
                 await storage.update(graph: graph)
             }
-            if !snapshot.binaryCacheItems.isEmpty {
-                await storage.update(binaryCacheItems: snapshot.binaryCacheItems)
+            if !runMetadata.binaryCacheItems.isEmpty {
+                await storage.update(binaryCacheItems: runMetadata.binaryCacheItems)
             }
-            if !snapshot.selectiveTestingCacheItems.isEmpty {
-                await storage.update(selectiveTestingCacheItems: snapshot.selectiveTestingCacheItems)
+            if !runMetadata.selectiveTestingCacheItems.isEmpty {
+                await storage.update(selectiveTestingCacheItems: runMetadata.selectiveTestingCacheItems)
             }
-            if !snapshot.targetContentHashSubhashes.isEmpty {
-                await storage.update(targetContentHashSubhashes: snapshot.targetContentHashSubhashes)
+            if !runMetadata.targetContentHashSubhashes.isEmpty {
+                await storage.update(targetContentHashSubhashes: runMetadata.targetContentHashSubhashes)
             }
-            if let buildRunId = snapshot.buildRunId {
+            if let buildRunId = runMetadata.buildRunId {
                 await storage.update(buildRunId: buildRunId)
             }
         } catch {
-            Logger.current.warning("Failed to restore run metadata snapshot: \(error.localizedDescription)")
+            Logger.current.warning("Failed to restore run metadata: \(error.localizedDescription)")
         }
     }
 

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1867,13 +1867,14 @@ public struct TestService { // swiftlint:disable:this type_body_length
 
         let gitInfo = try await gitController.gitInfo(workingDirectory: gitInfoDirectory)
         let ciInfo = ciController.ciInfo()
+        let buildRunId = await RunMetadataStorage.current.buildRunId
 
         let test = try await createTestService.createTest(
             fullHandle: fullHandle,
             serverURL: serverURL,
             id: nil,
             testSummary: testSummary,
-            buildRunId: nil,
+            buildRunId: buildRunId,
             gitBranch: gitInfo.branch,
             gitCommitSHA: gitInfo.sha,
             gitRef: gitInfo.ref,

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -579,6 +579,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
                 try await fileSystem.writeAsJSON(selectiveTestingGraph, at: selectiveTestingGraphPath)
 
+                try await writeRunMetadataSnapshot(at: testProductsPath)
+
                 if isSharding,
                    let fullHandle = config.fullHandle
                 {
@@ -665,6 +667,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 relativeTo: shardCurrentPath
             )
         }
+
+        await restoreRunMetadataSnapshotIfPresent(at: shard.testProductsPath)
 
         var shardPassthroughArguments = passthroughXcodeBuildArguments
         if let xcTestRunPath = shard.xcTestRunPath {
@@ -763,6 +767,8 @@ public struct TestService { // swiftlint:disable:this type_body_length
             at: selectiveTestingGraphPath
         )
 
+        await restoreRunMetadataSnapshotIfPresent(at: testProductsPath)
+
         let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
 
         let runResultBundlePath =
@@ -856,6 +862,49 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         AlertController.current.success(.alert("The project tests ran successfully"))
+    }
+
+    private func writeRunMetadataSnapshot(at testProductsPath: AbsolutePath) async throws {
+        let storage = RunMetadataStorage.current
+        let snapshot = await RunMetadataSnapshot(
+            graph: storage.graph,
+            binaryCacheItems: storage.binaryCacheItems,
+            selectiveTestingCacheItems: storage.selectiveTestingCacheItems,
+            targetContentHashSubhashes: storage.targetContentHashSubhashes,
+            buildRunId: storage.buildRunId
+        )
+        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
+        do {
+            try await fileSystem.writeAsJSON(snapshot, at: snapshotPath)
+        } catch {
+            Logger.current.warning("Failed to persist run metadata snapshot: \(error.localizedDescription)")
+        }
+    }
+
+    private func restoreRunMetadataSnapshotIfPresent(at testProductsPath: AbsolutePath) async {
+        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
+        guard (try? await fileSystem.exists(snapshotPath)) == true else { return }
+        do {
+            let snapshot: RunMetadataSnapshot = try await fileSystem.readJSONFile(at: snapshotPath)
+            let storage = RunMetadataStorage.current
+            if let graph = snapshot.graph {
+                await storage.update(graph: graph)
+            }
+            if !snapshot.binaryCacheItems.isEmpty {
+                await storage.update(binaryCacheItems: snapshot.binaryCacheItems)
+            }
+            if !snapshot.selectiveTestingCacheItems.isEmpty {
+                await storage.update(selectiveTestingCacheItems: snapshot.selectiveTestingCacheItems)
+            }
+            if !snapshot.targetContentHashSubhashes.isEmpty {
+                await storage.update(targetContentHashSubhashes: snapshot.targetContentHashSubhashes)
+            }
+            if let buildRunId = snapshot.buildRunId {
+                await storage.update(buildRunId: buildRunId)
+            }
+        } catch {
+            Logger.current.warning("Failed to restore run metadata snapshot: \(error.localizedDescription)")
+        }
     }
 
     private func removeOption(_ option: String, from arguments: [String]) -> [String] {

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -579,7 +579,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
                 )
                 try await fileSystem.writeAsJSON(selectiveTestingGraph, at: selectiveTestingGraphPath)
 
-                try await writeRunMetadata(at: testProductsPath)
+                await RunMetadataStorage.current.writeMetadata(
+                    to: testProductsPath,
+                    fileSystem: fileSystem
+                )
 
                 if isSharding,
                    let fullHandle = config.fullHandle
@@ -668,7 +671,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
             )
         }
 
-        await restoreRunMetadataIfPresent(at: shard.testProductsPath)
+        await RunMetadataStorage.current.restoreMetadata(
+            from: shard.testProductsPath,
+            fileSystem: fileSystem
+        )
 
         var shardPassthroughArguments = passthroughXcodeBuildArguments
         if let xcTestRunPath = shard.xcTestRunPath {
@@ -767,7 +773,10 @@ public struct TestService { // swiftlint:disable:this type_body_length
             at: selectiveTestingGraphPath
         )
 
-        await restoreRunMetadataIfPresent(at: testProductsPath)
+        await RunMetadataStorage.current.restoreMetadata(
+            from: testProductsPath,
+            fileSystem: fileSystem
+        )
 
         let cacheStorage = try await cacheStorageFactory.cacheStorage(config: config)
 
@@ -862,49 +871,6 @@ public struct TestService { // swiftlint:disable:this type_body_length
         }
 
         AlertController.current.success(.alert("The project tests ran successfully"))
-    }
-
-    private func writeRunMetadata(at testProductsPath: AbsolutePath) async throws {
-        let storage = RunMetadataStorage.current
-        let runMetadata = await RunMetadata(
-            graph: storage.graph,
-            binaryCacheItems: storage.binaryCacheItems,
-            selectiveTestingCacheItems: storage.selectiveTestingCacheItems,
-            targetContentHashSubhashes: storage.targetContentHashSubhashes,
-            buildRunId: storage.buildRunId
-        )
-        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
-        do {
-            try await fileSystem.writeAsJSON(runMetadata, at: runMetadataPath)
-        } catch {
-            Logger.current.warning("Failed to persist run metadata: \(error.localizedDescription)")
-        }
-    }
-
-    private func restoreRunMetadataIfPresent(at testProductsPath: AbsolutePath) async {
-        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
-        guard (try? await fileSystem.exists(runMetadataPath)) == true else { return }
-        do {
-            let runMetadata: RunMetadata = try await fileSystem.readJSONFile(at: runMetadataPath)
-            let storage = RunMetadataStorage.current
-            if let graph = runMetadata.graph {
-                await storage.update(graph: graph)
-            }
-            if !runMetadata.binaryCacheItems.isEmpty {
-                await storage.update(binaryCacheItems: runMetadata.binaryCacheItems)
-            }
-            if !runMetadata.selectiveTestingCacheItems.isEmpty {
-                await storage.update(selectiveTestingCacheItems: runMetadata.selectiveTestingCacheItems)
-            }
-            if !runMetadata.targetContentHashSubhashes.isEmpty {
-                await storage.update(targetContentHashSubhashes: runMetadata.targetContentHashSubhashes)
-            }
-            if let buildRunId = runMetadata.buildRunId {
-                await storage.update(buildRunId: buildRunId)
-            }
-        } catch {
-            Logger.current.warning("Failed to restore run metadata: \(error.localizedDescription)")
-        }
     }
 
     private func removeOption(_ option: String, from arguments: [String]) -> [String] {

--- a/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
@@ -325,6 +325,78 @@ struct UploadResultBundleServiceTests {
     }
 
     @Test(.withMockedEnvironment())
+    func inspectResultBundle_prefersRunMetadataStorageBuildRunIdOverActivityLog() async throws {
+        // Given
+        let mockedEnvironment = try #require(Environment.mocked)
+        let currentWorkingDirectory = try await mockedEnvironment.currentWorkingDirectory()
+        let derivedDataDirectory = currentWorkingDirectory.appending(component: "DerivedData")
+        let activityLogPath = derivedDataDirectory.appending(components: "Logs", "Build", "stale-build.xcactivitylog")
+
+        let testSummary = TestSummary(testPlanName: nil, status: .passed, duration: 100, testModules: [])
+
+        gitController.reset()
+        given(gitController)
+            .isInGitRepository(workingDirectory: .any)
+            .willReturn(true)
+        given(gitController)
+            .topLevelGitDirectory(workingDirectory: .any)
+            .willReturn(currentWorkingDirectory)
+        given(gitController)
+            .gitInfo(workingDirectory: .any)
+            .willReturn(.test())
+
+        xcActivityLogController.reset()
+        given(xcActivityLogController)
+            .mostRecentActivityLogFile(projectDerivedDataDirectory: .value(derivedDataDirectory), filter: .any)
+            .willReturn(
+                XCActivityLogFile(
+                    path: activityLogPath,
+                    timeStoppedRecording: Date(),
+                    signature: "Build"
+                )
+            )
+
+        let storage = RunMetadataStorage()
+        await storage.update(buildRunId: "snapshot-build-run")
+
+        // When
+        try await RunMetadataStorage.$current.withValue(storage) {
+            _ = try await subject.uploadTestSummary(
+                testSummary: testSummary,
+                projectDerivedDataDirectory: derivedDataDirectory,
+                config: .test(fullHandle: "tuist/tuist"),
+                shardPlanId: nil,
+                shardIndex: nil
+            )
+        }
+
+        // Then — snapshot-restored buildRunId wins over the local activity log.
+        verify(createTestService)
+            .createTest(
+                fullHandle: .any,
+                serverURL: .any,
+                id: .any,
+                testSummary: .any,
+                buildRunId: .value("snapshot-build-run"),
+                gitBranch: .any,
+                gitCommitSHA: .any,
+                gitRef: .any,
+                gitRemoteURLOrigin: .any,
+                isCI: .any,
+                modelIdentifier: .any,
+                macOSVersion: .any,
+                xcodeVersion: .any,
+                ciRunId: .any,
+                ciProjectHandle: .any,
+                ciHost: .any,
+                ciProvider: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(1)
+    }
+
+    @Test(.withMockedEnvironment())
     func inspectResultBundle_passesCIMetadata() async throws {
         // Given
         let mockedEnvironment = try #require(Environment.mocked)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4241,6 +4241,122 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_testWithoutBuilding_restoresRunMetadataSnapshot_fromBundle() async throws {
+        // Given
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(
+            testTargetHashes: ["MyTests": "abc123"]
+        )
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        let projectPath = try AbsolutePath(validating: "/tmp/Project")
+        let project = Project.test(
+            path: projectPath,
+            name: "Project",
+            targets: [.test(name: "MyTests")]
+        )
+        let graph = Graph.test(
+            name: "MyApp",
+            path: projectPath,
+            workspace: .test(),
+            projects: [projectPath: project]
+        )
+        let binaryCacheItems: [AbsolutePath: [String: CacheItem]] = [
+            projectPath: [
+                "MyTests": CacheItem.test(name: "MyTests", hash: "binary-hash", source: .remote, cacheCategory: .binaries),
+            ],
+        ]
+        let selectiveTestingCacheItems: [AbsolutePath: [String: CacheItem]] = [
+            projectPath: [
+                "MyTests": CacheItem.test(
+                    name: "MyTests",
+                    hash: "selective-hash",
+                    source: .remote,
+                    cacheCategory: .selectiveTests
+                ),
+            ],
+        ]
+        let snapshot = RunMetadataSnapshot(
+            graph: graph,
+            binaryCacheItems: binaryCacheItems,
+            selectiveTestingCacheItems: selectiveTestingCacheItems,
+            targetContentHashSubhashes: [:],
+            buildRunId: "BUILD-RUN-ID"
+        )
+        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
+        try JSONEncoder().encode(snapshot).write(to: snapshotPath.url)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — RunMetadataStorage should be populated from the snapshot
+        let restoredBuildRunId = await runMetadataStorage.buildRunId
+        XCTAssertEqual(restoredBuildRunId, "BUILD-RUN-ID")
+        let restoredBinaryCacheItems = await runMetadataStorage.binaryCacheItems
+        XCTAssertEqual(restoredBinaryCacheItems, binaryCacheItems)
+        let restoredSelectiveTestingCacheItems = await runMetadataStorage.selectiveTestingCacheItems
+        XCTAssertEqual(restoredSelectiveTestingCacheItems, selectiveTestingCacheItems)
+        let restoredGraph = await runMetadataStorage.graph
+        XCTAssertEqual(restoredGraph?.name, "MyApp")
+        XCTAssertEqual(restoredGraph?.projects[projectPath]?.name, "Project")
+    }
+
+    func test_run_testWithoutBuilding_skipsRunMetadataRestore_whenSnapshotMissing() async throws {
+        // Given
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+
+        let selectiveTestingGraph = SelectiveTestingGraph(
+            testTargetHashes: ["MyTests": "abc123"]
+        )
+        let graphPath = testProductsPath.appending(component: SelectiveTestingGraph.fileName)
+        try JSONEncoder().encode(selectiveTestingGraph).write(to: graphPath.url)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(project: .testGeneratedProject()))
+
+        given(xcodebuildController)
+            .run(arguments: .any)
+            .willReturn(())
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — RunMetadataStorage stays untouched (no snapshot file present)
+        let buildRunId = await runMetadataStorage.buildRunId
+        XCTAssertNil(buildRunId)
+        let binaryCacheItems = await runMetadataStorage.binaryCacheItems
+        XCTAssertTrue(binaryCacheItems.isEmpty)
+        let selectiveTestingCacheItems = await runMetadataStorage.selectiveTestingCacheItems
+        XCTAssertTrue(selectiveTestingCacheItems.isEmpty)
+    }
+
     func test_run_testWithoutBuilding_fallsBackToGeneration_whenNoSelectiveTestingGraph() async throws {
         // Given
         givenGenerator()

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4411,7 +4411,10 @@ final class TestServiceTests: TuistUnitTestCase {
         // matching .xctestrun (i.e. selective testing pruned every target), so the test phase
         // skips xcodebuild entirely and uploads a synthesized "skipped" test summary. Before
         // this fix, uploadSkippedTestSummary hardcoded buildRunId: nil, which dropped the link
-        // back to the originating build run.
+        // back to the originating build run. The restore from a real snapshot file is covered
+        // by test_run_testWithoutBuilding_restoresRunMetadata_fromBundle; here we pre-populate
+        // RunMetadataStorage directly to keep the test focused on the skip path's buildRunId
+        // forwarding.
         let path = try temporaryPath()
         let testProductsPath = path.appending(component: "MyApp.xctestproducts")
         try await fileSystem.makeDirectory(at: testProductsPath)
@@ -4424,15 +4427,7 @@ final class TestServiceTests: TuistUnitTestCase {
         try JSONEncoder().encode(selectiveTestingGraph)
             .write(to: testProductsPath.appending(component: SelectiveTestingGraph.fileName).url)
 
-        let runMetadata = RunMetadata(
-            graph: nil,
-            binaryCacheItems: [:],
-            selectiveTestingCacheItems: [:],
-            targetContentHashSubhashes: [:],
-            buildRunId: "BUILD-RUN-ID"
-        )
-        try JSONEncoder().encode(runMetadata)
-            .write(to: testProductsPath.appending(component: RunMetadata.fileName).url)
+        await runMetadataStorage.update(buildRunId: "BUILD-RUN-ID")
 
         given(configLoader)
             .loadConfig(path: .any)
@@ -4443,6 +4438,9 @@ final class TestServiceTests: TuistUnitTestCase {
                     url: URL(string: "https://tuist.dev")!
                 )
             )
+        given(xcodebuildController)
+            .version()
+            .willReturn(nil)
         given(createTestService)
             .createTest(
                 fullHandle: .any,
@@ -4486,8 +4484,8 @@ final class TestServiceTests: TuistUnitTestCase {
             )
         }
 
-        // Then — the snapshot-restored buildRunId is forwarded to createTest so the test
-        // run record links back to the build run.
+        // Then — the buildRunId from RunMetadataStorage is forwarded to createTest so the
+        // test run record links back to the build run.
         verify(createTestService)
             .createTest(
                 fullHandle: .value("tuist/tuist"),

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4241,7 +4241,7 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
-    func test_run_testWithoutBuilding_restoresRunMetadataSnapshot_fromBundle() async throws {
+    func test_run_testWithoutBuilding_restoresRunMetadata_fromBundle() async throws {
         // Given
         let path = try temporaryPath()
         let testProductsPath = path.appending(component: "MyApp.xctestproducts")
@@ -4280,15 +4280,15 @@ final class TestServiceTests: TuistUnitTestCase {
                 ),
             ],
         ]
-        let snapshot = RunMetadataSnapshot(
+        let runMetadata = RunMetadata(
             graph: graph,
             binaryCacheItems: binaryCacheItems,
             selectiveTestingCacheItems: selectiveTestingCacheItems,
             targetContentHashSubhashes: [:],
             buildRunId: "BUILD-RUN-ID"
         )
-        let snapshotPath = testProductsPath.appending(component: RunMetadataSnapshot.fileName)
-        try JSONEncoder().encode(snapshot).write(to: snapshotPath.url)
+        let runMetadataPath = testProductsPath.appending(component: RunMetadata.fileName)
+        try JSONEncoder().encode(runMetadata).write(to: runMetadataPath.url)
 
         given(configLoader)
             .loadConfig(path: .any)
@@ -4319,7 +4319,7 @@ final class TestServiceTests: TuistUnitTestCase {
         XCTAssertEqual(restoredGraph?.projects[projectPath]?.name, "Project")
     }
 
-    func test_run_testWithoutBuilding_skipsRunMetadataRestore_whenSnapshotMissing() async throws {
+    func test_run_testWithoutBuilding_skipsRunMetadataRestore_whenMissing() async throws {
         // Given
         let path = try temporaryPath()
         let testProductsPath = path.appending(component: "MyApp.xctestproducts")
@@ -4424,15 +4424,15 @@ final class TestServiceTests: TuistUnitTestCase {
         try JSONEncoder().encode(selectiveTestingGraph)
             .write(to: testProductsPath.appending(component: SelectiveTestingGraph.fileName).url)
 
-        let snapshot = RunMetadataSnapshot(
+        let runMetadata = RunMetadata(
             graph: nil,
             binaryCacheItems: [:],
             selectiveTestingCacheItems: [:],
             targetContentHashSubhashes: [:],
             buildRunId: "BUILD-RUN-ID"
         )
-        try JSONEncoder().encode(snapshot)
-            .write(to: testProductsPath.appending(component: RunMetadataSnapshot.fileName).url)
+        try JSONEncoder().encode(runMetadata)
+            .write(to: testProductsPath.appending(component: RunMetadata.fileName).url)
 
         given(configLoader)
             .loadConfig(path: .any)

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -4406,6 +4406,113 @@ final class TestServiceTests: TuistUnitTestCase {
             .called(1)
     }
 
+    func test_run_testWithoutBuilding_skippedSummary_propagatesRestoredBuildRunId() async throws {
+        // Given — a bundle whose selective testing graph attempts a test plan that has no
+        // matching .xctestrun (i.e. selective testing pruned every target), so the test phase
+        // skips xcodebuild entirely and uploads a synthesized "skipped" test summary. Before
+        // this fix, uploadSkippedTestSummary hardcoded buildRunId: nil, which dropped the link
+        // back to the originating build run.
+        let path = try temporaryPath()
+        let testProductsPath = path.appending(component: "MyApp.xctestproducts")
+        try await fileSystem.makeDirectory(at: testProductsPath)
+        let testPlan = "IntegrationTestSuite"
+
+        let selectiveTestingGraph = SelectiveTestingGraph(
+            testTargetHashes: ["IntegrationTests": "abc123"],
+            attemptedTestPlans: [testPlan]
+        )
+        try JSONEncoder().encode(selectiveTestingGraph)
+            .write(to: testProductsPath.appending(component: SelectiveTestingGraph.fileName).url)
+
+        let snapshot = RunMetadataSnapshot(
+            graph: nil,
+            binaryCacheItems: [:],
+            selectiveTestingCacheItems: [:],
+            targetContentHashSubhashes: [:],
+            buildRunId: "BUILD-RUN-ID"
+        )
+        try JSONEncoder().encode(snapshot)
+            .write(to: testProductsPath.appending(component: RunMetadataSnapshot.fileName).url)
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                .test(
+                    project: .testGeneratedProject(),
+                    fullHandle: "tuist/tuist",
+                    url: URL(string: "https://tuist.dev")!
+                )
+            )
+        given(createTestService)
+            .createTest(
+                fullHandle: .any,
+                serverURL: .any,
+                id: .any,
+                testSummary: .any,
+                buildRunId: .any,
+                gitBranch: .any,
+                gitCommitSHA: .any,
+                gitRef: .any,
+                gitRemoteURLOrigin: .any,
+                isCI: .any,
+                modelIdentifier: .any,
+                macOSVersion: .any,
+                xcodeVersion: .any,
+                ciRunId: .any,
+                ciProjectHandle: .any,
+                ciHost: .any,
+                ciProvider: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .willReturn(
+                Components.Schemas.RunsTest(
+                    duration: 0,
+                    id: "test-id",
+                    project_id: 1,
+                    test_case_runs: [],
+                    _type: .test,
+                    url: "https://tuist.dev/tuist/tuist/tests/test-runs/test-id"
+                )
+            )
+
+        // When
+        try await AlertController.$current.withValue(AlertController()) {
+            try await testRun(
+                path: path,
+                action: .testWithoutBuilding,
+                testPlanConfiguration: TestPlanConfiguration(testPlan: testPlan),
+                passthroughXcodeBuildArguments: ["-testProductsPath", testProductsPath.pathString]
+            )
+        }
+
+        // Then — the snapshot-restored buildRunId is forwarded to createTest so the test
+        // run record links back to the build run.
+        verify(createTestService)
+            .createTest(
+                fullHandle: .value("tuist/tuist"),
+                serverURL: .any,
+                id: .any,
+                testSummary: .any,
+                buildRunId: .value("BUILD-RUN-ID"),
+                gitBranch: .any,
+                gitCommitSHA: .any,
+                gitRef: .any,
+                gitRemoteURLOrigin: .any,
+                isCI: .any,
+                modelIdentifier: .any,
+                macOSVersion: .any,
+                xcodeVersion: .any,
+                ciRunId: .any,
+                ciProjectHandle: .any,
+                ciHost: .any,
+                ciProvider: .any,
+                shardPlanId: .any,
+                shardIndex: .any
+            )
+            .called(1)
+    }
+
     func test_run_testWithoutBuilding_skipsWhenRequestedTestPlanXCTestRunIsMissing() async throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
### Context

When `tuist test --build-only` and `tuist test --without-building -testProductsPath …` run as separate processes (typically across CI machines via a shared `.xctestproducts` bundle), the test phase had no access to the build phase's `RunMetadataStorage`. The resulting test run reported:

- empty Module Cache tab
- empty Selective Testing tab
- no link back to the build run

This setup is uncommon — most users hit `tuist test` in a single process, where `RunMetadataStorage` survives end-to-end — but it's the standard split for the "build once, test on many shards/machines" CI topology, and the analytics gap is visible on the test run page.

### What changed

Added a new `RunMetadata` Codable struct that captures the analytics fields the test phase needs: graph, binary cache items, selective-testing cache items, target content hash subhashes, and `buildRunId`. The build phase writes it as `run-metadata.json` alongside the existing `selective-testing-graph.json` inside the `.xctestproducts` bundle whenever `--build-only` produces one. The test phase restores it best-effort before `xcodebuild test-without-building` runs, in both `runTestWithoutBuildingFromBundle` and the shard execute path.

When `TrackableCommand` later assembles the command event for upload, `RunMetadataStorage` is now populated as if the test phase had generated the project itself, so the test run gets:

- Selective Testing tab with the original cache items
- Module Cache tab with the binary cache items
- a `buildRunId` link to the originating build run

### Notes for reviewers

- **Backwards compatible:** the read-side is best-effort; bundles produced before this change have no run-metadata file and the test phase falls back to today's behavior.
- **Sharding:** `archiveXCTestProducts` only excludes `.dSYM`, so the snapshot file rides along with the bundle to the server and back.
- **Path keys:** the graph's `[AbsolutePath: Project]` keys and the cache-item dictionaries are produced together on the build machine. They match each other inside the snapshot regardless of where the test machine extracts the bundle, so `CommandEventFactory.map`'s lookups work on the test side.
- **Failure handling:** snapshot read/write failures log a warning and never abort the test run.

### E2E verification

In addition to the new `TuistKitTests` cases (run-metadata round-trip + missing-file fallback), I verified the full upload path against a real Tuist server.

Setup: a minimal Tuist-generated macOS app fixture pointing at `tuist/tuist` on production.

```bash
# Build phase — writes run-metadata.json into the bundle
tuist test --build-only App -- \
  -destination 'platform=macOS' \
  -derivedDataPath /tmp/dd \
  -testProductsPath /tmp/snapshot-e2e.xctestproducts

# Test phase — restores run metadata, uploads with the build-run link
tuist test --without-building App -- \
  -destination 'platform=macOS' \
  -testProductsPath /tmp/snapshot-e2e.xctestproducts
```

Confirmed end to end on `tuist.dev/tuist/tuist`:

- Build run created: https://tuist.dev/tuist/tuist/builds/build-runs/847d1736-6e7e-4436-9710-208b254ec410
- Run-metadata file contained `"buildRunId": "847D1736-6E7E-4436-9710-208B254EC410"` (matches the build-run UUID).
- Test phase logged `Skipping project generation, using selective testing graph from .xctestproducts bundle...` — confirms the restore path ran.
- HTTP request bodies (from `~/.local/state/tuist/sessions/.../logs.txt`) carried the same `build_run_id` in both uploads:
  - `POST /api/projects/tuist/tuist/tests` → `build_run_id: 847D1736-…`
  - `POST /api/analytics?project_id=tuist%2Ftuist` → `build_run_id: 847D1736-…`
- Server response on the analytics upload redirected to `/builds/build-runs/847d1736-…` — this branch in `analytics_controller.ex` only fires when `build_run_id` is non-nil, so the link was persisted.
- Test run: https://tuist.dev/tuist/tuist/tests/test-runs/6699b64b-eacf-448f-a75b-50c64749cdb5 — opens with the "Build: {scheme}" link button driven by `:if={@run.build_run}` in `test_run_live.html.heex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
