### PR TITLE
fix(capi-scaleway): let helm update fleet CRs + parallelize provisioning

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -67,6 +67,8 @@ func main() {
 		tartKubeletHostMemory        int
 		tartKubeletMaxPods           int
 		tartKubeletMaxUpdateAttempts int
+
+		machineMaxConcurrentReconciles int
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint")
@@ -100,6 +102,15 @@ func main() {
 	flag.IntVar(&tartKubeletMaxUpdateAttempts, "tartkubelet-max-update-attempts", 5,
 		"Drift-loop retries before transitioning the CR to a terminal Failed state. "+
 			"Set to 0 to disable the cap (not recommended for production).")
+	flag.IntVar(&machineMaxConcurrentReconciles, "machine-max-concurrent-reconciles", 4,
+		"How many ScalewayAppleSiliconMachine reconciles run in parallel. The "+
+			"default of 1 (controller-runtime's default) serializes the whole "+
+			"fleet behind one worker — first-time bring-up of N Mac minis takes "+
+			"N × bootstrap time because each CreateServer + SSH bootstrap "+
+			"blocks the worker for ~50 min. Bumping this lets distinct machines "+
+			"provision in parallel; reconciles for the same machine remain "+
+			"serialized by controller-runtime's per-key locking. 4 covers the "+
+			"production fleet size with headroom; raise if fleets grow.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -187,6 +198,7 @@ func main() {
 		TartKubeletHostMemoryMB:      tartKubeletHostMemory,
 		TartKubeletMaxPods:           tartKubeletMaxPods,
 		TartKubeletMaxUpdateAttempts: int32(tartKubeletMaxUpdateAttempts),
+		MaxConcurrentReconciles:      machineMaxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup MachineReconciler")
 		os.Exit(1)

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/scalewayapplesiliconmachine_controller.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -91,6 +92,15 @@ type ScalewayAppleSiliconMachineReconciler struct {
 	// terminal-failure surface for ops. Defaulted to 5 attempts in
 	// the manager binary; chart can override per env if needed.
 	TartKubeletMaxUpdateAttempts int32
+
+	// MaxConcurrentReconciles is how many machines this controller
+	// reconciles in parallel. controller-runtime's default of 1
+	// serializes first-time fleet bring-up: each Mac mini's
+	// CreateServer + SSH bootstrap blocks the worker for ~50 min, so
+	// N machines take N × that wall-clock. Reconciles for the same
+	// machine are still serialized by controller-runtime's per-key
+	// locking — bumping this only parallelizes across distinct CRs.
+	MaxConcurrentReconciles int
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=scalewayapplesiliconmachines,verbs=get;list;watch;create;update;patch;delete
@@ -534,8 +544,13 @@ func machineIP(m *infrav1.ScalewayAppleSiliconMachine) string {
 }
 
 func (r *ScalewayAppleSiliconMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	concurrency := r.MaxConcurrentReconciles
+	if concurrency <= 0 {
+		concurrency = 1
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.ScalewayAppleSiliconMachine{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: concurrency}).
 		Complete(r)
 }
 

--- a/infra/helm/tuist/templates/macos-fleet.yaml
+++ b/infra/helm/tuist/templates/macos-fleet.yaml
@@ -26,17 +26,24 @@ metadata:
     {{- include "tuist.labels" $ | nindent 4 }}
     app.kubernetes.io/component: macos-fleet
     tuist.dev/fleet: {{ $fleetName }}
-  annotations:
-    # Operator owns the CR lifecycle via finalizers (Scaleway server
-    # release + bootstrap Secret cleanup). If helm rolls back to a
-    # revision without macosFleet.enabled while the operator is being
-    # rolled, helm tries to delete the CR but the finalizer blocks
-    # forever (no operator to remove it), and the next upgrade ends
-    # up applying a new CR over the still-Terminating one. `keep`
-    # tells helm to leave the CR alone on uninstall/rollback —
-    # explicit `kubectl delete` is the only way to remove it, which
-    # forces the operator to be running.
-    helm.sh/resource-policy: keep
+  # No `helm.sh/resource-policy: keep` — that annotation makes Helm
+  # silently skip kept resources during BOTH uninstall AND upgrade
+  # (despite Helm's docs only describing the uninstall path). With it,
+  # spec changes (machine type, zone, OS) made via overlays are
+  # rendered into `helm get manifest` but never patched onto the live
+  # CR, so the operator keeps reconciling against the original spec
+  # forever and only manual `kubectl patch` reconciles the drift.
+  #
+  # Without `keep`, helm uninstall will request CR deletion and the
+  # operator's finalizer must clear before the CR actually goes away.
+  # That's fine in normal teardown — the operator deployment lives in
+  # the same release, k8s sets DeletionTimestamps in parallel, and
+  # controller-runtime's graceful shutdown drains the workqueue
+  # before the operator pod exits, so reconcileDelete runs and the
+  # finalizer clears. The hazardous case is `macosFleet.enabled=false`
+  # in a single upgrade that ALSO removes the operator — don't do
+  # that; scale `replicas` to 0 first, let the operator drain, then
+  # disable the chart in a follow-up.
 spec:
   type: {{ $.Values.macosFleet.machine.type | default "M4-S" | quote }}
   zone: {{ $.Values.macosFleet.machine.zone | default "fr-par-1" | quote }}


### PR DESCRIPTION
## Summary

Two adjacent fleet-bring-up bugs surfaced during today's first production rollout of the k8s-managed Mac mini fleet ([run 25492551965](https://github.com/tuist/tuist/actions/runs/25492551965), then 25505420596). Both unblocks fix what is otherwise a manual-patch-every-time experience.

### Bug 1 — `helm.sh/resource-policy: keep` blocks updates, not just deletes

`ScalewayAppleSiliconMachine` carried `helm.sh/resource-policy: keep` to protect the operator's finalizer from a rollback deadlock (helm tries to delete the CR, finalizer blocks, helm has already torn down the operator that would clear it).

In Helm v3 the annotation also silently skips upgrades to kept resources. Helm's docs only describe the uninstall path, but in practice once a resource is `keep`-ed, Helm orphans it from the release's update cycle — `helm get manifest` shows the new spec, but Helm never patches the live object.

Real-world impact: bumping `macosFleet.machine.type` from `M4-S` to `M2-L` in [#10671](https://github.com/tuist/tuist/pull/10671) rendered correctly into the helm manifest, but the live `ScalewayAppleSiliconMachine` CRs in production stayed at `type: M4-S`. The operator kept ordering M4-S Mac minis (out of stock) for ~2h until manual `kubectl patch` reconciled the drift.

Fix: drop the annotation. The original deadlock concern was largely theoretical:

- The operator deployment lives in the same Helm release as the CRs, so `helm uninstall` schedules deletion of both.
- controller-runtime's graceful shutdown drains the reconcile workqueue before the operator pod exits, so `reconcileDelete` runs on each CR and clears the finalizer before the operator is gone.
- The hazardous case is `macosFleet.enabled=false` in the same upgrade that removes the operator. Documented in the new template comment as: scale `replicas` to 0 first, let the operator drain, then disable.

### Bug 2 — single reconcile worker serializes the whole fleet

The machine controller used controller-runtime's default `MaxConcurrentReconciles: 1`. Each Mac mini's `CreateServer` + SSH bootstrap blocks the worker for ~50 min, so first-time provision of `replicas: N` took **N × ~50 min** wall-clock — production's two machines should have come up in parallel but went serially while we watched.

Fix: new `--machine-max-concurrent-reconciles` flag (default 4) wired through the reconciler struct's `MaxConcurrentReconciles` field. Per-key locking inside controller-runtime still serializes reconciles for the same CR, so this only parallelizes across distinct machines.

## Test plan

- [x] `go build ./...` and `go test ./...` in `infra/cluster-api-provider-scaleway-applesilicon`.
- [x] `helm template` confirms the rendered CR no longer carries `helm.sh/resource-policy: keep`.
- [ ] Once the next operator image rolls out: bump `macosFleet.machine.type` in a values overlay, deploy, and verify the live CR's spec is patched (no manual `kubectl patch` needed).
- [ ] On a fresh fleet (canary or a test env with replicas≥2), verify two machines hit `Provisioning → Ordering` events within seconds of each other rather than ~50 min apart.
- [ ] Confirm uninstall path: scale `macosFleet.replicas` to 0, watch CR finalizers clear before the operator deployment goes away. (Don't combine into a single `helm uninstall` step until we have a pre-delete hook.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)