### PR TITLE
feat(capi-scaleway): auto-roll xcresult-processor on fleet-shape change

### DIFF
--- a/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go
@@ -69,6 +69,9 @@ func main() {
 		tartKubeletMaxUpdateAttempts int
 
 		machineMaxConcurrentReconciles int
+
+		fleetSpreadDeployment string
+		fleetSpreadNamespace  string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Prometheus metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Liveness/readiness probe endpoint")
@@ -111,6 +114,23 @@ func main() {
 			"provision in parallel; reconciles for the same machine remain "+
 			"serialized by controller-runtime's per-key locking. 4 covers the "+
 			"production fleet size with headroom; raise if fleets grow.")
+	flag.StringVar(&fleetSpreadDeployment, "fleet-spread-deployment",
+		envOrDefault("CAPI_FLEET_SPREAD_DEPLOYMENT", ""),
+		"Deployment name to roll on fleet-shape change (typically "+
+			"the xcresult-processor). When set, the operator stamps a hash of "+
+			"the Ready Mac mini set onto the Deployment's pod template "+
+			"annotation, forcing a new ReplicaSet whenever the fleet grows or "+
+			"shrinks — the rolling update then redistributes Pods across hosts "+
+			"via the Deployment's existing topologySpreadConstraints. The "+
+			"scheduler doesn't rebalance running Pods on its own, so without "+
+			"this we'd need a manual `kubectl rollout restart` every time a "+
+			"Mac mini joins or leaves. Empty disables the controller (OSS "+
+			"deployments without a workload to spread).")
+	flag.StringVar(&fleetSpreadNamespace, "fleet-spread-namespace",
+		envOrDefault("CAPI_FLEET_SPREAD_NAMESPACE", ""),
+		"Namespace of the Deployment named by --fleet-spread-deployment. "+
+			"Defaults to --secrets-namespace, which matches the chart's "+
+			"single-namespace install layout.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
@@ -202,6 +222,24 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "setup MachineReconciler")
 		os.Exit(1)
+	}
+
+	if fleetSpreadDeployment != "" {
+		ns := fleetSpreadNamespace
+		if ns == "" {
+			ns = secretsNamespace
+		}
+		if err := (&controllers.FleetSpreadReconciler{
+			Client:         mgr.GetClient(),
+			APIReader:      mgr.GetAPIReader(),
+			DeploymentName: fleetSpreadDeployment,
+			Namespace:      ns,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "setup FleetSpreadReconciler")
+			os.Exit(1)
+		}
+		setupLog.Info("fleet-spread controller enabled",
+			"deployment", fleetSpreadDeployment, "namespace", ns)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
@@ -8,31 +8,50 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // FleetHashAnnotation is stamped on the target Deployment's pod
-// template whenever the set of Ready Mac minis changes. K8s sees the
-// new annotation, mints a new ReplicaSet, and the rolling update
+// template whenever the set of Ready Mac mini Nodes changes. K8s sees
+// the new annotation, mints a new ReplicaSet, and the rolling update
 // re-evaluates topologySpreadConstraints — which is the only way to
 // rebalance Pods after a fleet-shape change, since the scheduler
 // doesn't reconsider placement of running Pods on its own.
 const FleetHashAnnotation = "tuist.dev/fleet-hash"
 
-// FleetSpreadReconciler watches ScalewayAppleSiliconMachine and patches
-// a target Deployment's pod-template annotation with a hash of the
-// Ready fleet members. When fleet-1 transitions Ready, the hash
-// changes from `{fleet-0}` to `{fleet-0,fleet-1}` and the Deployment
-// rolls — pods then spread one-per-host via the Deployment's existing
+// FleetNodeSelector picks out Mac mini Nodes (the ones tart-kubelet
+// registered) from the rest of the cluster. Matches the nodeSelector
+// the chart's xcresult-processor Deployment uses, so the hash is over
+// exactly the set of hosts that workload can schedule on.
+var FleetNodeSelector = labels.SelectorFromSet(labels.Set{
+	"kubernetes.io/os":   "darwin",
+	"tuist.dev/runtime":  "tart",
+})
+
+// FleetSpreadReconciler watches Mac mini Nodes and patches a target
+// Deployment's pod-template annotation with a hash of the Ready
+// members. When fleet-1's Node transitions Ready, the hash changes
+// from `{fleet-0}` to `{fleet-0,fleet-1}` and the Deployment rolls —
+// pods then spread one-per-host via the Deployment's existing
 // topologySpreadConstraints. Without this, fleet additions don't
 // rebalance Pods and operators have to `kubectl rollout restart`
 // every time a Mac mini is added or replaced.
+//
+// We hash on Node Ready, not Machine Phase=Ready, on purpose. The
+// machine controller sets Phase=Ready as soon as bootstrap returns,
+// but tart-kubelet's first heartbeat may not have landed yet — the
+// kube Node can still be NotReady. Rolling at Phase=Ready means the
+// new ReplicaSet's Pods can't schedule on the not-yet-Ready Node,
+// the topology spread settles for `ScheduleAnyway` on the only
+// Ready host (fleet-0 again), and the imbalance reappears.
 //
 // Disabled when DeploymentName is empty, so OSS deployments that
 // don't run xcresult-processor aren't affected by it.
@@ -51,25 +70,25 @@ type FleetSpreadReconciler struct {
 	// Empty disables the controller.
 	DeploymentName string
 
-	// Namespace is where DeploymentName lives. The reconciler also
-	// scopes ScalewayAppleSiliconMachine listing to this namespace —
-	// fleets are namespace-local in practice (chart deploys both the
-	// CRs and the workload into the same release namespace).
+	// Namespace is where DeploymentName lives. Chart deploys both the
+	// macOS fleet CRs and the workload into the same release
+	// namespace; this scopes the Deployment Get/Patch to that one
+	// namespace (Nodes themselves are cluster-scoped).
 	Namespace string
 }
 
-// Reconcile ignores req.NamespacedName: any machine event fires the
-// same idempotent "list Ready machines, hash, patch deployment" pass.
-// Cheap because patches that don't change the value are k8s no-ops,
-// and steady state is one List + one Get per machine event.
+// Reconcile ignores req.NamespacedName: any Node event fires the
+// same idempotent "list Ready fleet Nodes, hash, patch deployment"
+// pass. Cheap because patches that don't change the value are k8s
+// no-ops, and steady state is one List + one Get per Node event.
 func (r *FleetSpreadReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("deployment", r.DeploymentName, "namespace", r.Namespace)
 
-	var machines infrav1.ScalewayAppleSiliconMachineList
-	if err := r.List(ctx, &machines, client.InNamespace(r.Namespace)); err != nil {
+	var nodes corev1.NodeList
+	if err := r.List(ctx, &nodes, &client.ListOptions{LabelSelector: FleetNodeSelector}); err != nil {
 		return ctrl.Result{}, err
 	}
-	hash := readyFleetHash(machines.Items)
+	hash := readyNodeHash(nodes.Items)
 
 	reader := r.APIReader
 	if reader == nil {
@@ -104,37 +123,49 @@ func (r *FleetSpreadReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
-// readyFleetHash is a stable, order-independent hash of the Ready
-// fleet members. Includes only Ready, non-deleting machines: a
-// machine flapping through transient phases (Provisioning,
-// Bootstrapping) won't roll the workload until the host actually
-// comes Ready, and a machine being torn down stops counting the
-// moment it's marked for deletion (rather than when its finalizer
-// finally clears, which can be minutes later).
-func readyFleetHash(machines []infrav1.ScalewayAppleSiliconMachine) string {
-	names := make([]string, 0, len(machines))
-	for _, m := range machines {
-		if !m.DeletionTimestamp.IsZero() {
+// readyNodeHash is a stable, order-independent hash of the schedulable
+// Mac mini Nodes. Source of truth is `NodeReady=True`: the kube
+// scheduler will only place new Pods onto a Ready Node, so anything
+// else doesn't count toward the spread. A Node being drained or
+// torn down (DeletionTimestamp set) drops out the moment the delete
+// is observed, before its Pods get evicted — the Deployment rolls
+// onto the surviving hosts ahead of time.
+func readyNodeHash(nodes []corev1.Node) string {
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if !n.DeletionTimestamp.IsZero() {
 			continue
 		}
-		if m.Status.Phase != "Ready" {
+		if !isNodeReady(n) {
 			continue
 		}
-		names = append(names, m.Name)
+		names = append(names, n.Name)
 	}
 	sort.Strings(names)
 	sum := sha256.Sum256([]byte(strings.Join(names, ",")))
 	return hex.EncodeToString(sum[:8])
 }
 
-// SetupWithManager wires the controller's only watch:
-// ScalewayAppleSiliconMachine. Reconciles ignore the request key
-// (we always operate on the configured Deployment), so every
-// machine event triggers the same idempotent pass — no Watches()
-// gymnastics needed.
+func isNodeReady(n corev1.Node) bool {
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// SetupWithManager watches Nodes filtered to the Mac mini fleet —
+// that's the source of truth for "Pod can schedule here." Predicate
+// trims the watch to fleet Nodes server-side via the cache's label
+// selector index, so the operator doesn't churn through Linux node
+// updates from the rest of the cluster.
 func (r *FleetSpreadReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	fleetNode := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return FleetNodeSelector.Matches(labels.Set(o.GetLabels()))
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("fleet-spread").
-		For(&infrav1.ScalewayAppleSiliconMachine{}).
+		For(&corev1.Node{}, builder.WithPredicates(fleetNode)).
 		Complete(r)
 }

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
@@ -1,0 +1,140 @@
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+)
+
+// FleetHashAnnotation is stamped on the target Deployment's pod
+// template whenever the set of Ready Mac minis changes. K8s sees the
+// new annotation, mints a new ReplicaSet, and the rolling update
+// re-evaluates topologySpreadConstraints — which is the only way to
+// rebalance Pods after a fleet-shape change, since the scheduler
+// doesn't reconsider placement of running Pods on its own.
+const FleetHashAnnotation = "tuist.dev/fleet-hash"
+
+// FleetSpreadReconciler watches ScalewayAppleSiliconMachine and patches
+// a target Deployment's pod-template annotation with a hash of the
+// Ready fleet members. When fleet-1 transitions Ready, the hash
+// changes from `{fleet-0}` to `{fleet-0,fleet-1}` and the Deployment
+// rolls — pods then spread one-per-host via the Deployment's existing
+// topologySpreadConstraints. Without this, fleet additions don't
+// rebalance Pods and operators have to `kubectl rollout restart`
+// every time a Mac mini is added or replaced.
+//
+// Disabled when DeploymentName is empty, so OSS deployments that
+// don't run xcresult-processor aren't affected by it.
+type FleetSpreadReconciler struct {
+	client.Client
+
+	// APIReader bypasses the manager's informer cache for Deployment
+	// Gets. Without this, controller-runtime would build a Deployment
+	// informer and need list+watch RBAC over the resource — broader
+	// than the named-resource get+patch we want to grant. Reads via
+	// APIReader hit the API server directly. Wired by the manager
+	// binary to mgr.GetAPIReader().
+	APIReader client.Reader
+
+	// DeploymentName is the workload to patch on fleet-shape change.
+	// Empty disables the controller.
+	DeploymentName string
+
+	// Namespace is where DeploymentName lives. The reconciler also
+	// scopes ScalewayAppleSiliconMachine listing to this namespace —
+	// fleets are namespace-local in practice (chart deploys both the
+	// CRs and the workload into the same release namespace).
+	Namespace string
+}
+
+// Reconcile ignores req.NamespacedName: any machine event fires the
+// same idempotent "list Ready machines, hash, patch deployment" pass.
+// Cheap because patches that don't change the value are k8s no-ops,
+// and steady state is one List + one Get per machine event.
+func (r *FleetSpreadReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("deployment", r.DeploymentName, "namespace", r.Namespace)
+
+	var machines infrav1.ScalewayAppleSiliconMachineList
+	if err := r.List(ctx, &machines, client.InNamespace(r.Namespace)); err != nil {
+		return ctrl.Result{}, err
+	}
+	hash := readyFleetHash(machines.Items)
+
+	reader := r.APIReader
+	if reader == nil {
+		reader = r.Client
+	}
+	var dep appsv1.Deployment
+	depKey := types.NamespacedName{Namespace: r.Namespace, Name: r.DeploymentName}
+	if err := reader.Get(ctx, depKey, &dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Chart-managed Deployment may not exist yet during
+			// first-time bring-up (helm orders resources by kind +
+			// our CRs sort before the Deployment's kind). Trust
+			// the next reconcile to find it.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if dep.Spec.Template.Annotations[FleetHashAnnotation] == hash {
+		return ctrl.Result{}, nil
+	}
+
+	patch := client.MergeFrom(dep.DeepCopy())
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations[FleetHashAnnotation] = hash
+	if err := r.Patch(ctx, &dep, patch); err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.Info("rolled deployment on fleet-shape change", "fleet-hash", hash)
+	return ctrl.Result{}, nil
+}
+
+// readyFleetHash is a stable, order-independent hash of the Ready
+// fleet members. Includes only Ready, non-deleting machines: a
+// machine flapping through transient phases (Provisioning,
+// Bootstrapping) won't roll the workload until the host actually
+// comes Ready, and a machine being torn down stops counting the
+// moment it's marked for deletion (rather than when its finalizer
+// finally clears, which can be minutes later).
+func readyFleetHash(machines []infrav1.ScalewayAppleSiliconMachine) string {
+	names := make([]string, 0, len(machines))
+	for _, m := range machines {
+		if !m.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if m.Status.Phase != "Ready" {
+			continue
+		}
+		names = append(names, m.Name)
+	}
+	sort.Strings(names)
+	sum := sha256.Sum256([]byte(strings.Join(names, ",")))
+	return hex.EncodeToString(sum[:8])
+}
+
+// SetupWithManager wires the controller's only watch:
+// ScalewayAppleSiliconMachine. Reconciles ignore the request key
+// (we always operate on the configured Deployment), so every
+// machine event triggers the same idempotent pass — no Watches()
+// gymnastics needed.
+func (r *FleetSpreadReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("fleet-spread").
+		For(&infrav1.ScalewayAppleSiliconMachine{}).
+		Complete(r)
+}

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
@@ -1,0 +1,220 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
+)
+
+func TestReadyFleetHash_StableAcrossReorderings(t *testing.T) {
+	a := []infrav1.ScalewayAppleSiliconMachine{
+		readyMachine("fleet-0"),
+		readyMachine("fleet-1"),
+	}
+	b := []infrav1.ScalewayAppleSiliconMachine{
+		readyMachine("fleet-1"),
+		readyMachine("fleet-0"),
+	}
+	if readyFleetHash(a) != readyFleetHash(b) {
+		t.Fatalf("hash should be order-independent: %q vs %q",
+			readyFleetHash(a), readyFleetHash(b))
+	}
+}
+
+func TestReadyFleetHash_ChangesWhenMembershipChanges(t *testing.T) {
+	one := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
+	two := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0"), readyMachine("fleet-1")}
+	if readyFleetHash(one) == readyFleetHash(two) {
+		t.Fatal("hash must distinguish {fleet-0} from {fleet-0, fleet-1}")
+	}
+}
+
+func TestReadyFleetHash_ExcludesNonReady(t *testing.T) {
+	mixed := []infrav1.ScalewayAppleSiliconMachine{
+		readyMachine("fleet-0"),
+		machineWithPhase("fleet-1", "Provisioning"),
+	}
+	onlyReady := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
+	if readyFleetHash(mixed) != readyFleetHash(onlyReady) {
+		t.Fatal("non-Ready machines must not contribute to the hash")
+	}
+}
+
+func TestReadyFleetHash_ExcludesMachinesPendingDeletion(t *testing.T) {
+	now := metav1.Now()
+	terminating := readyMachine("fleet-1")
+	terminating.DeletionTimestamp = &now
+	terminating.Finalizers = []string{"hold"}
+
+	withTerminating := []infrav1.ScalewayAppleSiliconMachine{
+		readyMachine("fleet-0"),
+		terminating,
+	}
+	onlyAlive := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
+	if readyFleetHash(withTerminating) != readyFleetHash(onlyAlive) {
+		t.Fatal("terminating machines should drop out of the hash immediately, not after finalizer clears")
+	}
+}
+
+// TestReconcile_StampsAnnotationOnFirstReady locks in the headline
+// behaviour: when fleet-0 transitions Ready, the Deployment gets a
+// fresh fleet-hash annotation. Without it, helm-managed workloads
+// like xcresult-processor never rebalance after fleet additions.
+func TestReconcile_StampsAnnotationOnFirstReady(t *testing.T) {
+	ready := readyMachine("fleet-0")
+	dep := emptyDeployment("xcresult-processor", "tuist")
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready, &dep)
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := getAnnotation(t, r, "tuist", "xcresult-processor")
+	if got == "" {
+		t.Fatal("annotation not stamped on first reconcile with a Ready machine")
+	}
+}
+
+// TestReconcile_NoOpWhenHashMatches locks in idempotence so we don't
+// churn ReplicaSets every reconcile pass in steady state.
+func TestReconcile_NoOpWhenHashMatches(t *testing.T) {
+	ready := readyMachine("fleet-0")
+	dep := emptyDeployment("xcresult-processor", "tuist")
+	dep.Spec.Template.Annotations = map[string]string{
+		FleetHashAnnotation: readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{ready}),
+	}
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready, &dep)
+
+	// fake client assigns ResourceVersion on store; capture the
+	// post-store value as the baseline. Patch would bump it, so RV
+	// stability across Reconcile proves we short-circuited.
+	var before appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &before); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var after appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("expected no patch on stable hash, RV %q -> %q", before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+// TestReconcile_RepatchesOnFleetGrowth covers the production case
+// this PR is for: fleet-1 joins, hash changes, deployment annotation
+// changes, k8s rolls a new ReplicaSet, topology spread distributes
+// pods across the now-two hosts.
+func TestReconcile_RepatchesOnFleetGrowth(t *testing.T) {
+	m0 := readyMachine("fleet-0")
+	m1 := readyMachine("fleet-1")
+	dep := emptyDeployment("xcresult-processor", "tuist")
+	dep.Spec.Template.Annotations = map[string]string{
+		FleetHashAnnotation: readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{m0}),
+	}
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &m0, &m1, &dep)
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got := getAnnotation(t, r, "tuist", "xcresult-processor")
+	want := readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{m0, m1})
+	if got != want {
+		t.Fatalf("hash not updated on fleet growth: got %q, want %q", got, want)
+	}
+}
+
+// TestReconcile_NoOpWhenDeploymentMissing covers the chart-bring-up
+// race: the operator can win leadership and reconcile before helm
+// has installed the workload Deployment. The reconciler must not
+// error in that window — the next machine event will retry.
+func TestReconcile_NoOpWhenDeploymentMissing(t *testing.T) {
+	ready := readyMachine("fleet-0")
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready)
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile must tolerate missing deployment, got %v", err)
+	}
+}
+
+// === helpers ================================================================
+
+func readyMachine(name string) infrav1.ScalewayAppleSiliconMachine {
+	return machineWithPhase(name, "Ready")
+}
+
+func machineWithPhase(name, phase string) infrav1.ScalewayAppleSiliconMachine {
+	return infrav1.ScalewayAppleSiliconMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "tuist",
+		},
+		Status: infrav1.ScalewayAppleSiliconMachineStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func emptyDeployment(name, namespace string) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+		},
+	}
+}
+
+func newFleetSpreadReconciler(t *testing.T, namespace, deployment string, objs ...client.Object) (*FleetSpreadReconciler, context.Context) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &FleetSpreadReconciler{
+		Client:         cli,
+		DeploymentName: deployment,
+		Namespace:      namespace,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return r, ctx
+}
+
+func getAnnotation(t *testing.T, r *FleetSpreadReconciler, namespace, name string) string {
+	t.Helper()
+	var dep appsv1.Deployment
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &dep); err != nil {
+		t.Fatal(err)
+	}
+	return dep.Spec.Template.Annotations[FleetHashAnnotation]
+}

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
@@ -13,69 +13,80 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-scaleway-applesilicon/api/v1alpha1"
 )
 
-func TestReadyFleetHash_StableAcrossReorderings(t *testing.T) {
-	a := []infrav1.ScalewayAppleSiliconMachine{
-		readyMachine("fleet-0"),
-		readyMachine("fleet-1"),
-	}
-	b := []infrav1.ScalewayAppleSiliconMachine{
-		readyMachine("fleet-1"),
-		readyMachine("fleet-0"),
-	}
-	if readyFleetHash(a) != readyFleetHash(b) {
+func TestReadyNodeHash_StableAcrossReorderings(t *testing.T) {
+	a := []corev1.Node{readyNode("fleet-0"), readyNode("fleet-1")}
+	b := []corev1.Node{readyNode("fleet-1"), readyNode("fleet-0")}
+	if readyNodeHash(a) != readyNodeHash(b) {
 		t.Fatalf("hash should be order-independent: %q vs %q",
-			readyFleetHash(a), readyFleetHash(b))
+			readyNodeHash(a), readyNodeHash(b))
 	}
 }
 
-func TestReadyFleetHash_ChangesWhenMembershipChanges(t *testing.T) {
-	one := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
-	two := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0"), readyMachine("fleet-1")}
-	if readyFleetHash(one) == readyFleetHash(two) {
+func TestReadyNodeHash_ChangesWhenMembershipChanges(t *testing.T) {
+	one := []corev1.Node{readyNode("fleet-0")}
+	two := []corev1.Node{readyNode("fleet-0"), readyNode("fleet-1")}
+	if readyNodeHash(one) == readyNodeHash(two) {
 		t.Fatal("hash must distinguish {fleet-0} from {fleet-0, fleet-1}")
 	}
 }
 
-func TestReadyFleetHash_ExcludesNonReady(t *testing.T) {
-	mixed := []infrav1.ScalewayAppleSiliconMachine{
-		readyMachine("fleet-0"),
-		machineWithPhase("fleet-1", "Provisioning"),
+// TestReadyNodeHash_ExcludesNotReady is the key invariant the P2
+// review caught: a Mac mini whose ScalewayAppleSiliconMachine has
+// flipped to Phase=Ready can still have a NotReady kube Node (tart-
+// kubelet's first heartbeat hasn't landed). Hashing on Phase would
+// roll the Deployment too early — Pods can't schedule onto a
+// NotReady Node, so they bounce back to the old host and the
+// imbalance recurs. Source-of-truth must be Node Ready.
+func TestReadyNodeHash_ExcludesNotReady(t *testing.T) {
+	mixed := []corev1.Node{
+		readyNode("fleet-0"),
+		nodeWithReady("fleet-1", corev1.ConditionFalse),
 	}
-	onlyReady := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
-	if readyFleetHash(mixed) != readyFleetHash(onlyReady) {
-		t.Fatal("non-Ready machines must not contribute to the hash")
+	onlyReady := []corev1.Node{readyNode("fleet-0")}
+	if readyNodeHash(mixed) != readyNodeHash(onlyReady) {
+		t.Fatal("NotReady Nodes must not contribute to the hash")
 	}
 }
 
-func TestReadyFleetHash_ExcludesMachinesPendingDeletion(t *testing.T) {
+// TestReadyNodeHash_ExcludesNodesWithoutReadyCondition covers the
+// brand-new-Node window before kubelet has reported any conditions
+// at all. Same logic as NotReady — Pods can't schedule there.
+func TestReadyNodeHash_ExcludesNodesWithoutReadyCondition(t *testing.T) {
+	mixed := []corev1.Node{
+		readyNode("fleet-0"),
+		{ObjectMeta: metav1.ObjectMeta{Name: "fleet-1"}},
+	}
+	onlyReady := []corev1.Node{readyNode("fleet-0")}
+	if readyNodeHash(mixed) != readyNodeHash(onlyReady) {
+		t.Fatal("Nodes without a Ready condition must not contribute to the hash")
+	}
+}
+
+func TestReadyNodeHash_ExcludesNodesPendingDeletion(t *testing.T) {
 	now := metav1.Now()
-	terminating := readyMachine("fleet-1")
+	terminating := readyNode("fleet-1")
 	terminating.DeletionTimestamp = &now
 	terminating.Finalizers = []string{"hold"}
 
-	withTerminating := []infrav1.ScalewayAppleSiliconMachine{
-		readyMachine("fleet-0"),
-		terminating,
-	}
-	onlyAlive := []infrav1.ScalewayAppleSiliconMachine{readyMachine("fleet-0")}
-	if readyFleetHash(withTerminating) != readyFleetHash(onlyAlive) {
-		t.Fatal("terminating machines should drop out of the hash immediately, not after finalizer clears")
+	withTerminating := []corev1.Node{readyNode("fleet-0"), terminating}
+	onlyAlive := []corev1.Node{readyNode("fleet-0")}
+	if readyNodeHash(withTerminating) != readyNodeHash(onlyAlive) {
+		t.Fatal("terminating Nodes should drop out of the hash immediately")
 	}
 }
 
 // TestReconcile_StampsAnnotationOnFirstReady locks in the headline
-// behaviour: when fleet-0 transitions Ready, the Deployment gets a
-// fresh fleet-hash annotation. Without it, helm-managed workloads
-// like xcresult-processor never rebalance after fleet additions.
+// behaviour: when fleet-0's Node transitions Ready, the Deployment
+// gets a fresh fleet-hash annotation. Without it, helm-managed
+// workloads like xcresult-processor never rebalance after fleet
+// additions.
 func TestReconcile_StampsAnnotationOnFirstReady(t *testing.T) {
-	ready := readyMachine("fleet-0")
+	node := readyNode("fleet-0")
 	dep := emptyDeployment("xcresult-processor", "tuist")
 
-	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready, &dep)
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &node, &dep)
 
 	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -83,24 +94,21 @@ func TestReconcile_StampsAnnotationOnFirstReady(t *testing.T) {
 
 	got := getAnnotation(t, r, "tuist", "xcresult-processor")
 	if got == "" {
-		t.Fatal("annotation not stamped on first reconcile with a Ready machine")
+		t.Fatal("annotation not stamped on first reconcile with a Ready Node")
 	}
 }
 
 // TestReconcile_NoOpWhenHashMatches locks in idempotence so we don't
 // churn ReplicaSets every reconcile pass in steady state.
 func TestReconcile_NoOpWhenHashMatches(t *testing.T) {
-	ready := readyMachine("fleet-0")
+	node := readyNode("fleet-0")
 	dep := emptyDeployment("xcresult-processor", "tuist")
 	dep.Spec.Template.Annotations = map[string]string{
-		FleetHashAnnotation: readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{ready}),
+		FleetHashAnnotation: readyNodeHash([]corev1.Node{node}),
 	}
 
-	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready, &dep)
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &node, &dep)
 
-	// fake client assigns ResourceVersion on store; capture the
-	// post-store value as the baseline. Patch would bump it, so RV
-	// stability across Reconcile proves we short-circuited.
 	var before appsv1.Deployment
 	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &before); err != nil {
 		t.Fatal(err)
@@ -120,38 +128,75 @@ func TestReconcile_NoOpWhenHashMatches(t *testing.T) {
 }
 
 // TestReconcile_RepatchesOnFleetGrowth covers the production case
-// this PR is for: fleet-1 joins, hash changes, deployment annotation
-// changes, k8s rolls a new ReplicaSet, topology spread distributes
-// pods across the now-two hosts.
+// this PR is for: fleet-1's Node joins as Ready, hash changes,
+// deployment annotation changes, k8s rolls a new ReplicaSet,
+// topology spread distributes pods across the now-two hosts.
 func TestReconcile_RepatchesOnFleetGrowth(t *testing.T) {
-	m0 := readyMachine("fleet-0")
-	m1 := readyMachine("fleet-1")
+	n0 := readyNode("fleet-0")
+	n1 := readyNode("fleet-1")
 	dep := emptyDeployment("xcresult-processor", "tuist")
 	dep.Spec.Template.Annotations = map[string]string{
-		FleetHashAnnotation: readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{m0}),
+		FleetHashAnnotation: readyNodeHash([]corev1.Node{n0}),
 	}
 
-	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &m0, &m1, &dep)
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &n0, &n1, &dep)
 
 	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
 
 	got := getAnnotation(t, r, "tuist", "xcresult-processor")
-	want := readyFleetHash([]infrav1.ScalewayAppleSiliconMachine{m0, m1})
+	want := readyNodeHash([]corev1.Node{n0, n1})
 	if got != want {
 		t.Fatalf("hash not updated on fleet growth: got %q, want %q", got, want)
+	}
+}
+
+// TestReconcile_DoesNotRollOnPhaseReadyBeforeNodeReady is the P2
+// regression test. A new Mac mini whose ScalewayAppleSiliconMachine
+// has Phase=Ready but whose kube Node hasn't reported NodeReady yet
+// must NOT contribute to the hash — otherwise we roll into a
+// scheduling cul-de-sac. Verify by setting up a NotReady Node with
+// the right labels and asserting the hash matches "only the Ready
+// Node" state.
+func TestReconcile_DoesNotRollOnPhaseReadyBeforeNodeReady(t *testing.T) {
+	readyOnly := readyNode("fleet-0")
+	notYet := nodeWithReady("fleet-1", corev1.ConditionFalse)
+
+	dep := emptyDeployment("xcresult-processor", "tuist")
+	dep.Spec.Template.Annotations = map[string]string{
+		FleetHashAnnotation: readyNodeHash([]corev1.Node{readyOnly}),
+	}
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &readyOnly, &notYet, &dep)
+
+	var before appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &before); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var after appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("expected no patch while fleet-1 Node is NotReady, RV %q -> %q",
+			before.ResourceVersion, after.ResourceVersion)
 	}
 }
 
 // TestReconcile_NoOpWhenDeploymentMissing covers the chart-bring-up
 // race: the operator can win leadership and reconcile before helm
 // has installed the workload Deployment. The reconciler must not
-// error in that window — the next machine event will retry.
+// error in that window — the next Node event will retry.
 func TestReconcile_NoOpWhenDeploymentMissing(t *testing.T) {
-	ready := readyMachine("fleet-0")
+	node := readyNode("fleet-0")
 
-	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &ready)
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &node)
 
 	if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
 		t.Fatalf("reconcile must tolerate missing deployment, got %v", err)
@@ -160,18 +205,26 @@ func TestReconcile_NoOpWhenDeploymentMissing(t *testing.T) {
 
 // === helpers ================================================================
 
-func readyMachine(name string) infrav1.ScalewayAppleSiliconMachine {
-	return machineWithPhase(name, "Ready")
+func readyNode(name string) corev1.Node {
+	return nodeWithReady(name, corev1.ConditionTrue)
 }
 
-func machineWithPhase(name, phase string) infrav1.ScalewayAppleSiliconMachine {
-	return infrav1.ScalewayAppleSiliconMachine{
+// nodeWithReady builds a Node carrying the same labels the chart's
+// xcresult-processor selects on, so it matches FleetNodeSelector.
+func nodeWithReady(name string, ready corev1.ConditionStatus) corev1.Node {
+	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "tuist",
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/os":  "darwin",
+				"tuist.dev/runtime": "tart",
+			},
 		},
-		Status: infrav1.ScalewayAppleSiliconMachineStatus{
-			Phase: phase,
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:   corev1.NodeReady,
+				Status: ready,
+			}},
 		},
 	}
 }
@@ -196,7 +249,7 @@ func newFleetSpreadReconciler(t *testing.T, namespace, deployment string, objs .
 	if err := appsv1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
-	if err := infrav1.AddToScheme(scheme); err != nil {
+	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -97,17 +97,50 @@ rules:
     resources: [configmaps]
     resourceNames: [cluster-info]
     verbs: [get]
-  {{- if .Values.xcresultProcessor.enabled }}
+{{- if .Values.xcresultProcessor.enabled }}
+---
+# Namespaced Role for the fleet-spread controller's one operation:
+# patching the xcresult-processor Deployment's pod-template
+# annotation to roll a new ReplicaSet on fleet-shape change. Done
+# as a Role (not a ClusterRole rule with resourceNames) because
+# RBAC's resourceNames matches across all namespaces — a
+# ClusterRole granting `get,patch` on `deployments/xcresult-
+# processor` would let the operator patch any same-named Deployment
+# anywhere in the cluster, not just the one in this release. A
+# namespace-scoped Role caps the blast radius at the release
+# namespace where the operator actually needs to operate.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-fleet-spread
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-scaleway-applesilicon
+rules:
   - apiGroups: ["apps"]
-    # Fleet-spread controller patches a single Deployment's pod-
-    # template annotation to roll a new ReplicaSet on fleet-shape
-    # change. Scoped to the one Deployment by name so the operator
-    # can't patch arbitrary workloads even if compromised.
     resources: [deployments]
     resourceNames:
       - {{ include "tuist.componentName" (dict "root" . "component" "xcresult-processor") }}
     verbs: [get, patch]
-  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-fleet-spread
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: capi-scaleway-applesilicon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}-fleet-spread
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
+++ b/infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml
@@ -97,6 +97,17 @@ rules:
     resources: [configmaps]
     resourceNames: [cluster-info]
     verbs: [get]
+  {{- if .Values.xcresultProcessor.enabled }}
+  - apiGroups: ["apps"]
+    # Fleet-spread controller patches a single Deployment's pod-
+    # template annotation to roll a new ReplicaSet on fleet-shape
+    # change. Scoped to the one Deployment by name so the operator
+    # can't patch arbitrary workloads even if compromised.
+    resources: [deployments]
+    resourceNames:
+      - {{ include "tuist.componentName" (dict "root" . "component" "xcresult-processor") }}
+    verbs: [get, patch]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -156,6 +167,16 @@ spec:
             - --tartkubelet-host-cpu={{ .Values.macosFleet.tartKubelet.hostCPU | default 8 }}
             - --tartkubelet-host-memory-mb={{ .Values.macosFleet.tartKubelet.hostMemoryMB | default 16384 }}
             - --tartkubelet-max-pods={{ .Values.macosFleet.tartKubelet.maxPods | default 3 }}
+            {{- if .Values.xcresultProcessor.enabled }}
+            # Auto-roll the xcresult-processor Deployment whenever the
+            # set of Ready Mac minis changes, so Pods spread across new
+            # hosts without a manual `kubectl rollout restart`. The
+            # Deployment's existing topologySpreadConstraints handle
+            # the placement; this just forces a new ReplicaSet on
+            # fleet-shape change. See controllers/fleetspread_controller.go.
+            - --fleet-spread-deployment={{ include "tuist.componentName" (dict "root" . "component" "xcresult-processor") }}
+            - --fleet-spread-namespace={{ .Release.Namespace }}
+            {{- end }}
           env:
             # Scaleway credentials. ESO syncs them from 1Password into
             # this Secret automatically (see


### PR DESCRIPTION
## Summary

Today's production fleet bring-up surfaced a sharp edge in the k8s scheduler model: it places Pods at admission time and **never rebalances them on its own**, so when a new Mac mini joins (or leaves) the fleet, the xcresult-processor Pods stay where the scheduler put them at the previous topology.

Concretely: production deployed with `replicas: 2` for the xcresult-processor, fleet-0 came Ready first, both replicas landed on it (legitimately — `whenUnsatisfiable: ScheduleAnyway` lets that happen). When fleet-1 came Ready ~50 min later, nothing moved. We had to `kubectl rollout restart deploy/...-xcresult-processor` by hand to let the topology spread relocate one Pod onto the new host.

This PR makes that automatic.

## How

New `FleetSpreadReconciler` in the CAPI operator. It watches `ScalewayAppleSiliconMachine`, computes a stable hash of the Ready members, and patches a target Deployment's `spec.template.metadata.annotations[tuist.dev/fleet-hash]` whenever the hash changes. K8s sees the new annotation, mints a new ReplicaSet, the rolling update fires, and the Deployment's existing `topologySpreadConstraints` redistribute Pods across the now-current host set.

Steady-state reconciles are no-ops (idempotent patch on matching hash).

### Hash semantics

- Only `Ready`, non-deleting machines count. A machine flapping through `Provisioning`/`Bootstrapping` doesn't roll the workload until the host actually comes up; a machine being torn down stops counting the moment it gets a `DeletionTimestamp` rather than when its finalizer finally clears.
- Hash is order-independent (sorted before SHA), so reordering between List calls doesn't churn ReplicaSets.

### Wiring

Operator binary:
- `--fleet-spread-deployment` / `--fleet-spread-namespace` flags. Empty disables the controller (OSS deployments without a workload to spread).
- `mgr.GetAPIReader()` for the Deployment Get — bypasses controller-runtime's informer cache so we don't need cluster-wide `list,watch` on Deployments. The `ScalewayAppleSiliconMachine` List goes through the normal cache.

Chart:
- Adds the two args under `{{- if .Values.xcresultProcessor.enabled }}`, pointing at the rendered xcresult-processor Deployment name.
- ClusterRole gets `get,patch` on `apps/deployments` *scoped via `resourceNames`* to that single Deployment — a compromised operator can't patch arbitrary workloads.

## Tests

`go test ./controllers/...` covers:
- Hash stability across reorderings, distinguishing membership changes, excluding non-Ready, excluding terminating machines (delete-timestamp set).
- Reconcile stamps the annotation on first Ready transition.
- Reconcile is idempotent — `ResourceVersion` doesn't budge when the hash already matches.
- Reconcile re-patches on fleet growth (the production scenario this PR is for).
- Reconcile tolerates a missing target Deployment (chart-bring-up race; helm orders resources by kind and CRs may sort before Deployments).

## Test plan

- [x] `go test ./...` in the operator module.
- [x] `helm template` confirms args + scoped RBAC render correctly.
- [ ] After the next operator release lands and rolls onto canary/production: scale `macosFleet.replicas` up by 1 (or remove a machine) and verify the xcresult-processor Deployment annotation flips and a new ReplicaSet rolls without manual intervention.
- [ ] Verify the operator pod doesn't grow CPU/memory under the new watch (List of all machines on every machine event in a small fleet should be ~free, but worth eyeballing in steady state).

## Worth flagging (potential follow-ups)

- **Rollout storms**: if a Mac mini flaps Ready/NotReady (network blip, partial bootstrap failure), the Deployment will roll repeatedly. With PDB `minAvailable: 1` worst case is a single Pod down at a time, but a debounce / "only react to the Ready set growing" mode could be added later.
- **Other workloads**: only one target Deployment per operator instance today. If we ever pin more workloads to the macOS fleet, generalize to a list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)