### PR TITLE
fix(server): accept text/plain on OpenAI Apps challenge endpoint

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -412,9 +412,14 @@ defmodule TuistWeb.Router do
     get "/oauth-protected-resource/*resource_path", WellKnownController, :oauth_protected_resource
     get "/jwks.json", WellKnownController, :jwks
     get "/mcp/server-card.json", WellKnownController, :mcp_server_card
-    get "/openai-apps-challenge", WellKnownController, :openai_apps_challenge
     get "/apple-app-site-association", WellKnownController, :apple_app_site_association
     get "/assetlinks.json", WellKnownController, :assetlinks
+  end
+
+  scope "/.well-known", TuistWeb do
+    pipe_through :open_api
+
+    get "/openai-apps-challenge", WellKnownController, :openai_apps_challenge
   end
 
   scope "/" do

--- a/server/test/tuist_web/controllers/well_known_controller_test.exs
+++ b/server/test/tuist_web/controllers/well_known_controller_test.exs
@@ -129,6 +129,18 @@ defmodule TuistWeb.WellKnownControllerTest do
       assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
     end
 
+    test "returns the OpenAI Apps challenge token when the Accept header is text/plain", %{conn: conn} do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+
+      conn =
+        conn
+        |> put_req_header("accept", "text/plain")
+        |> get("/.well-known/openai-apps-challenge")
+
+      assert response(conn, 200) == "YoBqoSMoA-RuEX8RMuCKrLnPCXDYUsYtKg-yjFBHmDQ"
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+
     test "returns not found for on-premise deployments", %{conn: conn} do
       expect(Environment, :tuist_hosted?, fn -> false end)
 


### PR DESCRIPTION
Resolves the 406 the OpenAI Apps verifier hits when requesting `/.well-known/openai-apps-challenge`.

The route was scoped under the `:non_authenticated_api` pipeline, which has `plug :accepts, ["json"]`. The verifier sends `Accept: text/plain`, so Phoenix rejected the request before the controller could respond with the challenge token. Moved that single route into its own `/.well-known` scope without the JSON accepts constraint; the controller already sets `text/plain` itself.

### How to test locally

- `cd server && mix test test/tuist_web/controllers/well_known_controller_test.exs`
- Or curl the endpoint with the verifier's headers:

  ```
  curl -i -H 'Accept: text/plain' http://localhost:8080/.well-known/openai-apps-challenge
  ```

  Should return `200` with the token; previously returned `406`.
