### PR TITLE
fix(cli): CLI hangs running processes concurrently

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "58318f245c453bcc86ded1815713805b94e3a9cce0d2337346fda57c1ab2e4b0",
+  "originHash" : "6509c5128720e5500134753128a176cdd86aad821edf5a7082044e263f85cac0",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -94,7 +94,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "1.11.0"
+        "version" : "1.12.0"
       }
     },
     {
@@ -335,7 +335,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.6.1"
+        "version" : "0.6.2"
       }
     },
     {
@@ -591,7 +591,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.14.1"
+        "version" : "0.14.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1739,7 +1739,7 @@ let package = Package(
         .package(id: "tuist.Path", .upToNextMajor(from: "0.3.8")),
         .package(id: "p-x9.MachOKit", .upToNextMajor(from: "0.46.1")),
         .package(id: "tuist.FileSystem", .upToNextMajor(from: "0.17.3")),
-        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.1")),
+        .package(id: "tuist.Command", .upToNextMajor(from: "0.14.4")),
         .package(id: "apple.swift-crypto", from: "3.0.0"),
         .package(id: "crspybits.swift-log-file", .upToNextMajor(from: "0.1.0")),
         .package(id: "tuist.Noora", from: "0.55.0"),


### PR DESCRIPTION
## Summary
- Bumps the `tuist.Command` registry dependency from `0.14.1` to `0.14.4`.
- Updates `Package.resolved` accordingly. The release artifacts have already been synced into the production cache nodes so the registry can serve them.

## Test plan
- [ ] CI green (build + tests on the `tuist` scheme)