### PR TITLE
fix(server): collapse per-project authorization N+1 in dashboard layout

### DIFF
--- a/server/lib/tuist_web/live/layout_live.ex
+++ b/server/lib/tuist_web/live/layout_live.ex
@@ -219,10 +219,17 @@ defmodule TuistWeb.LayoutLive do
   end
 
   defp get_projects(account, current_user) do
+    # All projects share `account`, so the membership half of
+    # `:project_url_access` is identical for every row. Resolve it once
+    # rather than re-querying accounts/organizations/users_roles per project.
+    user_belongs_to_account? =
+      not is_nil(current_user) and
+        Accounts.owns_account_or_belongs_to_account_organization?(current_user, %{id: account.id})
+
     account
     |> Projects.get_all_project_accounts()
-    |> Enum.filter(fn %{account: account, project: project} ->
-      Authorization.authorize(:project_url_access, current_user, %{project | account: account}) == :ok
+    |> Enum.filter(fn %{project: project} ->
+      user_belongs_to_account? or project.visibility == :public
     end)
     |> Enum.map(&%{&1.project | account: &1.account})
   end


### PR DESCRIPTION
### Purpose

Pages under `/:account_handle/:project_handle/` (builds, tests, flaky-tests, etc.) take 6–7 seconds to mount on accounts with many projects. Tracing pinned 96.6% of the request time on `TuistWeb.BuildsLive.mount`, with ~880 sequential queries against `accounts`, `organizations`, `users_roles`, and `oauth2_identities`.

Root cause: the breadcrumb dropdown's project list ran `Authorization.authorize(:project_url_access, current_user, project)` per project. The user-role half of that rule funnels into `Accounts.owns_account_or_belongs_to_account_organization?/2`, which issues ~5 SQL queries per call (account fetch + organization preload, `organization_admin?`, `organization_user?`, `belongs_to_sso_organization?`). On a 100+ project account that's hundreds of round-trips on every mount.

Since `Projects.get_all_project_accounts/1` returns projects all under the same account, the membership half is identical for every row. Resolve it once, then combine with an in-memory `project.visibility == :public` check to keep the public-project fallback intact.

### Behavior preserved

- Authenticated members of the account (owner / org admin / org user / SSO member) see all projects, same as before.
- Authenticated non-members see only public projects in the dropdown.
- Unauthenticated viewers (`:optional_project` path) see only public projects.
- The unrelated `require_user_can_read_project` guard at the start of `on_mount(:project, ...)` still gates access to the page itself.

### How to test locally

- Sign in as a member of an organization with multiple projects.
- Visit `/<account>/<project>/builds` and confirm the breadcrumb dropdown still lists every project you have access to.
- Visit a public project as an unauthenticated user (or signed in as a non-member) and confirm only public projects appear in the breadcrumb dropdown.
- Run `mix test test/tuist_web/live/layout_live_test.exs --only describe:'on_mount/4 when :project'` — 4 tests, all passing.