### PR TITLE
fix(infra): drop replicas from autoscaled MD topologies

### DIFF
--- a/infra/k8s/clusters/cluster-production-us-east.yaml
+++ b/infra/k8s/clusters/cluster-production-us-east.yaml
@@ -37,7 +37,6 @@ spec:
         # workers for the default three replicas.
         - class: hcloud-worker
           name: kura
-          replicas: 3
           failureDomain: ash
           metadata:
             labels:

--- a/infra/k8s/clusters/cluster-production-us-west.yaml
+++ b/infra/k8s/clusters/cluster-production-us-west.yaml
@@ -37,7 +37,6 @@ spec:
         # workers for the default three replicas.
         - class: hcloud-worker
           name: kura
-          replicas: 3
           failureDomain: hil
           metadata:
             labels:

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -59,13 +59,12 @@ spec:
         #     -o jsonpath='{.metadata.annotations}'
         - class: hcloud-worker
           name: md-processor
+          replicas: 2
           failureDomain: fsn1
           metadata:
             labels:
               node.cluster.x-k8s.io/pool: processor
             annotations:
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "2"
-              cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "6"
               cluster.x-k8s.io/cluster-autoscaler-node-group-min-size: "2"
               cluster.x-k8s.io/cluster-autoscaler-node-group-max-size: "6"
           variables:

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -59,7 +59,6 @@ spec:
         #     -o jsonpath='{.metadata.annotations}'
         - class: hcloud-worker
           name: md-processor
-          replicas: 2
           failureDomain: fsn1
           metadata:
             labels:
@@ -83,7 +82,6 @@ spec:
         # and general/server pods pin to their own pools.
         - class: hcloud-worker
           name: kura
-          replicas: 3
           failureDomain: fsn1
           metadata:
             labels:


### PR DESCRIPTION
Follow-up to #10489.

The post-merge `Mgmt Cluster Apply` job ([run 25548905847](https://github.com/tuist/tuist/actions/runs/25548905847/job/74991751450)) failed at the first new cluster:

```
Cluster "tuist-kura-us-east" is invalid:
  spec.topology.workers.machineDeployments[kura].replicas: Invalid value: 3:
  cannot be set ... if the same MachineDeploymentTopology has autoscaler annotations
```

CAPI v1beta2's webhook forbids `replicas` on a `MachineDeploymentTopology` once `cluster.x-k8s.io/cluster-api-autoscaler-node-group-{min,max}-size` are set: the autoscaler owns the count and CAPI seeds initial replicas from `min-size`.

This PR is scoped to the kura pools added in #10489. For each kura MD, `replicas:` is dropped; CAPI seeds the initial count from `cluster-api-autoscaler-node-group-min-size: "3"`, matching the README's target shape:

- `infra/k8s/clusters/cluster-production-us-east.yaml`: kura
- `infra/k8s/clusters/cluster-production-us-west.yaml`: kura
- `infra/k8s/clusters/cluster-production.yaml`: kura

The `md-processor` MD on the production `tuist` cluster also picked up the new `cluster-api-autoscaler-*` annotations in #10489 and would hit the same webhook on the next apply, but its current live `spec.replicas` is meaningful state. Reverting that portion of #10489 separately keeps this fix focused on kura; `md-processor` is restored to its pre-#10489 shape (`replicas: 2` with only the legacy `cluster-autoscaler-*` annotations).

### How to test locally

- Wait for the `Mgmt Cluster Apply` workflow to run on this PR's merge commit and confirm it goes green.
- Optional dry-run if you have the mgmt kubeconfig: `for f in infra/k8s/clusters/cluster-*.yaml; do kubectl apply --dry-run=server -f "$f"; done` should report `configured` / `created` for every file.
