### PR TITLE
fix(server): drop unprocessable xcresult uploads instead of retrying

### DIFF
--- a/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
+++ b/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
@@ -20,12 +20,16 @@ import XCResultParser
 
 public enum UploadResultBundleServiceError: Equatable, LocalizedError {
     case missingFullHandle
+    case bundleMissingInfoPlist(AbsolutePath)
 
     public var errorDescription: String? {
         switch self {
         case .missingFullHandle:
             return
                 "The 'Tuist.swift' file is missing a fullHandle. See how to set up a Tuist project at: https://tuist.dev/en/docs/guides/server/accounts-and-projects#projects"
+        case let .bundleMissingInfoPlist(path):
+            return
+                "The xcresult bundle at \(path.pathString) is missing 'Info.plist' — xcodebuild did not finish populating it (the test action was likely interrupted or failed before producing results). Skipping upload."
         }
     }
 }
@@ -176,6 +180,15 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
         // xcodebuild creates result-bundle as a symlink to result-bundle.xcresult,
         // so we resolve it to ensure the archiver zips the actual directory.
         let resolvedResultBundlePath = try await fileSystem.resolveSymbolicLink(resultBundlePath)
+
+        // A populated xcresult bundle has Info.plist at its root. If it's
+        // missing, xcodebuild was interrupted before writing results — uploading
+        // the empty skeleton just produces a 5-attempt failure on the server side
+        // and a Sentry alert for nothing actionable.
+        let infoPlistPath = resolvedResultBundlePath.appending(component: "Info.plist")
+        if !(try await fileSystem.exists(infoPlistPath)) {
+            throw UploadResultBundleServiceError.bundleMissingInfoPlist(resolvedResultBundlePath)
+        }
 
         if !quarantinedTests.isEmpty {
             try await writeQuarantinedTests(quarantinedTests, to: resolvedResultBundlePath)

--- a/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InspectResultBundleServiceTests.swift
@@ -739,6 +739,7 @@ struct UploadResultBundleServiceTests {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let xcresultPath = temporaryDirectory.appending(component: "Test.xcresult")
         try await fileSystem.makeDirectory(at: xcresultPath)
+        try await fileSystem.writeText("", at: xcresultPath.appending(component: "Info.plist"))
 
         given(analyticsArtifactUploadService)
             .uploadResultBundle(
@@ -798,6 +799,7 @@ struct UploadResultBundleServiceTests {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let xcresultPath = temporaryDirectory.appending(component: "Test.xcresult")
         try await fileSystem.makeDirectory(at: xcresultPath)
+        try await fileSystem.writeText("", at: xcresultPath.appending(component: "Info.plist"))
 
         given(analyticsArtifactUploadService)
             .uploadResultBundle(
@@ -838,6 +840,7 @@ struct UploadResultBundleServiceTests {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let xcresultPath = temporaryDirectory.appending(component: "result-bundle.xcresult")
         try await fileSystem.makeDirectory(at: xcresultPath)
+        try await fileSystem.writeText("", at: xcresultPath.appending(component: "Info.plist"))
         let symlinkPath = temporaryDirectory.appending(component: "result-bundle")
         try FileManager.default.createSymbolicLink(
             atPath: symlinkPath.pathString,
@@ -884,5 +887,33 @@ struct UploadResultBundleServiceTests {
                 shardIndex: nil
             )
         }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func uploadResultBundle_throwsWhenInfoPlistMissing() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcresultPath = temporaryDirectory.appending(component: "Test.xcresult")
+        try await fileSystem.makeDirectory(at: xcresultPath)
+
+        await #expect(
+            throws: UploadResultBundleServiceError.bundleMissingInfoPlist(xcresultPath)
+        ) {
+            try await subject.uploadResultBundle(
+                resultBundlePath: xcresultPath,
+                config: .test(fullHandle: "tuist/tuist"),
+                quarantinedTests: [],
+                shardPlanId: nil,
+                shardIndex: nil
+            )
+        }
+
+        verify(analyticsArtifactUploadService)
+            .uploadResultBundle(
+                .any,
+                fullHandle: .any,
+                commandEventId: .any,
+                serverURL: .any
+            )
+            .called(0)
     }
 }

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -38,7 +38,8 @@ defmodule Tuist.Processor.XCResultProcessor do
 
   defp process_archive(archive_path, temp_dir) do
     with :ok <- extract_archive(archive_path, temp_dir),
-         xcresult_path when not is_nil(xcresult_path) <- find_xcresult(temp_dir) do
+         xcresult_path when not is_nil(xcresult_path) <- find_xcresult(temp_dir),
+         :ok <- validate_xcresult(xcresult_path) do
       root_dir = Path.dirname(xcresult_path)
 
       with {:ok, parsed_data} <- parse_xcresult(xcresult_path, root_dir) do
@@ -48,6 +49,20 @@ defmodule Tuist.Processor.XCResultProcessor do
     else
       nil -> {:error, :xcresult_not_found}
       {:error, _} = error -> error
+    end
+  end
+
+  # An xcresult bundle that xcodebuild populated has an `Info.plist` at its
+  # root. CLI clients sometimes upload a bundle that xcodebuild never wrote
+  # to (e.g. `xcodebuild test` was killed mid-build) — the directory exists
+  # only because Tuist's CLI dropped `quarantined_tests.json` into it before
+  # archiving. Detect that shape here so callers can drop the job cleanly
+  # instead of letting `xcresulttool` fail and bubble up as a generic error.
+  defp validate_xcresult(xcresult_path) do
+    if File.exists?(Path.join(xcresult_path, "Info.plist")) do
+      :ok
+    else
+      {:error, :bundle_invalid}
     end
   end
 

--- a/server/lib/tuist/tests/workers/process_xcresult_worker.ex
+++ b/server/lib/tuist/tests/workers/process_xcresult_worker.ex
@@ -22,6 +22,14 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
 
   require Logger
 
+  # Failures whose root cause is the uploaded archive itself, not anything
+  # transient. Retrying is pointless and surfacing them as Oban errors lights
+  # up Sentry every five attempts for what is fundamentally a CLI-side
+  # mistake (xcodebuild never populated the bundle, or the upload was a
+  # bare `quarantined_tests.json` skeleton). We mark the run as
+  # `failed_processing` once and discard the job.
+  @unprocessable_input_reasons [:bundle_invalid, :xcresult_not_found]
+
   @impl Oban.Worker
   def perform(%Oban.Job{
         args: %{"test_run_id" => test_run_id, "storage_key" => storage_key, "account_id" => account_id} = args,
@@ -38,6 +46,14 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorker do
         end
 
         :ok
+
+      {:error, reason} when reason in @unprocessable_input_reasons ->
+        Logger.info(
+          "Discarding xcresult for test run #{test_run_id}: uploaded archive is unprocessable (#{inspect(reason)})"
+        )
+
+        mark_failed_processing(args)
+        {:discard, reason}
 
       {:error, reason} ->
         if attempt >= max_attempts do

--- a/server/native/xcresult_nif/nif_bridge.c
+++ b/server/native/xcresult_nif/nif_bridge.c
@@ -61,8 +61,28 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     free(path);
     free(root_dir);
 
-    if (result != 0 || output == NULL) {
+    if (result != 0) {
+        /* Swift writes a JSON error blob into `output` when parsing fails;
+         * surface it as a binary so the Elixir caller can log the actual
+         * reason instead of a bare `:parse_failed` atom. Fall back to that
+         * atom only when the Swift side returned no message at all
+         * (allocation failure, etc). */
+        if (output != NULL && output_len > 0) {
+            ERL_NIF_TERM message_binary;
+            unsigned char *bin_data = enif_make_new_binary(env, output_len, &message_binary);
+            memcpy(bin_data, output, output_len);
+            free(output);
+            return enif_make_tuple2(env, enif_make_atom(env, "error"), message_binary);
+        }
         if (output) free(output);
+        return enif_make_tuple2(
+            env,
+            enif_make_atom(env, "error"),
+            enif_make_atom(env, "parse_failed")
+        );
+    }
+
+    if (output == NULL) {
         return enif_make_tuple2(
             env,
             enif_make_atom(env, "error"),

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -340,6 +340,19 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert {:error, "decompression failed"} = XCResultProcessor.process_local(fixture_path)
     end
 
+    @tag :tmp_dir
+    test "returns :bundle_invalid when the .xcresult bundle has no Info.plist", %{tmp_dir: tmp_dir} do
+      {:ok, fixture_zip} =
+        :zip.create(
+          ~c"#{Path.join(tmp_dir, "fixture.zip")}",
+          [{~c"Test.xcresult/quarantined_tests.json", "[]"}]
+        )
+
+      reject(&XCResultNIF.parse/2)
+
+      assert {:error, :bundle_invalid} = XCResultProcessor.process_local(to_string(fixture_zip))
+    end
+
     test "cleans up temp directory even when processing fails" do
       missing_path = Path.join(System.tmp_dir!(), "definitely-not-an-archive-#{:erlang.unique_integer([:positive])}")
 

--- a/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
+++ b/server/test/tuist/tests/workers/process_xcresult_worker_test.exs
@@ -399,6 +399,28 @@ defmodule Tuist.Tests.Workers.ProcessXcresultWorkerTest do
       assert {:error, _} =
                ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 3))
     end
+
+    for reason <- [:bundle_invalid, :xcresult_not_found] do
+      test "discards the job and marks failed_processing on the first attempt for #{inspect(reason)}", %{
+        account: account,
+        project: project
+      } do
+        test_run_id = Ecto.UUID.generate()
+
+        expect(Tuist.Accounts, :get_account_by_id, fn _id -> {:ok, account} end)
+        expect(Tuist.Storage, :download_to_file, fn _key, _path, _account -> {:ok, :done} end)
+        expect(XCResultProcessor, :process_local, fn _path, _opts -> {:error, unquote(reason)} end)
+
+        expect(Tuist.Tests, :create_test, fn attrs ->
+          assert attrs.id == test_run_id
+          assert attrs.status == "failed_processing"
+          {:ok, %{id: test_run_id}}
+        end)
+
+        assert {:discard, unquote(reason)} =
+                 ProcessXcresultWorker.perform(oban_job(job_args(test_run_id, account.id, project.id), 1, 5))
+      end
+    end
   end
 
   describe "perform/1 VCS comment refresh" do


### PR DESCRIPTION
> Tracks Sentry issue [TUIST-EX](https://tuist.sentry.io/issues/118344376/) — `Oban.PerformError: Tuist.Tests.Workers.ProcessXcresultWorker failed with {:error, :parse_failed}`. 49 occurrences in 16h, all firing 5× per upload from a single customer's CI.

## Why

A CLI `tuist test` invocation produces an empty `.xcresult/` directory whenever `xcodebuild` is interrupted before populating the bundle (CI step timeout, build phase killed, etc.). The CLI then writes `quarantined_tests.json` into the empty directory, archives it with AppleArchive (1.4 KB), and uploads it to S3. The `process_xcresult` Oban worker downloads it, asks `xcresulttool` to parse, gets back "Info.plist does not exist" — and surfaces that as a generic `{:error, :parse_failed}`. Five attempts later the run is marked `failed_processing`, but each attempt has already paged Sentry.

The bundle is structurally invalid before we even hand it to Swift. There's nothing transient about it, retries don't help, and the alert is for a CLI mistake not a server fault.

## What

**Server**
- `xcresult_processor.ex` — early `Info.plist` check inside `process_archive`; missing plist returns `{:error, :bundle_invalid}`.
- `process_xcresult_worker.ex` — `:bundle_invalid` and `:xcresult_not_found` are terminal client-input errors. Mark the run `failed_processing` once and return `{:discard, reason}` so Oban drops the job without retrying or raising `Oban.PerformError`.
- `native/xcresult_nif/nif_bridge.c` — surface Swift's JSON error blob as a binary instead of swallowing it for a bare `:parse_failed` atom (mirrors the existing xcactivitylog NIF). Future parse failures will arrive in Sentry with the real reason.

**CLI**
- `UploadResultBundleService.uploadResultBundle` — after resolving the symlink, throw `bundleMissingInfoPlist` if the bundle has no `Info.plist`. Stops the empty skeleton from being uploaded in the first place.

## How to test locally

- `mix test test/tuist/processor/xcresult_processor_test.exs test/tuist/tests/workers/process_xcresult_worker_test.exs` (run from `server/`) — 30 tests pass; new coverage for `:bundle_invalid` parse and discarded-job paths.
- `tuist generate tuist TuistKit TuistKitTests --no-open && xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/UploadResultBundleServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` — adds `uploadResultBundle_throwsWhenInfoPlistMissing` and updates the happy-path fixtures to include `Info.plist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)