### PR TITLE
fix(infra): unbreak capi-scaleway canary; stop racing on chart values in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1858,16 +1858,6 @@ jobs:
             git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
-      - name: Bump operator image pin in chart values
-        run: |
-          # values-managed-common.yaml carries multiple `tag:` lines
-          # (server, xcresult-processor, macosFleet). Use a sed range
-          # anchored to the operator's repository line so the
-          # substitution only fires for the macosFleet block.
-          sed -i '/repository: ghcr.io\/tuist\/capi-provider-scaleway-applesilicon/,/tag:/{
-            s|tag: "[^"]*"|tag: "${{ needs.check-releases.outputs.capi-scaleway-next-version-number }}"|
-          }' infra/helm/tuist/values-managed-common.yaml
-
       - name: Set up Docker Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@v0
 
@@ -1892,10 +1882,13 @@ jobs:
       - name: Upload capi-scaleway artifacts
         uses: actions/upload-artifact@v4
         with:
+          # values-managed-common.yaml is bumped by commit-and-release
+          # against its own checkout, not packaged here, so two parallel
+          # release-* jobs touching different `tag:` lines in the same
+          # file can't trample each other on artifact extract.
           name: capi-scaleway-artifacts
           path: |
             infra/cluster-api-provider-scaleway-applesilicon/CHANGELOG.md
-            infra/helm/tuist/values-managed-common.yaml
           retention-days: 1
 
   release-xcresult-processor-image:
@@ -1961,15 +1954,6 @@ jobs:
             git cliff "${INCLUDE_PATHS[@]}" --config cliff.toml --repository "../../" --bump -o CHANGELOG.md 2>/dev/null
           fi
 
-      - name: Bump xcresult-processor image pin in chart values
-        run: |
-          # values-managed-common.yaml carries multiple `tag:` lines.
-          # Anchor the substitution to the xcresult-processor's
-          # repository line so only that block's tag is rewritten.
-          sed -i '' '/repository: ghcr.io\/tuist\/tuist-xcresult-processor/,/tag:/{
-            s|tag: "[^"]*"|tag: "${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"|
-          }' infra/helm/tuist/values-managed-common.yaml
-
       - name: Build server release for macOS
         id: release
         working-directory: server
@@ -2033,10 +2017,13 @@ jobs:
       - name: Upload xcresult-processor-image artifacts
         uses: actions/upload-artifact@v4
         with:
+          # values-managed-common.yaml is bumped by commit-and-release
+          # against its own checkout, not packaged here, so two parallel
+          # release-* jobs touching different `tag:` lines in the same
+          # file can't trample each other on artifact extract.
           name: xcresult-processor-image-artifacts
           path: |
             infra/xcresult-processor-image/CHANGELOG.md
-            infra/helm/tuist/values-managed-common.yaml
           retention-days: 1
 
       - name: Cleanup
@@ -2238,6 +2225,28 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: xcresult-processor-image-artifacts
+
+      - name: Bump chart image pins for released components
+        # Single writer for values-managed-common.yaml. Each release-*
+        # job pushes its image to ghcr.io and surfaces the new version
+        # via check-releases outputs; we apply the corresponding `tag:`
+        # bumps here against this job's own checkout. Doing it here
+        # (rather than in each release-* job + bundling the file in the
+        # artifact) prevents the artifact-extract overwrite that
+        # previously dropped capi-scaleway's bump on the floor whenever
+        # both capi-scaleway and xcresult-processor-image released in
+        # the same run.
+        run: |
+          if [ "${{ needs.check-releases.outputs.capi-scaleway-should-release }}" == "true" ] && [ "${{ needs.release-capi-scaleway.result }}" == "success" ]; then
+            sed -i '/repository: ghcr.io\/tuist\/capi-provider-scaleway-applesilicon/,/tag:/{
+              s|tag: "[^"]*"|tag: "${{ needs.check-releases.outputs.capi-scaleway-next-version-number }}"|
+            }' infra/helm/tuist/values-managed-common.yaml
+          fi
+          if [ "${{ needs.check-releases.outputs.xcresult-processor-image-should-release }}" == "true" ] && [ "${{ needs.release-xcresult-processor-image.result }}" == "success" ]; then
+            sed -i '/repository: ghcr.io\/tuist\/tuist-xcresult-processor/,/tag:/{
+              s|tag: "[^"]*"|tag: "${{ needs.check-releases.outputs.xcresult-processor-image-next-version-number }}"|
+            }' infra/helm/tuist/values-managed-common.yaml
+          fi
 
       - name: Create tags for successfully released components
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2213,18 +2213,23 @@ jobs:
           path: infra/helm
 
       - name: Download CAPI operator artifacts
-        # No `path:` so the artifact's `infra/...` paths land back at
-        # workspace root for the later `git add` to find them.
+        # `path:` matches the upload's LCA so CHANGELOG.md lands back at
+        # `infra/cluster-api-provider-scaleway-applesilicon/CHANGELOG.md`
+        # for the later `git add` to find. upload-artifact@v4 strips the
+        # LCA from each entry's archive path, so a workspace-root
+        # download would put it at `<workspace>/CHANGELOG.md`.
         if: needs.check-releases.outputs.capi-scaleway-should-release == 'true' && needs.release-capi-scaleway.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: capi-scaleway-artifacts
+          path: infra/cluster-api-provider-scaleway-applesilicon
 
       - name: Download xcresult-processor-image artifacts
         if: needs.check-releases.outputs.xcresult-processor-image-should-release == 'true' && needs.release-xcresult-processor-image.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: xcresult-processor-image-artifacts
+          path: infra/xcresult-processor-image
 
       - name: Bump chart image pins for released components
         # Single writer for values-managed-common.yaml. Each release-*

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -221,7 +221,7 @@ macosFleet:
     # release.yml has run for this scope, pin to a known-good
     # SHA-tagged build that the standalone
     # capi-provider-scaleway-applesilicon-image.yml workflow pushed.
-    tag: "0.1.0"
+    tag: "0.2.0"
 
 # Everything below = external. The managed deployment never runs embedded
 # Postgres / ClickHouse / object storage / observability stacks.


### PR DESCRIPTION
### Purpose

Canary's `tuist-tuist-capi-scaleway-applesilicon` pod was in CrashLoopBackOff since the last deploy: <1s startup crash, no logs. Root cause was a flag/image mismatch caused by a race in the release auto-commit flow.

**The crash.** The chart now passes `--fleet-spread-deployment` and `--fleet-spread-namespace` to the operator (added in #10675), but `values-managed-common.yaml` still pinned the image at `0.1.0` — built before those flags existed. Go's `flag.Parse()` rejects the unknown flag and `os.Exit(2)`s before zap is wired up, so the container dies in <1s with no structured logs. Classic chart-ahead-of-image.

**Why the chart bump went missing.** The `0.2.0` image was actually built and pushed (the `capi-scaleway@0.2.0` tag exists), but auto-release commit `ecc1160445` never bumped the chart pin. Looking at `release.yml`: `release-capi-scaleway` and `release-xcresult-processor-image` both ran from clean checkouts, both `sed`-bumped a different `tag:` line in the same `values-managed-common.yaml`, and both packaged that file into their artifacts. In `commit-and-release` the second `download-artifact` extract overwrote the first, so whichever ran last won — and the macOS bare-metal xcresult-processor job did, dropping capi-scaleway's bump on the floor.

### Changes

- `values-managed-common.yaml`: bump capi-scaleway pin from `0.1.0` to `0.2.0`. Unblocks canary on the next deploy.
- `release.yml`: remove `values-managed-common.yaml` from both `release-capi-scaleway` and `release-xcresult-processor-image` artifacts and drop their per-job `sed` steps. Add a single \`Bump chart image pins for released components\` step in `commit-and-release` that re-applies both bumps against its own checkout using `check-releases` outputs. One writer for that file = no overwrite race.

The existing `git add infra/helm/tuist/values-managed-common.yaml` lines later in `commit-and-release` already stage the now-bumped file, so the auto-release commit will carry both tag bumps going forward.

### How to test locally

The release flow runs in CI and isn't exercised end-to-end locally. To sanity-check the new step's logic, render the workflow with [act](https://github.com/nektos/act) or just dry-run the inline `sed`:

\`\`\`bash
sed -n '/repository: ghcr.io\/tuist\/capi-provider-scaleway-applesilicon/,/tag:/p' \
  infra/helm/tuist/values-managed-common.yaml
sed -n '/repository: ghcr.io\/tuist\/tuist-xcresult-processor/,/tag:/p' \
  infra/helm/tuist/values-managed-common.yaml
\`\`\`

For the chart bump, the next canary deploy after this lands should bring `tuist-tuist-capi-scaleway-applesilicon` to `Running` instead of `CrashLoopBackOff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)