### PR TITLE
fix(infra): pin capi-scaleway image to a tag that has --fleet-spread-deployment

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -221,7 +221,7 @@ macosFleet:
     # release.yml has run for this scope, pin to a known-good
     # SHA-tagged build that the standalone
     # capi-provider-scaleway-applesilicon-image.yml workflow pushed.
-    tag: "0.1.0"
+    tag: "7f775497"
 
 # Everything below = external. The managed deployment never runs embedded
 # Postgres / ClickHouse / object storage / observability stacks.


### PR DESCRIPTION
Follow-up to #10675.

## What's broken

The canary helm release (`tuist`/`tuist-canary`) has been stuck in `pending-upgrade` since 09:33 UTC, and the production deploy queue has piled up behind it.

The new pod for `tuist-tuist-capi-scaleway-applesilicon` crash-loops on startup with:

```
flag provided but not defined: -fleet-spread-deployment
```

PR #10675 added `--fleet-spread-deployment` / `--fleet-spread-namespace` to the chart args at `infra/helm/tuist/templates/capi-scaleway-applesilicon.yaml:210-211` and to the Go binary at `infra/cluster-api-provider-scaleway-applesilicon/cmd/manager/main.go:117`, but the chart still pins `image.tag: "0.1.0"`, whose binary predates the flag.

The `release.yml` run at `ecc11604` that was supposed to ship `capi-scaleway@0.2.0` (build the new image, push the semver tag, and rewrite this `tag:` line) was cancelled before it could do any of those things, so `:0.2.0` was never published.

## Fix

Bump the chart pin to `7f775497`, the SHA-tagged build the standalone `capi-provider-scaleway-applesilicon-image.yml` workflow pushed for commit `7f775497c4` (the same commit that introduced the flag). This is the fallback already documented in the file's comment.

## Followups (not in this PR)

- Investigate why the cancelled `release.yml` run on `ecc11604` didn't get retried — the auto-release commit landed on main with a message promising `capi-scaleway@0.2.0`, but neither the image nor the values bump exists.
- Once `release.yml` runs cleanly for this scope, this pin will revert to `0.2.0` (or higher) on its own.

## Operational note

The canary helm release will still need to be unstuck manually before the next deploy can proceed:

```sh
KUBECONFIG=~/.kube/tuist-canary.yaml \
  helm rollback tuist 41 -n tuist-canary --wait --timeout=5m
gh run cancel 25547949239
```

After this PR merges, the resulting deploy will install the working image and the helm release will land cleanly.

### How to test locally

- This change is data-only (a tag string in a values file). Verify by inspecting the diff and confirming `ghcr.io/tuist/capi-provider-scaleway-applesilicon:7f775497` exists in ghcr (it was pushed by the 09:25 run of `capi-provider-scaleway-applesilicon-image.yml` on commit `7f775497c4`).
