### PR TITLE
fix(server): skip CSRF cross-origin check for FunWithFlags UI assets

### DIFF
--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -1016,7 +1016,13 @@ defmodule TuistWeb.Router do
   # FunWithFlags.UI serves its bundled JS via Plug.Static after the :browser_app
   # pipeline registers Plug.CSRFProtection's before_send callback, which raises
   # InvalidCrossOriginRequestError on any non-XHR GET that returns a JS response.
-  defp skip_csrf_for_fun_with_flags_assets(%Plug.Conn{path_info: ["ops", "flags", "assets" | _]} = conn, _opts) do
+  # Constrained to safe methods so any future state-changing route under this
+  # prefix still goes through CSRF protection.
+  defp skip_csrf_for_fun_with_flags_assets(
+         %Plug.Conn{method: method, path_info: ["ops", "flags", "assets" | _]} = conn,
+         _opts
+       )
+       when method in ["GET", "HEAD"] do
     Plug.Conn.put_private(conn, :plug_skip_csrf_protection, true)
   end
 

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -699,6 +699,7 @@ defmodule TuistWeb.Router do
   pipeline :ops do
     plug TuistWeb.Authorization, [:current_user, :read, :ops]
     plug :assign_current_path
+    plug :skip_csrf_for_fun_with_flags_assets
   end
 
   scope "/ops", TuistWeb do
@@ -1011,4 +1012,13 @@ defmodule TuistWeb.Router do
       disable_robot_indexing(conn, params)
     end
   end
+
+  # FunWithFlags.UI serves its bundled JS via Plug.Static after the :browser_app
+  # pipeline registers Plug.CSRFProtection's before_send callback, which raises
+  # InvalidCrossOriginRequestError on any non-XHR GET that returns a JS response.
+  defp skip_csrf_for_fun_with_flags_assets(%Plug.Conn{path_info: ["ops", "flags", "assets" | _]} = conn, _opts) do
+    Plug.Conn.put_private(conn, :plug_skip_csrf_protection, true)
+  end
+
+  defp skip_csrf_for_fun_with_flags_assets(conn, _opts), do: conn
 end

--- a/server/test/tuist_web/router_test.exs
+++ b/server/test/tuist_web/router_test.exs
@@ -3,12 +3,13 @@ defmodule TuistWeb.RouterTest do
   use TuistTestSupport.Cases.StubCase, billing: true
   use Mimic
 
+  alias Tuist.Environment
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   test "marketing pages are non-indexable and non-followable when a production and on-premise environment",
        %{conn: conn} do
-    stub(Tuist.Environment, :tuist_hosted?, fn -> false end)
-    stub(Tuist.Environment, :prod?, fn -> true end)
+    stub(Environment, :tuist_hosted?, fn -> false end)
+    stub(Environment, :prod?, fn -> true end)
 
     for route <- [~p"/blog", ~p"/about", ~p"/pricing", ~p"/terms", ~p"/blog"] do
       assert conn |> get(route) |> get_resp_header("x-robots-tag") == ["noindex, nofollow"]
@@ -17,7 +18,7 @@ defmodule TuistWeb.RouterTest do
 
   test "marketing pages are non-indexable and non-followable when a non-production environment",
        %{conn: conn} do
-    stub(Tuist.Environment, :prod?, fn -> false end)
+    stub(Environment, :prod?, fn -> false end)
 
     for route <- [~p"/blog", ~p"/about", ~p"/pricing", ~p"/terms", ~p"/blog"] do
       assert conn |> get(route) |> get_resp_header("x-robots-tag") == ["noindex, nofollow"]
@@ -26,8 +27,8 @@ defmodule TuistWeb.RouterTest do
 
   test "marketing pages are indexable and followable when a production and non on-premise environment",
        %{conn: conn} do
-    stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
-    stub(Tuist.Environment, :prod?, fn -> true end)
+    stub(Environment, :tuist_hosted?, fn -> true end)
+    stub(Environment, :prod?, fn -> true end)
 
     for route <- [~p"/blog", ~p"/about", ~p"/pricing", ~p"/terms", ~p"/blog"] do
       assert conn |> get(route) |> get_resp_header("x-robots-tag") == ["index, follow"]
@@ -73,5 +74,22 @@ defmodule TuistWeb.RouterTest do
     assert conn
            |> get("/en/docs/guides/install-tuist")
            |> html_response(200) =~ "Install Tuist"
+  end
+
+  test "FunWithFlags UI assets are served without triggering CSRF cross-origin check",
+       %{conn: conn} do
+    user = AccountsFixtures.user_fixture(preload: [:account])
+    stub(Environment, :ops_user_handles, fn -> [user.account.name] end)
+
+    conn =
+      conn
+      |> log_in_user(user)
+      |> get("/ops/flags/assets/details.js")
+
+    assert conn.status == 200
+
+    assert conn
+           |> get_resp_header("content-type")
+           |> Enum.any?(&String.starts_with?(&1, ~w(text/javascript application/javascript)))
   end
 end


### PR DESCRIPTION
Fixes [TUIST-F1](https://tuist.sentry.io/issues/118505612/).

### Summary

`Plug.CSRFProtection` registers a `before_send` callback that raises `InvalidCrossOriginRequestError` on any non-XHR `GET` returning a JS content-type, regardless of `Origin` / `Sec-Fetch-Site` headers (see `Plug.CSRFProtection.cross_origin_js?/1`). `FunWithFlags.UI.Router` serves its bundled JS via `Plug.Static` after the `:browser_app` pipeline arms that callback, so every browser hit on `/ops/flags/assets/*.js` was 500-ing in production with that exception.

Set `plug_skip_csrf_protection` on the conn for paths starting with `/ops/flags/assets/`, registered as a single small plug in the existing `:ops` pipeline. Only static GETs are exempt — CSRF still applies to the FunWithFlags admin pages and the flag-toggle form submissions.

### How to test locally

1. Sign in as an ops user and navigate to `/ops/flags`.
2. Open a flag detail page (which loads `/ops/flags/assets/details.js`); the bundled JS should load without errors and the flag UI should render normally.
3. The added regression test covers the asset path: `mix test test/tuist_web/router_test.exs`.