### PR TITLE
fix(cli): allow folder resources to overlap sources

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -71,6 +71,7 @@ class ProjectFileElements {
     // MARK: - Attributes
 
     var elements: [AbsolutePath: PBXFileElement] = [:]
+    var folderReferences: [AbsolutePath: PBXFileReference] = [:]
     var products: [String: PBXFileReference] = [:]
     var compiled: [AbsolutePath: PBXFileReference] = [:]
     var knownRegions: Set<String> = Set([])
@@ -416,7 +417,11 @@ class ProjectFileElements {
         sourceRootPath: AbsolutePath
     ) throws {
         // The file already exists
-        if elements[fileElement.path] != nil { return }
+        if elements[fileElement.path] != nil,
+           !(fileElement.isFolderReference && folderReferences[fileElement.path] == nil)
+        {
+            return
+        }
 
         let fileElementRelativeToSourceRoot = fileElement.path.relative(to: sourceRootPath)
         let closestRelativeRelativePath =
@@ -498,7 +503,16 @@ class ProjectFileElements {
         pbxproj: PBXProj
     ) -> (element: PBXFileElement, path: AbsolutePath)? {
         let absolutePath = from.appending(relativePath)
-        if elements[absolutePath] != nil {
+        let isFolderReferenceLeaf = if isLeaf,
+                                       case let GroupFileElement.folder(path: folderPath, _) = element,
+                                       folderPath == absolutePath
+        {
+            true
+        } else {
+            false
+        }
+
+        if !isFolderReferenceLeaf, elements[absolutePath] != nil {
             return (element: elements[absolutePath]!, path: from.appending(relativePath))
         }
 
@@ -552,6 +566,19 @@ class ProjectFileElements {
                 toGroup: toGroup,
                 pbxproj: pbxproj
             )
+        } else if isFolderReferenceLeaf {
+            if let fileReference = folderReferences[absolutePath] {
+                return (element: fileReference, path: absolutePath)
+            }
+            addFolderReferenceElementRelativeToGroup(
+                from: from,
+                folderAbsolutePath: absolutePath,
+                folderRelativePath: relativePath,
+                name: name,
+                toGroup: toGroup,
+                pbxproj: pbxproj
+            )
+            return nil
         } else {
             addFileElementRelativeToGroup(
                 from: from,
@@ -723,6 +750,24 @@ class ProjectFileElements {
         elements[fileAbsolutePath] = file
     }
 
+    func addFolderReferenceElementRelativeToGroup(
+        from _: AbsolutePath,
+        folderAbsolutePath: AbsolutePath,
+        folderRelativePath: RelativePath,
+        name: String?,
+        toGroup: PBXGroup,
+        pbxproj: PBXProj
+    ) {
+        let file = PBXFileReference(
+            sourceTree: .group,
+            name: name,
+            path: folderRelativePath.pathString
+        )
+        pbxproj.add(object: file)
+        toGroup.children.append(file)
+        folderReferences[folderAbsolutePath] = file
+    }
+
     @discardableResult
     func addFileElementWithAbsolutePath(
         from _: AbsolutePath,
@@ -799,7 +844,7 @@ class ProjectFileElements {
     }
 
     func file(path: AbsolutePath) -> PBXFileReference? {
-        elements[path] as? PBXFileReference
+        elements[path] as? PBXFileReference ?? folderReferences[path]
     }
 
     func isLocalized(path: AbsolutePath) -> Bool {
@@ -922,5 +967,12 @@ class ProjectFileElements {
         .flatMap { $0 }
 
         return gpxFiles
+    }
+}
+
+extension GroupFileElement {
+    fileprivate var isFolderReference: Bool {
+        if case .folder = self { return true }
+        return false
     }
 }

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -143,6 +143,29 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
+    func test_addElement_allowsFolderReferenceAndNestedFileToSharePath() throws {
+        // Given
+        let folderPath = try AbsolutePath(validating: "/path/Package/Tests/TargetTests")
+        let sourcePath = folderPath.appending(component: "TargetTests.swift")
+        let elements = [
+            GroupFileElement.file(path: sourcePath, group: .group(name: "Project")),
+            GroupFileElement.folder(path: folderPath, group: .group(name: "Project")),
+        ]
+
+        // When
+        try subject.generate(
+            files: elements,
+            groups: groups,
+            pbxproj: pbxproj,
+            sourceRootPath: "/path"
+        )
+
+        // Then
+        XCTAssertNotNil(subject.file(path: folderPath))
+        XCTAssertNotNil(subject.group(path: folderPath))
+        XCTAssertNotNil(subject.file(path: sourcePath))
+    }
+
     func test_addElement_parentDirectories() throws {
         // Given
         let element = GroupFileElement.file(


### PR DESCRIPTION
> [!NOTE]
> TL;DR;
> - Before #10268: local Swift package test targets were pruned, so app-only package dependencies did not exercise package test resources.
> - Regression: #10268 correctly preserved those local package test targets, which exposed that `.copy(".")` can make a test target directory both a copied folder resource and a source group.
> - Fix: keep the test targets and let folder references coexist with logical groups at the same absolute path.

## Summary
- Track folder references separately from logical file groups when generating project file elements.
- Allow a copied resource folder to coexist with nested source file references at the same path.
- Add regression coverage for the Swift package test resource shape behind #10680.

Fixes #10680

## Testing
- `tuist generate tuist TuistGenerator TuistGeneratorTests ProjectDescription --no-open`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistGeneratorTests/ProjectFileElementsTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`
- `mise run cli:lint --fix`