### PR TITLE
fix(cli): limit implicit import source scans

### DIFF
--- a/cli/Sources/TuistInspectCommand/Services/TargetImportsScanner.swift
+++ b/cli/Sources/TuistInspectCommand/Services/TargetImportsScanner.swift
@@ -21,14 +21,31 @@
 
     struct TargetImportsScanner: TargetImportsScanning {
         private let importSourceCodeScanner: ImportSourceCodeScanner
-        private let fileSystem: FileSystem
+        private let maxConcurrentFileScans: Int
+        private let sourceCodeReader: (AbsolutePath) async throws -> String?
 
         init(
             importSourceCodeScanner: ImportSourceCodeScanner = ImportSourceCodeScanner(),
-            fileSystem: FileSystem = FileSystem()
+            fileSystem: FileSysteming = FileSystem(),
+            maxConcurrentFileScans: Int = 100
+        ) {
+            self.init(
+                importSourceCodeScanner: importSourceCodeScanner,
+                maxConcurrentFileScans: maxConcurrentFileScans
+            ) { path in
+                guard try await fileSystem.exists(path) else { return nil }
+                return try await fileSystem.readTextFile(at: path)
+            }
+        }
+
+        init(
+            importSourceCodeScanner: ImportSourceCodeScanner = ImportSourceCodeScanner(),
+            maxConcurrentFileScans: Int = 100,
+            sourceCodeReader: @escaping (AbsolutePath) async throws -> String?
         ) {
             self.importSourceCodeScanner = importSourceCodeScanner
-            self.fileSystem = fileSystem
+            self.maxConcurrentFileScans = max(1, maxConcurrentFileScans)
+            self.sourceCodeReader = sourceCodeReader
         }
 
         func imports(
@@ -43,7 +60,7 @@
                 filesToScan.append(contentsOf: headers.project)
             }
             var imports = Set(
-                try await filesToScan.concurrentMap { file in
+                try await filesToScan.concurrentMap(maxConcurrentTasks: maxConcurrentFileScans) { file in
                     try await matchPattern(at: file, reachableModules: reachableModules)
                 }
                 .flatMap { $0 }
@@ -66,16 +83,15 @@
                 return []
             }
 
-            if try await fileSystem.exists(path) {
-                let sourceCode = try await fileSystem.readTextFile(at: path)
-                return try importSourceCodeScanner.extractImports(
-                    from: sourceCode,
-                    language: language,
-                    reachableModules: reachableModules
-                )
-            } else {
+            guard let sourceCode = try await sourceCodeReader(path) else {
                 return Set()
             }
+
+            return try importSourceCodeScanner.extractImports(
+                from: sourceCode,
+                language: language,
+                reachableModules: reachableModules
+            )
         }
     }
 #endif

--- a/cli/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
+++ b/cli/Tests/TuistKitTests/ImportFinder/TargetImportsScannerTests.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import Foundation
+import Path
 import Testing
 import TuistSupport
 import TuistTesting
@@ -127,5 +128,43 @@ struct TargetImportsScannerTests {
             // Then
             #expect(result == [])
         }
+    }
+
+    @Test func imports_limitsConcurrentFileScans() async throws {
+        // Given
+        let sourceCodeReader = ConcurrentSourceCodeReader()
+        let sources = try (0 ..< 20).map { index -> SourceFile in
+            let path = try AbsolutePath(validating: "/Target/Sources/File\(index).swift")
+            return SourceFile(path: path)
+        }
+        let target = Target.test(
+            name: "FirstTarget",
+            sources: sources
+        )
+
+        // When
+        let result = try await TargetImportsScanner(
+            maxConcurrentFileScans: 3,
+            sourceCodeReader: sourceCodeReader.read(at:)
+        )
+        .imports(for: target)
+
+        // Then
+        #expect(result == ["SecondTarget"])
+        #expect(await sourceCodeReader.maxConcurrentReads <= 3)
+    }
+}
+
+private actor ConcurrentSourceCodeReader {
+    private var activeReads = 0
+    private(set) var maxConcurrentReads = 0
+
+    func read(at _: AbsolutePath) async throws -> String? {
+        activeReads += 1
+        maxConcurrentReads = max(maxConcurrentReads, activeReads)
+        defer { activeReads -= 1 }
+
+        try await Task.sleep(nanoseconds: 10_000_000)
+        return "import SecondTarget"
     }
 }


### PR DESCRIPTION
## Summary

- Limit implicit import source scans to 100 concurrent file reads to avoid file descriptor pressure in large projects.
- Keep missing-file handling intact while making the scanner source reader injectable for deterministic testing.
- Add regression coverage that verifies the scanner respects the concurrency cap.

## Root Cause

`TargetImportsScanner` used unbounded `concurrentMap`, so a target with many source files could start too many file reads at once through the FileSystem read path.

> [!NOTE]
> I initially misunderstood FileSystem's guarantees and assumed it would apply backpressure for open file descriptors. The current implementation does not appear to do that: `readTextFile` delegates to a full file read that opens and closes a descriptor for each read, maps `EMFILE` and `ENFILE` to `tooManyOpenFiles`, and provides concurrent-safe operations where documented, but it does not queue or cap concurrent file reads. The scanner therefore needs to bound its own fan-out.

Fixes #7454

## Validation

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistKitTests/TargetImportsScannerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -quiet`
- `mise run cli:lint --fix`
- `git diff --check`
