### PR TITLE
fix(server): retry slow xcresult attachment uploads per chunk

### DIFF
--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -279,13 +279,30 @@ defmodule Tuist.Processor.XCResultProcessor do
         {:exit, reason} -> {:error, {:chunk_task_exit, reason}}
       end)
 
-    case Enum.find(results, &match?({:error, _}, &1)) do
-      nil ->
-        {:ok, results}
+    cond do
+      results == [] ->
+        upload_empty_part(bucket, s3_key, upload_id)
 
+      error = Enum.find(results, &match?({:error, _}, &1)) ->
+        bucket |> ExAws.S3.abort_multipart_upload(s3_key, upload_id) |> ExAws.request()
+        error
+
+      true ->
+        {:ok, results}
+    end
+  end
+
+  # S3's CompleteMultipartUpload rejects an empty part list. For zero-byte
+  # files we upload a single empty part so the request is well-formed,
+  # matching ExAws.S3.Upload.complete/3's behaviour for empty sources.
+  defp upload_empty_part(bucket, s3_key, upload_id) do
+    case upload_part_with_retry({"", 1}, bucket, s3_key, upload_id, 1) do
       {:error, _} = error ->
         bucket |> ExAws.S3.abort_multipart_upload(s3_key, upload_id) |> ExAws.request()
         error
+
+      part ->
+        {:ok, [part]}
     end
   end
 

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -173,7 +173,7 @@ defmodule Tuist.Processor.XCResultProcessor do
         |> Task.async_stream(
           &upload_attachment(&1, bucket, account_handle, project_handle, test_run_id),
           max_concurrency: 30,
-          timeout: 60_000,
+          timeout: 180_000,
           on_timeout: :kill_task
         )
         |> Enum.zip(all_attachments)
@@ -226,20 +226,31 @@ defmodule Tuist.Processor.XCResultProcessor do
       s3_key =
         "#{String.downcase(account_handle)}/#{String.downcase(project_handle)}/tests/runs/#{test_run_id}/attachments/#{attachment_id}/#{file_name}"
 
-      case file_path
-           |> ExAws.S3.Upload.stream_file()
-           |> ExAws.S3.upload(bucket, s3_key)
-           |> ExAws.request() do
-        {:ok, _} ->
-          uploaded =
-            attachment
-            |> Map.delete("file_path")
-            |> Map.put("attachment_id", attachment_id)
+      # ExAws.S3.Upload internally fans chunks out via Task.async_stream with a
+      # 30s default per-chunk timeout. A slow chunk crashes the inner task and
+      # Logger reports it as a SASL crash, even though the outer reducer
+      # already drops the attachment cleanly. Catch the exit here so transient
+      # slowness fails as a normal `:error` instead of paging.
+      try do
+        case file_path
+             |> ExAws.S3.Upload.stream_file()
+             |> ExAws.S3.upload(bucket, s3_key, timeout: 120_000)
+             |> ExAws.request() do
+          {:ok, _} ->
+            uploaded =
+              attachment
+              |> Map.delete("file_path")
+              |> Map.put("attachment_id", attachment_id)
 
-          {:ok, uploaded}
+            {:ok, uploaded}
 
-        {:error, reason} ->
-          Logger.error("Failed to upload attachment #{file_name}: #{inspect(reason)}")
+          {:error, reason} ->
+            Logger.error("Failed to upload attachment #{file_name}: #{inspect(reason)}")
+            :error
+        end
+      catch
+        :exit, reason ->
+          Logger.error("Attachment upload exited for #{file_name}: #{inspect(reason)}")
           :error
       end
     else

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -21,6 +21,10 @@ defmodule Tuist.Processor.XCResultProcessor do
 
   require Logger
 
+  @chunk_max_attempts 3
+  @chunk_attempt_timeout 30_000
+  @attachment_upload_timeout @chunk_attempt_timeout * @chunk_max_attempts + 30_000
+
   def process_local(archive_path, opts \\ []) do
     bucket = Keyword.get(opts, :s3_bucket) || Tuist.Environment.s3_bucket_name()
     temp_dir = make_temp_dir()
@@ -173,7 +177,7 @@ defmodule Tuist.Processor.XCResultProcessor do
         |> Task.async_stream(
           &upload_attachment(&1, bucket, account_handle, project_handle, test_run_id),
           max_concurrency: 30,
-          timeout: 60_000,
+          timeout: @attachment_upload_timeout,
           on_timeout: :kill_task
         )
         |> Enum.zip(all_attachments)
@@ -217,8 +221,6 @@ defmodule Tuist.Processor.XCResultProcessor do
     end)
   end
 
-  @upload_max_attempts 3
-
   defp upload_attachment(attachment, bucket, account_handle, project_handle, test_run_id) do
     file_path = Map.get(attachment, "file_path")
     file_name = Map.get(attachment, "file_name")
@@ -228,7 +230,7 @@ defmodule Tuist.Processor.XCResultProcessor do
       s3_key =
         "#{String.downcase(account_handle)}/#{String.downcase(project_handle)}/tests/runs/#{test_run_id}/attachments/#{attachment_id}/#{file_name}"
 
-      case upload_to_s3(file_path, bucket, s3_key, file_name, 1) do
+      case upload_to_s3(file_path, bucket, s3_key) do
         {:ok, _} ->
           uploaded =
             attachment
@@ -246,37 +248,84 @@ defmodule Tuist.Processor.XCResultProcessor do
     end
   end
 
-  # ExAws.S3.Upload fans chunks out via an internal Task.async_stream with a
-  # 30s per-chunk timeout; a slow chunk crashes the upload Task. Retry up to
-  # @upload_max_attempts times to ride through transient slowness; on the
-  # final attempt nothing is caught, so a real outage still propagates as a
-  # crash and surfaces in Sentry.
-  defp upload_to_s3(file_path, bucket, s3_key, file_name, attempt) when attempt < @upload_max_attempts do
-    case do_s3_upload(file_path, bucket, s3_key) do
-      {:ok, _} = ok ->
-        ok
-
-      {:error, reason} ->
-        Logger.warning("xcresult attachment upload errored (#{file_name}, attempt #{attempt}): #{inspect(reason)}")
-
-        upload_to_s3(file_path, bucket, s3_key, file_name, attempt + 1)
+  # ExAws.S3.Upload.perform/2 fans every chunk into one Task.async_stream
+  # (30s per-chunk default) and bails on the first failure. We drive the
+  # multipart upload ourselves so each chunk gets its own retry budget; a
+  # slow chunk no longer aborts an otherwise-healthy upload on the first 30s
+  # timeout. After retries are exhausted the multipart upload is aborted and
+  # the error surfaces to the caller, which logs it (Sentry's Logger backend
+  # picks that up so genuine failures still alert).
+  defp upload_to_s3(file_path, bucket, s3_key) do
+    with {:ok, %{body: %{upload_id: upload_id}}} <-
+           bucket |> ExAws.S3.initiate_multipart_upload(s3_key) |> ExAws.request(),
+         {:ok, parts} <- upload_parts(file_path, bucket, s3_key, upload_id) do
+      bucket |> ExAws.S3.complete_multipart_upload(s3_key, upload_id, parts) |> ExAws.request()
     end
-  catch
-    :exit, reason ->
-      Logger.warning("xcresult attachment upload exited (#{file_name}, attempt #{attempt}): #{inspect(reason)}")
-
-      upload_to_s3(file_path, bucket, s3_key, file_name, attempt + 1)
   end
 
-  defp upload_to_s3(file_path, bucket, s3_key, _file_name, _attempt) do
-    do_s3_upload(file_path, bucket, s3_key)
+  defp upload_parts(file_path, bucket, s3_key, upload_id) do
+    results =
+      file_path
+      |> ExAws.S3.Upload.stream_file()
+      |> Stream.with_index(1)
+      |> Task.async_stream(
+        fn chunk -> upload_part_with_retry(chunk, bucket, s3_key, upload_id, 1) end,
+        max_concurrency: 4,
+        timeout: @chunk_attempt_timeout * @chunk_max_attempts + 5_000,
+        on_timeout: :kill_task
+      )
+      |> Enum.map(fn
+        {:ok, val} -> val
+        {:exit, reason} -> {:error, {:chunk_task_exit, reason}}
+      end)
+
+    case Enum.find(results, &match?({:error, _}, &1)) do
+      nil ->
+        {:ok, results}
+
+      {:error, _} = error ->
+        bucket |> ExAws.S3.abort_multipart_upload(s3_key, upload_id) |> ExAws.request()
+        error
+    end
   end
 
-  defp do_s3_upload(file_path, bucket, s3_key) do
-    file_path
-    |> ExAws.S3.Upload.stream_file()
-    |> ExAws.S3.upload(bucket, s3_key)
-    |> ExAws.request()
+  defp upload_part_with_retry({chunk, i}, bucket, s3_key, upload_id, attempt) when attempt < @chunk_max_attempts do
+    case attempt_part_upload(chunk, i, bucket, s3_key, upload_id) do
+      {:ok, etag} -> {i, etag}
+      _ -> upload_part_with_retry({chunk, i}, bucket, s3_key, upload_id, attempt + 1)
+    end
+  end
+
+  defp upload_part_with_retry({chunk, i}, bucket, s3_key, upload_id, _attempt) do
+    case attempt_part_upload(chunk, i, bucket, s3_key, upload_id) do
+      {:ok, etag} -> {i, etag}
+      other -> {:error, other}
+    end
+  end
+
+  # Wrap each part attempt in its own Task so a hung HTTP request can be
+  # killed at @chunk_attempt_timeout without taking down the parent task; the
+  # next attempt then gets a fresh shot.
+  defp attempt_part_upload(chunk, i, bucket, s3_key, upload_id) do
+    task =
+      Task.async(fn ->
+        bucket |> ExAws.S3.upload_part(s3_key, upload_id, i, chunk) |> ExAws.request()
+      end)
+
+    case Task.yield(task, @chunk_attempt_timeout) || Task.shutdown(task) do
+      nil ->
+        :timeout
+
+      {:ok, {:ok, %{headers: headers}}} ->
+        etag = Enum.find_value(headers, fn {k, v} -> if String.downcase(k) == "etag", do: v end)
+        {:ok, etag}
+
+      {:ok, {:error, reason}} ->
+        {:error, reason}
+
+      {:exit, reason} ->
+        {:exit, reason}
+    end
   end
 
   defp make_temp_dir do

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -173,7 +173,7 @@ defmodule Tuist.Processor.XCResultProcessor do
         |> Task.async_stream(
           &upload_attachment(&1, bucket, account_handle, project_handle, test_run_id),
           max_concurrency: 30,
-          timeout: 180_000,
+          timeout: 60_000,
           on_timeout: :kill_task
         )
         |> Enum.zip(all_attachments)
@@ -217,6 +217,8 @@ defmodule Tuist.Processor.XCResultProcessor do
     end)
   end
 
+  @upload_max_attempts 3
+
   defp upload_attachment(attachment, bucket, account_handle, project_handle, test_run_id) do
     file_path = Map.get(attachment, "file_path")
     file_name = Map.get(attachment, "file_name")
@@ -226,36 +228,55 @@ defmodule Tuist.Processor.XCResultProcessor do
       s3_key =
         "#{String.downcase(account_handle)}/#{String.downcase(project_handle)}/tests/runs/#{test_run_id}/attachments/#{attachment_id}/#{file_name}"
 
-      # ExAws.S3.Upload internally fans chunks out via Task.async_stream with a
-      # 30s default per-chunk timeout. A slow chunk crashes the inner task and
-      # Logger reports it as a SASL crash, even though the outer reducer
-      # already drops the attachment cleanly. Catch the exit here so transient
-      # slowness fails as a normal `:error` instead of paging.
-      try do
-        case file_path
-             |> ExAws.S3.Upload.stream_file()
-             |> ExAws.S3.upload(bucket, s3_key, timeout: 120_000)
-             |> ExAws.request() do
-          {:ok, _} ->
-            uploaded =
-              attachment
-              |> Map.delete("file_path")
-              |> Map.put("attachment_id", attachment_id)
+      case upload_to_s3(file_path, bucket, s3_key, file_name, 1) do
+        {:ok, _} ->
+          uploaded =
+            attachment
+            |> Map.delete("file_path")
+            |> Map.put("attachment_id", attachment_id)
 
-            {:ok, uploaded}
+          {:ok, uploaded}
 
-          {:error, reason} ->
-            Logger.error("Failed to upload attachment #{file_name}: #{inspect(reason)}")
-            :error
-        end
-      catch
-        :exit, reason ->
-          Logger.error("Attachment upload exited for #{file_name}: #{inspect(reason)}")
+        {:error, reason} ->
+          Logger.error("Failed to upload attachment #{file_name}: #{inspect(reason)}")
           :error
       end
     else
       :error
     end
+  end
+
+  # ExAws.S3.Upload fans chunks out via an internal Task.async_stream with a
+  # 30s per-chunk timeout; a slow chunk crashes the upload Task. Retry up to
+  # @upload_max_attempts times to ride through transient slowness; on the
+  # final attempt nothing is caught, so a real outage still propagates as a
+  # crash and surfaces in Sentry.
+  defp upload_to_s3(file_path, bucket, s3_key, file_name, attempt) when attempt < @upload_max_attempts do
+    case do_s3_upload(file_path, bucket, s3_key) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning("xcresult attachment upload errored (#{file_name}, attempt #{attempt}): #{inspect(reason)}")
+
+        upload_to_s3(file_path, bucket, s3_key, file_name, attempt + 1)
+    end
+  catch
+    :exit, reason ->
+      Logger.warning("xcresult attachment upload exited (#{file_name}, attempt #{attempt}): #{inspect(reason)}")
+
+      upload_to_s3(file_path, bucket, s3_key, file_name, attempt + 1)
+  end
+
+  defp upload_to_s3(file_path, bucket, s3_key, _file_name, _attempt) do
+    do_s3_upload(file_path, bucket, s3_key)
+  end
+
+  defp do_s3_upload(file_path, bucket, s3_key) do
+    file_path
+    |> ExAws.S3.Upload.stream_file()
+    |> ExAws.S3.upload(bucket, s3_key)
+    |> ExAws.request()
   end
 
   defp make_temp_dir do

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -239,7 +239,7 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         {:ok, %{status_code: 200}}
       end)
 
-      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
+      stub(ExAws.S3, :upload, fn stream, _bucket, key, _opts ->
         %Upload{bucket: "tuist", path: key, src: stream}
       end)
 

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -239,7 +239,7 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         {:ok, %{status_code: 200}}
       end)
 
-      stub(ExAws.S3, :upload, fn stream, _bucket, key, _opts ->
+      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
         %Upload{bucket: "tuist", path: key, src: stream}
       end)
 
@@ -261,6 +261,119 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert attachment["attachment_id"]
       assert attachment["file_name"] == "screenshot.png"
       refute Map.has_key?(attachment, "file_path")
+    end
+
+    test "retries attachment upload on transient ExAws error before succeeding" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      attachment_file = Path.join(fixture_dir, "screenshot.png")
+      File.write!(attachment_file, "fake-png-data")
+
+      parsed_data = %{
+        "test_modules" => [
+          %{
+            "name" => "Module",
+            "test_cases" => [
+              %{
+                "name" => "test_example",
+                "attachments" => [
+                  %{
+                    "file_path" => attachment_file,
+                    "file_name" => "screenshot.png",
+                    "repetition_number" => nil
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
+      on_exit(fn -> if Process.alive?(attempts), do: Agent.stop(attempts) end)
+
+      stub(ExAws, :request, fn %Upload{} ->
+        case Agent.get_and_update(attempts, &{&1 + 1, &1 + 1}) do
+          1 -> {:error, :timeout}
+          _ -> {:ok, %{status_code: 200}}
+        end
+      end)
+
+      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
+        %Upload{bucket: "tuist", path: key, src: stream}
+      end)
+
+      expect(XCResultNIF, :parse, fn _path, _root -> {:ok, parsed_data} end)
+
+      opts = [
+        test_run_id: "run-123",
+        account_handle: "MyOrg",
+        project_handle: "MyProject"
+      ]
+
+      assert {:ok, result} = XCResultProcessor.process_local(fixture_zip, opts)
+
+      [module] = result["test_modules"]
+      [test_case] = module["test_cases"]
+      [attachment] = test_case["attachments"]
+      assert attachment["attachment_id"]
+      assert Agent.get(attempts, & &1) == 2
+    end
+
+    test "drops attachment after retries are exhausted" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      attachment_file = Path.join(fixture_dir, "screenshot.png")
+      File.write!(attachment_file, "fake-png-data")
+
+      parsed_data = %{
+        "test_modules" => [
+          %{
+            "name" => "Module",
+            "test_cases" => [
+              %{
+                "name" => "test_example",
+                "attachments" => [
+                  %{
+                    "file_path" => attachment_file,
+                    "file_name" => "screenshot.png",
+                    "repetition_number" => nil
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
+      on_exit(fn -> if Process.alive?(attempts), do: Agent.stop(attempts) end)
+
+      stub(ExAws, :request, fn %Upload{} ->
+        Agent.update(attempts, &(&1 + 1))
+        {:error, :timeout}
+      end)
+
+      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
+        %Upload{bucket: "tuist", path: key, src: stream}
+      end)
+
+      expect(XCResultNIF, :parse, fn _path, _root -> {:ok, parsed_data} end)
+
+      opts = [
+        test_run_id: "run-123",
+        account_handle: "MyOrg",
+        project_handle: "MyProject"
+      ]
+
+      assert {:ok, result} = XCResultProcessor.process_local(fixture_zip, opts)
+
+      [module] = result["test_modules"]
+      [test_case] = module["test_cases"]
+      assert test_case["attachments"] == []
+      assert Agent.get(attempts, & &1) == 3
     end
 
     test "dispatches to AppleArchive NIF when the downloaded payload is not PKZIP" do

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -2,9 +2,30 @@ defmodule Tuist.Processor.XCResultProcessorTest do
   use ExUnit.Case, async: true
   use Mimic
 
-  alias ExAws.S3.Upload
   alias Tuist.Processor.XCResultNIF
   alias Tuist.Processor.XCResultProcessor
+
+  defp handle_multipart_request(op, opts \\ %{}) do
+    case op do
+      %{http_method: :post, resource: "uploads"} ->
+        {:ok, %{body: %{upload_id: "test-upload-id"}}}
+
+      %{http_method: :put, params: %{"partNumber" => n, "uploadId" => _}} ->
+        case Map.get(opts, :on_part) do
+          nil -> {:ok, %{headers: [{"ETag", "etag-#{n}"}]}}
+          fun -> fun.(n)
+        end
+
+      %{http_method: :post, params: %{"uploadId" => _}} ->
+        {:ok, %{}}
+
+      %{http_method: :delete, params: %{"uploadId" => _}} ->
+        case Map.get(opts, :on_abort) do
+          nil -> {:ok, %{}}
+          fun -> fun.()
+        end
+    end
+  end
 
   setup :verify_on_exit!
 
@@ -232,16 +253,7 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         ]
       }
 
-      # Upload call for the attachment (streaming multipart upload)
-      expect(ExAws, :request, fn %Upload{bucket: _bucket, path: path} ->
-        assert String.contains?(path, "tests/runs/run-123/attachments/")
-        assert String.ends_with?(path, "/screenshot.png")
-        {:ok, %{status_code: 200}}
-      end)
-
-      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
-        %Upload{bucket: "tuist", path: key, src: stream}
-      end)
+      stub(ExAws, :request, &handle_multipart_request/1)
 
       expect(XCResultNIF, :parse, fn _path, _root ->
         {:ok, parsed_data}
@@ -263,7 +275,7 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       refute Map.has_key?(attachment, "file_path")
     end
 
-    test "retries attachment upload on transient ExAws error before succeeding" do
+    test "retries part upload on transient ExAws error before succeeding" do
       {fixture_dir, fixture_zip} = create_xcresult_zip()
       on_exit(fn -> File.rm_rf(fixture_dir) end)
 
@@ -293,16 +305,14 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       {:ok, attempts} = Agent.start_link(fn -> 0 end)
       on_exit(fn -> if Process.alive?(attempts), do: Agent.stop(attempts) end)
 
-      stub(ExAws, :request, fn %Upload{} ->
+      on_part = fn n ->
         case Agent.get_and_update(attempts, &{&1 + 1, &1 + 1}) do
           1 -> {:error, :timeout}
-          _ -> {:ok, %{status_code: 200}}
+          _ -> {:ok, %{headers: [{"ETag", "etag-#{n}"}]}}
         end
-      end)
+      end
 
-      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
-        %Upload{bucket: "tuist", path: key, src: stream}
-      end)
+      stub(ExAws, :request, &handle_multipart_request(&1, %{on_part: on_part}))
 
       expect(XCResultNIF, :parse, fn _path, _root -> {:ok, parsed_data} end)
 
@@ -321,7 +331,7 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert Agent.get(attempts, & &1) == 2
     end
 
-    test "drops attachment after retries are exhausted" do
+    test "aborts multipart upload and drops attachment after retries are exhausted" do
       {fixture_dir, fixture_zip} = create_xcresult_zip()
       on_exit(fn -> File.rm_rf(fixture_dir) end)
 
@@ -348,17 +358,24 @@ defmodule Tuist.Processor.XCResultProcessorTest do
         ]
       }
 
-      {:ok, attempts} = Agent.start_link(fn -> 0 end)
-      on_exit(fn -> if Process.alive?(attempts), do: Agent.stop(attempts) end)
+      {:ok, counters} = Agent.start_link(fn -> %{part: 0, abort: 0} end)
+      on_exit(fn -> if Process.alive?(counters), do: Agent.stop(counters) end)
 
-      stub(ExAws, :request, fn %Upload{} ->
-        Agent.update(attempts, &(&1 + 1))
+      on_part = fn _n ->
+        Agent.update(counters, &%{&1 | part: &1.part + 1})
         {:error, :timeout}
-      end)
+      end
 
-      stub(ExAws.S3, :upload, fn stream, _bucket, key ->
-        %Upload{bucket: "tuist", path: key, src: stream}
-      end)
+      on_abort = fn ->
+        Agent.update(counters, &%{&1 | abort: &1.abort + 1})
+        {:ok, %{}}
+      end
+
+      stub(
+        ExAws,
+        :request,
+        &handle_multipart_request(&1, %{on_part: on_part, on_abort: on_abort})
+      )
 
       expect(XCResultNIF, :parse, fn _path, _root -> {:ok, parsed_data} end)
 
@@ -373,7 +390,10 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       [module] = result["test_modules"]
       [test_case] = module["test_cases"]
       assert test_case["attachments"] == []
-      assert Agent.get(attempts, & &1) == 3
+
+      state = Agent.get(counters, & &1)
+      assert state.part == 3
+      assert state.abort == 1
     end
 
     test "dispatches to AppleArchive NIF when the downloaded payload is not PKZIP" do

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -277,6 +277,52 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       refute Map.has_key?(attachment, "file_path")
     end
 
+    test "uploads an empty part for zero-byte attachments" do
+      {fixture_dir, fixture_zip} = create_xcresult_zip()
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      attachment_file = Path.join(fixture_dir, "empty.log")
+      File.write!(attachment_file, "")
+
+      parsed_data = %{
+        "test_modules" => [
+          %{
+            "name" => "Module",
+            "test_cases" => [
+              %{
+                "name" => "test_example",
+                "attachments" => [
+                  %{
+                    "file_path" => attachment_file,
+                    "file_name" => "empty.log",
+                    "repetition_number" => nil
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      stub(ExAws, :request, &handle_multipart_request/1)
+
+      expect(XCResultNIF, :parse, fn _path, _root -> {:ok, parsed_data} end)
+
+      opts = [
+        test_run_id: "run-123",
+        account_handle: "MyOrg",
+        project_handle: "MyProject"
+      ]
+
+      assert {:ok, result} = XCResultProcessor.process_local(fixture_zip, opts)
+
+      [module] = result["test_modules"]
+      [test_case] = module["test_cases"]
+      [attachment] = test_case["attachments"]
+      assert attachment["attachment_id"]
+      assert attachment["file_name"] == "empty.log"
+    end
+
     test "retries part upload on transient ExAws error before succeeding" do
       {fixture_dir, fixture_zip} = create_xcresult_zip()
       on_exit(fn -> File.rm_rf(fixture_dir) end)


### PR DESCRIPTION
Fixes TUIST-F2

### Short description

Sentry alert [TUIST-F2](https://tuist.sentry.io/issues/TUIST-F2) fired on a `Task.Supervised.stream(30000)` timeout when an xcresult-processor pod tried to upload a multi-MB `.ips` crash-log attachment to S3.

### Root cause

`ExAws.S3.Upload.perform/2` fans every chunk into a single `Task.async_stream` with a 30s default per-chunk timeout, and bails on the first failure. A slow chunk (high-latency Mac mini → S3 path is the typical culprit) trips that inner timeout, crashing the upload Task. The outer `Task.async_stream` in `XCResultProcessor.upload_attachments/3` already handled the failure cleanly (drop the attachment, keep processing), but the inner crash got reported as a SASL error and forwarded to Sentry on the very first transient hiccup.

### Fix

Drive the multipart upload directly so each chunk gets its own retry budget. The library has no retry hook on its multipart pipeline, but the building blocks (`ExAws.S3.initiate_multipart_upload`, `upload_part`, `complete_multipart_upload`, `abort_multipart_upload`) are public; we call them ourselves.

- Each part runs inside its own `Task.async` with a 30s yield/shutdown timeout, so a hung HTTP request is killed at the per-attempt boundary instead of taking down the parent.
- Parts are retried up to 3 times; chunks that already succeeded in a previous attempt are not re-uploaded.
- Zero-byte attachments upload a single empty part so `CompleteMultipartUpload` accepts the request, matching `ExAws.S3.Upload.complete/3`'s fallback.
- After retries are exhausted the multipart upload is aborted (avoids orphaned parts in S3) and the error surfaces to the caller. `upload_attachment/5` logs at `:error` level, so Sentry's Logger backend still alerts on genuine failures.
- The outer `Task.async_stream` timeout is bumped from 60s to ~120s so it cannot kill the parent task before the per-chunk retry budget completes.

### Considered: extracting a shared `Tuist.S3` module

We weighed pulling the multipart-with-retry logic into a reusable module so other call sites could opt in. Today there is exactly one caller of `ExAws.S3.upload` outside this PR (`Tuist.Storage.upload/3`), and it has no callers itself; everything else goes through `put_object` or presigned URLs. Extracting now would be a one-caller abstraction shaped by guesses about future needs, so we kept it as private functions on `XCResultProcessor`. The `upload_to_s3 / upload_parts / upload_part_with_retry / attempt_part_upload / upload_empty_part` cluster lifts cleanly into a `Tuist.S3.MultipartUpload` module when a real second caller shows up.

### How to test locally

- `cd server && mix test test/tuist/processor/xcresult_processor_test.exs` — covers happy path, zero-byte attachments, transient-error retry, and the exhausted-retry-with-abort path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)