### PR TITLE
[codex] test(server): cover Kura cache endpoint feature flag

### DIFF
--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -230,6 +230,36 @@ defmodule TuistWeb.API.CacheControllerTest do
                Enum.sort(["https://kura-cache-1.example.com", "https://kura-cache-2.example.com"])
     end
 
+    test "returns default endpoints when Kura endpoints exist but the client feature flag is not set", %{
+      conn: conn
+    } do
+      # Given
+      user = AccountsFixtures.user_fixture()
+      account = Accounts.get_account_from_user(user)
+
+      {:ok, _} =
+        Accounts.create_account_cache_endpoint(account, %{
+          url: "https://kura-cache.example.com",
+          technology: :kura
+        })
+
+      expected_endpoints = [
+        "https://cache-eu-central-test.tuist.dev",
+        "https://cache-us-east-test.tuist.dev"
+      ]
+
+      stub(Tuist.Environment, :cache_endpoints, fn -> expected_endpoints end)
+
+      conn = Authentication.put_current_user(conn, user)
+
+      # When
+      conn = get(conn, ~p"/api/cache/endpoints?account_handle=#{account.name}")
+
+      # Then
+      response = json_response(conn, 200)
+      assert response["endpoints"] == expected_endpoints
+    end
+
     test "returns empty list when Kura is requested without account-specific endpoints", %{
       conn: conn
     } do


### PR DESCRIPTION
## Summary

This keeps the merged Kura settings UI from #10489 intact and adds a controller regression test for the cache endpoint selection behavior.

The expected split is:

- `/api/cache/endpoints` returns Kura endpoints only when the client feature flag header includes `kura`.
- The account settings UI is shown through the account-scoped FunWithFlags `:kura` flag, as implemented in #10489.

## Why

Kura endpoints can exist for an account, but the API should not return them to clients unless the client explicitly opts into Kura through the feature flag header. This test protects that behavior.

## Validation

Attempted focused test:

```sh
mise exec -- mix test test/tuist_web/controllers/api/cache_controller_test.exs
```

The test run is currently blocked before tests execute by an existing compile error outside this PR:

```text
== Compilation error in file lib/tuist_web/plugs/api/authorization/authorization_plug.ex ==
** (RuntimeError) duplicate call to "use Phoenix.VerifiedRoutes" found, make sure it is used only once per module
```
