### PR TITLE
fix(cli): make metadata upload non-fatal

### DIFF
--- a/cli/Sources/TuistHTTP/RetryMiddleware.swift
+++ b/cli/Sources/TuistHTTP/RetryMiddleware.swift
@@ -5,7 +5,6 @@ import TuistLogging
 
 public struct RetryMiddleware: ClientMiddleware {
     private let maxRetries: Int
-    private static let retryableStatusCodes: Set<Int> = [429, 500, 502, 503, 504]
 
     public init(maxRetries: Int = 3) {
         self.maxRetries = maxRetries
@@ -29,7 +28,7 @@ public struct RetryMiddleware: ClientMiddleware {
             let replayBody = bodyData.map { HTTPBody($0) }
             do {
                 let (response, responseBody) = try await next(request, replayBody, baseURL)
-                guard Self.retryableStatusCodes.contains(response.status.code) else {
+                guard Self.isRetryableStatusCode(response.status.code) else {
                     return (response, responseBody)
                 }
                 Logger.current.debug(
@@ -54,5 +53,9 @@ public struct RetryMiddleware: ClientMiddleware {
         let baseInterval = TimeInterval(100_000_000) // 100ms
         let jitter = Double.random(in: 0 ... 100_000_000) // 0-100ms jitter
         return UInt64(baseInterval * pow(2, Double(retry)) + jitter)
+    }
+
+    private static func isRetryableStatusCode(_ statusCode: Int) -> Bool {
+        statusCode == 408 || statusCode == 429 || (500 ..< 600).contains(statusCode)
     }
 }

--- a/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/cli/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -89,7 +89,7 @@ public class TrackableCommand {
                         try command.run()
                     }
                     if let fullHandle, let serverURL, shouldTrackAnalytics {
-                        try await uploadCommandEvent(
+                        await uploadCommandEvent(
                             timer: timer,
                             status: .success,
                             runId: runMetadataStorage.runId,
@@ -102,7 +102,7 @@ public class TrackableCommand {
                     }
                 } catch {
                     if let fullHandle, let serverURL, shouldTrackAnalytics {
-                        try await uploadCommandEvent(
+                        await uploadCommandEvent(
                             timer: timer,
                             status: .failure("\(error)"),
                             runId: await runMetadataStorage.runId,
@@ -128,48 +128,49 @@ public class TrackableCommand {
         fullHandle: String,
         serverURL: URL,
         ranAt: Date
-    ) async throws {
-        if ServerAuthenticationConfig.current.optionalAuthentication {
-            let token = try? await serverAuthenticationController.authenticationToken(
-                serverURL: serverURL,
-                refreshIfNeeded: false
-            )
-            if token == nil {
-                Logger.current.debug("Skipping run metadata upload: no authentication credentials available.")
-                return
+    ) async {
+        do {
+            if ServerAuthenticationConfig.current.optionalAuthentication {
+                let token = try? await serverAuthenticationController.authenticationToken(
+                    serverURL: serverURL,
+                    refreshIfNeeded: false
+                )
+                if token == nil {
+                    Logger.current.debug("Skipping run metadata upload: no authentication credentials available.")
+                    return
+                }
             }
-        }
-        let durationInSeconds = timer.stop()
-        let durationInMs = Int(durationInSeconds * 1000)
-        let configuration = type(of: command).configuration
-        let (name, subcommand) = extractCommandName(from: configuration)
-        let info = await TrackableCommandInfo(
-            runId: runId,
-            name: name,
-            subcommand: subcommand,
-            commandArguments: commandArguments,
-            durationInMs: durationInMs,
-            status: status,
-            graph: runMetadataStorage.graph,
-            graphBinaryBuildDuration: runMetadataStorage.graphBinaryBuildDuration,
-            binaryCacheItems: runMetadataStorage.binaryCacheItems,
-            selectiveTestingCacheItems: runMetadataStorage.selectiveTestingCacheItems,
-            targetContentHashSubhashes: runMetadataStorage.targetContentHashSubhashes,
-            previewId: runMetadataStorage.previewId,
-            resultBundlePath: runMetadataStorage.resultBundlePath,
-            ranAt: ranAt,
-            buildRunId: runMetadataStorage.buildRunId,
-            testRunId: runMetadataStorage.testRunId,
-            cacheEndpoint: runMetadataStorage.cacheEndpoint
-        )
-        let commandEvent = try await commandEventFactory.make(
-            from: info,
-            path: path
-        )
-        let buildRunURL = await runMetadataStorage.buildRunURL
-        if (command as? TrackableParsableCommand)?.analyticsRequired == true || Environment.current.isCI {
-            Logger.current.info("Uploading run metadata...")
-            do {
+
+            let durationInSeconds = timer.stop()
+            let durationInMs = Int(durationInSeconds * 1000)
+            let configuration = type(of: command).configuration
+            let (name, subcommand) = extractCommandName(from: configuration)
+            let info = await TrackableCommandInfo(
+                runId: runId,
+                name: name,
+                subcommand: subcommand,
+                commandArguments: commandArguments,
+                durationInMs: durationInMs,
+                status: status,
+                graph: runMetadataStorage.graph,
+                graphBinaryBuildDuration: runMetadataStorage.graphBinaryBuildDuration,
+                binaryCacheItems: runMetadataStorage.binaryCacheItems,
+                selectiveTestingCacheItems: runMetadataStorage.selectiveTestingCacheItems,
+                targetContentHashSubhashes: runMetadataStorage.targetContentHashSubhashes,
+                previewId: runMetadataStorage.previewId,
+                resultBundlePath: runMetadataStorage.resultBundlePath,
+                ranAt: ranAt,
+                buildRunId: runMetadataStorage.buildRunId,
+                testRunId: runMetadataStorage.testRunId,
+                cacheEndpoint: runMetadataStorage.cacheEndpoint
+            )
+            let commandEvent = try await commandEventFactory.make(
+                from: info,
+                path: path
+            )
+            let buildRunURL = await runMetadataStorage.buildRunURL
+            if (command as? TrackableParsableCommand)?.analyticsRequired == true || Environment.current.isCI {
+                Logger.current.info("Uploading run metadata...")
                 let serverCommandEvent = try await uploadAnalyticsService.upload(
                     commandEvent: commandEvent,
                     fullHandle: fullHandle,
@@ -192,26 +193,25 @@ public class TrackableCommand {
                             "You can view a detailed run report at: \(serverCommandEvent.url.absoluteString)"
                         )
                 }
-            } catch let error as ClientError {
-                Logger.current
-                    .warning("Failed to upload run metadata: \(String(describing: error.underlyingError))")
-            } catch {
-                Logger.current.warning("Failed to upload run metadata: \(String(describing: error))")
+            } else {
+                let tempDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "analytics")
+                let commandEventPath = tempDirectory.appending(component: "command-event.json")
+                try await fileSystem.writeAsJSON(commandEvent, at: commandEventPath)
+                try backgroundProcessRunner.runInBackground(
+                    [Environment.current.currentExecutablePath()?.pathString ?? "tuist"] + [
+                        "analytics-upload",
+                        commandEventPath.pathString,
+                        fullHandle,
+                        serverURL.absoluteString,
+                        sessionDirectory.pathString,
+                    ],
+                    environment: ProcessInfo.processInfo.environment
+                )
             }
-        } else {
-            let tempDirectory = try await fileSystem.makeTemporaryDirectory(prefix: "analytics")
-            let commandEventPath = tempDirectory.appending(component: "command-event.json")
-            try await fileSystem.writeAsJSON(commandEvent, at: commandEventPath)
-            try backgroundProcessRunner.runInBackground(
-                [Environment.current.currentExecutablePath()?.pathString ?? "tuist"] + [
-                    "analytics-upload",
-                    commandEventPath.pathString,
-                    fullHandle,
-                    serverURL.absoluteString,
-                    sessionDirectory.pathString,
-                ],
-                environment: ProcessInfo.processInfo.environment
-            )
+        } catch let error as ClientError {
+            Logger.current.warning("Failed to upload run metadata: \(String(describing: error.underlyingError))")
+        } catch {
+            Logger.current.warning("Failed to upload run metadata: \(String(describing: error))")
         }
     }
 

--- a/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
+++ b/cli/Sources/TuistKit/Services/InspectResultBundleService.swift
@@ -256,7 +256,7 @@ public struct UploadResultBundleService: UploadResultBundleServicing {
         )
         guard let run = testCaseRunsByIdentity[identityKey] else { return }
 
-        await testCase.attachments.forEach(context: .concurrent) { attachment in
+        await testCase.attachments.forEach(context: .serial) { attachment in
             do {
                 let argumentId: String? = attachment.argumentName.flatMap { argName in
                     run.arguments?.first(where: { $0.name == argName })?.id

--- a/cli/Tests/TuistHTTPTests/RetryMiddlewareTests.swift
+++ b/cli/Tests/TuistHTTPTests/RetryMiddlewareTests.swift
@@ -24,7 +24,7 @@ struct RetryMiddlewareTests {
         #expect(callCount == 1)
     }
 
-    @Test(arguments: [429, 500, 502, 503, 504])
+    @Test(arguments: [408, 429, 500, 502, 503, 504, 525])
     func retries_on_retryable_status_code(statusCode: Int) async throws {
         let subject = RetryMiddleware(maxRetries: 2)
         var callCount = 0

--- a/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/cli/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -217,6 +217,42 @@ final class TrackableCommandTests: TuistTestCase {
             .called(1)
     }
 
+    func test_whenRunMetadataUploadTimesOut_doesNotFailCommand() async throws {
+        // Given
+        uploadAnalyticsService.reset()
+        given(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .willThrow(URLError(.timedOut))
+        try makeSubject(analyticsRequired: true)
+
+        // When/Then
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+    }
+
+    func test_whenRunMetadataCreationFails_doesNotFailCommand() async throws {
+        // Given
+        gitController.reset()
+        given(gitController)
+            .gitInfo(workingDirectory: .any)
+            .willThrow(NSError(domain: "TestDomain", code: 525))
+        try makeSubject(analyticsRequired: true)
+
+        // When/Then
+        try await subject.run(
+            fullHandle: "tuist/tuist",
+            serverURL: .test(),
+            shouldTrackAnalytics: true
+        )
+
+        verify(uploadAnalyticsService)
+            .upload(commandEvent: .any, fullHandle: .any, serverURL: .any, sessionDirectory: .any)
+            .called(0)
+    }
+
     func test_whenOptionalAuthenticationIsEnabled_background_upload_does_not_add_a_flag() async throws {
         // Given
         try makeSubject(analyticsRequired: false)


### PR DESCRIPTION
## Summary

- Make run metadata event creation and upload best effort so metadata failures log a warning and never fail the command.
- Broaden retry handling to include HTTP 408, 429, and every 5xx response, including 525.
- Add coverage for run metadata upload timeouts, run metadata creation failures, and retryable 525 responses.

## Testing

- `mise run cli:lint --fix`
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistHTTPTests/RetryMiddlewareTests -only-testing TuistKitTests/TrackableCommandTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`