### PR TITLE
fix(server): log temp dir contents when xcresult extraction yields no bundle

### DIFF
--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -252,7 +252,7 @@ defmodule Tuist.Processor.XCResultProcessor do
         else
           Logger.error(
             "xcresult bundle not found after extraction in #{temp_dir}: " <>
-              "contents=#{inspect(temp_dir |> Path.join("**") |> Path.wildcard() |> Enum.take(30))}"
+              "contents=#{temp_dir |> Path.join("**") |> Path.wildcard() |> Enum.take(30) |> inspect()}"
           )
 
           nil

--- a/server/lib/tuist/processor/xcresult_processor.ex
+++ b/server/lib/tuist/processor/xcresult_processor.ex
@@ -247,7 +247,16 @@ defmodule Tuist.Processor.XCResultProcessor do
       # the base directory preserved). Treat the temp dir as the bundle when
       # `Info.plist` is present at its root.
       nil ->
-        if File.exists?(Path.join(temp_dir, "Info.plist")), do: temp_dir
+        if File.exists?(Path.join(temp_dir, "Info.plist")) do
+          temp_dir
+        else
+          Logger.error(
+            "xcresult bundle not found after extraction in #{temp_dir}: " <>
+              "contents=#{inspect(temp_dir |> Path.join("**") |> Path.wildcard() |> Enum.take(30))}"
+          )
+
+          nil
+        end
 
       path ->
         path

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -2,6 +2,8 @@ defmodule Tuist.Processor.XCResultProcessorTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  import ExUnit.CaptureLog
+
   alias ExAws.S3.Upload
   alias Tuist.Processor.XCResultNIF
   alias Tuist.Processor.XCResultProcessor
@@ -319,6 +321,32 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       end)
 
       assert {:ok, ^parsed_data} = XCResultProcessor.process_local(fixture_path)
+    end
+
+    test "logs temp_dir contents when extraction yields no recognizable bundle" do
+      fixture_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "xcresult_no_bundle_#{:erlang.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(fixture_dir)
+      fixture_path = Path.join(fixture_dir, "fixture.aar")
+      File.write!(fixture_path, <<0x62, 0x76, 0x78, 0x32, "fake-aar-body">>)
+      on_exit(fn -> File.rm_rf(fixture_dir) end)
+
+      expect(XCResultNIF, :decompress_archive, fn _archive_path, temp_dir ->
+        File.write!(Path.join(temp_dir, "stray.txt"), "no plist, no xcresult")
+        :ok
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :xcresult_not_found} = XCResultProcessor.process_local(fixture_path)
+        end)
+
+      assert log =~ "xcresult bundle not found after extraction"
+      assert log =~ "stray.txt"
     end
 
     test "surfaces NIF decompression failures for AppleArchive payloads" do

--- a/server/test/tuist/processor/xcresult_processor_test.exs
+++ b/server/test/tuist/processor/xcresult_processor_test.exs
@@ -323,17 +323,10 @@ defmodule Tuist.Processor.XCResultProcessorTest do
       assert {:ok, ^parsed_data} = XCResultProcessor.process_local(fixture_path)
     end
 
-    test "logs temp_dir contents when extraction yields no recognizable bundle" do
-      fixture_dir =
-        Path.join(
-          System.tmp_dir!(),
-          "xcresult_no_bundle_#{:erlang.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(fixture_dir)
-      fixture_path = Path.join(fixture_dir, "fixture.aar")
+    @tag :tmp_dir
+    test "logs temp_dir contents when extraction yields no recognizable bundle", %{tmp_dir: tmp_dir} do
+      fixture_path = Path.join(tmp_dir, "fixture.aar")
       File.write!(fixture_path, <<0x62, 0x76, 0x78, 0x32, "fake-aar-body">>)
-      on_exit(fn -> File.rm_rf(fixture_dir) end)
 
       expect(XCResultNIF, :decompress_archive, fn _archive_path, temp_dir ->
         File.write!(Path.join(temp_dir, "stray.txt"), "no plist, no xcresult")


### PR DESCRIPTION
## Summary

- One tenant has been hitting `:xcresult_not_found` repeatedly since the new Tart VM image started serving prod xcresult processing on 2026-05-07. The error site only tells us that `find_xcresult/1` returned `nil`, which can mean two very different things:
  1. The Swift NIF returned `:ok` without actually writing files (silent extraction failure — read-only `/tmp`, FS quota, codesign/arch issue, etc.).
  2. The NIF wrote a layout the lookup doesn't recognize (e.g. a wrapping `result_bundle/` dir, so `Info.plist` lives one level deeper than the fallback checks).
- I pulled the actual failing archive, extracted it locally with the production NIF code (built from this branch on the same Darwin version the Mac mini reports), and the bundle parses cleanly end-to-end. So the bug isn't in the upload — it's in the runtime of the new image fleet, and the current logs aren't enough to tell which side.
- This patch logs `temp_dir` and the first 30 entries from a recursive glob right before returning `nil`. Next failing job in Sentry will have everything we need to pick between the two hypotheses.

## Why diagnostic-only

The archive itself is well-formed and the extraction code is verified correct on identical hardware/OS. Without log evidence from a real failing job, any "fix" would be speculation. The follow-up (recursive `Info.plist` search, NIF rebuild, /tmp probing on the VM, etc.) waits for the next failure to land in Sentry with the contents listing attached.

## Test plan

- [x] `mix test test/tuist/processor/xcresult_processor_test.exs` — 12 passing including new coverage on the diagnostic path
- [ ] After merge: watch [TUIST-EY](https://tuist.sentry.io/issues/TUIST-EY) for the next event; the breadcrumb should now carry the temp_dir listing