### PR TITLE
fix(cli): remove noisy transport-level HTTP error logging

### DIFF
--- a/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
+++ b/cli/Sources/TuistHTTP/TuistURLSessionTransport.swift
@@ -1,7 +1,6 @@
 import Foundation
 import HTTPTypes
 import OpenAPIRuntime
-import TuistLogging
 
 #if canImport(FoundationNetworking)
     import FoundationNetworking
@@ -52,19 +51,6 @@ public struct TuistURLSessionTransport: ClientTransport {
 
         let responseHeaders = buildHTTPFields(from: httpResponse)
         let httpResponseObj = HTTPResponse(status: .init(code: httpResponse.statusCode), headerFields: responseHeaders)
-
-        if httpResponse.statusCode >= 400 {
-            Logger.current.error(
-                """
-                Received HTTP error response. Status: \(httpResponse.statusCode), method: \(request.method.rawValue), \
-                baseURL: \(baseURL.absoluteString), path: \(request.path ?? ""), \
-                requestID: \(request.requestID ?? "unknown"), \
-                responseRequestID: \(httpResponse.requestID ?? "unknown"), \
-                contentType: \(httpResponse.value(forHTTPHeaderField: "content-type") ?? "unknown"), \
-                contentLength: \(httpResponse.value(forHTTPHeaderField: "content-length") ?? "unknown")
-                """
-            )
-        }
 
         let responseBody: HTTPBody? = data.isEmpty ? nil : HTTPBody(data)
 


### PR DESCRIPTION
### Summary

The HTTP transport layer (`TuistURLSessionTransport`) was logging every response with status `>= 400` at `error` level. This produced thousands of noisy error lines in CI logs from cache lookups that return `404` (normal cache misses).

The original logging was added in #10593 to help debug auth token recovery, but it treated all 4xx responses as errors regardless of context. Status codes are already handled correctly at higher layers:

- Cache services return `false` for misses
- Other services throw typed errors

So the transport-level error logging was redundant and misleading. `VerboseLoggingMiddleware` remains available for debug-level network inspection when needed.

### Changes

- Remove the `if httpResponse.statusCode >= 400` error log block from `TuistURLSessionTransport.send`
- Remove the now-unused `import TuistLogging` from that file

### How to test locally

- Run a CLI flow that exercises cache lookups (which produce 404s for misses) and confirm the log output no longer contains the `Received HTTP error response. Status: 404 ...` lines.
- Real auth/server errors continue to surface through the typed errors raised by the service layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)