### PR TITLE
fix(infra): use supported Kura regional control plane type

### DIFF
--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -35,8 +35,8 @@ clusters/
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx31 |
 | `tuist-canary` | 3× cpx22 | md-0: 2× cpx31 |
 | `tuist` (production) | 3× cpx22 | md-0: 2× ccx23 (`pool=general`); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
-| `tuist-kura-us-east` (production Kura `us-east-1`) | 3× cpx22 in `ash` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
-| `tuist-kura-us-west` (production Kura `us-west-1`) | 3× cpx22 in `hil` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
+| `tuist-kura-us-east` (production Kura `us-east-1`) | 3× ccx13 in `ash` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
+| `tuist-kura-us-west` (production Kura `us-west-1`) | 3× ccx13 in `hil` | kura: 3× ccx13 (`pool=kura`, autoscaled 3→12) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 
 Variables exposed by the ClusterClass: control plane replicas + machine

--- a/infra/k8s/clusters/cluster-production-us-east.yaml
+++ b/infra/k8s/clusters/cluster-production-us-east.yaml
@@ -24,7 +24,7 @@ spec:
       - name: region
         value: ash
       - name: hcloudControlPlaneMachineType
-        value: cpx22
+        value: ccx13
       - name: hcloudWorkerMachineType
         value: ccx13
       - name: hcloudSSHKeyName

--- a/infra/k8s/clusters/cluster-production-us-west.yaml
+++ b/infra/k8s/clusters/cluster-production-us-west.yaml
@@ -24,7 +24,7 @@ spec:
       - name: region
         value: hil
       - name: hcloudControlPlaneMachineType
-        value: cpx22
+        value: ccx13
       - name: hcloudWorkerMachineType
         value: ccx13
       - name: hcloudSSHKeyName

--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -17,6 +17,15 @@ storageClasses:
 
 controller:
   replicaCount: 1
+  # During bootstrap, only the first control-plane node may be joined when
+  # the CSI chart is installed. Schedule the controller there so Helm's
+  # readiness wait does not depend on worker-node provisioning.
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   resources:
     requests:
       cpu: 50m

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -23,8 +23,9 @@
 #   8. Install the platform chart (cert-manager, ESO, ingress-nginx,
 #      external-dns).
 #   9. Install the monitoring chart (Grafana Cloud agent).
-#  10. Install the tuist app chart with the env-specific values.
-#  11. Print the externally-routable LB IP for DNS cut.
+#  10. Pre-create the app namespace.
+#  11. Install the Cloudflare origin cert TLS Secret.
+#  12. Smoke ingress + upload workload kubeconfig to 1Password.
 #
 # Idempotent: re-running is safe; helm upgrades in-place, kubectl
 # create | apply uses --dry-run + apply.
@@ -67,7 +68,7 @@ log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 err() { printf '\n\033[1;31mERROR: %s\033[0m\n' "$*" >&2; }
 
 # ---------------------------------------------------------------------------
-log "Step 1/11: extract workload kubeconfig + API endpoint from mgmt"
+log "Step 1/12: extract workload kubeconfig + API endpoint from mgmt"
 
 if ! KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" >/dev/null 2>&1; then
   err "Cluster $NAMESPACE/$CLUSTER_NAME not found on mgmt cluster ($MGMT_KUBECONFIG). Apply the Cluster CR first."
@@ -95,11 +96,19 @@ REGION=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLU
   -o jsonpath='{.spec.topology.variables[?(@.name=="region")].value}' | tr -d '"')
 REGION="${REGION:-fsn1}"
 
+CONTROL_PLANE_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" \
+  -o jsonpath='{.spec.topology.controlPlane.replicas}')
+CONTROL_PLANE_REPLICAS="${CONTROL_PLANE_REPLICAS:-1}"
+WORKER_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" \
+  -o jsonpath='{range .spec.topology.workers.machineDeployments[*]}{.replicas}{"\n"}{end}' | awk '{sum += $1} END {print sum + 0}')
+EXPECTED_MACHINE_COUNT=$((CONTROL_PLANE_REPLICAS + WORKER_REPLICAS))
+
 echo "API endpoint: ${API_HOST}:${API_PORT}"
 echo "Region:       $REGION"
+echo "Machines:     $EXPECTED_MACHINE_COUNT (${CONTROL_PLANE_REPLICAS} control plane, ${WORKER_REPLICAS} workers)"
 
 # ---------------------------------------------------------------------------
-log "Step 2/11: install Cilium (CNI must be first)"
+log "Step 2/12: install Cilium (CNI must be first)"
 
 # Repo add is idempotent.
 helm repo add cilium https://helm.cilium.io >/dev/null 2>&1 || true
@@ -118,7 +127,7 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install cilium cilium/cilium \
 # only depend on the agent, not hubble-relay.
 
 # ---------------------------------------------------------------------------
-log "Step 3/11: create workload Hetzner Secrets"
+log "Step 3/12: create workload Hetzner Secrets"
 
 HCLOUD_TOKEN=$(op read --account tuist.1password.com "op://Founders/tuist-workloads/password")
 
@@ -153,7 +162,7 @@ fi
 unset HCLOUD_SECRET_TOKEN
 
 # ---------------------------------------------------------------------------
-log "Step 4/11: install hcloud-cloud-controller-manager"
+log "Step 4/12: install hcloud-cloud-controller-manager"
 
 helm repo add hcloud https://charts.hetzner.cloud >/dev/null 2>&1 || true
 helm repo update hcloud >/dev/null
@@ -165,7 +174,7 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hccm hcloud/hcloud-cloud-cont
   --wait --timeout 3m
 
 # ---------------------------------------------------------------------------
-log "Step 5/11: install hcloud-csi-driver"
+log "Step 5/12: install hcloud-csi-driver"
 
 KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hcloud-csi hcloud/hcloud-csi \
   --namespace kube-system \
@@ -173,12 +182,40 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install hcloud-csi hcloud/hcloud-csi 
   --wait --timeout 3m
 
 # ---------------------------------------------------------------------------
-log "Step 6/11: wait for nodes to go Ready"
+log "Step 6/12: wait for CAPI machines and workload nodes to go Ready"
+
+echo -n "Waiting for $EXPECTED_MACHINE_COUNT CAPI Machines to exist"
+MACHINE_COUNT=0
+for _ in $(seq 1 120); do
+  MACHINE_COUNT=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get machines.cluster.x-k8s.io \
+    -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$MACHINE_COUNT" -ge "$EXPECTED_MACHINE_COUNT" ]; then
+    break
+  fi
+  printf '.'
+  sleep 5
+done
+echo
+
+if [ "$MACHINE_COUNT" -lt "$EXPECTED_MACHINE_COUNT" ]; then
+  err "Only $MACHINE_COUNT/$EXPECTED_MACHINE_COUNT CAPI Machines exist for $CLUSTER_NAME."
+  KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get machines.cluster.x-k8s.io \
+    -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o wide >&2 || true
+  exit 1
+fi
+
+if ! KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" wait --for=condition=Ready \
+  machines.cluster.x-k8s.io -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" --timeout=20m; then
+  err "Not all CAPI Machines for $CLUSTER_NAME became Ready."
+  KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get machines.cluster.x-k8s.io,hcloudmachines.infrastructure.cluster.x-k8s.io \
+    -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o wide >&2 || true
+  exit 1
+fi
 
 KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready nodes --all --timeout=5m
 
 # ---------------------------------------------------------------------------
-log "Step 7/11: install platform chart (cert-manager, ESO, ingress-nginx)"
+log "Step 7/12: install platform chart (cert-manager, ESO, ingress-nginx)"
 
 helm dependency update "$REPO_ROOT/infra/helm/platform" >/dev/null
 
@@ -217,7 +254,7 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install platform "$REPO_ROOT/infra/he
   --wait --timeout 5m
 
 # ---------------------------------------------------------------------------
-log "Step 8/11: wire ESO -> 1Password for the per-env vault"
+log "Step 8/12: wire ESO -> 1Password for the per-env vault"
 
 OP_TOKEN=$(op read --account tuist.1password.com "op://Founders/${OP_TOKEN_ID}/credential")
 
@@ -241,7 +278,7 @@ unset OP_TOKEN
 KUBECONFIG="$WL_KUBECONFIG" kubectl wait --for=condition=Ready clustersecretstore/onepassword --timeout=2m
 
 # ---------------------------------------------------------------------------
-log "Step 9/11: install monitoring chart"
+log "Step 9/12: install monitoring chart"
 
 helm dependency update "$REPO_ROOT/infra/helm/k8s-monitoring" >/dev/null
 

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -12,12 +12,12 @@
 #   1. Extract the workload kubeconfig + API endpoint from the mgmt
 #      cluster's ClusterCR + minted Secret.
 #   2. Install Cilium (must be first — nothing networks without it).
-#   3. Install hcloud-cloud-controller-manager (sets providerID,
+#   3. Create the legacy `hetzner` Secret on the workload cluster and
+#      wait for caph's `hcloud` Secret. HCCM + CSI read `hcloud`.
+#   4. Install hcloud-cloud-controller-manager (sets providerID,
 #      enables LoadBalancer Services).
-#   4. Install hcloud-csi-driver (for parity; no PVCs use it today).
-#   5. Wait for nodes to go Ready (CNI- and CCM-dependent).
-#   6. Create the `hetzner` Secret on the workload cluster (same
-#      project token as the mgmt-side Secret; HCCM + CSI both read it).
+#   5. Install hcloud-csi-driver (for parity; no PVCs use it today).
+#   6. Wait for nodes to go Ready (CNI- and CCM-dependent).
 #   7. Create the `onepassword` namespace + service-account-token
 #      Secret + ClusterSecretStore so ESO can pull from 1Password.
 #   8. Install the platform chart (cert-manager, ESO, ingress-nginx,
@@ -118,14 +118,39 @@ KUBECONFIG="$WL_KUBECONFIG" helm upgrade --install cilium cilium/cilium \
 # only depend on the agent, not hubble-relay.
 
 # ---------------------------------------------------------------------------
-log "Step 3/11: create hetzner Secret on workload (HCCM + CSI both read it)"
+log "Step 3/11: create workload Hetzner Secrets"
 
 HCLOUD_TOKEN=$(op read --account tuist.1password.com "op://Founders/tuist-workloads/password")
 
+# Older bootstrap wiring created kube-system/hetzner directly. Keep it
+# idempotently present for compatibility, but HCCM and hcloud-csi consume
+# kube-system/hcloud, which caph writes after the first control-plane node
+# comes up.
 KUBECONFIG="$WL_KUBECONFIG" kubectl -n kube-system create secret generic hetzner \
   --from-literal=hcloud="$HCLOUD_TOKEN" \
   --dry-run=client -o yaml | KUBECONFIG="$WL_KUBECONFIG" kubectl apply -f -
 unset HCLOUD_TOKEN
+
+echo -n "Waiting for caph-provisioned kube-system/hcloud Secret"
+HCLOUD_SECRET_TOKEN=""
+for _ in $(seq 1 60); do
+  HCLOUD_SECRET_TOKEN=$(KUBECONFIG="$WL_KUBECONFIG" kubectl -n kube-system get secret hcloud \
+    -o jsonpath='{.data.token}' 2>/dev/null || true)
+  if [ -n "$HCLOUD_SECRET_TOKEN" ]; then
+    break
+  fi
+  printf '.'
+  sleep 5
+done
+echo
+
+if [ -z "$HCLOUD_SECRET_TOKEN" ]; then
+  err "kube-system/hcloud Secret did not appear after 5 minutes. HCCM and hcloud-csi need it."
+  err "Check caph reconciliation on the management cluster:"
+  err "  KUBECONFIG=$MGMT_KUBECONFIG kubectl -n $NAMESPACE describe cluster $CLUSTER_NAME"
+  exit 1
+fi
+unset HCLOUD_SECRET_TOKEN
 
 # ---------------------------------------------------------------------------
 log "Step 4/11: install hcloud-cloud-controller-manager"

--- a/infra/mise/tasks/k8s/bootstrap-workload.sh
+++ b/infra/mise/tasks/k8s/bootstrap-workload.sh
@@ -97,10 +97,21 @@ REGION=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLU
 REGION="${REGION:-fsn1}"
 
 CONTROL_PLANE_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" \
-  -o jsonpath='{.spec.topology.controlPlane.replicas}')
+  -o jsonpath='{.status.controlPlane.desiredReplicas}')
+if [ -z "$CONTROL_PLANE_REPLICAS" ]; then
+  CONTROL_PLANE_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" \
+    -o jsonpath='{.spec.topology.controlPlane.replicas}')
+fi
 CONTROL_PLANE_REPLICAS="${CONTROL_PLANE_REPLICAS:-1}"
+
 WORKER_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get cluster "$CLUSTER_NAME" \
-  -o jsonpath='{range .spec.topology.workers.machineDeployments[*]}{.replicas}{"\n"}{end}' | awk '{sum += $1} END {print sum + 0}')
+  -o jsonpath='{.status.workers.desiredReplicas}')
+if [ -z "$WORKER_REPLICAS" ]; then
+  WORKER_REPLICAS=$(KUBECONFIG="$MGMT_KUBECONFIG" kubectl -n "$NAMESPACE" get machinedeployments.cluster.x-k8s.io \
+    -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" \
+    -o jsonpath='{range .items[*]}{.spec.replicas}{"\n"}{end}' | awk '{sum += $1} END {print sum + 0}')
+fi
+WORKER_REPLICAS="${WORKER_REPLICAS:-0}"
 EXPECTED_MACHINE_COUNT=$((CONTROL_PLANE_REPLICAS + WORKER_REPLICAS))
 
 echo "API endpoint: ${API_HOST}:${API_PORT}"


### PR DESCRIPTION
## Summary

- Switch Kura regional control-plane nodes in `ash` and `hil` from `cpx22` to `ccx13`.
- Update the cluster target-shape documentation to match the manifests.
- Wait for the caph-provisioned `kube-system/hcloud` Secret before installing HCCM during workload bootstrap.
- Let the hcloud CSI controller schedule on the first control-plane node during bootstrap.
- Wait for the expected CAPI Machines before installing platform, so quota or provisioning failures surface before Helm hooks time out.
- Count desired worker replicas from CAPI status so generated MachineDeployments are included.

## Context

The production Kura regional clusters could not provision because Hetzner rejects `cpx22` in `ash` and `hil` with `unsupported location for server type`. `ccx13` is supported in those regions and is already the worker type for these clusters.

During bootstrap, HCCM can start before caph has written the workload `hcloud` Secret, which leaves the deployment unavailable until Helm times out. The CSI controller can also be blocked while only the tainted control-plane node has joined. The bootstrap task now handles both cases explicitly.

Live reconciliation also surfaced a Hetzner dedicated-core quota limit after some `ccx13` nodes were created. This PR makes the manifests region-compatible and makes bootstrap fail earlier with CAPI status, but the production topology still needs enough Hetzner dedicated-core quota to reach the desired 3 control-plane and 3 worker nodes per regional cluster.

## Validation

- `mise run k8s:lint-version-drift`
- `bash -n infra/mise/tasks/k8s/bootstrap-workload.sh`
- `helm template hcloud-csi hcloud/hcloud-csi --namespace kube-system -f infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml`
- Live expected-machine calculation resolves `6 (3 control plane, 3 workers)` for `tuist-kura-us-east`
- `git diff --check`