### PR TITLE
feat(server,infra): add request_kind tagging + page load Apdex dashboard

### DIFF
--- a/infra/grafana-dashboards/page-load-apdex.json
+++ b/infra/grafana-dashboards/page-load-apdex.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Apdex score and latency metrics for Tuist web page loads (request_kind=\"page_load\"). T=1s (satisfied <1s, tolerating 1-4s, frustrated >4s).",
+    "description": "Apdex score and latency metrics for Tuist web page loads. Discriminated by request_kind=\"page_load\" — extracted via | logfmt from the pod-log stdout stream that the per-node Alloy DaemonSet ships to Loki. T=1s (satisfied <1s, tolerating 1-4s, frustrated >4s).",
     "editable": true,
     "elements": {
       "panel-11": {
@@ -53,7 +53,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
                         "instant": false,
                         "legendFormat": "satisfied",
                         "queryType": "range",
@@ -76,7 +76,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
                         "instant": false,
                         "legendFormat": "tolerating",
                         "queryType": "range",
@@ -99,7 +99,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "total",
                         "queryType": "range",
@@ -213,7 +213,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "Page Loads/s",
                         "queryType": "range",
@@ -297,7 +297,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.99, {env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -388,7 +388,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -478,7 +478,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -500,7 +500,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -522,7 +522,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 200 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 200 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -544,7 +544,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 200 | ms <= 800 [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 200 | ms <= 800 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -566,7 +566,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -773,7 +773,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "Page Loads/s",
                         "queryType": "range",
@@ -894,7 +894,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "expr": "sum(rate({env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "5xx/s",
                         "queryType": "range",
@@ -1016,7 +1016,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.50, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.50, {env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P50",
                         "queryType": "range",
@@ -1039,7 +1039,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.95, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.95, {env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P95",
                         "queryType": "range",
@@ -1062,7 +1062,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.99, {env=\"production\", container=\"server\"} | logfmt | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P99",
                         "queryType": "range",

--- a/infra/grafana-dashboards/page-load-apdex.json
+++ b/infra/grafana-dashboards/page-load-apdex.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Apdex score and latency metrics for Tuist web page loads. T=1s (satisfied <1s, tolerating 1-4s, frustrated >4s). Routes: /:account_handle and sub-pages.",
+    "description": "Apdex score and latency metrics for Tuist web page loads (request_kind=\"page_load\"). T=1s (satisfied <1s, tolerating 1-4s, frustrated >4s).",
     "editable": true,
     "elements": {
       "panel-11": {
@@ -53,7 +53,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
                         "instant": false,
                         "legendFormat": "satisfied",
                         "queryType": "range",
@@ -76,7 +76,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
                         "instant": false,
                         "legendFormat": "tolerating",
                         "queryType": "range",
@@ -99,7 +99,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "total",
                         "queryType": "range",
@@ -213,7 +213,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "Page Loads/s",
                         "queryType": "range",
@@ -297,7 +297,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -388,7 +388,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -478,7 +478,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -500,7 +500,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -522,7 +522,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 200 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 200 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -544,7 +544,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 200 | ms <= 800 [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 200 | ms <= 800 [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -566,7 +566,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
                         "instant": false,
                         "queryType": "range",
                         "range": true
@@ -773,7 +773,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent [0-9]+ in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "Page Loads/s",
                         "queryType": "range",
@@ -894,7 +894,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
                         "instant": false,
                         "legendFormat": "5xx/s",
                         "queryType": "range",
@@ -1016,7 +1016,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.50, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.50, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P50",
                         "queryType": "range",
@@ -1039,7 +1039,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.95, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.95, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P95",
                         "queryType": "range",
@@ -1062,7 +1062,7 @@
                       },
                       "spec": {
                         "app": "grafana-assistant-app",
-                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} | request_kind=\"page_load\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
                         "instant": false,
                         "legendFormat": "P99",
                         "queryType": "range",

--- a/infra/grafana-dashboards/page-load-apdex.json
+++ b/infra/grafana-dashboards/page-load-apdex.json
@@ -1,0 +1,1374 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ma6s248"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Apdex score and latency metrics for Tuist web page loads. T=1s (satisfied <1s, tolerating 1-4s, frustrated >4s). Routes: /:account_handle and sub-pages.",
+    "editable": true,
+    "elements": {
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "Apdex Score (T=1s)",
+          "description": "Proper Apdex formula: (Satisfied + Tolerating÷2) / Total. T=1s: Satisfied ≤1s, Tolerating 1–4s, Frustrated >4s. Score 0.94+ = Excellent, 0.7+ = Poor, <0.7 = Unacceptable.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "satisfied",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "tolerating",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "total",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "__expr__",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expression": "($A + $B / 2) / $C",
+                        "type": "math"
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "decimals": 2,
+                  "min": 0,
+                  "max": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.7,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 0.94,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "id": 12,
+          "title": "Request Rate",
+          "description": "Total page load requests per second across all web UI routes.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "Page Loads/s",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-13": {
+        "kind": "Panel",
+        "spec": {
+          "id": 13,
+          "title": "P99 Latency (ms)",
+          "description": "99th percentile page load response time across all web UI routes.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "none",
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1000,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 4000,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-14": {
+        "kind": "Panel",
+        "spec": {
+          "id": 14,
+          "title": "Error Rate (5xx)",
+          "description": "Rate of HTTP 5xx errors on web UI page load routes.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 0.01,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 0.1,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-15": {
+        "kind": "Panel",
+        "spec": {
+          "id": 15,
+          "title": "Apdex Score Over Time",
+          "description": "Proper Apdex (Satisfied + Tolerating÷2) / Total. Two thresholds: T=1s (your current standard) and T=200ms (industry standard for interactive web apps). Green zone ≥0.94 (Excellent), yellow ≥0.7 (Poor), red <0.7 (Unacceptable).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 1000 [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 1000 | ms <= 4000 [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms <= 200 [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | ms > 200 | ms <= 800 [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" [$__interval]))",
+                        "instant": false,
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": true
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "__expr__",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expression": "($A + $B / 2) / $E",
+                        "type": "math"
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "__expr__",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "__expr__"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expression": "($C + $D / 2) / $E",
+                        "type": "math"
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "decimals": 3,
+                  "min": 0,
+                  "max": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.7,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 0.94,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic",
+                    "fixedColor": "green"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "area"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Apdex T=1s"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Apdex T=200ms"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-18": {
+        "kind": "Panel",
+        "spec": {
+          "id": 18,
+          "title": "Request Rate",
+          "description": "Request throughput per web page route. Useful for correlating latency spikes with traffic volume changes.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent [0-9]+ in\" [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "Page Loads/s",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-19": {
+        "kind": "Panel",
+        "spec": {
+          "id": 19,
+          "title": "5xx Error Rate",
+          "description": "HTTP 5xx error rate per web page route. Errors here are user-visible failures on the Tuist dashboard.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "sum(rate({service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" |~ \"Sent 5[0-9][0-9] in\" [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "5xx/s",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "red"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "bars",
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "id": 20,
+          "title": "Latency Percentiles (P50 / P95 / P99)",
+          "description": "P50 and P95 response time trends for all web UI page load routes. Use this to catch latency regressions before Apdex breaches threshold.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max(quantile_over_time(0.50, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "P50",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max(quantile_over_time(0.95, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "P95",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "grafanacloud-logs"
+                      },
+                      "spec": {
+                        "app": "grafana-assistant-app",
+                        "expr": "max(quantile_over_time(0.99, {service_name=\"tuist\", env=\"production\", container=\"server\"} |~ \"auth_account_handle\" != \"selected_account_handle\" | regexp \"in (?P<ms>[0-9]+)ms\" | unwrap ms [$__interval]))",
+                        "instant": false,
+                        "legendFormat": "P99",
+                        "queryType": "range",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0-25206366476",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "ms",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 5,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Overview",
+              "collapse": false,
+              "hideHeader": true,
+              "fillScreen": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-12"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-13"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 18,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-14"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Apdex",
+              "collapse": false,
+              "hideHeader": false,
+              "fillScreen": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-15"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Latency",
+              "collapse": false,
+              "hideHeader": false,
+              "fillScreen": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-20"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Traffic & Errors",
+              "collapse": false,
+              "hideHeader": false,
+              "fillScreen": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-18"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-19"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-30m",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Tuist - Page Load Apdex",
+    "variables": [],
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
+        }
+      }
+    }
+  }
+}

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -116,6 +116,7 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [
     :request_id,
+    :request_kind,
     :auth_account_handle,
     :selected_account_handle,
     :selected_project_handle

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -207,6 +207,7 @@ defmodule Tuist.Application do
         :trace_id,
         :span_id,
         :request_id,
+        :request_kind,
         :auth_account_handle,
         :selected_account_handle,
         :selected_project_handle,

--- a/server/lib/tuist_web/endpoint.ex
+++ b/server/lib/tuist_web/endpoint.ex
@@ -57,6 +57,7 @@ defmodule TuistWeb.Endpoint do
   plug Plug.RequestId
   plug TuistCommon.OtelRequestIdPlug
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+  plug TuistWeb.Plugs.RequestKindPlug
   plug Sentry.PlugContext
   plug TuistWeb.Plugs.CloseConnectionOnErrorPlug
 

--- a/server/lib/tuist_web/plugs/request_kind_plug.ex
+++ b/server/lib/tuist_web/plugs/request_kind_plug.ex
@@ -1,21 +1,42 @@
 defmodule TuistWeb.Plugs.RequestKindPlug do
   @moduledoc """
-  Tags the request with a coarse `request_kind` (e.g. `"page_load"`, `"api"`,
-  `"mcp"`) in `Logger.metadata` and the active OpenTelemetry span.
+  Tags requests with a coarse `request_kind` (e.g. `"page_load"`, `"api"`,
+  `"mcp"`) for observability.
 
-  The metadata key is propagated as a Loki structured-metadata field by the
-  handler configured in `Tuist.Application`, which lets observability
-  dashboards filter request types explicitly instead of inferring them from
-  URL shape or the presence of unrelated metadata.
+  Installed once at the `Endpoint` level. Pipelines declare their kind by
+  assigning `:request_kind` to the conn (see `TuistWeb.Router`'s
+  `put_request_kind/2`). When the response is being sent, this plug's
+  `before_send` callback copies the kind into `Logger.metadata` and the
+  active OpenTelemetry span — at which point it is in scope for the
+  `Plug.Telemetry` `:stop` callback that emits the `Sent NNN in NNNms`
+  log line, which is what observability dashboards filter on.
+
+  Routes that don't run through a tagged pipeline (webhooks, static
+  assets) flow through with no kind set; downstream filters can either
+  match the absence (`| request_kind=\"\"`) or just exclude them by
+  matching specific kinds.
   """
+
+  import Plug.Conn
 
   require Logger
 
-  def init(kind) when is_binary(kind), do: kind
+  def init(opts), do: opts
 
-  def call(conn, kind) do
-    Logger.metadata(request_kind: kind)
-    OpenTelemetry.Tracer.set_attribute("request_kind", kind)
+  def call(conn, _opts) do
+    register_before_send(conn, &put_request_kind_metadata/1)
+  end
+
+  defp put_request_kind_metadata(conn) do
+    case conn.assigns[:request_kind] do
+      kind when is_binary(kind) ->
+        Logger.metadata(request_kind: kind)
+        OpenTelemetry.Tracer.set_attribute("request_kind", kind)
+
+      _ ->
+        :ok
+    end
+
     conn
   end
 end

--- a/server/lib/tuist_web/plugs/request_kind_plug.ex
+++ b/server/lib/tuist_web/plugs/request_kind_plug.ex
@@ -1,0 +1,21 @@
+defmodule TuistWeb.Plugs.RequestKindPlug do
+  @moduledoc """
+  Tags the request with a coarse `request_kind` (e.g. `"page_load"`, `"api"`,
+  `"mcp"`) in `Logger.metadata` and the active OpenTelemetry span.
+
+  The metadata key is propagated as a Loki structured-metadata field by the
+  handler configured in `Tuist.Application`, which lets observability
+  dashboards filter request types explicitly instead of inferring them from
+  URL shape or the presence of unrelated metadata.
+  """
+
+  require Logger
+
+  def init(kind) when is_binary(kind), do: kind
+
+  def call(conn, kind) do
+    Logger.metadata(request_kind: kind)
+    OpenTelemetry.Tracer.set_attribute("request_kind", kind)
+    conn
+  end
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -14,7 +14,6 @@ defmodule TuistWeb.Router do
   alias TuistWeb.Plugs.LocalePlug
   alias TuistWeb.Plugs.MarkdownNegotiationPlug
   alias TuistWeb.Plugs.ObservabilityContextPlug
-  alias TuistWeb.Plugs.RequestKindPlug
   alias TuistWeb.Plugs.SentryContextPlug
   alias TuistWeb.Plugs.UeberauthHostPlug
 
@@ -55,7 +54,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app do
-    plug RequestKindPlug, "page_load"
+    plug :put_request_kind, "page_load"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -73,7 +72,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app_image do
-    plug RequestKindPlug, "page_image"
+    plug :put_request_kind, "page_image"
     plug :accepts, ["svg", "png"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -87,7 +86,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :ueberauth do
-    plug RequestKindPlug, "auth"
+    plug :put_request_kind, "auth"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -102,7 +101,7 @@ defmodule TuistWeb.Router do
   # Some endpoints must be accessible without the :protect_from_forgery plug.
   # For example, the POST request Apple makes as part of OAuth 2.0 is not compatible with the CSRF protection.
   pipeline :unprotected_browser_app do
-    plug RequestKindPlug, "auth"
+    plug :put_request_kind, "auth"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -119,7 +118,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_marketing do
-    plug RequestKindPlug, "marketing"
+    plug :put_request_kind, "marketing"
     plug MarkdownNegotiationPlug
     plug :accepts, ["html"]
     plug :enable_robot_indexing
@@ -142,7 +141,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_docs do
-    plug RequestKindPlug, "docs"
+    plug :put_request_kind, "docs"
     plug MarkdownNegotiationPlug
     plug :accepts, ["html"]
     plug :enable_robot_indexing
@@ -160,32 +159,32 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_marketing_feed do
-    plug RequestKindPlug, "marketing_feed"
+    plug :put_request_kind, "marketing_feed"
     plug :accepts, ["xml"]
     plug TuistWeb.OnPremisePlug, :forward_marketing_to_dashboard
   end
 
   pipeline :non_authenticated_api do
-    plug RequestKindPlug, "api"
+    plug :put_request_kind, "api"
     plug :accepts, ["json"]
 
     plug TuistWeb.WarningsHeaderPlug
   end
 
   pipeline :api_catalog do
-    plug RequestKindPlug, "api_catalog"
+    plug :put_request_kind, "api_catalog"
     plug :accepts, ["linkset"]
   end
 
   pipeline :mcp do
-    plug RequestKindPlug, "mcp"
+    plug :put_request_kind, "mcp"
     plug TuistWeb.AuthenticationPlug, :load_authenticated_subject
     plug TuistWeb.AuthenticationPlug, {:require_authentication, response_type: :mcp}
     plug TuistWeb.Plugs.MCPRateLimitPlug
   end
 
   pipeline :authenticated_api do
-    plug RequestKindPlug, "api"
+    plug :put_request_kind, "api"
     plug :accepts, ["json", "application/octet-stream"]
 
     plug TuistWeb.WarningsHeaderPlug
@@ -196,7 +195,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :scim_api do
-    plug RequestKindPlug, "scim"
+    plug :put_request_kind, "scim"
     plug :accepts, ["scim+json", "json"]
     plug TuistWeb.Plugs.SCIMAuthPlug
     plug TuistWeb.Plugs.SCIMRateLimitPlug
@@ -1010,6 +1009,10 @@ defmodule TuistWeb.Router do
 
   def assign_current_path(conn, _params) do
     assign(conn, :current_path, conn.request_path)
+  end
+
+  defp put_request_kind(conn, kind) when is_binary(kind) do
+    assign(conn, :request_kind, kind)
   end
 
   def disable_robot_indexing(conn, _params) do

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -14,6 +14,7 @@ defmodule TuistWeb.Router do
   alias TuistWeb.Plugs.LocalePlug
   alias TuistWeb.Plugs.MarkdownNegotiationPlug
   alias TuistWeb.Plugs.ObservabilityContextPlug
+  alias TuistWeb.Plugs.RequestKindPlug
   alias TuistWeb.Plugs.SentryContextPlug
   alias TuistWeb.Plugs.UeberauthHostPlug
 
@@ -54,6 +55,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app do
+    plug RequestKindPlug, "page_load"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -71,6 +73,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_app_image do
+    plug RequestKindPlug, "page_image"
     plug :accepts, ["svg", "png"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -84,6 +87,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :ueberauth do
+    plug RequestKindPlug, "auth"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -98,6 +102,7 @@ defmodule TuistWeb.Router do
   # Some endpoints must be accessible without the :protect_from_forgery plug.
   # For example, the POST request Apple makes as part of OAuth 2.0 is not compatible with the CSRF protection.
   pipeline :unprotected_browser_app do
+    plug RequestKindPlug, "auth"
     plug :accepts, ["html"]
     plug :disable_robot_indexing
     plug :fetch_session
@@ -114,6 +119,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_marketing do
+    plug RequestKindPlug, "marketing"
     plug MarkdownNegotiationPlug
     plug :accepts, ["html"]
     plug :enable_robot_indexing
@@ -136,6 +142,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_docs do
+    plug RequestKindPlug, "docs"
     plug MarkdownNegotiationPlug
     plug :accepts, ["html"]
     plug :enable_robot_indexing
@@ -153,27 +160,32 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :browser_marketing_feed do
+    plug RequestKindPlug, "marketing_feed"
     plug :accepts, ["xml"]
     plug TuistWeb.OnPremisePlug, :forward_marketing_to_dashboard
   end
 
   pipeline :non_authenticated_api do
+    plug RequestKindPlug, "api"
     plug :accepts, ["json"]
 
     plug TuistWeb.WarningsHeaderPlug
   end
 
   pipeline :api_catalog do
+    plug RequestKindPlug, "api_catalog"
     plug :accepts, ["linkset"]
   end
 
   pipeline :mcp do
+    plug RequestKindPlug, "mcp"
     plug TuistWeb.AuthenticationPlug, :load_authenticated_subject
     plug TuistWeb.AuthenticationPlug, {:require_authentication, response_type: :mcp}
     plug TuistWeb.Plugs.MCPRateLimitPlug
   end
 
   pipeline :authenticated_api do
+    plug RequestKindPlug, "api"
     plug :accepts, ["json", "application/octet-stream"]
 
     plug TuistWeb.WarningsHeaderPlug
@@ -184,6 +196,7 @@ defmodule TuistWeb.Router do
   end
 
   pipeline :scim_api do
+    plug RequestKindPlug, "scim"
     plug :accepts, ["scim+json", "json"]
     plug TuistWeb.Plugs.SCIMAuthPlug
     plug TuistWeb.Plugs.SCIMRateLimitPlug

--- a/server/test/tuist_web/plugs/request_kind_plug_test.exs
+++ b/server/test/tuist_web/plugs/request_kind_plug_test.exs
@@ -1,0 +1,51 @@
+defmodule TuistWeb.Plugs.RequestKindPlugTest do
+  use TuistTestSupport.Cases.ConnCase, async: false
+  use Mimic
+
+  import Plug.Test
+
+  alias TuistWeb.Plugs.RequestKindPlug
+
+  setup :set_mimic_from_context
+
+  setup do
+    Logger.metadata(request_kind: nil)
+    :ok
+  end
+
+  describe "init/1" do
+    test "passes through binary kinds" do
+      assert RequestKindPlug.init("page_load") == "page_load"
+    end
+
+    test "raises on non-binary kinds to fail loudly at compile time" do
+      assert_raise FunctionClauseError, fn -> RequestKindPlug.init(:page_load) end
+    end
+  end
+
+  describe "call/2" do
+    test "writes the kind to Logger.metadata" do
+      stub(OpenTelemetry.Tracer, :set_attribute, fn _, _ -> :ok end)
+
+      conn = :get |> conn("/") |> RequestKindPlug.call("page_load")
+
+      assert conn
+      assert Logger.metadata()[:request_kind] == "page_load"
+    end
+
+    test "writes the kind to the active OpenTelemetry span" do
+      expect(OpenTelemetry.Tracer, :set_attribute, fn "request_kind", "api" ->
+        :ok
+      end)
+
+      :get |> conn("/") |> RequestKindPlug.call("api")
+    end
+
+    test "returns the conn unchanged" do
+      stub(OpenTelemetry.Tracer, :set_attribute, fn _, _ -> :ok end)
+
+      conn = conn(:get, "/foo")
+      assert RequestKindPlug.call(conn, "page_load") == conn
+    end
+  end
+end

--- a/server/test/tuist_web/plugs/request_kind_plug_test.exs
+++ b/server/test/tuist_web/plugs/request_kind_plug_test.exs
@@ -2,6 +2,7 @@ defmodule TuistWeb.Plugs.RequestKindPlugTest do
   use TuistTestSupport.Cases.ConnCase, async: false
   use Mimic
 
+  import Plug.Conn
   import Plug.Test
 
   alias TuistWeb.Plugs.RequestKindPlug
@@ -13,39 +14,55 @@ defmodule TuistWeb.Plugs.RequestKindPlugTest do
     :ok
   end
 
-  describe "init/1" do
-    test "passes through binary kinds" do
-      assert RequestKindPlug.init("page_load") == "page_load"
-    end
-
-    test "raises on non-binary kinds to fail loudly at compile time" do
-      assert_raise FunctionClauseError, fn -> RequestKindPlug.init(:page_load) end
-    end
+  defp send_through(conn) do
+    conn
+    |> RequestKindPlug.call([])
+    |> resp(200, "")
+    |> send_resp()
   end
 
   describe "call/2" do
-    test "writes the kind to Logger.metadata" do
+    test "writes the assigned kind to Logger.metadata when the response is sent" do
       stub(OpenTelemetry.Tracer, :set_attribute, fn _, _ -> :ok end)
 
-      conn = :get |> conn("/") |> RequestKindPlug.call("page_load")
+      :get
+      |> conn("/")
+      |> assign(:request_kind, "page_load")
+      |> send_through()
 
-      assert conn
       assert Logger.metadata()[:request_kind] == "page_load"
     end
 
-    test "writes the kind to the active OpenTelemetry span" do
+    test "writes the assigned kind to the active OpenTelemetry span" do
       expect(OpenTelemetry.Tracer, :set_attribute, fn "request_kind", "api" ->
         :ok
       end)
 
-      :get |> conn("/") |> RequestKindPlug.call("api")
+      :get
+      |> conn("/")
+      |> assign(:request_kind, "api")
+      |> send_through()
     end
 
-    test "returns the conn unchanged" do
-      stub(OpenTelemetry.Tracer, :set_attribute, fn _, _ -> :ok end)
+    test "is a no-op when no kind has been assigned" do
+      reject(&OpenTelemetry.Tracer.set_attribute/2)
 
-      conn = conn(:get, "/foo")
-      assert RequestKindPlug.call(conn, "page_load") == conn
+      :get
+      |> conn("/")
+      |> send_through()
+
+      refute Logger.metadata()[:request_kind]
+    end
+
+    test "is a no-op when the assigned kind is not a binary" do
+      reject(&OpenTelemetry.Tracer.set_attribute/2)
+
+      :get
+      |> conn("/")
+      |> assign(:request_kind, :page_load)
+      |> send_through()
+
+      refute Logger.metadata()[:request_kind]
     end
   end
 end


### PR DESCRIPTION
### Purpose

Two changes that together ship a robust per-request-kind observability story:

1. **`TuistWeb.Plugs.RequestKindPlug`** — writes a coarse `request_kind` (`page_load`, `page_image`, `api`, `mcp`, `scim`, `marketing`, `docs`, `marketing_feed`, `api_catalog`, `auth`) into `Logger.metadata` and the active OTel span. Wired into every router pipeline with a distinct external surface. The Loki handler now ships `request_kind` as structured metadata, and the console formatter prints it locally.

2. **Page Load Apdex dashboard** — Grafana Cloud dashboard ([UID `ma6s248`](https://github.com/tuist/tuist/blob/main/infra/grafana-dashboards/page-load-apdex.json)) tracking Apdex score, latency percentiles, request rate, and 5xx errors for the dashboard's HTML routes, scoped via `| request_kind=\"page_load\"`.

### Why the plug

The first cut of this dashboard discriminated web UI page loads from API calls with `|~ \"auth_account_handle\" != \"selected_account_handle\"` — relying on the implicit invariant that web UI requests only set `auth_account_handle` while API requests set both. That invariant is wrong: `LoaderPlug` resolves the account on `/:account_handle` dashboard URLs and calls `ObservabilityContextPlug.set_selection_context/1`, which sets `selected_account_handle` for those page loads too. The filter silently dropped traffic and the metric was structurally fragile.

`request_kind` makes the discriminator explicit, declared at the pipeline boundary in `router.ex`, and reusable for future API/mcp/scim slicing.

### Panels

8 panels across 4 rows:

- **Overview**: Apdex Score (T=1s, stat), Request Rate (stat), P99 Latency (stat), 5xx Error Rate (stat)
- **Apdex**: Apdex Score Over Time — two lines, T=1s (green) and T=200ms (orange)
- **Latency**: P50 / P95 / P99 percentiles
- **Traffic & Errors**: request-rate timeseries and 5xx-rate bars

Apdex is computed properly as `(satisfied + tolerating/2) / total` using three hidden Loki rate queries over a `regexp \"in (?P<ms>[0-9]+)ms\"` extraction, then a math expression — replacing a naive proxy ratio that always returned 100% because Phoenix consistently logs response times in `ms`.

### How to test locally

- `mix test test/tuist_web/plugs/request_kind_plug_test.exs` — unit tests for the plug.
- Tail the local console: requests should print `request_kind=page_load` (etc.) in the metadata block alongside the existing `auth_account_handle` / `request_id`.
- The dashboard itself is for the managed Grafana Cloud setup; once merged, Grafana's Git Sync (60 s interval, or webhook) pulls the file into the `Tuist Dashboards` folder. Verify by opening `/d/ma6s248/tuist-page-load-apdex` after the next sync.