### PR TITLE
fix(infra): avoid xcresult rollout races

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -216,7 +216,7 @@ jobs:
     concurrency:
       group: server-deploy-${{ inputs.environment }}
       cancel-in-progress: false
-    timeout-minutes: 105
+    timeout-minutes: 130
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
       NAMESPACE: ${{ inputs.environment == 'production' && 'tuist' || format('tuist-{0}', inputs.environment) }}
@@ -302,7 +302,7 @@ jobs:
               fi
 
               helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
-                --namespace "$NAMESPACE" --wait --timeout 10m
+                --namespace "$NAMESPACE" --wait --timeout 25m
               ;;
             *)
               echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."
@@ -357,15 +357,11 @@ jobs:
         # them across rollbacks) finish in 5-15 min and never approach
         # this ceiling.
         #
-        # timeout-minutes: 95 is the runner-level kill ceiling — 5 min
-        # over helm's own --timeout. Without it, the only kill semantic
-        # for a hung helm is the job-level timeout; helm under
-        # `--atomic --wait` ignores SIGINT/SIGTERM until its in-process
-        # rollback completes, so a manual `gh run cancel` doesn't free
-        # the concurrency lock for ~90 min. With this in place the
-        # runner SIGKILLs helm 5 min after its own timeout would have
-        # fired, bounding the recovery window.
-        timeout-minutes: 95
+        # timeout-minutes: 120 leaves 30 min over helm's own --timeout
+        # for the in-process `--atomic` rollback. Five minutes was too
+        # tight for macOS-fleet rollbacks and could kill helm after it had
+        # already moved the release into pending-rollback.
+        timeout-minutes: 120
         run: |
           # Stream cluster state every 30s while helm waits. helm
           # --atomic --wait produces no stdout during the wait, so
@@ -458,6 +454,24 @@ jobs:
             kubectl -n "$NAMESPACE" logs "$pod" --all-containers --tail=500 || true
             echo "--- logs $pod (previous) ---"
             kubectl -n "$NAMESPACE" logs "$pod" --all-containers --previous --tail=500 || true
+          done
+          echo "::endgroup::"
+          echo "::group::xcresult processor deployment + pods"
+          kubectl -n "$NAMESPACE" describe deploy/tuist-tuist-xcresult-processor || true
+          for pod in $(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=xcresult-processor -o name 2>/dev/null); do
+            echo "--- describe $pod ---"
+            kubectl -n "$NAMESPACE" describe "$pod" || true
+            echo "--- logs $pod (current) ---"
+            kubectl -n "$NAMESPACE" logs "$pod" --all-containers --tail=500 || true
+            echo "--- logs $pod (previous) ---"
+            kubectl -n "$NAMESPACE" logs "$pod" --all-containers --previous --tail=500 || true
+          done
+          echo "::endgroup::"
+          echo "::group::macOS fleet nodes"
+          kubectl get nodes -l kubernetes.io/os=darwin,tuist.dev/runtime=tart -o wide || true
+          for node in $(kubectl get nodes -l kubernetes.io/os=darwin,tuist.dev/runtime=tart -o name 2>/dev/null); do
+            echo "--- describe $node ---"
+            kubectl describe "$node" || true
           done
           echo "::endgroup::"
           echo "::group::external secrets"

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"sort"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,13 +28,15 @@ import (
 // doesn't reconsider placement of running Pods on its own.
 const FleetHashAnnotation = "tuist.dev/fleet-hash"
 
+const rolloutRequeueAfter = 30 * time.Second
+
 // FleetNodeSelector picks out Mac mini Nodes (the ones tart-kubelet
 // registered) from the rest of the cluster. Matches the nodeSelector
 // the chart's xcresult-processor Deployment uses, so the hash is over
 // exactly the set of hosts that workload can schedule on.
 var FleetNodeSelector = labels.SelectorFromSet(labels.Set{
-	"kubernetes.io/os":   "darwin",
-	"tuist.dev/runtime":  "tart",
+	"kubernetes.io/os":  "darwin",
+	"tuist.dev/runtime": "tart",
 })
 
 // FleetSpreadReconciler watches Mac mini Nodes and patches a target
@@ -110,6 +113,10 @@ func (r *FleetSpreadReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (
 	if dep.Spec.Template.Annotations[FleetHashAnnotation] == hash {
 		return ctrl.Result{}, nil
 	}
+	if !deploymentRolloutSettled(dep) {
+		logger.Info("deferring fleet-shape rollout while deployment is still settling", "fleet-hash", hash)
+		return ctrl.Result{RequeueAfter: rolloutRequeueAfter}, nil
+	}
 
 	patch := client.MergeFrom(dep.DeepCopy())
 	if dep.Spec.Template.Annotations == nil {
@@ -121,6 +128,27 @@ func (r *FleetSpreadReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (
 	}
 	logger.Info("rolled deployment on fleet-shape change", "fleet-hash", hash)
 	return ctrl.Result{}, nil
+}
+
+func deploymentRolloutSettled(dep appsv1.Deployment) bool {
+	desired := int32(1)
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
+
+	if dep.Generation > dep.Status.ObservedGeneration {
+		return false
+	}
+	if dep.Status.UpdatedReplicas != desired {
+		return false
+	}
+	if dep.Status.Replicas != desired {
+		return false
+	}
+	if dep.Status.AvailableReplicas != desired {
+		return false
+	}
+	return dep.Status.UnavailableReplicas == 0
 }
 
 // readyNodeHash is a stable, order-independent hash of the schedulable

--- a/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
+++ b/infra/cluster-api-provider-scaleway-applesilicon/controllers/fleetspread_controller_test.go
@@ -152,6 +152,60 @@ func TestReconcile_RepatchesOnFleetGrowth(t *testing.T) {
 	}
 }
 
+// TestReconcile_DefersPatchWhileDeploymentRolling covers the
+// production failure mode where Helm is already rolling the
+// xcresult-processor Deployment and a fleet Node event asks the
+// controller to stamp another pod-template annotation. Patching in
+// that window mints a second ReplicaSet, deletes the first replacement
+// Pod, and can strand the newest Pod behind hostPort/max-pods
+// constraints on a two-host fleet.
+func TestReconcile_DefersPatchWhileDeploymentRolling(t *testing.T) {
+	n0 := readyNode("fleet-0")
+	n1 := readyNode("fleet-1")
+	dep := emptyDeployment("xcresult-processor", "tuist")
+	replicas := int32(2)
+	dep.Spec.Replicas = &replicas
+	dep.Generation = 3
+	dep.Status = appsv1.DeploymentStatus{
+		ObservedGeneration:  3,
+		Replicas:            2,
+		UpdatedReplicas:     1,
+		ReadyReplicas:       1,
+		AvailableReplicas:   1,
+		UnavailableReplicas: 1,
+	}
+	dep.Spec.Template.Annotations = map[string]string{
+		FleetHashAnnotation: readyNodeHash([]corev1.Node{n0}),
+	}
+
+	r, ctx := newFleetSpreadReconciler(t, "tuist", "xcresult-processor", &n0, &n1, &dep)
+
+	var before appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &before); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter != rolloutRequeueAfter {
+		t.Fatalf("expected requeue after %s, got %s", rolloutRequeueAfter, result.RequeueAfter)
+	}
+
+	var after appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "tuist", Name: "xcresult-processor"}, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("expected no patch while deployment is rolling, RV %q -> %q",
+			before.ResourceVersion, after.ResourceVersion)
+	}
+	if got := after.Spec.Template.Annotations[FleetHashAnnotation]; got != readyNodeHash([]corev1.Node{n0}) {
+		t.Fatalf("hash changed while deployment was rolling: got %q", got)
+	}
+}
+
 // TestReconcile_DoesNotRollOnPhaseReadyBeforeNodeReady is the P2
 // regression test. A new Mac mini whose ScalewayAppleSiliconMachine
 // has Phase=Ready but whose kube Node hasn't reported NodeReady yet
@@ -230,15 +284,25 @@ func nodeWithReady(name string, ready corev1.ConditionStatus) corev1.Node {
 }
 
 func emptyDeployment(name, namespace string) appsv1.Deployment {
+	replicas := int32(1)
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:       name,
+			Namespace:  namespace,
+			Generation: 1,
 		},
 		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           replicas,
+			UpdatedReplicas:    replicas,
+			ReadyReplicas:      replicas,
+			AvailableReplicas:  replicas,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

The latest `main` server production deployment did not work. Run `25565111613` for `0807d87643619d144ecc3162d6cd72fe7952bb84` passed canary, acceptance tests, image build, and observability, then failed in production during `helm upgrade --install`.

The deployment got stuck on `xcresult-processor`. Helm created a replacement ReplicaSet, then the newly rolled `capi-scaleway-applesilicon` operator patched the same Deployment with a fleet hash while that rollout was still settling. That second template change created another ReplicaSet, deleted the first replacement pod, and left the newest pod unschedulable because one Mac mini was at its pod limit and the other still had the terminating replacement holding hostPort `9091`. Helm timed out and its `--atomic` rollback was still running when the workflow timeout killed the job, leaving the release in `pending-rollback`.

This PR makes the fleet-spread controller defer hash stamping until the target Deployment has fully settled, so Node/fleet events do not mint a competing ReplicaSet during Helm rollouts. It also keeps the deployment workflow recovery changes so interrupted atomic rollbacks get enough time to finish and future failures include xcresult processor plus darwin/tart node diagnostics.

## Validation

- `mise exec go@1.25 -- go test -mod=readonly ./...` from `infra/cluster-api-provider-scaleway-applesilicon`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/server-deployment.yml'); puts 'ok'"`
- `git diff --check`