### PR TITLE
fix(cli): route static xcframeworks behind dynamic via search paths, not relink

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -516,9 +516,18 @@ public class GraphTraverser: GraphTraversing {
     public func searchablePathDependencies(path: Path.AbsolutePath, name: String) throws -> Set<
         GraphDependencyReference
     > {
-        try linkableDependencies(path: path, name: name, shouldExcludeHostAppDependencies: false)
+        let staticXCFrameworksBehindDynamic = staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+            path: path,
+            name: name
+        )
+        let staticReferences = staticXCFrameworksBehindDynamic.compactMap {
+            dependencyReference(to: $0, from: .target(name: name, path: path))
+        }
+
+        return try linkableDependencies(path: path, name: name, shouldExcludeHostAppDependencies: false)
             .union(staticPrecompiledFrameworksDependencies(path: path, name: name))
             .union(transitiveStaticDependenciesOfDynamicFrameworkDependencies(path: path, name: name))
+            .union(staticReferences)
     }
 
     public func linkableDependencies(path: Path.AbsolutePath, name: String) throws -> Set<
@@ -590,13 +599,14 @@ public class GraphTraverser: GraphTraversing {
             name: name
         )
 
-        let staticXCFrameworksLinkedByDynamicXCFrameworkDependencies = filterDependencies(
-            from: Set(precompiledDynamicLibrariesAndFrameworks).filter { $0.xcframeworkDependency != nil },
-            test: {
-                $0.xcframeworkDependency?.linking == .static &&
-                    $0.xcframeworkDependency?.swiftModules.isEmpty == false
-            },
-            skip: { $0.xcframeworkDependency == nil }
+        // Static xcframeworks reached through a dynamic xcframework are intentionally NOT
+        // linked at the consumer level. The dynamic xcframework already absorbed their symbols
+        // during its build; relinking here causes duplicate symbols and breaks libraries with
+        // global state (e.g. FirebaseApp's singleton registry). Module visibility for these
+        // statics is provided through `searchablePathDependencies` instead.
+        let staticXCFrameworksLinkedByDynamicXCFrameworkDependencies = staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+            path: path,
+            name: name
         )
 
         let libraryDependenciesLinkedByStaticXCFrameworks =
@@ -610,7 +620,6 @@ public class GraphTraverser: GraphTraversing {
         let precompiledLibrariesAndFrameworks =
             (
                 precompiledDynamicLibrariesAndFrameworks
-                    + staticXCFrameworksLinkedByDynamicXCFrameworkDependencies
                     + libraryDependenciesLinkedByStaticXCFrameworks
             )
             .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
@@ -712,6 +721,25 @@ public class GraphTraverser: GraphTraversing {
                 $0.xcframeworkDependency?.linking == .static &&
                     $0.xcframeworkDependency?.swiftModules.isEmpty == true &&
                     $0.xcframeworkDependency?.moduleMaps.isEmpty == false
+            },
+            skip: { $0.xcframeworkDependency == nil }
+        )
+    }
+
+    public func staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+        path: Path.AbsolutePath,
+        name: String
+    ) -> Set<GraphDependency> {
+        filterDependencies(
+            from: Set(
+                precompiledDynamicLibrariesAndFrameworks(
+                    path: path,
+                    name: name
+                )
+            ).filter { $0.xcframeworkDependency != nil },
+            test: {
+                $0.xcframeworkDependency?.linking == .static &&
+                    $0.xcframeworkDependency?.swiftModules.isEmpty == false
             },
             skip: { $0.xcframeworkDependency == nil }
         )

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -339,6 +339,18 @@ public protocol GraphTraversing {
         name: String
     ) -> Set<GraphDependency>
 
+    /// Given a target's project path and name, it returns all static XCFramework
+    /// dependencies with Swift modules that are reached through a dynamic XCFramework.
+    /// These need module visibility (FRAMEWORK_SEARCH_PATHS) at the consumer level
+    /// but must NOT be relinked, since the dynamic xcframework already absorbed them.
+    /// - Parameters:
+    ///   - path: Project path.
+    ///   - name: Target name.
+    func staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+        path: AbsolutePath,
+        name: String
+    ) -> Set<GraphDependency>
+
     /// Given a scheme, it returns the runnable target.
     /// - Parameter scheme: Scheme to check against.
     /// - Returns: The runnable target if any.

--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -50,7 +50,23 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                     }
                 }
 
-            guard !staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.isEmpty else { return [:] }
+            // Static Swift xcframeworks reached through a dynamic xcframework are not relinked
+            // at the consumer level (their symbols are already absorbed into the dynamic
+            // xcframework's binary). They still need module visibility for the compiler to
+            // resolve `import` statements that the dynamic xcframework's swiftinterface references.
+            let staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+                .staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
+                    path: project.path,
+                    name: target.name
+                )
+                .sorted()
+                .compactMap { dependency -> GraphDependency.XCFramework? in
+                    if case let .xcframework(xcframework) = dependency { return xcframework } else { return nil }
+                }
+
+            guard !staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.isEmpty
+                || !staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies.isEmpty
+            else { return [:] }
 
             let staticObjcXCFrameworksWithLibrariesLinkedByDynamicXCFrameworkDependencies =
                 staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies
@@ -66,10 +82,13 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                     .filter { !$0.containsLibrary() }
 
             var settings = SettingsDictionary()
-            if !staticObjcXCFrameworksWithoutLibrariesLinkedByDynamicXCFrameworkDependencies.isEmpty {
+            let xcframeworksRequiringPerSDKSearchPaths =
+                staticObjcXCFrameworksWithoutLibrariesLinkedByDynamicXCFrameworkDependencies
+                    + staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies
+            if !xcframeworksRequiringPerSDKSearchPaths.isEmpty {
                 var pathsBySDKCondition: [String: [String]] = [:]
 
-                for xcframework in staticObjcXCFrameworksWithoutLibrariesLinkedByDynamicXCFrameworkDependencies {
+                for xcframework in xcframeworksRequiringPerSDKSearchPaths {
                     for library in xcframework.infoPlist.libraries {
                         let platform = library.platform.graphPlatform
                         guard target.supportedPlatforms.contains(platform) else { continue }
@@ -82,7 +101,9 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping {
                 }
 
                 for sdkCondition in pathsBySDKCondition.keys.sorted() {
-                    settings["FRAMEWORK_SEARCH_PATHS[\(sdkCondition)]"] = .array(pathsBySDKCondition[sdkCondition]!)
+                    settings["FRAMEWORK_SEARCH_PATHS[\(sdkCondition)]"] = .array(
+                        ["$(inherited)"] + pathsBySDKCondition[sdkCondition]!
+                    )
                 }
             }
 

--- a/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/cli/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -2115,12 +2115,20 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // When
         let got = try subject.linkableDependencies(path: project.path, name: target.name).sorted()
 
-        // Then
+        // Then: static xcframeworks reached through a dynamic xcframework are NOT relinked
+        // at the consumer level. The dynamic xcframework absorbs their symbols at build time;
+        // relinking would duplicate symbols and break libraries with global state.
         XCTAssertEqual(got, [
             GraphDependencyReference(dependencyDynamicXCFramework),
-            GraphDependencyReference(dependencyStaticXCFrameworkA),
-            GraphDependencyReference(dependencyStaticXCFrameworkB),
         ])
+
+        // When
+        let searchablePaths = try subject.searchablePathDependencies(path: project.path, name: target.name)
+
+        // Then: static xcframeworks remain reachable via FRAMEWORK_SEARCH_PATHS so the
+        // compiler can resolve `import StaticFrameworkA` / `import StaticFrameworkB`.
+        XCTAssertTrue(searchablePaths.contains(GraphDependencyReference(dependencyStaticXCFrameworkA)))
+        XCTAssertTrue(searchablePaths.contains(GraphDependencyReference(dependencyStaticXCFrameworkB)))
 
         // When
         let embeddable = subject.embeddableFrameworks(path: project.path, name: target.name)
@@ -2215,7 +2223,9 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // When
         let got = try subject.linkableDependencies(path: project.path, name: target.name).sorted()
 
-        // Then
+        // Then: the static xcframework itself is not relinked, but the system library it
+        // declared as a dependency must still be linked at the consumer level (otherwise
+        // unresolved system symbols would surface during the consumer's link step).
         XCTAssertBetterEqual(got, [
             .sdk(
                 path: try AbsolutePath(validating: "/libc++.tbd"),
@@ -2224,8 +2234,13 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 condition: nil
             ),
             GraphDependencyReference(dependencyDynamicXCFramework),
-            GraphDependencyReference(dependencyStaticXCFrameworkA),
         ])
+
+        // When
+        let searchablePaths = try subject.searchablePathDependencies(path: project.path, name: target.name)
+
+        // Then
+        XCTAssertTrue(searchablePaths.contains(GraphDependencyReference(dependencyStaticXCFrameworkA)))
 
         // When
         let embeddable = subject.embeddableFrameworks(path: project.path, name: target.name)

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -236,6 +236,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         settings: .test(
                             base: [
                                 "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": [
+                                    "$(inherited)",
                                     "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64\"",
                                 ],
                             ]
@@ -350,9 +351,11 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         settings: .test(
                             base: [
                                 "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": [
+                                    "$(inherited)",
                                     "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64\"",
                                 ],
                                 "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]": [
+                                    "$(inherited)",
                                     "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64-simulator\"",
                                 ],
                             ]
@@ -867,6 +870,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         settings: .test(
                             base: [
                                 "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": [
+                                    "$(inherited)",
                                     "\"$(SRCROOT)/../BuiltFrameworks/GoogleMaps.xcframework/ios-arm64\"",
                                 ],
                             ]
@@ -1372,6 +1376,7 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
                         settings: .test(
                             base: [
                                 "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]": [
+                                    "$(inherited)",
                                     "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64\"",
                                 ],
                             ]


### PR DESCRIPTION
## Summary

- When a cached dynamic xcframework absorbs a Swift static xcframework, the previous fix from #6520 relinked the static at the consumer level. For libraries with global state (Firebase) this duplicates symbols and crashes at runtime when `+[FIRApp configureWithOptions:]` runs against duplicated Obj-C class registrations.
- Symbol resolution doesn't actually need the relink — the absorbing dynamic xcframework re-exports the public Obj-C/Swift symbols through its own binary (verified with `nm` on the cached `Analytics.xcframework`). What the consumer needs is **compile-time module visibility** so `import FooStatic` resolves.
- This PR drops the static-xcframework-via-dynamic contribution from `linkableDependencies` and routes the same set into `FRAMEWORK_SEARCH_PATHS` (unqualified, via `searchablePathDependencies`) and per-SDK `FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]` / `[sdk=iphonesimulator*]` entries through the existing `StaticXCFrameworkModuleMapGraphMapper`, which already handled the analogous Obj-C case. `$(inherited)` is added to the per-SDK arrays so the unqualified setting isn't shadowed.

## Test plan

- [x] `mise run lint` passes (swiftformat + swiftlint).
- [x] `xcodebuild test` for `TuistCoreTests`, `TuistKitTests`, `TuistCacheEETests`, `TuistGeneratorTests` — 1659 / 1659 passing locally with `TUIST_EE=1`.
- [x] **Pavel's reproduction** (private project he sent on Telegram — Firebase static xcframeworks behind a dynamic `Analytics` framework). After `tuist cache warm` + `tuist generate App --cache-profile all-possible`:
  - App's link phase contains only `Analytics.xcframework` and `SomeTarget.xcframework` (was: + 8 Firebase static xcframeworks).
  - App's compiled debug dylib has 0 `FIRApp` / `FIRAnalytics` symbols (no duplication); only `@rpath` deps on `Analytics.framework` and `SomeTarget.framework`.
  - `xcodebuild build` succeeds for iphonesimulator.
- [x] **#6520 fixture** (`examples/xcode/generated_ios_app_with_dynamic_frameworks_linking_static_frameworks` — App's Swift code consumes `CasePaths.is(_:)` transitively through `DynamicFrameworkA`). After `tuist cache warm` + `tuist generate App --cache-profile all-possible`:
  - App's link phase contains only `DynamicFrameworkA.xcframework` and `DynamicFrameworkB.xcframework` (was: + CasePaths/CasePathsCore/IssueReporting/XCTestDynamicOverlay).
  - `import` of CasePaths-derived APIs through `DynamicFrameworkA` compiles cleanly via the per-SDK `FRAMEWORK_SEARCH_PATHS`.
  - `xcodebuild build` succeeds for iphonesimulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)