### PR TITLE
fix(server): drop custom Finch from Tuist.Kubernetes.Client

### DIFF
--- a/server/lib/tuist/kubernetes/client.ex
+++ b/server/lib/tuist/kubernetes/client.ex
@@ -90,7 +90,6 @@ defmodule Tuist.Kubernetes.Client do
             url: url(config, path),
             headers: request_headers(config, headers),
             params: query,
-            finch: Tuist.Finch,
             connect_options: [transport_opts: config.transport_opts]
           ],
           body


### PR DESCRIPTION
> Describe here the purpose of your PR.

PR #10489 (multi-region Kura) refactored `Tuist.Kubernetes.Client` into a generic `request/3` helper and reintroduced `finch: Tuist.Finch`, which #10497 had previously removed. Req rejects combining a custom `finch:` pool with per-call `connect_options:` (the pool has its own connection settings), so every K8s call now crashes with:

```
ArgumentError: cannot set both :finch and :connect_options
```

This shows up as soon as anything reaches into K8s, e.g. visiting the Account Settings page (`AccountSettingsLive.kura_nodes/2` → `KubernetesController.nodes/2` → `Tuist.Kubernetes.Client.request/3`).

The client needs per-call `transport_opts` because each kubeconfig brings its own CA bundle and client cert/key paths, so the custom pool has to go. Falls back to Req's default Finch instance, which honors `connect_options.transport_opts`. K8s API call volume is small (per-reconcile-tick + occasional UI lookups), so a separate pool is acceptable.

### How to test locally

- Open the Account Settings page on an account that surfaces Kura nodes and confirm the page no longer raises `ArgumentError: cannot set both :finch and :connect_options`.
- Or call `Tuist.Kubernetes.Client.get("/api/v1/nodes", mode: :kubeconfig, kubeconfig_path: "...")` from `iex` and confirm it returns `{:ok, _}` instead of raising.
