### PR TITLE
fix(server): bump fast-uri to 3.1.2 to address CVE-2026-6321/6322

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
       "dompurify": "3.4.0",
+      "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "yaml": "2.8.3",
       "defu": "6.1.5",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   axios: 1.15.2
   defu: 6.1.5
   dompurify: 3.4.0
+  fast-uri: 3.1.2
   flatted: 3.4.2
   follow-redirects: 1.16.0
   mdast-util-to-hast: 13.2.1
@@ -18,6 +19,7 @@ overrides:
 
 time:
   axios@1.15.2: 2026-04-21T17:53:03.731Z
+  fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
 
 importers:
 
@@ -747,8 +749,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -2350,7 +2352,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2483,7 +2485,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.0.6: {}
+  fast-uri@3.1.2: {}
 
   fflate@0.4.8: {}
 


### PR DESCRIPTION
## Summary

Two HIGH-severity advisories were published against `fast-uri@3.0.6` on 2026-05-10:

- [CVE-2026-6321](https://avd.aquasec.com/nvd/cve-2026-6321) — path traversal allows bypass of security policies (fixed in 3.1.1)
- [CVE-2026-6322](https://avd.aquasec.com/nvd/cve-2026-6322) — \`normalize()\` decoded percent-encoded authority delimiters (fixed in 3.1.2)

Trivy started failing the \`Security\` check on every PR opened after the publish date (verified on at least #10705 and #10706). \`fast-uri\` is pulled in transitively via \`ajv@8.18.0\`. Pinning via the existing \`pnpm.overrides\` block is consistent with the other transitive pins already there.

## Test plan

- [x] \`aube install --lockfile-only\` regenerates \`server/pnpm-lock.yaml\` cleanly
- [x] \`grep \"fast-uri@3.0\" server/pnpm-lock.yaml\` returns 0 matches
- [x] \`fast-uri@3.1.2\` is now the only resolution in the lockfile
- [ ] CI \`Security\` check passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)