### PR TITLE
fix(server): strip path/query/fragment from GHES client_url

### DIFF
--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -113,13 +113,18 @@ defmodule Tuist.VCS do
   Validates a user-supplied `client_url` for a forge instance. Returns
   `{:ok, normalized_url}` on success or `{:error, reason}` otherwise.
 
-  This is a *shape* check — it verifies the URL has an https scheme and a
-  non-empty host, and trims trailing slashes. The scheme is restricted to
-  https because the manifest exchange transports a fresh GitHub App's
-  private key, client secret, and webhook secret; allowing http would
-  expose those credentials in transit. http:// is permitted only for
-  the dev/test envs so local fixtures (e.g. `http://localhost:4002`)
-  keep working.
+  The normalized URL is the bare origin (`scheme://host[:port]`) — any
+  path, query, or fragment in the input is dropped. Downstream code
+  (the GitHub App manifest flow, the API base URL builder) appends
+  fixed suffixes like `/settings/apps/new` or `/api/v3`, so letting a
+  user-supplied path through produces a 404 on GHES. The default port
+  for the scheme is omitted so the output stays canonical.
+
+  The scheme is restricted to https because the manifest exchange
+  transports a fresh GitHub App's private key, client secret, and
+  webhook secret; allowing http would expose those credentials in
+  transit. http:// is permitted only for the dev/test envs so local
+  fixtures (e.g. `http://localhost:4002`) keep working.
 
   The validator deliberately does not perform DNS resolution: SSRF
   protection happens at request time via `Tuist.OAuth2.SSRFGuard.pin/1`
@@ -127,15 +132,13 @@ defmodule Tuist.VCS do
   bypass it.
   """
   def validate_client_url(url) when is_binary(url) do
-    trimmed = url |> String.trim() |> String.trim_trailing("/")
+    case URI.parse(String.trim(url)) do
+      %URI{scheme: "https", host: host} = uri when is_binary(host) and host != "" ->
+        {:ok, build_origin(uri)}
 
-    case URI.parse(trimmed) do
-      %URI{scheme: "https", host: host} when is_binary(host) and host != "" ->
-        {:ok, trimmed}
-
-      %URI{scheme: "http", host: host} when is_binary(host) and host != "" ->
+      %URI{scheme: "http", host: host} = uri when is_binary(host) and host != "" ->
         if Environment.env() in [:dev, :test] do
-          {:ok, trimmed}
+          {:ok, build_origin(uri)}
         else
           {:error, :insecure_scheme}
         end
@@ -146,6 +149,14 @@ defmodule Tuist.VCS do
   end
 
   def validate_client_url(_), do: {:error, :invalid_url}
+
+  defp build_origin(%URI{scheme: scheme, host: host, port: port}) do
+    if is_integer(port) and port != URI.default_port(scheme) do
+      "#{scheme}://#{host}:#{port}"
+    else
+      "#{scheme}://#{host}"
+    end
+  end
 
   @doc """
   Returns the GitHub App credentials Tuist should use to act on behalf of
@@ -1437,7 +1448,12 @@ defmodule Tuist.VCS do
   defp normalize_client_url(nil), do: default_client_url()
   defp normalize_client_url(""), do: default_client_url()
 
-  defp normalize_client_url(url) when is_binary(url), do: url |> String.trim() |> String.trim_trailing("/")
+  defp normalize_client_url(url) when is_binary(url) do
+    case validate_client_url(url) do
+      {:ok, normalized} -> normalized
+      {:error, _} -> url |> String.trim() |> String.trim_trailing("/")
+    end
+  end
 
   # GitHub State Token functions
 

--- a/server/lib/tuist/vcs/github_app_installation.ex
+++ b/server/lib/tuist/vcs/github_app_installation.ex
@@ -137,7 +137,10 @@ defmodule Tuist.VCS.GitHubAppInstallation do
         put_change(changeset, :client_url, @default_client_url)
 
       url when is_binary(url) ->
-        put_change(changeset, :client_url, url |> String.trim() |> String.trim_trailing("/"))
+        case VCS.validate_client_url(url) do
+          {:ok, normalized} -> put_change(changeset, :client_url, normalized)
+          {:error, _} -> changeset
+        end
 
       _ ->
         changeset

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -3526,6 +3526,24 @@ defmodule Tuist.VCSTest do
       assert installation.client_url == "https://github.example.com"
     end
 
+    test "strips a path component from a GHES client_url" do
+      # Given
+      account = AccountsFixtures.account_fixture()
+
+      # When
+      {:ok, installation} =
+        Repo.insert(
+          GitHubAppInstallation.changeset(%GitHubAppInstallation{}, %{
+            account_id: account.id,
+            installation_id: "ghes-id",
+            client_url: "https://github.bumble.dev/ios/bumble"
+          })
+        )
+
+      # Then
+      assert installation.client_url == "https://github.bumble.dev"
+    end
+
     test "rejects invalid client_url values" do
       # Given
       account = AccountsFixtures.account_fixture()
@@ -3571,6 +3589,71 @@ defmodule Tuist.VCSTest do
 
     test "defaults to github when no provider is given" do
       assert VCS.default_client_url() == "https://github.com"
+    end
+  end
+
+  describe "validate_client_url/1" do
+    test "returns a clean https origin unchanged" do
+      assert VCS.validate_client_url("https://github.example.com") ==
+               {:ok, "https://github.example.com"}
+    end
+
+    test "trims surrounding whitespace and trailing slashes" do
+      assert VCS.validate_client_url("  https://github.example.com/  ") ==
+               {:ok, "https://github.example.com"}
+    end
+
+    test "strips a path component so the manifest action stays on /settings/apps/new" do
+      # Without this, a user pasting their org/repo URL produces a 404 on
+      # GHES because the manifest controller appends `/settings/apps/new`
+      # to the client_url verbatim. See:
+      # https://github.bumble.dev/ios/bumble/settings/apps/new -> 404
+      assert VCS.validate_client_url("https://github.bumble.dev/ios/bumble") ==
+               {:ok, "https://github.bumble.dev"}
+    end
+
+    test "strips a query string" do
+      assert VCS.validate_client_url("https://github.example.com/?ref=share") ==
+               {:ok, "https://github.example.com"}
+    end
+
+    test "strips a fragment" do
+      assert VCS.validate_client_url("https://github.example.com/#anchor") ==
+               {:ok, "https://github.example.com"}
+    end
+
+    test "preserves a non-default port" do
+      assert VCS.validate_client_url("https://github.example.com:8443/foo") ==
+               {:ok, "https://github.example.com:8443"}
+    end
+
+    test "omits the default port for https" do
+      assert VCS.validate_client_url("https://github.example.com:443/foo") ==
+               {:ok, "https://github.example.com"}
+    end
+
+    test "rejects a string without a scheme/host" do
+      assert VCS.validate_client_url("not-a-url") == {:error, :invalid_url}
+    end
+
+    test "rejects the empty string" do
+      assert VCS.validate_client_url("") == {:error, :invalid_url}
+    end
+
+    test "rejects a non-string input" do
+      assert VCS.validate_client_url(nil) == {:error, :invalid_url}
+    end
+
+    test "rejects http outside dev/test environments" do
+      stub(Environment, :env, fn -> :prod end)
+      assert VCS.validate_client_url("http://github.example.com") == {:error, :insecure_scheme}
+    end
+
+    test "accepts http in dev/test for local fixtures" do
+      stub(Environment, :env, fn -> :test end)
+
+      assert VCS.validate_client_url("http://localhost:4002/some/path") ==
+               {:ok, "http://localhost:4002"}
     end
   end
 


### PR DESCRIPTION
### Why

A Tuist user trying the new GHES integration entered an org/repo-style URL into the Server URL field and landed on `https://<ghes>/<org>/<repo>/settings/apps/new` with a 404. `Tuist.VCS.validate_client_url/1` was a shape check that only verified scheme + host, so a path on the user-supplied URL leaked through; the manifest controller then appends `/settings/apps/new` verbatim, yielding the bad URL.

### What changed

- `Tuist.VCS.validate_client_url/1` now normalizes the input to the bare origin (`scheme://host[:port]`), dropping path/query/fragment. The default port for the scheme is omitted so the output stays canonical.
- Both `normalize_client_url/1` helpers (one in `Tuist.VCS`, used by the state-token roundtrip, and one in `Tuist.VCS.GitHubAppInstallation`'s changeset, used when persisting the row) now delegate to the validator so the canonical origin propagates through every consumer: state token, form action URL, persisted `client_url`, API base URL, commit/branch link rendering.
- Added a `describe "validate_client_url/1"` block in `vcs_test.exs` (12 tests) covering: clean URLs, trailing-slash trimming, path stripping, query stripping, fragment stripping, non-default-port preservation, default-port omission, whitespace, http-in-dev/test, and rejections for non-URL/empty/non-binary inputs. Added one changeset-level regression test that explicitly uses the URL shape from the bug report.

### How to test locally

`mix test test/tuist/vcs_test.exs test/tuist_web/controllers/github_app_manifest_controller_test.exs test/tuist_web/live/integrations_live_test.exs test/tuist/vcs/github_app_installation_test.exs test/tuist_web/controllers/github_app_setup_controller_test.exs` — 144 tests, 0 failures.

For a manual end-to-end check on a self-hosted Tuist server:

1. Enter `https://github.example.com/some/path` in the GHES Server URL field on the integrations page.
2. The Install button should kick off the manifest flow and produce a form action of exactly `https://github.example.com/settings/apps/new?state=...` — the `/some/path` should be gone.
🤖 Generated with [Claude Code](https://claude.com/claude-code)