### PR TITLE
fix(server): drop `installation` from GHES manifest default_events

### DIFF
--- a/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
+++ b/server/lib/tuist_web/controllers/github_app_manifest_controller.ex
@@ -168,7 +168,7 @@ defmodule TuistWeb.GitHubAppManifestController do
         checks: "write",
         metadata: "read"
       },
-      default_events: ["check_run", "pull_request", "issue_comment", "installation"]
+      default_events: ["check_run", "pull_request", "issue_comment"]
     }
   end
 


### PR DESCRIPTION
## Summary

The GHES App-manifest flow shipped in [tuist#10471](https://github.com/tuist/tuist/pull/10471) lists `installation` in `default_events`, which GHES rejects at submit time:

> Default events unsupported: installation
> Default events are not supported by permissions: installation

`installation` (and `installation_repositories`) are auto-delivered to every GitHub App and cannot be subscribed to via `default_events`. Removing it lets the manifest validate. The webhook handler still receives `installation` events because GitHub sends them regardless.

## Test plan

- [ ] Manually retry the manifest flow against a GHES instance (cannot reproduce locally without a GHES tenant — same e2e gap called out in the original PR).