### PR TITLE
fix(server): recover interrupted helm releases without waiting

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -301,8 +301,18 @@ jobs:
                 exit 1
               fi
 
+              # This is a metadata recovery path, not the real health gate.
+              # An interrupted atomic rollback can leave the latest Helm
+              # revision in pending-rollback even when the last deployed
+              # revision is the only viable base for the next deploy. Waiting
+              # here replays the old manifest's readiness problems and can
+              # strand this recovery step before the current chart gets a
+              # chance to fix them. The following helm upgrade owns the full
+              # --wait/--atomic rollout with richer diagnostics.
               helm rollback "$HELM_RELEASE_NAME" "$deployed_revision" \
-                --namespace "$NAMESPACE" --wait --timeout 25m
+                --namespace "$NAMESPACE" --timeout 5m
+
+              helm status "$HELM_RELEASE_NAME" -n "$NAMESPACE"
               ;;
             *)
               echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."


### PR DESCRIPTION
## Summary
- stop waiting during interrupted Helm release metadata recovery
- keep the real helm upgrade as the readiness gate with existing diagnostics
- print helm status after recovery for visibility

## Verification
- git diff --check
- ruby -e 'require "psych"; Psych.parse_file(".github/workflows/server-deployment.yml")'

Debugged from https://github.com/tuist/tuist/actions/runs/25636687946/job/75250679208