### PR TITLE
fix(server): cast date to DateTime for CAS month-interval analytics

### DIFF
--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -1094,7 +1094,7 @@ defmodule Tuist.Builds.Analytics do
       ClickHouseRepo.query!(
         """
         SELECT
-          toStartOfInterval(date, INTERVAL #{interval_str}, 'UTC') as period,
+          toStartOfInterval(toDateTime(date), INTERVAL #{interval_str}, 'UTC') as period,
           SUM(total_size) as total_size
         FROM cas_events_daily_stats
         WHERE project_id = {project_id:Int64}

--- a/server/test/tuist/builds/analytics_test.exs
+++ b/server/test/tuist/builds/analytics_test.exs
@@ -3,6 +3,7 @@ defmodule Tuist.Builds.AnalyticsTest do
   use Mimic
 
   alias Tuist.Builds.Analytics
+  alias Tuist.IngestRepo
   alias Tuist.Xcode.XcodeGraph.Buffer
   alias TuistTestSupport.Fixtures.CommandEventsFixtures
   alias TuistTestSupport.Fixtures.ProjectsFixtures
@@ -2772,6 +2773,39 @@ defmodule Tuist.Builds.AnalyticsTest do
         )
 
       assert got.series == []
+    end
+  end
+
+  describe "cas_uploads_analytics/2" do
+    test "returns CAS upload analytics aggregated by month for a range spanning 60+ days" do
+      # Given
+      stub(DateTime, :utc_now, fn -> ~U[2024-06-30 10:00:00Z] end)
+      project = ProjectsFixtures.project_fixture()
+
+      IngestRepo.query!(
+        """
+        INSERT INTO cas_events_daily_stats (project_id, action, date, total_size, event_count)
+        VALUES
+          ({pid:Int64}, 'upload', toDate('2024-04-15'), 1024, 2),
+          ({pid:Int64}, 'upload', toDate('2024-05-15'), 2048, 3),
+          ({pid:Int64}, 'upload', toDate('2024-06-15'), 4096, 4),
+          ({pid:Int64}, 'download', toDate('2024-05-15'), 9999, 1)
+        """,
+        %{pid: project.id}
+      )
+
+      # When
+      got =
+        Analytics.cas_uploads_analytics(
+          project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-06-30 00:00:00Z]
+        )
+
+      # Then
+      assert got.total_size == 7168
+      assert got.values == [1024, 2048, 4096]
+      assert Enum.map(got.dates, &Date.to_iso8601/1) == ["2024-04-01", "2024-05-01", "2024-06-01"]
     end
   end
 end


### PR DESCRIPTION
[Sentry error](https://tuist.sentry.io/issues/119009194/?referrer=slack&environment=prod&alert_rule_id=389667&alert_type=issue)

### Purpose

The Xcode cache LiveView was throwing `ILLEGAL_TYPE_OF_ARGUMENT` from ClickHouse whenever a CAS analytics query covered 60+ days:

```
DB::Exception: A timezone argument of function toStartOfInterval with interval type Month is allowed only when the 1st argument has the type DateTime or DateTime64
```

`cas_events_daily_stats.date` is a `Date` column, so `toStartOfInterval(date, INTERVAL 1 month, 'UTC')` is rejected — ClickHouse only allows the timezone argument with month-or-larger intervals when the value is `DateTime`/`DateTime64`. Date ranges of 60+ days select the `:month` period (see `date_period/1`) and hit this error.

The fix wraps the column with `toDateTime(date)` in `cas_action_analytics/3`. Downstream `normalise_date/2` already handles `DateTime` values, so no other changes are needed. The sibling queries in this file already use `inserted_at` (DateTime), so this CAS query was the only one affected.

### How to test locally

1. Open the Xcode cache page for a project with CAS events that span more than 60 days.
2. Select a date range of 60+ days (which forces the `:month` interval).
3. Confirm the upload/download charts render instead of crashing with the ClickHouse error.
