### PR TITLE
fix(server): prevent IRSA S3 auth cache crashes

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -341,25 +341,15 @@ if Tuist.Environment.env() not in [:test] do
   config :ex_aws, :s3, s3_config
 
   config :ex_aws,
+         Tuist.AWS.S3AuthenticationConfig.ex_aws_config(
+           Tuist.Environment.s3_authentication_method(secrets),
+           secrets
+         )
+
+  config :ex_aws,
     http_client: TuistCommon.AWS.Client
 
   config :tuist_common, finch_name: Tuist.Finch
-
-  case Tuist.Environment.s3_authentication_method(secrets) do
-    :env_access_key_id_and_secret_access_key ->
-      config :ex_aws,
-        secret_access_key: Tuist.Environment.s3_secret_access_key(secrets),
-        access_key_id: Tuist.Environment.s3_access_key_id(secrets)
-
-    :aws_web_identity_token_from_env_vars ->
-      config :ex_aws,
-        secret_access_key: [{:awscli, "profile_name", 30}],
-        access_key_id: [{:awscli, "profile_name", 30}],
-        awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
-
-    _ ->
-      nil
-  end
 end
 
 # Stripe config

--- a/server/lib/tuist/aws/s3_authentication_config.ex
+++ b/server/lib/tuist/aws/s3_authentication_config.ex
@@ -1,0 +1,28 @@
+defmodule Tuist.AWS.S3AuthenticationConfig do
+  @moduledoc false
+
+  alias Tuist.Environment
+
+  @aws_web_identity_token_profile "tuist_web_identity_token"
+  @aws_web_identity_token_refresh_interval_seconds 30
+
+  def ex_aws_config(:env_access_key_id_and_secret_access_key, secrets) do
+    [
+      secret_access_key: Environment.s3_secret_access_key(secrets),
+      access_key_id: Environment.s3_access_key_id(secrets)
+    ]
+  end
+
+  def ex_aws_config(:aws_web_identity_token_from_env_vars, _secrets) do
+    # ExAws runs the awscli provider before the STS adapter. The empty in-memory
+    # profile keeps IRSA from depending on ~/.aws/config or configparser_ex.
+    [
+      secret_access_key: [{:awscli, @aws_web_identity_token_profile, @aws_web_identity_token_refresh_interval_seconds}],
+      access_key_id: [{:awscli, @aws_web_identity_token_profile, @aws_web_identity_token_refresh_interval_seconds}],
+      awscli_credentials: %{@aws_web_identity_token_profile => %{}},
+      awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
+    ]
+  end
+
+  def ex_aws_config(_authentication_method, _secrets), do: []
+end

--- a/server/test/tuist/aws/s3_authentication_config_test.exs
+++ b/server/test/tuist/aws/s3_authentication_config_test.exs
@@ -1,0 +1,34 @@
+defmodule Tuist.AWS.S3AuthenticationConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.AWS.S3AuthenticationConfig
+
+  describe "ex_aws_config/2" do
+    test "uses access key credentials" do
+      secrets = %{
+        "s3" => %{
+          "access_key_id" => "access-key-id",
+          "secret_access_key" => "secret-access-key"
+        }
+      }
+
+      assert S3AuthenticationConfig.ex_aws_config(:env_access_key_id_and_secret_access_key, secrets) == [
+               secret_access_key: "secret-access-key",
+               access_key_id: "access-key-id"
+             ]
+    end
+
+    test "uses an in-memory awscli profile for web identity token credentials" do
+      assert S3AuthenticationConfig.ex_aws_config(:aws_web_identity_token_from_env_vars, %{}) == [
+               secret_access_key: [{:awscli, "tuist_web_identity_token", 30}],
+               access_key_id: [{:awscli, "tuist_web_identity_token", 30}],
+               awscli_credentials: %{"tuist_web_identity_token" => %{}},
+               awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
+             ]
+    end
+
+    test "ignores unsupported authentication methods" do
+      assert S3AuthenticationConfig.ex_aws_config(:unsupported, %{}) == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the S3 authentication config used by self-hosted AWS deployments with IRSA. The web identity token mode now configures an in-memory awscli profile so ExAws can reach the STS web identity adapter without reading ~/.aws/config or requiring configparser_ex.

## Root cause

The previous `aws_web_identity_token_from_env_vars` branch configured `{:awscli, "profile_name", 30}` directly. ExAws resolves that provider through the AWS CLI credentials loader before invoking `ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter`. In containerized EKS deployments without AWS CLI config files or the optional INI parser dependency, that raised inside `ExAws.Config.AuthCache` and terminated the ExAws application.

## Changes

- Extracted S3 auth config into `Tuist.AWS.S3AuthenticationConfig`.
- Added an empty in-memory awscli profile for the IRSA mode.
- Added focused tests for static credentials, IRSA credentials, and unsupported modes.

## Validation

- `mise exec -- mix test test/tuist/aws/s3_authentication_config_test.exs`