### PR TITLE
refactor(server): hide infra details from Kura cache servers table

### DIFF
--- a/server/lib/tuist/kubernetes/client.ex
+++ b/server/lib/tuist/kubernetes/client.ex
@@ -61,10 +61,6 @@ defmodule Tuist.Kubernetes.Client do
     delete("/apis/kura.tuist.dev/v1alpha1/namespaces/#{namespace}/kurainstances/#{name}", opts)
   end
 
-  def list_pods(namespace, label_selector, opts \\ []) when is_binary(label_selector) do
-    request(:get, "/api/v1/namespaces/#{namespace}/pods", opts: opts, query: %{"labelSelector" => label_selector})
-  end
-
   defp manifest_path(%{
          "apiVersion" => "kura.tuist.dev/v1alpha1",
          "kind" => "KuraInstance",

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -268,14 +268,6 @@ defmodule Tuist.Kura do
     Repo.get_by(Server, id: server_id, account_id: account_id)
   end
 
-  @doc "Returns runtime nodes for a server scoped to the given account."
-  def list_nodes_for_server(account_id, server_id) do
-    case get_server(account_id, server_id) do
-      nil -> {:error, :not_found}
-      %Server{} = server -> Provisioner.nodes(server)
-    end
-  end
-
   @doc """
   Marks a server as `:active`, mirrors its URL into
   `account_cache_endpoints`, and broadcasts. Public DNS is checked

--- a/server/lib/tuist/kura/provisioner.ex
+++ b/server/lib/tuist/kura/provisioner.ex
@@ -81,10 +81,6 @@ defmodule Tuist.Kura.Provisioner do
   @callback current_image_tag(ref :: String.t(), Regions.t()) ::
               {:ok, String.t() | nil} | {:error, term()}
 
-  @doc "Returns the Kura runtime nodes backing one provisioned server."
-  @callback nodes(ref :: String.t(), Regions.t()) ::
-              {:ok, [map()]} | {:error, term()}
-
   @doc "Returns the provisioner's default resource description for one Kura server."
   @callback resources_for(Server.t()) :: map()
 
@@ -122,13 +118,6 @@ defmodule Tuist.Kura.Provisioner do
   def current_image_tag(%Server{provisioner_node_ref: ref, region: region_id}) do
     with {:ok, region} <- Regions.fetch(region_id) do
       region.provisioner.current_image_tag(ref, region)
-    end
-  end
-
-  @doc "Calls `nodes/2` on the region's provisioner."
-  def nodes(%Server{provisioner_node_ref: ref, region: region_id}) do
-    with {:ok, region} <- Regions.fetch(region_id) do
-      region.provisioner.nodes(ref, region)
     end
   end
 end

--- a/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
+++ b/server/lib/tuist/kura/provisioner/kubernetes_controller.ex
@@ -83,13 +83,6 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   end
 
   @impl true
-  def nodes(name, %Regions{} = region) do
-    with {:ok, body} <- client_list_pods(@namespace, "app.kubernetes.io/instance=#{name}", region) do
-      parse_nodes_body(body)
-    end
-  end
-
-  @impl true
   def resources_for(%Server{}), do: %{}
 
   def instance_name(handle, %Regions{provisioner_config: %{cluster_id: cluster_id}}) do
@@ -219,35 +212,6 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
   defp node_selector(%Regions{provisioner_config: %{node_selector: node_selector}}), do: node_selector
   defp node_selector(_), do: nil
 
-  @doc false
-  def parse_nodes(json) do
-    case Jason.decode(json) do
-      {:ok, body} -> parse_nodes_body(body)
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp parse_nodes_body(%{"items" => items}) when is_list(items), do: {:ok, Enum.map(items, &node_from_pod/1)}
-  defp parse_nodes_body(_), do: {:error, "unexpected Kubernetes pod list shape"}
-
-  defp node_from_pod(%{"metadata" => metadata, "status" => status} = pod) do
-    %{
-      name: metadata["name"],
-      pod_ip: status["podIP"],
-      host_ip: status["hostIP"],
-      node_name: pod |> Map.get("spec", %{}) |> Map.get("nodeName"),
-      phase: status["phase"],
-      ready: pod_ready?(status),
-      started_at: status["startTime"]
-    }
-  end
-
-  defp pod_ready?(%{"conditions" => conditions}) when is_list(conditions) do
-    Enum.any?(conditions, &(&1["type"] == "Ready" and &1["status"] == "True"))
-  end
-
-  defp pod_ready?(_), do: false
-
   defp interpolate_host(template, handle, %{cluster_id: cluster_id}) do
     template
     |> String.replace("{account_handle}", handle)
@@ -314,13 +278,6 @@ defmodule Tuist.Kura.Provisioner.KubernetesController do
     case kubernetes_client_opts(region) do
       [] -> Client.delete_kura_instance(namespace, name)
       opts -> Client.delete_kura_instance(namespace, name, opts)
-    end
-  end
-
-  defp client_list_pods(namespace, label_selector, region) do
-    case kubernetes_client_opts(region) do
-      [] -> Client.list_pods(namespace, label_selector)
-      opts -> Client.list_pods(namespace, label_selector, opts)
     end
   end
 

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -311,7 +311,6 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:available_kura_regions, [])
     |> assign(:latest_kura_version, nil)
     |> assign(:add_kura_server_form, default_kura_server_form([]))
-    |> assign(:kura_nodes, %{})
   end
 
   defp load_kura_state(socket, opts \\ []) do
@@ -327,7 +326,6 @@ defmodule TuistWeb.AccountSettingsLive do
     |> assign(:available_kura_regions, available_regions)
     |> assign(:latest_kura_version, latest)
     |> assign(:add_kura_server_form, default_kura_server_form(available_regions))
-    |> assign(:kura_nodes, kura_nodes(account, servers))
   end
 
   defp kura_enabled?(account) do
@@ -360,18 +358,6 @@ defmodule TuistWeb.AccountSettingsLive do
 
   defp default_kura_server_form([region | _]) do
     to_form(%{"region" => region.id}, as: :server)
-  end
-
-  defp kura_nodes(account, servers) do
-    Map.new(servers, fn server ->
-      nodes =
-        case Kura.list_nodes_for_server(account.id, server.id) do
-          {:ok, nodes} -> nodes
-          {:error, reason} -> {:error, reason}
-        end
-
-      {server.id, nodes}
-    end)
   end
 
   defp create_kura_server(socket, attrs) do
@@ -422,7 +408,6 @@ defmodule TuistWeb.AccountSettingsLive do
   end
 
   attr(:kura_servers, :list, required: true)
-  attr(:kura_nodes, :map, required: true)
   attr(:available_kura_regions, :list, required: true)
   attr(:add_kura_server_form, Form, required: true)
   attr(:latest_kura_version, :map, default: nil)
@@ -558,12 +543,6 @@ defmodule TuistWeb.AccountSettingsLive do
               style="light-fill"
             />
           </:col>
-          <:col :let={server} label={dgettext("dashboard_account", "Machine")}>
-            <.text_and_description_cell
-              label={kura_machine_label(Map.get(@kura_nodes, server.id))}
-              description={kura_machine_sublabel(Map.get(@kura_nodes, server.id))}
-            />
-          </:col>
           <:col :let={server} label={dgettext("dashboard_account", "Domain")}>
             <.text_cell label={server.url || dgettext("dashboard_account", "Pending")} />
           </:col>
@@ -612,32 +591,6 @@ defmodule TuistWeb.AccountSettingsLive do
       region -> region.display_name
     end
   end
-
-  def kura_machine_label({:error, _}), do: dgettext("dashboard_account", "Unavailable")
-  def kura_machine_label([]), do: dgettext("dashboard_account", "Pending")
-
-  def kura_machine_label(nodes) when is_list(nodes) do
-    ready = Enum.count(nodes, & &1[:ready])
-    dgettext("dashboard_account", "%{ready}/%{total} nodes ready", ready: ready, total: length(nodes))
-  end
-
-  def kura_machine_label(_), do: dgettext("dashboard_account", "Pending")
-
-  def kura_machine_sublabel({:error, _}), do: dgettext("dashboard_account", "Could not query Kubernetes.")
-  def kura_machine_sublabel([]), do: dgettext("dashboard_account", "Waiting for the controller.")
-
-  def kura_machine_sublabel(nodes) when is_list(nodes) do
-    nodes
-    |> Enum.map(fn node -> node[:node_name] || node[:name] end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-    |> case do
-      [] -> dgettext("dashboard_account", "Waiting for scheduling.")
-      names -> Enum.join(names, ", ")
-    end
-  end
-
-  def kura_machine_sublabel(_), do: dgettext("dashboard_account", "Waiting for the controller.")
 
   attr(:preferred_locale_form, :any, required: true)
 

--- a/server/lib/tuist_web/live/account_settings_live.html.heex
+++ b/server/lib/tuist_web/live/account_settings_live.html.heex
@@ -16,7 +16,6 @@
     <.kura_servers_section
       :if={@kura_enabled}
       kura_servers={@kura_servers}
-      kura_nodes={@kura_nodes}
       available_kura_regions={@available_kura_regions}
       add_kura_server_form={@add_kura_server_form}
       latest_kura_version={@latest_kura_version}
@@ -175,7 +174,6 @@
     <.kura_servers_section
       :if={@kura_enabled}
       kura_servers={@kura_servers}
-      kura_nodes={@kura_nodes}
       available_kura_regions={@available_kura_regions}
       add_kura_server_form={@add_kura_server_form}
       latest_kura_version={@latest_kura_version}

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -72,13 +72,13 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:709
+#: lib/tuist_web/live/account_settings_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:113
-#: lib/tuist_web/live/account_settings_live.html.heex:270
+#: lib/tuist_web/live/account_settings_live.html.heex:112
+#: lib/tuist_web/live/account_settings_live.html.heex:268
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this?"
 msgstr ""
@@ -99,13 +99,13 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:515
-#: lib/tuist_web/live/account_settings_live.ex:781
-#: lib/tuist_web/live/account_settings_live.ex:868
-#: lib/tuist_web/live/account_settings_live.html.heex:77
-#: lib/tuist_web/live/account_settings_live.html.heex:151
-#: lib/tuist_web/live/account_settings_live.html.heex:234
-#: lib/tuist_web/live/account_settings_live.html.heex:306
+#: lib/tuist_web/live/account_settings_live.ex:500
+#: lib/tuist_web/live/account_settings_live.ex:734
+#: lib/tuist_web/live/account_settings_live.ex:821
+#: lib/tuist_web/live/account_settings_live.html.heex:76
+#: lib/tuist_web/live/account_settings_live.html.heex:150
+#: lib/tuist_web/live/account_settings_live.html.heex:232
+#: lib/tuist_web/live/account_settings_live.html.heex:304
 #: lib/tuist_web/live/authentication_settings_live.html.heex:513
 #: lib/tuist_web/live/create_organization_live.ex:83
 #: lib/tuist_web/live/members_live.ex:157
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:693
+#: lib/tuist_web/live/account_settings_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -211,17 +211,17 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:842
-#: lib/tuist_web/live/account_settings_live.ex:876
-#: lib/tuist_web/live/account_settings_live.ex:888
-#: lib/tuist_web/live/account_settings_live.html.heex:159
-#: lib/tuist_web/live/account_settings_live.html.heex:314
+#: lib/tuist_web/live/account_settings_live.ex:795
+#: lib/tuist_web/live/account_settings_live.ex:829
+#: lib/tuist_web/live/account_settings_live.ex:841
+#: lib/tuist_web/live/account_settings_live.html.heex:158
+#: lib/tuist_web/live/account_settings_live.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:255
-#: lib/tuist_web/live/account_settings_live.html.heex:276
+#: lib/tuist_web/live/account_settings_live.html.heex:253
+#: lib/tuist_web/live/account_settings_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Delete account"
 msgstr ""
@@ -296,18 +296,18 @@ msgstr ""
 msgid "The client secret from your OAuth2 application."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:98
-#: lib/tuist_web/live/account_settings_live.html.heex:119
+#: lib/tuist_web/live/account_settings_live.html.heex:97
+#: lib/tuist_web/live/account_settings_live.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Delete organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:132
+#: lib/tuist_web/live/account_settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Deleting the organization will delete all of its projects"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:288
+#: lib/tuist_web/live/account_settings_live.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "Deleting your account will also delete all the projects that belong to it"
 msgstr ""
@@ -338,12 +338,12 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:139
+#: lib/tuist_web/live/account_settings_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Enter this organization's name to confirm"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:295
+#: lib/tuist_web/live/account_settings_live.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Enter your username to confirm"
 msgstr ""
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:710
+#: lib/tuist_web/live/account_settings_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -540,8 +540,8 @@ msgstr ""
 msgid "Open source"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:68
-#: lib/tuist_web/live/account_settings_live.html.heex:142
+#: lib/tuist_web/live/account_settings_live.html.heex:67
+#: lib/tuist_web/live/account_settings_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Organization name"
 msgstr ""
@@ -573,10 +573,8 @@ msgstr ""
 msgid "Payments for your subscription are made using the default card."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:568
-#: lib/tuist_web/live/account_settings_live.ex:571
-#: lib/tuist_web/live/account_settings_live.ex:617
-#: lib/tuist_web/live/account_settings_live.ex:624
+#: lib/tuist_web/live/account_settings_live.ex:547
+#: lib/tuist_web/live/account_settings_live.ex:550
 #: lib/tuist_web/live/members_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -614,10 +612,10 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:470
-#: lib/tuist_web/live/account_settings_live.ex:483
-#: lib/tuist_web/live/account_settings_live.ex:551
-#: lib/tuist_web/live/account_settings_live.ex:706
+#: lib/tuist_web/live/account_settings_live.ex:455
+#: lib/tuist_web/live/account_settings_live.ex:468
+#: lib/tuist_web/live/account_settings_live.ex:536
+#: lib/tuist_web/live/account_settings_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -643,30 +641,30 @@ msgstr ""
 msgid "Remove member"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:85
-#: lib/tuist_web/live/account_settings_live.html.heex:242
+#: lib/tuist_web/live/account_settings_live.html.heex:84
+#: lib/tuist_web/live/account_settings_live.html.heex:240
 #, elixir-autogen, elixir-format
 msgid "Rename"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:27
-#: lib/tuist_web/live/account_settings_live.html.heex:51
+#: lib/tuist_web/live/account_settings_live.html.heex:26
+#: lib/tuist_web/live/account_settings_live.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Rename organization"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:45
+#: lib/tuist_web/live/account_settings_live.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Rename your organization?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:63
-#: lib/tuist_web/live/account_settings_live.html.heex:221
+#: lib/tuist_web/live/account_settings_live.html.heex:62
+#: lib/tuist_web/live/account_settings_live.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Renaming can have unexpected consequences"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:30
+#: lib/tuist_web/live/account_settings_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Renaming your organization can have unintended side effects."
 msgstr ""
@@ -702,7 +700,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:701
+#: lib/tuist_web/live/account_settings_live.ex:654
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -733,13 +731,13 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:554
+#: lib/tuist_web/live/account_settings_live.ex:539
 #: lib/tuist_web/live/members_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:690
+#: lib/tuist_web/live/account_settings_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -754,8 +752,8 @@ msgstr ""
 msgid "Tailored agreements to meet your specific needs"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:101
-#: lib/tuist_web/live/account_settings_live.html.heex:258
+#: lib/tuist_web/live/account_settings_live.html.heex:100
+#: lib/tuist_web/live/account_settings_live.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone."
 msgstr ""
@@ -781,12 +779,12 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:711
+#: lib/tuist_web/live/account_settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
 
-#: lib/tuist/vcs.ex:505
+#: lib/tuist/vcs.ex:639
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -806,18 +804,18 @@ msgstr ""
 msgid "Update payment method"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:186
-#: lib/tuist_web/live/account_settings_live.html.heex:210
+#: lib/tuist_web/live/account_settings_live.html.heex:184
+#: lib/tuist_web/live/account_settings_live.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Update username"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:204
+#: lib/tuist_web/live/account_settings_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Update your username?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:189
+#: lib/tuist_web/live/account_settings_live.html.heex:187
 #, elixir-autogen, elixir-format
 msgid "Updating your username can have unintended consequences."
 msgstr ""
@@ -884,8 +882,8 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.html.heex:226
-#: lib/tuist_web/live/account_settings_live.html.heex:298
+#: lib/tuist_web/live/account_settings_live.html.heex:224
+#: lib/tuist_web/live/account_settings_live.html.heex:296
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
@@ -968,57 +966,57 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:789
+#: lib/tuist_web/live/account_settings_live.ex:742
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:751
+#: lib/tuist_web/live/account_settings_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:758
+#: lib/tuist_web/live/account_settings_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:771
+#: lib/tuist_web/live/account_settings_live.ex:724
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:828
+#: lib/tuist_web/live/account_settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:835
+#: lib/tuist_web/live/account_settings_live.ex:788
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:855
+#: lib/tuist_web/live/account_settings_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:733
+#: lib/tuist_web/live/account_settings_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:737
+#: lib/tuist_web/live/account_settings_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:805
+#: lib/tuist_web/live/account_settings_live.ex:758
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:817
+#: lib/tuist_web/live/account_settings_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
@@ -1161,23 +1159,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:645
+#: lib/tuist_web/live/account_settings_live.ex:598
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:655
+#: lib/tuist_web/live/account_settings_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:652
+#: lib/tuist_web/live/account_settings_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:660
-#: lib/tuist_web/live/account_settings_live.ex:665
+#: lib/tuist_web/live/account_settings_live.ex:613
+#: lib/tuist_web/live/account_settings_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1378,64 +1376,54 @@ msgstr ""
 msgid "Revoke token"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:621
-#, elixir-autogen, elixir-format
-msgid "%{ready}/%{total} nodes ready"
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:598
+#: lib/tuist_web/live/account_settings_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:626
-#, elixir-autogen, elixir-format
-msgid "Could not query Kubernetes."
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:533
-#: lib/tuist_web/live/account_settings_live.ex:539
+#: lib/tuist_web/live/account_settings_live.ex:518
+#: lib/tuist_web/live/account_settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Deploy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:447
-#: lib/tuist_web/live/account_settings_live.ex:454
+#: lib/tuist_web/live/account_settings_live.ex:432
+#: lib/tuist_web/live/account_settings_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Deploy Kura server"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:438
+#: lib/tuist_web/live/account_settings_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Deploy regional Kura cache servers for this account. Each region can have at most one server."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:597
+#: lib/tuist_web/live/account_settings_live.ex:576
 #, elixir-autogen, elixir-format
 msgid "Deploying"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:384
+#: lib/tuist_web/live/account_settings_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Deploying Kura in %{region}..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:577
+#: lib/tuist_web/live/account_settings_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Destroy"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:583
+#: lib/tuist_web/live/account_settings_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Destroy the Kura server in %{region}? This removes the account's Kura cache endpoint for that region."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:601
+#: lib/tuist_web/live/account_settings_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "Destroyed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:600
+#: lib/tuist_web/live/account_settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Destroying"
 msgstr ""
@@ -1445,23 +1433,23 @@ msgstr ""
 msgid "Destroying Kura server..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:567
+#: lib/tuist_web/live/account_settings_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Domain"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:599
+#: lib/tuist_web/live/account_settings_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:394
-#: lib/tuist_web/live/account_settings_live.ex:403
+#: lib/tuist_web/live/account_settings_live.ex:380
+#: lib/tuist_web/live/account_settings_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Failed to deploy Kura: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:435
+#: lib/tuist_web/live/account_settings_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Kura cache servers"
 msgstr ""
@@ -1471,44 +1459,23 @@ msgstr ""
 msgid "Kura server not found."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:561
-#, elixir-autogen, elixir-format
-msgid "Machine"
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:502
+#: lib/tuist_web/live/account_settings_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "New servers start on Kura"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:616
-#, elixir-autogen, elixir-format
-msgid "Unavailable"
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:570
+#: lib/tuist_web/live/account_settings_live.ex:549
 #, elixir-autogen, elixir-format
 msgid "Version"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:635
-#, elixir-autogen, elixir-format
-msgid "Waiting for scheduling."
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:627
-#: lib/tuist_web/live/account_settings_live.ex:640
-#, elixir-autogen, elixir-format
-msgid "Waiting for the controller."
-msgstr ""
-
-#: lib/tuist_web/live/account_settings_live.ex:504
+#: lib/tuist_web/live/account_settings_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "(current deploy)."
 msgstr ""
 
 #: lib/tuist_web/live/account_settings_live.ex:252
-#: lib/tuist_web/live/account_settings_live.ex:497
+#: lib/tuist_web/live/account_settings_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "No Kura runtime image is configured right now. Try again after the next server deploy."
 msgstr ""

--- a/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
+++ b/server/test/tuist/kura/provisioner/kubernetes_controller_test.exs
@@ -199,42 +199,6 @@ defmodule Tuist.Kura.Provisioner.KubernetesControllerTest do
     end
   end
 
-  describe "parse_nodes/1" do
-    test "maps Kubernetes pod JSON to Kura node maps" do
-      json =
-        Jason.encode!(%{
-          "items" => [
-            %{
-              "metadata" => %{"name" => "kura-tuist-eu-central-1-0"},
-              "spec" => %{"nodeName" => "worker-1"},
-              "status" => %{
-                "phase" => "Running",
-                "podIP" => "10.42.0.12",
-                "hostIP" => "10.0.0.2",
-                "startTime" => "2026-05-06T10:00:00Z",
-                "conditions" => [
-                  %{"type" => "Ready", "status" => "True"}
-                ]
-              }
-            }
-          ]
-        })
-
-      assert {:ok,
-              [
-                %{
-                  name: "kura-tuist-eu-central-1-0",
-                  node_name: "worker-1",
-                  pod_ip: "10.42.0.12",
-                  host_ip: "10.0.0.2",
-                  phase: "Running",
-                  ready: true,
-                  started_at: "2026-05-06T10:00:00Z"
-                }
-              ]} = KubernetesController.parse_nodes(json)
-    end
-  end
-
   defp eu_region do
     %Regions{
       id: "eu-central",

--- a/server/test/tuist/kura_test.exs
+++ b/server/test/tuist/kura_test.exs
@@ -7,7 +7,6 @@ defmodule Tuist.KuraTest do
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Kura
   alias Tuist.Kura.Deployment
-  alias Tuist.Kura.Provisioner
   alias Tuist.Kura.Server
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
@@ -272,46 +271,6 @@ defmodule Tuist.KuraTest do
       ids = account.id |> Kura.list_servers_for_account() |> Enum.map(& &1.id)
       assert kept.id in ids
       refute gone.id in ids
-    end
-  end
-
-  describe "list_nodes_for_server/2" do
-    test "returns nodes through the server's provisioner scoped to the account" do
-      user = AccountsFixtures.user_fixture()
-      account = Accounts.get_account_from_user(user)
-
-      {:ok, server} =
-        Kura.create_server(%{
-          account_id: account.id,
-          region: "local-controller",
-          image_tag: "0.5.2"
-        })
-
-      expect(Provisioner, :nodes, fn queried_server ->
-        assert queried_server.id == server.id
-        {:ok, [%{name: "kura-tuist-local-0", ready: true}]}
-      end)
-
-      assert {:ok, [%{name: "kura-tuist-local-0", ready: true}]} =
-               Kura.list_nodes_for_server(account.id, server.id)
-    end
-
-    test "does not query Kubernetes for a server outside the account" do
-      user = AccountsFixtures.user_fixture()
-      other_user = AccountsFixtures.user_fixture()
-      account = Accounts.get_account_from_user(user)
-      other_account = Accounts.get_account_from_user(other_user)
-
-      {:ok, server} =
-        Kura.create_server(%{
-          account_id: other_account.id,
-          region: "local-controller",
-          image_tag: "0.5.2"
-        })
-
-      reject(&Provisioner.nodes/1)
-
-      assert Kura.list_nodes_for_server(account.id, server.id) == {:error, :not_found}
     end
   end
 

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -99,7 +99,7 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     refute has_element?(lv, "#kura-servers-table")
   end
 
-  test "shows Kura server state, machine, domain, and version", %{conn: conn, account: account} do
+  test "shows Kura server state, domain, and version", %{conn: conn, account: account} do
     FunWithFlags.enable(:kura, for_actor: account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
 
@@ -112,17 +112,9 @@ defmodule TuistWeb.AccountSettingsLiveTest do
 
     {:ok, server} = Kura.activate_server(server, "0.5.2")
 
-    stub(Kura, :list_nodes_for_server, fn account_id, server_id ->
-      assert account_id == account.id
-      assert server_id == server.id
-      {:ok, [%{name: "kura-test-0", node_name: "kura-pool-1", ready: true}]}
-    end)
-
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
 
     assert html =~ "Active"
-    assert html =~ "1/1 nodes ready"
-    assert html =~ "kura-pool-1"
     assert html =~ server.url
     assert html =~ "0.5.2"
   end
@@ -130,8 +122,6 @@ defmodule TuistWeb.AccountSettingsLiveTest do
   test "deploys a Kura server from account settings", %{conn: conn, account: account} do
     FunWithFlags.enable(:kura, for_actor: account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
-    account_id = account.id
-    stub(Kura, :list_nodes_for_server, fn ^account_id, _server_id -> {:ok, []} end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")
 
@@ -147,8 +137,6 @@ defmodule TuistWeb.AccountSettingsLiveTest do
   test "deploys the only available Kura region when the portaled form omits inputs", %{conn: conn, account: account} do
     FunWithFlags.enable(:kura, for_actor: account)
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
-    account_id = account.id
-    stub(Kura, :list_nodes_for_server, fn ^account_id, _server_id -> {:ok, []} end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/settings")
 


### PR DESCRIPTION
The account settings page surfaced a "Machine" column on the Kura cache servers table that exposed pod readiness ("3/3 nodes ready") and internal Kubernetes node names. That's infra detail customers shouldn't see. The Status column already communicates the customer-facing state (Deploying / Active / Failed / Destroying / Destroyed).

This PR removes the column and the supporting code paths:

- `Kura.list_nodes_for_server/2`
- `Tuist.Kura.Provisioner.nodes/1` dispatcher and the `nodes/2` callback
- `Tuist.Kura.Provisioner.KubernetesController.nodes/2` plus the pod parsing helpers
- `Tuist.Kubernetes.Client.list_pods/3` (no other callers)
- The corresponding LiveView helpers, assigns, and tests
- `dashboard_account.pot` regenerated

### How to test locally

1. Boot the server with `mise run dev` and log in as an account with the `:kura` feature flag enabled.
2. Visit `/{account}/settings` and scroll to the Kura cache servers section.
3. Confirm the table only shows Region, Status, Domain, Version, and the Destroy button — no "Machine" column.
4. Run `mise exec -- mix test test/tuist_web/live/account_settings_live_test.exs test/tuist/kura_test.exs test/tuist/kura/provisioner/kubernetes_controller_test.exs` once the DB is set up locally.
