### PR TITLE
fix(server): allow tart kubelet to clear pod finalizers

### DIFF
--- a/infra/helm/tuist/templates/tart-kubelet-rbac.yaml
+++ b/infra/helm/tuist/templates/tart-kubelet-rbac.yaml
@@ -28,6 +28,12 @@ rules:
   - apiGroups: [""]
     resources: [pods, pods/status]
     verbs: [get, list, watch, update, patch]
+  # The pod agent adds a finalizer before starting the Tart VM and
+  # removes it only after VM teardown, so stale API Pods cannot
+  # disappear while their guest is still running on the Mac host.
+  - apiGroups: [""]
+    resources: [pods/finalizers]
+    verbs: [update, patch]
   # Resolve `valueFrom` / `envFrom` references in Pod env, exactly the
   # way a real kubelet does.
   - apiGroups: [""]


### PR DESCRIPTION
## Summary
- grant tart-kubelet access to the pods/finalizers subresource
- keep VM teardown cluster-owned: tart-kubelet removes its Pod finalizer only after deleting the Tart guest
- remove the pipeline-side stale Pod cleanup workaround from this follow-up

## Why
The stuck deployment is caused by old xcresult-processor Pods remaining in Terminating while still occupying Mac mini maxPods/hostPort capacity. Tart kubelet already owns a finalizer for this lifecycle, but its ClusterRole could update pods and pods/status, not pods/finalizers, so finalizer removal can be denied and Kubernetes never completes deletion.

## Verification
- git diff --check origin/main..HEAD
- helm template tuist infra/helm/tuist -n tuist -f infra/helm/tuist/values-managed-common.yaml -f infra/helm/tuist/values-managed-production.yaml --set server.image.tag=test --set kuraController.image.tag=test --set kuraRuntime.image.tag=test

Follow-up to #10710. Debugged from https://github.com/tuist/tuist/actions/runs/25659314606/job/75328082230