### PR TITLE
feat(server): show Deploying badge for Kura servers with an in-flight deployment

### DIFF
--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -538,8 +538,8 @@ defmodule TuistWeb.AccountSettingsLive do
           </:col>
           <:col :let={server} label={dgettext("dashboard_account", "Status")}>
             <.badge_cell
-              label={kura_server_status_label(server.status)}
-              color={kura_server_status_color(server.status)}
+              label={kura_display_status_label(server)}
+              color={kura_display_status_color(server)}
               style="light-fill"
             />
           </:col>
@@ -573,6 +573,18 @@ defmodule TuistWeb.AccountSettingsLive do
     """
   end
 
+  def kura_display_status_label(server) do
+    if show_deploying?(server),
+      do: dgettext("dashboard_account", "Deploying"),
+      else: kura_server_status_label(server.status)
+  end
+
+  def kura_display_status_color(server) do
+    if show_deploying?(server),
+      do: "information",
+      else: kura_server_status_color(server.status)
+  end
+
   def kura_server_status_label(:provisioning), do: dgettext("dashboard_account", "Deploying")
   def kura_server_status_label(:active), do: dgettext("dashboard_account", "Active")
   def kura_server_status_label(:failed), do: dgettext("dashboard_account", "Failed")
@@ -584,6 +596,14 @@ defmodule TuistWeb.AccountSettingsLive do
   def kura_server_status_color(:failed), do: "destructive"
   def kura_server_status_color(:destroying), do: "warning"
   def kura_server_status_color(:destroyed), do: "neutral"
+
+  defp show_deploying?(%{status: status}) when status in [:destroying, :destroyed], do: false
+
+  defp show_deploying?(%{deployments: deployments}) when is_list(deployments) do
+    Enum.any?(deployments, &(&1.status in [:pending, :running]))
+  end
+
+  defp show_deploying?(_), do: false
 
   defp kura_region_label(region_id) do
     case Regions.get(region_id) do

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -110,6 +110,10 @@ defmodule TuistWeb.AccountSettingsLiveTest do
         image_tag: "0.5.2"
       })
 
+    deployment = hd(server.deployments)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, _deployment} = Kura.mark_succeeded(deployment)
+
     {:ok, server} = Kura.activate_server(server, "0.5.2")
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
@@ -117,6 +121,30 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     assert html =~ "Active"
     assert html =~ server.url
     assert html =~ "0.5.2"
+  end
+
+  test "shows Deploying when an active Kura server has an in-flight deployment", %{conn: conn, account: account} do
+    FunWithFlags.enable(:kura, for_actor: account)
+    stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.3", released_at: DateTime.utc_now(:second)}] end)
+
+    {:ok, server} =
+      Kura.create_server(%{
+        account_id: account.id,
+        region: "local-controller",
+        image_tag: "0.5.2"
+      })
+
+    deployment = hd(server.deployments)
+    {:ok, deployment} = Kura.mark_running(deployment)
+    {:ok, _deployment} = Kura.mark_succeeded(deployment)
+
+    {:ok, server} = Kura.activate_server(server, "0.5.2")
+    {:ok, _deployment} = Kura.create_deployment(server, "0.5.3")
+
+    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/settings")
+
+    assert html =~ "Deploying"
+    refute html =~ ">Active<"
   end
 
   test "deploys a Kura server from account settings", %{conn: conn, account: account} do


### PR DESCRIPTION
## Summary
- Renders the "Deploying" status in the account settings Kura table whenever a server has a `:pending` or `:running` `kura_deployments` row, covering both initial installs and version bumps on already-active servers.
- The signal is derived from the deployments preloaded by `Kura.list_servers_for_account/1`, so no extra query and no Kubernetes call.
- Customers see that a deploy is in flight without any pod/node detail leaking into the UI.

Follow-up to #10713 — the merged refactor dropped the Machine column on purpose. This restores the deployment-in-progress signal at a product level instead of an infra level.

## Test plan
- [x] `mix test test/tuist_web/live/account_settings_live_test.exs`
- [x] Existing "shows Kura server state, domain, and version" test updated so the initial deployment is marked succeeded before asserting "Active".
- [x] New "shows Deploying when an active Kura server has an in-flight deployment" asserts the badge flips to "Deploying" when a version-bump deployment is queued on an active server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)