### PR TITLE
fix(cli): handle nested buildable folder xcstrings

### DIFF
--- a/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/cli/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -430,55 +430,42 @@ class ProjectFileElements {
         case let .group(name: groupName):
             group = try groups.projectGroup(named: groupName)
         }
-        guard let firstElement = addElement(
-            fileElement,
-            relativePath: closestRelativeRelativePath,
-            isLeaf: closestRelativeRelativePath == fileElementRelativeToSourceRoot,
-            from: sourceRootPath,
-            toGroup: group,
-            pbxproj: pbxproj
-        )
-        else {
-            return
+        let remainingRelativePaths = if closestRelativeAbsolutePath == fileElement.path {
+            [RelativePath]()
+        } else {
+            try fileElement.path.relative(to: closestRelativeAbsolutePath).components
+                .map { try RelativePath(validating: $0) }
         }
-
-        // If it matches the file that we are adding or it's not a group we can exit.
-        if closestRelativeAbsolutePath == fileElement.path {
-            return
-        }
-
-        if firstElement.element is PBXFileSystemSynchronizedRootGroup {
-            addFileElementRelativeToGroup(
-                from: sourceRootPath,
-                fileAbsolutePath: fileElement.path,
-                fileRelativePath: fileElementRelativeToSourceRoot,
-                name: fileElement.path.basename,
-                expectedSignature: expectedSignature,
-                toGroup: group,
-                pbxproj: pbxproj
-            )
-            return
-        }
-
-        if !(firstElement.element is PBXGroup) {
-            return
-        }
-
-        var lastGroup: PBXGroup! = firstElement.element as? PBXGroup
-        var lastPath: AbsolutePath = firstElement.path
-        let components = fileElement.path.relative(to: lastPath).components
-        for component in components.enumerated() {
+        let relativePaths = [closestRelativeRelativePath] + remainingRelativePaths
+        var lastGroup: PBXGroup! = group
+        var lastPath = sourceRootPath
+        for relativePath in relativePaths.enumerated() {
             if lastGroup == nil { return }
             guard let element = addElement(
                 fileElement,
-                relativePath: try RelativePath(validating: component.element),
+                relativePath: relativePath.element,
                 expectedSignature: expectedSignature,
-                isLeaf: component.offset == components.count - 1,
+                isLeaf: relativePath.offset == relativePaths.count - 1,
                 from: lastPath,
                 toGroup: lastGroup!,
                 pbxproj: pbxproj
             )
             else {
+                return
+            }
+            if element.path == fileElement.path {
+                return
+            }
+            if element.element is PBXFileSystemSynchronizedRootGroup {
+                addFileElementRelativeToGroup(
+                    from: lastPath,
+                    fileAbsolutePath: fileElement.path,
+                    fileRelativePath: fileElement.path.relative(to: lastPath),
+                    name: fileElement.path.basename,
+                    expectedSignature: expectedSignature,
+                    toGroup: lastGroup!,
+                    pbxproj: pbxproj
+                )
                 return
             }
             lastGroup = element.element as? PBXGroup

--- a/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -529,6 +529,54 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
+    func test_generateProjectFiles_whenExplicitResourceIsInsideNestedSynchronizedGroup() throws {
+        // Given
+        let xcstringsPath = try AbsolutePath(validating: "/project/Resources/MyModule/Localizable.xcstrings")
+        let target = Target.test(
+            name: "MyModule",
+            resources: .init([.file(path: xcstringsPath)]),
+            buildableFolders: []
+        )
+        let resourcesTarget = Target.test(
+            name: "MyModuleResources",
+            resources: .init([]),
+            buildableFolders: [
+                BuildableFolder(
+                    path: "/project/Resources/MyModule",
+                    exceptions: BuildableFolderExceptions(exceptions: []),
+                    resolvedFiles: [
+                        BuildableFolderFile(path: xcstringsPath, compilerFlags: nil),
+                    ]
+                ),
+            ]
+        )
+        let project = Project.test(
+            path: "/project",
+            sourceRootPath: "/project",
+            xcodeProjPath: "/project/Project.xcodeproj",
+            targets: [target, resourcesTarget]
+        )
+        let graph = Graph.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+
+        // When
+        try subject.generateProjectFiles(
+            project: project,
+            graphTraverser: graphTraverser,
+            groups: groups,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        XCTAssertNotNil(subject.file(path: xcstringsPath))
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren.sorted(), [
+            "Resources/Localizable.xcstrings",
+            "Resources/MyModule",
+        ])
+    }
+
     func test_generateProducts_stableOrder() throws {
         for _ in 0 ..< 5 {
             let pbxproj = PBXProj()


### PR DESCRIPTION
### What changed

Fix project file generation when an explicit resource is located inside a nested buildable folder synchronized group. This lets promoted `.xcstrings` resources resolve to a normal `PBXFileReference` even when the synchronized folder is nested, for example `Resources/MyModule`.

### Why

Static frameworks with buildable folders can promote `.xcstrings` to explicit resources on the original target while the generated resource bundle owns the synchronized folder. The top-level synchronized folder case already created a separate file reference for the explicit resource, but the nested case stopped traversal at the synchronized group and left the build phase without a file reference.

Fixes #10718.

### Validation

- `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -destination 'platform=macOS,arch=arm64' -only-testing TuistGeneratorTests/ProjectFileElementsTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" COMPILATION_CACHE_ENABLE_CACHING=NO`\n- `git diff --check`