### PR TITLE
fix(server): reap dead Postgres pool sockets via client-side TCP keepalive

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -42,10 +42,36 @@ if Enum.member?([:prod, :stag, :can], env) do
   parsed_url = URI.parse(database_url)
   [username, password] = String.split(parsed_url.userinfo, ":")
 
+  # `{:keepalive, true}` enables SO_KEEPALIVE but inherits the OS default
+  # `tcp_keepalive_time` (7200s on Linux), so the pool keeps handing out
+  # half-dead sockets long after a cloud-egress NAT drops the idle TCP
+  # connection — surfaced as `DBConnection.ConnectionError: ssl recv
+  # (idle): closed`, fired ~14k times from `Oban.Met.Reporter` after the
+  # Render→K8s migration added NAT hops on the Supabase egress path.
+  # Postgres-side `tcp_keepalives_idle: "60"` only helps when those
+  # probes actually reach the client across the new path; mirror the
+  # same 60s/15s/4-probe cadence on the client socket so dead idles
+  # get reaped within ~2 min, well under any cloud NAT timeout.
+  # Postgrex hands `socket_options` straight to `:gen_tcp` / `:ssl`,
+  # so the `{:raw, _, _, _}` 4-tuples work here (unlike Mint, whose
+  # `Keyword.merge/2` normalization rejects them — see commit d803ae28cd).
+  tcp_keepalive_raw_opts =
+    case :os.type() do
+      {:unix, :linux} ->
+        [
+          {:raw, 6, 4, <<60::native-32>>},
+          {:raw, 6, 5, <<15::native-32>>},
+          {:raw, 6, 6, <<4::native-32>>}
+        ]
+
+      _ ->
+        []
+    end
+
   socket_opts =
     if Tuist.Environment.use_ipv6?(secrets) in ~w(true 1),
-      do: [:inet6, {:keepalive, true}],
-      else: [{:keepalive, true}]
+      do: [:inet6, {:keepalive, true}] ++ tcp_keepalive_raw_opts,
+      else: [{:keepalive, true}] ++ tcp_keepalive_raw_opts
 
   # Picks the connection shape based on `TUIST_DATABASE_POOLED` (set by the
   # chart on processor pods, unset on server pods). Direct Postgres keeps


### PR DESCRIPTION
## Summary

- Adds raw TCP keepalive socket options (60s idle / 15s interval / 4 probes) to the Postgres `socket_options` so dead idle sockets get reaped within ~2 min, well under any cloud-egress NAT timeout.
- Without this, `{:keepalive, true}` alone inherits Linux's 7200s default `tcp_keepalive_time`; Postgres-side `tcp_keepalives_idle: "60"` only helps when those probes survive the K8s egress NAT path.
- Surfaces visibly as the canary [`TUIST-CC` issue](https://tuist.sentry.io/issues/TUIST-CC): `DBConnection.ConnectionError: ssl recv (idle): closed` fired ~14k times from `Oban.Met.Reporter.cache_queues/1` since the Render→K8s migration.

Postgrex forwards `socket_options` straight to `:gen_tcp.connect/4` (`deps/postgrex/lib/postgrex/protocol.ex:727`), so the `{:raw, _, _, _}` 4-tuples work here — unlike with Mint, whose `Keyword.merge/2` normalization rejected the same tuples and forced the revert in d803ae28cd.

## Test plan

- [ ] Canary deploy ships, watch [`TUIST-CC`](https://tuist.sentry.io/issues/TUIST-CC) event volume drop to ~0 over the next 24h.
- [ ] Confirm Postgres pool checkout latency and Oban.Met Grafana panels stay flat post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)