### PR TITLE
fix(server): bound ClickHouse memory for rolling-window flaky-tests MV backfill

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -318,6 +318,57 @@ jobs:
               echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."
               ;;
           esac
+      - name: Unstick kura namespace if Terminating
+        # The chart owns the `kura` namespace. If someone deleted it
+        # manually (or `helm uninstall` was attempted) while a
+        # KuraInstance CR was still present, the namespace gets pinned in
+        # Terminating because the Go controller's pod was torn down
+        # before it could drop its own finalizer
+        # (`kurainstances.kura.tuist.dev/finalizer`). Helm then fails the
+        # next N upgrades with `unable to create new content in namespace
+        # kura because it is being terminated`. Detect that state and
+        # clear the finalizer so the namespace can finish; the Tuist
+        # server's Kura reconciler will re-apply the CR from the
+        # kura_servers row in Postgres on its next tick, and the
+        # reborn controller will adopt the still-running regional
+        # StatefulSet.
+        run: |
+          set -euo pipefail
+
+          deletion_ts="$(
+            kubectl get ns kura -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true
+          )"
+
+          if [ -z "$deletion_ts" ]; then
+            echo "kura namespace not Terminating; nothing to unstick."
+            exit 0
+          fi
+
+          echo "kura namespace has deletionTimestamp=$deletion_ts; clearing KuraInstance finalizers."
+          kubectl -n kura get kurainstances.kura.tuist.dev \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
+            while read -r name; do
+              [ -z "$name" ] && continue
+              echo "Clearing finalizers on kurainstance/$name"
+              kubectl -n kura patch kurainstance "$name" \
+                --type=merge -p '{"metadata":{"finalizers":[]}}' || true
+            done
+
+          # Helm's atomic upgrade fails fast on a Terminating namespace,
+          # so wait for the apiserver to garbage-collect it before
+          # handing control back. 2 min is well over the typical few
+          # seconds it takes once finalizers are clear.
+          for _ in $(seq 1 24); do
+            if ! kubectl get ns kura >/dev/null 2>&1; then
+              echo "kura namespace fully terminated."
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "kura namespace still present after 2m; aborting so the next deploy can retry." >&2
+          kubectl get ns kura -o yaml >&2 || true
+          exit 1
       - name: Clean up stale migration Jobs
         # The chart's pre-upgrade migration hook is named
         # `tuist-tuist-server-migrate` (stable across revisions). Any

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -318,57 +318,6 @@ jobs:
               echo "Release $HELM_RELEASE_NAME status is ${status:-not-installed}; no recovery needed."
               ;;
           esac
-      - name: Unstick kura namespace if Terminating
-        # The chart owns the `kura` namespace. If someone deleted it
-        # manually (or `helm uninstall` was attempted) while a
-        # KuraInstance CR was still present, the namespace gets pinned in
-        # Terminating because the Go controller's pod was torn down
-        # before it could drop its own finalizer
-        # (`kurainstances.kura.tuist.dev/finalizer`). Helm then fails the
-        # next N upgrades with `unable to create new content in namespace
-        # kura because it is being terminated`. Detect that state and
-        # clear the finalizer so the namespace can finish; the Tuist
-        # server's Kura reconciler will re-apply the CR from the
-        # kura_servers row in Postgres on its next tick, and the
-        # reborn controller will adopt the still-running regional
-        # StatefulSet.
-        run: |
-          set -euo pipefail
-
-          deletion_ts="$(
-            kubectl get ns kura -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true
-          )"
-
-          if [ -z "$deletion_ts" ]; then
-            echo "kura namespace not Terminating; nothing to unstick."
-            exit 0
-          fi
-
-          echo "kura namespace has deletionTimestamp=$deletion_ts; clearing KuraInstance finalizers."
-          kubectl -n kura get kurainstances.kura.tuist.dev \
-            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
-            while read -r name; do
-              [ -z "$name" ] && continue
-              echo "Clearing finalizers on kurainstance/$name"
-              kubectl -n kura patch kurainstance "$name" \
-                --type=merge -p '{"metadata":{"finalizers":[]}}' || true
-            done
-
-          # Helm's atomic upgrade fails fast on a Terminating namespace,
-          # so wait for the apiserver to garbage-collect it before
-          # handing control back. 2 min is well over the typical few
-          # seconds it takes once finalizers are clear.
-          for _ in $(seq 1 24); do
-            if ! kubectl get ns kura >/dev/null 2>&1; then
-              echo "kura namespace fully terminated."
-              exit 0
-            fi
-            sleep 5
-          done
-
-          echo "kura namespace still present after 2m; aborting so the next deploy can retry." >&2
-          kubectl get ns kura -o yaml >&2 || true
-          exit 1
       - name: Clean up stale migration Jobs
         # The chart's pre-upgrade migration hook is named
         # `tuist-tuist-server-migrate` (stable across revisions). Any

--- a/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
+++ b/server/priv/ingest_repo/migrations/20260508130000_create_test_case_runs_recent_per_case_mv.exs
@@ -95,6 +95,18 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
         # group, so `groupArrayLast(N)` captures the actual last N runs by
         # `ran_at`. Without the setting the aggregation is parallelised and
         # per-group order is undefined.
+        #
+        # `max_bytes_before_external_group_by` caps the in-memory hash
+        # table for the GROUP BY and spills the rest to disk. Production's
+        # `test_case_runs` has hundreds of millions of rows per monthly
+        # partition; the `groupArrayLast(1000)` state per group is up to
+        # ~9 KB, and the aggregator builds per-thread states that
+        # collectively pushed total ClickHouse process memory past its
+        # 18 GiB OvercommitTracker ceiling without the spill threshold.
+        # `max_threads = 4` is the matching half: fewer parallel
+        # aggregators means fewer concurrent partial-state hash tables,
+        # which keeps the worst-case memory bounded even on the largest
+        # partitions.
         IngestRepo.query!(
           """
           INSERT INTO test_case_runs_recent_per_case
@@ -105,7 +117,10 @@ defmodule Tuist.IngestRepo.Migrations.CreateTestCaseRunsRecentPerCaseMv do
           FROM test_case_runs
           WHERE toYYYYMM(inserted_at) = {partition:UInt32} AND test_case_id IS NOT NULL
           GROUP BY project_id, test_case_id
-          SETTINGS optimize_aggregation_in_order = 1
+          SETTINGS
+            optimize_aggregation_in_order = 1,
+            max_threads = 4,
+            max_bytes_before_external_group_by = 6000000000
           """,
           %{partition: String.to_integer(partition)},
           timeout: 1_200_000


### PR DESCRIPTION
## Summary

The flaky-tests rolling-window MV migration (`20260508130000_create_test_case_runs_recent_per_case_mv.exs`, added in #10674) OOM'd ClickHouse on the production pre-upgrade migration hook and blocked the deploy of [run 25680357022](https://github.com/tuist/tuist/actions/runs/25680357022):

```
Code: 241. DB::Exception: (total) memory limit exceeded:
would use 18.06 GiB (attempt to allocate chunk of 127.89 MiB),
current RSS: 17.94 GiB, maximum: 18.00 GiB.
OvercommitTracker decision: Query was selected to stop ...
While executing AggregatingInOrderTransform. (MEMORY_LIMIT_EXCEEDED)
```

The per-partition backfill builds a `groupArrayLast(1000)` state per `(project_id, test_case_id)` over each monthly partition of `test_case_runs`. Production's partitions are 200M+ rows; per-thread aggregator hash tables collectively push ClickHouse past its 18 GiB ceiling. Canary passed because canary's `test_case_runs` is small.

Two `SETTINGS` additions to the per-partition backfill INSERT:

- `max_bytes_before_external_group_by = 6 GB` — spills the GROUP BY hash table to disk before the OvercommitTracker kills the query.
- `max_threads = 4` — fewer parallel aggregators means fewer concurrent partial-state hash tables.

Production never recorded this migration as completed, so the rerun starts fresh; AggregatingMergeTree merges in `groupArrayLastState` will combine any partial rows the OOM'd attempt left behind.

## Test plan

- [ ] CI passes on this branch
- [ ] Production deploy succeeds and the migration completes without OOM
- [ ] `test_case_runs_recent_per_case` ends up with one state row per `(project_id, test_case_id)` after AggregatingMergeTree merge
- [ ] Rolling-window flaky-tests query returns expected last-N runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)