### PR TITLE
fix(cli): avoid invalidating shared URLSession on no-op HTTPSettings writes

### DIFF
--- a/cli/Sources/TuistHTTP/HTTPSettings.swift
+++ b/cli/Sources/TuistHTTP/HTTPSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct HTTPSettings: Sendable {
+public struct HTTPSettings: Equatable, Sendable {
     public var useEnvironmentProxy: Bool
 
     private static let lock = NSLock()
@@ -18,9 +18,12 @@ public struct HTTPSettings: Sendable {
         }
         set {
             lock.lock()
+            let didChange = storedCurrent != newValue
             storedCurrent = newValue
             lock.unlock()
-            invalidateSharedTuistURLSession()
+            if didChange {
+                invalidateSharedTuistURLSession()
+            }
         }
     }
 }

--- a/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
+++ b/cli/Tests/TuistHTTPTests/URLSessionTuistTests.swift
@@ -101,5 +101,22 @@
                     == "proxy.tuist.dev"
             )
         }
+
+        @Test(.withMockedEnvironment())
+        func tuistShared_preserves_the_shared_session_when_runtime_settings_are_rewritten_with_the_same_value() async throws {
+            let environment = try #require(Environment.mocked)
+            environment.variables["HTTPS_PROXY"] = "http://proxy.tuist.dev:8080"
+
+            let previousSettings = HTTPSettings.current
+            defer { HTTPSettings.current = previousSettings }
+
+            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            let firstSession = URLSession.tuistShared
+
+            HTTPSettings.current = .init(useEnvironmentProxy: true)
+            let secondSession = URLSession.tuistShared
+
+            #expect(firstSession === secondSession)
+        }
     }
 #endif


### PR DESCRIPTION
### Summary

`tuist generate --binary-cache` crashes mid-fetch with:

```
*** Terminating app due to uncaught exception 'NSGenericException',
    reason: 'Task created in a session that has been invalidated'
```

…when the user is on `TUIST_LEGACY_MODULE_CACHE=true`. Customer report shows the crash inside the cache-fetch path (`CacheRemoteStorage.fetchItems` → `CacheRemoteStorageDownloader.download` → `URLSession.download(for:)`).

### Root cause

`HTTPSettings.current` setter unconditionally calls `invalidateSharedTuistURLSession()`, even when the new value equals the old one. `ConfigLoader.applyRuntimeSettings` writes `HTTPSettings.current = .init(useEnvironmentProxy: config.network.proxy)` on every `loadConfig` call, which fires repeatedly during `tuist generate` (`TuistCommand`, `GenerateService`, `ManifestGraphLoader.loadPlugins`, `Generator.lint`, `Generator.postGenerationActions`). Each spurious invalidation tears down the shared `URLSession`.

`CacheRemoteStorageDownloader` was the only consumer that captured `URLSession.tuistShared` eagerly at init (every other service — `MultipartUploadArtifactService`, `FileClient`, `TuistURLSessionTransport`, … — resolves it lazily). Once its captured session got invalidated, the next `download(for:)` crashed with the NSException above.

Was introduced by #10513 (the re-add of config-driven network proxy opt-out). `SharedTuistURLSession.resolve` already handles legitimate proxy-mode transitions, so the explicit invalidation from the setter is redundant for value changes too — it's only harmful when nothing changed.

### Changes

- **`HTTPSettings`** — make `Equatable`; only invalidate the shared `URLSession` when the new value actually differs from the stored one.
- **Companion PR in `TuistCacheEE`**: tuist/TuistCacheEE#60 — switch `CacheRemoteStorageDownloader` to lazy `.tuistShared` resolution, matching every other service. Submodule pointer is bumped here.

### How to test locally

- `swift test --replace-scm-with-registry --filter URLSessionTuistTests` — 7 tests pass, including the new regression test `tuistShared_preserves_the_shared_session_when_runtime_settings_are_rewritten_with_the_same_value`. Confirmed the new test fails without the `HTTPSettings` fix (`firstSession !== secondSession`) and passes with it.
- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO ...` with `TUIST_EE=true` succeeds, including the `TuistCacheEE` framework target with the companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)