### PR TITLE
fix(ci): mask SLACK_WEBHOOK_URL in notify workflows

### DIFF
--- a/.github/workflows/notify-deploy-success.yml
+++ b/.github/workflows/notify-deploy-success.yml
@@ -24,7 +24,9 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
-          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+          SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')
+          echo "::add-mask::$SLACK_WEBHOOK_URL"
+          echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> $GITHUB_ENV
       - name: Build Slack payload
         env:
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -39,7 +39,9 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.CACHE_OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
-          echo "SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')" >> $GITHUB_ENV
+          SLACK_WEBHOOK_URL=$(op read 'op://cache/SLACK_WEBHOOK_URL/password')
+          echo "::add-mask::$SLACK_WEBHOOK_URL"
+          echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> $GITHUB_ENV
       - name: Build Slack payload
         env:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}


### PR DESCRIPTION
## Summary

- Register `SLACK_WEBHOOK_URL` with `::add-mask::` immediately after loading it from 1Password in `notify-failure.yml` and `notify-deploy-success.yml`, so it is redacted from workflow run logs.
- GitHub Actions only auto-masks values that flow through `${{ secrets.X }}`. A value sourced from `op read` and written into `$GITHUB_ENV` is not masked, so the URL was being printed in plaintext in two places on every run: the env group GHA prints at the start of each subsequent step, and the `with:` echo of `slackapi/slack-github-action@v2`. Since this repo is public, those logs are world-readable.
- The webhook itself has been rotated separately, so the URL exposed in past run logs is no longer valid.

## Test plan

- [ ] After merge, trigger a run of `notify-failure.yml` (e.g. by letting a flaky workflow fail on `main`) or `notify-deploy-success.yml` (next production deploy) and confirm `SLACK_WEBHOOK_URL` and `webhook` appear as `***` in the run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)