### PR TITLE
fix(cli): coordinate SwiftPM graph reads

### DIFF
--- a/cli/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
+++ b/cli/Sources/TuistCore/Graph/ModelExtensions/Project+Core.swift
@@ -42,13 +42,15 @@ extension Project {
     }
 
     public func derivedDirectoryPath(for target: Target) -> AbsolutePath {
+        let resolvedSwiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
+            containingCheckout: path,
+            knownScratchDirectory: swiftPackageManagerScratchDirectory
+        )
         if case .external = type,
-           path.pathString
-           .contains("\(Constants.SwiftPackageManager.packageBuildDirectoryName)/checkouts")
+           let resolvedSwiftPackageManagerScratchDirectory,
+           SwiftPackageManagerPaths.isPath(path, inCheckoutsOf: resolvedSwiftPackageManagerScratchDirectory)
         {
-            return path
-                // Leads to SPM's .build directory
-                .parentDirectory.parentDirectory
+            return resolvedSwiftPackageManagerScratchDirectory
                 .appending(
                     components: [
                         Constants.DerivedDirectory.dependenciesDerivedDirectory,

--- a/cli/Sources/TuistDependencies/AGENTS.md
+++ b/cli/Sources/TuistDependencies/AGENTS.md
@@ -3,12 +3,12 @@
 This module manages external dependencies (e.g., Swift packages) used by Tuist projects.
 
 ## Responsibilities
-- Apply workspace/project mapping for external dependencies (e.g., rewriting paths under `.build/checkouts`).
+- Apply workspace/project mapping for external dependencies (e.g., rewriting paths under SwiftPM scratch-directory checkouts).
 - Ensure external project settings (like `SRCROOT`) are consistent for generated projects.
 
 ## Related Context
 - Project generation: `cli/Sources/TuistGenerator/AGENTS.md`
 
 ## Invariants
-- External projects under SwiftPM checkouts are remapped into derived dependencies directories.
-- Local packages outside `.build/checkouts` are not remapped.
+- External projects under SwiftPM scratch-directory checkouts are remapped into derived dependencies directories.
+- Local packages outside SwiftPM scratch-directory checkouts are not remapped.

--- a/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -20,12 +20,17 @@ public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
     // MARK: - Helpers
 
     private func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        let swiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
+            containingCheckout: project.path,
+            knownScratchDirectory: project.swiftPackageManagerScratchDirectory
+        )
         guard case .external = project.type,
-              project.path.parentDirectory.basename == "checkouts"
+              let swiftPackageManagerScratchDirectory,
+              SwiftPackageManagerPaths.isPath(project.path, inCheckoutsOf: swiftPackageManagerScratchDirectory)
         else { return (project, []) }
         var project = project
         let xcodeProjBasename = project.xcodeProjPath.basename
-        let derivedDirectory = project.path.parentDirectory.parentDirectory.appending(
+        let derivedDirectory = swiftPackageManagerScratchDirectory.appending(
             components: [
                 Constants.DerivedDirectory.dependenciesDerivedDirectory,
                 Constants.DerivedDirectory.dependenciesProjectDirectory,

--- a/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Sources/TuistDependencies/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -21,8 +21,7 @@ public struct ExternalDependencyPathWorkspaceMapper: WorkspaceMapping {
 
     private func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
         guard case .external = project.type,
-              // We don't want to update local packages (which are defined outside the `checkouts` directory in `.build`
-              project.path.parentDirectory.parentDirectory.basename == Constants.SwiftPackageManager.packageBuildDirectoryName
+              project.path.parentDirectory.basename == "checkouts"
         else { return (project, []) }
         var project = project
         let xcodeProjBasename = project.xcodeProjPath.basename

--- a/cli/Sources/TuistKit/Services/InstallService.swift
+++ b/cli/Sources/TuistKit/Services/InstallService.swift
@@ -17,6 +17,7 @@ struct InstallService {
     private let pluginService: PluginServicing
     private let configLoader: ConfigLoading
     private let swiftPackageManagerController: SwiftPackageManagerControlling
+    private let swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator
     private let manifestFilesLocator: ManifestFilesLocating
     private let fileSystem: FileSysteming
 
@@ -24,12 +25,15 @@ struct InstallService {
         pluginService: PluginServicing = PluginService(),
         configLoader: ConfigLoading = ConfigLoader(),
         swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(),
+        swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator =
+            SwiftPackageManagerScratchDirectoryLocator(),
         fileSystem: FileSysteming = FileSystem(),
         manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator()
     ) {
         self.pluginService = pluginService
         self.configLoader = configLoader
         self.swiftPackageManagerController = swiftPackageManagerController
+        self.swiftPackageManagerScratchDirectoryLocator = swiftPackageManagerScratchDirectoryLocator
         self.fileSystem = fileSystem
         self.manifestFilesLocator = manifestFilesLocator
     }
@@ -71,6 +75,10 @@ struct InstallService {
         let config = try await configLoader.loadConfig(path: path)
 
         let mergedArguments = arguments(config: config, passthroughArguments: passthroughArguments)
+        let scratchDirectory = try await swiftPackageManagerScratchDirectory(
+            packagePath: packageManifestPath.parentDirectory,
+            arguments: mergedArguments
+        )
 
         if update {
             Logger.current.notice("Updating dependencies.", metadata: .section)
@@ -90,21 +98,38 @@ struct InstallService {
             )
         }
 
-        try await savePackageResolved(at: packageManifestPath.parentDirectory)
+        try await savePackageResolved(
+            at: packageManifestPath.parentDirectory,
+            scratchDirectory: scratchDirectory
+        )
     }
 
     private func arguments(config: Tuist, passthroughArguments: [String]) -> [String] {
         let configArguments = config.project.generatedProject?.installOptions.passthroughSwiftPackageManagerArguments ?? []
-        // Passthrough arguments come last so they override config arguments (last flag wins)
+        // Passthrough arguments come last so duplicate SwiftPM options can be overridden by the command line.
         return configArguments + passthroughArguments
     }
 
-    private func savePackageResolved(at path: AbsolutePath) async throws {
+    private func swiftPackageManagerScratchDirectory(
+        packagePath: AbsolutePath,
+        arguments: [String]
+    ) async throws -> AbsolutePath {
+        try swiftPackageManagerScratchDirectoryLocator.locate(
+            packagePath: packagePath,
+            arguments: arguments,
+            environment: Environment.current.variables,
+            workingDirectory: try await Environment.current.currentWorkingDirectory()
+        )
+    }
+
+    private func savePackageResolved(
+        at path: AbsolutePath,
+        scratchDirectory: AbsolutePath
+    ) async throws {
         let sourcePath = path.appending(component: Constants.SwiftPackageManager.packageResolvedName)
         guard try await fileSystem.exists(sourcePath) else { return }
 
-        let destinationPath = path.appending(components: [
-            Constants.SwiftPackageManager.packageBuildDirectoryName,
+        let destinationPath = scratchDirectory.appending(components: [
             Constants.DerivedDirectory.name,
             Constants.SwiftPackageManager.packageResolvedName,
         ])

--- a/cli/Sources/TuistKit/Utils/AnalyticsStateController.swift
+++ b/cli/Sources/TuistKit/Utils/AnalyticsStateController.swift
@@ -43,6 +43,5 @@ public struct AnalyticsStateController {
         if try await fileSystem.exists(keyValueDirectory) {
             try await fileSystem.remove(keyValueDirectory)
         }
-
     }
 }

--- a/cli/Sources/TuistKit/Utils/AnalyticsStateController.swift
+++ b/cli/Sources/TuistKit/Utils/AnalyticsStateController.swift
@@ -4,7 +4,7 @@ import Path
 import TuistCASAnalytics
 
 /// Cleans up stale analytics state entries from the CAS analytics database
-/// and the legacy file-based directories and `logs/` directory.
+/// and the legacy file-based directories.
 public struct AnalyticsStateController {
     private let fileSystem: FileSystem
     private let database: CASAnalyticsDatabasing
@@ -44,9 +44,5 @@ public struct AnalyticsStateController {
             try await fileSystem.remove(keyValueDirectory)
         }
 
-        let logsDirectory = stateDirectory.appending(component: "logs")
-        if try await fileSystem.exists(logsDirectory) {
-            try await fileSystem.remove(logsDirectory)
-        }
     }
 }

--- a/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -2,6 +2,7 @@ import Foundation
 import Mockable
 import Path
 import ProjectDescription
+import TuistConfig
 import TuistConfigLoader
 import TuistCore
 import TuistDependencies
@@ -107,14 +108,15 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
         let config = try await configLoader.loadConfig(path: path)
         let manifestEnvironment = config.project.generatedProject?.generationOptions.manifestEnvironment ?? []
         return try await Environment.$additionalManifestEnvironmentKeys.withValue(manifestEnvironment) {
-            try await loadInternal(path: path, disableSandbox: disableSandbox)
+            try await loadInternal(path: path, disableSandbox: disableSandbox, config: config)
         }
     }
 
     // swiftlint:disable:next function_body_length
     private func loadInternal(
         path: AbsolutePath,
-        disableSandbox: Bool
+        disableSandbox: Bool,
+        config: TuistConfig.Tuist
     ) async throws -> (Graph, [SideEffectDescriptor], MapperEnvironment, [LintingIssue]) { // swiftlint:disable:this large_tuple
         try await manifestLoader.validateHasRootManifest(at: path)
 
@@ -145,7 +147,9 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
             let (manifestsDependencyGraph, loadedSpmLintingIssues) = try await swiftPackageManagerGraphLoader.load(
                 packagePath: packagePath,
                 packageSettings: loadedPackageSettings,
-                disableSandbox: disableSandbox
+                disableSandbox: disableSandbox,
+                swiftPackageManagerArguments: config.project.generatedProject?.installOptions
+                    .passthroughSwiftPackageManagerArguments ?? []
             )
             spmLintingIssues = loadedSpmLintingIssues
             dependenciesGraph = try await converter.convert(dependenciesGraph: manifestsDependencyGraph, path: path)

--- a/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/cli/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -132,12 +132,19 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
 
         let dependenciesGraph: XcodeGraph.DependenciesGraph
         let packageSettings: TuistCore.PackageSettings?
+        let swiftPackageManagerScratchDirectory: AbsolutePath?
         var spmLintingIssues: [LintingIssue] = []
 
         // Load SPM graph only if is SPM Project only or the workspace is using external dependencies
         if let packagePath = try await manifestFilesLocator.locatePackageManifest(at: path),
            isSPMProjectOnly || hasExternalDependencies
         {
+            let swiftPackageManagerArguments = config.project.generatedProject?.installOptions
+                .passthroughSwiftPackageManagerArguments ?? []
+            swiftPackageManagerScratchDirectory = try await self.swiftPackageManagerScratchDirectory(
+                packagePath: packagePath.parentDirectory,
+                arguments: swiftPackageManagerArguments
+            )
             let loadedPackageSettings = try await packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins,
@@ -148,14 +155,14 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
                 packagePath: packagePath,
                 packageSettings: loadedPackageSettings,
                 disableSandbox: disableSandbox,
-                swiftPackageManagerArguments: config.project.generatedProject?.installOptions
-                    .passthroughSwiftPackageManagerArguments ?? []
+                swiftPackageManagerArguments: swiftPackageManagerArguments
             )
             spmLintingIssues = loadedSpmLintingIssues
             dependenciesGraph = try await converter.convert(dependenciesGraph: manifestsDependencyGraph, path: path)
             packageSettings = loadedPackageSettings
         } else {
             packageSettings = nil
+            swiftPackageManagerScratchDirectory = nil
             dependenciesGraph = .none
         }
 
@@ -164,12 +171,17 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
             allManifests = try await recursiveManifestLoader.loadAndMergePackageProjects(
                 in: allManifests,
                 packageSettings: packageSettings,
-                disableSandbox: disableSandbox
+                disableSandbox: disableSandbox,
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         }
 
         let (workspaceModels, manifestProjects) = (
-            try await converter.convert(manifest: allManifests.workspace, path: allManifests.path),
+            try await converter.convert(
+                manifest: allManifests.workspace,
+                path: allManifests.path,
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
+            ),
             allManifests.projects
         )
 
@@ -217,6 +229,18 @@ public struct ManifestGraphLoader: ManifestGraphLoading {
             modelMapperSideEffects + graphMapperSideEffects,
             environment,
             lintingIssues
+        )
+    }
+
+    private func swiftPackageManagerScratchDirectory(
+        packagePath: AbsolutePath,
+        arguments: [String]
+    ) async throws -> AbsolutePath {
+        try SwiftPackageManagerScratchDirectoryLocator().locate(
+            packagePath: packagePath,
+            arguments: arguments,
+            environment: Environment.current.variables,
+            workingDirectory: try await Environment.current.currentWorkingDirectory()
         )
     }
 

--- a/cli/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
+++ b/cli/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
@@ -12,6 +12,11 @@ import XcodeGraph
 public protocol ManifestModelConverting {
     func convert(manifest: ProjectDescription.Workspace, path: AbsolutePath) async throws -> XcodeGraph.Workspace
     func convert(
+        manifest: ProjectDescription.Workspace,
+        path: AbsolutePath,
+        swiftPackageManagerScratchDirectory: AbsolutePath?
+    ) async throws -> XcodeGraph.Workspace
+    func convert(
         manifest: ProjectDescription.Project,
         path: AbsolutePath,
         plugins: Plugins,
@@ -90,6 +95,14 @@ public struct ManifestModelConverter: ManifestModelConverting {
         manifest: ProjectDescription.Workspace,
         path: AbsolutePath
     ) async throws -> XcodeGraph.Workspace {
+        try await convert(manifest: manifest, path: path, swiftPackageManagerScratchDirectory: nil)
+    }
+
+    public func convert(
+        manifest: ProjectDescription.Workspace,
+        path: AbsolutePath,
+        swiftPackageManagerScratchDirectory: AbsolutePath?
+    ) async throws -> XcodeGraph.Workspace {
         let rootDirectory: AbsolutePath = try await rootDirectoryLocator.locate(from: path)
         let generatorPaths = GeneratorPaths(
             manifestDirectory: path,
@@ -100,7 +113,8 @@ public struct ManifestModelConverter: ManifestModelConverting {
             path: path,
             generatorPaths: generatorPaths,
             manifestLoader: manifestLoader,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
         )
         return workspace
     }
@@ -128,6 +142,8 @@ public struct ManifestModelConverter: ManifestModelConverting {
             uniqueKeysWithValues: dependenciesGraph.externalProjects
                 .concurrentMap { path, project in
                     let projectPath = try AbsolutePath(validating: path.pathString)
+                    let swiftPackageManagerScratchDirectory = try project.swiftPackageManagerScratchDirectory
+                        .map { try AbsolutePath(validating: $0.pathString) }
                     var project = try await convert(
                         manifest: project.manifest,
                         path: projectPath,
@@ -135,6 +151,7 @@ public struct ManifestModelConverter: ManifestModelConverting {
                         externalDependencies: externalDependencies,
                         type: .external(hash: project.hash)
                     )
+                    project.swiftPackageManagerScratchDirectory = swiftPackageManagerScratchDirectory
                     // Disable all lastUpgradeCheck related warnings on projects generated from dependencies
                     project.lastUpgradeCheck = Version(99, 9, 9)
                     return (projectPath, project)

--- a/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -28,7 +28,8 @@ public protocol RecursiveManifestLoading {
     func loadAndMergePackageProjects(
         in loadedWorkspace: LoadedWorkspace,
         packageSettings: TuistCore.PackageSettings,
-        disableSandbox: Bool
+        disableSandbox: Bool,
+        swiftPackageManagerScratchDirectory: AbsolutePath?
     ) async throws -> LoadedWorkspace
 }
 
@@ -108,7 +109,8 @@ public struct RecursiveManifestLoader: RecursiveManifestLoading {
     public func loadAndMergePackageProjects(
         in loadedWorkspace: LoadedWorkspace,
         packageSettings: TuistCore.PackageSettings,
-        disableSandbox: Bool
+        disableSandbox: Bool,
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
     ) async throws -> LoadedWorkspace {
         let rootDirectory: AbsolutePath = try await rootDirectoryLocator.locate(from: loadedWorkspace.path)
         let generatorPaths = GeneratorPaths(
@@ -125,8 +127,13 @@ public struct RecursiveManifestLoader: RecursiveManifestLoading {
             try await fileSystem.exists($0, isDirectory: true) && $0.basename != Constants.tuistDirectoryName
         }.concurrentFilter {
             let manifests = try await manifestLoader.manifests(at: $0)
-            return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace) && !$0
-                .pathString.contains("/checkouts/")
+            return manifests.contains(.package)
+                && !manifests.contains(.project)
+                && !manifests.contains(.workspace)
+                && !SwiftPackageManagerPaths.isPath(
+                    $0,
+                    inSwiftPackageManagerCheckoutsOf: swiftPackageManagerScratchDirectory
+                )
         }
 
         let packageProjects = try await loadPackageProjects(

--- a/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -126,7 +126,7 @@ public struct RecursiveManifestLoader: RecursiveManifestLoading {
         }.concurrentFilter {
             let manifests = try await manifestLoader.manifests(at: $0)
             return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace) && !$0
-                .pathString.contains(".build/checkouts")
+                .pathString.contains("/checkouts/")
         }
 
         let packageProjects = try await loadPackageProjects(

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -285,9 +285,17 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
             .reduce(into: [:]) { result, item in
                 let (packageInfo, hash, projectManifest) = item
                 if let projectManifest {
+                    let swiftPackageManagerScratchDirectory: Path? = if Self.isLocalDependencyKind(packageInfo.kind) {
+                        nil
+                    } else {
+                        SwiftPackageManagerPaths
+                            .scratchDirectory(containingCheckout: packageInfo.folder)
+                            .map { Path.path($0.pathString) }
+                    }
                     result[.path(packageInfo.folder.pathString)] = DependenciesGraph.ExternalProject(
                         manifest: projectManifest,
-                        hash: hash
+                        hash: hash,
+                        swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
                     )
                 }
             }

--- a/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -5,6 +5,7 @@ import ProjectDescription
 import TSCUtility
 import TuistConstants
 import TuistCore
+import TuistEnvironment
 import TuistLogging
 import TuistSupport
 import XcodeGraph
@@ -49,7 +50,8 @@ public protocol SwiftPackageManagerGraphLoading {
     func load(
         packagePath: AbsolutePath,
         packageSettings: TuistCore.PackageSettings,
-        disableSandbox: Bool
+        disableSandbox: Bool,
+        swiftPackageManagerArguments: [String]
     ) async throws -> (TuistLoader.DependenciesGraph, [LintingIssue])
 }
 
@@ -59,30 +61,56 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
     private let manifestLoader: ManifestLoading
     private let fileSystem: FileSysteming
     private let contentHasher: ContentHashing
+    private let swiftPackageManagerLock: SwiftPackageManagerLock
+    private let swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator
 
     public init(
         swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(),
         packageInfoMapper: PackageInfoMapping = PackageInfoMapper(),
         manifestLoader: ManifestLoading = ManifestLoader.current,
         fileSystem: FileSysteming = FileSystem(),
-        contentHasher: ContentHashing = ContentHasher()
+        contentHasher: ContentHashing = ContentHasher(),
+        swiftPackageManagerLock: SwiftPackageManagerLock = SwiftPackageManagerLock(),
+        swiftPackageManagerScratchDirectoryLocator: SwiftPackageManagerScratchDirectoryLocator =
+            SwiftPackageManagerScratchDirectoryLocator()
     ) {
         self.swiftPackageManagerController = swiftPackageManagerController
         self.packageInfoMapper = packageInfoMapper
         self.manifestLoader = manifestLoader
         self.fileSystem = fileSystem
         self.contentHasher = contentHasher
+        self.swiftPackageManagerLock = swiftPackageManagerLock
+        self.swiftPackageManagerScratchDirectoryLocator = swiftPackageManagerScratchDirectoryLocator
     }
 
     // swiftlint:disable:next function_body_length
     public func load(
         packagePath: AbsolutePath,
         packageSettings: TuistCore.PackageSettings,
-        disableSandbox: Bool
+        disableSandbox: Bool,
+        swiftPackageManagerArguments: [String] = []
     ) async throws -> (TuistLoader.DependenciesGraph, [LintingIssue]) {
-        let path = packagePath.parentDirectory.appending(
-            component: Constants.SwiftPackageManager.packageBuildDirectoryName
+        let scratchDirectory = try await swiftPackageManagerScratchDirectory(
+            packagePath: packagePath.parentDirectory,
+            arguments: swiftPackageManagerArguments
         )
+        return try await swiftPackageManagerLock.withLock(scratchDirectory: scratchDirectory) {
+            try await loadUnsafe(
+                packagePath: packagePath,
+                packageSettings: packageSettings,
+                disableSandbox: disableSandbox,
+                scratchDirectory: scratchDirectory
+            )
+        }
+    }
+
+    private func loadUnsafe(
+        packagePath: AbsolutePath,
+        packageSettings: TuistCore.PackageSettings,
+        disableSandbox: Bool,
+        scratchDirectory: AbsolutePath
+    ) async throws -> (TuistLoader.DependenciesGraph, [LintingIssue]) {
+        let path = scratchDirectory
         let checkoutsFolder = path.appending(component: "checkouts")
         let workspacePath = path.appending(component: "workspace-state.json")
 
@@ -93,7 +121,10 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         let workspaceState = try JSONDecoder()
             .decode(SwiftPackageManagerWorkspaceState.self, from: try await fileSystem.readFile(at: workspacePath))
 
-        let outdatedDependencyIssues = try await validatePackageResolved(at: packagePath.parentDirectory)
+        let outdatedDependencyIssues = try await validatePackageResolved(
+            at: packagePath.parentDirectory,
+            scratchDirectory: scratchDirectory
+        )
 
         let rootPackage = try await manifestLoader.loadPackage(at: packagePath.parentDirectory, disableSandbox: disableSandbox)
 
@@ -218,6 +249,7 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
 
         let externalDependencies = try await packageInfoMapper.resolveExternalDependencies(
             path: path,
+            packagePath: packagePath.parentDirectory,
             packageInfos: packageInfoDictionary,
             packageToFolder: packageToFolder,
             packageToTargetsToArtifactPaths: packageToTargetsToArtifactPaths,
@@ -366,9 +398,23 @@ public struct SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoading {
         }
     }
 
-    private func validatePackageResolved(at path: AbsolutePath) async throws -> [LintingIssue] {
-        let savedPackageResolvedPath = path.appending(components: [
-            Constants.SwiftPackageManager.packageBuildDirectoryName,
+    private func swiftPackageManagerScratchDirectory(
+        packagePath: AbsolutePath,
+        arguments: [String]
+    ) async throws -> AbsolutePath {
+        try swiftPackageManagerScratchDirectoryLocator.locate(
+            packagePath: packagePath,
+            arguments: arguments,
+            environment: Environment.current.variables,
+            workingDirectory: try await Environment.current.currentWorkingDirectory()
+        )
+    }
+
+    private func validatePackageResolved(
+        at path: AbsolutePath,
+        scratchDirectory: AbsolutePath
+    ) async throws -> [LintingIssue] {
+        let savedPackageResolvedPath = scratchDirectory.appending(components: [
             Constants.DerivedDirectory.name,
             Constants.SwiftPackageManager.packageResolvedName,
         ])

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
@@ -18,7 +18,8 @@ extension XcodeGraph.Workspace {
         path: AbsolutePath,
         generatorPaths: GeneratorPaths,
         manifestLoader _: ManifestLoading,
-        fileSystem: FileSysteming
+        fileSystem: FileSysteming,
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
     ) async throws -> XcodeGraph.Workspace {
         func globProjects(_ path: Path) async throws -> [AbsolutePath] {
             let resolvedPath = try generatorPaths.resolve(path: path)
@@ -31,7 +32,13 @@ extension XcodeGraph.Workspace {
             )
             .collect()
             .map(\.parentDirectory)
-            .filter { $0.basename != Constants.tuistDirectoryName && !$0.pathString.contains("/checkouts/") }
+            .filter {
+                $0.basename != Constants.tuistDirectoryName
+                    && !SwiftPackageManagerPaths.isPath(
+                        $0,
+                        inSwiftPackageManagerCheckoutsOf: swiftPackageManagerScratchDirectory
+                    )
+            }
             .uniqued()
 
             if projects.isEmpty {

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
@@ -31,7 +31,7 @@ extension XcodeGraph.Workspace {
             )
             .collect()
             .map(\.parentDirectory)
-            .filter { $0.basename != Constants.tuistDirectoryName && !$0.pathString.contains(".build/checkouts") }
+            .filter { $0.basename != Constants.tuistDirectoryName && !$0.pathString.contains("/checkouts/") }
             .uniqued()
 
             if projects.isEmpty {

--- a/cli/Sources/TuistLoader/Models/DependenciesGraph.swift
+++ b/cli/Sources/TuistLoader/Models/DependenciesGraph.swift
@@ -10,10 +10,16 @@ public struct DependenciesGraph: Equatable, Codable { // swiftlint:disable:this 
     public struct ExternalProject: Equatable, Codable {
         public var manifest: ProjectDescription.Project
         public var hash: String?
+        public var swiftPackageManagerScratchDirectory: Path?
 
-        public init(manifest: ProjectDescription.Project, hash: String?) {
+        public init(
+            manifest: ProjectDescription.Project,
+            hash: String?,
+            swiftPackageManagerScratchDirectory: Path? = nil
+        ) {
             self.manifest = manifest
             self.hash = hash
+            self.swiftPackageManagerScratchDirectory = swiftPackageManagerScratchDirectory
         }
     }
 

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -109,6 +109,7 @@ public protocol PackageInfoMapping {
     /// - Returns: Mapped project
     func resolveExternalDependencies(
         path: AbsolutePath,
+        packagePath: AbsolutePath?,
         packageInfos: [String: PackageInfo],
         packageToFolder: [String: AbsolutePath],
         packageToTargetsToArtifactPaths: [String: [String: AbsolutePath]],
@@ -159,6 +160,7 @@ public struct PackageInfoMapper: PackageInfoMapping {
     /// - Returns: Mapped project
     public func resolveExternalDependencies(
         path: AbsolutePath,
+        packagePath: AbsolutePath? = nil,
         packageInfos: [String: PackageInfo],
         packageToFolder: [String: AbsolutePath],
         packageToTargetsToArtifactPaths: [String: [String: AbsolutePath]],
@@ -233,9 +235,10 @@ public struct PackageInfoMapper: PackageInfoMapping {
                 }
             }
         // Include dependencies added as binary targets
+        let packageName = (packagePath ?? path.parentDirectory).basename.lowercased()
         let remoteXcframeworksPath = path.appending(components: [
             "artifacts",
-            path.removingLastComponent().url.lastPathComponent.lowercased(),
+            packageName,
         ])
         let remoteXcframeworks = try await fileSystem.glob(directory: remoteXcframeworksPath, include: ["**/*.xcframework"])
             .collect()
@@ -243,8 +246,9 @@ public struct PackageInfoMapper: PackageInfoMapping {
             .filter { $0.parentDirectory.basenameWithoutExt != "__MACOSX" }
         for xcframework in remoteXcframeworks {
             let dependencyName = xcframework.relative(to: remoteXcframeworksPath).basenameWithoutExt
+            let rootDirectory: AbsolutePath = try await rootDirectoryLocator.locate(from: packagePath ?? path)
             let xcframeworkPath = Path
-                .relativeToRoot(xcframework.relative(to: try await rootDirectoryLocator.locate(from: path)).pathString)
+                .relativeToRoot(xcframework.relative(to: rootDirectory).pathString)
             let signature = packageSettings.expectedSignatures[dependencyName]
                 .map(ProjectDescription.XCFrameworkSignature.from)
             externalDependencies[dependencyName] = [.xcframework(path: xcframeworkPath, expectedSignature: signature)]

--- a/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -98,6 +98,13 @@ public enum PackageType {
         }
         return false
     }
+
+    fileprivate var isRemoteExternal: Bool {
+        if case .external(origin: .remote, artifactPaths: _) = self {
+            return true
+        }
+        return false
+    }
 }
 
 // MARK: - PackageInfo Mapper
@@ -609,10 +616,16 @@ public struct PackageInfoMapper: PackageInfoMapping {
             let effectiveName = PackageInfoMapper.effectiveModuleName(
                 targetName: target.name, products: products, packageTargets: packageInfo.targets
             )
+            let swiftPackageManagerScratchDirectory: AbsolutePath? = if packageType.isRemoteExternal {
+                SwiftPackageManagerPaths.scratchDirectory(containingCheckout: path)
+            } else {
+                nil
+            }
             moduleMap = try await moduleMapGenerator.generate(
                 packageDirectory: path,
                 moduleName: effectiveName,
-                publicHeadersPath: target.publicHeadersPath(packageFolder: path)
+                publicHeadersPath: target.publicHeadersPath(packageFolder: path),
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         default:
             moduleMap = nil

--- a/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/cli/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -41,7 +41,8 @@ public protocol SwiftPackageManagerModuleMapGenerating {
     func generate(
         packageDirectory: AbsolutePath,
         moduleName: String,
-        publicHeadersPath: AbsolutePath
+        publicHeadersPath: AbsolutePath,
+        swiftPackageManagerScratchDirectory: AbsolutePath?
     ) async throws -> ModuleMap
 }
 
@@ -61,7 +62,8 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
     public func generate(
         packageDirectory: AbsolutePath,
         moduleName: String,
-        publicHeadersPath: AbsolutePath
+        publicHeadersPath: AbsolutePath,
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
     ) async throws -> ModuleMap {
         let sanitizedModuleName = moduleName.sanitizedModuleName
         let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
@@ -70,10 +72,14 @@ public struct SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerModuleMa
         let customModuleMapPath = try await customModuleMapPath(publicHeadersPath: publicHeadersPath)
         let generatedModuleMapPath: AbsolutePath
 
-        if publicHeadersPath.pathString.contains("\(Constants.SwiftPackageManager.packageBuildDirectoryName)/checkouts") {
-            generatedModuleMapPath = packageDirectory
-                .parentDirectory
-                .parentDirectory
+        let resolvedSwiftPackageManagerScratchDirectory = SwiftPackageManagerPaths.scratchDirectory(
+            containingCheckout: publicHeadersPath,
+            knownScratchDirectory: swiftPackageManagerScratchDirectory
+        )
+        if let resolvedSwiftPackageManagerScratchDirectory,
+           SwiftPackageManagerPaths.isPath(publicHeadersPath, inCheckoutsOf: resolvedSwiftPackageManagerScratchDirectory)
+        {
+            generatedModuleMapPath = resolvedSwiftPackageManagerScratchDirectory
                 .appending(
                     components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
                     Constants.DerivedDirectory.dependenciesModuleMapsDirectory,

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerLock.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerLock.swift
@@ -1,0 +1,22 @@
+import Path
+import TSCBasic
+import TuistLogging
+
+public struct SwiftPackageManagerLock: Sendable {
+    public init() {}
+
+    public func withLock<T>(
+        scratchDirectory: Path.AbsolutePath,
+        operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        let fileLock = try TSCBasic.FileLock.prepareLock(
+            fileToLock: try TSCBasic.AbsolutePath(validating: scratchDirectory.pathString)
+        )
+        Logger.current.debug("Waiting for Swift Package Manager lock at \(scratchDirectory.pathString)")
+
+        return try await fileLock.withLock(type: .exclusive) {
+            Logger.current.debug("Acquired Swift Package Manager lock at \(scratchDirectory.pathString)")
+            return try await operation()
+        }
+    }
+}

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerPaths.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerPaths.swift
@@ -1,0 +1,52 @@
+import Path
+
+public enum SwiftPackageManagerPaths {
+    public static let checkoutsDirectoryName = "checkouts"
+    public static let defaultScratchDirectoryName = ".build"
+
+    public static func checkoutsDirectory(in scratchDirectory: AbsolutePath) -> AbsolutePath {
+        scratchDirectory.appending(component: checkoutsDirectoryName)
+    }
+
+    public static func isPath(_ path: AbsolutePath, inCheckoutsOf scratchDirectory: AbsolutePath) -> Bool {
+        path.isDescendantOfOrEqual(to: checkoutsDirectory(in: scratchDirectory))
+    }
+
+    public static func isPath(
+        _ path: AbsolutePath,
+        inSwiftPackageManagerCheckoutsOf scratchDirectory: AbsolutePath?
+    ) -> Bool {
+        if let scratchDirectory {
+            return isPath(path, inCheckoutsOf: scratchDirectory)
+        }
+        return defaultScratchDirectory(containingCheckout: path) != nil
+    }
+
+    public static func scratchDirectory(containingCheckout path: AbsolutePath) -> AbsolutePath? {
+        var current = path
+        while current != .root {
+            if current.basename == checkoutsDirectoryName {
+                return current.parentDirectory
+            }
+            current = current.parentDirectory
+        }
+        return nil
+    }
+
+    public static func defaultScratchDirectory(containingCheckout path: AbsolutePath) -> AbsolutePath? {
+        guard let scratchDirectory = scratchDirectory(containingCheckout: path),
+              scratchDirectory.basename == defaultScratchDirectoryName
+        else { return nil }
+        return scratchDirectory
+    }
+
+    public static func scratchDirectory(
+        containingCheckout path: AbsolutePath,
+        knownScratchDirectory: AbsolutePath?
+    ) -> AbsolutePath? {
+        if let knownScratchDirectory, isPath(path, inCheckoutsOf: knownScratchDirectory) {
+            return knownScratchDirectory
+        }
+        return defaultScratchDirectory(containingCheckout: path)
+    }
+}

--- a/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerScratchDirectoryLocator.swift
+++ b/cli/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerScratchDirectoryLocator.swift
@@ -1,0 +1,41 @@
+import Path
+
+public struct SwiftPackageManagerScratchDirectoryLocator: Sendable {
+    public init() {}
+
+    public func locate(
+        packagePath: AbsolutePath,
+        arguments: [String],
+        environment: [String: String],
+        workingDirectory: AbsolutePath
+    ) throws -> AbsolutePath {
+        if let buildDirectory = environment["SWIFTPM_BUILD_DIR"], !buildDirectory.isEmpty {
+            return try AbsolutePath(validating: buildDirectory, relativeTo: workingDirectory)
+        }
+
+        if let scratchPath = argumentValue(named: "--scratch-path", in: arguments) {
+            return try AbsolutePath(validating: scratchPath, relativeTo: workingDirectory)
+        }
+
+        if let buildPath = argumentValue(named: "--build-path", in: arguments) {
+            return try AbsolutePath(validating: buildPath, relativeTo: workingDirectory)
+        }
+
+        return packagePath.appending(component: ".build")
+    }
+
+    private func argumentValue(named name: String, in arguments: [String]) -> String? {
+        var value: String?
+
+        for index in arguments.indices {
+            let argument = arguments[index]
+            if argument == name, arguments.indices.contains(index + 1) {
+                value = arguments[index + 1]
+            } else if argument.hasPrefix("\(name)=") {
+                value = String(argument.dropFirst(name.count + 1))
+            }
+        }
+
+        return value
+    }
+}

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Project.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/Project.swift
@@ -77,6 +77,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// It represents the type of project.
     public var type: ProjectType
 
+    /// SwiftPM scratch directory for external projects checked out by SwiftPM.
+    public var swiftPackageManagerScratchDirectory: AbsolutePath?
+
     // MARK: - Init
 
     /// Initializes the project with its attributes.
@@ -101,6 +104,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     ///   - resourceSynthesizers: `ResourceSynthesizers` that will be applied on individual target's resources
     ///   - lastUpgradeCheck: The version in which a check happened related to recommended settings after updating Xcode.
     ///   - type: The type of project, either local or external. This attribute supersedes `isExternal`
+    ///   - swiftPackageManagerScratchDirectory: SwiftPM scratch directory for external projects checked out by SwiftPM.
     public init(
         path: AbsolutePath,
         sourceRootPath: AbsolutePath,
@@ -120,7 +124,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
         additionalFiles: [FileElement],
         resourceSynthesizers: [ResourceSynthesizer],
         lastUpgradeCheck: Version?,
-        type: ProjectType
+        type: ProjectType,
+        swiftPackageManagerScratchDirectory: AbsolutePath? = nil
     ) {
         self.path = path
         self.sourceRootPath = sourceRootPath
@@ -141,6 +146,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
         self.resourceSynthesizers = resourceSynthesizers
         self.lastUpgradeCheck = lastUpgradeCheck
         self.type = type
+        self.swiftPackageManagerScratchDirectory = swiftPackageManagerScratchDirectory
     }
 
     // MARK: - CustomStringConvertible
@@ -191,7 +197,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             additionalFiles: [FileElement] = [],
             resourceSynthesizers: [ResourceSynthesizer] = [],
             lastUpgradeCheck: Version? = nil,
-            type: ProjectType = .local
+            type: ProjectType = .local,
+            swiftPackageManagerScratchDirectory: AbsolutePath? = nil
         ) -> Project {
             Project(
                 path: path,
@@ -212,7 +219,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
                 additionalFiles: additionalFiles,
                 resourceSynthesizers: resourceSynthesizers,
                 lastUpgradeCheck: lastUpgradeCheck,
-                type: type
+                type: type,
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         }
 
@@ -236,7 +244,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
             additionalFiles: [FileElement] = [],
             resourceSynthesizers: [ResourceSynthesizer] = [],
             lastUpgradeCheck: Version? = nil,
-            type: ProjectType = .external(hash: "project-hash")
+            type: ProjectType = .external(hash: "project-hash"),
+            swiftPackageManagerScratchDirectory: AbsolutePath? = nil
         ) -> Project {
             Project(
                 path: path,
@@ -257,7 +266,8 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
                 additionalFiles: additionalFiles,
                 resourceSynthesizers: resourceSynthesizers,
                 lastUpgradeCheck: lastUpgradeCheck,
-                type: type
+                type: type,
+                swiftPackageManagerScratchDirectory: swiftPackageManagerScratchDirectory
             )
         }
     #endif

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -137,4 +137,43 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
             )
         )
     }
+
+    func test_map_when_externalProjectUsesCustomScratchPath() throws {
+        // Given
+        let externalProjectBasePath = try temporaryPath().appending(component: "custom-build")
+        let externalProjectPath = externalProjectBasePath.appending(
+            components: [
+                "checkouts",
+                "ExternalDependency",
+            ]
+        )
+        let externalProject = Project.test(
+            path: externalProjectPath,
+            sourceRootPath: externalProjectPath,
+            xcodeProjPath: externalProjectPath.appending(component: "ExternalDependency.xcodeproj"),
+            name: "ExternalDependency",
+            type: .external(hash: nil)
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try subject.map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            externalProjectBasePath.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesProjectDirectory,
+                    "ExternalDependency",
+                    "ExternalDependency.xcodeproj",
+                ]
+            )
+        )
+    }
 }

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -93,7 +93,8 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
                             ),
                         ]
                     ),
-                    type: .external(hash: nil)
+                    type: .external(hash: nil),
+                    swiftPackageManagerScratchDirectory: externalProjectBasePath
                 ),
             ]
         )
@@ -153,7 +154,8 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
             sourceRootPath: externalProjectPath,
             xcodeProjPath: externalProjectPath.appending(component: "ExternalDependency.xcodeproj"),
             name: "ExternalDependency",
-            type: .external(hash: nil)
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: externalProjectBasePath
         )
 
         // When

--- a/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
+++ b/cli/Tests/TuistDependenciesTests/Mappers/ExternalDependencyPathWorkspaceMapper.swift
@@ -44,7 +44,8 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
             sourceRootPath: externalProjectPath,
             xcodeProjPath: externalProjectPath.appending(component: "ExternalDependency.xcodeproj"),
             name: "ExternalDependency",
-            type: .external(hash: nil)
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: externalProjectBasePath
         )
 
         let workspace = Workspace.test(
@@ -174,6 +175,34 @@ final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
                     "ExternalDependency.xcodeproj",
                 ]
             )
+        )
+    }
+
+    func test_map_when_externalProjectPathContainsUnrelatedCheckoutsDirectory() throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(components: "checkouts", "ExternalDependency")
+        let externalProject = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            xcodeProjPath: projectPath.appending(component: "ExternalDependency.xcodeproj"),
+            name: "ExternalDependency",
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: projectPath.parentDirectory.parentDirectory.appending(component: "custom-build")
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try subject.map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            projectPath.appending(component: "ExternalDependency.xcodeproj")
         )
     }
 }

--- a/cli/Tests/TuistKitTests/Mappers/ExternalDependencyPathWorkspaceMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/ExternalDependencyPathWorkspaceMapperTests.swift
@@ -1,0 +1,76 @@
+import TuistConstants
+import TuistCore
+import TuistDependencies
+import TuistTesting
+import XcodeGraph
+import XCTest
+
+final class ExternalDependencyPathWorkspaceMapperTests: TuistUnitTestCase {
+    func test_map_whenExternalProjectUsesCustomScratchPath() throws {
+        // Given
+        let scratchDirectory = try temporaryPath().appending(component: "custom-build")
+        let externalProjectPath = scratchDirectory.appending(
+            components: [
+                "checkouts",
+                "ExternalDependency",
+            ]
+        )
+        let externalProject = Project.test(
+            path: externalProjectPath,
+            sourceRootPath: externalProjectPath,
+            xcodeProjPath: externalProjectPath.appending(component: "ExternalDependency.xcodeproj"),
+            name: "ExternalDependency",
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try ExternalDependencyPathWorkspaceMapper().map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            scratchDirectory.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesProjectDirectory,
+                    "ExternalDependency",
+                    "ExternalDependency.xcodeproj",
+                ]
+            )
+        )
+    }
+
+    func test_map_whenExternalProjectPathContainsUnrelatedCheckoutsDirectory() throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(components: "checkouts", "ExternalDependency")
+        let externalProject = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            xcodeProjPath: projectPath.appending(component: "ExternalDependency.xcodeproj"),
+            name: "ExternalDependency",
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: projectPath.parentDirectory.parentDirectory.appending(component: "custom-build")
+        )
+
+        // When
+        let (gotWorkspaceWithProjects, _) = try ExternalDependencyPathWorkspaceMapper().map(
+            workspace: WorkspaceWithProjects(
+                workspace: .test(name: "A"),
+                projects: [externalProject]
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            gotWorkspaceWithProjects.projects.first?.xcodeProjPath,
+            projectPath.appending(component: "ExternalDependency.xcodeproj")
+        )
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/InstallServiceTests.swift
@@ -228,6 +228,60 @@ final class InstallServiceTests: TuistUnitTestCase {
         XCTAssertEqual(savedPackageResolvedContents, "resolved")
     }
 
+    func test_run_when_installing_dependencies_with_scratchPath_savesPackageResolvedInScratchDirectory() async throws {
+        // Given
+        let stubbedPath = try temporaryPath()
+        let scratchDirectory = try temporaryPath()
+        let expectedPackageResolvedPath = stubbedPath.appending(components: ["Tuist", "Package.resolved"])
+
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(stubbedPath.appending(components: "Tuist", "Package.swift"))
+        given(swiftPackageManagerController)
+            .resolve(at: .any, arguments: .any, printOutput: .any)
+            .willReturn()
+
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(
+                Tuist.test(project: .generated(.test()))
+            )
+
+        pluginService.fetchRemotePluginsStub = { _ in }
+
+        try await fileSystem.touch(
+            stubbedPath.appending(
+                component: Manifest.package.fileName(stubbedPath)
+            )
+        )
+
+        try await fileSystem.makeDirectory(at: expectedPackageResolvedPath.parentDirectory)
+        try await fileSystem.writeText("resolved", at: expectedPackageResolvedPath)
+
+        // When
+        try await subject.run(
+            path: stubbedPath.pathString,
+            update: false,
+            passthroughArguments: ["--scratch-path", scratchDirectory.pathString]
+        )
+
+        let savedPackageResolvedPath = scratchDirectory.appending(components: [
+            "Derived",
+            "Package.resolved",
+        ])
+        let savedPackageResolvedContents = try await fileSystem.readTextFile(at: savedPackageResolvedPath)
+
+        // Then
+        verify(swiftPackageManagerController)
+            .resolve(
+                at: .any,
+                arguments: .value(["--scratch-path", scratchDirectory.pathString]),
+                printOutput: .any
+            )
+            .called(1)
+        XCTAssertEqual(savedPackageResolvedContents, "resolved")
+    }
+
     func test_install_when_from_a_tuist_project_directory() async throws {
         // Given
         let temporaryDirectory = try temporaryPath()

--- a/cli/Tests/TuistKitTests/Utils/AnalyticsStateControllerTests.swift
+++ b/cli/Tests/TuistKitTests/Utils/AnalyticsStateControllerTests.swift
@@ -35,7 +35,7 @@ struct AnalyticsStateControllerTests {
     }
 
     @Test(.inTemporaryDirectory)
-    func clean_removesLegacyLogsDirectory() async throws {
+    func clean_preservesLegacyLogsDirectory() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
 
         let logsDirectory = temporaryDirectory.appending(component: "logs")
@@ -50,7 +50,8 @@ struct AnalyticsStateControllerTests {
             stateDirectory: temporaryDirectory
         )
 
-        #expect(try await !fileSystem.exists(logsDirectory))
+        #expect(try await fileSystem.exists(logsDirectory))
+        #expect(try await fileSystem.exists(logsDirectory.appending(component: "old-log.txt")))
     }
 
     @Test(.inTemporaryDirectory)

--- a/cli/Tests/TuistLoaderTests/Graph/ProjectCoreTests.swift
+++ b/cli/Tests/TuistLoaderTests/Graph/ProjectCoreTests.swift
@@ -1,0 +1,62 @@
+import TuistConstants
+import XcodeGraph
+import XCTest
+@testable import TuistCore
+@testable import TuistTesting
+
+final class ProjectCoreTests: TuistUnitTestCase {
+    func test_derivedDirectoryPath_whenExternalProjectUsesCustomSwiftPMScratchDirectory() throws {
+        // Given
+        let scratchDirectory = try temporaryPath()
+            .appending(component: "custom-build")
+        let projectPath = scratchDirectory.appending(components: "checkouts", "ExternalDependency")
+        let target = Target.test(name: "ExternalTarget")
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            xcodeProjPath: projectPath.appending(component: "ExternalDependency.xcodeproj"),
+            targets: [target],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // When
+        let got = project.derivedDirectoryPath(for: target)
+
+        // Then
+        XCTAssertEqual(
+            got,
+            scratchDirectory.appending(
+                components: [
+                    Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                    Constants.DerivedDirectory.dependenciesTargetDirectory,
+                    target.name,
+                ]
+            )
+        )
+    }
+
+    func test_derivedDirectoryPath_whenExternalProjectPathContainsUnrelatedCheckoutsDirectory() throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(components: "checkouts", "ExternalDependency")
+        let target = Target.test(name: "ExternalTarget")
+        let project = Project.test(
+            path: projectPath,
+            sourceRootPath: projectPath,
+            xcodeProjPath: projectPath.appending(component: "ExternalDependency.xcodeproj"),
+            targets: [target],
+            type: .external(hash: nil),
+            swiftPackageManagerScratchDirectory: projectPath.parentDirectory.parentDirectory.appending(component: "custom-build")
+        )
+
+        // When
+        let got = project.derivedDirectoryPath(for: target)
+
+        // Then
+        XCTAssertEqual(
+            got,
+            projectPath.appending(component: Constants.DerivedDirectory.name)
+        )
+    }
+}

--- a/cli/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -356,6 +356,40 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
+    func test_loadSPM_Package_ignoresPackagesInCustomSwiftPMCheckouts() async throws {
+        // Given
+        let packageA = createPackage(name: "PackageA")
+        let checkoutPackage = createPackage(name: "CheckoutPackage")
+        try await stub(manifest: packageA, at: try RelativePath(validating: "Some/Path/A"))
+        try await stub(
+            manifest: checkoutPackage,
+            at: try RelativePath(validating: "Some/Path/A/custom-build/checkouts/CheckoutPackage")
+        )
+        given(packageInfoMapper).map(
+            packageInfo: .value(packageA),
+            path: .any,
+            packageType: .any,
+            packageSettings: .any,
+            packageModuleAliases: .any,
+            enabledTraits: .any
+        )
+        .willReturn(
+            .test(name: "PackageA")
+        )
+
+        // When
+        var manifests = try await subject.loadWorkspace(
+            at: path.appending(try RelativePath(validating: "Some/Path/A")),
+            disableSandbox: false
+        )
+        manifests = try await subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test(), disableSandbox: false)
+
+        // Then
+        XCTAssertEqual(withRelativePaths(manifests.projects), [
+            "Some/Path/A": .test(name: "PackageA"),
+        ])
+    }
+
     // MARK: - Helpers
 
     private func createProject(

--- a/cli/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -348,7 +348,11 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
             at: path.appending(try RelativePath(validating: "Some/Path/A")),
             disableSandbox: false
         )
-        manifests = try await subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test(), disableSandbox: false)
+        manifests = try await subject.loadAndMergePackageProjects(
+            in: manifests,
+            packageSettings: .test(),
+            disableSandbox: false
+        )
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -382,11 +386,50 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
             at: path.appending(try RelativePath(validating: "Some/Path/A")),
             disableSandbox: false
         )
-        manifests = try await subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test(), disableSandbox: false)
+        manifests = try await subject.loadAndMergePackageProjects(
+            in: manifests,
+            packageSettings: .test(),
+            disableSandbox: false,
+            swiftPackageManagerScratchDirectory: path.appending(try RelativePath(validating: "Some/Path/A/custom-build"))
+        )
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
             "Some/Path/A": .test(name: "PackageA"),
+        ])
+    }
+
+    func test_loadSPM_Package_whenPathContainsCheckouts_doesNotFilterItOut() async throws {
+        // Given
+        let packageA = createPackage(name: "PackageA")
+        try await stub(manifest: packageA, at: try RelativePath(validating: "Some/checkouts/A"))
+        given(packageInfoMapper).map(
+            packageInfo: .value(packageA),
+            path: .any,
+            packageType: .any,
+            packageSettings: .any,
+            packageModuleAliases: .any,
+            enabledTraits: .any
+        )
+        .willReturn(
+            .test(name: "PackageA")
+        )
+
+        // When
+        var manifests = try await subject.loadWorkspace(
+            at: path.appending(try RelativePath(validating: "Some/checkouts/A")),
+            disableSandbox: false
+        )
+        manifests = try await subject.loadAndMergePackageProjects(
+            in: manifests,
+            packageSettings: .test(),
+            disableSandbox: false,
+            swiftPackageManagerScratchDirectory: path.appending(try RelativePath(validating: "Some/custom-build"))
+        )
+
+        // Then
+        XCTAssertEqual(withRelativePaths(manifests.projects), [
+            "Some/checkouts/A": .test(name: "PackageA"),
         ])
     }
 

--- a/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerGraphLoaderTests.swift
@@ -97,6 +97,7 @@ struct SwiftPackageManagerGraphLoaderTests {
                 given(packageInfoMapper)
                     .resolveExternalDependencies(
                         path: .any,
+                        packagePath: .any,
                         packageInfos: .any,
                         packageToFolder: .any,
                         packageToTargetsToArtifactPaths: .any,
@@ -123,6 +124,93 @@ struct SwiftPackageManagerGraphLoaderTests {
                 )
             }
         }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func load_when_scratchPathArgumentIsPresent_readsStateFromScratchDirectory() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let scratchDirectory = temporaryDirectory.appending(component: "custom-build")
+
+        // Given
+        let packageSettings = PackageSettings.test()
+
+        let workspacePath = scratchDirectory.appending(component: "workspace-state.json")
+        try await fileSystem.makeDirectory(at: workspacePath.parentDirectory)
+        try await fileSystem.writeText(
+            """
+            {
+              "object" : {
+                "artifacts" : [],
+                "dependencies" : [
+                  {
+                    "basedOn" : null,
+                    "packageRef" : {
+                      "identity" : "Alamofire.Alamofire",
+                      "kind" : "registry",
+                      "location" : "Alamofire.Alamofire",
+                      "name" : "Alamofire.Alamofire"
+                    },
+                    "state" : {
+                      "name" : "registryDownload",
+                      "version" : "5.10.2"
+                    },
+                    "subpath" : "Alamofire/Alamofire/5.10.2"
+                  }
+                ],
+              }
+            }
+            """,
+            at: workspacePath
+        )
+
+        try await fileSystem.makeDirectory(at: scratchDirectory.appending(component: "Derived"))
+        try await fileSystem.touch(
+            scratchDirectory.appending(components: [
+                "Derived", "Package.resolved",
+            ])
+        )
+        try await fileSystem.touch(
+            temporaryDirectory.appending(component: "Package.resolved")
+        )
+
+        given(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .any,
+                packagePath: .any,
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .willReturn([:])
+
+        // When
+        let (got, lintingIssues) = try await subject.load(
+            packagePath: temporaryDirectory.appending(component: "Package.swift"),
+            packageSettings: packageSettings,
+            disableSandbox: true,
+            swiftPackageManagerArguments: ["--scratch-path", scratchDirectory.pathString]
+        )
+
+        // Then
+        #expect(
+            got.externalProjects.values.map(\.hash) == [
+                "Alamofire.Alamofire-5.10.2",
+            ]
+        )
+        #expect(lintingIssues.isEmpty)
+        verify(packageInfoMapper)
+            .resolveExternalDependencies(
+                path: .value(scratchDirectory),
+                packagePath: .value(temporaryDirectory),
+                packageInfos: .any,
+                packageToFolder: .any,
+                packageToTargetsToArtifactPaths: .any,
+                packageModuleAliases: .any,
+                packageSettings: .any
+            )
+            .called(1)
     }
 
     @Test
@@ -196,6 +284,7 @@ struct SwiftPackageManagerGraphLoaderTests {
                 given(packageInfoMapper)
                     .resolveExternalDependencies(
                         path: .any,
+                        packagePath: .any,
                         packageInfos: .any,
                         packageToFolder: .any,
                         packageToTargetsToArtifactPaths: .any,
@@ -325,6 +414,7 @@ struct SwiftPackageManagerGraphLoaderTests {
         given(packageInfoMapper)
             .resolveExternalDependencies(
                 path: .any,
+                packagePath: .any,
                 packageInfos: .any,
                 packageToFolder: .any,
                 packageToTargetsToArtifactPaths: .any,
@@ -433,6 +523,7 @@ struct SwiftPackageManagerGraphLoaderTests {
         given(packageInfoMapper)
             .resolveExternalDependencies(
                 path: .any,
+                packagePath: .any,
                 packageInfos: .any,
                 packageToFolder: .any,
                 packageToTargetsToArtifactPaths: .any,
@@ -493,6 +584,7 @@ struct SwiftPackageManagerGraphLoaderTests {
                 given(packageInfoMapper)
                     .resolveExternalDependencies(
                         path: .any,
+                        packagePath: .any,
                         packageInfos: .any,
                         packageToFolder: .any,
                         packageToTargetsToArtifactPaths: .any,

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Workspace+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/Workspace+ManifestMapperTests.swift
@@ -70,4 +70,74 @@ final class WorkspaceManifestMapperTests: TuistUnitTestCase {
             )
         )
     }
+
+    func test_from_when_workspacePathContainsCheckouts_doesNotFilterItOut() async throws {
+        // Given
+        given(manifestLoader)
+            .manifests(at: .any)
+            .willReturn([.project])
+
+        let rootPath = try temporaryPath()
+        let workspacePath = rootPath.appending(components: "checkouts", "App")
+        let scratchDirectory = rootPath.appending(component: "custom-build")
+
+        try await fileSystem.makeDirectory(at: workspacePath)
+        try await fileSystem.makeDirectory(at: scratchDirectory.appending(component: "checkouts"))
+        try await fileSystem.touch(workspacePath.appending(component: "Project.swift"))
+
+        // When
+        let got = try await XcodeGraph.Workspace.from(
+            manifest: .test(
+                projects: [
+                    "**",
+                ]
+            ),
+            path: workspacePath,
+            generatorPaths: .init(
+                manifestDirectory: workspacePath,
+                rootDirectory: rootPath
+            ),
+            manifestLoader: manifestLoader,
+            fileSystem: fileSystem,
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // Then
+        XCTAssertEqual(got.projects, [workspacePath])
+    }
+
+    func test_from_when_usingCustomSwiftPMScratchDirectory_ignoresPackagesInCheckouts() async throws {
+        // Given
+        given(manifestLoader)
+            .manifests(at: .any)
+            .willReturn([.project])
+
+        let workspacePath = try temporaryPath()
+        let scratchDirectory = workspacePath.appending(component: "custom-build")
+        let checkoutPath = scratchDirectory.appending(components: "checkouts", "Dependency")
+
+        try await fileSystem.touch(workspacePath.appending(component: "Project.swift"))
+        try await fileSystem.makeDirectory(at: checkoutPath)
+        try await fileSystem.touch(checkoutPath.appending(component: "Package.swift"))
+
+        // When
+        let got = try await XcodeGraph.Workspace.from(
+            manifest: .test(
+                projects: [
+                    "**",
+                ]
+            ),
+            path: workspacePath,
+            generatorPaths: .init(
+                manifestDirectory: workspacePath,
+                rootDirectory: workspacePath
+            ),
+            manifestLoader: manifestLoader,
+            fileSystem: fileSystem,
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // Then
+        XCTAssertEqual(got.projects, [workspacePath])
+    }
 }

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -251,6 +251,51 @@ struct PackageInfoMapperTests {
     }
 
     @Test(
+        .inTemporaryDirectory,
+        .withMockedSwiftVersionProvider
+    ) func resolveDependencies_whenArtifactsUseCustomScratchPath_mapsRemoteXcframeworks() async throws {
+        let basePath = try #require(FileSystem.temporaryTestDirectory)
+        let packagePath = basePath.appending(component: "Tuist")
+        let scratchPath = basePath.appending(component: "custom-build")
+        let artifactsPath = scratchPath.appending(components: "artifacts", "tuist")
+
+        let validXCFramework = artifactsPath.appending(components: "ValidFramework", "ValidFramework.xcframework")
+        try await fileSystem.makeDirectory(at: validXCFramework)
+        try await fileSystem.makeDirectory(at: packagePath)
+        try await fileSystem.makeDirectory(at: basePath.appending(try RelativePath(validating: "Sources/Target_1")))
+
+        let resolvedDependencies = try await subject.resolveExternalDependencies(
+            path: scratchPath,
+            packagePath: packagePath,
+            packageInfos: [
+                "Package": .test(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target_1"),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ],
+            packageToFolder: ["Package": basePath],
+            packageToTargetsToArtifactPaths: [:],
+            packageModuleAliases: [:],
+            packageSettings: .test()
+        )
+
+        let validFrameworkDependency = try #require(resolvedDependencies["ValidFramework"])
+        let dep = try #require(validFrameworkDependency.first)
+        if case let .xcframework(path, _, _, _) = dep {
+            #expect(path.pathString.contains("custom-build/artifacts/tuist/ValidFramework/ValidFramework.xcframework"))
+        }
+    }
+
+    @Test(
         .inTemporaryDirectory, .withMockedSwiftVersionProvider
     ) func resolveDependencies_whenProductContainsBinaryTargetMissingFrom_packageToTargetsToArtifactPaths() async throws {
         let basePath = try #require(FileSystem.temporaryTestDirectory)

--- a/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
+++ b/cli/Tests/TuistLoaderTests/SwiftPackageManager/SwiftPackageManagerModuleMapGeneratorTests.swift
@@ -103,6 +103,67 @@ final class SwiftPackageManagerModuleMapGeneratorTests: TuistUnitTestCase {
         )
     }
 
+    func test_generate_when_externalPackageUsesCustomScratchDirectory() async throws {
+        // Given
+        let scratchDirectory = try temporaryPath()
+            .appending(component: "custom-build")
+        let packageDirectory = scratchDirectory.appending(components: "checkouts", "PackageDir")
+        let publicHeadersPath = packageDirectory.appending(components: "Sources", "Module", "include")
+        try await fileSystem.makeDirectory(at: publicHeadersPath)
+        try await fileSystem.touch(publicHeadersPath.appending(component: "Module.h"))
+
+        // When
+        let got = try await subject.generate(
+            packageDirectory: packageDirectory,
+            moduleName: "Module",
+            publicHeadersPath: publicHeadersPath,
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .header(
+                publicHeadersPath.appending(component: "Module.h"),
+                moduleMapPath: scratchDirectory.appending(
+                    components: [
+                        Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                        Constants.DerivedDirectory.dependenciesModuleMapsDirectory,
+                        "Module",
+                        "Module.modulemap",
+                    ]
+                )
+            )
+        )
+    }
+
+    func test_generate_whenPathContainsUnrelatedCheckoutsDirectory() async throws {
+        // Given
+        let packageDirectory = try temporaryPath()
+            .appending(components: "checkouts", "PackageDir")
+        let publicHeadersPath = packageDirectory.appending(components: "Sources", "Module", "include")
+        let scratchDirectory = packageDirectory.parentDirectory.parentDirectory.appending(component: "custom-build")
+        try await fileSystem.makeDirectory(at: publicHeadersPath)
+        try await fileSystem.touch(publicHeadersPath.appending(component: "Module.h"))
+
+        // When
+        let got = try await subject.generate(
+            packageDirectory: packageDirectory,
+            moduleName: "Module",
+            publicHeadersPath: publicHeadersPath,
+            swiftPackageManagerScratchDirectory: scratchDirectory
+        )
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .header(
+                publicHeadersPath.appending(component: "Module.h"),
+                moduleMapPath: packageDirectory.appending(components: "Derived", "Module.modulemap")
+            )
+        )
+    }
+
     func test_generate_when_moduleMap_already_exists_on_disk() async throws {
         // Given: an external package with an umbrella header
         let packageDirectory = try temporaryPath()

--- a/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerScratchDirectoryLocatorTests.swift
+++ b/cli/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerScratchDirectoryLocatorTests.swift
@@ -1,0 +1,97 @@
+import Path
+import XCTest
+@testable import TuistSupport
+
+final class SwiftPackageManagerScratchDirectoryLocatorTests: XCTestCase {
+    private let subject = SwiftPackageManagerScratchDirectoryLocator()
+
+    func test_locate_when_no_override_is_present() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: [],
+                environment: [:],
+                workingDirectory: workingDirectory
+            ),
+            packagePath.appending(component: ".build")
+        )
+    }
+
+    func test_locate_when_scratchPath_is_present() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: ["--scratch-path", "custom-build"],
+                environment: [:],
+                workingDirectory: workingDirectory
+            ),
+            workingDirectory.appending(component: "custom-build")
+        )
+    }
+
+    func test_locate_when_scratchPath_uses_equals_syntax() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: ["--scratch-path=custom-build"],
+                environment: [:],
+                workingDirectory: workingDirectory
+            ),
+            workingDirectory.appending(component: "custom-build")
+        )
+    }
+
+    func test_locate_when_buildPath_is_present() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: ["--build-path", "custom-build"],
+                environment: [:],
+                workingDirectory: workingDirectory
+            ),
+            workingDirectory.appending(component: "custom-build")
+        )
+    }
+
+    func test_locate_when_scratchPath_and_buildPath_are_present() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: ["--build-path", "build-dir", "--scratch-path", "scratch-dir"],
+                environment: [:],
+                workingDirectory: workingDirectory
+            ),
+            workingDirectory.appending(component: "scratch-dir")
+        )
+    }
+
+    func test_locate_when_swiftpmBuildDirectory_is_present() throws {
+        let packagePath = try AbsolutePath(validating: "/tmp/project/Tuist")
+        let workingDirectory = try AbsolutePath(validating: "/tmp/project")
+
+        XCTAssertEqual(
+            try subject.locate(
+                packagePath: packagePath,
+                arguments: ["--scratch-path", "scratch-dir"],
+                environment: ["SWIFTPM_BUILD_DIR": "env-build-dir"],
+                workingDirectory: workingDirectory
+            ),
+            workingDirectory.appending(component: "env-build-dir")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- take SwiftPM's own scratch-directory workspace lock while `SwiftPackageManagerGraphLoader` directly reads SwiftPM state
- resolve that scratch directory with SwiftPM's precedence: `SWIFTPM_BUILD_DIR`, `--scratch-path`, `--build-path`, then the package `.build` directory
- use the selected scratch directory for `workspace-state.json`, checkouts, registry downloads, binary artifacts, and the saved `Derived/Package.resolved` marker
- avoid hard-coded `.build/checkouts` assumptions for source-control checkouts under a custom scratch directory
- preserve the legacy `state/logs` directory during analytics cleanup so concurrently running processes do not lose log files

## Root cause
SwiftPM already serializes commands that use the same package scratch directory. I validated this in the SwiftPM source and with parallel `swift package resolve` runs, where later processes wait on the existing scratch-directory lock. Because of that, this PR does not wrap Tuist's `swift package` command invocations.

The evidence-backed Tuist gap is narrower: after SwiftPM has produced scratch-directory state, `SwiftPackageManagerGraphLoader` reads `workspace-state.json`, dependency checkout folders, registry downloads, binary artifact folders, and package manifests directly. Those reads were not coordinated with another process running SwiftPM against the same scratch directory. The fix makes Tuist join SwiftPM's own lock before doing those direct reads.

The log crash has a separate root cause: analytics cleanup removed the legacy `state/logs` directory, which can race with processes still trying to open a log file there.

## What this does not claim
This does not claim that SwiftPM itself lacks process-level locking for `swift package resolve` or `swift package dump-package`. The direct `swift package resolve` failure still needs more data if it reproduces after this change, because SwiftPM should already serialize same-scratch-directory resolver processes unless something is using `--ignore-lock`, a different scratch directory, or mutating the package workspace outside SwiftPM.

## Validation
- cloned `swiftlang/swift-package-manager` and verified `SwiftCommandState.getActiveWorkspace()` acquires an exclusive scratch-directory lock with `FileLock.prepareLock(fileToLock: self.scratchDirectory)`
- stress-ran 8 concurrent `swift package --package-path <package> resolve` processes and observed SwiftPM serializing them with "Another instance of SwiftPM is already running using ... waiting..."
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistLoaderTests/PackageInfoMapperTests -only-testing TuistLoaderTests/SwiftPackageManagerGraphLoaderTests -only-testing TuistLoaderTests/RecursiveManifestLoaderTests/test_loadSPM_Package_ignoresPackagesInCustomSwiftPMCheckouts -only-testing TuistSupportTests/SwiftPackageManagerScratchDirectoryLocatorTests -only-testing TuistKitTests/InstallServiceTests/test_run_when_installing_dependencies_with_scratchPath_savesPackageResolvedInScratchDirectory -only-testing TuistKitTests/AnalyticsStateControllerTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
